### PR TITLE
Add RTDB rules tooling bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The main pieces:
 3. **Ask an agent for help** through `pyric serve --bridge` or the included
    [Claude Code plugin](pyric-plugin/README.md).
 4. **Ship deliberately** by building normally against real Firebase and using
-   `pyric deploy <rules|indexes|hosting|functions>` when you want Pyric's
+   `pyric deploy <rules|indexes|database|hosting|functions>` when you want Pyric's
    deploy helpers.
 
 ## Packages

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -49,19 +49,26 @@ read, batch, transact, undo/redo, inspect the event log.
 `firestore_extract_indexes` — derive composite-index definitions from query
 shapes.
 
-## Realtime Database — `createRtdbAdminTools` (`pyric/database`)
+## Realtime Database rules — `createRtdbRulesTools` (`pyric/rules/rtdb`)
 
-Data plane + rules tooling for RTDB.
+Rules tooling for RTDB. `createRtdbAdminTools` (`pyric/database`) remains as a
+backwards-compatible union of the rules and data factories.
+
+`rtdb_get_rules` · `rtdb_deploy_rules` · `rtdb_simulate_access` ·
+`rtdb_build_expression`
+
+## Realtime Database data — `createRtdbDataTools` (`pyric/database`)
+
+Data plane tooling for RTDB.
 
 `rtdb_get` · `rtdb_set` · `rtdb_update` · `rtdb_push` · `rtdb_delete` ·
-`rtdb_validated_write` · `rtdb_crawl_structure` · `rtdb_get_rules` ·
-`rtdb_deploy_rules` · `rtdb_simulate_access` · `rtdb_build_expression`
+`rtdb_validated_write` · `rtdb_crawl_structure`
 
 ## Storage control plane — `createStorageAdminTools` (`pyric/storage`)
 
 `storage_get_status` · `storage_provision`
 
-## Deploy — `createFirestoreDeployTools` / `createHostingDeployTools` / `createFunctionsDeployTools` (`pyric-tools/deploy`)
+## Deploy — `createFirestoreDeployTools` / `createRtdbDeployTools` / `createHostingDeployTools` / `createFunctionsDeployTools` (`pyric-tools/deploy`)
 
 The Firebase control plane over REST — no `firebase-tools` CLI required.
 Docs: [`packages/pyric-tools/docs/deploy/`](../packages/pyric-tools/docs/deploy/README.md).
@@ -69,6 +76,7 @@ Docs: [`packages/pyric-tools/docs/deploy/`](../packages/pyric-tools/docs/deploy/
 `firestore_get_rules` · `firestore_deploy_rules` · `firestore_ensure_rules` ·
 `firestore_provision_database` · `firestore_deploy_indexes` ·
 `firestore_create_index` · `firestore_get_index_status` ·
+`rtdb_get_rules` · `rtdb_deploy_rules` ·
 `hosting_deploy` · `hosting_ensure_site` ·
 `functions_deploy`
 
@@ -84,7 +92,10 @@ Identity Toolkit project configuration.
 
 ---
 
-**Total: 51 tools.** Removed since the legacy project-level SDK:
+**Total: 51 unique tool names.** There are 53 factory entries when counting the
+scope-based `createRtdbDeployTools` `rtdb_get_rules` / `rtdb_deploy_rules`
+handlers separately from the host-backed RTDB rules factory. Removed since the
+legacy project-level SDK:
 `firebase_get_project`, `firebase_get_client_config` (died with that
 package; project overview is now `sandbox_inspect` +
 `firestore_discover_paths` + `auth_get_config` composed).

--- a/packages/pyric-tools/README.md
+++ b/packages/pyric-tools/README.md
@@ -11,10 +11,13 @@ The Pyric CLI + programmatic helpers for `firebase-tools`-shaped work
 | `pyric bridge` | Stand up an HTTP+WebSocket bridge an MCP client (Claude Code, Cursor) connects to |
 | `pyric serve` | Local dev server with the pyric sandbox standing in for Firebase: serves `hosting.public`, resolves unmodified `firebase/*` imports to a pyric sandbox via a served import map, deploys + hot-reloads `firestore.rules` (SSE), opens an emulator-style sign-in helper for `signInWithPopup`/`signInWithRedirect`. The sandbox runs in a **SharedWorker by default** — one backend shared by every tab of the origin (live cross-tab sync), kept in the browser's IndexedDB so **data survives a refresh/restart by default**; a per-tab in-page sandbox is the fallback when SharedWorker is unavailable. Flags + exit codes: [CLI reference](docs/reference/cli.md#pyric-serve); persistence, ephemeral runs, clearing data, and SharedWorker tips: [persistence & multi-tab](docs/how-to/serve-persistence-and-multi-tab.md) |
 | `pyric snapshot` | Promote lived sandbox state (live `serve --persist`, else `.pyric/state/state.json`) to a committable fixture; `pyric serve --seed <fixture>` re-serves it (docs + users). `--out`, `--port`, `--force`, `--json` |
-| `pyric deploy <target>` | Deploy `rules` / `indexes` / `hosting` / `functions` to a real Firebase project |
+| `pyric deploy <target>` | Deploy `rules` / `indexes` / `database` / `hosting` / `functions` to a real Firebase project |
 | `pyric rules:lint <path>` | Lint a Firestore rules file |
-| `pyric rules:validate <path>` | Validate against a project |
+| `pyric rules:validate <path>` | Validate Firestore rules structure |
 | `pyric rules:simulate` | Local rules simulator |
+| `pyric database:rules:lint <path>` | Lint a Realtime Database rules JSON file |
+| `pyric database:rules:validate <path>` | Validate Realtime Database rules expressions |
+| `pyric database:rules:simulate` | Local Realtime Database rules simulator |
 | `pyric auth:configure-provider <id> <enabled>` | Identity Toolkit: enable/disable an auth provider |
 | `pyric auth:manage-domains <add\|remove\|list> [domain]` | Identity Toolkit: authorized domains |
 | `pyric firestore:discover [collection]` | Crawl a Firestore to infer schema |
@@ -63,7 +66,7 @@ rulesHash}`.
 
 | Subpath | Surface |
 |---|---|
-| `pyric-tools/deploy` | `fromServiceAccount`, `getDeploy`, `createFirestoreDeployTools`, `createHostingDeployTools`, `createFunctionsDeployTools` |
+| `pyric-tools/deploy` | `fromServiceAccount`, `getDeploy`, `createFirestoreDeployTools`, `createRtdbDeployTools`, `createHostingDeployTools`, `createFunctionsDeployTools` |
 | `pyric-tools/bridge` | `createBridge`, `startServer` (Node) / `connectBridge` (browser via conditional export). Vite integration is `pyricSandbox({ bridge })` in `pyric-tools/vite`. |
 | `pyric-tools/vite` | `pyricSandbox(opts)`, the dev-only firebase→sandbox swap plugin. Opts: `rules`, `persist`/`fresh`, `seed`, `capture`, `bridge` (MCP), `ui` (Pyric Studio at `/__pyric/ui/`, parity with `serve --ui`). |
 | `pyric-tools/discover` | `crawl`, `findCollectionGroup`, `createRestCrawlerFirestore`, `createFirestoreDiscoverTools` |

--- a/packages/pyric-tools/docs/deploy/README.md
+++ b/packages/pyric-tools/docs/deploy/README.md
@@ -43,6 +43,7 @@ Documentation is organised under [`docs/`](./) following the [Diataxis](https://
 - **First time here?** Work through [Deploy a Cloud Function](./tutorials/01-deploy-a-cloud-function.md).
 - **Setting up auth?** See [Build a `ProjectScope` from a service account](./how-to/build-projectscope-from-service-account.md).
 - **Building an agent?** See [Register deploy tools with an agent](./how-to/register-tools-with-an-agent.md) and the [API reference](./reference/api.md).
+- **Deploying Realtime Database rules?** See [Deploy Realtime Database rules](./how-to/deploy-realtime-database-rules.md) and the [`rtdb` namespace reference](./reference/rtdb-namespace.md).
 
 ## Position in the Pyric stack
 

--- a/packages/pyric-tools/docs/deploy/README.md
+++ b/packages/pyric-tools/docs/deploy/README.md
@@ -1,12 +1,12 @@
 # `pyric-tools/deploy`
 
-Firebase control-plane primitives — Hosting, Cloud Functions Gen 2, Firestore rules, indexes, and database provisioning — without the `firebase` CLI. Pure-fetch over OAuth access tokens; works in Node and the browser alike.
+Firebase control-plane primitives — Hosting, Cloud Functions Gen 2, Firestore rules, Firestore indexes, Firestore database provisioning, and Realtime Database rules — without the `firebase` CLI. Pure-fetch over OAuth access tokens; works in Node and the browser alike.
 
 The package is organised around three things:
 
 - **`ProjectScope`** — a tiny `{ projectId, resolveToken }` pair every primitive takes as its first argument. Build one from a service-account JSON (Node) or from `firebaseAuth.currentUser.getIdToken()` (browser).
-- **Namespaced primitives** — `hosting`, `functions`, `firestore`, and `recipes`. Each groups the operations for one Firebase product.
-- **Tool factories** — `createHostingDeployTools`, `createFunctionsDeployTools`, `createFirestoreDeployTools`. Each returns a `ToolHandler[]` ready to feed an `@inbrowser/agent` registry.
+- **Namespaced primitives** — `hosting`, `functions`, `firestore`, `rtdb`, and `recipes`. Each groups the operations for one Firebase product.
+- **Tool factories** — `createHostingDeployTools`, `createFunctionsDeployTools`, `createFirestoreDeployTools`, `createRtdbDeployTools`. Each returns a `ToolHandler[]` ready to feed an `@inbrowser/agent` registry.
 
 ## Install
 

--- a/packages/pyric-tools/docs/deploy/how-to/deploy-realtime-database-rules.md
+++ b/packages/pyric-tools/docs/deploy/how-to/deploy-realtime-database-rules.md
@@ -1,0 +1,151 @@
+# How to deploy Realtime Database rules
+
+This guide shows you how to deploy a Realtime Database rules JSON file through
+the Pyric CLI or through `pyric-tools/deploy`.
+
+## Prepare the rules file
+
+Put the complete RTDB rules JSON in a file such as `database.rules.json`:
+
+```json
+{
+  "rules": {
+    "profiles": {
+      "$uid": {
+        ".read": "auth.uid === $uid",
+        ".write": "auth.uid === $uid"
+      }
+    }
+  }
+}
+```
+
+Add the file to `firebase.json`:
+
+```json
+{
+  "database": {
+    "rules": "database.rules.json"
+  }
+}
+```
+
+If the project has more than one RTDB instance, or instance discovery is not
+available to the credential, include the URL:
+
+```json
+{
+  "database": {
+    "rules": "database.rules.json",
+    "url": "https://demo-default-rtdb.firebaseio.com"
+  }
+}
+```
+
+## Check the rules locally
+
+Run the linter:
+
+```bash
+pyric database:rules:lint database.rules.json
+```
+
+Run validation:
+
+```bash
+pyric database:rules:validate database.rules.json
+```
+
+To run a specific local simulation, pipe a request through stdin:
+
+```bash
+printf '%s\n' '{
+  "rulesPath": "database.rules.json",
+  "operation": "read",
+  "path": "/profiles/alice",
+  "auth": { "uid": "alice", "token": {} },
+  "mockData": {}
+}' | pyric database:rules:simulate --stdin
+```
+
+## Deploy from the CLI
+
+Deploy with the URL from `firebase.json.database.url`:
+
+```bash
+pyric deploy database --project demo-project
+```
+
+To override the URL for one deploy:
+
+```bash
+pyric deploy database \
+  --project demo-project \
+  --database-url https://demo-default-rtdb.firebaseio.com
+```
+
+In CI, set `FIREBASE_DATABASE_URL` instead of adding the URL to
+`firebase.json`:
+
+```bash
+FIREBASE_DATABASE_URL=https://demo-default-rtdb.firebaseio.com \
+  pyric deploy database --project demo-project
+```
+
+When no URL is supplied, Pyric attempts to discover the single default RTDB
+instance for the project. If discovery finds multiple candidates, pass an
+explicit URL.
+
+## Deploy from code
+
+Use the `rtdb.rules` namespace when you are writing your own deploy flow:
+
+```ts
+import { fromServiceAccount, rtdb } from 'pyric-tools/deploy';
+
+const scope = await fromServiceAccount('./service-account.json');
+const rulesJson = {
+  rules: {
+    profiles: {
+      '$uid': {
+        '.read': 'auth.uid === $uid',
+        '.write': 'auth.uid === $uid',
+      },
+    },
+  },
+};
+
+await rtdb.rules.deploy(scope, {
+  rulesJson,
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+## Register the deploy tools with an agent
+
+When the caller uses `@inbrowser/agent`, register the RTDB deploy factory next
+to the other deploy factories:
+
+```ts
+import { createToolRegistry } from '@inbrowser/agent';
+import {
+  createFirestoreDeployTools,
+  createRtdbDeployTools,
+  createHostingDeployTools,
+} from 'pyric-tools/deploy';
+
+const registry = createToolRegistry();
+const deps = { scope };
+
+for (const tool of createFirestoreDeployTools(deps)) registry.register(tool);
+for (const tool of createRtdbDeployTools(deps)) registry.register(tool);
+for (const tool of createHostingDeployTools(deps)) registry.register(tool);
+```
+
+The RTDB deploy factory exposes `rtdb_get_rules` and `rtdb_deploy_rules`.
+
+## Where to look next
+
+- For exact function signatures, see [`rtdb` namespace](../reference/rtdb-namespace.md).
+- For deploy tool schemas, see [Tool factories](../reference/tool-factories.md).
+- For building a `ProjectScope`, see [Build a `ProjectScope` from a service account](./build-projectscope-from-service-account.md).

--- a/packages/pyric-tools/docs/deploy/reference/api.md
+++ b/packages/pyric-tools/docs/deploy/reference/api.md
@@ -110,6 +110,12 @@ Firestore rules, indexes, and database primitives. See [`firestore` namespace](.
 - `firestore.indexes.{ create, deployAll, getStatus }`
 - `firestore.databases.{ provision }`
 
+### `const rtdb`
+
+Realtime Database rules primitives:
+
+- `rtdb.rules.{ fetch, deploy, discoverDefaultDatabaseUrl, resolveDatabaseUrl }`
+
 ### `const recipes`
 
 Paste-in templates for `firestore.rules.ensure`:
@@ -136,6 +142,13 @@ Returns two handlers:
 
 - `hosting_deploy`
 - `hosting_ensure_site`
+
+### `createRtdbDeployTools(deps): ToolHandler[]`
+
+Returns two handlers:
+
+- `rtdb_get_rules`
+- `rtdb_deploy_rules`
 
 ### `createFunctionsDeployTools(deps): ToolHandler[]`
 
@@ -177,5 +190,9 @@ Re-exported from the relevant submodule:
 - `QueryScope`, `IndexFieldOrder`, `ArrayConfig`, `IndexState`, `ApiScope`, `Density`, `VectorConfig`, `IndexField`, `Index`, `IndexesConfigEntry`, `IndexesConfig`, `IndexOperation`.
 - `DeployIndexesOptions`, `PerIndexOutcome`, `DeployIndexesOutcome`.
 - `GetIndexStatusOutcome`.
+
+### Realtime Database
+
+- `RtdbDeployRulesInput`, `RtdbFetchRulesInput`, `RtdbRulesDiscoveryResult`.
 
 See [Error codes by operation](./error-codes.md) for the values each error union can take.

--- a/packages/pyric-tools/docs/deploy/reference/api.md
+++ b/packages/pyric-tools/docs/deploy/reference/api.md
@@ -112,7 +112,7 @@ Firestore rules, indexes, and database primitives. See [`firestore` namespace](.
 
 ### `const rtdb`
 
-Realtime Database rules primitives:
+Realtime Database rules primitives. See [`rtdb` namespace](./rtdb-namespace.md):
 
 - `rtdb.rules.{ fetch, deploy, discoverDefaultDatabaseUrl, resolveDatabaseUrl }`
 

--- a/packages/pyric-tools/docs/deploy/reference/rtdb-namespace.md
+++ b/packages/pyric-tools/docs/deploy/reference/rtdb-namespace.md
@@ -1,0 +1,144 @@
+# `rtdb` namespace
+
+Realtime Database rules deploy primitives.
+
+```ts
+import { rtdb } from 'pyric-tools/deploy';
+```
+
+The namespace works with Firebase RTDB rules JSON:
+
+```ts
+const rulesJson = {
+  rules: {
+    messages: {
+      '$messageId': {
+        '.read': 'auth !== null',
+        '.write': 'auth !== null',
+      },
+    },
+  },
+};
+```
+
+## `rtdb.rules`
+
+### `fetch(scope, input?): Promise<RtdbIR>`
+
+Fetch the deployed RTDB rules and return Pyric's RTDB rule IR.
+
+```ts
+const ir = await rtdb.rules.fetch(scope, {
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+`input.databaseUrl` is optional. When omitted, the function attempts default
+instance discovery.
+
+### `deploy(scope, input): Promise<void>`
+
+Deploy a complete RTDB rules JSON document.
+
+```ts
+await rtdb.rules.deploy(scope, {
+  rulesJson,
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+`rulesJson` must contain a top-level `rules` object. The function maps the JSON
+through `RtdbMapper.mapToIR` before writing it to the RTDB rules endpoint.
+
+### `discoverDefaultDatabaseUrl(scope): Promise<RtdbRulesDiscoveryResult>`
+
+List RTDB instances for the project through the RTDB management API and return
+the single default URL when it can be determined.
+
+```ts
+type RtdbRulesDiscoveryResult = {
+  databaseUrl: string | null;
+  candidates: string[];
+};
+```
+
+`databaseUrl` is `null` when no instances are found or when multiple candidates
+exist and no single default can be selected.
+
+### `resolveDatabaseUrl(scope, explicitDatabaseUrl?): Promise<string>`
+
+Return `explicitDatabaseUrl` when supplied. Otherwise, call
+`discoverDefaultDatabaseUrl(scope)` and return the discovered default URL.
+
+Throws when no URL can be resolved.
+
+## Input types
+
+### `RtdbDeployRulesInput`
+
+```ts
+interface RtdbDeployRulesInput {
+  rulesJson: unknown;
+  databaseUrl?: string;
+}
+```
+
+### `RtdbFetchRulesInput`
+
+```ts
+interface RtdbFetchRulesInput {
+  databaseUrl?: string;
+}
+```
+
+## Tool factory
+
+`createRtdbDeployTools({ scope })` returns two deploy handlers.
+
+| Tool | Parameters | Result data |
+|---|---|---|
+| `rtdb_get_rules` | `{ databaseUrl?: string }` | `{ ir: RtdbIR }` |
+| `rtdb_deploy_rules` | `{ rulesJson: object; databaseUrl?: string }` | `undefined` |
+
+The handler names match the host-backed RTDB rules tools from
+`pyric/rules/rtdb`. Do not register both factories in the same registry unless
+the registry supports explicit replacement.
+
+## CLI config shape
+
+`pyric deploy database` reads:
+
+```json
+{
+  "database": {
+    "rules": "database.rules.json",
+    "url": "https://demo-default-rtdb.firebaseio.com"
+  }
+}
+```
+
+`database.rules` is required. `database.url` is optional.
+
+URL precedence:
+
+1. `--database-url`
+2. `FIREBASE_DATABASE_URL`
+3. `firebase.json.database.url`
+4. Default instance discovery
+
+## OAuth scope
+
+RTDB rules deploys require:
+
+```ts
+SCOPES.firebaseDatabase
+```
+
+The scope string is:
+
+```text
+https://www.googleapis.com/auth/firebase.database
+```
+
+It is not part of `BASE_SCOPES`; login-based credentials request it only when a
+database deploy needs it.

--- a/packages/pyric-tools/docs/deploy/reference/tool-factories.md
+++ b/packages/pyric-tools/docs/deploy/reference/tool-factories.md
@@ -1,6 +1,6 @@
 # Tool factories
 
-Three factories wrap the namespaces as `@inbrowser/agent` `ToolHandler[]`. Each takes a `ProjectScopedDeps` shape and returns the handlers for its domain.
+Four factories wrap the namespaces as `@inbrowser/agent` `ToolHandler[]`. Each takes a `ProjectScopedDeps` shape and returns the handlers for its domain.
 
 ```ts
 interface ProjectScopedDeps {
@@ -32,6 +32,17 @@ Two handlers.
 |---|---|---|
 | `hosting_deploy` | `hosting.deployFiles` | `DeployHostingResult` |
 | `hosting_ensure_site` | `hosting.sites.ensure` | `EnsureSiteResult` |
+
+## `createRtdbDeployTools(deps): ToolHandler[]`
+
+Two handlers covering Realtime Database rules. `databaseUrl` is optional; when
+omitted the tool tries to discover the single default RTDB instance for the
+project.
+
+| Tool name | Backing call | `data` shape |
+|---|---|---|
+| `rtdb_get_rules` | `rtdb.rules.fetch` | `{ ir: RtdbIR }` |
+| `rtdb_deploy_rules` | `rtdb.rules.deploy` | `undefined` |
 
 ## `createFunctionsDeployTools(deps): ToolHandler[]`
 
@@ -85,6 +96,7 @@ Per pre-mortem M8, every handler checks `ctx.signal.aborted` before starting wor
 import { createToolRegistry } from '@inbrowser/agent';
 import {
   createFirestoreDeployTools,
+  createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
 } from 'pyric-tools/deploy';
@@ -92,6 +104,7 @@ import {
 const registry = createToolRegistry();
 const deps = { scope };
 for (const h of createFirestoreDeployTools(deps)) registry.register(h);
+for (const h of createRtdbDeployTools(deps)) registry.register(h);
 for (const h of createHostingDeployTools(deps)) registry.register(h);
 for (const h of createFunctionsDeployTools(deps)) registry.register(h);
 ```

--- a/packages/pyric-tools/docs/reference/cli.md
+++ b/packages/pyric-tools/docs/reference/cli.md
@@ -23,13 +23,14 @@ Run `pyric --help` for the same surface inline, or `pyric --version`.
 | `PYRIC_VERBOSE` | all | Verbose logging when set. |
 | `FIREBASE_SA_BASE64` | `deploy`, `auth:*`, `firestore:discover` | base64-encoded service-account JSON. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `deploy`, `auth:*`, `firestore:discover` | Filesystem path to service-account JSON. |
+| `FIREBASE_DATABASE_URL` | `deploy database` | Realtime Database instance URL, used when `--database-url` and `firebase.json.database.url` are absent. |
 | `PYRIC_SA_PATH` | `bridge --mode prod` | Service-account path for prod bridge mode. |
 
 Commands that touch a **real Firebase project** (`deploy`, `auth:*`,
 `firestore:discover`, `bridge --mode prod`) require credentials via
 `FIREBASE_SA_BASE64` or `GOOGLE_APPLICATION_CREDENTIALS`, plus a project id via
 `--project` / `PYRIC_PROJECT` / `.firebaserc`. The local sandbox commands
-(`serve`, `init`, `snapshot`, `verify`, `rules:*`) need none.
+(`serve`, `init`, `snapshot`, `verify`, `rules:*`, `database:rules:*`) need none.
 
 ---
 
@@ -136,12 +137,17 @@ real Firebase project (guarded). See [bridge](../bridge/README.md).
 
 ## Deploy
 
-### `pyric deploy <rules|indexes|hosting|functions>`
+### `pyric deploy <rules|indexes|database|hosting|functions>`
 
 Deploy to a real Firebase project. Each target has its own surface (selectors,
 agent I/O via `--schema` / `--json`, preview channels for hosting). The full
 deploy documentation lives in [`../deploy/`](../deploy/README.md) — including the
 [CLI agent I/O reference](../deploy/reference/cli-agent-io.md).
+
+`pyric deploy database` reads `firebase.json.database.rules` as a Realtime
+Database rules JSON file. The database URL is resolved in this order:
+`--database-url`, `FIREBASE_DATABASE_URL`, `firebase.json.database.url`, then
+single default instance discovery via the RTDB management API.
 
 ### `pyric hosting:channel:deploy <channelId> [--expires <ttl>]`
 
@@ -170,6 +176,22 @@ Local rules simulator.
 | Flag | Description |
 |---|---|
 | `--stdin` | Read a scripted simulation from stdin instead of running the interactive smoke-test. |
+
+### `pyric database:rules:lint <path>`
+
+Run the Realtime Database rules JSON expression linter against a file.
+
+### `pyric database:rules:validate <path>`
+
+Validate Realtime Database rules JSON expressions against the local parser and
+expression validator.
+
+### `pyric database:rules:simulate [--stdin]`
+
+Local Realtime Database rules simulator. With no flags, reads
+`firebase.json.database.rules` and runs a sample anonymous read. With `--stdin`,
+reads a JSON payload with `rulesJson` or `rulesPath`, `operation`, `path`,
+optional `auth`, `mockData`, and `newData`.
 
 ---
 

--- a/packages/pyric-tools/docs/tutorials/getting-started.md
+++ b/packages/pyric-tools/docs/tutorials/getting-started.md
@@ -111,7 +111,7 @@ npx pyric snapshot        # dump sandbox state to a file
 A local Firebase-shaped dev loop where the backend lives in your browser
 tab, rules are enforced for real, and an agent can safely operate on all
 of it — and the same app code deploys unchanged against real Firebase
-(`pyric deploy <rules|indexes|hosting|functions>`).
+(`pyric deploy <rules|indexes|database|hosting|functions>`).
 
 ## Where next
 

--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -20,6 +20,11 @@ import { describe, it, expect, mock } from 'bun:test';
 import { parseArgs } from './parse-args.js';
 import { runDeploy, runHostingChannelDeploy } from './deploy.js';
 import { runRulesLint, runRulesValidate, runRulesSimulate } from './rules.js';
+import {
+  runDatabaseRulesLint,
+  runDatabaseRulesValidate,
+  runDatabaseRulesSimulate,
+} from './database-rules.js';
 import { runAuthConfigureProvider, runAuthManageDomains } from './auth.js';
 import { runFirestoreDiscover } from './discover.js';
 import { runInit } from './init.js';
@@ -773,6 +778,67 @@ describe('runRulesSimulate', () => {
     const callArgs = (simulateFn.mock.calls[0] ?? []) as [string, unknown[]];
     expect(callArgs[0]).toBe('inline rules');
     expect(callArgs[1]).toHaveLength(2);
+  });
+});
+
+// ── database rules ───────────────────────────────────────────────────
+
+describe('runDatabaseRulesLint', () => {
+  it('errors out when no path given', async () => {
+    const io = bufferIo();
+    const code = await runDatabaseRulesLint(parseArgs(['database:rules:lint']), { ...io });
+    expect(code).toBe(1);
+    expect(io.getErr()).toContain('missing rules-file path');
+  });
+
+  it('prints RTDB expression lints as JSON', async () => {
+    const io = bufferIo();
+    const code = await runDatabaseRulesLint(parseArgs(['database:rules:lint', 'database.rules.json']), {
+      ...io,
+      cwd: '/tmp',
+      readFile: (async () => '{"rules":{".read":true,".write":false}}') as never,
+    });
+    expect(code).toBe(0);
+    const out = JSON.parse(io.getOut()) as { warnings: Array<{ code: string }> };
+    expect(out.warnings.map((finding) => finding.code).sort()).toEqual([
+      'HARDCODED_FALSE',
+      'HARDCODED_TRUE',
+    ]);
+  });
+});
+
+describe('runDatabaseRulesValidate', () => {
+  it('reports RTDB expression parse errors', async () => {
+    const io = bufferIo();
+    const code = await runDatabaseRulesValidate(parseArgs(['database:rules:validate', 'database.rules.json']), {
+      ...io,
+      cwd: '/tmp',
+      readFile: (async () => '{"rules":{".read":"auth.uid =="}}') as never,
+    });
+    expect(code).toBe(0);
+    const out = JSON.parse(io.getOut()) as { errors: Array<{ code: string }> };
+    expect(out.errors.some((finding) => finding.code === 'PARSE_ERROR')).toBe(true);
+  });
+});
+
+describe('runDatabaseRulesSimulate', () => {
+  it('simulates inline RTDB rules from stdin', async () => {
+    const io = bufferIo();
+    const code = await runDatabaseRulesSimulate(parseArgs(['database:rules:simulate', '--stdin']), {
+      ...io,
+      readStdin: async () =>
+        JSON.stringify({
+          rulesJson: { rules: { '.read': true } },
+          operation: 'read',
+          path: '/sample',
+          auth: null,
+          mockData: {},
+        }),
+    });
+    expect(code).toBe(0);
+    const result = JSON.parse(io.getOut()) as { success: boolean; data: { allowed: boolean } };
+    expect(result.success).toBe(true);
+    expect(result.data.allowed).toBe(true);
   });
 });
 

--- a/packages/pyric-tools/src/cli/database-rules.ts
+++ b/packages/pyric-tools/src/cli/database-rules.ts
@@ -1,0 +1,271 @@
+/**
+ * `pyric database:rules:*` subcommands — local tooling for Realtime Database
+ * rules JSON.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import {
+  RtdbMapper,
+  SimulateHandler,
+  type RtdbIR,
+  type RtdbNode,
+  type SimulationInput,
+} from 'pyric/rules/rtdb';
+import type { ParsedArgs } from './parse-args.js';
+import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
+
+const LOCAL_DATABASE_URL = 'https://local-rtdb.firebaseio.com';
+
+export interface DatabaseRulesDeps {
+  readFile?: typeof readFile;
+  readFirebaseJson?: (cwd: string) => Promise<FirebaseJson>;
+  simulate?: (ir: RtdbIR, input: SimulationInput) => ReturnType<SimulateHandler['execute']>;
+  cwd?: string;
+  readStdin?: () => Promise<string>;
+  stdout?: { write(s: string): void };
+  stderr?: { write(s: string): void };
+}
+
+interface RuleFinding {
+  path: string;
+  rule: '.read' | '.write' | '.validate';
+  code: string;
+  message: string;
+}
+
+function defaultReadStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function parseRulesJson(raw: string, databaseUrl = LOCAL_DATABASE_URL): RtdbIR {
+  return RtdbMapper.mapToIR(JSON.parse(raw), null, databaseUrl);
+}
+
+function collectFindings(node: RtdbNode, kind: 'errors' | 'warnings'): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  const rules = [
+    ['.read', node.read],
+    ['.write', node.write],
+    ['.validate', node.validate],
+  ] as const;
+  for (const [rule, expr] of rules) {
+    for (const finding of expr?.parsed[kind] ?? []) {
+      findings.push({
+        path: node.path,
+        rule,
+        code: finding.code,
+        message: finding.message,
+      });
+    }
+  }
+  for (const child of node.children) {
+    findings.push(...collectFindings(child, kind));
+  }
+  return findings;
+}
+
+async function readRulesFile(
+  path: string,
+  deps: DatabaseRulesDeps,
+): Promise<{ ok: true; raw: string } | { ok: false; message: string }> {
+  const cwd = deps.cwd ?? process.cwd();
+  const readFileFn = deps.readFile ?? readFile;
+  try {
+    return { ok: true, raw: await readFileFn(resolvePath(cwd, path), 'utf-8') };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function jsonError(code: string, message: string): { errors: RuleFinding[]; warnings: RuleFinding[] } {
+  return {
+    errors: [{ path: '/', rule: '.read', code, message }],
+    warnings: [],
+  };
+}
+
+export async function runDatabaseRulesLint(
+  parsed: ParsedArgs,
+  deps: DatabaseRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const path = parsed.positional[0];
+  if (!path) {
+    err.write('pyric database:rules:lint: missing rules-file path. Usage: pyric database:rules:lint <path>\n');
+    return 1;
+  }
+
+  const file = await readRulesFile(path, deps);
+  if (!file.ok) {
+    err.write(`pyric database:rules:lint: ${file.message}\n`);
+    return 1;
+  }
+
+  try {
+    const ir = parseRulesJson(file.raw);
+    const root = ir.rules as RtdbNode;
+    out.write(`${JSON.stringify({ warnings: collectFindings(root, 'warnings') }, null, 2)}\n`);
+    return 0;
+  } catch (e) {
+    out.write(`${JSON.stringify(jsonError('INVALID_RULES_JSON', e instanceof Error ? e.message : String(e)), null, 2)}\n`);
+    return 2;
+  }
+}
+
+export async function runDatabaseRulesValidate(
+  parsed: ParsedArgs,
+  deps: DatabaseRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const path = parsed.positional[0];
+  if (!path) {
+    err.write('pyric database:rules:validate: missing rules-file path. Usage: pyric database:rules:validate <path>\n');
+    return 1;
+  }
+
+  const file = await readRulesFile(path, deps);
+  if (!file.ok) {
+    err.write(`pyric database:rules:validate: ${file.message}\n`);
+    return 1;
+  }
+
+  try {
+    const ir = parseRulesJson(file.raw);
+    const root = ir.rules as RtdbNode;
+    out.write(`${JSON.stringify({ errors: collectFindings(root, 'errors') }, null, 2)}\n`);
+    return 0;
+  } catch (e) {
+    out.write(`${JSON.stringify(jsonError('INVALID_RULES_JSON', e instanceof Error ? e.message : String(e)), null, 2)}\n`);
+    return 2;
+  }
+}
+
+interface SimulatePayload {
+  rulesJson?: unknown;
+  rules?: unknown;
+  rulesPath?: string;
+  databaseUrl?: string;
+  operation?: SimulationInput['operation'];
+  path?: string;
+  auth?: SimulationInput['auth'];
+  mockData?: Record<string, unknown>;
+  newData?: unknown;
+}
+
+async function readFirebaseRules(
+  deps: DatabaseRulesDeps,
+): Promise<{ ok: true; raw: string } | { ok: false; message: string }> {
+  const cwd = deps.cwd ?? process.cwd();
+  const fjRead = deps.readFirebaseJson ?? readFirebaseJson;
+  let firebaseJson: FirebaseJson;
+  try {
+    firebaseJson = await fjRead(cwd);
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : String(e) };
+  }
+  const rulesPath = firebaseJson.database?.rules;
+  if (!rulesPath) {
+    return { ok: false, message: 'firebase.json has no `database.rules` path.' };
+  }
+  return readRulesFile(rulesPath, deps);
+}
+
+export async function runDatabaseRulesSimulate(
+  parsed: ParsedArgs,
+  deps: DatabaseRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const readFileFn = deps.readFile ?? readFile;
+  const simulateFn =
+    deps.simulate ??
+    ((ir: RtdbIR, input: SimulationInput) => new SimulateHandler().execute(ir, input));
+
+  let rulesJson: unknown;
+  let databaseUrl = LOCAL_DATABASE_URL;
+  let input: SimulationInput;
+
+  if (parsed.flags.get('stdin') === true) {
+    const readStdinFn = deps.readStdin ?? defaultReadStdin;
+    let payload: SimulatePayload;
+    try {
+      payload = JSON.parse(await readStdinFn()) as SimulatePayload;
+    } catch (e) {
+      err.write(`pyric database:rules:simulate: failed to parse stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`);
+      return 1;
+    }
+    if (!payload.operation || !payload.path) {
+      err.write('pyric database:rules:simulate: stdin payload must include `operation` and `path`.\n');
+      return 1;
+    }
+    databaseUrl = payload.databaseUrl ?? databaseUrl;
+    if (payload.rulesJson !== undefined || payload.rules !== undefined) {
+      rulesJson = payload.rulesJson ?? payload.rules;
+    } else if (payload.rulesPath) {
+      try {
+        rulesJson = JSON.parse(await readFileFn(resolvePath(deps.cwd ?? process.cwd(), payload.rulesPath), 'utf-8'));
+      } catch (e) {
+        err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+        return 1;
+      }
+    } else {
+      const file = await readFirebaseRules(deps);
+      if (!file.ok) {
+        err.write(`pyric database:rules:simulate: ${file.message}\n`);
+        return 1;
+      }
+      try {
+        rulesJson = JSON.parse(file.raw);
+      } catch (e) {
+        err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+        return 2;
+      }
+    }
+    input = {
+      operation: payload.operation,
+      path: payload.path,
+      auth: payload.auth ?? null,
+      mockData: payload.mockData ?? {},
+      ...(payload.newData !== undefined ? { newData: payload.newData } : {}),
+    };
+  } else {
+    const file = await readFirebaseRules(deps);
+    if (!file.ok) {
+      err.write(`pyric database:rules:simulate: ${file.message}\n`);
+      return 1;
+    }
+    try {
+      rulesJson = JSON.parse(file.raw);
+    } catch (e) {
+      err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+      return 2;
+    }
+    input = {
+      operation: 'read',
+      path: '/sample/x',
+      auth: null,
+      mockData: {},
+    };
+  }
+
+  try {
+    const ir = RtdbMapper.mapToIR(rulesJson, null, databaseUrl);
+    const result = simulateFn(ir, input);
+    out.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.success ? 0 : 2;
+  } catch (e) {
+    err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 2;
+  }
+}

--- a/packages/pyric-tools/src/cli/deploy.ts
+++ b/packages/pyric-tools/src/cli/deploy.ts
@@ -5,7 +5,7 @@
  * `PYRIC_PROJECT` / `.firebaserc`; resolves a service-account scope
  * from env.
  *
- * Supported targets: `rules`, `indexes`, `hosting`, `functions`.
+ * Supported targets: `rules`, `indexes`, `database`, `hosting`, `functions`.
  * `functions` requires `--source <dir>` and a JSON-formatted
  * `--config` (FunctionDeployConfig[]); this is the minimum to make
  * the CLI a real handle on the library — extras (multi-function
@@ -23,6 +23,7 @@ import { readFile } from 'node:fs/promises';
 import type { ToolHandler } from '@inbrowser/agent';
 import {
   createFirestoreDeployTools,
+  createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
   type ProjectScope,
@@ -56,8 +57,10 @@ export interface DeployDeps {
   ensureApis?: typeof ensureApisEnabled;
   readFile?: typeof readFile;
   createFirestoreDeployTools?: typeof createFirestoreDeployTools;
+  createRtdbDeployTools?: typeof createRtdbDeployTools;
   createHostingDeployTools?: typeof createHostingDeployTools;
   createFunctionsDeployTools?: typeof createFunctionsDeployTools;
+  env?: Record<string, string | undefined>;
   /**
    * Current git branch resolver for `--channel auto` — used in tests.
    * Defaults to `git rev-parse --abbrev-ref HEAD`. Resolves `null`
@@ -84,7 +87,7 @@ export interface DeployDeps {
 //                      (mirror of firebase-tools' global -j/--json,
 //                      clones/firebase-tools/src/index.ts:16)
 // Every deploy target wraps a ToolHandler, so adding one = one entry
-// here. Hosting is wired today; rules/indexes/functions are follow-ups.
+// here. Hosting is wired today; rules/indexes/database/functions are follow-ups.
 interface AgentIoEntry {
   toolName: string;
   tools(deps: DeployDeps, scope: ProjectScope): ToolHandler[];
@@ -130,7 +133,7 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
   }
   if (machineOutput && !agentIo) {
     err.write(
-      `pyric deploy ${target}: --json is not wired for '${target}' yet (hosting only; rules/indexes/functions are follow-ups).\n`,
+      `pyric deploy ${target}: --json is not wired for '${target}' yet (hosting only; rules/indexes/database/functions are follow-ups).\n`,
     );
     return 1;
   }
@@ -211,6 +214,7 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
       flags: parsed.flags,
       projectId: scope.projectId,
       cwd,
+      env: deps.env ?? process.env,
       readFile: (p) => readFileFn(p, 'utf-8') as Promise<string>,
       getGitBranch: () => (deps.getGitBranch ?? getGitBranch)(cwd),
     },
@@ -252,6 +256,8 @@ function resolveDeployTools(provider: DeployProvider, scope: ProjectScope, deps:
         ? deps.createHostingDeployTools
         : provider.target === 'rules' || provider.target === 'indexes'
           ? deps.createFirestoreDeployTools
+          : provider.target === 'database'
+            ? deps.createRtdbDeployTools
           : undefined;
   return override ? override({ scope }) : provider.tools(scope);
 }
@@ -348,7 +354,7 @@ function printToolSchema(
 ): number {
   if (!agentIo) {
     err.write(
-      `pyric deploy ${target}: --schema is not wired for '${target}' yet (hosting only; rules/indexes/functions are follow-ups).\n`,
+      `pyric deploy ${target}: --schema is not wired for '${target}' yet (hosting only; rules/indexes/database/functions are follow-ups).\n`,
     );
     return 1;
   }

--- a/packages/pyric-tools/src/cli/firebase-json.ts
+++ b/packages/pyric-tools/src/cli/firebase-json.ts
@@ -19,6 +19,11 @@ export interface FirebaseJson {
     indexes?: string;
     database?: string;
   };
+  /** Realtime Database rules path plus optional explicit instance URL. */
+  database?: {
+    rules?: string;
+    url?: string;
+  };
   hosting?: unknown;
   functions?: unknown;
   /** Storage rules + (optional) target bucket. A single object, or an array for

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -9,11 +9,14 @@
  *   pyric vendor [dir] [--json]
  *   pyric snapshot [--out FILE] [--port N] [--force] [--json] [--include-passwords]
  *   pyric mcp
- *   pyric deploy <rules|indexes|hosting|functions>
+ *   pyric deploy <rules|indexes|database|hosting|functions>
  *   pyric hosting:channel:deploy <channelId> [--expires <ttl>]
  *   pyric rules:lint <path>
  *   pyric rules:validate <path>
  *   pyric rules:simulate [--stdin]
+ *   pyric database:rules:lint <path>
+ *   pyric database:rules:validate <path>
+ *   pyric database:rules:simulate [--stdin]
  *   pyric auth:configure-provider <provider> <true|false>
  *   pyric auth:manage-domains <add|remove|list> [domain]
  *   pyric firestore:discover [collection]
@@ -30,6 +33,7 @@
  *   PYRIC_VERBOSE                    — set to 1 for per-tool-call logging
  *   FIREBASE_SA_BASE64               — base64-encoded service-account JSON (deploy / auth / discover)
  *   GOOGLE_APPLICATION_CREDENTIALS   — path to service-account JSON (deploy / auth / discover)
+ *   FIREBASE_DATABASE_URL            — Realtime Database URL for deploy database
  *   PYRIC_OAUTH_CLIENT_ID            — Google "Desktop app" OAuth client id (pyric login)
  *   PYRIC_OAUTH_CLIENT_SECRET        — its client secret (pyric login; required by Google)
  *   PYRIC_REFRESH_TOKEN              — CI refresh token from `pyric login --ci`
@@ -45,6 +49,11 @@ import { parseArgs, type ParsedArgs } from './parse-args.js';
 import { runDeploy, runHostingChannelDeploy } from './deploy.js';
 import { runLoginCommand, runLogoutCommand, runWhoamiCommand } from './login.js';
 import { runRulesLint, runRulesValidate, runRulesSimulate } from './rules.js';
+import {
+  runDatabaseRulesLint,
+  runDatabaseRulesValidate,
+  runDatabaseRulesSimulate,
+} from './database-rules.js';
 import { runAuthConfigureProvider, runAuthManageDomains } from './auth.js';
 import { runFirestoreDiscover } from './discover.js';
 import { runInit, runVendor } from './init.js';
@@ -69,11 +78,14 @@ USAGE
   pyric init [dir] [--template=web|node]
   pyric snapshot [--out=FILE]
   pyric verify [fixture|dir] [--rules=firestore.rules]
-  pyric deploy <rules|indexes|hosting|functions>
+  pyric deploy <rules|indexes|database|hosting|functions>
   pyric hosting:channel:deploy <channelId> [--expires <ttl>]
   pyric rules:lint <path>
   pyric rules:validate <path>
   pyric rules:simulate [--stdin]
+  pyric database:rules:lint <path>
+  pyric database:rules:validate <path>
+  pyric database:rules:simulate [--stdin]
   pyric auth:configure-provider <anonymous|email|phone|google> <true|false>
   pyric auth:manage-domains <add|remove|list> [domain]
   pyric firestore:discover [collection]
@@ -110,7 +122,7 @@ COMMANDS
                              replays the latest \`pyric serve\` capture (.pyric/last-session.json).
                              --rules=PATH (default firestore.rules), --json. Exit 1 on
                              any real divergence.
-  deploy [target]            Deploy rules / indexes / hosting / functions.
+  deploy [target]            Deploy rules / indexes / database / hosting / functions.
                              hosting: deploys the firebase.json hosting block
                              (rewrites/redirects/headers/cleanUrls/trailingSlash/
                              appAssociation/i18n + ignore globs). --only
@@ -126,11 +138,18 @@ COMMANDS
                              firebase.json); bare --json = machine output for
                              a normal deploy (results to stdout, errors to
                              stderr, as JSON).
+                             database: deploys firebase.json database.rules.
+                             URL precedence: --database-url,
+                             FIREBASE_DATABASE_URL, firebase.json
+                             database.url, then default instance discovery.
   hosting:channel:deploy     Mirror of \`deploy hosting --channel <channelId>\`
                              (firebase-tools spelling) — identical behavior.
   rules:lint                 Run firestore-rules linter against a file.
   rules:validate             Validate firestore-rules structure against a file.
   rules:simulate             Local rules simulator (smoke-test or --stdin scripted).
+  database:rules:lint        Run Realtime Database rules JSON expression linter.
+  database:rules:validate    Validate Realtime Database rules JSON expressions.
+  database:rules:simulate    Local RTDB rules simulator (smoke-test or --stdin scripted).
   auth:configure-provider    Identity Toolkit: enable/disable an auth provider.
   auth:manage-domains        Identity Toolkit: add/remove/list authorized domains.
   firestore:discover         Crawl a Firestore to infer schema.
@@ -211,6 +230,7 @@ CREDENTIALS
     4. ~/.pyric/credentials.json     the \`pyric login\` user (granted scopes only)
     5. ADC                           \`gcloud auth application-default login\` (ambient)
   PYRIC_PROJECT / --project          project id for user/ADC creds (else .firebaserc default)
+  FIREBASE_DATABASE_URL              Realtime Database URL for \`pyric deploy database\`
 `);
 }
 
@@ -439,6 +459,12 @@ export async function dispatch(parsed: ParsedArgs): Promise<number> {
       return await runRulesValidate(parsed);
     case 'rules:simulate':
       return await runRulesSimulate(parsed);
+    case 'database:rules:lint':
+      return await runDatabaseRulesLint(parsed);
+    case 'database:rules:validate':
+      return await runDatabaseRulesValidate(parsed);
+    case 'database:rules:simulate':
+      return await runDatabaseRulesSimulate(parsed);
     case 'auth:configure-provider':
       return await runAuthConfigureProvider(parsed);
     case 'auth:manage-domains':

--- a/packages/pyric-tools/src/credentials/core/scopes.ts
+++ b/packages/pyric-tools/src/credentials/core/scopes.ts
@@ -11,6 +11,7 @@ export const SCOPES = {
   openid: 'openid',
   email: 'email',
   firebase: 'https://www.googleapis.com/auth/firebase',
+  firebaseDatabase: 'https://www.googleapis.com/auth/firebase.database',
   datastore: 'https://www.googleapis.com/auth/datastore',
   cloudPlatform: 'https://www.googleapis.com/auth/cloud-platform',
 } as const;

--- a/packages/pyric-tools/src/deploy/index.ts
+++ b/packages/pyric-tools/src/deploy/index.ts
@@ -43,7 +43,7 @@ export { withResolvedScope } from './with-resolved-scope.js';
 // per F4. The previous `pyric-tools/deploy/{hosting,functions}` sub-path
 // exports are removed.
 
-export { hosting, functions, firestore, recipes } from './namespaces.js';
+export { hosting, functions, firestore, rtdb, recipes } from './namespaces.js';
 export type { DeployHostingScopedOptions, DeployFunctionsLocalOptions } from './namespaces.js';
 
 // ─── Firestore namespace types (Slice 4) ──────────────────────────────
@@ -73,6 +73,11 @@ export type {
   DeployIndexesOutcome,
   GetIndexStatusOutcome,
 } from './firestore/indexes.js';
+export type {
+  RtdbDeployRulesInput,
+  RtdbFetchRulesInput,
+  RtdbRulesDiscoveryResult,
+} from './rtdb/rules.js';
 
 // ─── Portable primitive types — still useful for direct consumers ────
 //
@@ -130,6 +135,7 @@ export {
 // ─── Tool factories (Slice 9) ────────────────────────────────────────
 export {
   createFirestoreDeployTools,
+  createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
   type ProjectScopedDeps,

--- a/packages/pyric-tools/src/deploy/namespaces.ts
+++ b/packages/pyric-tools/src/deploy/namespaces.ts
@@ -31,6 +31,7 @@ import * as rulesImpl from './firestore/rules.js';
 import * as indexesImpl from './firestore/indexes.js';
 import * as databasesImpl from './firestore/databases.js';
 import * as recipesImpl from './firestore/recipes.js';
+import * as rtdbRulesImpl from './rtdb/rules.js';
 import { grantPublicInvoker } from './functions/iam.js';
 import type { HostingJsonConfig } from './hosting/spec.js';
 import type { ProjectScope } from './scope.js';
@@ -239,6 +240,17 @@ export const firestore = {
   },
   databases: {
     provision: databasesImpl.provision,
+  },
+};
+
+// ─── realtime database namespace ────────────────────────────────────
+
+export const rtdb = {
+  rules: {
+    fetch: rtdbRulesImpl.fetchRules,
+    deploy: rtdbRulesImpl.deployRules,
+    discoverDefaultDatabaseUrl: rtdbRulesImpl.discoverDefaultDatabaseUrl,
+    resolveDatabaseUrl: rtdbRulesImpl.resolveDatabaseUrl,
   },
 };
 

--- a/packages/pyric-tools/src/deploy/provider.ts
+++ b/packages/pyric-tools/src/deploy/provider.ts
@@ -76,6 +76,7 @@ export interface ConfigSource {
   flags: ReadonlyMap<string, string | boolean>;
   projectId: string;
   cwd: string;
+  env?: Record<string, string | undefined>;
   readFile(path: string): Promise<string>;
   getGitBranch(): Promise<string | null>;
 }

--- a/packages/pyric-tools/src/deploy/providers/database.ts
+++ b/packages/pyric-tools/src/deploy/providers/database.ts
@@ -1,0 +1,45 @@
+import { resolve as resolvePath } from 'node:path';
+import { createRtdbDeployTools } from '../tools.js';
+import type { DeployProvider, ResolveResult } from '../provider.js';
+import { SCOPES } from '../../credentials/core/scopes.js';
+
+interface DatabaseRulesArgs {
+  rulesJson: unknown;
+  databaseUrl?: string;
+}
+
+function stringFlag(flags: ReadonlyMap<string, string | boolean>, name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export const databaseRulesProvider: DeployProvider<DatabaseRulesArgs> = {
+  target: 'database',
+  summary: 'Deploy Realtime Database security rules',
+  operations: [{ name: 'deploy', default: true, toolName: 'rtdb_deploy_rules' }],
+  requiredScope: SCOPES.firebaseDatabase,
+  requiredApis: ['firebasedatabase.googleapis.com'],
+  tools: (scope) => createRtdbDeployTools({ scope }),
+  async resolveConfig(_op, src): Promise<ResolveResult<DatabaseRulesArgs>> {
+    const rulesPath = src.firebaseJson.database?.rules;
+    if (!rulesPath) return { ok: false, message: 'firebase.json has no `database.rules` path.' };
+
+    const raw = await src.readFile(resolvePath(src.cwd, rulesPath));
+    let rulesJson: unknown;
+    try {
+      rulesJson = JSON.parse(raw);
+    } catch (e) {
+      return { ok: false, message: `failed to parse ${rulesPath}: ${e instanceof Error ? e.message : String(e)}` };
+    }
+
+    const databaseUrl =
+      stringFlag(src.flags, 'database-url') ??
+      stringFlag(src.flags, 'databaseUrl') ??
+      src.env?.FIREBASE_DATABASE_URL ??
+      src.firebaseJson.database?.url;
+    return {
+      ok: true,
+      units: [{ rulesJson, ...(databaseUrl ? { databaseUrl } : {}) }],
+    };
+  },
+};

--- a/packages/pyric-tools/src/deploy/registry.ts
+++ b/packages/pyric-tools/src/deploy/registry.ts
@@ -16,10 +16,12 @@ import { functionsProvider } from './providers/functions.js';
 import { hostingProvider } from './providers/hosting.js';
 import { storageProvider } from './providers/storage.js';
 import { firestoreRulesProvider, firestoreIndexesProvider } from './providers/firestore.js';
+import { databaseRulesProvider } from './providers/database.js';
 
 export const DEPLOY_PROVIDERS: readonly DeployProvider[] = [
   firestoreRulesProvider,
   firestoreIndexesProvider,
+  databaseRulesProvider,
   hostingProvider,
   functionsProvider,
   storageProvider,

--- a/packages/pyric-tools/src/deploy/rtdb/rules.ts
+++ b/packages/pyric-tools/src/deploy/rtdb/rules.ts
@@ -1,0 +1,135 @@
+import {
+  GenerateIRHandler,
+  RtdbMapper,
+  WriteRulesHandler,
+  type RtdbHost,
+  type RtdbIR,
+} from 'pyric/rules/rtdb';
+import { AdminApiError, type ProjectScope } from '../scope.js';
+
+const RTDB_ADMIN_API = 'https://firebasedatabase.googleapis.com/v1beta';
+
+export interface RtdbDeployRulesInput {
+  rulesJson: unknown;
+  databaseUrl?: string;
+}
+
+export interface RtdbFetchRulesInput {
+  databaseUrl?: string;
+}
+
+export interface RtdbRulesDiscoveryResult {
+  databaseUrl: string | null;
+  candidates: string[];
+}
+
+function hostFor(scope: ProjectScope, databaseUrl: string): RtdbHost {
+  return {
+    projectId: scope.projectId,
+    databaseUrl,
+    resolveAdminToken: () => scope.resolveToken(),
+    resolveUserToken: async () => {
+      throw new Error('RTDB deploy tools do not mint user tokens');
+    },
+    getClientForUser: async () => {
+      throw new Error('RTDB deploy tools do not create client SDK handles');
+    },
+  };
+}
+
+function normalizeDatabaseUrl(raw: string): string {
+  const url = new URL(raw);
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+function extractDatabaseUrl(instance: unknown): string | null {
+  if (!instance || typeof instance !== 'object') return null;
+  const obj = instance as Record<string, unknown>;
+  const direct = obj.databaseUrl;
+  if (typeof direct === 'string' && direct.length > 0) return normalizeDatabaseUrl(direct);
+
+  const name = obj.name;
+  if (typeof name !== 'string') return null;
+  const instanceId = name.split('/').filter(Boolean).at(-1);
+  return instanceId ? `https://${instanceId}.firebaseio.com` : null;
+}
+
+export async function discoverDefaultDatabaseUrl(scope: ProjectScope): Promise<RtdbRulesDiscoveryResult> {
+  const token = await scope.resolveToken();
+  const res = await fetch(
+    `${RTDB_ADMIN_API}/projects/${encodeURIComponent(scope.projectId)}/locations/-/instances`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new AdminApiError(
+      res.status,
+      body,
+      `RTDB instance discovery failed: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const body = await res.json().catch(() => ({})) as { instances?: unknown[] };
+  const instances = Array.isArray(body.instances) ? body.instances : [];
+  const candidates = [
+    ...new Set(instances.map(extractDatabaseUrl).filter((url): url is string => Boolean(url))),
+  ];
+  if (candidates.length === 0) return { databaseUrl: null, candidates };
+  if (candidates.length === 1) return { databaseUrl: candidates[0], candidates };
+
+  const defaultCandidates = [
+    ...new Set(
+      instances
+        .filter((instance) => (
+          typeof instance === 'object' &&
+          instance !== null &&
+          (instance as Record<string, unknown>).type === 'DEFAULT_DATABASE'
+        ))
+        .map(extractDatabaseUrl)
+        .filter((url): url is string => Boolean(url)),
+    ),
+  ];
+  return {
+    databaseUrl: defaultCandidates.length === 1 ? defaultCandidates[0] : null,
+    candidates,
+  };
+}
+
+export async function resolveDatabaseUrl(
+  scope: ProjectScope,
+  explicitDatabaseUrl?: string,
+): Promise<string> {
+  if (explicitDatabaseUrl) return normalizeDatabaseUrl(explicitDatabaseUrl);
+
+  const discovered = await discoverDefaultDatabaseUrl(scope);
+  if (discovered.databaseUrl) return discovered.databaseUrl;
+
+  const suffix = discovered.candidates.length > 0
+    ? ` Found multiple RTDB instances: ${discovered.candidates.join(', ')}.`
+    : '';
+  throw new Error(
+    `Could not resolve a Realtime Database URL for project '${scope.projectId}'. ` +
+      `Pass --database-url, set FIREBASE_DATABASE_URL, or add "database.url" to firebase.json.${suffix}`,
+  );
+}
+
+export async function fetchRules(scope: ProjectScope, input: RtdbFetchRulesInput = {}): Promise<RtdbIR> {
+  const databaseUrl = await resolveDatabaseUrl(scope, input.databaseUrl);
+  const result = await new GenerateIRHandler().execute(hostFor(scope, databaseUrl));
+  if (!result.success) {
+    throw new Error(`${result.error.code}: ${result.error.message}`);
+  }
+  return result.data;
+}
+
+export async function deployRules(scope: ProjectScope, input: RtdbDeployRulesInput): Promise<void> {
+  const databaseUrl = await resolveDatabaseUrl(scope, input.databaseUrl);
+  const ir = RtdbMapper.mapToIR(input.rulesJson, null, databaseUrl);
+  const result = await new WriteRulesHandler().execute(hostFor(scope, databaseUrl), ir);
+  if (!result.success) {
+    throw new Error(`${result.error.code}: ${result.error.message}`);
+  }
+}

--- a/packages/pyric-tools/src/deploy/tools.ts
+++ b/packages/pyric-tools/src/deploy/tools.ts
@@ -20,8 +20,9 @@
  */
 
 import type { ToolHandler } from '@inbrowser/agent';
-import { firestore, hosting, functions } from './namespaces.js';
+import { firestore, hosting, functions, rtdb } from './namespaces.js';
 import type { ProjectScope } from './scope.js';
+import type { RtdbIR } from 'pyric/rules/rtdb';
 import type {
   IndexesConfig,
   IndexesConfigEntry,
@@ -64,10 +65,60 @@ export interface DeployToolData {
   hosting_deploy: DeployHostingResult;
   hosting_ensure_site: EnsureSiteResult;
   functions_deploy: DeployFunctionsResult;
+  rtdb_get_rules: { ir: RtdbIR };
+  rtdb_deploy_rules: undefined;
 }
 
 export interface ProjectScopedDeps {
   scope: ProjectScope;
+}
+
+// ─── Realtime Database deploy tools ─────────────────────────────────
+
+export function createRtdbDeployTools(deps: ProjectScopedDeps): ToolHandler[] {
+  const { scope } = deps;
+  return [
+    {
+      name: 'rtdb_get_rules',
+      description: 'Fetch the deployed Realtime Database rules for this project or an explicit database URL.',
+      parameters: {
+        type: 'object',
+        properties: {
+          databaseUrl: { type: 'string' },
+        },
+      },
+      async execute(args) {
+        const { databaseUrl } = args as { databaseUrl?: string };
+        try {
+          const ir = await rtdb.rules.fetch(scope, { databaseUrl });
+          return { ok: true, summary: `Fetched RTDB rules from ${ir.databaseUrl}`, data: { ir } };
+        } catch (e) {
+          return { ok: false, summary: e instanceof Error ? e.message : String(e) };
+        }
+      },
+    },
+    {
+      name: 'rtdb_deploy_rules',
+      description: 'Deploy Realtime Database security rules JSON. Pass databaseUrl or let the tool discover the single default RTDB instance.',
+      parameters: {
+        type: 'object',
+        properties: {
+          rulesJson: { type: 'object' },
+          databaseUrl: { type: 'string' },
+        },
+        required: ['rulesJson'],
+      },
+      async execute(args) {
+        const { rulesJson, databaseUrl } = args as { rulesJson: unknown; databaseUrl?: string };
+        try {
+          await rtdb.rules.deploy(scope, { rulesJson, databaseUrl });
+          return { ok: true, summary: 'Deployed Realtime Database rules' };
+        } catch (e) {
+          return { ok: false, summary: e instanceof Error ? e.message : String(e) };
+        }
+      },
+    },
+  ];
 }
 
 // ─── Firestore deploy tools ──────────────────────────────────────────

--- a/packages/pyric-tools/src/registry/compose.ts
+++ b/packages/pyric-tools/src/registry/compose.ts
@@ -16,6 +16,7 @@ import { createToolRegistry, type ToolHandler, type ToolRegistry } from '@inbrow
 import { fromServiceAccount, type ProjectScope } from '../deploy/index.js';
 import {
   createFirestoreDeployTools,
+  createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
 } from '../deploy/index.js';
@@ -28,7 +29,8 @@ import {
 } from 'pyric/firestore';
 import { createFirestoreDiscoverTools } from '../discover/index.js';
 import { createAuthAdminTools } from '../auth/index.js';
-import { createRtdbAdminTools, type RtdbHost } from 'pyric/database';
+import { createRtdbDataTools } from 'pyric/database';
+import { createRtdbRulesTools, type RtdbHost } from 'pyric/rules/rtdb';
 
 /**
  * Admin SDK deps for the Firestore admin-mode + user-mode dispatch factories.
@@ -127,6 +129,7 @@ export async function composeMcpRegistry(
   const factories: ToolHandler[][] = [
     // Control plane — every profile.
     createFirestoreDeployTools({ scope }),
+    ...(opts.rtdbHost && profile !== 'browser-parity' ? [] : [createRtdbDeployTools({ scope })]),
     createHostingDeployTools({ scope }),
     createFunctionsDeployTools({ scope }),
     // Rules tooling — full + browser-parity.
@@ -151,7 +154,10 @@ export async function composeMcpRegistry(
         ]
       : []),
     ...(opts.rtdbHost && profile !== 'browser-parity'
-      ? [createRtdbAdminTools({ host: opts.rtdbHost })]
+      ? [
+          createRtdbRulesTools({ host: opts.rtdbHost }),
+          createRtdbDataTools({ host: opts.rtdbHost }),
+        ]
       : []),
   ];
   for (const handlers of factories) {

--- a/packages/pyric-tools/test/cli/deploy.test.ts
+++ b/packages/pyric-tools/test/cli/deploy.test.ts
@@ -69,6 +69,14 @@ describe('runDeploy dispatch', () => {
     expect(err.join('')).toContain('storage');
   });
 
+  it('database is an accepted target, usage error without a database block', async () => {
+    const { deps, err } = harness();
+    const code = await runDeploy(parsed(['database']), deps);
+    expect(code).toBe(1);
+    expect(err.join('')).not.toContain('unknown target');
+    expect(err.join('')).toContain('database.rules');
+  });
+
   it('login user lacking cloud-platform -> scope-upgrade preflight fails fast', async () => {
     const { deps, err } = harness({
       resolveScope: async () => ({
@@ -93,5 +101,18 @@ describe('runDeploy dispatch', () => {
     expect(await runDeploy(parsed(['hosting']), deps)).toBe(1);
     expect(err.join('')).not.toContain('cloud-platform'); // preflight passed (firebase covers hosting)
     expect(err.join('')).toContain('hosting'); // reached resolveConfig
+  });
+
+  it('login user lacking firebase.database -> scope-upgrade preflight fails fast', async () => {
+    const { deps, err } = harness({
+      resolveScope: async () => ({
+        scope: { projectId: 'demo', resolveToken: async () => 'tkn' },
+        source: 'login',
+        grantedScopes: ['https://www.googleapis.com/auth/firebase'],
+      }),
+    });
+    expect(await runDeploy(parsed(['database']), deps)).toBe(1);
+    expect(err.join('')).toContain('firebase.database');
+    expect(err.join('')).toContain('pyric login');
   });
 });

--- a/packages/pyric-tools/test/deploy/providers.test.ts
+++ b/packages/pyric-tools/test/deploy/providers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { hostingProvider } from '../../src/deploy/providers/hosting.js';
 import { storageProvider } from '../../src/deploy/providers/storage.js';
 import { firestoreRulesProvider, firestoreIndexesProvider } from '../../src/deploy/providers/firestore.js';
+import { databaseRulesProvider } from '../../src/deploy/providers/database.js';
 import type { ConfigSource } from '../../src/deploy/provider.js';
 import type { FirebaseJson, FirebaseRc } from '../../src/cli/firebase-json.js';
 
@@ -12,6 +13,7 @@ function src(opts: {
   files?: Record<string, string>;
   projectId?: string;
   gitBranch?: string | null;
+  env?: Record<string, string | undefined>;
 }): ConfigSource {
   return {
     firebaseJson: opts.firebaseJson ?? {},
@@ -19,6 +21,7 @@ function src(opts: {
     flags: new Map(Object.entries(opts.flags ?? {})),
     projectId: opts.projectId ?? 'demo',
     cwd: '/proj',
+    env: opts.env,
     readFile: async (path) => {
       const f = (opts.files ?? {})[path];
       if (f === undefined) throw new Error(`ENOENT ${path}`);
@@ -144,5 +147,40 @@ describe('firestore providers resolveConfig', () => {
       src({ firebaseJson: { firestore: { indexes: 'idx.json' } }, files: { '/proj/idx.json': '{bad' } }),
     );
     expect(bad.ok).toBe(false);
+  });
+});
+
+describe('databaseRulesProvider.resolveConfig', () => {
+  it('usage error with no database.rules path', async () => {
+    expect((await databaseRulesProvider.resolveConfig('deploy', src({}))).ok).toBe(false);
+  });
+
+  it('reads RTDB rules JSON and honors --database-url', async () => {
+    const r = await databaseRulesProvider.resolveConfig(
+      'deploy',
+      src({
+        firebaseJson: { database: { rules: 'database.rules.json' } },
+        flags: { 'database-url': 'https://demo-default-rtdb.firebaseio.com' },
+        files: { '/proj/database.rules.json': '{"rules":{".read":false}}' },
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.units[0].databaseUrl).toBe('https://demo-default-rtdb.firebaseio.com');
+      expect(r.units[0].rulesJson).toEqual({ rules: { '.read': false } });
+    }
+  });
+
+  it('uses FIREBASE_DATABASE_URL when no flag is present', async () => {
+    const r = await databaseRulesProvider.resolveConfig(
+      'deploy',
+      src({
+        firebaseJson: { database: { rules: 'database.rules.json' } },
+        env: { FIREBASE_DATABASE_URL: 'https://env-db.firebaseio.com' },
+        files: { '/proj/database.rules.json': '{"rules":{".read":true}}' },
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.units[0].databaseUrl).toBe('https://env-db.firebaseio.com');
   });
 });

--- a/packages/pyric-tools/test/deploy/tools.test.ts
+++ b/packages/pyric-tools/test/deploy/tools.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { createToolRegistry, createDispatch } from '@inbrowser/agent';
 import {
   createFirestoreDeployTools,
+  createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
   type ProjectScope,
@@ -64,6 +65,31 @@ describe('createHostingDeployTools', () => {
   });
 });
 
+describe('createRtdbDeployTools', () => {
+  const tools = createRtdbDeployTools({ scope });
+
+  it('emits RTDB deploy tool set', () => {
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'rtdb_deploy_rules',
+      'rtdb_get_rules',
+    ]);
+  });
+
+  it('deploys explicit database rules without discovery', async () => {
+    installMock([new Response('{}', { status: 200 })]);
+    const tool = tools.find((t) => t.name === 'rtdb_deploy_rules');
+    expect(tool).toBeDefined();
+    const result = await tool!.execute(
+      {
+        databaseUrl: 'https://p-default-rtdb.firebaseio.com',
+        rulesJson: { rules: { '.read': false, '.write': false } },
+      },
+      ctx,
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe('createFunctionsDeployTools', () => {
   const tools = createFunctionsDeployTools({ scope });
 
@@ -76,10 +102,11 @@ describe('cross-factory composition', () => {
   it('full Deployment Agent registry assembles cleanly (smoke)', () => {
     const registry = createToolRegistry();
     for (const t of createFirestoreDeployTools({ scope })) registry.register(t);
+    for (const t of createRtdbDeployTools({ scope })) registry.register(t);
     for (const t of createHostingDeployTools({ scope })) registry.register(t);
     for (const t of createFunctionsDeployTools({ scope })) registry.register(t);
     const names = registry.list().map((h) => h.name);
-    expect(names.length).toBe(10);
+    expect(names.length).toBe(12);
     // No duplicate names — register would have thrown.
     expect(new Set(names).size).toBe(names.length);
   });

--- a/packages/pyric/README.md
+++ b/packages/pyric/README.md
@@ -14,6 +14,7 @@ backend, plus Pyric's rules tooling and sandbox runtime.
 | `pyric/storage` | Storage modular SDK mirror plus storage admin tools |
 | `pyric/rules` | Firestore rules parser, linter, validator, simulator, stdlib tooling |
 | `pyric/rules/node` | Node-only rules module resolution helpers |
+| `pyric/rules/rtdb` | Realtime Database rules facade: mapper, parser/linter, simulator, deploy/read rule tool factory |
 | `pyric/rules/rtdb-constraints` | Realtime Database rules constraint helpers |
 | `pyric/sandbox` | In-process Firebase sandbox runtime |
 | `pyric/sandbox/internal` | Adapter-only internal protocol surface |

--- a/packages/pyric/docs/database/README.md
+++ b/packages/pyric/docs/database/README.md
@@ -1,0 +1,17 @@
+# Realtime Database
+
+Pyric's Realtime Database surface has two parts:
+
+- `pyric/database` mirrors the Firebase Database modular SDK and exposes
+  host-backed data tools.
+- `pyric/rules/rtdb` exposes the rules tooling facade: rule JSON mapping,
+  expression parsing and linting, local simulation, and rules-focused agent
+  tools.
+
+## Where to go next
+
+| If you want to | Read |
+|---|---|
+| Look up the RTDB rules tooling API | [RTDB rules tooling reference](./reference/rules-tooling.md) |
+| Check Firebase Database compatibility status | [Compatibility matrix](./COMPAT.md) |
+

--- a/packages/pyric/docs/database/reference/rules-tooling.md
+++ b/packages/pyric/docs/database/reference/rules-tooling.md
@@ -1,0 +1,176 @@
+# RTDB rules tooling
+
+The `pyric/rules/rtdb` subpath is the canonical Realtime Database rules tooling
+entrypoint.
+
+```ts
+import {
+  RtdbMapper,
+  createRtdbRulesTools,
+  SimulateHandler,
+} from 'pyric/rules/rtdb';
+```
+
+It re-exports the RTDB rule mapper, expression parser, validator, linter,
+simulation handler, write handler, rule constraints, and the rules-focused tool
+factory.
+
+## Rule JSON and IR
+
+### `RtdbMapper.mapToIR(rulesJson, shallowData, databaseUrl): RtdbIR`
+
+Convert Firebase RTDB rules JSON into Pyric's rule IR.
+
+```ts
+const ir = RtdbMapper.mapToIR(
+  {
+    rules: {
+      profiles: {
+        '$uid': {
+          '.read': 'auth.uid === $uid',
+        },
+      },
+    },
+  },
+  null,
+  'https://demo-default-rtdb.firebaseio.com',
+);
+```
+
+### `RtdbMapper.mapToRulesJSON(ir): { rules: Record<string, unknown> }`
+
+Convert Pyric's RTDB rule IR back to Firebase RTDB rules JSON.
+
+### `RtdbIR`
+
+```ts
+type RtdbIR = {
+  service: 'realtime-database';
+  databaseUrl: string;
+  rules: RtdbNode;
+};
+```
+
+## Expressions
+
+### `parseExpression(raw): ParsedExpression`
+
+Parse one RTDB rule expression.
+
+### `buildRuleExpression(raw, context, pathVariables?): RtdbRuleExpression`
+
+Parse, validate, and lint one expression for a rule context.
+
+```ts
+const expr = buildRuleExpression('auth.uid === $uid', 'read', ['$uid']);
+```
+
+`context` is one of `'read'`, `'write'`, or `'validate'`.
+
+### `validateExpression(raw, context, pathVariables?): RuleError[]`
+
+Return validation errors for one expression.
+
+### `lintExpression(raw, context): RuleLint[]`
+
+Return linter warnings for one expression.
+
+## Local simulation
+
+### `class SimulateHandler`
+
+Evaluate an RTDB rule IR against one simulation input.
+
+```ts
+const result = new SimulateHandler().execute(ir, {
+  operation: 'read',
+  path: '/profiles/alice',
+  auth: { uid: 'alice', token: {} },
+  mockData: {},
+});
+```
+
+`SimulationInput`:
+
+```ts
+type SimulationInput = {
+  operation: 'read' | 'write' | 'validate';
+  path: string;
+  auth: { uid: string; token: Record<string, unknown> } | null;
+  mockData: Record<string, unknown>;
+  newData?: unknown;
+};
+```
+
+## Rules write handler
+
+### `class WriteRulesHandler`
+
+Write a complete `RtdbIR` to the RTDB rules endpoint through an `RtdbHost`.
+
+```ts
+const result = await new WriteRulesHandler().execute(host, ir);
+```
+
+The handler returns `WriteRulesResult` rather than throwing for Firebase rule
+write failures.
+
+## Host-backed tool factories
+
+### `createRtdbRulesTools({ host }): ToolHandler[]`
+
+Rules-focused RTDB tools.
+
+| Tool | Purpose |
+|---|---|
+| `rtdb_build_expression` | Parse, validate, and lint one RTDB rule expression. |
+| `rtdb_get_rules` | Fetch and map deployed RTDB rules into IR. |
+| `rtdb_simulate_access` | Evaluate rules locally against mock data. |
+| `rtdb_deploy_rules` | Deploy a complete RTDB rule IR. |
+
+### `createRtdbDataTools({ host }): ToolHandler[]`
+
+Data-focused RTDB tools.
+
+| Tool | Purpose |
+|---|---|
+| `rtdb_crawl_structure` | Inspect RTDB path structure. |
+| `rtdb_get` | Read data at a path. |
+| `rtdb_set` | Replace data at a path. |
+| `rtdb_update` | Merge data or run a multi-location update. |
+| `rtdb_push` | Create a child with an auto-generated key. |
+| `rtdb_delete` | Delete data at a path. |
+| `rtdb_validated_write` | Check schema and simulate rules before writing. |
+
+### `createRtdbAdminTools({ host }): ToolHandler[]`
+
+Backwards-compatible union of `createRtdbRulesTools({ host })` and
+`createRtdbDataTools({ host })`.
+
+## `RtdbHost`
+
+```ts
+interface RtdbHost {
+  readonly projectId: string;
+  readonly databaseUrl: string;
+  resolveAdminToken(): Promise<string>;
+  resolveUserToken(auth: UserAuth): Promise<string>;
+  getClientForUser(auth: UserAuth): Promise<Database>;
+}
+```
+
+`resolveAdminToken` is used for rule fetch/deploy and admin REST paths.
+`resolveUserToken` and `getClientForUser` are used for rules-enforcing
+user-mode data operations.
+
+## Constraint helpers
+
+`pyric/rules/rtdb` also re-exports the RTDB rule constraint helpers from
+`pyric/rules/rtdb-constraints`, including:
+
+- boolean composition: `expr`, `all`, `any`, `not`, `deny`, `always`
+- auth and ownership predicates: `authenticated`, `ownPath`, `ownField`
+- schema predicates: `hasChildren`, `hasChild`, `fieldIsString`,
+  `fieldIsNumber`, `fieldIsBoolean`, `fieldEnum`
+- policy helpers: `pathOwnerOnly`, `fieldOwnerOnly`, `ownerOrNew`,
+  `hasRole`, `isMember`, `required`, `transition`

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/rules/extract.d.ts",
       "import": "./dist/rules/extract.js"
     },
+    "./rules/rtdb": {
+      "types": "./dist/rules/rtdb.d.ts",
+      "import": "./dist/rules/rtdb.js"
+    },
     "./rules/rtdb-constraints": {
       "types": "./dist/database/constraints/index.d.ts",
       "import": "./dist/database/constraints/index.js"

--- a/packages/pyric/src/database/index.ts
+++ b/packages/pyric/src/database/index.ts
@@ -13,8 +13,16 @@ export * from './types.js';
 export type { RtdbHost } from './host.js';
 export { fetchDatabase } from './host.js';
 export { getRtdbTools } from './resolver.js';
-export { createRtdbAdminTools } from './tools.js';
-export type { RtdbAdminToolDeps } from './tools.js';
+export {
+  createRtdbAdminTools,
+  createRtdbDataTools,
+  createRtdbRulesTools,
+} from './tools.js';
+export type {
+  RtdbAdminToolDeps,
+  RtdbDataToolDeps,
+  RtdbRulesToolDeps,
+} from './tools.js';
 export * from './mapper.js';
 export { GenerateIRInputSchema, RtdbIRErrorCode } from './ir/spec.js';
 export type { GenerateIRInput, GenerateIRSpec } from './ir/spec.js';

--- a/packages/pyric/src/database/tools.ts
+++ b/packages/pyric/src/database/tools.ts
@@ -19,6 +19,9 @@ export interface RtdbAdminToolDeps {
   host: RtdbHost;
 }
 
+export type RtdbRulesToolDeps = RtdbAdminToolDeps;
+export type RtdbDataToolDeps = RtdbAdminToolDeps;
+
 /** JSON Schema for the optional per-call `auth` argument shared by
  *  every data tool. When supplied, the operation goes through
  *  `host.getClientForUser(auth)` so rules are enforced; when omitted,
@@ -48,7 +51,7 @@ function assertSafeCrawlPath(path: string): void {
   }
 }
 
-export function createRtdbAdminTools(deps: RtdbAdminToolDeps): ToolHandler[] {
+export function createRtdbRulesTools(deps: RtdbRulesToolDeps): ToolHandler[] {
   const { host } = deps;
   const db = getRtdbTools(host);
 
@@ -74,29 +77,6 @@ export function createRtdbAdminTools(deps: RtdbAdminToolDeps): ToolHandler[] {
         };
         const data = buildRuleExpression(expression, context, pathVariables);
         return { ok: true, summary: `Built ${context} expression`, data };
-      },
-    },
-    {
-      name: 'rtdb_crawl_structure',
-      description:
-        'Discover the shape of the Realtime Database by recursively fetching paths without downloading values. Returns a tree of paths with child counts. Use this to understand what data exists before generating code or writing rules.',
-      parameters: {
-        type: 'object',
-        properties: {
-          path: { type: 'string', description: 'Starting path, defaults to root /' },
-          maxDepth: { type: 'number', description: 'How many levels deep to crawl, defaults to 10' },
-          maxChildren: { type: 'number', description: 'Max children to explore per node, defaults to 100' },
-        },
-      },
-      async execute(args) {
-        const params = (args ?? {}) as { path?: string; maxDepth?: number; maxChildren?: number };
-        if (params.path !== undefined) assertSafeCrawlPath(params.path);
-        const result = await db.crawlStructure(params);
-        return {
-          ok: result.success,
-          summary: result.success ? 'Crawled structure' : `Crawl failed: ${result.error.code}`,
-          data: result,
-        };
       },
     },
     {
@@ -154,6 +134,37 @@ export function createRtdbAdminTools(deps: RtdbAdminToolDeps): ToolHandler[] {
         return {
           ok: result.success,
           summary: result.success ? 'Rules deployed' : `Deploy failed: ${result.error.code}`,
+          data: result,
+        };
+      },
+    },
+  ];
+}
+
+export function createRtdbDataTools(deps: RtdbDataToolDeps): ToolHandler[] {
+  const { host } = deps;
+  const db = getRtdbTools(host);
+
+  return [
+    {
+      name: 'rtdb_crawl_structure',
+      description:
+        'Discover the shape of the Realtime Database by recursively fetching paths without downloading values. Returns a tree of paths with child counts. Use this to understand what data exists before generating code or writing rules.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Starting path, defaults to root /' },
+          maxDepth: { type: 'number', description: 'How many levels deep to crawl, defaults to 10' },
+          maxChildren: { type: 'number', description: 'Max children to explore per node, defaults to 100' },
+        },
+      },
+      async execute(args) {
+        const params = (args ?? {}) as { path?: string; maxDepth?: number; maxChildren?: number };
+        if (params.path !== undefined) assertSafeCrawlPath(params.path);
+        const result = await db.crawlStructure(params);
+        return {
+          ok: result.success,
+          summary: result.success ? 'Crawled structure' : `Crawl failed: ${result.error.code}`,
           data: result,
         };
       },
@@ -294,5 +305,12 @@ export function createRtdbAdminTools(deps: RtdbAdminToolDeps): ToolHandler[] {
         };
       },
     },
+  ];
+}
+
+export function createRtdbAdminTools(deps: RtdbAdminToolDeps): ToolHandler[] {
+  return [
+    ...createRtdbRulesTools(deps),
+    ...createRtdbDataTools(deps),
   ];
 }

--- a/packages/pyric/src/rules/rtdb.ts
+++ b/packages/pyric/src/rules/rtdb.ts
@@ -1,0 +1,118 @@
+/**
+ * RTDB rules tooling facade.
+ *
+ * Firestore rules live under `pyric/rules`; this subpath gives
+ * Realtime Database rules the same first-class packaging without
+ * moving the existing implementation out of `pyric/database`.
+ */
+export type { RtdbHost } from '../database/host.js';
+export { fetchDatabase } from '../database/host.js';
+export {
+  createRtdbRulesTools,
+  type RtdbRulesToolDeps,
+} from '../database/tools.js';
+export { getRtdbTools } from '../database/resolver.js';
+export {
+  buildRuleExpression,
+  RtdbMapper,
+} from '../database/mapper.js';
+
+export { parseExpression } from '../database/grammar/RtdbExprParser.js';
+export { validateExpression } from '../database/grammar/validator.js';
+export { lintExpression } from '../database/grammar/linter.js';
+
+export {
+  GenerateIRInputSchema,
+  RtdbIRErrorCode,
+} from '../database/ir/spec.js';
+export type {
+  GenerateIRInput,
+  GenerateIRResult,
+  GenerateIRSpec,
+} from '../database/ir/spec.js';
+export { GenerateIRHandler } from '../database/ir/handler.js';
+
+export {
+  SimulationInputSchema,
+  SimulateErrorCode,
+  SimulationResultSchema,
+} from '../database/simulation/spec.js';
+export type {
+  SimulationInput,
+  SimulationResult,
+  SimulateResult,
+} from '../database/simulation/spec.js';
+export { SimulateHandler } from '../database/simulation/handler.js';
+
+export { WriteRulesErrorCode } from '../database/write/spec.js';
+export type {
+  WriteRulesResult,
+  WriteRulesSpec,
+} from '../database/write/spec.js';
+export { WriteRulesHandler } from '../database/write/handler.js';
+
+export type {
+  ParsedExpression,
+  ParsedExpression as RtdbExpressionParseResult,
+  RtdbIR,
+  RtdbNode,
+  RtdbRuleExpression,
+  RtdbTools,
+  RuleError,
+  RuleLint,
+  UserAuth,
+} from '../database/types.js';
+
+export {
+  expr,
+  all,
+  any,
+  not,
+  deny,
+  always,
+  authenticated,
+  ownPath,
+  ownField,
+  isNew,
+  hasChildren,
+  hasChild,
+  fieldIsString,
+  fieldIsNumber,
+  fieldIsBoolean,
+  fieldEnum,
+  immutable,
+  immutableSelf,
+  rootExists,
+  rootEquals,
+  pathOwnerOnly,
+  fieldOwnerOnly,
+  ownerOrNew,
+  hasRole,
+  isMember,
+  required,
+  transition,
+  dataVal,
+  newDataVal,
+  dataExists,
+  newDataExists,
+  newDataIs,
+  dataParentVal,
+  newDataParentVal,
+  newDataParentExists,
+  eq,
+  neq,
+  gt,
+  lte,
+  AUTH_UID,
+  turnGuard,
+  flip,
+  winCheckHelper,
+  schemaRules,
+  ruleset,
+} from '../database/constraints/index.js';
+export type {
+  Expr,
+  PathDef,
+  RulesetContext,
+  Segment,
+} from '../database/constraints/index.js';

--- a/packages/pyric/test/database/tools.test.ts
+++ b/packages/pyric/test/database/tools.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { createRtdbAdminTools } from '../../src/database/tools.js';
+import {
+  createRtdbAdminTools,
+  createRtdbDataTools,
+  createRtdbRulesTools,
+} from '../../src/database/tools.js';
 import type { RtdbHost } from '../../src/database/host.js';
 
 const VALID_RULES = { rules: { '.read': 'auth !== null', '.write': 'false' } };
@@ -27,6 +31,25 @@ beforeEach(() => {
 afterEach(() => { global.fetch = realFetch; });
 
 describe('createRtdbAdminTools', () => {
+  test('rules and data factories split the legacy tool set', () => {
+    const host = makeHost();
+    expect(createRtdbRulesTools({ host }).map((t) => t.name).sort()).toEqual([
+      'rtdb_build_expression',
+      'rtdb_deploy_rules',
+      'rtdb_get_rules',
+      'rtdb_simulate_access',
+    ]);
+    expect(createRtdbDataTools({ host }).map((t) => t.name).sort()).toEqual([
+      'rtdb_crawl_structure',
+      'rtdb_delete',
+      'rtdb_get',
+      'rtdb_push',
+      'rtdb_set',
+      'rtdb_update',
+      'rtdb_validated_write',
+    ]);
+  });
+
   test('returns 11 tools', () => {
     const tools = createRtdbAdminTools({ host: makeHost() });
     expect(tools).toHaveLength(11);

--- a/packages/pyric/test/rules/rtdb-export.test.ts
+++ b/packages/pyric/test/rules/rtdb-export.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildRuleExpression,
+  createRtdbRulesTools,
+  parseExpression,
+  RtdbMapper,
+} from '../../src/rules/rtdb.js';
+import type { RtdbHost } from '../../src/rules/rtdb.js';
+
+function host(): RtdbHost {
+  return {
+    projectId: 'demo',
+    databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+    resolveAdminToken: async () => 'token',
+    resolveUserToken: async () => 'user-token',
+    getClientForUser: async () => {
+      throw new Error('not implemented');
+    },
+  };
+}
+
+describe('pyric/rules/rtdb facade', () => {
+  test('exports the RTDB rules helpers and factory', () => {
+    expect(parseExpression('auth !== null').valid).toBe(true);
+    expect(buildRuleExpression('auth.uid === $uid', 'read', ['$uid']).parsed.valid).toBe(true);
+    expect(createRtdbRulesTools({ host: host() }).map((t) => t.name).sort()).toEqual([
+      'rtdb_build_expression',
+      'rtdb_deploy_rules',
+      'rtdb_get_rules',
+      'rtdb_simulate_access',
+    ]);
+  });
+
+  test('maps Firebase RTDB rules JSON to IR through the facade', () => {
+    const ir = RtdbMapper.mapToIR({ rules: { users: { '$uid': { '.read': 'auth.uid === $uid' } } } }, null, host().databaseUrl);
+    expect(ir.service).toBe('realtime-database');
+    expect(ir.databaseUrl).toBe(host().databaseUrl);
+  });
+});

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -45,6 +45,7 @@ declare -a PYRIC_SUBPATHS=(
   "pyric/rules"
   "pyric/rules/node"
   "pyric/rules/extract"
+  "pyric/rules/rtdb"
   "pyric/rules/rtdb-constraints"
   "pyric/sandbox"
   "pyric/sandbox/admin-compat"


### PR DESCRIPTION
## A rules workflow that looks like the rest of Pyric

```ts
import { RtdbMapper, createRtdbRulesTools } from "pyric/rules/rtdb";
import { createRtdbDeployTools, rtdb } from "pyric-tools/deploy";

const rulesJson = {
  rules: {
    profiles: {
      "$uid": {
        ".read": "auth.uid === $uid",
        ".write": "auth.uid === $uid",
      },
    },
  },
};

const databaseUrl = "https://demo-default-rtdb.firebaseio.com";
const ir = RtdbMapper.mapToIR(rulesJson, null, databaseUrl);

const ruleTools = createRtdbRulesTools({ host });
const deployTools = createRtdbDeployTools({ scope });

await deployTools
  .find((tool) => tool.name === "rtdb_deploy_rules")!
  .execute({ rulesJson, databaseUrl: ir.databaseUrl }, { signal });
```

The same rules JSON now has a first-class path through package imports, deploy tools, MCP composition, and CLI commands. Local checks use `pyric database:rules:lint`, `pyric database:rules:validate`, and `pyric database:rules:simulate`; project deploys use `pyric deploy database`.

## API surface introduced

- Adds `pyric/rules/rtdb` as the canonical RTDB rules subpath, re-exporting the mapper, expression parser/linter/validator, simulator, write/read rules handlers, constraint helpers, and `createRtdbRulesTools`.
- Splits RTDB agent factories into `createRtdbRulesTools({ host })` and `createRtdbDataTools({ host })`, while preserving `createRtdbAdminTools({ host })` as the backwards-compatible union.
- Adds `pyric-tools/deploy` support for RTDB rules through the `rtdb.rules` namespace and `createRtdbDeployTools({ scope })`.
- Adds `pyric deploy database`, reading `firebase.json.database.rules` and resolving the RTDB URL from `--database-url`, `FIREBASE_DATABASE_URL`, `firebase.json.database.url`, or single-default-instance discovery.
- Adds local RTDB rules CLI commands: `database:rules:lint`, `database:rules:validate`, and `database:rules:simulate`.
- Adds `SCOPES.firebaseDatabase` without including it in base login scopes, so RTDB deploys request the extra OAuth scope only when needed.

## Registry and packaging

- Wires MCP registry composition to use host-backed `createRtdbRulesTools` plus `createRtdbDataTools` when an RTDB host is present, and scope-backed deploy tools otherwise.
- Adds `pyric/rules/rtdb` to package exports and packaging subpath checks.
- Updates API docs, CLI docs, package READMEs, and agent-tool inventory for the new RTDB surfaces.

## Verification

- `bun run build`
- `bun test packages/pyric/test/database/tools.test.ts packages/pyric/test/rules/rtdb-export.test.ts packages/pyric-tools/test/deploy/tools.test.ts packages/pyric-tools/test/deploy/providers.test.ts packages/pyric-tools/test/cli/deploy.test.ts packages/pyric-tools/src/cli/cli.test.ts packages/pyric-tools/test/registry/compose.test.ts packages/pyric-tools/test/deploy/registry.test.ts`
- `NPM_CONFIG_CACHE=/private/tmp/pyric-npm-cache bash scripts/manifest-lint.sh`
- `HOME=/private/tmp/pyric-home NPM_CONFIG_CACHE=/private/tmp/pyric-npm-cache bash scripts/packaging-test.sh`
