### PR TITLE
Add service-adaptable verify fixtures

### DIFF
--- a/packages/pyric-tools/docs/README.md
+++ b/packages/pyric-tools/docs/README.md
@@ -33,6 +33,8 @@ Real Firebase projects:
 
 - **[CLI reference](reference/cli.md)** — every `pyric` command, every flag,
   exit codes, environment variables. The authoritative source.
+- [Verify API](reference/verify.md) — programmatic captured-session replay for
+  Firestore and RTDB rules.
 - [Deploy library + agent I/O](deploy/README.md) — `pyric-tools/deploy` API,
   namespaces, error codes, [CLI agent I/O](deploy/reference/cli-agent-io.md).
 - [Bridge](bridge/README.md) — `pyric-tools/bridge` (server + client).

--- a/packages/pyric-tools/docs/how-to/verify-against-a-captured-session.md
+++ b/packages/pyric-tools/docs/how-to/verify-against-a-captured-session.md
@@ -1,10 +1,9 @@
 # How to verify your rules against a captured session
 
-`pyric verify` replays a captured sandbox session against a ruleset and reports
-**real divergences** — writes that succeeded in the sandbox while you were
-building, but that your new rules would deny or silently change. It answers the
-one question that makes "build in the sandbox, swap to prod" safe: *will the
-rules I'm about to ship break what I built?*
+`pyric verify` replays a captured sandbox session against candidate rules and
+reports service-labelled divergences. It works for Firestore and Realtime
+Database captures. It answers the question that makes "build in the sandbox,
+swap to prod" safe: *will the rules I'm about to ship break what I built?*
 
 ## Capture a session, then verify
 
@@ -28,20 +27,43 @@ Capture is on by default in `pyric serve`, so the loop is just three steps.
    pyric verify
    ```
 
-   With no positional argument, `verify` reads `.pyric/last-session.json` and
-   checks it against `firestore.rules` in the current directory.
+   With no positional argument, `verify` reads `.pyric/last-session.json`.
+   It verifies the Firestore and RTDB services present in that capture.
+   Candidate rules are resolved from `firebase.json`:
+
+   ```json
+   {
+     "firestore": { "rules": "firestore.rules" },
+     "database": { "rules": "database.rules.json" }
+   }
+   ```
 
 ## Verify against edited rules
 
 If you've tightened or rewritten your rules and want to check them before
-deploying, point `--rules` at the file:
+deploying, pass service-qualified rules overrides:
 
 ```sh
-pyric verify --rules path/to/firestore.rules
+pyric verify --rules firestore=path/to/firestore.rules
+pyric verify --rules rtdb=path/to/database.rules.json
 ```
 
 The capture stays fixed; only the ruleset changes. The diff between what the
 sandbox allowed and what these rules allow is exactly what surfaces.
+
+For a mixed capture, repeat `--rules`:
+
+```sh
+pyric verify \
+  --rules firestore=firestore.rules \
+  --rules rtdb=database.rules.json
+```
+
+To check only one service in a mixed capture, use `--service`:
+
+```sh
+pyric verify --service rtdb --rules rtdb=database.rules.json
+```
 
 ## Verify a specific fixture
 
@@ -53,25 +75,24 @@ pyric verify journeys/checkout.json
 
 ## Interpreting the result
 
-A session **fails** (exit code `1`) when the replay finds a real divergence: a
-write that succeeded in the sandbox would now be denied, or would land with
-different data. Each failing leaf is named with its path and the
-`before → after` delta so you can see which rule bites:
+A session **fails** (exit code `1`) when replay finds a failing divergence:
+a write that succeeded in the sandbox would now be denied, an operation is not
+replayable, or the replayed state differs from the captured state. Each failure
+is labelled by service:
 
 ```
-✗ checkout — 1 real-divergence(s)
-    orders/abc123.status: "paid" → null
+✗ chat - rtdb: 1 failure(s)
+    [rtdb] now-denied: set /rooms/r1/messages/m1 (PERMISSION_DENIED)
 ```
 
-Other divergences — `autoid-alias`, `time-drift`, `sentinel-drift` — are
-**informational**. The replay engine licenses them (they're expected artefacts
-of replaying server-generated IDs, timestamps, and sentinels), so they're
-listed but do **not** fail the run. A clean run exits `0`:
+Firestore auto-id aliases, time drift, and sentinel drift are informational.
+They are expected artefacts of replaying generated values, so they do not fail
+the run. A clean run exits `0`:
 
 ```
-✓ checkout — 0 informational divergence(s)
+✓ chat - firestore: ok (0 informational), rtdb: ok (0 informational)
 
-✓ all sessions replay cleanly under firestore.rules.
+✓ all selected services replay cleanly.
 ```
 
 ## Run a suite in CI
@@ -81,7 +102,7 @@ To verify many captured journeys at once, point `verify` at a directory. Every
 diverges:
 
 ```sh
-pyric verify journeys/ --rules firestore.rules
+pyric verify journeys/ --rules firestore=firestore.rules
 ```
 
 Add `--json` for machine-readable output to feed into a dashboard or gate.
@@ -91,9 +112,29 @@ the rules being shipped:
 
 ```yaml
 - name: Verify rules against captured journeys
-  run: pyric verify journeys/ --rules firestore.rules
+  run: pyric verify journeys/ --rules firestore=firestore.rules
 ```
 
 The non-zero exit on a real divergence is what blocks the merge.
+
+## Verify from code
+
+Use `pyric-tools/verify` when your RTDB rules are authored in memory:
+
+```ts
+import { verifyFixture } from 'pyric-tools/verify';
+import { rules } from './database.rules.js';
+
+const fixture = JSON.parse(await Bun.file('.pyric/last-session.json').text());
+
+const result = await verifyFixture(fixture, {
+  rules: { rtdb: rules },
+});
+
+if (!result.ok) process.exit(1);
+```
+
+`rules` can be an RTDB rules JSON object or an `RtdbRulesDocument` from
+`defineRtdbRules()`.
 
 For the full flag list, see the [`pyric verify` reference](../reference/cli.md#pyric-verify).

--- a/packages/pyric-tools/docs/reference/cli.md
+++ b/packages/pyric-tools/docs/reference/cli.md
@@ -52,7 +52,7 @@ is unavailable). `firestore.rules` is deployed and hot-reloaded over SSE.
 | `--persist` | off | Persist sandbox state (docs + auth users) to a committable `.pyric/state/state.json`. Once a state file exists it wins; `--seed` then applies only on the first run. (On the SharedWorker path data is already durable in IndexedDB; this adds the on-disk, shareable copy.) |
 | `--fresh` | off | With `--persist`: discard the existing state file and re-seed from scratch. Does not clear the browser's IndexedDB. |
 | `--seed <file>` | — | Load a `"collection/doc" → fields` JSON map admin-style before app code runs. Also accepts a `pyric snapshot` state file (detected by its `version` key) — seeds docs + auth users. |
-| `--no-capture` | capture on | Disable the session capture. By default serve writes `.pyric/last-session.json` for `pyric verify` to replay. |
+| `--no-capture` | capture on | Disable the session capture. By default serve writes `.pyric/last-session.json` for `pyric verify` to replay. Captures use `pyric.verify.fixture.v1`, with one event timeline and per-service Firestore/RTDB rules + state blocks. |
 | `--no-watch` | watch on | Disable `firestore.rules` hot-reload. |
 | `--no-open` | auto-open on | Don't auto-open the browser. (Auto-open is already suppressed under `--json`, no TTY, and CI.) |
 | `--no-cache` | cache on | Rebuild the served SDK + worker bundles instead of using `~/.pyric/serve-cache`. |
@@ -95,18 +95,34 @@ See [promote sandbox state to a fixture](../how-to/promote-sandbox-state-to-a-fi
 <a id="pyric-verify"></a>
 ### `pyric verify [fixture|dir] [flags]`
 
-Replay a captured sandbox session against a ruleset and report **real
-divergences** — writes that succeeded in the sandbox but would be denied by the
-rules you're shipping. With no positional argument it replays the latest
-`pyric serve` capture at `.pyric/last-session.json`.
+Replay a captured sandbox session against candidate rules. Captures can contain
+Firestore and Realtime Database services; `verify` checks the verifiable
+services present in the fixture unless `--service` filters them. With no
+positional argument it replays the latest `pyric serve` capture at
+`.pyric/last-session.json`.
 
 | Flag | Default | Description |
 |---|---|---|
-| `--rules <path>` | `firestore.rules` | Ruleset to verify against. |
+| `--service <firestore\|rtdb>` | all services in fixture | Verify one service. Repeat to verify several selected services. `database` is accepted as an alias for `rtdb`. |
+| `--rules <service=path>` | from `firebase.json` | Candidate rules to verify against. Repeat for mixed-service captures. Firestore rules are source files; RTDB rules are JSON files. |
 | `--json` | off | Machine output on stdout. |
 
-**Exit code:** `1` on any real divergence, `0` otherwise. autoid-alias /
-time-drift / sentinel-drift divergences are informational and do not fail.
+Default candidate rules come from `firebase.json.firestore.rules` and
+`firebase.json.database.rules`. Captured rules are informational and are not
+used as the candidate ruleset.
+
+**Exit code:** `1` on any failing divergence, `0` otherwise. Missing fixture or
+missing candidate rules exits `2`. Firestore auto-id aliases, time drift, and
+sentinel drift are informational and do not fail.
+
+Examples:
+
+```sh
+pyric verify
+pyric verify journeys/ --rules firestore=firestore.rules
+pyric verify --service rtdb --rules rtdb=database.rules.json
+pyric verify --rules firestore=firestore.rules --rules rtdb=database.rules.json
+```
 
 See [verify against a captured session](../how-to/verify-against-a-captured-session.md).
 

--- a/packages/pyric-tools/docs/reference/verify.md
+++ b/packages/pyric-tools/docs/reference/verify.md
@@ -1,0 +1,65 @@
+# Verify API
+
+`pyric-tools/verify` verifies captured sandbox sessions from code. It uses the
+same fixture format and replay behavior as `pyric verify`.
+
+## `verifyFixture(fixture, options)`
+
+```ts
+import { verifyFixture } from 'pyric-tools/verify';
+
+const result = await verifyFixture(fixture, {
+  rules: {
+    firestore: firestoreRulesSource,
+    rtdb: rtdbRulesDocumentOrJson,
+  },
+});
+```
+
+`fixture` must use schema `pyric.verify.fixture.v1`. The fixture has one
+ordered `events` timeline and per-service blocks under `services`.
+
+```ts
+type VerifyRulesInput = {
+  firestore?: string | { source: string };
+  rtdb?: { rules: Record<string, unknown> } | RtdbRulesDocument;
+  storage?: string | { source: string };
+};
+```
+
+`RtdbRulesDocument` values are compiled with `toJSON()` before replay.
+
+## Result shape
+
+```ts
+type VerifyResult = {
+  ok: boolean;
+  services: {
+    firestore?: VerifyServiceResult;
+    rtdb?: VerifyServiceResult;
+  };
+};
+
+type VerifyServiceResult = {
+  service: 'firestore' | 'rtdb';
+  ok: boolean;
+  checkedEvents: number;
+  divergences: VerifyDivergence[];
+};
+```
+
+Failing divergence kinds are `now-denied`, `state-drift`, and `unsupported`.
+`expected-drift` is informational.
+
+## Fixture helpers
+
+```ts
+import {
+  buildVerifyFixture,
+  parseVerifyFixture,
+} from 'pyric-tools/verify';
+```
+
+`buildVerifyFixture()` is used by `pyric serve` capture. Most users read the
+captured JSON from `.pyric/last-session.json`; custom harnesses can use the
+builder to emit the same schema.

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/credentials/node/index.d.ts",
       "import": "./dist/credentials/node/index.js"
     },
+    "./verify": {
+      "types": "./dist/verify/index.d.ts",
+      "import": "./dist/verify/index.js"
+    },
     "./bridge": {
       "types": "./dist/bridge/server.d.ts",
       "node": {

--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -96,6 +96,24 @@ describe('parseArgs', () => {
     const p = parseArgs(['rules:simulate', '--stdin']);
     expect(p.flags.get('stdin')).toBe(true);
   });
+
+  it('preserves repeated long flags in order', () => {
+    const p = parseArgs([
+      'verify',
+      '--service',
+      'firestore',
+      '--service',
+      'rtdb',
+      '--rules=firestore=firestore.rules',
+      '--rules',
+      'rtdb=database.rules.json',
+    ]);
+    expect(p.flags.get('service')).toEqual(['firestore', 'rtdb']);
+    expect(p.flags.get('rules')).toEqual([
+      'firestore=firestore.rules',
+      'rtdb=database.rules.json',
+    ]);
+  });
 });
 
 // ── deploy ────────────────────────────────────────────────────────────

--- a/packages/pyric-tools/src/cli/deploy.ts
+++ b/packages/pyric-tools/src/cli/deploy.ts
@@ -211,7 +211,7 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
     {
       firebaseJson,
       firebaseRc: rc,
-      flags: parsed.flags,
+      flags: singleValueFlags(parsed.flags),
       projectId: scope.projectId,
       cwd,
       env: deps.env ?? process.env,
@@ -236,6 +236,14 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
     deps.stdout === undefined && process.stdout.isTTY === true,
   );
 
+}
+
+function singleValueFlags(flags: ParsedArgs['flags']): ReadonlyMap<string, string | boolean> {
+  const out = new Map<string, string | boolean>();
+  for (const [key, value] of flags) {
+    out.set(key, Array.isArray(value) ? value[value.length - 1] ?? true : value);
+  }
+  return out;
 }
 
 // ─── Agent I/O helpers (A6) ──────────────────────────────────────────

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -77,7 +77,7 @@ USAGE
   pyric serve [flags]
   pyric init [dir] [--template=web|node]
   pyric snapshot [--out=FILE]
-  pyric verify [fixture|dir] [--rules=firestore.rules]
+  pyric verify [fixture|dir] [--service firestore|rtdb] [--rules service=path]
   pyric deploy <rules|indexes|database|hosting|functions>
   pyric hosting:channel:deploy <channelId> [--expires <ttl>]
   pyric rules:lint <path>
@@ -116,12 +116,12 @@ COMMANDS
                              .pyric/state/state.json) to a committable fixture that
                              \`pyric serve --seed FILE\` re-serves. Passwords are redacted
                              by default (--include-passwords keeps them). --port, --force, --json.
-  verify [fixture|dir]       Replay a captured sandbox session against your rules and
-                             report real divergences — writes that worked in the sandbox
-                             but would be DENIED by the rules you're shipping. No arg
-                             replays the latest \`pyric serve\` capture (.pyric/last-session.json).
-                             --rules=PATH (default firestore.rules), --json. Exit 1 on
-                             any real divergence.
+  verify [fixture|dir]       Replay a captured sandbox session against candidate rules
+                             for the Firestore/RTDB services present in the fixture.
+                             No arg replays the latest \`pyric serve\` capture
+                             (.pyric/last-session.json). --service filters services.
+                             --rules service=path overrides firebase.json resolution
+                             (repeat for mixed captures). --json. Exit 1 on divergence.
   deploy [target]            Deploy rules / indexes / database / hosting / functions.
                              hosting: deploys the firebase.json hosting block
                              (rewrites/redirects/headers/cleanUrls/trailingSlash/
@@ -238,10 +238,11 @@ function printVersion(): void {
   process.stdout.write(`${VERSION}\n`);
 }
 
-function splitCommaList(value: string | boolean | undefined): string[] {
-  if (typeof value !== 'string') return [];
-  return value
-    .split(',')
+function splitCommaList(value: string | boolean | Array<string | boolean> | undefined): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .filter((v): v is string => typeof v === 'string')
+    .flatMap((v) => v.split(','))
     .map((v) => v.trim())
     .filter((v) => v.length > 0);
 }

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -353,21 +353,6 @@ async function runBridge(parsed: ParsedArgs): Promise<number> {
           (requireConfirmAll ? `  ⚠  Paranoid mode: every tool prompts, even reads.\n` : '')
       : '';
 
-  process.stdout.write(
-    `\npyric bridge ${VERSION} ready\n` +
-      `  mode:    ${handle.bridge.mode}\n` +
-      `  project: ${handle.bridge.project}\n` +
-      `  health:  ${handle.url}/health\n` +
-      `  mcp:     ${handle.url}/mcp\n` +
-      `  sandbox: ${handle.url.replace('http://', 'ws://')}/sandbox\n` +
-      (handle.auditLogPath ? `  audit:   ${handle.auditLogPath}\n` : '') +
-      prodNotes +
-      `\nRegister with Claude Code:\n` +
-      `  claude mcp add --transport http pyric ${handle.url}/mcp --scope project\n` +
-      `\nBridge will log peer connect/disconnect to stderr. Set PYRIC_VERBOSE=1 for per-tool-call logs.\n` +
-      `Press Ctrl-C to stop.\n`,
-  );
-
   // Graceful shutdown. Idempotent because:
   //   1. npx forwards SIGINT to its child AND the terminal sends SIGINT
   //      to the process group, so one Ctrl-C delivers SIGINT TWICE to
@@ -404,6 +389,21 @@ async function runBridge(parsed: ParsedArgs): Promise<number> {
   };
   process.on('SIGINT', () => void stop('SIGINT'));
   process.on('SIGTERM', () => void stop('SIGTERM'));
+
+  process.stdout.write(
+    `\npyric bridge ${VERSION} ready\n` +
+      `  mode:    ${handle.bridge.mode}\n` +
+      `  project: ${handle.bridge.project}\n` +
+      `  health:  ${handle.url}/health\n` +
+      `  mcp:     ${handle.url}/mcp\n` +
+      `  sandbox: ${handle.url.replace('http://', 'ws://')}/sandbox\n` +
+      (handle.auditLogPath ? `  audit:   ${handle.auditLogPath}\n` : '') +
+      prodNotes +
+      `\nRegister with Claude Code:\n` +
+      `  claude mcp add --transport http pyric ${handle.url}/mcp --scope project\n` +
+      `\nBridge will log peer connect/disconnect to stderr. Set PYRIC_VERBOSE=1 for per-tool-call logs.\n` +
+      `Press Ctrl-C to stop.\n`,
+  );
 
   // Keep the event loop alive.
   return await new Promise<number>(() => {});

--- a/packages/pyric-tools/src/cli/parse-args.ts
+++ b/packages/pyric-tools/src/cli/parse-args.ts
@@ -10,12 +10,14 @@
 
 export interface ParsedArgs {
   subcommand: string | null;
-  flags: Map<string, string | boolean>;
+  flags: Map<string, FlagValue>;
   positional: string[];
 }
 
+export type FlagValue = string | boolean | Array<string | boolean>;
+
 export function parseArgs(argv: string[]): ParsedArgs {
-  const flags = new Map<string, string | boolean>();
+  const flags = new Map<string, FlagValue>();
   const positional: string[] = [];
   let subcommand: string | null = null;
   let i = 0;
@@ -28,18 +30,18 @@ export function parseArgs(argv: string[]): ParsedArgs {
     if (arg.startsWith('--')) {
       const eq = arg.indexOf('=');
       if (eq !== -1) {
-        flags.set(arg.slice(2, eq), arg.slice(eq + 1));
+        setFlag(flags, arg.slice(2, eq), arg.slice(eq + 1));
       } else {
         const next = argv[i + 1];
         if (next && !next.startsWith('-')) {
-          flags.set(arg.slice(2), next);
+          setFlag(flags, arg.slice(2), next);
           i += 1;
         } else {
-          flags.set(arg.slice(2), true);
+          setFlag(flags, arg.slice(2), true);
         }
       }
     } else if (arg.startsWith('-')) {
-      flags.set(arg.slice(1), true);
+      setFlag(flags, arg.slice(1), true);
     } else if (subcommand === null) {
       subcommand = arg;
     } else {
@@ -48,4 +50,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
     i += 1;
   }
   return { subcommand, flags, positional };
+}
+
+function setFlag(flags: Map<string, FlagValue>, key: string, value: string | boolean): void {
+  const current = flags.get(key);
+  if (current === undefined) {
+    flags.set(key, value);
+  } else if (Array.isArray(current)) {
+    current.push(value);
+  } else {
+    flags.set(key, [current, value]);
+  }
 }

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -22,7 +22,7 @@ import {
   materializeStudioUi,
   embeddedWorkerVersion,
 } from '../serve/standalone-assets.js';
-import { loadProjectRules, watchProjectRules } from '../serve/rules.js';
+import { loadProjectDatabaseRules, loadProjectRules, watchProjectRules } from '../serve/rules.js';
 import { createEventHub, createPyricNamespace, injectServeTags, type InitPayload } from '../serve/namespace.js';
 import { createStateStore, STATE_FILE_VERSION, type PyricStateFile } from '../serve/state-store.js';
 import { diskProjectStore, diskWorkspace } from '../serve/studio/index.js';
@@ -77,6 +77,7 @@ export function serveJsonLine(runtime: ServeRuntime): string {
     uiUrl: runtime.uiUrl,
     mcpUrl: runtime.mcpUrl,
     rulesHash: runtime.payload().rulesHash,
+    databaseRulesHash: runtime.payload().databaseRulesHash ?? null,
     persist: runtime.persist !== null,
     restoredDocs: runtime.persist?.restoredDocs ?? 0,
     restoredUsers: runtime.persist?.restoredUsers ?? 0,
@@ -157,7 +158,14 @@ export async function startServe(opts: {
   // Held in a mutable box — the watcher swaps it and the payload producer
   // always serves the live version.
   const loaded = await loadProjectRules(opts.cwd, config);
-  const live = { rules: loaded.rules, rulesHash: loaded.rulesHash };
+  const loadedDatabase = await loadProjectDatabaseRules(opts.cwd, config);
+  const live = {
+    rules: loaded.rules,
+    rulesHash: loaded.rulesHash,
+    databaseRules: loadedDatabase.rules,
+    databaseRulesHash: loadedDatabase.rulesHash,
+    databaseUrl: loadedDatabase.databaseUrl,
+  };
 
   // --capture (default on): the capture store writes .pyric/last-session.json
   // whenever the page pushes its session fixture via POST /__pyric/capture.
@@ -264,6 +272,9 @@ export async function startServe(opts: {
   const payload = (): InitPayload => ({
     rules: live.rules,
     rulesHash: live.rulesHash,
+    databaseRules: live.databaseRules,
+    databaseRulesHash: live.databaseRulesHash,
+    databaseUrl: live.databaseUrl,
     bridgeUrl: mount && origin.port > 0 ? mount.wsUrl(origin) : null,
     // Precedence: once a state file exists, the lived state is the truth —
     // --seed applies only on the first (state-less) run.
@@ -394,6 +405,11 @@ export async function startServe(opts: {
     loaded.rules
       ? `✔ rules    ${loaded.sourcePath} → deployed to the in-page sandbox (hash ${loaded.rulesHash})`
       : `• rules    no firestore.rules — sandbox runs with default rules`,
+  );
+  logger.info(
+    loadedDatabase.rules
+      ? `✔ rules    ${loadedDatabase.sourcePath} → deployed to the RTDB sandbox (hash ${loadedDatabase.rulesHash})`
+      : `• rules    no database.rules — RTDB sandbox runs with default rules`,
   );
   if (uiUrl) {
     logger.info(`✔ studio   Pyric Studio: ${uiUrl}`);

--- a/packages/pyric-tools/src/cli/verify.ts
+++ b/packages/pyric-tools/src/cli/verify.ts
@@ -1,121 +1,92 @@
-/**
- * `pyric verify` — the swap-trust capstone.
- *
- * Replays a captured sandbox session against a ruleset and reports
- * `real-divergence`s: writes that SUCCEEDED at capture time but are denied
- * or changed under the rules you're about to deploy. That's the "will the
- * rules I'm shipping break what I built in the sandbox?" check — the
- * verification half of pyric's "build in sandbox, swap to prod" pitch.
- *
- * The engine is `replay()` from `pyric/sandbox` (shipped). This command is
- * the user-facing wrapper: take a fixture (or a directory of them) +
- * a rules file, replay, classify, exit nonzero on any real divergence.
- *
- *   pyric verify [fixture|dir] [--rules firestore.rules] [--json]
- *
- * With no positional arg it replays the latest `pyric serve` capture at
- * `.pyric/last-session.json`, so the loop is: serve → use your app →
- * `pyric verify`. autoid-alias / time-drift / sentinel-drift divergences are
- * informational (the engine licenses them); only `real-divergence` fails.
- *
- * Everything above the CLI entry is pure/synchronous given its inputs — the
- * same shape as `examples/replay/ci/check-fixtures.ts`, which this promotes
- * from a CI script into a real subcommand.
- */
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
-import { replay, type Divergence, type SandboxEvent } from 'pyric/sandbox';
-import type { ParsedArgs } from './parse-args.js';
+import {
+  fixtureVerifiableServices,
+  parseVerifyFixture,
+  verifyFixture,
+  VerifyInputError,
+  type PyricVerifyFixture,
+  type VerifiableService,
+  type VerifyDivergence,
+  type VerifyResult,
+  type VerifyRulesInput,
+  type VerifyServiceResult,
+} from '../verify/index.js';
+import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
+import type { FlagValue, ParsedArgs } from './parse-args.js';
 
-/** One captured user journey. Matches the fixture shape produced by serve
- *  capture and `examples/replay/ci/check-fixtures.ts`. */
-export interface Fixture {
-  description?: string;
-  /** Rules at capture time — informational; the replay runs against the
-   *  rules file passed to verify. The diff between the two is what surfaces
-   *  real divergences. */
-  rules: string;
-  events: SandboxEvent[];
-  state: Record<string, Record<string, unknown>>;
-}
+export type Fixture = PyricVerifyFixture;
 
 export interface FixtureResult {
   name: string;
   description?: string;
-  realDivergences: Divergence[];
-  /** Non-bug-signal divergences: autoid-alias, time-drift, sentinel-drift. */
-  otherDivergences: Divergence[];
   ok: boolean;
+  result: VerifyResult;
 }
 
-/** Replay one fixture against `currentRules`, splitting real divergences
- *  (the bug signal) from the licensed/informational ones. */
-export function runFixture(name: string, fixture: Fixture, currentRules: string): FixtureResult {
-  const { divergences } = replay(fixture.events, currentRules, {}, fixture.state);
-  const realDivergences = divergences.filter((d) => d.kind === 'real-divergence');
-  const otherDivergences = divergences.filter((d) => d.kind !== 'real-divergence');
+export const SERVE_CAPTURE_PATH = '.pyric/last-session.json';
+
+export function loadFixture(path: string): Fixture {
+  return parseVerifyFixture(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+export async function runFixture(
+  name: string,
+  fixture: Fixture,
+  rules: VerifyRulesInput,
+  services?: VerifiableService[],
+): Promise<FixtureResult> {
+  const result = await verifyFixture(fixture, { rules, ...(services ? { services } : {}) });
   return {
     name,
     ...(fixture.description !== undefined ? { description: fixture.description } : {}),
-    realDivergences,
-    otherDivergences,
-    ok: realDivergences.length === 0,
+    ok: result.ok,
+    result,
   };
 }
 
-export function loadFixture(path: string): Fixture {
-  return JSON.parse(readFileSync(path, 'utf8')) as Fixture;
-}
-
-/** Replay every `*.json` fixture in a directory. */
-export function checkDirectory(dir: string, currentRules: string): { results: FixtureResult[]; allOk: boolean } {
+export async function checkDirectory(
+  dir: string,
+  rules: VerifyRulesInput,
+  services?: VerifiableService[],
+): Promise<{ results: FixtureResult[]; allOk: boolean }> {
   const files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
-  const results = files.map((f) => runFixture(basename(f, '.json'), loadFixture(join(dir, f)), currentRules));
+  const results = await Promise.all(
+    files.map((f) => runFixture(basename(f, '.json'), loadFixture(join(dir, f)), rules, services)),
+  );
   return { results, allOk: results.every((r) => r.ok) };
 }
 
 export function formatResults(results: FixtureResult[]): string {
   const lines: string[] = [];
-  for (const r of results) {
-    const marker = r.ok ? '✓' : '✗';
-    const desc = r.description ? ` — ${r.description}` : '';
-    const summary = r.ok
-      ? `${r.otherDivergences.length} informational divergence(s)`
-      : `${r.realDivergences.length} real-divergence(s)`;
-    lines.push(`${marker} ${r.name}${desc} — ${summary}`);
-    // Point at the offending leaf so the failure names its cause.
-    for (const d of r.realDivergences) {
-      const where = d.kind === 'real-divergence' ? `${d.path}${d.field ? '.' + d.field : ''}` : '';
-      const delta = d.kind === 'real-divergence' ? `${JSON.stringify(d.before)} → ${JSON.stringify(d.after)}` : '';
-      lines.push(`    ${where}: ${delta}`);
+  for (const result of results) {
+    const marker = result.ok ? '✓' : '✗';
+    const desc = result.description ? ` - ${result.description}` : '';
+    const serviceSummary = Object.values(result.result.services)
+      .filter((service): service is VerifyServiceResult => service !== undefined)
+      .map((service) => {
+        const failures = failingDivergences(service.divergences).length;
+        const info = service.divergences.length - failures;
+        return service.ok
+          ? `${service.service}: ok (${info} informational)`
+          : `${service.service}: ${failures} failure(s)`;
+      })
+      .join(', ');
+    lines.push(`${marker} ${result.name}${desc} - ${serviceSummary}`);
+    for (const service of Object.values(result.result.services)) {
+      if (!service) continue;
+      for (const divergence of failingDivergences(service.divergences)) {
+        lines.push(`    [${service.service}] ${formatDivergence(divergence)}`);
+      }
     }
   }
   return lines.join('\n');
 }
 
-/** Default capture location written by `pyric serve` (Piece 2). */
-export const SERVE_CAPTURE_PATH = '.pyric/last-session.json';
-
-/**
- * CLI entry. `pyric verify [fixture|dir] [--rules <path>] [--json]`.
- * Exit: 0 = no real divergence, 1 = at least one, 2 = usage/missing input.
- */
 export async function runVerify(parsed: ParsedArgs): Promise<number> {
   const cwd = process.cwd();
   const json = parsed.flags.get('json') === true;
 
-  const rulesFlag = parsed.flags.get('rules');
-  const rulesPath = resolve(cwd, typeof rulesFlag === 'string' ? rulesFlag : 'firestore.rules');
-  if (!existsSync(rulesPath)) {
-    process.stderr.write(
-      `pyric verify: rules file not found: ${rulesPath}\n` +
-        `  Pass --rules <path> to point at the ruleset you're verifying against.\n`,
-    );
-    return 2;
-  }
-  const currentRules = readFileSync(rulesPath, 'utf8');
-
-  // No positional → the latest serve capture. A path → that file or dir.
   const target = parsed.positional[0];
   const inputPath = resolve(cwd, target ?? SERVE_CAPTURE_PATH);
   if (!existsSync(inputPath)) {
@@ -124,56 +95,215 @@ export async function runVerify(parsed: ParsedArgs): Promise<number> {
     } else {
       process.stderr.write(
         `pyric verify: no captured session at ${SERVE_CAPTURE_PATH}.\n` +
-          `  Run \`pyric serve\`, exercise your app, then \`pyric verify\` — or pass a fixture path.\n`,
+          '  Run `pyric serve`, exercise your app, then `pyric verify`, or pass a fixture path.\n',
       );
     }
     return 2;
   }
 
-  let results: FixtureResult[];
-  let allOk: boolean;
+  let loaded: Array<{ name: string; fixture: Fixture }>;
   try {
-    if (statSync(inputPath).isDirectory()) {
-      ({ results, allOk } = checkDirectory(inputPath, currentRules));
-      if (results.length === 0) {
-        process.stderr.write(`pyric verify: no .json fixtures in ${inputPath}\n`);
-        return 2;
-      }
-    } else {
-      const result = runFixture(basename(inputPath, '.json'), loadFixture(inputPath), currentRules);
-      results = [result];
-      allOk = result.ok;
-    }
+    loaded = statSync(inputPath).isDirectory()
+      ? loadFixturesFromDirectory(inputPath)
+      : [{ name: basename(inputPath, '.json'), fixture: loadFixture(inputPath) }];
   } catch (e) {
-    process.stderr.write(`pyric verify: failed to replay: ${e instanceof Error ? e.message : String(e)}\n`);
+    process.stderr.write(`pyric verify: failed to load fixture: ${messageOf(e)}\n`);
     return 2;
   }
+  if (loaded.length === 0) {
+    process.stderr.write(`pyric verify: no .json fixtures in ${inputPath}\n`);
+    return 2;
+  }
+
+  let services: VerifiableService[];
+  try {
+    services = selectedServices(parsed.flags.get('service'), loaded.map((item) => item.fixture));
+  } catch (e) {
+    process.stderr.write(`pyric verify: ${messageOf(e)}\n`);
+    return 2;
+  }
+
+  let rulesResolution: { rules: VerifyRulesInput; paths: Partial<Record<VerifiableService, string>> };
+  try {
+    rulesResolution = await resolveCandidateRules(cwd, services, parsed.flags.get('rules'));
+  } catch (e) {
+    process.stderr.write(`pyric verify: ${messageOf(e)}\n`);
+    return 2;
+  }
+
+  let results: FixtureResult[];
+  try {
+    results = await Promise.all(
+      loaded.map((item) => runFixture(item.name, item.fixture, rulesResolution.rules, services)),
+    );
+  } catch (e) {
+    const prefix = e instanceof VerifyInputError ? 'invalid input' : 'failed to replay';
+    process.stderr.write(`pyric verify: ${prefix}: ${messageOf(e)}\n`);
+    return 2;
+  }
+  const allOk = results.every((result) => result.ok);
 
   if (json) {
     process.stdout.write(
       JSON.stringify({
         ok: allOk,
-        rulesPath,
-        results: results.map((r) => ({
-          name: r.name,
-          description: r.description,
-          ok: r.ok,
-          realDivergences: r.realDivergences,
-          otherDivergenceCount: r.otherDivergences.length,
+        rulesPaths: rulesResolution.paths,
+        results: results.map((result) => ({
+          name: result.name,
+          description: result.description,
+          ok: result.ok,
+          services: result.result.services,
         })),
       }) + '\n',
     );
   } else {
     process.stdout.write(formatResults(results) + '\n');
     if (!allOk) {
-      const failed = results.filter((r) => !r.ok).length;
+      const failed = results.filter((result) => !result.ok).length;
+      const rules = Object.entries(rulesResolution.paths)
+        .map(([service, path]) => `${service}=${basename(path)}`)
+        .join(', ');
       process.stderr.write(
-        `\n✗ ${failed} session(s) regressed under ${basename(rulesPath)} — ` +
-          `writes that worked in the sandbox would be DENIED by these rules.\n`,
+        `\n✗ ${failed} session(s) regressed under ${rules}.\n`,
       );
     } else {
-      process.stdout.write(`\n✓ all sessions replay cleanly under ${basename(rulesPath)}.\n`);
+      process.stdout.write('\n✓ all selected services replay cleanly.\n');
     }
   }
   return allOk ? 0 : 1;
+}
+
+function loadFixturesFromDirectory(dir: string): Array<{ name: string; fixture: Fixture }> {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((f) => ({ name: basename(f, '.json'), fixture: loadFixture(join(dir, f)) }));
+}
+
+function selectedServices(flag: FlagValue | undefined, fixtures: Fixture[]): VerifiableService[] {
+  const explicit = flagStrings(flag);
+  if (explicit.length > 0) {
+    return explicit.map(toVerifiableService);
+  }
+
+  const union = new Set<VerifiableService>();
+  for (const fixture of fixtures) {
+    for (const service of fixtureVerifiableServices(fixture)) {
+      union.add(service);
+    }
+  }
+  if (union.size === 0) {
+    throw new Error('fixture does not contain firestore or rtdb rules services.');
+  }
+  return [...union].sort();
+}
+
+async function resolveCandidateRules(
+  cwd: string,
+  services: VerifiableService[],
+  rulesFlag: FlagValue | undefined,
+): Promise<{ rules: VerifyRulesInput; paths: Partial<Record<VerifiableService, string>> }> {
+  const overrides = parseRulesOverrides(rulesFlag);
+  const needsDefaults = services.some((service) => !overrides.has(service));
+  const firebaseJson = needsDefaults ? await readFirebaseJsonOrNull(cwd) : null;
+
+  const rules: VerifyRulesInput = {};
+  const paths: Partial<Record<VerifiableService, string>> = {};
+  for (const service of services) {
+    const rel = overrides.get(service) ?? defaultRulesPath(firebaseJson, service);
+    if (!rel) {
+      throw new Error(
+        `missing candidate ${service} rules. Pass --rules ${service}=<path> or configure firebase.json.`,
+      );
+    }
+    const path = resolve(cwd, rel);
+    if (!existsSync(path)) {
+      throw new Error(`rules file not found for ${service}: ${path}`);
+    }
+    paths[service] = path;
+    if (service === 'firestore') {
+      rules.firestore = readFileSync(path, 'utf8');
+    } else if (service === 'rtdb') {
+      rules.rtdb = parseRtdbRulesFile(path);
+    }
+  }
+  return { rules, paths };
+}
+
+function parseRulesOverrides(flag: FlagValue | undefined): Map<VerifiableService, string> {
+  const out = new Map<VerifiableService, string>();
+  for (const raw of flagStrings(flag)) {
+    const eq = raw.indexOf('=');
+    if (eq <= 0 || eq === raw.length - 1) {
+      throw new Error(`--rules must use service-qualified values like --rules rtdb=database.rules.json.`);
+    }
+    const service = toVerifiableService(raw.slice(0, eq));
+    out.set(service, raw.slice(eq + 1));
+  }
+  return out;
+}
+
+function defaultRulesPath(config: FirebaseJson | null, service: VerifiableService): string | undefined {
+  if (service === 'firestore') return config?.firestore?.rules;
+  if (service === 'rtdb') return config?.database?.rules;
+  return undefined;
+}
+
+async function readFirebaseJsonOrNull(cwd: string): Promise<FirebaseJson | null> {
+  try {
+    return await readFirebaseJson(cwd);
+  } catch {
+    return null;
+  }
+}
+
+function parseRtdbRulesFile(path: string): { rules: Record<string, unknown> } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    throw new Error(`failed to parse RTDB rules JSON at ${path}: ${messageOf(e)}`);
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.rules)) {
+    throw new Error(`RTDB rules file must contain a top-level "rules" object: ${path}`);
+  }
+  return parsed as { rules: Record<string, unknown> };
+}
+
+function toVerifiableService(raw: string): VerifiableService {
+  if (raw === 'firestore' || raw === 'rtdb') return raw;
+  if (raw === 'database') return 'rtdb';
+  throw new Error(`unsupported verify service '${raw}'. Supported services: firestore, rtdb.`);
+}
+
+function flagStrings(value: FlagValue | undefined): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function failingDivergences(divergences: VerifyDivergence[]): VerifyDivergence[] {
+  return divergences.filter((divergence) => divergence.kind !== 'expected-drift');
+}
+
+function formatDivergence(divergence: VerifyDivergence): string {
+  if (divergence.kind === 'now-denied') {
+    const method = divergence.method ? `${divergence.method} ` : '';
+    return `now-denied: ${method}${divergence.path ?? ''}${divergence.reason ? ` (${divergence.reason})` : ''}`;
+  }
+  if (divergence.kind === 'state-drift') {
+    const where = `${divergence.path ?? ''}${divergence.field ? `.${divergence.field}` : ''}`;
+    return `state-drift: ${where}: ${JSON.stringify(divergence.before)} -> ${JSON.stringify(divergence.after)}`;
+  }
+  if (divergence.kind === 'unsupported') {
+    return `unsupported: ${divergence.method ?? 'operation'} ${divergence.path ?? ''}: ${divergence.reason}`;
+  }
+  return `${divergence.drift}: ${divergence.path ?? ''}`;
+}
+
+function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/serve/bundler.ts
+++ b/packages/pyric-tools/src/serve/bundler.ts
@@ -38,7 +38,7 @@ import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
 /** Modules the import map serves. Keys are the bare specifiers app code uses. */
-export const SDK_MODULES = ['firebase/app', 'firebase/auth', 'firebase/firestore'] as const;
+export const SDK_MODULES = ['firebase/app', 'firebase/auth', 'firebase/firestore', 'firebase/database'] as const;
 
 /**
  * The wrapper entries shipped with pyric-tools, located relative to this
@@ -54,7 +54,13 @@ export function defaultSdkEntries(): Record<string, string> {
     if (existsSync(ts)) return ts;
     throw new Error(`pyric serve: missing SDK entry '${name}' next to ${here}`);
   };
-  return { app: pick('app'), auth: pick('auth'), firestore: pick('firestore'), init: pick('init') };
+  return {
+    app: pick('app'),
+    auth: pick('auth'),
+    firestore: pick('firestore'),
+    database: pick('database'),
+    init: pick('init'),
+  };
 }
 
 /**

--- a/packages/pyric-tools/src/serve/entries/database.ts
+++ b/packages/pyric-tools/src/serve/entries/database.ts
@@ -1,0 +1,92 @@
+/**
+ * The bundle the import map serves for `firebase/database`.
+ *
+ * The SharedWorker client already carries the RTDB data-plane used by Studio
+ * and the Playground. This entry gives served apps the same common modular SDK
+ * surface while the in-page fallback delegates to `pyric/database`.
+ */
+import * as ip from 'pyric/database/modular';
+import { getDatabase as pyricGetDatabase } from 'pyric/database/modular';
+import {
+  rtdbChild,
+  rtdbConnectDatabaseEmulator,
+  rtdbGet,
+  rtdbGetDatabase,
+  rtdbOff,
+  rtdbOnValue,
+  rtdbPush,
+  rtdbRef,
+  rtdbRemove,
+  rtdbServerTimestamp,
+  rtdbSet,
+  rtdbUpdate,
+} from '../worker/client.js';
+import { sandbox, workerDb, useWorker } from './runtime.js';
+
+export const getDatabase = (
+  useWorker
+    ? (_app?: unknown) => rtdbGetDatabase(workerDb!)
+    : (target?: Parameters<typeof pyricGetDatabase>[0]) =>
+        pyricGetDatabase((target ?? sandbox) as never)
+) as typeof pyricGetDatabase;
+
+export const ref = (useWorker ? rtdbRef : ip.ref) as typeof ip.ref;
+export const child = (useWorker ? rtdbChild : ip.child) as typeof ip.child;
+export const get = (useWorker ? rtdbGet : ip.get) as typeof ip.get;
+export const set = (useWorker ? rtdbSet : ip.set) as typeof ip.set;
+export const update = (useWorker ? rtdbUpdate : ip.update) as typeof ip.update;
+export const remove = (useWorker ? rtdbRemove : ip.remove) as typeof ip.remove;
+export const push = (useWorker ? rtdbPush : ip.push) as typeof ip.push;
+export const onValue = (useWorker ? rtdbOnValue : ip.onValue) as typeof ip.onValue;
+export const off = (useWorker ? rtdbOff : ip.off) as typeof ip.off;
+export const serverTimestamp = (
+  useWorker ? rtdbServerTimestamp : ip.serverTimestamp
+) as typeof ip.serverTimestamp;
+export const connectDatabaseEmulator = (
+  useWorker ? rtdbConnectDatabaseEmulator : ip.connectDatabaseEmulator
+) as typeof ip.connectDatabaseEmulator;
+
+function unsupportedWorkerApi(name: string): never {
+  throw new Error(
+    `firebase/database ${name}() is not supported over the pyric SharedWorker yet. ` +
+      'Use the in-page fallback for this operation.',
+  );
+}
+
+export const runTransaction = (
+  useWorker ? (() => unsupportedWorkerApi('runTransaction')) : ip.runTransaction
+) as typeof ip.runTransaction;
+
+export const query = (
+  useWorker ? (() => unsupportedWorkerApi('query')) : ip.query
+) as typeof ip.query;
+export const orderByChild = (
+  useWorker ? (() => unsupportedWorkerApi('orderByChild')) : ip.orderByChild
+) as typeof ip.orderByChild;
+export const orderByKey = (
+  useWorker ? (() => unsupportedWorkerApi('orderByKey')) : ip.orderByKey
+) as typeof ip.orderByKey;
+export const orderByValue = (
+  useWorker ? (() => unsupportedWorkerApi('orderByValue')) : ip.orderByValue
+) as typeof ip.orderByValue;
+export const startAt = (
+  useWorker ? (() => unsupportedWorkerApi('startAt')) : ip.startAt
+) as typeof ip.startAt;
+export const startAfter = (
+  useWorker ? (() => unsupportedWorkerApi('startAfter')) : ip.startAfter
+) as typeof ip.startAfter;
+export const endAt = (
+  useWorker ? (() => unsupportedWorkerApi('endAt')) : ip.endAt
+) as typeof ip.endAt;
+export const endBefore = (
+  useWorker ? (() => unsupportedWorkerApi('endBefore')) : ip.endBefore
+) as typeof ip.endBefore;
+export const equalTo = (
+  useWorker ? (() => unsupportedWorkerApi('equalTo')) : ip.equalTo
+) as typeof ip.equalTo;
+export const limitToFirst = (
+  useWorker ? (() => unsupportedWorkerApi('limitToFirst')) : ip.limitToFirst
+) as typeof ip.limitToFirst;
+export const limitToLast = (
+  useWorker ? (() => unsupportedWorkerApi('limitToLast')) : ip.limitToLast
+) as typeof ip.limitToLast;

--- a/packages/pyric-tools/src/serve/entries/runtime.ts
+++ b/packages/pyric-tools/src/serve/entries/runtime.ts
@@ -20,6 +20,7 @@ import {
   bundleRecords,
 } from 'pyric/sandbox';
 import { getFirestore, sandbox as sandboxOps } from 'pyric/firestore';
+import { getDatabase, sandbox as rtdbSandbox } from 'pyric/database/modular';
 import { getAuth, onAuthStateChanged, signOut, sandbox as authOps, type SeedUser } from 'pyric/auth';
 import {
   getFirestore as workerGetFirestore,
@@ -33,6 +34,7 @@ import {
 import { SessionStore } from './session-store.js';
 import { keepaliveSafe } from './keepalive.js';
 import { toPageOriginWsUrl } from './bridge-url.js';
+import { buildVerifyFixture } from '../../verify/fixture.js';
 
 /**
  * The DEFAULT-ON worker path (Phase 3c): when SharedWorker is available the
@@ -136,6 +138,10 @@ interface InitPayload {
   rules: string | null;
   /** sha256 prefix of the rules source — diagnostics + hot-reload diffing. */
   rulesHash: string | null;
+  /** Firebase RTDB rules JSON, when firebase.json has database.rules. */
+  databaseRules?: { rules: Record<string, unknown> } | null;
+  databaseRulesHash?: string | null;
+  databaseUrl?: string | null;
   /** Bridge WS URL when `--bridge` is on (P2); null otherwise. */
   bridgeUrl: string | null;
   /** `--seed` documents (path → fields), applied admin-style before app code runs.
@@ -157,7 +163,9 @@ interface InitPayload {
 interface ServeDiagnostics {
   sandboxReady: boolean;
   rulesDeployed: boolean;
+  databaseRulesDeployed: boolean;
   rulesHash: string | null;
+  databaseRulesHash: string | null;
   initError: string | null;
   bridgeConnected: boolean;
   seededDocs: number;
@@ -176,7 +184,9 @@ declare global {
 const diagnostics: ServeDiagnostics = {
   sandboxReady: true,
   rulesDeployed: false,
+  databaseRulesDeployed: false,
   rulesHash: null,
+  databaseRulesHash: null,
   initError: null,
   bridgeConnected: false,
   seededDocs: 0,
@@ -209,6 +219,11 @@ if (!useWorker) try {
     }
     diagnostics.rulesDeployed = true;
     diagnostics.rulesHash = payload.rulesHash;
+  }
+  if (payload.databaseRules) {
+    rtdbSandbox.setRules(getDatabase(sandbox), payload.databaseRules);
+    diagnostics.databaseRulesDeployed = true;
+    diagnostics.databaseRulesHash = payload.databaseRulesHash ?? null;
   }
   // Auth users land first in either mode (persist restore or state-file
   // fixture) so restored docs' owner uids resolve in rules and the session
@@ -355,11 +370,22 @@ if (!useWorker) try {
     // --persist — capture is about the verify loop, persist is about
     // cross-reload durability.
     const flushCapture = (): void => {
-      const body = JSON.stringify({
-        rules: payload.rules ?? '',
-        events: sandbox.history(),
-        state: sandbox.snapshot().firestore,
-      });
+      const rtdbState =
+        payload.databaseRules || sandbox.history().some((event) => event.service === 'rtdb')
+          ? rtdbSandbox.snapshotState(getDatabase(sandbox))
+          : undefined;
+      const auth = getAuth(sandbox);
+      const body = JSON.stringify(buildVerifyFixture({
+        sandbox,
+        firestoreRules: payload.rules,
+        rtdbRules: payload.databaseRules ?? null,
+        rtdbState,
+        rtdbDatabaseUrl: payload.databaseUrl ?? null,
+        authState: {
+          users: authOps.exportUsers(auth),
+          currentUser: auth.currentUser,
+        },
+      }));
       fetch('/__pyric/capture', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },

--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -23,6 +23,9 @@ import { contentTypeFor, resolveStaticFile } from './server.js';
 export interface InitPayload {
   rules: string | null;
   rulesHash: string | null;
+  databaseRules?: { rules: Record<string, unknown> } | null;
+  databaseRulesHash?: string | null;
+  databaseUrl?: string | null;
   bridgeUrl: string | null;
   /** `--seed` documents (path → fields), applied admin-style at page init.
    *  Null in persist mode once a state file exists — the lived state wins. */

--- a/packages/pyric-tools/src/serve/rules.ts
+++ b/packages/pyric-tools/src/serve/rules.ts
@@ -25,6 +25,13 @@ export interface LoadedRules {
   sourcePath: string | null;
 }
 
+export interface LoadedDatabaseRules {
+  rules: { rules: Record<string, unknown> } | null;
+  rulesHash: string | null;
+  sourcePath: string | null;
+  databaseUrl: string | null;
+}
+
 export function rulesHashOf(source: string): string {
   return createHash('sha256').update(source).digest('hex').slice(0, 12);
 }
@@ -91,6 +98,49 @@ export async function loadProjectRules(
   return { rules, rulesHash: rulesHashOf(rules), sourcePath: path };
 }
 
+export async function loadProjectDatabaseRules(
+  cwd: string,
+  config: FirebaseJson | null,
+): Promise<LoadedDatabaseRules> {
+  const configured = config?.database?.rules;
+  if (!configured) {
+    return {
+      rules: null,
+      rulesHash: null,
+      sourcePath: null,
+      databaseUrl: config?.database?.url ?? null,
+    };
+  }
+
+  const path = isAbsolute(configured) ? configured : join(cwd, configured);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`pyric serve: firebase.json points database.rules at ${path}, but it does not exist.`);
+    }
+    throw e;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`pyric serve: ${path} failed to parse as RTDB rules JSON: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.rules)) {
+    throw new Error(`pyric serve: ${path} must contain a top-level "rules" object.`);
+  }
+
+  return {
+    rules: parsed as { rules: Record<string, unknown> },
+    rulesHash: rulesHashOf(raw),
+    sourcePath: path,
+    databaseUrl: config?.database?.url ?? null,
+  };
+}
+
 /**
  * Watch the rules file and invoke `onChange` with freshly prepared
  * (resolved + linted) source. Broken intermediate saves are LOGGED and
@@ -121,4 +171,8 @@ export function watchProjectRules(
       );
     }, debounceMs);
   });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/serve/vite-plugin.ts
+++ b/packages/pyric-tools/src/serve/vite-plugin.ts
@@ -56,7 +56,7 @@ import {
 import { createEventHub, createPyricNamespace, type InitPayload } from './namespace.js';
 import { diskWorkspace, diskProjectStore } from './studio/index.js';
 import { createBridgeMount } from './bridge-mount.js';
-import { loadProjectRules, prepareRulesSource, rulesHashOf } from './rules.js';
+import { loadProjectDatabaseRules, loadProjectRules, prepareRulesSource, rulesHashOf } from './rules.js';
 import { createStateStore, STATE_FILE_VERSION, type PyricStateFile } from './state-store.js';
 import { createCaptureStore } from './capture-store.js';
 import { isAllowedHost } from './server.js';
@@ -65,7 +65,7 @@ import { readFirebaseJson, type FirebaseJson } from '../cli/firebase-json.js';
 /** Any `firebase/<sub>` specifier. */
 const FB_ANY = /^firebase\/([a-z-]+)$/;
 /** The only subpaths with a swap entry (mirror of `SDK_MODULES`). */
-const SERVED = new Set(['app', 'auth', 'firestore']);
+const SERVED = new Set(['app', 'auth', 'firestore', 'database']);
 const STUB_PREFIX = '\0pyric:fb-stub:';
 const NODE_SHIM_PREFIX = '\0pyric:node-shim:';
 
@@ -204,7 +204,19 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
 
   // Live rules box — the watcher swaps it; the init payload always serves the
   // current version.
-  const live: { rules: string | null; rulesHash: string | null } = { rules: null, rulesHash: null };
+  const live: {
+    rules: string | null;
+    rulesHash: string | null;
+    databaseRules: { rules: Record<string, unknown> } | null;
+    databaseRulesHash: string | null;
+    databaseUrl: string | null;
+  } = {
+    rules: null,
+    rulesHash: null,
+    databaseRules: null,
+    databaseRulesHash: null,
+    databaseUrl: null,
+  };
 
   // M2: the SharedWorker bundle's content hash (sync) — stamped into the page so
   // a still-running OLD worker is detected as stale. `workerReady` flips true once
@@ -292,8 +304,12 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
         ? { ...(fbJson ?? {}), firestore: { ...(fbJson?.firestore ?? {}), rules: options.rules } }
         : fbJson;
       const loaded = await loadProjectRules(cwd, config);
+      const loadedDatabase = await loadProjectDatabaseRules(cwd, config);
       live.rules = loaded.rules;
       live.rulesHash = loaded.rulesHash;
+      live.databaseRules = loadedDatabase.rules;
+      live.databaseRulesHash = loadedDatabase.rulesHash;
+      live.databaseUrl = loadedDatabase.databaseUrl;
 
       // ── M2 durable stores (mirrors serve's startServe orchestration) ──────
       // Capture (default-on): the worker/page pushes its session fixture to
@@ -394,6 +410,9 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
       const initPayload = (): InitPayload => ({
         rules: live.rules,
         rulesHash: live.rulesHash,
+        databaseRules: live.databaseRules,
+        databaseRulesHash: live.databaseRulesHash,
+        databaseUrl: live.databaseUrl,
         // The bound port is known only after `listen`; initPayload runs per
         // request (after listen), so resolve it lazily here. Absolute ws://host:port
         // mirrors serve (the browser reads this as the bridge peer URL).

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -28,11 +28,13 @@
  */
 
 import { sandbox as sandboxOps } from 'pyric/firestore';
+import { getDatabase, sandbox as rtdbSandbox } from 'pyric/database/modular';
 import { sandbox as authOps, type SeedUser } from 'pyric/auth';
 import type { PersistenceBackend } from 'pyric/sandbox';
 import { serializeToBuckets, bundleRecords, parseBundle } from 'pyric/sandbox';
 import type { InitPayload } from '../namespace.js';
 import { ensureAuth, type HostCtx } from './host.js';
+import { buildVerifyFixture } from '../../verify/fixture.js';
 
 /** Injected environment — `fetch` is the only ambient the worker init needs
  *  (capture POSTs through it). Injectable so tests drive it with a stub. */
@@ -128,6 +130,17 @@ export function applyServeInit(
       result.rulesDeployed = true;
     }
   }
+  if (payload.databaseRules) {
+    const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
+    rtdbSandbox.setRules(rtdb, payload.databaseRules);
+    ctx.activeRules ??= {};
+    ctx.activeRules.database = {
+      source: payload.databaseRules,
+      updatedAt: Date.now(),
+      status: 'active',
+      messages: [],
+    };
+  }
 
   // 2. Auth users — seed BEFORE docs so any owner-uid the rules reference
   //    resolves, and before session restore so there is a DB to restore into.
@@ -152,11 +165,23 @@ export function applyServeInit(
     let timer: ReturnType<typeof setTimeout> | null = null;
 
     const flush = (): void => {
-      const body = JSON.stringify({
-        rules: payload.rules ?? '',
-        events: ctx.sandbox.history(),
-        state: ctx.sandbox.snapshot().firestore,
-      });
+      const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
+      const rtdbState =
+        payload.databaseRules || ctx.sandbox.history().some((event) => event.service === 'rtdb')
+          ? rtdbSandbox.snapshotState(rtdb)
+          : undefined;
+      const auth = ensureAuth(ctx);
+      const body = JSON.stringify(buildVerifyFixture({
+        sandbox: ctx.sandbox,
+        firestoreRules: payload.rules,
+        rtdbRules: payload.databaseRules ?? null,
+        rtdbState,
+        rtdbDatabaseUrl: payload.databaseUrl ?? null,
+        authState: {
+          users: authOps.exportUsers(auth),
+          currentUser: ctx.sandbox.currentUser,
+        },
+      }));
       // Relative URL resolves against the worker script's origin (same origin
       // as the page). Fire-and-forget — capture failures never break ops.
       env

--- a/packages/pyric-tools/src/verify/fixture.ts
+++ b/packages/pyric-tools/src/verify/fixture.ts
@@ -1,0 +1,184 @@
+import type { EventService, Sandbox, SandboxEvent } from 'pyric/sandbox';
+
+export const VERIFY_FIXTURE_SCHEMA = 'pyric.verify.fixture.v1' as const;
+
+export interface VerifyFirestoreRulesBlock {
+  format: 'firestore.rules';
+  source: string;
+}
+
+export interface VerifyRtdbRulesBlock {
+  format: 'rtdb.rules.json';
+  json: { rules: Record<string, unknown> };
+}
+
+export interface PyricVerifyFixture {
+  schema: typeof VERIFY_FIXTURE_SCHEMA;
+  description?: string;
+  createdAt?: string;
+  events: SandboxEvent[];
+  services: {
+    firestore?: {
+      rules: VerifyFirestoreRulesBlock;
+      state: { documents: Record<string, Record<string, unknown>> };
+    };
+    rtdb?: {
+      rules: VerifyRtdbRulesBlock;
+      state: { tree: unknown };
+      databaseUrl?: string;
+    };
+    auth?: {
+      state: {
+        users?: unknown[];
+        currentUser?: unknown;
+      };
+    };
+    storage?: {
+      rules?: { format: 'storage.rules'; source: string };
+      state: unknown;
+    };
+    [service: string]: unknown;
+  };
+}
+
+export interface BuildVerifyFixtureInput {
+  sandbox: Pick<Sandbox, 'history' | 'snapshot'> & { currentUser?: unknown };
+  description?: string;
+  firestoreRules?: string | null;
+  rtdbRules?: { rules: Record<string, unknown> } | null;
+  rtdbState?: unknown;
+  rtdbDatabaseUrl?: string | null;
+  authState?: {
+    users?: unknown[];
+    currentUser?: unknown;
+  } | null;
+  createdAt?: string;
+}
+
+export function buildVerifyFixture(input: BuildVerifyFixtureInput): PyricVerifyFixture {
+  const events = input.sandbox.history();
+  const snapshot = input.sandbox.snapshot();
+  const firestoreDocuments = snapshot.firestore;
+  const services: PyricVerifyFixture['services'] = {};
+
+  if (
+    input.firestoreRules != null ||
+    Object.keys(firestoreDocuments).length > 0 ||
+    events.some((event) => eventService(event) === 'firestore')
+  ) {
+    services.firestore = {
+      rules: {
+        format: 'firestore.rules',
+        source: input.firestoreRules ?? '',
+      },
+      state: { documents: firestoreDocuments },
+    };
+  }
+
+  if (
+    input.rtdbRules != null ||
+    input.rtdbState !== undefined ||
+    events.some((event) => eventService(event) === 'rtdb')
+  ) {
+    services.rtdb = {
+      rules: {
+        format: 'rtdb.rules.json',
+        json: input.rtdbRules ?? { rules: {} },
+      },
+      state: { tree: input.rtdbState ?? null },
+      ...(input.rtdbDatabaseUrl ? { databaseUrl: input.rtdbDatabaseUrl } : {}),
+    };
+  }
+
+  const authUsers = input.authState?.users;
+  const currentUser = input.authState?.currentUser ?? input.sandbox.currentUser;
+  if ((authUsers && authUsers.length > 0) || currentUser != null) {
+    services.auth = {
+      state: {
+        ...(authUsers ? { users: authUsers } : {}),
+        ...(currentUser != null ? { currentUser } : {}),
+      },
+    };
+  }
+
+  return {
+    schema: VERIFY_FIXTURE_SCHEMA,
+    ...(input.description ? { description: input.description } : {}),
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    events,
+    services,
+  };
+}
+
+export function parseVerifyFixture(value: unknown): PyricVerifyFixture {
+  if (!isRecord(value)) {
+    throw new Error('fixture must be a JSON object.');
+  }
+  if (value.schema !== VERIFY_FIXTURE_SCHEMA) {
+    throw new Error(`fixture schema must be '${VERIFY_FIXTURE_SCHEMA}'.`);
+  }
+  if (!Array.isArray(value.events)) {
+    throw new Error('fixture.events must be an array.');
+  }
+  if (!isRecord(value.services)) {
+    throw new Error('fixture.services must be an object.');
+  }
+
+  const services = value.services;
+  if (services.firestore !== undefined) {
+    assertFirestoreService(services.firestore);
+  }
+  if (services.rtdb !== undefined) {
+    assertRtdbService(services.rtdb);
+  }
+  if (services.auth !== undefined && !isRecord(services.auth)) {
+    throw new Error('fixture.services.auth must be an object.');
+  }
+
+  return value as unknown as PyricVerifyFixture;
+}
+
+export function fixtureVerifiableServices(
+  fixture: PyricVerifyFixture,
+): Array<'firestore' | 'rtdb'> {
+  const services: Array<'firestore' | 'rtdb'> = [];
+  if (fixture.services.firestore) services.push('firestore');
+  if (fixture.services.rtdb) services.push('rtdb');
+  return services;
+}
+
+function assertFirestoreService(value: unknown): void {
+  if (!isRecord(value)) throw new Error('fixture.services.firestore must be an object.');
+  if (!isRecord(value.rules) || value.rules.format !== 'firestore.rules' || typeof value.rules.source !== 'string') {
+    throw new Error('fixture.services.firestore.rules must contain firestore.rules source.');
+  }
+  if (!isRecord(value.state) || !isRecord(value.state.documents)) {
+    throw new Error('fixture.services.firestore.state.documents must be an object.');
+  }
+}
+
+function assertRtdbService(value: unknown): void {
+  if (!isRecord(value)) throw new Error('fixture.services.rtdb must be an object.');
+  if (
+    !isRecord(value.rules) ||
+    value.rules.format !== 'rtdb.rules.json' ||
+    !isRecord(value.rules.json) ||
+    !isRecord(value.rules.json.rules)
+  ) {
+    throw new Error('fixture.services.rtdb.rules must contain RTDB rules JSON.');
+  }
+  if (!isRecord(value.state) || !('tree' in value.state)) {
+    throw new Error('fixture.services.rtdb.state.tree is required.');
+  }
+}
+
+function eventService(event: SandboxEvent): EventService {
+  if ('service' in event && typeof event.service === 'string') {
+    return event.service as EventService;
+  }
+  return 'firestore';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -1,0 +1,401 @@
+import {
+  initializeSandbox,
+  replay,
+  type Divergence,
+  type EventService,
+  type SandboxCommitEvent,
+  type SandboxEvent,
+} from 'pyric/sandbox';
+import {
+  getAdminDatabase,
+  getDatabase,
+  ref,
+  remove,
+  runTransaction,
+  set,
+  update,
+  sandbox as rtdbSandbox,
+} from 'pyric/database/modular';
+import type { RtdbRulesDocument } from 'pyric/rules/rtdb';
+import {
+  fixtureVerifiableServices,
+  parseVerifyFixture,
+  VERIFY_FIXTURE_SCHEMA,
+  type PyricVerifyFixture,
+} from './fixture.js';
+
+export {
+  buildVerifyFixture,
+  fixtureVerifiableServices,
+  parseVerifyFixture,
+  VERIFY_FIXTURE_SCHEMA,
+  type BuildVerifyFixtureInput,
+  type PyricVerifyFixture,
+  type VerifyFirestoreRulesBlock,
+  type VerifyRtdbRulesBlock,
+} from './fixture.js';
+
+export type VerifiableService = 'firestore' | 'rtdb';
+
+export type VerifyRulesInput = {
+  firestore?: string | { source: string };
+  rtdb?: { rules: Record<string, unknown> } | RtdbRulesDocument;
+  storage?: string | { source: string };
+};
+
+export interface VerifyFixtureOptions {
+  rules: VerifyRulesInput;
+  services?: VerifiableService[];
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  services: Partial<Record<VerifiableService, VerifyServiceResult>>;
+}
+
+export interface VerifyServiceResult {
+  service: VerifiableService;
+  ok: boolean;
+  checkedEvents: number;
+  divergences: VerifyDivergence[];
+}
+
+export type VerifyDivergence =
+  | {
+      service: EventService | string;
+      kind: 'now-denied';
+      path?: string;
+      method?: string;
+      reason?: string;
+    }
+  | {
+      service: EventService | string;
+      kind: 'state-drift';
+      path?: string;
+      field?: string;
+      before: unknown;
+      after: unknown;
+    }
+  | {
+      service: EventService | string;
+      kind: 'unsupported';
+      path?: string;
+      method?: string;
+      reason: string;
+    }
+  | {
+      service: EventService | string;
+      kind: 'expected-drift';
+      drift: string;
+      path?: string;
+      field?: string;
+      before?: unknown;
+      after?: unknown;
+    };
+
+export class VerifyInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VerifyInputError';
+  }
+}
+
+export async function verifyFixture(
+  fixtureInput: PyricVerifyFixture | unknown,
+  opts: VerifyFixtureOptions,
+): Promise<VerifyResult> {
+  const fixture = parseVerifyFixture(fixtureInput);
+  const selected = opts.services ?? fixtureVerifiableServices(fixture);
+  if (selected.length === 0) {
+    throw new VerifyInputError(
+      `fixture ${fixture.schema} does not contain a verifiable rules service.`,
+    );
+  }
+
+  const services: Partial<Record<VerifiableService, VerifyServiceResult>> = {};
+  for (const service of selected) {
+    if (service === 'firestore') {
+      services.firestore = verifyFirestore(fixture, requireFirestoreRules(opts.rules));
+    } else if (service === 'rtdb') {
+      services.rtdb = await verifyRtdb(fixture, requireRtdbRules(opts.rules));
+    } else {
+      const exhaustive: never = service;
+      throw new VerifyInputError(`unsupported verify service: ${exhaustive}`);
+    }
+  }
+  return {
+    ok: Object.values(services).every((result) => result?.ok !== false),
+    services,
+  };
+}
+
+function verifyFirestore(
+  fixture: PyricVerifyFixture,
+  rules: string,
+): VerifyServiceResult {
+  const firestore = fixture.services.firestore;
+  if (!firestore) {
+    throw new VerifyInputError('fixture does not contain services.firestore.');
+  }
+
+  const { divergences } = replay(
+    fixture.events,
+    rules,
+    {},
+    firestore.state.documents,
+  );
+  const mapped = divergences.map(mapFirestoreDivergence);
+  return {
+    service: 'firestore',
+    ok: mapped.every(isInformational),
+    checkedEvents: fixture.events.filter((event) => event.kind === 'write').length,
+    divergences: mapped,
+  };
+}
+
+async function verifyRtdb(
+  fixture: PyricVerifyFixture,
+  rulesJson: { rules: Record<string, unknown> },
+): Promise<VerifyServiceResult> {
+  const rtdb = fixture.services.rtdb;
+  if (!rtdb) {
+    throw new VerifyInputError('fixture does not contain services.rtdb.');
+  }
+
+  const sandbox = initializeSandbox();
+  const db = getDatabase(sandbox);
+  const adminDb = getAdminDatabase(sandbox);
+  rtdbSandbox.setRules(db, rulesJson);
+  rtdbSandbox.setData(adminDb, { '/': rtdb.state.tree });
+
+  const divergences: VerifyDivergence[] = [];
+  const commits = fixture.events.filter(isRtdbCommit);
+  let checkedEvents = 0;
+  await rewindRtdbCommits(adminDb, commits);
+
+  for (const commit of commits) {
+    const path = commit.path ?? '/';
+    if (commit.detail?.admin === true) {
+      await replayRtdbAdminCommit(sandbox, commit, divergences);
+      continue;
+    }
+
+    checkedEvents += 1;
+    try {
+      await replayRtdbAppCommit(sandbox, commit, divergences);
+    } catch (e) {
+      divergences.push({
+        service: 'rtdb',
+        kind: 'now-denied',
+        path,
+        method: commit.method,
+        reason: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  const replayedState = rtdbSandbox.snapshotState(adminDb);
+  collectStateDrift('rtdb', rtdb.state.tree, replayedState, '/', divergences);
+
+  return {
+    service: 'rtdb',
+    ok: divergences.every(isInformational),
+    checkedEvents,
+    divergences,
+  };
+}
+
+function requireFirestoreRules(input: VerifyRulesInput): string {
+  const rules = input.firestore;
+  if (typeof rules === 'string') return rules;
+  if (rules && typeof rules.source === 'string') return rules.source;
+  throw new VerifyInputError('missing candidate Firestore rules. Pass rules.firestore.');
+}
+
+function requireRtdbRules(input: VerifyRulesInput): { rules: Record<string, unknown> } {
+  const rules = input.rtdb;
+  if (isRtdbRulesDocument(rules)) return rules.toJSON();
+  if (isRtdbRulesJson(rules)) return rules;
+  throw new VerifyInputError('missing candidate RTDB rules. Pass rules.rtdb.');
+}
+
+function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'toJSON' in value &&
+    typeof (value as { toJSON?: unknown }).toJSON === 'function'
+  );
+}
+
+function isRtdbRulesJson(value: unknown): value is { rules: Record<string, unknown> } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'rules' in value &&
+    isRecord((value as { rules?: unknown }).rules)
+  );
+}
+
+function mapFirestoreDivergence(divergence: Divergence): VerifyDivergence {
+  switch (divergence.kind) {
+    case 'real-divergence':
+      return {
+        service: 'firestore',
+        kind: 'state-drift',
+        path: divergence.path,
+        field: divergence.field,
+        before: divergence.before,
+        after: divergence.after,
+      };
+    case 'autoid-alias':
+      return {
+        service: 'firestore',
+        kind: 'expected-drift',
+        drift: 'autoid-alias',
+        path: divergence.originalPath,
+        before: divergence.originalPath,
+        after: divergence.replayedPath,
+      };
+    case 'sentinel-drift':
+      return {
+        service: 'firestore',
+        kind: 'expected-drift',
+        drift: 'sentinel-drift',
+        path: divergence.path,
+        field: divergence.field,
+        before: divergence.before,
+        after: divergence.after,
+      };
+    case 'time-drift':
+      return {
+        service: 'firestore',
+        kind: 'expected-drift',
+        drift: 'time-drift',
+        path: divergence.path,
+        field: divergence.field,
+        before: divergence.before,
+        after: divergence.after,
+      };
+  }
+}
+
+async function replayRtdbAppCommit(
+  sandbox: ReturnType<typeof initializeSandbox>,
+  commit: SandboxCommitEvent,
+  divergences: VerifyDivergence[],
+): Promise<void> {
+  const db = getDatabase(sandbox.withAuth(commit.auth));
+  await replayRtdbCommitWithDatabase(db, commit, divergences);
+}
+
+async function replayRtdbAdminCommit(
+  sandbox: ReturnType<typeof initializeSandbox>,
+  commit: SandboxCommitEvent,
+  divergences: VerifyDivergence[],
+): Promise<void> {
+  const db = getAdminDatabase(sandbox);
+  await replayRtdbCommitWithDatabase(db, commit, divergences);
+}
+
+async function rewindRtdbCommits(
+  adminDb: ReturnType<typeof getAdminDatabase>,
+  commits: SandboxCommitEvent[],
+): Promise<void> {
+  for (const commit of [...commits].reverse()) {
+    if (!commit.path) continue;
+    await set(ref(adminDb, commit.path), commit.priorState ?? null);
+  }
+}
+
+async function replayRtdbCommitWithDatabase(
+  db: ReturnType<typeof getDatabase>,
+  commit: SandboxCommitEvent,
+  divergences: VerifyDivergence[],
+): Promise<void> {
+  const path = commit.path ?? '/';
+  const dbRef = ref(db, path);
+  switch (commit.method) {
+    case 'set':
+      await set(dbRef, commit.data);
+      break;
+    case 'remove':
+      await remove(dbRef);
+      break;
+    case 'update':
+      if (!isRecord(commit.data)) {
+        divergences.push({
+          service: 'rtdb',
+          kind: 'unsupported',
+          path,
+          method: commit.method,
+          reason: 'captured RTDB update commit did not contain an object patch.',
+        });
+        return;
+      }
+      await update(dbRef, commit.data);
+      break;
+    case 'transaction':
+      await runTransaction(
+        dbRef,
+        () => commit.data as never,
+        { applyLocally: false },
+      );
+      break;
+    default:
+      divergences.push({
+        service: 'rtdb',
+        kind: 'unsupported',
+        path,
+        method: commit.method,
+        reason: `RTDB replay does not support '${commit.method}' commits.`,
+      });
+  }
+}
+
+function isRtdbCommit(event: SandboxEvent): event is SandboxCommitEvent {
+  return event.kind === 'commit' && event.service === 'rtdb';
+}
+
+function collectStateDrift(
+  service: EventService,
+  expected: unknown,
+  actual: unknown,
+  path: string,
+  out: VerifyDivergence[],
+): void {
+  if (deepEqual(expected, actual)) return;
+  if (!isRecord(expected) || !isRecord(actual)) {
+    out.push({
+      service,
+      kind: 'state-drift',
+      path,
+      before: expected,
+      after: actual,
+    });
+    return;
+  }
+
+  const keys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  for (const key of keys) {
+    collectStateDrift(
+      service,
+      expected[key],
+      actual[key],
+      path === '/' ? `/${key}` : `${path}/${key}`,
+      out,
+    );
+  }
+}
+
+function isInformational(divergence: VerifyDivergence): boolean {
+  return divergence.kind === 'expected-drift';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/pyric-tools/test/cli/verify.test.ts
+++ b/packages/pyric-tools/test/cli/verify.test.ts
@@ -1,18 +1,13 @@
-/**
- * `pyric verify` CLI wrapper (runVerify). The pure replay helpers
- * (runFixture/checkDirectory/formatResults) mirror — and are covered by —
- * examples/replay/ci/check-fixtures.test.ts; this file pins the CLI-specific
- * behavior: exit codes, rules-file resolution, the default serve-capture
- * path, and the --json contract.
- */
 import { afterEach, describe, expect, it } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { initializeSandbox } from 'pyric/sandbox';
+import { join } from 'node:path';
+import { getDatabase, ref, set, sandbox as rtdbSandbox } from 'pyric/database';
 import { getFirestore } from 'pyric/sandbox/admin-firestore';
-import { runVerify, type Fixture } from '../../src/cli/verify.js';
+import { initializeSandbox } from 'pyric/sandbox';
+import { buildVerifyFixture, type PyricVerifyFixture } from '../../src/verify/index.js';
 import { parseArgs } from '../../src/cli/parse-args.js';
+import { runVerify } from '../../src/cli/verify.js';
 
 const ALICE_RULES = `rules_version = '2';
 service cloud.firestore {
@@ -21,28 +16,74 @@ service cloud.firestore {
   }
 }`;
 
-const DENY_ALL_RULES = `rules_version = '2';
+const DENY_ALL_FIRESTORE_RULES = `rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
     match /notes/{id} { allow read, write: if false; }
   }
 }`;
 
-async function captureFixture(): Promise<Fixture> {
+const RTDB_MEMBER_RULES = {
+  rules: {
+    rooms: {
+      '$roomId': {
+        messages: {
+          '$messageId': {
+            '.write': "root.child('members').child($roomId).child(auth.uid).exists()",
+            '.read': "root.child('members').child($roomId).child(auth.uid).exists()",
+          },
+        },
+      },
+    },
+    members: {
+      '.read': false,
+      '.write': false,
+    },
+  },
+};
+
+const DENY_ALL_RTDB_RULES = {
+  rules: {
+    '.read': false,
+    '.write': false,
+  },
+};
+
+async function captureFirestoreFixture(): Promise<PyricVerifyFixture> {
   const sandbox = initializeSandbox();
   const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
   db.setRules(ALICE_RULES);
   await db.doc('notes/welcome').set({ title: 'welcome', priority: 1 });
   await db.doc('notes/first').set({ title: 'first', priority: 2 });
-  return {
+  return buildVerifyFixture({
+    sandbox,
     description: 'alice creates two notes',
-    rules: ALICE_RULES,
-    events: sandbox.history(),
-    state: sandbox.snapshot().firestore,
-  };
+    firestoreRules: ALICE_RULES,
+  });
 }
 
-/** Run `pyric verify <argv>` inside `dir` (runVerify reads process.cwd()). */
+async function captureRtdbFixture(): Promise<PyricVerifyFixture> {
+  const sandbox = initializeSandbox();
+  const adminDb = getDatabase(sandbox);
+  rtdbSandbox.setRules(adminDb, RTDB_MEMBER_RULES);
+  rtdbSandbox.setData(adminDb, {
+    '/members/r1/alice': true,
+  });
+
+  const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));
+  await set(ref(db, '/rooms/r1/messages/m1'), {
+    author: 'alice',
+    text: 'hello',
+  });
+
+  return buildVerifyFixture({
+    sandbox,
+    description: 'alice writes an RTDB room message',
+    rtdbRules: RTDB_MEMBER_RULES,
+    rtdbState: rtdbSandbox.snapshotState(adminDb),
+  });
+}
+
 async function verifyIn(dir: string, argv: string[]): Promise<number> {
   const prev = process.cwd();
   process.chdir(dir);
@@ -59,58 +100,115 @@ function tmp(): string {
   dirs.push(d);
   return d;
 }
+
+function writeFirebaseJson(dir: string, config: Record<string, unknown>): void {
+  writeFileSync(join(dir, 'firebase.json'), JSON.stringify(config, null, 2));
+}
+
 afterEach(() => {
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 
 describe('runVerify', () => {
-  it('exit 0 when the captured session replays cleanly under the rules', async () => {
+  it('exit 0 when the captured Firestore session replays cleanly under firebase.json rules', async () => {
     const dir = tmp();
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
     writeFileSync(join(dir, 'firestore.rules'), ALICE_RULES);
-    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFixture()));
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
     expect(await verifyIn(dir, ['session.json'])).toBe(0);
   });
 
-  it('exit 1 when the rules would deny captured writes (real divergence)', async () => {
+  it('exit 1 when Firestore candidate rules would change captured writes', async () => {
     const dir = tmp();
-    writeFileSync(join(dir, 'firestore.rules'), DENY_ALL_RULES);
-    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFixture()));
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
+    writeFileSync(join(dir, 'firestore.rules'), DENY_ALL_FIRESTORE_RULES);
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
     expect(await verifyIn(dir, ['session.json'])).toBe(1);
   });
 
-  it('no positional arg → replays the latest serve capture (.pyric/last-session.json)', async () => {
+  it('no positional arg replays the latest serve capture', async () => {
     const dir = tmp();
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
     writeFileSync(join(dir, 'firestore.rules'), ALICE_RULES);
     mkdirSync(join(dir, '.pyric'), { recursive: true });
-    writeFileSync(join(dir, '.pyric', 'last-session.json'), JSON.stringify(await captureFixture()));
+    writeFileSync(join(dir, '.pyric', 'last-session.json'), JSON.stringify(await captureFirestoreFixture()));
     expect(await verifyIn(dir, [])).toBe(0);
   });
 
   it('exit 2 when there is no captured session and none was passed', async () => {
     const dir = tmp();
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
     writeFileSync(join(dir, 'firestore.rules'), ALICE_RULES);
     expect(await verifyIn(dir, [])).toBe(2);
   });
 
-  it('exit 2 when the rules file is missing', async () => {
+  it('exit 2 when selected service rules cannot be resolved', async () => {
     const dir = tmp();
-    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFixture()));
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
     expect(await verifyIn(dir, ['session.json'])).toBe(2);
   });
 
-  it('honors --rules pointing at an alternate ruleset', async () => {
+  it('honors service-qualified --rules overrides', async () => {
     const dir = tmp();
-    // firestore.rules is permissive, but we verify against a deny-all file.
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
     writeFileSync(join(dir, 'firestore.rules'), ALICE_RULES);
-    writeFileSync(join(dir, 'prod.rules'), DENY_ALL_RULES);
-    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFixture()));
-    expect(await verifyIn(dir, ['session.json', '--rules', 'prod.rules'])).toBe(1);
+    writeFileSync(join(dir, 'prod.rules'), DENY_ALL_FIRESTORE_RULES);
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
+    expect(await verifyIn(dir, ['session.json', '--rules', 'firestore=prod.rules'])).toBe(1);
   });
 
-  it('--json still returns the right exit code', async () => {
+  it('rejects unqualified --rules values', async () => {
     const dir = tmp();
-    writeFileSync(join(dir, 'firestore.rules'), DENY_ALL_RULES);
-    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFixture()));
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
+    writeFileSync(join(dir, 'firestore.rules'), ALICE_RULES);
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
+    expect(await verifyIn(dir, ['session.json', '--rules', 'prod.rules'])).toBe(2);
+  });
+
+  it('verifies RTDB fixtures against database.rules from firebase.json', async () => {
+    const dir = tmp();
+    writeFirebaseJson(dir, { database: { rules: 'database.rules.json' } });
+    writeFileSync(join(dir, 'database.rules.json'), JSON.stringify(RTDB_MEMBER_RULES));
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureRtdbFixture()));
+    expect(await verifyIn(dir, ['session.json'])).toBe(0);
+  });
+
+  it('exit 1 when RTDB candidate rules now deny captured writes', async () => {
+    const dir = tmp();
+    writeFirebaseJson(dir, { database: { rules: 'database.rules.json' } });
+    writeFileSync(join(dir, 'database.rules.json'), JSON.stringify(DENY_ALL_RTDB_RULES));
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureRtdbFixture()));
+    expect(await verifyIn(dir, ['session.json'])).toBe(1);
+  });
+
+  it('filters services with repeated --service and repeated --rules', async () => {
+    const dir = tmp();
+    writeFirebaseJson(dir, {
+      firestore: { rules: 'firestore.rules' },
+      database: { rules: 'database.rules.json' },
+    });
+    writeFileSync(join(dir, 'firestore.rules'), DENY_ALL_FIRESTORE_RULES);
+    writeFileSync(join(dir, 'database.rules.json'), JSON.stringify(DENY_ALL_RTDB_RULES));
+    writeFileSync(join(dir, 'rtdb-allow.json'), JSON.stringify(RTDB_MEMBER_RULES));
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureRtdbFixture()));
+    expect(
+      await verifyIn(dir, [
+        'session.json',
+        '--service',
+        'rtdb',
+        '--rules',
+        'firestore=firestore.rules',
+        '--rules',
+        'rtdb=rtdb-allow.json',
+      ]),
+    ).toBe(0);
+  });
+
+  it('--json returns the right exit code', async () => {
+    const dir = tmp();
+    writeFirebaseJson(dir, { firestore: { rules: 'firestore.rules' } });
+    writeFileSync(join(dir, 'firestore.rules'), DENY_ALL_FIRESTORE_RULES);
+    writeFileSync(join(dir, 'session.json'), JSON.stringify(await captureFirestoreFixture()));
     expect(await verifyIn(dir, ['session.json', '--json'])).toBe(1);
   });
 });

--- a/packages/pyric-tools/test/serve/bundler.test.ts
+++ b/packages/pyric-tools/test/serve/bundler.test.ts
@@ -112,9 +112,9 @@ export const db = getFirestore(initializeSandbox());`,
 });
 
 describe('the real wrapper entries (plan step 1.2)', () => {
-  it('defaultSdkEntries locates app + auth + firestore entries', () => {
+  it('defaultSdkEntries locates app + auth + firestore + database entries', () => {
     const entries = (require('../../src/serve/bundler.js') as typeof import('../../src/serve/bundler.js')).defaultSdkEntries();
-    expect(Object.keys(entries).sort()).toEqual(['app', 'auth', 'firestore', 'init']);
+    expect(Object.keys(entries).sort()).toEqual(['app', 'auth', 'database', 'firestore', 'init']);
   });
 
   it('bundles browser-standalone with a SINGLE shared runtime chunk', async () => {
@@ -125,6 +125,7 @@ describe('the real wrapper entries (plan step 1.2)', () => {
     const names = result.files.map((f) => f.split('/').pop()!);
     expect(names).toContain('app.js');
     expect(names).toContain('auth.js');
+    expect(names).toContain('database.js');
     expect(names).toContain('firestore.js');
     expect(names).toContain('init.js');
     // splitting produced shared chunk(s); the runtime/sandbox must NOT be
@@ -133,8 +134,10 @@ describe('the real wrapper entries (plan step 1.2)', () => {
     const chunks = names.filter((n) => n.startsWith('pyric-sandbox-'));
     expect(chunks.length).toBeGreaterThanOrEqual(1);
     const authSrc = readFileSync(result.files.find((f) => f.endsWith('/auth.js'))!, 'utf8');
+    const dbSrc = readFileSync(result.files.find((f) => f.endsWith('/database.js'))!, 'utf8');
     const fsSrc = readFileSync(result.files.find((f) => f.endsWith('/firestore.js'))!, 'utf8');
     expect(authSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
+    expect(dbSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
     expect(fsSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
     expect(authSrc).not.toMatch(/initializeSandbox/); // sandbox lives in the chunk
     expect(fsSrc).not.toMatch(/initializeSandbox/);
@@ -222,6 +225,17 @@ describe('the real wrapper entries (plan step 1.2)', () => {
       'GithubAuthProvider', 'OAuthProvider', 'setPersistence',
     ]) {
       expect(auth.has(name)).toBe(true);
+    }
+
+    const database = exportedNames(result.files.find((f) => f.endsWith('/database.js'))!);
+    for (const name of [
+      'getDatabase', 'ref', 'child', 'get', 'set', 'update', 'remove', 'push',
+      'onValue', 'off', 'serverTimestamp', 'connectDatabaseEmulator',
+      'runTransaction', 'query', 'orderByChild', 'orderByKey', 'orderByValue',
+      'startAt', 'startAfter', 'endAt', 'endBefore', 'equalTo',
+      'limitToFirst', 'limitToLast',
+    ]) {
+      expect(database.has(name)).toBe(true);
     }
   }, 30_000);
 });

--- a/packages/pyric-tools/test/serve/vite-plugin.test.ts
+++ b/packages/pyric-tools/test/serve/vite-plugin.test.ts
@@ -68,8 +68,8 @@ describe('resolveId — the importer-aware swap', () => {
     expect(resolveId('firebase/storage', pyricImporter)).toBe('\0pyric:fb-stub:firebase/storage');
   });
 
-  it('leaves non-served firebase from user/library code on real firebase', () => {
-    expect(resolveId('firebase/database', userImporter)).toBeNull();
+  it('swaps RTDB and leaves non-served firebase from user/library code on real firebase', () => {
+    expect(resolveId('firebase/database', userImporter)).toBe(entries.database);
     expect(resolveId('firebase/storage', userImporter)).toBeNull();
   });
 

--- a/packages/pyric-tools/test/serve/worker/serve-init.test.ts
+++ b/packages/pyric-tools/test/serve/worker/serve-init.test.ts
@@ -70,6 +70,13 @@ const DENY_ALL_RULES = `
   }
 `;
 
+const RTDB_RULES = {
+  rules: {
+    '.read': true,
+    '.write': true,
+  },
+};
+
 async function makeCtx(): Promise<HostCtx> {
   const sandbox = initializeSandbox();
   const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
@@ -208,12 +215,12 @@ describe('applyServeInit — seed + authUsers', () => {
 });
 
 describe('applyServeInit — capture (the verify loop)', () => {
-  it('POSTs the session fixture to /__pyric/capture on a write, then dispose stops it', async () => {
+  it('POSTs the service-shaped session fixture to /__pyric/capture, then dispose stops it', async () => {
     const ctx = await makeCtx();
     const fetchSpy = recordingFetch();
     const result = applyServeInit(
       ctx,
-      { ...basePayload, rules: PERMISSIVE_RULES, capture: true },
+      { ...basePayload, rules: PERMISSIVE_RULES, databaseRules: RTDB_RULES, capture: true },
       { fetch: fetchSpy, captureDebounceMs: 5 },
     );
     expect(result.captureEnabled).toBe(true);
@@ -221,14 +228,25 @@ describe('applyServeInit — capture (the verify loop)', () => {
     // A write emits a sandbox event → debounced capture POST.
     const port = fakePort();
     await handleMessage(ctx, port, { t: 'op', id: 'w1', method: 'setDoc', path: 'todos/t1', data: { title: 'live' } });
+    await handleMessage(ctx, port, { t: 'op', id: 'r1', method: 'rtdb.set', path: '/rooms/r1', value: { name: 'General' } });
     await tick(20);
 
     const captures = fetchSpy.calls.filter((c) => c.url === '/__pyric/capture');
     expect(captures.length).toBeGreaterThanOrEqual(1);
-    const body = JSON.parse(captures.at(-1)!.body) as { rules: string; events: unknown[]; state: Record<string, unknown> };
-    expect(body.rules).toContain('rules_version');
+    const body = JSON.parse(captures.at(-1)!.body) as {
+      schema: string;
+      events: unknown[];
+      services: {
+        firestore: { rules: { source: string }; state: { documents: Record<string, unknown> } };
+        rtdb: { rules: { json: unknown }; state: { tree: { rooms?: unknown } } };
+      };
+    };
+    expect(body.schema).toBe('pyric.verify.fixture.v1');
+    expect(body.services.firestore.rules.source).toContain('rules_version');
     expect(Array.isArray(body.events)).toBe(true);
-    expect(body.state['todos/t1']).toBeDefined();
+    expect(body.services.firestore.state.documents['todos/t1']).toBeDefined();
+    expect(body.services.rtdb.rules.json).toEqual(RTDB_RULES);
+    expect(body.services.rtdb.state.tree.rooms).toBeDefined();
 
     // After dispose, further writes do NOT capture.
     result.dispose();

--- a/packages/pyric-tools/test/verify/verify.test.ts
+++ b/packages/pyric-tools/test/verify/verify.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  getDatabase,
+  ref,
+  remove,
+  runTransaction,
+  set,
+  update,
+  sandbox as rtdbSandbox,
+} from 'pyric/database';
+import { defineRtdbRules, allow, deny } from 'pyric/rules/rtdb';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  buildVerifyFixture,
+  parseVerifyFixture,
+  verifyFixture,
+  type PyricVerifyFixture,
+} from '../../src/verify/index.js';
+
+const ALLOW_ALL_RTDB = { rules: { '.read': true, '.write': true } };
+const DENY_ALL_RTDB = { rules: { '.read': false, '.write': false } };
+
+async function captureRtdbJourney(): Promise<PyricVerifyFixture> {
+  const sandbox = initializeSandbox();
+  const adminDb = getDatabase(sandbox);
+  rtdbSandbox.setRules(adminDb, ALLOW_ALL_RTDB);
+  rtdbSandbox.setData(adminDb, {
+    '/counters/c1': 1,
+    '/gone/x': true,
+  });
+
+  const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));
+  await set(ref(db, '/profiles/alice'), { name: 'Alice' });
+  await update(ref(db, '/profiles/alice'), { active: true });
+  await remove(ref(db, '/gone/x'));
+  await runTransaction<number>(ref(db, '/counters/c1'), (current) => (current ?? 0) + 1, {
+    applyLocally: false,
+  });
+
+  return buildVerifyFixture({
+    sandbox,
+    rtdbRules: ALLOW_ALL_RTDB,
+    rtdbState: rtdbSandbox.snapshotState(adminDb),
+  });
+}
+
+describe('verifyFixture', () => {
+  it('parses service-shaped fixtures and rejects the old flat shape', () => {
+    const good = buildVerifyFixture({
+      sandbox: initializeSandbox(),
+      rtdbRules: ALLOW_ALL_RTDB,
+      rtdbState: {},
+    });
+    expect(parseVerifyFixture(good).schema).toBe('pyric.verify.fixture.v1');
+    expect(() => parseVerifyFixture({ rules: '', events: [], state: {} })).toThrow(
+      /fixture schema/,
+    );
+  });
+
+  it('accepts an RtdbRulesDocument and replays set, update, remove, and transaction commits', async () => {
+    const fixture = await captureRtdbJourney();
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: allow(), write: allow() },
+      },
+    });
+
+    const result = await verifyFixture(fixture, {
+      rules: { rtdb: rules },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.services.rtdb?.checkedEvents).toBe(4);
+  });
+
+  it('reports now-denied when RTDB candidate rules reject captured writes', async () => {
+    const fixture = await captureRtdbJourney();
+    const result = await verifyFixture(fixture, {
+      rules: { rtdb: DENY_ALL_RTDB },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.services.rtdb?.divergences.some((d) => d.kind === 'now-denied')).toBe(true);
+  });
+
+  it('reports state drift when replayed RTDB state differs from the fixture', async () => {
+    const fixture = await captureRtdbJourney();
+    const tampered = JSON.parse(JSON.stringify(fixture)) as PyricVerifyFixture;
+    const tree = tampered.services.rtdb!.state.tree as {
+      profiles: { alice: { name: string; active: boolean } };
+    };
+    tree.profiles.alice.name = 'Mallory';
+    const result = await verifyFixture(tampered, {
+      rules: { rtdb: ALLOW_ALL_RTDB },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.services.rtdb?.divergences.some((d) => d.kind === 'state-drift')).toBe(true);
+  });
+
+  it('compiles denying constraints documents through toJSON', async () => {
+    const fixture = await captureRtdbJourney();
+    const rules = defineRtdbRules({
+      paths: {
+        '/': { read: deny(), write: deny() },
+      },
+    });
+
+    const result = await verifyFixture(fixture, {
+      rules: { rtdb: rules },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.services.rtdb?.divergences.some((d) => d.kind === 'now-denied')).toBe(true);
+  });
+});

--- a/packages/pyric/docs/database/reference/rules-tooling.md
+++ b/packages/pyric/docs/database/reference/rules-tooling.md
@@ -106,6 +106,35 @@ type RtdbRulesCheckResult = {
 
 Compile failures return an error finding with code `COMPILE_ERROR`.
 
+### Verifying captured sessions
+
+Constraints documents can be passed directly to `pyric-tools/verify` as
+candidate RTDB rules:
+
+```ts
+import { verifyFixture } from 'pyric-tools/verify';
+import { rules } from './database.rules.js';
+
+const fixture = JSON.parse(await Bun.file('.pyric/last-session.json').text());
+
+const result = await verifyFixture(fixture, {
+  rules: { rtdb: rules },
+});
+```
+
+For CLI verification, generate JSON first and pass it as the RTDB rules file:
+
+```ts
+await Bun.write('database.rules.json', JSON.stringify(rules.toJSON(), null, 2));
+```
+
+```sh
+pyric verify --service rtdb --rules rtdb=database.rules.json
+```
+
+Verification lives in `pyric-tools/verify` because constraints are an authoring
+surface and captured-session replay is local tooling around an app session.
+
 ## Rule JSON and IR
 
 ### `RtdbMapper.mapToIR(rulesJson, shallowData, databaseUrl): RtdbIR`

--- a/packages/pyric/docs/database/tutorials/01-author-rtdb-rules-with-constraints.md
+++ b/packages/pyric/docs/database/tutorials/01-author-rtdb-rules-with-constraints.md
@@ -128,3 +128,30 @@ await writeFile('database.rules.json', JSON.stringify(rules.toJSON(), null, 2));
 
 You have built an in-memory rules document, checked it, simulated it, and
 generated the JSON expected by Firebase Realtime Database.
+
+## Verify a captured app journey
+
+After running `pyric serve` and exercising the app, the latest session is saved
+to `.pyric/last-session.json`. You can verify that capture against the in-memory
+rules document before generating JSON:
+
+```ts
+import { verifyFixture } from 'pyric-tools/verify';
+import { rules } from './database.rules.js';
+
+const fixture = JSON.parse(await Bun.file('.pyric/last-session.json').text());
+const result = await verifyFixture(fixture, {
+  rules: { rtdb: rules },
+});
+
+if (!result.ok) {
+  console.error(result.services.rtdb?.divergences);
+  process.exit(1);
+}
+```
+
+For the CLI path, use the JSON file from the previous step:
+
+```bash
+pyric verify --service rtdb --rules rtdb=database.rules.json
+```

--- a/packages/pyric/src/project-scope.ts
+++ b/packages/pyric/src/project-scope.ts
@@ -1,0 +1,4 @@
+export interface ProjectScope {
+  readonly projectId: string;
+  resolveToken(): Promise<string>;
+}

--- a/packages/pyric/src/rules/inspect/handler.ts
+++ b/packages/pyric/src/rules/inspect/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import type { InspectFirestoreRulesResult, RulesSummary } from './spec.js';
 import type { MatchBlock, AllowRule, Expression } from '../grammar/FirestoreAST.js';
 import { parseToASTOrError } from '../grammar/FirestoreParser.js';

--- a/packages/pyric/src/rules/inspect/tools.ts
+++ b/packages/pyric/src/rules/inspect/tools.ts
@@ -13,7 +13,7 @@
  * lifecycle (test, simulate, lint, resolve-modules).
  */
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import { InspectFirestoreRulesHandler } from './handler.js';
 
 export interface FirestoreInspectToolDeps {

--- a/packages/pyric/src/rules/test/handler.ts
+++ b/packages/pyric/src/rules/test/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import type { TestCase, TestResult, TestFirestoreRulesResult, ApiTestCase } from './spec.js';
 import { buildApiTestCase } from './spec.js';
 

--- a/packages/pyric/src/rules/tools.ts
+++ b/packages/pyric/src/rules/tools.ts
@@ -19,7 +19,7 @@
  */
 
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../project-scope.js';
 import { resolveModules } from './modules/resolver.js';
 import { SimulateFirestoreRulesHandler } from './simulator/handler.js';
 import { createFirestoreRulesStdlibTools } from './stdlib-tools.js';

--- a/packages/pyric/src/rules/write/handler.ts
+++ b/packages/pyric/src/rules/write/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import type { WriteFirestoreRulesResult } from './spec.js';
 import { parseToASTOrError } from '../grammar/FirestoreParser.js';
 import { validateFirestoreRules } from '../grammar/FirestoreValidator.js';

--- a/packages/pyric/src/storage/admin/handler.ts
+++ b/packages/pyric/src/storage/admin/handler.ts
@@ -17,7 +17,7 @@
  * `reason` field to a typed error code so callers can route to
  * actionable UX.
  */
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import {
   getDefaultLocation,
   getStorageServiceState,

--- a/packages/pyric/src/storage/admin/tools.ts
+++ b/packages/pyric/src/storage/admin/tools.ts
@@ -8,7 +8,7 @@
  * shape: a `ProjectScope` in, JSON-Schema-typed `ToolHandler`s out.
  */
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '../../project-scope.js';
 import { InspectStorageHandler, ProvisionStorageHandler } from './handler.js';
 import type { ProvisionStorageInput } from './spec.js';
 import type { ProvisionProgress } from './api.js';


### PR DESCRIPTION
## Replaying captured Firebase sessions across services

This PR turns `pyric verify` from a Firestore-only regression check into a service-adaptable verification surface for captured Firebase sessions. A captured session now contains one ordered event timeline plus service-specific rules and state blocks, so the same command and programmatic API can replay Firestore documents, RTDB JSON rules, and RTDB constraints-generated rules without inventing separate fixture formats for each service.

```ts
import { defineRtdbRules, allow, authenticated, all, eq, newDataVal, AUTH_UID } from 'pyric/rules/rtdb';
import { verifyFixture } from 'pyric-tools/verify';

const rtdbRules = defineRtdbRules({
  paths: {
    '/rooms/$roomId/messages/$messageId': {
      read: allow(),
      write: all(
        authenticated(),
        eq(newDataVal('author'), AUTH_UID),
      ),
    },
  },
});

const result = await verifyFixture(capturedSession, {
  rules: {
    firestore: { source: firestoreRulesSource },
    rtdb: rtdbRules,
  },
});

if (!result.ok) {
  for (const [service, serviceResult] of Object.entries(result.services)) {
    console.log(service, serviceResult.divergences);
  }
}
```

The important user-facing behavior is that RTDB constraints remain an authoring API. Verification still treats the output as RTDB rules. A `RtdbRulesDocument` is accepted in process and compiled with `toJSON()` internally, while CLI users pass the generated JSON rules file.

## What the fixture looks like now

Fixtures now use the service-extensible `pyric.verify.fixture.v1` shape:

```ts
{
  schema: 'pyric.verify.fixture.v1',
  description: 'alice creates a room message',
  events: [
    // one ordered sandbox history across Firestore, RTDB, Auth, and later services
  ],
  services: {
    firestore: {
      rules: { format: 'firestore.rules', source: '...' },
      state: { documents: { 'rooms/r1': { owner: 'alice' } } },
    },
    rtdb: {
      rules: {
        format: 'rtdb.rules.json',
        json: { rules: { rooms: { '$roomId': { '.read': true } } } },
      },
      state: {
        tree: {
          rooms: {
            r1: {
              messages: {
                m1: { author: 'alice', text: 'hello' },
              },
            },
          },
        },
      },
      databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
    },
    auth: {
      state: {
        currentUser: { uid: 'alice' },
      },
    },
  },
}
```

That layout makes the fixture adaptable before the package has users depending on the old shape. Firestore, RTDB, Auth, Storage, and future services can add state blocks without changing the global timeline or forcing service-specific fixture files.

## CLI usage

`pyric verify` now verifies every verifiable service present in the fixture:

```sh
pyric verify .pyric/last-session.json
```

Candidate rules are service-qualified instead of using one Firestore-biased `--rules` flag:

```sh
pyric verify \
  --rules firestore=firestore.rules \
  --rules rtdb=database.rules.json
```

Services can be filtered with repeated `--service` flags:

```sh
pyric verify .pyric/last-session.json --service rtdb

pyric verify .pyric/last-session.json \
  --service firestore \
  --service rtdb
```

When an override is not provided, the CLI resolves candidate rules from `firebase.json`:

```json
{
  "firestore": { "rules": "firestore.rules" },
  "database": { "rules": "database.rules.json" }
}
```

Captured rules remain part of the fixture as session context, but they are not silently reused as the candidate rules being checked. If a selected service has no override and no resolvable `firebase.json` rules path, the command returns a usage error.

## Programmatic API

`pyric-tools/verify` exports the reusable API behind the CLI:

```ts
import { verifyFixture, buildVerifyFixture } from 'pyric-tools/verify';

const fixture = buildVerifyFixture({
  sandbox,
  rules: {
    firestore: { source: firestoreRulesSource },
    rtdb: {
      json: { rules: databaseRulesJson.rules },
      databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
    },
  },
  description: 'alice edits a shared room',
});

const result = await verifyFixture(fixture, {
  rules: {
    firestore: firestoreRulesSource,
    rtdb: databaseRulesJson,
  },
});
```

The public rules input is intentionally service-shaped:

```ts
type VerifyRulesInput = {
  firestore?: string | { source: string };
  rtdb?: { rules: Record<string, unknown> } | RtdbRulesDocument;
  storage?: string | { source: string };
};
```

Results are grouped by service so callers can present Firestore and RTDB divergences separately:

```ts
type VerifyResult = {
  ok: boolean;
  services: Record<string, {
    service: string;
    ok: boolean;
    checkedEvents: number;
    divergences: Array<
      | { service: string; kind: 'now-denied'; path?: string; method?: string; reason?: string }
      | { service: string; kind: 'state-drift'; path?: string; before: unknown; after: unknown }
      | { service: string; kind: 'unsupported'; path?: string; method?: string; reason: string }
      | { service: string; kind: 'expected-drift'; drift: string; path?: string }
    >;
  }>;
};
```

## RTDB replay behavior

The RTDB adapter accepts raw RTDB JSON rules and `RtdbRulesDocument` values. It creates a fresh sandbox database, applies candidate rules, replays captured app commits, and compares the final tree against the fixture's captured RTDB state.

Supported replayed RTDB operations include:

```ts
await set(ref(db, 'rooms/r1/messages/m1'), {
  author: 'alice',
  text: 'hello',
});

await update(ref(db, 'rooms/r1/messages/m1'), {
  editedAt: 123,
});

await remove(ref(db, 'rooms/r1/drafts/d1'));

await runTransaction(ref(db, 'rooms/r1/counters/messageCount'), (value) => {
  return (value ?? 0) + 1;
});
```

Captured `push` writes replay as concrete writes to the generated paths recorded in the event timeline. Admin/setup commits are treated as fixture setup context rather than user behavior protected by rules.

## Capture and served SDK changes

`pyric serve` now captures Firestore and RTDB into the same fixture when both services are used. The runtime and worker capture paths both use the shared fixture builder, so browser sessions and worker sessions produce the same schema.

The served SDK set also includes a `firebase/database` entry, allowing app code using RTDB modular APIs to participate in capture:

```ts
import { getDatabase, ref, set } from 'firebase/database';

const db = getDatabase();
await set(ref(db, 'rooms/r1/messages/m1'), {
  author: 'alice',
  text: 'hello',
});
```

This makes RTDB rules and RTDB constraints part of the same capture-and-replay loop as Firestore instead of a parallel workflow.

## Documentation

The docs now cover:

- Capturing and replaying Firestore plus RTDB sessions with `pyric verify`.
- The new service-qualified CLI flags.
- The public `pyric-tools/verify` API.
- Feeding `defineRtdbRules()` documents into `verifyFixture()`.
- Feeding generated RTDB JSON into the CLI.
