### PR TITLE
Map RTDB SDK in pyric serve

### DIFF
--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -309,6 +309,7 @@ export function sdkImportMap(): Record<string, string> {
   return {
     'firebase/app': '/__pyric/sdk/app.js',
     'firebase/auth': '/__pyric/sdk/auth.js',
+    'firebase/database': '/__pyric/sdk/database.js',
     'firebase/firestore': '/__pyric/sdk/firestore.js',
   };
 }

--- a/packages/pyric-tools/test/serve/integration.test.ts
+++ b/packages/pyric-tools/test/serve/integration.test.ts
@@ -72,11 +72,12 @@ describe('pyric serve end-to-end (HTTP)', () => {
     expect(mapAt).toBeGreaterThan(-1);
     expect(mapAt).toBeLessThan(appAt);
     expect(html).toContain('"firebase/firestore":"/__pyric/sdk/firestore.js"');
+    expect(html).toContain('"firebase/database":"/__pyric/sdk/database.js"');
     expect(html).toContain('"firebase/app":"/__pyric/sdk/app.js"');
     expect(html).toContain('/__pyric/sdk/init.js');
 
     // 2. the mapped SDK files are served, browser-standalone
-    for (const mod of ['app', 'auth', 'firestore', 'init']) {
+    for (const mod of ['app', 'auth', 'firestore', 'database', 'init']) {
       const res = await fetch(`${base}/__pyric/sdk/${mod}.js`);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('javascript');

--- a/packages/pyric-tools/test/serve/namespace.test.ts
+++ b/packages/pyric-tools/test/serve/namespace.test.ts
@@ -13,6 +13,7 @@ function fixture() {
   for (const d of [site, sdk]) require('node:fs').mkdirSync(d);
   writeFileSync(join(site, 'index.html'), '<!doctype html><html><head><title>t</title></head><body></body></html>');
   writeFileSync(join(sdk, 'auth.js'), 'export const getAuth = 1;');
+  writeFileSync(join(sdk, 'database.js'), 'export const getDatabase = 1;');
   writeFileSync(join(sdk, 'init.js'), '// init');
   return { site, sdk };
 }
@@ -64,6 +65,7 @@ describe('injectServeTags', () => {
     expect(Object.keys(sdkImportMap()).sort()).toEqual([
       'firebase/app',
       'firebase/auth',
+      'firebase/database',
       'firebase/firestore',
     ]);
   });
@@ -108,6 +110,9 @@ describe('namespace over the real server', () => {
     const auth = await fetch(h.url + '/__pyric/sdk/auth.js');
     expect(auth.status).toBe(200);
     expect(auth.headers.get('content-type')).toContain('javascript');
+    const database = await fetch(h.url + '/__pyric/sdk/database.js');
+    expect(database.status).toBe(200);
+    expect(database.headers.get('content-type')).toContain('javascript');
     expect((await fetch(h.url + '/__pyric/sdk/../../etc/passwd')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/sdk/nope.js')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/unknown')).status).toBe(404);


### PR DESCRIPTION
## Import parity for RTDB

Standalone `pyric serve` now maps `firebase/database` the same way the Vite plugin and SDK bundler already do, so browser code can import RTDB through the served SDK namespace without a custom import-map patch.

```html
<script type="module">
  import { getDatabase, ref, set } from "firebase/database";

  const db = getDatabase();
  await set(ref(db, "rooms/r1/title"), "Launch room");
</script>
```

## API surface

- Adds `firebase/database` to the `pyric serve` SDK import map.
- Serves the RTDB SDK wrapper at `/__pyric/sdk/database.js` through the namespace server.
- Keeps the Vite plugin behavior unchanged; this closes the standalone serve gap.

## Tests

- Namespace import-map coverage includes `firebase/database`.
- Serve integration asserts `/__pyric/sdk/database.js` is reachable and mapped.
- Vite plugin tests remain green.