### PR TITLE
Add RTDB constraints document API

### DIFF
--- a/packages/pyric-tools/docs/deploy/how-to/deploy-realtime-database-rules.md
+++ b/packages/pyric-tools/docs/deploy/how-to/deploy-realtime-database-rules.md
@@ -121,6 +121,44 @@ await rtdb.rules.deploy(scope, {
 });
 ```
 
+If you author rules with `defineRtdbRules()`, pass the document directly:
+
+```ts
+import { z } from 'zod';
+import {
+  defineRtdbRules,
+  deny,
+  pathOwnerOnly,
+} from 'pyric/rules/rtdb';
+import { fromServiceAccount, rtdb } from 'pyric-tools/deploy';
+
+const scope = await fromServiceAccount('./service-account.json');
+
+const rules = defineRtdbRules({
+  paths: {
+    '/': { read: deny(), write: deny() },
+    '/profiles/$uid': {
+      read: pathOwnerOnly('$uid'),
+      write: pathOwnerOnly('$uid'),
+      schema: z.object({
+        displayName: z.string(),
+      }),
+    },
+  },
+});
+
+const check = rules.check();
+if (!check.ok) throw new Error(check.errors[0].message);
+
+await rtdb.rules.deploy(scope, {
+  rules,
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+For CLI workflows, write `rules.toJSON()` to the file referenced by
+`firebase.json.database.rules`, then run `pyric deploy database`.
+
 ## Register the deploy tools with an agent
 
 When the caller uses `@inbrowser/agent`, register the RTDB deploy factory next

--- a/packages/pyric-tools/docs/deploy/reference/rtdb-namespace.md
+++ b/packages/pyric-tools/docs/deploy/reference/rtdb-namespace.md
@@ -38,7 +38,8 @@ instance discovery.
 
 ### `deploy(scope, input): Promise<void>`
 
-Deploy a complete RTDB rules JSON document.
+Deploy a complete RTDB rules JSON document or an RTDB rules document created by
+`defineRtdbRules()`.
 
 ```ts
 await rtdb.rules.deploy(scope, {
@@ -47,8 +48,16 @@ await rtdb.rules.deploy(scope, {
 });
 ```
 
-`rulesJson` must contain a top-level `rules` object. The function maps the JSON
-through `RtdbMapper.mapToIR` before writing it to the RTDB rules endpoint.
+```ts
+await rtdb.rules.deploy(scope, {
+  rules,
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+`rulesJson` must contain a top-level `rules` object. When `rules` is supplied,
+the function calls `rules.toJSON()`. The function maps the JSON through
+`RtdbMapper.mapToIR` before writing it to the RTDB rules endpoint.
 
 ### `discoverDefaultDatabaseUrl(scope): Promise<RtdbRulesDiscoveryResult>`
 
@@ -77,10 +86,9 @@ Throws when no URL can be resolved.
 ### `RtdbDeployRulesInput`
 
 ```ts
-interface RtdbDeployRulesInput {
-  rulesJson: unknown;
-  databaseUrl?: string;
-}
+type RtdbDeployRulesInput =
+  | { rulesJson: unknown; databaseUrl?: string }
+  | { rules: RtdbRulesDocument; databaseUrl?: string };
 ```
 
 ### `RtdbFetchRulesInput`
@@ -103,6 +111,9 @@ interface RtdbFetchRulesInput {
 The handler names match the host-backed RTDB rules tools from
 `pyric/rules/rtdb`. Do not register both factories in the same registry unless
 the registry supports explicit replacement.
+
+Tool calls remain JSON-only. Pass `rules.toJSON()` as `rulesJson` when deploying
+a generated rules document through an agent registry.
 
 ## CLI config shape
 

--- a/packages/pyric-tools/src/deploy/rtdb/rules.ts
+++ b/packages/pyric-tools/src/deploy/rtdb/rules.ts
@@ -4,15 +4,21 @@ import {
   WriteRulesHandler,
   type RtdbHost,
   type RtdbIR,
+  type RtdbRulesDocument,
 } from 'pyric/rules/rtdb';
 import { AdminApiError, type ProjectScope } from '../scope.js';
 
 const RTDB_ADMIN_API = 'https://firebasedatabase.googleapis.com/v1beta';
 
-export interface RtdbDeployRulesInput {
-  rulesJson: unknown;
-  databaseUrl?: string;
-}
+export type RtdbDeployRulesInput =
+  | {
+    rulesJson: unknown;
+    databaseUrl?: string;
+  }
+  | {
+    rules: RtdbRulesDocument;
+    databaseUrl?: string;
+  };
 
 export interface RtdbFetchRulesInput {
   databaseUrl?: string;
@@ -55,6 +61,24 @@ function extractDatabaseUrl(instance: unknown): string | null {
   if (typeof name !== 'string') return null;
   const instanceId = name.split('/').filter(Boolean).at(-1);
   return instanceId ? `https://${instanceId}.firebaseio.com` : null;
+}
+
+function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toJSON?: unknown }).toJSON === 'function'
+  );
+}
+
+function rulesJsonFromInput(input: RtdbDeployRulesInput): unknown {
+  if ('rules' in input) {
+    if (!isRtdbRulesDocument(input.rules)) {
+      throw new Error('rtdb.rules.deploy: input.rules must be an RTDB rules document');
+    }
+    return input.rules.toJSON();
+  }
+  return input.rulesJson;
 }
 
 export async function discoverDefaultDatabaseUrl(scope: ProjectScope): Promise<RtdbRulesDiscoveryResult> {
@@ -127,7 +151,7 @@ export async function fetchRules(scope: ProjectScope, input: RtdbFetchRulesInput
 
 export async function deployRules(scope: ProjectScope, input: RtdbDeployRulesInput): Promise<void> {
   const databaseUrl = await resolveDatabaseUrl(scope, input.databaseUrl);
-  const ir = RtdbMapper.mapToIR(input.rulesJson, null, databaseUrl);
+  const ir = RtdbMapper.mapToIR(rulesJsonFromInput(input), null, databaseUrl);
   const result = await new WriteRulesHandler().execute(hostFor(scope, databaseUrl), ir);
   if (!result.success) {
     throw new Error(`${result.error.code}: ${result.error.message}`);

--- a/packages/pyric-tools/test/deploy/namespaces.test.ts
+++ b/packages/pyric-tools/test/deploy/namespaces.test.ts
@@ -11,7 +11,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { hosting, functions, type ProjectScope } from '../../src/deploy/index.js';
+import { defineRtdbRules, deny } from 'pyric/rules/rtdb';
+import { hosting, functions, rtdb, type ProjectScope } from '../../src/deploy/index.js';
 
 const originalFetch = globalThis.fetch;
 beforeEach(() => { globalThis.fetch = originalFetch; });
@@ -102,5 +103,30 @@ describe('functions.grantPublicInvoker (L14 smoke)', () => {
     });
     expect(calls[0].url).toContain('/projects/p/locations/us-central1/services/svc-abc:setIamPolicy');
     expect((calls[0].init?.headers as Record<string, string>).Authorization).toBe('Bearer TKN-x');
+  });
+});
+
+describe('rtdb.rules.deploy', () => {
+  it('accepts an RTDB rules document and writes the compiled JSON', async () => {
+    const { calls } = installFetchMock([jsonResponse(200, {})]);
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: deny(), write: deny() },
+      },
+    });
+
+    await rtdb.rules.deploy(makeScope('TKN-doc'), {
+      databaseUrl: 'https://p-default-rtdb.firebaseio.com',
+      rules,
+    });
+
+    expect(calls[0].url).toBe('https://p-default-rtdb.firebaseio.com/.settings/rules.json?access_token=TKN-doc');
+    expect(calls[0].init?.method).toBe('PUT');
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      rules: {
+        '.read': false,
+        '.write': false,
+      },
+    });
   });
 });

--- a/packages/pyric/docs/database/README.md
+++ b/packages/pyric/docs/database/README.md
@@ -12,6 +12,7 @@ Pyric's Realtime Database surface has two parts:
 
 | If you want to | Read |
 |---|---|
+| Learn the constraints authoring workflow | [Author your first RTDB rules with constraints](./tutorials/01-author-rtdb-rules-with-constraints.md) |
 | Look up the RTDB rules tooling API | [RTDB rules tooling reference](./reference/rules-tooling.md) |
+| Understand package boundaries for authoring and deploy | [Why RTDB rules authoring and deploy are separate](./explanation/rules-authoring-and-deploy-are-separate.md) |
 | Check Firebase Database compatibility status | [Compatibility matrix](./COMPAT.md) |
-

--- a/packages/pyric/docs/database/explanation/rules-authoring-and-deploy-are-separate.md
+++ b/packages/pyric/docs/database/explanation/rules-authoring-and-deploy-are-separate.md
@@ -1,0 +1,31 @@
+# Why RTDB rules authoring and deploy are separate
+
+Pyric keeps Realtime Database rules authoring in `pyric/rules/rtdb` and project
+deployment in `pyric-tools/deploy`.
+
+The authoring package is a pure rules surface. It can build a rules document,
+compile it to Firebase RTDB rules JSON, check parser and linter findings, and
+run local simulations. It does not need Firebase credentials, a project id, or
+network access.
+
+The deploy package is a control-plane surface. It resolves a `ProjectScope`,
+discovers or accepts a database URL, obtains an access token, and writes rules
+through the Realtime Database rules endpoint.
+
+That split keeps the in-memory workflow usable in tests, code generation, agent
+planning, and browser-like hosts. A caller can inspect `rules.toJSON()` without
+holding credentials, then choose the deploy path later:
+
+```ts
+import { rtdb } from 'pyric-tools/deploy';
+
+await rtdb.rules.deploy(scope, {
+  rules,
+  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
+});
+```
+
+Agent tools keep the same boundary. MCP and registry tools accept JSON-shaped
+arguments, so `rtdb_deploy_rules` continues to take `rulesJson`. In-process
+TypeScript callers may pass the document object directly because the deploy
+adapter can call `toJSON()` before writing.

--- a/packages/pyric/docs/database/reference/rules-tooling.md
+++ b/packages/pyric/docs/database/reference/rules-tooling.md
@@ -5,6 +5,7 @@ entrypoint.
 
 ```ts
 import {
+  defineRtdbRules,
   RtdbMapper,
   createRtdbRulesTools,
   SimulateHandler,
@@ -14,6 +15,96 @@ import {
 It re-exports the RTDB rule mapper, expression parser, validator, linter,
 simulation handler, write handler, rule constraints, and the rules-focused tool
 factory.
+
+## Constraints authoring
+
+### `defineRtdbRules(definition): RtdbRulesDocument`
+
+Create an in-memory RTDB rules document from path constraints.
+
+```ts
+import { defineRtdbRules, deny, pathOwnerOnly } from 'pyric/rules/rtdb';
+
+const rules = defineRtdbRules({
+  paths: {
+    '/': { read: deny(), write: deny() },
+    '/profiles/$uid': {
+      read: pathOwnerOnly('$uid'),
+      write: pathOwnerOnly('$uid'),
+    },
+  },
+});
+```
+
+`definition`:
+
+```ts
+type RtdbRulesDefinition = {
+  databaseUrl?: string;
+  paths: Record<string, PathDef> | ((ctx: RulesetContext) => void);
+};
+```
+
+`databaseUrl` is optional. Methods that need an IR use an explicit method
+argument first, then `definition.databaseUrl`, then the local fallback
+`https://local-rtdb.firebaseio.com`.
+
+### `RtdbRulesDocument`
+
+```ts
+interface RtdbRulesDocument {
+  toJSON(): { rules: Record<string, unknown> };
+  toIR(databaseUrl?: string): RtdbIR;
+  check(databaseUrl?: string): RtdbRulesCheckResult;
+  simulate(input: RtdbRulesSimulationInput, opts?: { databaseUrl?: string }): SimulateResult;
+}
+```
+
+`toJSON()` returns Firebase RTDB rules JSON. `toIR()` returns Pyric's RTDB rule
+IR. `check()` returns parser and linter findings without throwing for compile
+failures. `simulate()` normalises friendly input and delegates to
+`SimulateHandler`.
+
+```ts
+const check = rules.check();
+
+const result = rules.simulate({
+  operation: 'read',
+  path: '/profiles/alice',
+  auth: 'alice',
+  data: {},
+});
+```
+
+`RtdbRulesSimulationInput` accepts the existing simulation fields plus these
+authoring conveniences:
+
+```ts
+type RtdbRulesSimulationInput = {
+  operation: 'read' | 'write' | 'validate';
+  path: string;
+  auth?: string | { uid: string; token?: Record<string, unknown> } | null;
+  data?: Record<string, unknown>;
+  mockData?: Record<string, unknown>;
+  newData?: unknown;
+};
+```
+
+`auth: 'alice'` becomes `{ uid: 'alice', token: {} }`. `data` is an alias for
+`mockData`; if both are supplied, `mockData` is used.
+
+`RtdbRulesCheckResult`:
+
+```ts
+type RtdbRulesCheckResult = {
+  ok: boolean;
+  errors: RtdbRulesFinding[];
+  warnings: RtdbRulesFinding[];
+  ir?: RtdbIR;
+};
+```
+
+Compile failures return an error finding with code `COMPILE_ERROR`.
 
 ## Rule JSON and IR
 
@@ -165,12 +256,37 @@ user-mode data operations.
 
 ## Constraint helpers
 
-`pyric/rules/rtdb` also re-exports the RTDB rule constraint helpers from
-`pyric/rules/rtdb-constraints`, including:
+`pyric/rules/rtdb` also re-exports the RTDB rule constraint helpers. The
+canonical constraints-only package path is `pyric/rules/rtdb/constraints`.
+`pyric/rules/rtdb-constraints` remains available as a compatibility alias.
 
-- boolean composition: `expr`, `all`, `any`, `not`, `deny`, `always`
+The helper groups are:
+
+- boolean composition: `expr`, `all`, `any`, `not`, `deny`, `always`, `allow`
 - auth and ownership predicates: `authenticated`, `ownPath`, `ownField`
 - schema predicates: `hasChildren`, `hasChild`, `fieldIsString`,
   `fieldIsNumber`, `fieldIsBoolean`, `fieldEnum`
 - policy helpers: `pathOwnerOnly`, `fieldOwnerOnly`, `ownerOrNew`,
   `hasRole`, `isMember`, `required`, `transition`
+
+### `PathDef`
+
+```ts
+interface PathDef {
+  read?: Expr;
+  write?: Expr;
+  validate?: Expr;
+  schema?: z.ZodObject<any>;
+  fieldConstraints?: Record<string, Expr[]>;
+  indexOn?: string[];
+  children?: Record<string, PathDef>;
+}
+```
+
+`schema` supports Zod object fields composed from strings, numbers, booleans,
+enums, literals, unions of supported types, nested objects, and optional fields.
+Unsupported Zod types throw during compilation.
+
+Game-oriented helpers such as `turnGuard`, `flip`, and `winCheckHelper` remain
+exported for compatibility. Treat them as recipes rather than the primary
+constraints API.

--- a/packages/pyric/docs/database/tutorials/01-author-rtdb-rules-with-constraints.md
+++ b/packages/pyric/docs/database/tutorials/01-author-rtdb-rules-with-constraints.md
@@ -1,0 +1,130 @@
+# Author your first RTDB rules with constraints
+
+This tutorial creates a small Realtime Database rules document in memory, checks
+it, and simulates one write before you hand the generated JSON to deploy
+tooling.
+
+You will build rules for room messages:
+
+- nobody can read or write at the root
+- signed-in room members can write messages
+- each message must include `author`, `text`, and `createdAt`
+- `createdAt` cannot change after creation
+
+## Create the rules document
+
+Create `database.rules.ts`:
+
+```ts
+import { z } from 'zod';
+import {
+  AUTH_UID,
+  all,
+  authenticated,
+  defineRtdbRules,
+  deny,
+  eq,
+  immutable,
+  newDataVal,
+  rootExists,
+} from 'pyric/rules/rtdb';
+
+const isRoomMember = rootExists(['members', { $: '$roomId' }, { $: 'auth.uid' }]);
+
+export const rules = defineRtdbRules({
+  paths: {
+    '/': { read: deny(), write: deny() },
+    '/rooms/$roomId/messages/$messageId': {
+      read: isRoomMember,
+      write: all(
+        authenticated(),
+        isRoomMember,
+        eq(newDataVal('author'), AUTH_UID),
+        immutable('createdAt'),
+      ),
+      schema: z.object({
+        author: z.string(),
+        text: z.string(),
+        createdAt: z.number(),
+      }),
+      indexOn: ['createdAt'],
+    },
+  },
+});
+```
+
+## Check the document
+
+Add a small check script:
+
+```ts
+import { rules } from './database.rules.js';
+
+const check = rules.check();
+
+if (!check.ok) {
+  console.error(check.errors);
+  process.exit(1);
+}
+
+console.log(rules.toJSON());
+```
+
+Run it:
+
+```bash
+bun database.rules.check.ts
+```
+
+You will see a complete Firebase RTDB rules JSON object. The `check()` call
+also returns lint warnings, so you can decide whether to fail your own workflow
+on warnings.
+
+## Simulate a write
+
+Add one simulation:
+
+```ts
+import { rules } from './database.rules.js';
+
+const result = rules.simulate({
+  operation: 'write',
+  path: '/rooms/r1/messages/m1',
+  auth: 'alice',
+  data: {
+    members: {
+      r1: { alice: true },
+    },
+  },
+  newData: {
+    author: 'alice',
+    text: 'hello',
+    createdAt: 1,
+  },
+});
+
+console.log(result);
+```
+
+Run it:
+
+```bash
+bun database.rules.simulate.ts
+```
+
+The result is allowed. Change `auth` to `'bob'` or change `newData.author` to a
+different uid and run it again; the same rule document now denies the write.
+
+## Generate JSON for deployment
+
+Write the compiled JSON when you want to use the existing CLI flow:
+
+```ts
+import { writeFile } from 'node:fs/promises';
+import { rules } from './database.rules.js';
+
+await writeFile('database.rules.json', JSON.stringify(rules.toJSON(), null, 2));
+```
+
+You have built an in-memory rules document, checked it, simulated it, and
+generated the JSON expected by Firebase Realtime Database.

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/rules/rtdb.d.ts",
       "import": "./dist/rules/rtdb.js"
     },
+    "./rules/rtdb/constraints": {
+      "types": "./dist/database/constraints/index.d.ts",
+      "import": "./dist/database/constraints/index.js"
+    },
     "./rules/rtdb-constraints": {
       "types": "./dist/database/constraints/index.d.ts",
       "import": "./dist/database/constraints/index.js"

--- a/packages/pyric/src/database/constraints/compose.ts
+++ b/packages/pyric/src/database/constraints/compose.ts
@@ -19,3 +19,6 @@ export const deny = (): Expr => expr('false');
 
 /** Always allow (true). */
 export const always = (): Expr => expr('true');
+
+/** Always allow (true). Readable alias for always(). */
+export const allow = always;

--- a/packages/pyric/src/database/constraints/document.ts
+++ b/packages/pyric/src/database/constraints/document.ts
@@ -1,0 +1,152 @@
+import { RtdbMapper } from '../mapper.js';
+import { SimulateHandler } from '../simulation/handler.js';
+import type { SimulationInput, SimulateResult } from '../simulation/spec.js';
+import type { RtdbIR, RtdbNode, RtdbRuleExpression } from '../types.js';
+import { ruleset } from './ruleset.js';
+import type { PathDef, RulesetContext } from './types.js';
+
+const LOCAL_DATABASE_URL = 'https://local-rtdb.firebaseio.com';
+
+export interface RtdbRulesDefinition {
+  databaseUrl?: string;
+  paths: Record<string, PathDef> | ((ctx: RulesetContext) => void);
+}
+
+export type RtdbRulesJson = { rules: Record<string, unknown> };
+
+export type RtdbRulesFindingRule = '.read' | '.write' | '.validate' | 'ruleset';
+
+export interface RtdbRulesFinding {
+  path: string;
+  rule: RtdbRulesFindingRule;
+  code: string;
+  message: string;
+}
+
+export interface RtdbRulesCheckResult {
+  ok: boolean;
+  errors: RtdbRulesFinding[];
+  warnings: RtdbRulesFinding[];
+  ir?: RtdbIR;
+}
+
+export type RtdbRulesSimulationAuth =
+  | string
+  | { uid: string; token?: Record<string, unknown> }
+  | null;
+
+export type RtdbRulesSimulationInput =
+  Omit<SimulationInput, 'auth' | 'mockData'> & {
+    auth?: RtdbRulesSimulationAuth;
+    data?: Record<string, unknown>;
+    mockData?: Record<string, unknown>;
+  };
+
+export interface RtdbRulesDocument {
+  toJSON(): RtdbRulesJson;
+  toIR(databaseUrl?: string): RtdbIR;
+  check(databaseUrl?: string): RtdbRulesCheckResult;
+  simulate(
+    input: RtdbRulesSimulationInput,
+    opts?: { databaseUrl?: string },
+  ): SimulateResult;
+}
+
+function resolveDatabaseUrl(definition: RtdbRulesDefinition, databaseUrl?: string): string {
+  return databaseUrl ?? definition.databaseUrl ?? LOCAL_DATABASE_URL;
+}
+
+function normalizeAuth(auth: RtdbRulesSimulationAuth | undefined): SimulationInput['auth'] {
+  if (auth === undefined || auth === null) return null;
+  if (typeof auth === 'string') return { uid: auth, token: {} };
+  return { uid: auth.uid, token: auth.token ?? {} };
+}
+
+function normalizeSimulationInput(input: RtdbRulesSimulationInput): SimulationInput {
+  return {
+    operation: input.operation,
+    path: input.path,
+    auth: normalizeAuth(input.auth),
+    mockData: input.mockData ?? input.data ?? {},
+    ...(input.newData !== undefined ? { newData: input.newData } : {}),
+  };
+}
+
+function collectExpressionFindings(
+  path: string,
+  rule: Exclude<RtdbRulesFindingRule, 'ruleset'>,
+  expr: RtdbRuleExpression | undefined,
+  kind: 'errors' | 'warnings',
+): RtdbRulesFinding[] {
+  return (expr?.parsed[kind] ?? []).map((finding) => ({
+    path,
+    rule,
+    code: finding.code,
+    message: finding.message,
+  }));
+}
+
+function collectFindings(node: RtdbNode, kind: 'errors' | 'warnings'): RtdbRulesFinding[] {
+  const findings: RtdbRulesFinding[] = [
+    ...collectExpressionFindings(node.path, '.read', node.read, kind),
+    ...collectExpressionFindings(node.path, '.write', node.write, kind),
+    ...collectExpressionFindings(node.path, '.validate', node.validate, kind),
+  ];
+
+  for (const child of node.children) {
+    findings.push(...collectFindings(child, kind));
+  }
+
+  return findings;
+}
+
+class DefinedRtdbRulesDocument implements RtdbRulesDocument {
+  constructor(private readonly definition: RtdbRulesDefinition) {}
+
+  toIR(databaseUrl?: string): RtdbIR {
+    return ruleset(resolveDatabaseUrl(this.definition, databaseUrl), this.definition.paths);
+  }
+
+  toJSON(): RtdbRulesJson {
+    return RtdbMapper.mapToRulesJSON(this.toIR());
+  }
+
+  check(databaseUrl?: string): RtdbRulesCheckResult {
+    try {
+      const ir = this.toIR(databaseUrl);
+      const errors = collectFindings(ir.rules as RtdbNode, 'errors');
+      const warnings = collectFindings(ir.rules as RtdbNode, 'warnings');
+      return {
+        ok: errors.length === 0,
+        errors,
+        warnings,
+        ir,
+      };
+    } catch (e) {
+      return {
+        ok: false,
+        errors: [{
+          path: '/',
+          rule: 'ruleset',
+          code: 'COMPILE_ERROR',
+          message: e instanceof Error ? e.message : String(e),
+        }],
+        warnings: [],
+      };
+    }
+  }
+
+  simulate(
+    input: RtdbRulesSimulationInput,
+    opts: { databaseUrl?: string } = {},
+  ): SimulateResult {
+    return new SimulateHandler().execute(
+      this.toIR(opts.databaseUrl),
+      normalizeSimulationInput(input),
+    );
+  }
+}
+
+export function defineRtdbRules(definition: RtdbRulesDefinition): RtdbRulesDocument {
+  return new DefinedRtdbRulesDocument(definition);
+}

--- a/packages/pyric/src/database/constraints/index.ts
+++ b/packages/pyric/src/database/constraints/index.ts
@@ -1,5 +1,5 @@
 export type { Expr, Segment, PathDef, RulesetContext } from './types.js';
-export { expr, all, any, not, deny, always } from './compose.js';
+export { expr, all, any, not, deny, always, allow } from './compose.js';
 export {
   authenticated, ownPath, ownField, isNew,
   hasChildren, hasChild, fieldIsString, fieldIsNumber, fieldIsBoolean, fieldEnum,
@@ -16,4 +16,16 @@ export {
 } from './data.js';
 export { turnGuard, flip, winCheckHelper } from './game.js';
 export { schemaRules } from './schema.js';
+export type { SchemaRulesResult } from './schema.js';
 export { ruleset } from './ruleset.js';
+export { defineRtdbRules } from './document.js';
+export type {
+  RtdbRulesCheckResult,
+  RtdbRulesDefinition,
+  RtdbRulesDocument,
+  RtdbRulesFinding,
+  RtdbRulesFindingRule,
+  RtdbRulesJson,
+  RtdbRulesSimulationAuth,
+  RtdbRulesSimulationInput,
+} from './document.js';

--- a/packages/pyric/src/rules/rtdb.ts
+++ b/packages/pyric/src/rules/rtdb.ts
@@ -70,6 +70,7 @@ export {
   not,
   deny,
   always,
+  allow,
   authenticated,
   ownPath,
   ownField,
@@ -109,10 +110,20 @@ export {
   winCheckHelper,
   schemaRules,
   ruleset,
+  defineRtdbRules,
 } from '../database/constraints/index.js';
 export type {
   Expr,
   PathDef,
+  RtdbRulesCheckResult,
+  RtdbRulesDefinition,
+  RtdbRulesDocument,
+  RtdbRulesFinding,
+  RtdbRulesFindingRule,
+  RtdbRulesJson,
+  RtdbRulesSimulationAuth,
+  RtdbRulesSimulationInput,
   RulesetContext,
+  SchemaRulesResult,
   Segment,
 } from '../database/constraints/index.js';

--- a/packages/pyric/test/database/constraints/document.test.ts
+++ b/packages/pyric/test/database/constraints/document.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+import {
+  all,
+  allow,
+  dataVal,
+  defineRtdbRules,
+  deny,
+  eq,
+  expr,
+  immutable,
+  newDataVal,
+  pathOwnerOnly,
+  ruleset,
+} from '../../../src/database/constraints/index.js';
+import type { RtdbNode } from '../../../src/database/types.js';
+
+const LOCAL_URL = 'https://local-rtdb.firebaseio.com';
+const EXPLICIT_URL = 'https://demo-default-rtdb.firebaseio.com';
+
+describe('defineRtdbRules', () => {
+  test('compiles constraints to rules JSON', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: deny(), write: deny() },
+        '/rooms/$roomId/messages/$messageId': {
+          read: allow(),
+          write: all(pathOwnerOnly('$messageId'), immutable('createdAt')),
+          schema: z.object({
+            author: z.string(),
+            text: z.string(),
+            createdAt: z.number(),
+          }),
+          indexOn: ['createdAt'],
+        },
+      },
+    });
+
+    expect(rules.toJSON()).toEqual({
+      rules: {
+        '.read': false,
+        '.write': false,
+        rooms: {
+          '$roomId': {
+            messages: {
+              '.indexOn': ['createdAt'],
+              '$messageId': {
+                '.read': true,
+                '.write': '((auth !== null) && (auth.uid === $messageId)) && (!data.exists() || newData.child("createdAt").val() === data.child("createdAt").val())',
+                '.validate': '(newData.hasChildren()) && (newData.hasChild("author")) && (newData.hasChild("text")) && (newData.hasChild("createdAt"))',
+                author: { '.validate': 'newData.isString()' },
+                text: { '.validate': 'newData.isString()' },
+                createdAt: { '.validate': 'newData.isNumber()' },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('uses the local database URL by default and accepts explicit overrides', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: deny(), write: deny() },
+      },
+    });
+
+    expect(rules.toIR().databaseUrl).toBe(LOCAL_URL);
+    expect(rules.toIR(EXPLICIT_URL).databaseUrl).toBe(EXPLICIT_URL);
+  });
+
+  test('uses the definition database URL before the local fallback', () => {
+    const rules = defineRtdbRules({
+      databaseUrl: EXPLICIT_URL,
+      paths: {
+        '/': { read: deny(), write: deny() },
+      },
+    });
+
+    expect(rules.toIR().databaseUrl).toBe(EXPLICIT_URL);
+  });
+
+  test('check collects parser errors and lint warnings', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: expr('auth.uid ==='), write: expr('auth.uid == "alice"') },
+      },
+    });
+
+    const check = rules.check();
+    expect(check.ok).toBe(false);
+    expect(check.errors.map(e => e.code).length).toBeGreaterThan(0);
+    expect(check.warnings.map(w => w.code)).toContain('LOOSE_EQUALITY');
+  });
+
+  test('check converts compile failures to COMPILE_ERROR findings', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/items/$itemId': {
+          schema: z.object({ tags: z.array(z.string()) }),
+        },
+      },
+    });
+
+    const check = rules.check();
+    expect(check.ok).toBe(false);
+    expect(check.errors).toEqual([
+      expect.objectContaining({
+        path: '/',
+        rule: 'ruleset',
+        code: 'COMPILE_ERROR',
+      }),
+    ]);
+  });
+
+  test('simulate normalises auth strings and data aliases', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: deny(), write: deny() },
+        '/profiles/$uid': {
+          write: all(pathOwnerOnly('$uid'), eq(dataVal('locked'), false), eq(newDataVal('owner'), 'alice')),
+        },
+      },
+    });
+
+    const result = rules.simulate({
+      operation: 'write',
+      path: '/profiles/alice',
+      auth: 'alice',
+      data: { profiles: { alice: { locked: false } } },
+      newData: { owner: 'alice' },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(true);
+      expect(result.data.pathVariableBindings).toEqual({ '$uid': 'alice' });
+    }
+  });
+
+  test('simulate reports denied requests through the existing simulation result', () => {
+    const rules = defineRtdbRules({
+      paths: {
+        '/profiles/$uid': { read: pathOwnerOnly('$uid') },
+      },
+    });
+
+    const result = rules.simulate({
+      operation: 'read',
+      path: '/profiles/alice',
+      auth: { uid: 'bob' },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.allowed).toBe(false);
+  });
+
+  test('low-level ruleset stays available', () => {
+    const ir = ruleset(EXPLICIT_URL, { '/': { read: deny() } });
+    expect((ir.rules as RtdbNode).read?.raw).toBe('false');
+  });
+});

--- a/packages/pyric/test/rules/rtdb-export.test.ts
+++ b/packages/pyric/test/rules/rtdb-export.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
+  allow,
   buildRuleExpression,
   createRtdbRulesTools,
+  defineRtdbRules,
   parseExpression,
   RtdbMapper,
 } from '../../src/rules/rtdb.js';
@@ -35,5 +39,28 @@ describe('pyric/rules/rtdb facade', () => {
     const ir = RtdbMapper.mapToIR({ rules: { users: { '$uid': { '.read': 'auth.uid === $uid' } } } }, null, host().databaseUrl);
     expect(ir.service).toBe('realtime-database');
     expect(ir.databaseUrl).toBe(host().databaseUrl);
+  });
+
+  test('exports the constraints document API through the facade', () => {
+    const rules = defineRtdbRules({
+      paths: { '/': { read: allow() } },
+    });
+
+    expect(rules.toJSON()).toEqual({ rules: { '.read': true } });
+  });
+
+  test('declares canonical and compatibility constraints package paths', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(import.meta.dir, '../../package.json'), 'utf-8'),
+    ) as { exports: Record<string, unknown> };
+
+    expect(pkg.exports['./rules/rtdb/constraints']).toEqual({
+      types: './dist/database/constraints/index.d.ts',
+      import: './dist/database/constraints/index.js',
+    });
+    expect(pkg.exports['./rules/rtdb-constraints']).toEqual({
+      types: './dist/database/constraints/index.d.ts',
+      import: './dist/database/constraints/index.js',
+    });
   });
 });


### PR DESCRIPTION
## A rules document that can be checked, simulated, and deployed

```ts
import { z } from 'zod';
import {
  AUTH_UID,
  all,
  authenticated,
  defineRtdbRules,
  deny,
  eq,
  immutable,
  newDataVal,
  rootExists,
} from 'pyric/rules/rtdb';
import { rtdb } from 'pyric-tools/deploy';

const isRoomMember = rootExists(['members', { $: '$roomId' }, { $: 'auth.uid' }]);

const rules = defineRtdbRules({
  paths: {
    '/': { read: deny(), write: deny() },
    '/rooms/$roomId/messages/$messageId': {
      read: isRoomMember,
      write: all(
        authenticated(),
        isRoomMember,
        eq(newDataVal('author'), AUTH_UID),
        immutable('createdAt'),
      ),
      schema: z.object({
        author: z.string(),
        text: z.string(),
        createdAt: z.number(),
      }),
      indexOn: ['createdAt'],
    },
  },
});

const check = rules.check();
if (!check.ok) throw new Error(check.errors[0].message);

const result = rules.simulate({
  operation: 'write',
  path: '/rooms/r1/messages/m1',
  auth: 'alice',
  data: { members: { r1: { alice: true } } },
  newData: { author: 'alice', text: 'hello', createdAt: 1 },
});

await rtdb.rules.deploy(scope, {
  rules,
  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
});
```

This introduces an in-memory public API for Realtime Database rules constraints. The constraint helpers already existed, but the user experience was still centred on lower-level compiler pieces such as `ruleset()`, `RtdbMapper`, and `SimulateHandler`. This PR adds a document object that gives constraints a first-class authoring workflow:

1. define path constraints
2. compile to Firebase RTDB rules JSON
3. check parser/linter findings
4. simulate access locally with friendly input
5. pass the same document to deploy tooling in-process

## Public API surface

Adds `defineRtdbRules()` to `pyric/rules/rtdb`.

```ts
const rules = defineRtdbRules({
  databaseUrl?: string,
  paths,
});
```

`paths` accepts the existing constraints shape: either `Record<string, PathDef>` or the callback builder supported by `ruleset()`.

The returned `RtdbRulesDocument` exposes:

```ts
interface RtdbRulesDocument {
  toJSON(): { rules: Record<string, unknown> };
  toIR(databaseUrl?: string): RtdbIR;
  check(databaseUrl?: string): RtdbRulesCheckResult;
  simulate(input: RtdbRulesSimulationInput, opts?: { databaseUrl?: string }): SimulateResult;
}
```

Important behaviour:

- `toJSON()` returns Firebase RTDB rules JSON and throws on compile failures.
- `toIR()` returns the existing Pyric `RtdbIR`, using an explicit URL, the definition URL, or `https://local-rtdb.firebaseio.com`.
- `check()` returns `{ ok, errors, warnings, ir? }` and converts compile failures into a `COMPILE_ERROR` finding.
- `simulate()` delegates to the existing RTDB simulator after normalising ergonomic input.

The simulation input now supports authoring-friendly aliases:

```ts
type RtdbRulesSimulationInput = {
  operation: 'read' | 'write' | 'validate';
  path: string;
  auth?: string | { uid: string; token?: Record<string, unknown> } | null;
  data?: Record<string, unknown>;
  mockData?: Record<string, unknown>;
  newData?: unknown;
};
```

`auth: 'alice'` becomes `{ uid: 'alice', token: {} }`. `data` is accepted as a clearer alias for the existing simulator field `mockData`.

## Packaging and compatibility

Adds the canonical constraints-only package path:

```ts
import { defineRtdbRules } from 'pyric/rules/rtdb/constraints';
```

The existing compatibility path remains:

```ts
import { defineRtdbRules } from 'pyric/rules/rtdb-constraints';
```

The main RTDB rules facade also exports the new API:

```ts
import { defineRtdbRules } from 'pyric/rules/rtdb';
```

Other API additions:

- `allow()` as a readable alias for `always()`
- `SchemaRulesResult` type export
- document-related types: `RtdbRulesDefinition`, `RtdbRulesDocument`, `RtdbRulesCheckResult`, `RtdbRulesFinding`, `RtdbRulesJson`, `RtdbRulesSimulationAuth`, and `RtdbRulesSimulationInput`

Low-level APIs remain available and backwards compatible, including `ruleset()`, `schemaRules()`, `RtdbMapper`, `SimulateHandler`, expression helpers, and existing game-oriented helpers.

## Deploy integration

`pyric` remains authoring-only. The rules document does not gain a `deploy()` method.

Instead, `pyric-tools/deploy` accepts the document object in-process:

```ts
await rtdb.rules.deploy(scope, {
  rules,
  databaseUrl,
});
```

`RtdbDeployRulesInput` now supports either:

```ts
type RtdbDeployRulesInput =
  | { rulesJson: unknown; databaseUrl?: string }
  | { rules: RtdbRulesDocument; databaseUrl?: string };
```

MCP/agent deploy tools stay JSON-only. `rtdb_deploy_rules` still accepts `rulesJson`, because tool calls should not depend on passing class instances across a registry boundary. Callers can pass `rules.toJSON()` there.

## Documentation

Adds Diataxis-shaped documentation for the new concept:

- tutorial: author, check, simulate, and generate RTDB rules with constraints
- reference: exact document API, helper groups, package paths, and supported Zod shape
- explanation: why authoring lives in `pyric/rules/rtdb` while deployment lives in `pyric-tools/deploy`
- deploy how-to/reference updates for `rtdb.rules.deploy(scope, { rules })`

## Validation

- `bun test packages/pyric/test/database/constraints/document.test.ts packages/pyric/test/rules/rtdb-export.test.ts packages/pyric-tools/test/deploy/namespaces.test.ts packages/pyric-tools/test/deploy/tools.test.ts`
- `bun run build`
- package export smoke for `pyric/rules/rtdb/constraints`
- `git diff --check`
