### PR TITLE
Make Playground Firebase native by default

### DIFF
--- a/packages/playground/src/components/AgentModeControl.test.ts
+++ b/packages/playground/src/components/AgentModeControl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { SkillDefinition } from '~/lib/skills/registry';
-import { summarizeAgentMode } from './AgentModeControl';
+import { shouldShowSkillSearch, summarizeAgentMode } from './AgentModeControl';
 
 const APP_SKILL: SkillDefinition = {
   id: 'game-rules',
@@ -22,35 +22,59 @@ const TOOLING_SKILL: SkillDefinition = {
   manTopic: 'firestore-rules-audit',
   manSummary: 'summary',
   manBody: 'body',
-  promptProfile: 'firebase-tooling',
+  promptProfile: 'firebase',
 };
 
 describe('summarizeAgentMode', () => {
   test('shows default mode when no skills are active', () => {
     expect(summarizeAgentMode([])).toMatchObject({
-      label: 'Default',
-      detail: 'App builder',
+      icon: 'build',
+      label: 'Skills',
+      detail: '',
       activeCount: 0,
-      promptProfile: 'app-builder',
     });
   });
 
-  test('uses the single active skill as the visible mode', () => {
+  test('shows the single active specialist in the compact selector', () => {
     expect(summarizeAgentMode([APP_SKILL])).toMatchObject({
       icon: 'stadia_controller',
       label: 'Game rules',
-      detail: 'App builder',
+      detail: '',
       activeCount: 1,
-      promptProfile: 'app-builder',
     });
   });
 
-  test('collapses multiple tooling skills to one profile summary', () => {
+  test('collapses multiple specialist skills to one summary', () => {
     expect(summarizeAgentMode([APP_SKILL, TOOLING_SKILL])).toMatchObject({
-      label: 'Firebase tooling',
-      detail: '2 skills active',
+      icon: 'build',
+      label: '2 skills',
+      detail: '',
       activeCount: 2,
-      promptProfile: 'firebase-tooling',
     });
+  });
+});
+
+describe('shouldShowSkillSearch', () => {
+  test('keeps search hidden until the specialist list is long enough', () => {
+    expect(shouldShowSkillSearch([APP_SKILL, TOOLING_SKILL])).toBe(false);
+    expect(
+      shouldShowSkillSearch([
+        APP_SKILL,
+        TOOLING_SKILL,
+        { ...APP_SKILL, id: 'a' },
+        { ...APP_SKILL, id: 'b' },
+        { ...APP_SKILL, id: 'c' },
+      ]),
+    ).toBe(false);
+    expect(
+      shouldShowSkillSearch([
+        APP_SKILL,
+        TOOLING_SKILL,
+        { ...APP_SKILL, id: 'a' },
+        { ...APP_SKILL, id: 'b' },
+        { ...APP_SKILL, id: 'c' },
+        { ...APP_SKILL, id: 'd' },
+      ]),
+    ).toBe(true);
   });
 });

--- a/packages/playground/src/components/AgentModeControl.tsx
+++ b/packages/playground/src/components/AgentModeControl.tsx
@@ -1,17 +1,11 @@
 /**
- * Agent mode control — compact persistent state for session-scoped
- * skills. Slash commands remain the quick activation path; this
- * control is the place to review, enable, disable, or reset skills
- * without turning the footer into a registry toolbar.
+ * Skills control — compact persistent state for optional
+ * session-scoped expert overlays. Firebase Expert is the always-on
+ * product identity; skills add specialist posture without replacing it.
  */
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
-import {
-  listSkills,
-  resolveActiveSkills,
-  resolvePromptProfile,
-  type AgentPromptProfile,
-  type SkillDefinition,
-} from '~/lib/skills/registry';
+import { isSpecialistSkill } from '~/lib/agent/context';
+import { listSkills, resolveActiveSkills, type SkillDefinition } from '~/lib/skills/registry';
 import { useSkillsStore } from '~/lib/store/skills';
 
 export interface AgentModeSummary {
@@ -19,22 +13,15 @@ export interface AgentModeSummary {
   label: string;
   detail: string;
   activeCount: number;
-  promptProfile: AgentPromptProfile;
-}
-
-function profileLabel(profile: AgentPromptProfile): string {
-  return profile === 'firebase-tooling' ? 'Firebase tooling' : 'App builder';
 }
 
 export function summarizeAgentMode(activeSkills: readonly SkillDefinition[]): AgentModeSummary {
-  const promptProfile = resolvePromptProfile(activeSkills);
   if (activeSkills.length === 0) {
     return {
-      icon: 'auto_awesome',
-      label: 'Default',
-      detail: profileLabel(promptProfile),
+      icon: 'build',
+      label: 'Skills',
+      detail: '',
       activeCount: 0,
-      promptProfile,
     };
   }
   if (activeSkills.length === 1) {
@@ -42,18 +29,20 @@ export function summarizeAgentMode(activeSkills: readonly SkillDefinition[]): Ag
     return {
       icon: skill.icon,
       label: skill.label,
-      detail: profileLabel(promptProfile),
+      detail: '',
       activeCount: 1,
-      promptProfile,
     };
   }
   return {
-    icon: promptProfile === 'firebase-tooling' ? 'manage_search' : 'tune',
-    label: profileLabel(promptProfile),
-    detail: `${activeSkills.length} skills active`,
+    icon: 'build',
+    label: `${activeSkills.length} skills`,
+    detail: '',
     activeCount: activeSkills.length,
-    promptProfile,
   };
+}
+
+export function shouldShowSkillSearch(skills: readonly SkillDefinition[]): boolean {
+  return skills.length > 5;
 }
 
 interface AgentModeControlProps {
@@ -73,14 +62,15 @@ export function AgentModeControl({
   const [query, setQuery] = useState('');
   const rootRef = useRef<HTMLDivElement | null>(null);
   const panelId = useId();
-  const skills = listSkills();
+  const skills = useMemo(() => listSkills().filter(isSpecialistSkill), []);
+  const showSearch = shouldShowSkillSearch(skills);
   const activeSkills = useMemo(
-    () => resolveActiveSkills(activeSkillIds),
+    () => resolveActiveSkills(activeSkillIds).filter(isSpecialistSkill),
     [activeSkillIds],
   );
   const summary = useMemo(() => summarizeAgentMode(activeSkills), [activeSkills]);
   const activeSet = useMemo(() => new Set(activeSkillIds), [activeSkillIds]);
-  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedQuery = showSearch ? query.trim().toLowerCase() : '';
   const visibleSkills = useMemo(() => {
     if (!normalizedQuery) return skills;
     return skills.filter((skill) => {
@@ -109,8 +99,6 @@ export function AgentModeControl({
     };
   }, [open]);
 
-  if (skills.length === 0) return null;
-
   const toggle = (id: string) => {
     onToggleSkill(id);
   };
@@ -129,19 +117,13 @@ export function AgentModeControl({
             ? 'border-[#a4d4a8]/60 bg-[#14201a] text-[#a4d4a8]'
             : 'border-[#2a2a35] bg-transparent text-slate-gray hover:text-soft-white hover:border-[#3a3a48]',
         ].join(' ')}
-        title="Review agent mode and enabled skills"
+        title="Review Firebase Expert and skills"
       >
         <span className="material-symbols-outlined text-[14px]" aria-hidden>
           {summary.icon}
         </span>
-        <span className="min-w-0 flex items-baseline gap-1.5">
-          <span className="text-[9px] font-mono uppercase tracking-wider text-slate-gray/80 shrink-0">
-            mode
-          </span>
-          <span className="min-w-0 truncate text-[11px] font-mono">{summary.label}</span>
-          <span className="hidden sm:inline min-w-0 truncate text-[10px] text-slate-gray">
-            {summary.detail}
-          </span>
+        <span className="min-w-0 truncate text-[11px] font-mono">
+          {summary.label}
         </span>
         <span className="material-symbols-outlined text-[14px] text-slate-gray" aria-hidden>
           expand_more
@@ -161,34 +143,38 @@ export function AgentModeControl({
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
                 <div className="text-[10px] font-mono uppercase tracking-wider text-slate-gray">
-                  Agent mode
+                  Skills
                 </div>
                 <div className="mt-1 flex items-center gap-2 text-[13px] font-semibold text-soft-white">
                   <span className="material-symbols-outlined text-[16px] text-[#a4d4a8]" aria-hidden>
-                    {summary.icon}
+                    manage_search
                   </span>
-                  <span className="min-w-0 truncate">{summary.label}</span>
-                  <span className="text-[11px] font-normal text-slate-gray">{summary.detail}</span>
+                  <span className="min-w-0 truncate">Firebase expert</span>
+                  <span className="inline-flex h-5 shrink-0 items-center justify-center rounded-full border border-[#2a2a35] px-2 text-[10px] font-normal leading-none text-slate-gray">
+                    Always on
+                  </span>
                 </div>
               </div>
               <button
                 type="button"
                 onClick={() => setOpen(false)}
                 className="rounded-full p-1 text-slate-gray hover:text-soft-white hover:bg-[#20202c]"
-                aria-label="Close agent mode"
+                aria-label="Close skills"
               >
                 <span className="material-symbols-outlined text-[16px]" aria-hidden>
                   close
                 </span>
               </button>
             </div>
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              className="w-full rounded-md border border-[#2a2a35] bg-content-bg px-2.5 py-1.5 text-[12px] text-soft-white placeholder:text-slate-gray/60 focus:outline-none focus:border-slate-gray"
-              placeholder="Search skills"
-              aria-label="Search skills"
-            />
+            {showSearch ? (
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                className="w-full rounded-md border border-[#2a2a35] bg-content-bg px-2.5 py-1.5 text-[12px] text-soft-white placeholder:text-slate-gray/60 focus:outline-none focus:border-slate-gray"
+                placeholder="Search skills"
+                aria-label="Search skills"
+              />
+            ) : null}
           </div>
 
           <div className="max-h-[min(58vh,320px)] overflow-y-auto custom-scrollbar p-2">
@@ -217,14 +203,14 @@ export function AgentModeControl({
           </div>
 
           <div className="flex items-center justify-between gap-3 border-t border-[#2a2a35] p-2.5">
-            <span className="text-[11px] text-slate-gray">Type / in the composer for quick activation.</span>
+            <span className="text-[11px] text-slate-gray">Type / in the composer for shortcuts.</span>
             <button
               type="button"
               onClick={onClearSkills}
-              disabled={activeSkillIds.length === 0}
+              disabled={activeSkills.length === 0}
               className={[
                 'shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-mono uppercase tracking-wider transition-colors',
-                activeSkillIds.length > 0
+                activeSkills.length > 0
                   ? 'border-[#2a2a35] text-slate-gray hover:text-soft-white hover:border-[#3a3a48]'
                   : 'border-[#2a2a35] text-slate-gray/40 cursor-not-allowed',
               ].join(' ')}
@@ -262,7 +248,7 @@ function SkillGroup({ label, skills, activeSet, onToggle }: SkillGroupProps) {
             onClick={() => onToggle(skill.id)}
             className={[
               'grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2.5 py-2 text-left transition-colors',
-              active ? 'bg-[#20202c]' : 'hover:bg-[#1a1a24]',
+              active ? 'bg-[#20202c]' : 'hover:bg-[#20202c]',
             ].join(' ')}
           >
             <span

--- a/packages/playground/src/components/ComposeBar.tsx
+++ b/packages/playground/src/components/ComposeBar.tsx
@@ -12,9 +12,11 @@
  * Purely presentational — caller owns the submit handler and the
  * toggle state.
  */
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import { ContextWindowMeter } from './ContextWindowMeter';
+import { PromptHighlightTextarea } from './PromptHighlightTextarea';
 import { useSlashCommands } from './SlashCommandMenu';
+import { detectContextSignalMatches } from '~/lib/agent/context';
 import { listSkills } from '~/lib/skills/registry';
 import { useSkillsStore } from '~/lib/store/skills';
 import type { ContextWindowSnapshot } from '~/lib/agent/context-window';
@@ -48,7 +50,7 @@ export function ComposeBar({
   onStop,
   sending = false,
   disabled = false,
-  placeholder = 'Ask the agent to write rules, change code, or run something…',
+  placeholder = 'Ask about Firestore rules, data models, Auth, RTDB, or building an app…',
   enhanceMode = false,
   onToggleEnhance,
   contextWindow,
@@ -68,6 +70,8 @@ export function ComposeBar({
     }
   }, [externalText]);
   const canSubmit = !disabled && !sending && value.trim().length > 0;
+  const matches = useMemo(() => detectContextSignalMatches(value), [value]);
+
   const submit = () => {
     const text = value.trim();
     if (!text) return;
@@ -146,22 +150,26 @@ export function ComposeBar({
 
       <div className="relative">
         {slash.menu}
-        <textarea
-          ref={taRef}
-          className="w-full bg-content-bg border border-[#2a2a35] rounded-md px-3 py-2.5 text-[13px] text-soft-white placeholder:text-slate-gray/60 focus:outline-none focus:border-slate-gray transition-colors font-display resize-none min-h-[64px] max-h-[200px]"
-          placeholder={placeholder}
+        <PromptHighlightTextarea
+          textareaRef={taRef}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onValueChange={setValue}
+          matches={matches}
+          placeholder={placeholder}
           onKeyDown={onKey}
           rows={3}
           spellCheck={false}
           disabled={disabled || sending}
+          ariaLabel="Agent prompt"
+          className="rounded-md border border-[#2a2a35] bg-content-bg transition-colors focus-within:border-slate-gray"
+          textClassName="px-3 py-2.5 text-[13px] leading-relaxed font-display min-h-[64px] max-h-[200px]"
+          textareaClassName="custom-scrollbar resize-none"
         />
       </div>
       <div className="flex items-center justify-between gap-3">
         <span className="text-[11px] text-slate-gray">
           ⌘ / Ctrl + Enter to send
-          <span className="hidden sm:inline"> · type / for skills</span>
+          <span className="hidden sm:inline"> · type / for shortcuts</span>
         </span>
         <div className="flex items-center gap-2 shrink-0">
           {contextWindow ? (

--- a/packages/playground/src/components/FirebaseTab.tsx
+++ b/packages/playground/src/components/FirebaseTab.tsx
@@ -71,7 +71,7 @@ export function FirebaseTab({
   sandboxMode,
   sandboxModeDisabled,
   onSandboxModeChange,
-  promptProfile = 'app-builder',
+  promptProfile = 'firebase',
 }: FirebaseTabProps) {
   const subTabs = firebaseSubTabsForProfile(promptProfile);
   const activeSubTab = subTabs.some((tab) => tab.id === subTab) ? subTab : 'sandbox';

--- a/packages/playground/src/components/HomePage.tsx
+++ b/packages/playground/src/components/HomePage.tsx
@@ -44,6 +44,9 @@ import {
   type SessionPayload,
 } from '~/lib/sessions';
 import { stashPendingPrompt } from '~/lib/sessions/pending-prompt';
+import {
+  detectContextSignalMatches,
+} from '~/lib/agent/context';
 import { listSkills } from '~/lib/skills/registry';
 import { useSlashCommands } from './SlashCommandMenu';
 import { useHomeSessions } from '~/hooks/useHomeSessions';
@@ -84,13 +87,14 @@ import {
 } from './GitHubImportSetup';
 import { Modal } from './Modal';
 import { ModelPicker } from './ModelPicker';
+import { PromptHighlightTextarea } from './PromptHighlightTextarea';
 import { SettingsModal } from './SettingsModal';
 import { TopBar } from './TopBar';
 
 ensureBufferPolyfill();
 
 const PROMPT_PLACEHOLDER =
-  'Describe what you want to build — a todo app, a chat room, a leaderboard… (type / for skills)';
+  'Ask about Firestore rules, data models, Auth, RTDB, or building an app… (type / for shortcuts)';
 
 type EnhanceState =
   | { kind: 'idle' }
@@ -315,6 +319,7 @@ export function HomePage() {
         providerId,
         modelId,
         apiKey,
+        activeSkillIds: selectedSkills,
         signal: ac.signal,
       })) {
         if (ac.signal.aborted) return;
@@ -343,7 +348,7 @@ export function HomePage() {
     } finally {
       if (enhanceAbortRef.current === ac) enhanceAbortRef.current = null;
     }
-  }, [prompt, providerId, modelId]);
+  }, [prompt, providerId, modelId, selectedSkills]);
 
   const cancelEnhancement = useCallback(() => {
     enhanceAbortRef.current?.abort();
@@ -721,6 +726,8 @@ function PromptComposer({
     ta.style.height = `${Math.max(ta.scrollHeight, 160)}px`;
   }, [prompt]);
 
+  const matches = useMemo(() => detectContextSignalMatches(prompt), [prompt]);
+
   // `/` command menu — pick skills for the session about to be created.
   const slash = useSlashCommands({
     value: prompt,
@@ -747,10 +754,11 @@ function PromptComposer({
     >
       <div className="relative">
         {slash.menu}
-        <textarea
-          ref={taRef}
+        <PromptHighlightTextarea
+          textareaRef={taRef}
           value={prompt}
-          onChange={(e) => onPromptChange(e.target.value)}
+          onValueChange={onPromptChange}
+          matches={matches}
           onKeyDown={(e) => {
             if (slash.onKeyDown(e)) return;
             onKeyDown(e);
@@ -758,14 +766,10 @@ function PromptComposer({
           placeholder={PROMPT_PLACEHOLDER}
           rows={4}
           disabled={starting}
-          spellCheck
-          className={[
-            'w-full bg-transparent border-0 outline-none custom-scrollbar',
-            'text-soft-white placeholder:text-slate-gray/60',
-            'text-[15px] leading-relaxed font-display',
-            'resize-none disabled:opacity-60 min-h-[120px]',
-          ].join(' ')}
-          aria-label="New session prompt"
+          spellCheck={false}
+          ariaLabel="New session prompt"
+          textClassName="text-[15px] leading-relaxed font-display min-h-[120px]"
+          textareaClassName="custom-scrollbar resize-none disabled:opacity-60"
         />
       </div>
 

--- a/packages/playground/src/components/PlaygroundPage.tsx
+++ b/packages/playground/src/components/PlaygroundPage.tsx
@@ -66,7 +66,7 @@ import { useWorkspaceStore } from '~/lib/store/workspace';
 import { useFilesStore } from '~/lib/store/files';
 import { getAllTurnTraces, useTraceStore } from '~/lib/store/trace';
 import { useSkillsStore } from '~/lib/store/skills';
-import { resolveActiveSkills, resolveWorkbenchIntent } from '~/lib/skills/registry';
+import { resolveAgentContext } from '~/lib/agent/context';
 import {
   isPlaygroundCommandMessage,
   isStudioEmbedSearch,
@@ -337,13 +337,9 @@ export function PlaygroundPage() {
   // memo below lists this as a dep so the meter updates on toggle.
   const activeSkillIds = useSkillsStore((s) => s.activeSkillIds);
   const activeSkillKey = activeSkillIds.join('\u0000');
-  const activeSkills = useMemo(
-    () => resolveActiveSkills(activeSkillIds),
-    [activeSkillKey],
-  );
   const workbenchIntent = useMemo(
-    () => resolveWorkbenchIntent(activeSkills),
-    [activeSkills],
+    () => resolveAgentContext({ activeSkillIds }).workbenchIntent,
+    [activeSkillKey],
   );
   const setActiveFilePath = useFilesStore((s) => s.setActiveFilePath);
 
@@ -500,6 +496,7 @@ export function PlaygroundPage() {
             providerId,
             modelId,
             apiKey,
+            activeSkillIds,
             signal: ac.signal,
           })) {
             if (ac.signal.aborted) return;
@@ -521,12 +518,26 @@ export function PlaygroundPage() {
         }
       })();
     },
-    [providerId, modelId],
+    [providerId, modelId, activeSkillIds],
+  );
+
+  const applyPromptWorkbenchIntent = useCallback(
+    (prompt: string) => {
+      const intent = resolveAgentContext({
+        prompt,
+        activeSkillIds: useSkillsStore.getState().activeSkillIds,
+      }).workbenchIntent;
+      setWorkspaceTab(intent.primarySurface);
+      if (intent.defaultFirebaseSubtab) setFirebaseSubTab(intent.defaultFirebaseSubtab);
+      if (intent.defaultFilePath) setActiveFilePath(intent.defaultFilePath);
+    },
+    [setActiveFilePath],
   );
 
   const handleSubmit = useCallback(
     (text: string) => {
       if (!text) return;
+      applyPromptWorkbenchIntent(text);
       useMobileNavStore.getState().setActive('agent');
       setActiveTab('agent');
       setAgentSubTab('chat');
@@ -536,7 +547,7 @@ export function PlaygroundPage() {
       }
       void send(text);
     },
-    [send, enhanceModeActive, runEnhancement],
+    [send, enhanceModeActive, runEnhancement, applyPromptWorkbenchIntent],
   );
 
   // Auto-fire the agent (or enhancer) for the home page's pending
@@ -556,12 +567,13 @@ export function PlaygroundPage() {
     pendingPromptFiredRef.current = true;
     const pending = takePendingPrompt(sessionRouting.sessionId);
     if (!pending) return;
+    applyPromptWorkbenchIntent(pending.prompt);
     if (pending.mode === 'enhance') {
       runEnhancement(pending.prompt);
     } else {
       void send(pending.prompt);
     }
-  }, [sessionRouting.loaded, sessionRouting.sessionId, send, runEnhancement]);
+  }, [sessionRouting.loaded, sessionRouting.sessionId, send, runEnhancement, applyPromptWorkbenchIntent]);
 
   // One-tap "Fix" from the Preview's compile/runtime error views or
   // the App pane's banner — submit the pre-built repair prompt AND
@@ -728,7 +740,7 @@ export function PlaygroundPage() {
 
   const contextWindow = useMemo(() => {
     const delegated = isDelegatedProvider(providerId);
-    const forceDiagnostics = workbenchIntent.promptProfile === 'firebase-tooling';
+    const forceDiagnostics = workbenchIntent.promptProfile === 'firebase';
     const diagnosticsEnabled = pyricDiagnosticsEnabled || forceDiagnostics;
     const systemPrompt = delegated
       ? buildClaudeLanePrompt({ diagnosticsEnabled })

--- a/packages/playground/src/components/PromptHighlightTextarea.tsx
+++ b/packages/playground/src/components/PromptHighlightTextarea.tsx
@@ -1,0 +1,105 @@
+import { useLayoutEffect, useRef, type KeyboardEventHandler, type RefObject } from 'react';
+import type { ContextSignalMatch } from '~/lib/agent/context';
+
+interface PromptHighlightTextareaProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  matches: readonly ContextSignalMatch[];
+  placeholder?: string;
+  rows?: number;
+  disabled?: boolean;
+  spellCheck?: boolean;
+  ariaLabel: string;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
+  className?: string;
+  textClassName?: string;
+  textareaClassName?: string;
+}
+
+export function PromptHighlightTextarea({
+  value,
+  onValueChange,
+  textareaRef,
+  matches,
+  placeholder,
+  rows,
+  disabled = false,
+  spellCheck = true,
+  ariaLabel,
+  onKeyDown,
+  className = '',
+  textClassName = '',
+  textareaClassName = '',
+}: PromptHighlightTextareaProps) {
+  const mirrorRef = useRef<HTMLDivElement | null>(null);
+  const renderedValue = value.length > 0 ? value : '';
+
+  const syncScroll = () => {
+    const textarea = textareaRef.current;
+    const mirror = mirrorRef.current;
+    if (!textarea || !mirror) return;
+    mirror.scrollTop = textarea.scrollTop;
+    mirror.scrollLeft = textarea.scrollLeft;
+  };
+
+  useLayoutEffect(syncScroll, [value, textareaRef]);
+
+  return (
+    <div className={['relative overflow-hidden', className].filter(Boolean).join(' ')}>
+      <div
+        ref={mirrorRef}
+        aria-hidden
+        className={[
+          'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words text-soft-white',
+          textClassName,
+        ].join(' ')}
+      >
+        {renderHighlightedText(renderedValue, matches)}
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        onScroll={syncScroll}
+        placeholder={placeholder}
+        rows={rows}
+        disabled={disabled}
+        spellCheck={spellCheck}
+        aria-label={ariaLabel}
+        className={[
+          'relative z-10 w-full bg-transparent caret-soft-white placeholder:text-slate-gray/60 focus:outline-none selection:bg-[#3a3a48] selection:text-soft-white',
+          value.length > 0 ? 'text-transparent' : 'text-soft-white',
+          textClassName,
+          textareaClassName,
+        ].join(' ')}
+      />
+    </div>
+  );
+}
+
+function renderHighlightedText(value: string, matches: readonly ContextSignalMatch[]) {
+  if (!value) return null;
+
+  const parts: JSX.Element[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) {
+      parts.push(<span key={`text-${cursor}`}>{value.slice(cursor, match.start)}</span>);
+    }
+    parts.push(
+      <span
+        key={`${match.lensId}-${match.start}-${match.end}`}
+        className="prompt-signal-gradient-text"
+      >
+        {value.slice(match.start, match.end)}
+      </span>,
+    );
+    cursor = match.end;
+  }
+  if (cursor < value.length) {
+    parts.push(<span key={`text-${cursor}`}>{value.slice(cursor)}</span>);
+  }
+  return parts;
+}

--- a/packages/playground/src/components/WorkspacePanel.tsx
+++ b/packages/playground/src/components/WorkspacePanel.tsx
@@ -5,8 +5,8 @@
  *   Firebase — backend workbench for sandbox data/auth/rules/traffic/seed
  *   File    — whatever file is active in the Files panel, via FileEditor
  *
- * Preview leads for app-building sessions. Firebase leads when a
- * Firebase-tooling slash skill is active. The Files panel on the
+ * Firebase leads for the default expert sessions. Preview leads when
+ * the prompt is explicitly app-building. The Files panel on the
  * right drives which file the File tab is showing.
  *
  * On mobile, Preview ALSO exists as its own bottom-tab (`App`) so
@@ -48,7 +48,7 @@ interface WorkspacePanelProps {
 export function WorkspacePanel({
   onFixRequest,
   onOpenDenials,
-  promptProfile = 'app-builder',
+  promptProfile = 'firebase',
   activeTab,
   onTabChange,
   firebaseProps,

--- a/packages/playground/src/components/workbench-layout.test.ts
+++ b/packages/playground/src/components/workbench-layout.test.ts
@@ -10,8 +10,8 @@ describe('Playground workbench layout helpers', () => {
     ]);
   });
 
-  test('Firebase tooling left tabs make Firebase primary', () => {
-    expect(workspaceTabsForProfile('firebase-tooling').map((tab) => tab.id)).toEqual([
+  test('Firebase expert left tabs make Firebase primary', () => {
+    expect(workspaceTabsForProfile('firebase').map((tab) => tab.id)).toEqual([
       'firebase',
       'file',
       'preview',
@@ -31,8 +31,8 @@ describe('Playground workbench layout helpers', () => {
     ]);
   });
 
-  test('Firebase tooling Firebase workbench hides tertiary app-builder tabs', () => {
-    expect(firebaseSubTabsForProfile('firebase-tooling').map((tab) => tab.id)).toEqual([
+  test('Firebase expert workbench hides tertiary app-builder tabs', () => {
+    expect(firebaseSubTabsForProfile('firebase').map((tab) => tab.id)).toEqual([
       'sandbox',
       'data',
       'auth',

--- a/packages/playground/src/components/workbench-tabs.ts
+++ b/packages/playground/src/components/workbench-tabs.ts
@@ -14,21 +14,21 @@ export type FirebaseWorkbenchSubTab =
   | 'deploy';
 
 export function workspaceTabsForProfile(
-  promptProfile: AgentPromptProfile = 'app-builder',
+  promptProfile: AgentPromptProfile = 'firebase',
 ): readonly Tab[] {
   const tabs: readonly Tab[] = [
     { id: 'preview', label: 'Preview' },
     { id: 'firebase', label: 'Firebase' },
     { id: 'file', label: 'File' },
   ];
-  if (promptProfile === 'firebase-tooling') {
+  if (promptProfile === 'firebase') {
     return [tabs[1]!, tabs[2]!, tabs[0]!];
   }
   return tabs;
 }
 
 export function firebaseSubTabsForProfile(
-  promptProfile: AgentPromptProfile = 'app-builder',
+  promptProfile: AgentPromptProfile = 'firebase',
 ): readonly Tab[] {
   const focused: readonly Tab[] = [
     { id: 'sandbox', label: 'Sandbox' },
@@ -37,7 +37,7 @@ export function firebaseSubTabsForProfile(
     { id: 'traffic', label: 'Traffic' },
     { id: 'seed', label: 'Seed' },
   ];
-  if (promptProfile === 'firebase-tooling') return focused;
+  if (promptProfile === 'firebase') return focused;
   return [
     ...focused,
     { id: 'ideas', label: 'Ideas' },

--- a/packages/playground/src/lib/agent-shell/man-pages.ts
+++ b/packages/playground/src/lib/agent-shell/man-pages.ts
@@ -253,7 +253,14 @@ seed_firestore_data_as_admin — FIXTURE setup only (admin bypass; the
   read/update/delete rules can be probed. Testing whether rules ALLOW
   a write is simulate_firestore_write's job. Methods: set/delete only;
   ≤100 ops per call (TOO_MANY_OPERATIONS above); per-entry failures
-  land in errors[]. Seeded paths wake live onSnapshot listeners.
+  land in errors[]. Seeded paths wake live onSnapshot listeners. Use this
+  for live sandbox/demo/fixture state; workspace test-file seed blocks are
+  hermetic and do not populate the live sandbox. ID policy: autoId:true on
+  collection paths for addDoc-style user-created docs (posts, tasks,
+  messages, orders, game sessions); explicit document IDs for stable docs
+  like users/{uid}, membership keyed by UID, config/singleton docs, lookup
+  docs, or rule-test paths you must reference. Use data.generated paths
+  from auto-ID writes in follow-up references.
 
 generate_fixture_from_session — after the user validates a flow
   end-to-end, capture history + final state as a replay fixture

--- a/packages/playground/src/lib/agent/auth-ui-guidance.test.ts
+++ b/packages/playground/src/lib/agent/auth-ui-guidance.test.ts
@@ -14,7 +14,10 @@ import { buildSystemPrompt } from './system-prompt';
 import { ENHANCER_SYSTEM_PROMPT } from './prompt-enhancer/system-prompt';
 
 describe('agent system prompt — auth UI guidance', () => {
-  const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
+  const prompt = buildSystemPrompt({
+    diagnosticsEnabled: false,
+    prompt: 'Build an app with Google sign-in',
+  });
 
   test('forbids developer identity-switchers in app UI', () => {
     expect(prompt).toContain('NEVER render a developer identity-switcher');

--- a/packages/playground/src/lib/agent/backend-ui-guidance.test.ts
+++ b/packages/playground/src/lib/agent/backend-ui-guidance.test.ts
@@ -14,7 +14,7 @@
  * prompts so neither layer can silently drop the rule.
  */
 import { describe, expect, test } from 'bun:test';
-import { BACKEND_UI_GUIDANCE, buildSystemPrompt } from './system-prompt';
+import { BACKEND_UI_GUIDANCE, FIRESTORE_SEEDING_POLICY, buildSystemPrompt } from './system-prompt';
 import { composeDraftSystemPrompt } from './strategies/draft-then-validate';
 
 // The load-bearing strings — asserted verbatim against every prompt the
@@ -38,7 +38,10 @@ describe('backend-UI guidance — single source of truth', () => {
 });
 
 describe('react loop inherits the guidance (buildSystemPrompt)', () => {
-  const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
+  const prompt = buildSystemPrompt({
+    diagnosticsEnabled: false,
+    prompt: 'Build a menu ordering app with Firestore rules',
+  });
 
   test('forbids in-app seeding / admin code', () => {
     for (const pin of PINS) expect(prompt).toContain(pin);
@@ -65,5 +68,12 @@ describe('draft-validate inherits the SAME guidance (composeDraftSystemPrompt)',
   test('points the de-caged draft at the host seed tool, not in-app UI', () => {
     expect(draftPrompt).toContain('seed_firestore_data_as_admin');
     expect(draftPrompt).toContain('NEVER bake seeding into App.tsx');
+  });
+
+  test('carries the Firestore seed ID policy', () => {
+    expect(draftPrompt).toContain(FIRESTORE_SEEDING_POLICY);
+    expect(draftPrompt).toContain('Use `autoId: true` for addDoc-style user-created docs');
+    expect(draftPrompt).toContain('Use explicit IDs for semantic or stable docs');
+    expect(draftPrompt).toContain('test-file `seed` blocks');
   });
 });

--- a/packages/playground/src/lib/agent/claude-lane-prompt.test.ts
+++ b/packages/playground/src/lib/agent/claude-lane-prompt.test.ts
@@ -13,6 +13,14 @@ import { MCP_TOOL_NAMES } from '~/lib/server/claude-mcp';
 
 const laneOn = buildClaudeLanePrompt({ diagnosticsEnabled: true });
 const laneOff = buildClaudeLanePrompt({ diagnosticsEnabled: false });
+const laneAppOn = buildClaudeLanePrompt({
+  diagnosticsEnabled: true,
+  prompt: 'Build a notes app with Firestore rules',
+});
+const laneAppOff = buildClaudeLanePrompt({
+  diagnosticsEnabled: false,
+  prompt: 'Build a notes app with Firestore rules',
+});
 
 describe('claude lane prompt — MCP tool surface', () => {
   test('names every bridge tool by its real mcp__playground__ name (no drift)', () => {
@@ -54,7 +62,7 @@ describe('claude lane prompt — MCP tool surface', () => {
 
 describe('claude lane prompt — protected pins stay verbatim', () => {
   test('auth-UI guidance (the #575 pins)', () => {
-    for (const p of [laneOn, laneOff]) {
+    for (const p of [laneAppOn, laneAppOff]) {
       expect(p).toContain('NEVER render a developer identity-switcher');
       expect(p).toContain('no uid dropdowns');
       expect(p).toContain('SANDBOX/TOOL contexts only');
@@ -63,7 +71,7 @@ describe('claude lane prompt — protected pins stay verbatim', () => {
   });
 
   test('anti-footgun invariants (W2.2 pins)', () => {
-    for (const p of [laneOn, laneOff]) {
+    for (const p of [laneAppOn, laneAppOff]) {
       expect(p).toContain('replaces the whole file');
       expect(p).toContain('@pyric/*');
       expect(p).toContain('signInWithCustomToken');
@@ -83,12 +91,15 @@ describe('claude lane prompt — protected pins stay verbatim', () => {
   });
 
   test('shared sections are literally shared with the canonical prompt (one source)', () => {
-    const canonical = buildSystemPrompt({ diagnosticsEnabled: false });
+    const canonical = buildSystemPrompt({
+      diagnosticsEnabled: false,
+      prompt: 'Build a notes app with Firestore rules',
+    });
     // Spot-check a long pinned paragraph: byte-identical in both prompts.
     const authUiLine = canonical
       .split('\n')
       .find((l) => l.includes('NEVER render a developer identity-switcher'));
     expect(authUiLine).toBeDefined();
-    expect(laneOff).toContain(authUiLine!);
+    expect(laneAppOff).toContain(authUiLine!);
   });
 });

--- a/packages/playground/src/lib/agent/claude-lane-prompt.ts
+++ b/packages/playground/src/lib/agent/claude-lane-prompt.ts
@@ -47,11 +47,12 @@ import {
 } from './system-prompt';
 import { lintBlock } from './diagnostics/lint-block';
 import { pitfallsBlock } from './diagnostics/pitfalls-block';
-import { resolveActiveSkills, resolvePromptProfile } from '~/lib/skills/registry';
+import { resolveAgentContext } from './context';
 import { useSkillsStore } from '~/lib/store/skills';
 
 interface BuildClaudeLanePromptOpts {
   diagnosticsEnabled: boolean;
+  prompt?: string;
 }
 
 /** The replacement tool-surface section. Names MUST match what the MCP
@@ -76,15 +77,16 @@ const MCP_TOOLS = [
   'WORKFLOW — you own the whole turn; there is no outer agent dispatching for you. A typical build/modify request: read the current files → consult the stdlib (and lint candidates) → write rules + App TSX + tests via `mcp__playground__write_file` → run `mcp__playground__run_workspace_tests` → iterate until green → reply with a concise summary of what changed and why. Your file writes land in the user\'s workspace when the turn ends.',
 ].join('\n');
 
-const MCP_FIREBASE_TOOLING_PROFILE = [
-  'FIREBASE TOOLING MODE — this is not an app build.',
+const MCP_FIREBASE_PROFILE = [
+  'FIREBASE EXPERT MODE — this is the default Playground posture.',
+  '  Pyric is the local Firebase runtime and evidence surface. Do not recommend Firebase Emulators.',
   '  Do NOT create or edit `/workspace/src/App.tsx` unless the user explicitly asks for an app, UI, or preview. Primary outputs are rules, tests, audit reports, schema notes, simulations, and evidence-backed recommendations.',
   '  In this delegated lane, only the listed `mcp__playground__*` tools are callable. Use file tools, rules lint, Firestore simulations, workspace tests, and the rules stdlib for evidence.',
   '  Browser-only evidence such as Auth users, Traffic rows, sandbox discovery, and RTDB runtime inspection is not available through this MCP bridge. If a tooling task needs that evidence, say so explicitly and proceed with the available workspace/rules evidence.',
 ].join('\n');
 
-const MCP_FIREBASE_TOOLING_WORKFLOW = [
-  'WORKFLOW — evidence-first Firebase tooling. Plan briefly, inspect only the relevant files/evidence, analyze risks or data-model tradeoffs, then propose or apply rules/tests/seed artifacts only when requested.',
+const MCP_FIREBASE_WORKFLOW = [
+  'WORKFLOW — evidence-first Firebase expertise. Plan briefly, inspect only the relevant files/evidence, analyze risks or data-model tradeoffs, then propose or apply rules/tests/seed artifacts only when requested.',
   'Do not end by building App.tsx. Verify with lint, simulation, or workspace tests when useful.',
 ].join('\n');
 
@@ -93,16 +95,18 @@ const MCP_FIREBASE_TOOLING_WORKFLOW = [
  * `buildSystemPrompt`'s section order so the protected guidance reads
  * identically; only the tool-surface sections differ.
  */
-export function buildClaudeLanePrompt({ diagnosticsEnabled }: BuildClaudeLanePromptOpts): string {
-  const promptProfile = resolvePromptProfile(
-    resolveActiveSkills(useSkillsStore.getState().activeSkillIds),
-  );
+export function buildClaudeLanePrompt({ diagnosticsEnabled, prompt = '' }: BuildClaudeLanePromptOpts): string {
+  const agentContext = resolveAgentContext({
+    prompt,
+    activeSkillIds: useSkillsStore.getState().activeSkillIds,
+  });
+  const promptProfile = agentContext.promptProfile;
   const profileSections =
-    promptProfile === 'firebase-tooling'
+    promptProfile === 'firebase'
       ? [
-          MCP_FIREBASE_TOOLING_PROFILE,
+          MCP_FIREBASE_PROFILE,
           '',
-          MCP_FIREBASE_TOOLING_WORKFLOW,
+          MCP_FIREBASE_WORKFLOW,
           '',
           AUTH_SHAPE,
           '',

--- a/packages/playground/src/lib/agent/context.test.ts
+++ b/packages/playground/src/lib/agent/context.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  detectContextLensIds,
+  detectContextSignalMatches,
+  resolveAgentContext,
+  suggestedSkillIdsForPrompt,
+} from './context';
+
+describe('resolveAgentContext', () => {
+  test('defaults to Firebase expert context', () => {
+    const context = resolveAgentContext();
+    expect(context.promptProfile).toBe('firebase');
+    expect(context.workbenchIntent).toMatchObject({
+      promptProfile: 'firebase',
+      primarySurface: 'firebase',
+      defaultFirebaseSubtab: 'sandbox',
+      toolProfilePreference: 'diagnostic',
+      strategyPreference: 'react',
+    });
+  });
+
+  test('app intent opts into app-builder context', () => {
+    const context = resolveAgentContext({
+      prompt: 'Build a Kanban app with Firestore rules',
+    });
+    expect(context.promptProfile).toBe('app-builder');
+    expect(context.lenses.map((lens) => lens.id)).toContain('app-build');
+    expect(context.workbenchIntent.primarySurface).toBe('preview');
+  });
+
+  test('Firestore data-modeling prompt stays Firebase-native', () => {
+    const context = resolveAgentContext({
+      prompt: 'Model Firestore data for teams with role based access',
+    });
+    expect(context.promptProfile).toBe('firebase');
+    expect(context.lenses.map((lens) => lens.id)).toEqual(
+      expect.arrayContaining(['firestore', 'auth', 'rules', 'data-modeling']),
+    );
+    expect(context.workbenchIntent.primarySurface).not.toBe('preview');
+  });
+
+  test('dismissed lenses are excluded for the current prompt', () => {
+    expect(detectContextLensIds('Audit Firestore security rules')).toContain('audit');
+    expect(detectContextLensIds('Audit Firestore security rules', ['audit'])).not.toContain(
+      'audit',
+    );
+  });
+
+  test('detects non-overlapping signal matches for composer highlights', () => {
+    const matches = detectContextSignalMatches(
+      'Write a Firestore data model that uses role based access',
+    );
+    expect(matches.map((match) => [match.lensId, match.label])).toEqual([
+      ['firestore', 'Firestore'],
+      ['data-modeling', 'data model'],
+      ['rules', 'role based access'],
+    ]);
+    expect(matches.every((match, index) => index === 0 || match.start >= matches[index - 1]!.end)).toBe(
+      true,
+    );
+  });
+
+  test('specialist phrases suggest but do not enable niche skills', () => {
+    const context = resolveAgentContext({
+      prompt: 'Design turn-based multiplayer game rules',
+    });
+    expect(suggestedSkillIdsForPrompt('turn based multiplayer game')).toContain('game-rules');
+    expect(context.suggestedSkillIds).toContain('game-rules');
+    expect(context.activeSkills.map((skill) => skill.id)).not.toContain('game-rules');
+  });
+
+  test('game specialist suggestion avoids generic board/product language', () => {
+    expect(
+      suggestedSkillIdsForPrompt('Create a Firestore data model for a kanban board'),
+    ).not.toContain('game-rules');
+    expect(
+      suggestedSkillIdsForPrompt('Create a Firestore data model that uses role based access'),
+    ).not.toContain('game-rules');
+    expect(suggestedSkillIdsForPrompt('Model team membership for a project board')).not.toContain(
+      'game-rules',
+    );
+    expect(suggestedSkillIdsForPrompt('Design a multiplayer game with valid moves')).toContain(
+      'game-rules',
+    );
+    expect(suggestedSkillIdsForPrompt('Write rules for a chess lobby')).toContain('game-rules');
+  });
+});

--- a/packages/playground/src/lib/agent/context.ts
+++ b/packages/playground/src/lib/agent/context.ts
@@ -1,0 +1,276 @@
+import {
+  resolveActiveSkills,
+  resolveWorkbenchIntent,
+  type FirebaseWorkbenchSubtab,
+  type SkillDefinition,
+  type SkillStrategyPreference,
+  type SkillToolProfilePreference,
+  type WorkbenchSurface,
+} from '~/lib/skills/registry';
+
+export type ContextLensId =
+  | 'app-build'
+  | 'firestore'
+  | 'rtdb'
+  | 'auth'
+  | 'storage'
+  | 'rules'
+  | 'data-modeling'
+  | 'queries-indexes'
+  | 'seed-data'
+  | 'audit';
+
+export interface ContextLens {
+  id: ContextLensId;
+  label: string;
+  icon: string;
+}
+
+export interface ContextSignalMatch {
+  lensId: ContextLensId;
+  label: string;
+  icon: string;
+  start: number;
+  end: number;
+}
+
+export interface ResolvedAgentContext {
+  promptProfile: 'firebase' | 'app-builder';
+  lenses: ContextLens[];
+  suggestedSkillIds: string[];
+  activeSkills: SkillDefinition[];
+  workbenchIntent: {
+    promptProfile: 'firebase' | 'app-builder';
+    primarySurface: WorkbenchSurface;
+    defaultFirebaseSubtab?: FirebaseWorkbenchSubtab;
+    defaultFilePath?: string;
+    toolProfilePreference?: SkillToolProfilePreference;
+    strategyPreference?: SkillStrategyPreference;
+  };
+  toolProfilePreference?: SkillToolProfilePreference;
+  strategyPreference?: SkillStrategyPreference;
+}
+
+const LENS_META: Record<ContextLensId, ContextLens> = {
+  'app-build': { id: 'app-build', label: 'App build', icon: 'web_asset' },
+  firestore: { id: 'firestore', label: 'Firestore', icon: 'database' },
+  rtdb: { id: 'rtdb', label: 'RTDB', icon: 'account_tree' },
+  auth: { id: 'auth', label: 'Auth', icon: 'passkey' },
+  storage: { id: 'storage', label: 'Storage', icon: 'folder' },
+  rules: { id: 'rules', label: 'Rules', icon: 'policy' },
+  'data-modeling': { id: 'data-modeling', label: 'Data model', icon: 'schema' },
+  'queries-indexes': { id: 'queries-indexes', label: 'Indexes', icon: 'query_stats' },
+  'seed-data': { id: 'seed-data', label: 'Seed data', icon: 'grass' },
+  audit: { id: 'audit', label: 'Audit', icon: 'manage_search' },
+};
+
+const LENS_PATTERNS: Array<[ContextLensId, RegExp]> = [
+  [
+    'app-build',
+    /\b(App\.tsx|preview|web app|application UI)\b|\b(build|create|make|implement|scaffold|prototype|modify|update)\b.{0,48}\b(app|ui|interface|screen|component|preview|website|web app|page|dashboard)\b|\b(app|ui|interface|screen|component|preview|website|web app|page|dashboard)\b.{0,48}\b(build|create|make|implement|scaffold|prototype|modify|update)\b/i,
+  ],
+  ['firestore', /\b(firestore|collection|collections|document|documents|doc\b|collection group|query|queries|index|indexes)\b/i],
+  ['rtdb', /\b(rtdb|realtime database|database\.rules|database rules|json rules)\b/i],
+  ['auth', /\b(auth|authentication|sign[- ]?in|sign[- ]?out|user|users|uid|provider|claims?|custom claims?|role|roles|member|membership)\b/i],
+  ['storage', /\b(storage|bucket|object|file upload|download url|metadata)\b/i],
+  ['rules', /\b(rule|rules|security|permission|permissions|allow|deny|denied|access|owner|admin|role based|role-based|membership)\b/i],
+  [
+    'data-modeling',
+    /\b(data model|model data|model\b.{0,32}\bdata|data\b.{0,32}\bmodel|schema|shape|structure|collections?|documents?|paths?|membership|relationship|relationships)\b/i,
+  ],
+  ['queries-indexes', /\b(query|queries|index|indexes|orderBy|where|pagination|cursor|collection group|firestore_extract_indexes)\b/i],
+  ['seed-data', /\b(seed|fixture|fixtures|sample data|test data|auth users?|populate)\b/i],
+  ['audit', /\b(audit|review|inspect|assess|analyze|find gaps|vulnerab|security review)\b/i],
+];
+
+const SIGNAL_PATTERNS: Array<[ContextLensId, RegExp]> = [
+  ['app-build', /\b(App\.tsx|preview|web app|application UI|app|ui|interface|screen|component|website|dashboard)\b/gi],
+  ['firestore', /\b(Firestore|collection groups?|collections?|documents?|docs?)\b/gi],
+  ['rtdb', /\b(RTDB|Realtime Database|database\.rules|database rules|json rules)\b/gi],
+  ['auth', /\b(Auth|authentication|sign[- ]?in|sign[- ]?out|users?|uid|providers?|custom claims?|claims?)\b/gi],
+  ['storage', /\b(Storage|buckets?|objects?|file uploads?|download urls?|metadata)\b/gi],
+  ['rules', /\b(rules?|security|permissions?|allow|deny|denied|access|owners?|admins?|role[- ]based(?: access)?|membership)\b/gi],
+  ['data-modeling', /\b(data model(?:ing)?|model data|schema|shape|structure|relationships?|paths?)\b/gi],
+  ['queries-indexes', /\b(queries|query|indexes|index|orderBy|where|pagination|cursor|collection group|firestore_extract_indexes)\b/gi],
+  ['seed-data', /\b(seed data|seed|fixtures?|sample data|test data|auth users?|populate)\b/gi],
+  ['audit', /\b(audit|review|inspect|assess|analyze|find gaps|vulnerabilities|security review)\b/gi],
+];
+
+const GENERAL_FIREBASE_SKILL_TO_LENSES: Record<string, ContextLensId[]> = {
+  'firebase-audit': ['audit'],
+  'playground-firebase-auth-model': ['auth'],
+  'firestore-rules-audit': ['firestore', 'rules', 'audit'],
+  'playground-firestore-query-indexes': ['firestore', 'queries-indexes'],
+  'rtdb-security-rules': ['rtdb', 'rules'],
+  'rtdb-data-model': ['rtdb', 'data-modeling'],
+};
+
+function addLens(out: ContextLensId[], id: ContextLensId, dismissed: ReadonlySet<ContextLensId>) {
+  if (dismissed.has(id)) return;
+  if (!out.includes(id)) out.push(id);
+}
+
+export function detectContextLensIds(
+  prompt: string,
+  dismissedLensIds: readonly ContextLensId[] = [],
+): ContextLensId[] {
+  const dismissed = new Set(dismissedLensIds);
+  const out: ContextLensId[] = [];
+  for (const [id, re] of LENS_PATTERNS) {
+    if (re.test(prompt)) addLens(out, id, dismissed);
+  }
+  return out;
+}
+
+export function contextLensById(id: ContextLensId): ContextLens {
+  return LENS_META[id];
+}
+
+export function contextLensesForPrompt(
+  prompt: string,
+  dismissedLensIds: readonly ContextLensId[] = [],
+): ContextLens[] {
+  return detectContextLensIds(prompt, dismissedLensIds).map(contextLensById);
+}
+
+export function detectContextSignalMatches(prompt: string): ContextSignalMatch[] {
+  if (!prompt.trim()) return [];
+
+  const matches: ContextSignalMatch[] = [];
+  for (const [lensId, pattern] of SIGNAL_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of prompt.matchAll(pattern)) {
+      if (match.index === undefined || !match[0]) continue;
+      const meta = contextLensById(lensId);
+      matches.push({
+        lensId,
+        label: match[0],
+        icon: meta.icon,
+        start: match.index,
+        end: match.index + match[0].length,
+      });
+    }
+  }
+
+  return matches
+    .sort((a, b) => {
+      if (a.start !== b.start) return a.start - b.start;
+      return b.end - b.start - (a.end - a.start);
+    })
+    .reduce<ContextSignalMatch[]>((out, match) => {
+      const previous = out[out.length - 1];
+      if (previous && match.start < previous.end) return out;
+      out.push(match);
+      return out;
+    }, []);
+}
+
+export function suggestedSkillIdsForPrompt(prompt: string): string[] {
+  return /\b(game rules|turn[- ]based|multiplayer game|valid moves?|winner|tic[- ]tac[- ]toe|chess|checkers)\b/i.test(prompt) ||
+    /\bgame\b.{0,40}\b(score|moves?|turns?|winner|rules?)\b/i.test(prompt) ||
+    /\b(score|moves?|turns?|winner|rules?)\b.{0,40}\bgame\b/i.test(prompt)
+    ? ['game-rules']
+    : [];
+}
+
+export function isGeneralFirebaseSkill(skill: SkillDefinition): boolean {
+  return skill.id in GENERAL_FIREBASE_SKILL_TO_LENSES;
+}
+
+export function isSpecialistSkill(skill: SkillDefinition): boolean {
+  return !isGeneralFirebaseSkill(skill);
+}
+
+export function lensIdsFromSkills(skills: readonly SkillDefinition[]): ContextLensId[] {
+  const out: ContextLensId[] = [];
+  const none = new Set<ContextLensId>();
+  for (const skill of skills) {
+    for (const id of GENERAL_FIREBASE_SKILL_TO_LENSES[skill.id] ?? []) {
+      addLens(out, id, none);
+    }
+  }
+  return out;
+}
+
+function preferredWorkbenchForLenses(lenses: readonly ContextLens[]): {
+  primarySurface: WorkbenchSurface;
+  defaultFirebaseSubtab?: FirebaseWorkbenchSubtab;
+  defaultFilePath?: string;
+} {
+  const ids = new Set(lenses.map((lens) => lens.id));
+  if (ids.has('app-build')) return { primarySurface: 'preview' };
+  if (ids.has('audit')) return { primarySurface: 'firebase', defaultFirebaseSubtab: 'sandbox' };
+  if (ids.has('rules')) {
+    return {
+      primarySurface: 'file',
+      defaultFilePath: ids.has('rtdb')
+        ? '/workspace/database.rules.json'
+        : '/workspace/firestore.rules',
+    };
+  }
+  if (ids.has('auth')) return { primarySurface: 'firebase', defaultFirebaseSubtab: 'auth' };
+  if (ids.has('seed-data')) return { primarySurface: 'firebase', defaultFirebaseSubtab: 'seed' };
+  if (ids.has('data-modeling') || ids.has('queries-indexes') || ids.has('firestore')) {
+    return { primarySurface: 'firebase', defaultFirebaseSubtab: 'data' };
+  }
+  return { primarySurface: 'firebase', defaultFirebaseSubtab: 'sandbox' };
+}
+
+export function resolveAgentContext({
+  prompt = '',
+  activeSkillIds = [],
+  dismissedLensIds = [],
+}: {
+  prompt?: string;
+  activeSkillIds?: readonly string[];
+  dismissedLensIds?: readonly ContextLensId[];
+} = {}): ResolvedAgentContext {
+  const activeSkills = resolveActiveSkills(activeSkillIds);
+  const lensIds = [
+    ...detectContextLensIds(prompt, dismissedLensIds),
+    ...lensIdsFromSkills(activeSkills),
+  ].filter((id, index, ids) => ids.indexOf(id) === index);
+  const lenses = lensIds.map(contextLensById);
+  const promptProfile = lensIds.includes('app-build') ? 'app-builder' : 'firebase';
+  const skillIntent = resolveWorkbenchIntent(activeSkills);
+  const lensIntent = preferredWorkbenchForLenses(lenses);
+  const hasSkillWorkbenchIntent = activeSkills.some(
+    (skill) => skill.primarySurface || skill.defaultFirebaseSubtab || skill.defaultFilePath,
+  );
+  const toolProfilePreference =
+    skillIntent.toolProfilePreference ??
+    (promptProfile === 'firebase' || lenses.length > 0 ? 'diagnostic' : undefined);
+  const strategyPreference =
+    skillIntent.strategyPreference ?? (promptProfile === 'firebase' ? 'react' : undefined);
+
+  return {
+    promptProfile,
+    lenses,
+    suggestedSkillIds: suggestedSkillIdsForPrompt(prompt).filter(
+      (id) => !activeSkillIds.includes(id),
+    ),
+    activeSkills,
+    workbenchIntent: {
+      promptProfile,
+      primarySurface: hasSkillWorkbenchIntent ? skillIntent.primarySurface : lensIntent.primarySurface,
+      ...(hasSkillWorkbenchIntent ? skillIntent.defaultFirebaseSubtab : lensIntent.defaultFirebaseSubtab
+        ? {
+            defaultFirebaseSubtab: hasSkillWorkbenchIntent
+              ? skillIntent.defaultFirebaseSubtab
+              : lensIntent.defaultFirebaseSubtab,
+          }
+        : {}),
+      ...(hasSkillWorkbenchIntent ? skillIntent.defaultFilePath : lensIntent.defaultFilePath
+        ? {
+            defaultFilePath: hasSkillWorkbenchIntent
+              ? skillIntent.defaultFilePath
+              : lensIntent.defaultFilePath,
+          }
+        : {}),
+      ...(toolProfilePreference ? { toolProfilePreference } : {}),
+      ...(strategyPreference ? { strategyPreference } : {}),
+    },
+    ...(toolProfilePreference ? { toolProfilePreference } : {}),
+    ...(strategyPreference ? { strategyPreference } : {}),
+  };
+}

--- a/packages/playground/src/lib/agent/fresh-workspace-prompt.test.ts
+++ b/packages/playground/src/lib/agent/fresh-workspace-prompt.test.ts
@@ -11,9 +11,19 @@ function resetWorkspace() {
 describe('buildSystemPrompt — fresh-workspace directive', () => {
   afterEach(resetWorkspace);
 
-  test('empty workspace injects the skip-discovery directive', () => {
+  test('empty Firebase workspace injects the Firebase directive', () => {
     resetWorkspace();
     const p = buildSystemPrompt({ diagnosticsEnabled: false });
+    expect(p).toContain('WORKSPACE STATE — NEW FIREBASE SESSION');
+    expect(p).toContain('Do not treat that as a reason to build an app');
+  });
+
+  test('empty app-builder workspace injects the skip-discovery directive', () => {
+    resetWorkspace();
+    const p = buildSystemPrompt({
+      diagnosticsEnabled: false,
+      prompt: 'Build a todo app',
+    });
     expect(p).toContain('WORKSPACE STATE — NEW SESSION');
     expect(p).toContain('skip the analyze phase');
     expect(p).toContain('Do NOT call `list_files`');
@@ -23,20 +33,20 @@ describe('buildSystemPrompt — fresh-workspace directive', () => {
     resetWorkspace();
     useWorkspaceStore.getState().setAppSource('export default function App(){return null}');
     const p = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(p).not.toContain('WORKSPACE STATE — NEW SESSION');
+    expect(p).not.toContain('WORKSPACE STATE — NEW FIREBASE SESSION');
   });
 
   test('rules present alone → directive omitted', () => {
     resetWorkspace();
     useWorkspaceStore.getState().setRules("rules_version = '2';");
     const p = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(p).not.toContain('WORKSPACE STATE — NEW SESSION');
+    expect(p).not.toContain('WORKSPACE STATE — NEW FIREBASE SESSION');
   });
 
   test('whitespace-only content still counts as fresh', () => {
     resetWorkspace();
     useWorkspaceStore.getState().setAppSource('   \n  ');
     const p = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(p).toContain('WORKSPACE STATE — NEW SESSION');
+    expect(p).toContain('WORKSPACE STATE — NEW FIREBASE SESSION');
   });
 });

--- a/packages/playground/src/lib/agent/prompt-enhancer/enhance.test.ts
+++ b/packages/playground/src/lib/agent/prompt-enhancer/enhance.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { useSkillsStore } from '~/lib/store/skills';
+import { resolveEnhancerActiveSkills } from './enhance';
+
+describe('resolveEnhancerActiveSkills', () => {
+  afterEach(() => {
+    useSkillsStore.getState().clear();
+  });
+
+  test('uses explicit ids instead of stale global store state', () => {
+    useSkillsStore.getState().hydrate(['game-rules']);
+
+    expect(resolveEnhancerActiveSkills([]).map((skill) => skill.id)).toEqual([]);
+  });
+
+  test('falls back to store state for older callers', () => {
+    useSkillsStore.getState().hydrate(['game-rules']);
+
+    expect(resolveEnhancerActiveSkills().map((skill) => skill.id)).toEqual(['game-rules']);
+  });
+});

--- a/packages/playground/src/lib/agent/prompt-enhancer/enhance.ts
+++ b/packages/playground/src/lib/agent/prompt-enhancer/enhance.ts
@@ -21,7 +21,12 @@ export interface EnhanceParams {
   providerId: string;
   modelId: string;
   apiKey: string;
+  activeSkillIds?: readonly string[];
   signal?: AbortSignal;
+}
+
+export function resolveEnhancerActiveSkills(activeSkillIds?: readonly string[]) {
+  return resolveActiveSkills(activeSkillIds ?? useSkillsStore.getState().activeSkillIds);
 }
 
 export async function* enhancePrompt({
@@ -29,21 +34,22 @@ export async function* enhancePrompt({
   providerId,
   modelId,
   apiKey,
+  activeSkillIds,
   signal,
 }: EnhanceParams): AsyncGenerator<string> {
   const client = createInference();
+  const activeSkills = resolveEnhancerActiveSkills(activeSkillIds);
   const req: NormalizedRequest = {
     provider: providerId,
     model: modelId,
     apiKey,
     messages: [
-      // Skill-aware: an active skill with an enhancerShape (e.g. Game
-      // rules) reshapes the prompt for its domain.
+      // Firebase Expert is always on; explicit active skill ids add
+      // specialist overlays. The store fallback keeps older callers
+      // working while new-session compose passes local selected skills.
       {
         role: 'system',
-        text: buildEnhancerPrompt(
-          resolveActiveSkills(useSkillsStore.getState().activeSkillIds),
-        ),
+        text: buildEnhancerPrompt(activeSkills, rawInput),
       },
       { role: 'user', text: rawInput },
     ],
@@ -70,7 +76,7 @@ export async function* enhancePrompt({
   }
 }
 
-/** Word count for the card's 30-50w sweet-spot indicator. Matches the
+/** Word count for the card's 30-70w sweet-spot indicator. Matches the
  *  shape rule in `system-prompt.ts`. */
 export function countWords(text: string): number {
   const trimmed = text.trim();

--- a/packages/playground/src/lib/agent/prompt-enhancer/system-prompt.test.ts
+++ b/packages/playground/src/lib/agent/prompt-enhancer/system-prompt.test.ts
@@ -6,7 +6,7 @@
  * historically leaked into enhanced prompts and then into generated
  * app UI (identity switchers, references to host tabs). These tests
  * pin the instruction text itself: no host vocabulary, purity rules
- * present, and a game shape distinct from the CRUD-app shape.
+ * present, and Firebase-native shaping by default.
  */
 import { describe, expect, test } from 'bun:test';
 import { buildEnhancerPrompt, ENHANCER_SYSTEM_PROMPT } from './system-prompt';
@@ -43,27 +43,38 @@ describe('ENHANCER_SYSTEM_PROMPT domain purity', () => {
     expect(ENHANCER_SYSTEM_PROMPT).toContain('with Google sign-in');
   });
 
-  test('has a game shape distinct from the CRUD-app shape', () => {
-    expect(ENHANCER_SYSTEM_PROMPT).toContain('If the idea is a GAME');
-    expect(ENHANCER_SYSTEM_PROMPT).toContain('anti-cheat boundary');
-    expect(ENHANCER_SYSTEM_PROMPT).toContain('attempting an illegal move');
-    // The CRUD shape stays for non-game ideas.
-    expect(ENHANCER_SYSTEM_PROMPT).toContain('two collections');
+  test('defaults to a Firebase-native shape', () => {
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('FIREBASE EXPERT IS ALWAYS ON');
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('A well-shaped Firebase prompt states');
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('rules, seed docs, Auth users');
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('No app UI unless the user explicitly asks');
+    expect(ENHANCER_SYSTEM_PROMPT).not.toContain('two collections');
   });
 
   test('keeps the output discipline', () => {
     expect(ENHANCER_SYSTEM_PROMPT).toContain('Output ONLY the enhanced prompt');
-    expect(ENHANCER_SYSTEM_PROMPT).toContain('30–50 words');
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('30–70 words');
+  });
+
+  test('keeps internal seed tool names out of user-visible enhancement guidance', () => {
+    expect(ENHANCER_SYSTEM_PROMPT).toContain('seed data');
+    expect(ENHANCER_SYSTEM_PROMPT).not.toContain('seed_firestore_data_as_admin');
+    expect(ENHANCER_SYSTEM_PROMPT).not.toContain('autoId');
   });
 });
 
 describe('buildEnhancerPrompt — skill-aware shapes (P4)', () => {
-  test('active game skill takes over the shape section', () => {
-    const p = buildEnhancerPrompt([firestoreGameRulesSkill]);
-    expect(p).toContain('The user activated the "Game rules" skill');
+  test('active game skill adds an overlay without replacing Firebase Expert guidance', () => {
+    const p = buildEnhancerPrompt(
+      [firestoreGameRulesSkill],
+      'Create a Firestore data structure for a Connect Four game that prevents cheating',
+    );
+    expect(p).toContain('FIREBASE EXPERT IS ALWAYS ON');
+    expect(p).toContain('Shape this as a Firestore data modeling request');
+    expect(p).toContain('Active specialist skill: "Game rules"');
+    expect(p).toContain('Firebase Expert stays on');
     expect(p).toContain('anti-cheat boundary');
-    // The default app shape and the conditional game gate are replaced.
-    expect(p).not.toContain('two collections');
+    expect(p).not.toContain('shape EVERY idea');
     expect(p).not.toContain('If the idea is a GAME');
     // Purity + discipline survive in every composition.
     expect(p).toContain('DOMAIN PURITY');
@@ -71,36 +82,48 @@ describe('buildEnhancerPrompt — skill-aware shapes (P4)', () => {
     expect(p).not.toContain('Auth tab');
   });
 
-  test('active Firebase tooling skill takes over the shape section', () => {
+  test('legacy general Firebase audit skill resolves into lenses, not replacement blocks', () => {
     const p = buildEnhancerPrompt([firebaseAuditSkill]);
-    expect(p).toContain('The user activated the "Firebase audit" skill');
-    expect(p).toContain('prioritized audit report');
-    expect(p).toContain('not an app');
+    expect(p).toContain('FIREBASE EXPERT IS ALWAYS ON');
+    expect(p).toContain('Shape this as a rules audit request');
+    expect(p).not.toContain('The user activated');
+    expect(p).not.toContain('Active specialist skill');
     expect(p).not.toContain('two collections');
     expect(p).not.toContain('If the idea is a GAME');
   });
 
-  test('active Firebase Auth model skill shapes auth/rules requests', () => {
+  test('legacy Firebase Auth model skill shapes auth/rules requests through lenses', () => {
     const p = buildEnhancerPrompt([playgroundFirebaseAuthModelSkill]);
-    expect(p).toContain('The user activated the "Firebase auth" skill');
-    expect(p).toContain('custom-claim');
-    expect(p).toContain('auth/rules model');
-    expect(p).toContain('not an app');
+    expect(p).toContain('Shape this as a Firebase Auth modeling request');
+    expect(p).toContain('custom claims');
+    expect(p).not.toContain('The user activated');
     expect(p).not.toContain('two collections');
   });
 
-  test('active Firestore query/index skill shapes query proof requests', () => {
+  test('legacy Firestore query/index skill shapes query proof requests through lenses', () => {
     const p = buildEnhancerPrompt([playgroundFirestoreQueryIndexesSkill]);
-    expect(p).toContain('The user activated the "Firestore queries" skill');
-    expect(p).toContain('firestore.indexes.json');
-    expect(p).toContain('security-rule scope');
-    expect(p).toContain('not an app');
+    expect(p).toContain('Shape this as a Firestore query/index design request');
+    expect(p).toContain('index extraction');
+    expect(p).not.toContain('The user activated');
     expect(p).not.toContain('two collections');
   });
 
-  test('no active skills = the pinned default (single source of the game shape)', () => {
+  test('no active skills = the pinned Firebase-native default', () => {
     expect(buildEnhancerPrompt([])).toBe(ENHANCER_SYSTEM_PROMPT);
-    // The default's game gate reuses the skill's shape VERBATIM — no drift.
-    expect(ENHANCER_SYSTEM_PROMPT).toContain(firestoreGameRulesSkill.enhancerShape!);
+  });
+
+  test('app-build prompts opt into the app shape and game gate', () => {
+    const p = buildEnhancerPrompt([], 'Build a turn-based game app with Firestore rules');
+    expect(p).toContain('If the idea is a GAME');
+    expect(p).toContain(firestoreGameRulesSkill.enhancerShape!);
+    expect(p).toContain('two collections');
+  });
+
+  test('Firestore data modeling prompts use rules-first shape', () => {
+    const p = buildEnhancerPrompt([], 'Model Firestore data for teams with role based access');
+    expect(p).toContain('Shape this as a Firestore data modeling request');
+    expect(p).toContain('Start from the security rules boundary first');
+    expect(p).toContain('one allowed and one denied proof');
+    expect(p).not.toContain('two collections');
   });
 });

--- a/packages/playground/src/lib/agent/prompt-enhancer/system-prompt.ts
+++ b/packages/playground/src/lib/agent/prompt-enhancer/system-prompt.ts
@@ -17,22 +17,24 @@
  * and those phrases leaked into enhanced prompts and then into the
  * generated apps' UI. Never describe the host here.
  *
- * SKILL-AWARE (P4): active skills with an `enhancerShape` replace the
- * default five-property app shape — activating "Game rules" means
- * every idea is enhanced as a game prompt. With no skill active, the
- * default shape still carries a game gate pointing at the SAME shape
- * (single source: the skill definition).
+ * SKILL-AWARE (P4): Firebase Expert is always on. Detected context
+ * lenses choose the primary prompt shape; active specialist skills
+ * add small overlays when relevant instead of replacing the Firebase
+ * frame.
  */
+import { isSpecialistSkill, resolveAgentContext } from '~/lib/agent/context';
 import { firestoreGameRulesSkill } from '~/lib/skills/firestore-game-rules';
 import type { SkillDefinition } from '~/lib/skills/registry';
 
 const HEADER = [
-  'You rewrite a developer\'s rough idea into a single, well-shaped prompt for the pyric playground agent. The playground agent produces Firestore security rules, workspace tests, and a TSX app from a short natural-language request.',
+  'You rewrite a developer\'s rough idea into a single, well-shaped prompt for the Pyric Playground agent.',
+  '',
+  'FIREBASE EXPERT IS ALWAYS ON — Every enhancement starts from Firebase expertise: security rules, data models, Auth users, seed data, traffic, denials, tests, and app UI only when the user asks for an app.',
   '',
   'Your job is the prompt, NOT the implementation. Output ONLY the enhanced prompt as plain text — no preface, no code, no headings, no quoting, no explanation.',
   '',
-  'DOMAIN PURITY — the prompt must read as if written for a production app:',
-  '  - Describe the app in its own domain terms only.',
+  'DOMAIN PURITY — the prompt must read like a product/security request, not like instructions for the playground UI:',
+  '  - Describe the domain in its own terms only.',
   '  - Phrase auth simply: "with Google sign-in", "signed-in users", "admins".',
   '  - NEVER mention the playground, sandbox, tabs, test identities, or any development/test-harness UI.',
   '  - NEVER ask for an in-app identity switcher, "sign in as X" buttons, uid pickers, or role dropdowns — role boundaries are demonstrated with real sign-in, so just state who may do what.',
@@ -47,43 +49,120 @@ const APP_SHAPE = [
   '  5. Verifiable by attempting to violate — the user can SEE the agent succeeded without reading code (try an unauthorized action, watch the rule reject it).',
 ].join('\n');
 
+const FIREBASE_SHAPE = [
+  'A well-shaped Firebase prompt states:',
+  '  1. The Firebase surface involved: Firestore, RTDB, Auth, Storage, rules, indexes, seed data, or traffic.',
+  '  2. The security or data boundary to reason about: actors, ownership, roles, membership, allowed operations, denied operations.',
+  '  3. The evidence the agent should use or produce: rules, seed docs, Auth users, simulations, tests, traffic, denials, or an audit report.',
+  '  4. The teaching outcome: explain the modeling or rules principle before applying changes.',
+  '  5. No app UI unless the user explicitly asks to build or modify an app.',
+].join('\n');
+
+const FIRESTORE_DATA_MODEL_SHAPE = [
+  'Shape this as a Firestore data modeling request:',
+  '  - Start from the security rules boundary first.',
+  '  - Name actors, operations, paths, allowed cases, denied cases, and rule facts.',
+  '  - Derive collections, document IDs, fields, membership/role docs, and query shapes from enforceability.',
+  '  - Ask the agent to teach each decision before changing rules, seed data, or tests.',
+  '  - Require evidence with representative seed docs/Auth users plus one allowed and one denied proof.',
+].join('\n');
+
+const RULES_AUDIT_SHAPE = [
+  'Shape this as a rules audit request:',
+  '  - Name the service and rule file if known.',
+  '  - Ask for public access, ownership/role bypasses, missing validation, semantic errors, unsafe wildcards, and query-rule mismatches.',
+  '  - Require evidence from lint, simulations/tests, traffic, or denials where available.',
+].join('\n');
+
+const QUERY_INDEX_SHAPE = [
+  'Shape this as a Firestore query/index design request:',
+  '  - Name the read paths, filters, sort order, pagination/cursor needs, and collection-group needs.',
+  '  - Ask for index extraction and data-shape tradeoffs.',
+  '  - Require the agent to connect query shape back to rules enforceability.',
+].join('\n');
+
+const AUTH_SHAPE = [
+  'Shape this as a Firebase Auth modeling request:',
+  '  - Name providers, user lifecycle, custom claims, Auth users, and how identity maps into Firestore/RTDB rules.',
+  '  - Require seed Auth users when identity-specific rules need proof.',
+  '  - Avoid fake in-app identity switchers; describe the Auth identities and rule implications directly.',
+].join('\n');
+
+const RTDB_RULES_SHAPE = [
+  'Shape this as an RTDB rules request:',
+  '  - Name the paths, actors, read rules, write rules, validate rules, and cascading access assumptions.',
+  '  - Require proof for allowed and denied reads/writes, including child-path behavior where relevant.',
+  '  - Ask the agent to explain the rules principle before applying or auditing rules.',
+].join('\n');
+
+const RTDB_DATA_MODEL_SHAPE = [
+  'Shape this as an RTDB data modeling request:',
+  '  - Name the read and write paths, fan-out needs, denormalized copies, indexes, and update boundaries.',
+  '  - Connect the path shape to rules enforceability and query limits.',
+  '  - Require representative seed data plus allowed and denied proof for the modeled operations.',
+].join('\n');
+
 const TAIL = [
-  'Length: 30–50 words. Long enough to specify the requirements, short enough that the agent fills in design details on its own.',
+  'Length: 30–70 words. Long enough to specify the requirements, short enough that the agent fills in design details on its own.',
   '',
   'Canonical example (study its shape, do NOT echo it):',
   '  Create an app where a user can order from a menu but modify the price. The items are stored in the database and can only be modified by the admin. If the price doesn\'t match the order is rejected.',
   '',
-  'If the user\'s rough idea is missing one of the shape properties, infer the most likely fit and write the prompt as if they had specified it. Do not ask clarifying questions. Do not list the properties in your output. Do not invent unusual fields or exotic mechanics — pick the most natural, familiar shape for the domain.',
+  'If the user\'s rough idea is missing one of the shape properties, infer the most likely fit and write the prompt as if they had specified it. Do not ask clarifying questions. Do not list the properties in your output. Do not invent unusual fields or exotic mechanics — pick the most natural, familiar shape for the domain and Firebase surface.',
+  '',
+  'Do not name internal tools or UI surfaces in the enhanced prompt. Describe evidence generically as rules, seed data, Auth users, simulations, tests, traffic, or denials.',
   '',
   'Output: the enhanced prompt as one short paragraph, plain prose, no markdown.',
 ].join('\n');
 
 /**
- * Compose the enhancer prompt for the session's active skills. A skill
- * with an `enhancerShape` takes over the shape section — the user's
- * activation IS the intent signal, so every idea is shaped for that
- * domain. With none active, the default app shape applies, plus a
- * game gate reusing the game skill's shape verbatim.
+ * Compose the enhancer prompt for the session's active skills and
+ * current rough text. Firebase-native shaping is the default; app
+ * shaping appears only when the text clearly asks for app UI or
+ * preview work. Specialist skills add overlays rather than replacing
+ * the primary shape.
  */
-export function buildEnhancerPrompt(activeSkills: readonly SkillDefinition[]): string {
-  const shaped = activeSkills.filter((s) => s.enhancerShape);
+export function buildEnhancerPrompt(
+  activeSkills: readonly SkillDefinition[],
+  rawInput = '',
+): string {
+  const context = resolveAgentContext({
+    prompt: rawInput,
+    activeSkillIds: activeSkills.map((skill) => skill.id),
+  });
+  const lensIds = new Set(context.lenses.map((lens) => lens.id));
   const shape =
-    shaped.length > 0
-      ? shaped
-          .map((s) =>
-            [
-              `The user activated the "${s.label}" skill — shape EVERY idea for that domain. The prompt must specify:`,
-              s.enhancerShape,
-            ].join('\n'),
-          )
-          .join('\n\n')
-      : [
+    context.promptProfile === 'app-builder'
+      ? [
           `If the idea is a GAME (a board, turns, players, moves, score, win/lose), shape it as a game prompt instead of the app shape below. The prompt must specify:`,
           firestoreGameRulesSkill.enhancerShape,
           '',
           'Otherwise, ' + APP_SHAPE.charAt(0).toLowerCase() + APP_SHAPE.slice(1),
-        ].join('\n');
-  return [HEADER, '', shape, '', TAIL].join('\n');
+        ].join('\n')
+      : lensIds.has('data-modeling') && lensIds.has('firestore')
+        ? FIRESTORE_DATA_MODEL_SHAPE
+        : lensIds.has('queries-indexes')
+          ? QUERY_INDEX_SHAPE
+          : lensIds.has('auth')
+            ? AUTH_SHAPE
+            : lensIds.has('data-modeling') && lensIds.has('rtdb')
+              ? RTDB_DATA_MODEL_SHAPE
+              : lensIds.has('rules') && lensIds.has('rtdb')
+                ? RTDB_RULES_SHAPE
+                : lensIds.has('rules') || lensIds.has('audit')
+                  ? RULES_AUDIT_SHAPE
+                  : FIREBASE_SHAPE;
+  const overlays = activeSkills
+    .filter((skill) => isSpecialistSkill(skill) && skill.enhancerShape)
+    .map((skill) =>
+      [
+        `Active specialist skill: "${skill.label}". Firebase Expert stays on; do not replace the primary shape. When this specialist is relevant, add these requirements:`,
+        skill.enhancerShape,
+      ].join('\n'),
+    );
+  return [HEADER, '', shape, ...overlays.flatMap((overlay) => ['', overlay]), '', TAIL].join(
+    '\n',
+  );
 }
 
 /** The default (no active skills) prompt — kept as a constant for the

--- a/packages/playground/src/lib/agent/strategies/draft-then-validate.ts
+++ b/packages/playground/src/lib/agent/strategies/draft-then-validate.ts
@@ -64,7 +64,11 @@ import type {
   ToolResult,
   ToolSpec,
 } from '@inbrowser/agent';
-import { BACKEND_UI_GUIDANCE, WORKSPACE_FILE_REFERENCES } from '~/lib/agent/system-prompt';
+import {
+  BACKEND_UI_GUIDANCE,
+  FIRESTORE_SEEDING_POLICY,
+  WORKSPACE_FILE_REFERENCES,
+} from '~/lib/agent/system-prompt';
 import {
   parseWorkspaceTestFile,
   runWorkspaceTests,
@@ -503,11 +507,13 @@ export function defaultFloor(model: WorkspaceTestFile | null): WorkspaceTestFile
  *  artifacts in one pass; only reach for a tool to unblock, then keep
  *  composing. A small per-draft tool-call budget caps the escape hatch so
  *  de-caging can't degrade into thrash. */
-const DRAFT_GUIDANCE = `You are a Firebase agent drafting a complete small app in ONE pass. Compose the artifacts directly from the request and the context below.
+const DRAFT_GUIDANCE = `You are a Firebase agent. Compose the artifacts directly from the request and context below.
 
-COMPOSE THE FULL DRAFT FIRST. Write the artifacts directly from the request and the context below — that is the whole job. Most tasks need NO tools at all. Tools are a LAST-RESORT escape hatch for ONE specific missing fact (an existing schema you must discover, a single rule to simulate, a file to search/read, or demo data to seed so the app has something to render), reached for only AFTER you have composed everything you can — never as a way to explore or to start. Do not narrate a tool plan; do not call a tool per step; do not list/read files just to look around. When demo data is needed, call \`seed_firestore_data_as_admin\` — NEVER bake seeding into App.tsx.
+COMPOSE THE FULL DRAFT FIRST. Most tasks need NO tools. Tools are a LAST-RESORT escape hatch for ONE specific missing fact (an existing schema you must discover, a single rule to simulate, a file to search/read, or demo data to seed so the app has something to render), reached for only AFTER you have composed everything you can — never as a way to explore or to start. Do not narrate a tool plan; do not call a tool per step; do not list/read files just to look around. When demo data is needed, call \`seed_firestore_data_as_admin\` — NEVER bake seeding into App.tsx.
 
 ${BACKEND_UI_GUIDANCE}
+
+${FIRESTORE_SEEDING_POLICY}
 
 Emit the workspace artifacts as fenced blocks (any order):
 1. The app spec (access matrix) in a \`\`\`json app-spec fence — the heart of the draft. The host COMPILES your Firestore security rules deterministically FROM this matrix, so you do NOT write rules: get the access matrix right and correct rules follow for free.

--- a/packages/playground/src/lib/agent/strategy-router.test.ts
+++ b/packages/playground/src/lib/agent/strategy-router.test.ts
@@ -72,10 +72,10 @@ describe('routePrompt', () => {
     ).toBe('draft-validate');
   });
 
-  test('Firebase tooling profile routes to react even for build/data/security-shaped prompts', () => {
-    const d = routePrompt(DV_PROMPT, { promptProfile: 'firebase-tooling' });
+  test('Firebase expert profile routes to react even for build/data/security-shaped prompts', () => {
+    const d = routePrompt(DV_PROMPT, { promptProfile: 'firebase' });
     expect(d.strategy).toBe('react');
-    expect(d.reason).toContain('firebase-tooling');
+    expect(d.reason).toContain('firebase expert');
   });
 
   test('active skill strategy preference routes without becoming a user override', () => {
@@ -129,13 +129,13 @@ describe('createRoutedStrategy', () => {
     expect(react.calls.length).toBe(0);
   });
 
-  test('Firebase tooling profile does not enter draft-validate', async () => {
+  test('Firebase expert profile does not enter draft-validate', async () => {
     const react = stubStrategy('react', [{ kind: 'text', chunk: 'r' }]);
     const dv = stubStrategy('dv', [{ kind: 'text', chunk: 'd' }]);
     const routed = createRoutedStrategy({
       makeReact: () => react,
       makeDraftValidate: () => dv,
-      promptProfile: 'firebase-tooling',
+      promptProfile: 'firebase',
     });
     const events = await collect(routed, makeInput(DV_PROMPT));
     const routedEv = events.find((e) => e.kind === 'custom' && e.name === 'strategy_routed');

--- a/packages/playground/src/lib/agent/strategy-router.ts
+++ b/packages/playground/src/lib/agent/strategy-router.ts
@@ -77,11 +77,11 @@ export function routePrompt(
     strategyPreference?: SkillStrategyPreference;
   } = {},
 ): RouteDecision {
-  if (opts.promptProfile === 'firebase-tooling') {
+  if (opts.promptProfile === 'firebase') {
     return {
       strategy: 'react',
       source: 'heuristic',
-      reason: 'firebase-tooling skill active',
+      reason: 'firebase expert context',
     };
   }
   if (opts.strategyPreference && opts.strategyPreference !== 'auto') {
@@ -205,7 +205,7 @@ export interface RoutedStrategyConfig {
   makeDraftValidate: () => AgentStrategy;
   /** Explicit user override from settings; 'auto'/undefined → heuristic. */
   override?: RoutedStrategyName | 'auto';
-  /** Active prompt profile. Firebase tooling stays on ReAct under auto. */
+  /** Active prompt profile. Firebase expert context stays on ReAct under auto. */
   promptProfile?: AgentPromptProfile;
   /** Active skill routing preference. This is routed provenance, not a user override. */
   strategyPreference?: SkillStrategyPreference;

--- a/packages/playground/src/lib/agent/system-prompt-brief.test.ts
+++ b/packages/playground/src/lib/agent/system-prompt-brief.test.ts
@@ -16,6 +16,14 @@ import { useSkillsStore } from '~/lib/store/skills';
 describe('W2.2 environment brief', () => {
   const diagOn = buildSystemPrompt({ diagnosticsEnabled: true });
   const diagOff = buildSystemPrompt({ diagnosticsEnabled: false });
+  const appDiagOn = buildSystemPrompt({
+    diagnosticsEnabled: true,
+    prompt: 'Build a notes app with Firestore rules',
+  });
+  const appDiagOff = buildSystemPrompt({
+    diagnosticsEnabled: false,
+    prompt: 'Build a notes app with Firestore rules',
+  });
 
   test('points at the man pages (docs on demand)', () => {
     for (const p of [diagOn, diagOff]) {
@@ -28,7 +36,7 @@ describe('W2.2 environment brief', () => {
   });
 
   test('keeps the anti-footgun invariants in the standing prompt', () => {
-    for (const p of [diagOn, diagOff]) {
+    for (const p of [appDiagOn, appDiagOff]) {
       // write_file semantics — the invariant that prevents damage.
       expect(p).toContain('replaces the whole file');
       expect(p).toContain('edit_file');

--- a/packages/playground/src/lib/agent/system-prompt-profile.test.ts
+++ b/packages/playground/src/lib/agent/system-prompt-profile.test.ts
@@ -9,12 +9,12 @@ const TOOLING_SKILL: SkillDefinition = {
   id: 'fixture-tooling',
   label: 'Fixture tooling',
   icon: 'policy',
-  description: 'test-only Firebase tooling skill',
+  description: 'test-only Firebase expert skill',
   brief: 'FIXTURE TOOLING BRIEF',
   manTopic: 'fixture-tooling',
   manSummary: 'fixture tooling one-line summary',
   manBody: 'fixture tooling body',
-  promptProfile: 'firebase-tooling',
+  promptProfile: 'firebase',
   primarySurface: 'firebase',
   defaultFirebaseSubtab: 'sandbox',
 };
@@ -39,17 +39,10 @@ afterEach(() => {
 });
 
 describe('system prompt profiles', () => {
-  test('default app-builder prompt keeps the app workflow', () => {
+  test('default Firebase expert prompt replaces app-building guidance', () => {
     const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(prompt).toContain('BUILD App.tsx last');
-    expect(prompt).toContain('UI STYLE');
-    expect(prompt).toContain('NO IN-APP BACKEND/SEED/ADMIN CODE');
-  });
-
-  test('Firebase tooling prompt replaces app-building guidance', () => {
-    useSkillsStore.getState().toggleSkill('fixture-tooling');
-    const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(prompt).toContain('FIREBASE TOOLING MODE');
+    expect(prompt).toContain('FIREBASE EXPERT MODE');
+    expect(prompt).toContain('Pyric is the local Firebase runtime');
     expect(prompt).toContain('Do NOT create or edit `/workspace/src/App.tsx`');
     expect(prompt).toContain('rules, workspace tests, seed data, Auth users');
     expect(prompt).not.toContain('BUILD App.tsx last');
@@ -57,18 +50,57 @@ describe('system prompt profiles', () => {
     expect(prompt).not.toContain('NO IN-APP BACKEND/SEED/ADMIN CODE');
   });
 
-  test('fresh Firebase tooling sessions do not tell the agent to build', () => {
+  test('Firebase expert prompt teaches live seed data and Firestore ID policy', () => {
+    const prompt = buildSystemPrompt({
+      diagnosticsEnabled: false,
+      prompt: 'Model Firestore data for teams with role based access',
+    });
+    expect(prompt).toContain('FIRESTORE SEED ID POLICY');
+    expect(prompt).toContain('call `seed_firestore_data_as_admin`');
+    expect(prompt).toContain('test-file `seed` blocks');
+    expect(prompt).toContain('Use `autoId: true` for addDoc-style user-created docs');
+    expect(prompt).toContain('Use explicit IDs for semantic or stable docs');
+    expect(prompt).toContain('membership docs keyed by UID');
+    expect(prompt).toContain('read `data.generated`');
+    expect(prompt).toContain('RULES-FIRST FIRESTORE DATA MODELING WORKSHOP');
+    expect(prompt).toContain('using the Firestore seed ID policy');
+  });
+
+  test('app-building prompt keeps the app workflow', () => {
+    const prompt = buildSystemPrompt({
+      diagnosticsEnabled: false,
+      prompt: 'Build a notes app with Firestore rules',
+    });
+    expect(prompt).toContain('BUILD App.tsx last');
+    expect(prompt).toContain('UI STYLE');
+    expect(prompt).toContain('NO IN-APP BACKEND/SEED/ADMIN CODE');
+    expect(prompt).toContain('FIRESTORE SEED ID POLICY');
+    expect(prompt).toContain('SEED with `seed_firestore_data_as_admin` using the Firestore seed ID policy');
+    expect(prompt).not.toContain('SEED with `seed_firestore_data_as_admin` (`autoId: true`)');
+  });
+
+  test('Firebase expert prompt can still include active specialist briefs', () => {
     useSkillsStore.getState().toggleSkill('fixture-tooling');
     const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
-    expect(prompt).toContain('NEW FIREBASE TOOLING SESSION');
+    expect(prompt).toContain('FIREBASE EXPERT MODE');
+    expect(prompt).toContain('FIXTURE TOOLING BRIEF');
+    expect(prompt).toContain('Do NOT create or edit `/workspace/src/App.tsx`');
+    expect(prompt).toContain('rules, workspace tests, seed data, Auth users');
+    expect(prompt).not.toContain('BUILD App.tsx last');
+    expect(prompt).not.toContain('UI STYLE');
+    expect(prompt).not.toContain('NO IN-APP BACKEND/SEED/ADMIN CODE');
+  });
+
+  test('fresh Firebase expert sessions do not tell the agent to build', () => {
+    const prompt = buildSystemPrompt({ diagnosticsEnabled: false });
+    expect(prompt).toContain('NEW FIREBASE SESSION');
     expect(prompt).toContain('Do not treat that as a reason to build an app');
     expect(prompt).not.toContain('Go straight from your plan to building');
   });
 
-  test('Claude lane gets matching Firebase tooling intent without browser-only tool names', () => {
-    useSkillsStore.getState().toggleSkill('fixture-tooling');
+  test('Claude lane gets matching Firebase expert intent without browser-only tool names', () => {
     const prompt = buildClaudeLanePrompt({ diagnosticsEnabled: false });
-    expect(prompt).toContain('FIREBASE TOOLING MODE');
+    expect(prompt).toContain('FIREBASE EXPERT MODE');
     expect(prompt).toContain('mcp__playground__simulate_firestore_write');
     expect(prompt).toContain('Browser-only evidence');
     expect(prompt).not.toContain('seed_auth_users');

--- a/packages/playground/src/lib/agent/system-prompt.ts
+++ b/packages/playground/src/lib/agent/system-prompt.ts
@@ -21,15 +21,14 @@ import { useWorkspaceStore } from '~/lib/store/workspace';
 import { useSessionStore } from '~/lib/store/session';
 import { useGithubSessionStore } from '~/lib/store/github-session';
 import { useSkillsStore } from '~/lib/store/skills';
-import {
-  resolveActiveSkills,
-  resolvePromptProfile,
-} from '~/lib/skills/registry';
+import { resolveActiveSkills } from '~/lib/skills/registry';
+import { resolveAgentContext } from './context';
 import { DIAGNOSTIC_BLOCKS } from './diagnostics';
 import { APP_ENTRY_PATH, DATABASE_RULES_PATH, RULES_PATH } from '~/lib/store/files';
 
 interface BuildSystemPromptOpts {
   diagnosticsEnabled: boolean;
+  prompt?: string;
 }
 
 // NOTE: per-tool signatures + arg docs live in each tool's JSON schema (sent
@@ -101,26 +100,55 @@ export const WORKFLOW_PHASES = [
   '  1. PLAN the build + phases (a few bullets).',
   '  2. ANALYZE existing files + sandbox data (`sandbox_discover_paths`) + deployed rules; say what you found.',
   '  3. MODEL data + rules and WHY; write firestore.rules.',
-  '  4. SEED with `seed_firestore_data_as_admin` (`autoId: true`).',
+  '  4. SEED with `seed_firestore_data_as_admin` using the Firestore seed ID policy.',
   '  5. BUILD App.tsx last.',
 ].join('\n');
 
-export const FIREBASE_TOOLING_PROFILE = [
-  'FIREBASE TOOLING MODE — this is not an app build.',
+export const FIREBASE_PROFILE = [
+  'FIREBASE EXPERT MODE — this is the default Playground posture.',
+  '  Pyric is the local Firebase runtime and evidence surface. Do not recommend Firebase Emulators.',
   '  Do NOT create or edit `/workspace/src/App.tsx` unless the user explicitly asks for an app, UI, or preview. Do not end the task by building an app.',
   '  Primary outputs are rules, workspace tests, seed data, Auth users, audit reports, schema notes, simulations, and evidence-backed recommendations.',
   '  Use local sandbox/workspace evidence first: active rules, sandbox data shape, Auth users, traffic/denials, and files. Real-project tools are for explicitly requested signed-in project work only.',
+  '  Teach Firebase work as Lesson -> Action -> Evidence: explain the principle, apply the smallest useful change, then show the result with data, tests, simulations, traffic, or denials.',
   '  Keep the Firebase workbench as the visible state of the world: Sandbox, Data, Auth, Traffic, Seed, and File.',
 ].join('\n');
 
-export const FIREBASE_TOOLING_WORKFLOW = [
-  'WORKFLOW — evidence-first Firebase tooling. Open with a short written PLAN, then gather only the evidence needed for the requested audit/model/rules task.',
+export const FIREBASE_WORKFLOW = [
+  'WORKFLOW — evidence-first Firebase expertise. Open with a short written PLAN, then gather only the evidence needed for the requested audit/model/rules task.',
   '  1. PLAN the Firebase task and name the evidence you need.',
   '  2. INSPECT relevant workspace files, sandbox data/auth, rules, traffic, or tests.',
   '  3. ANALYZE risks, schema, access, or modeling tradeoffs with concrete evidence.',
-  '  4. PROPOSE or APPLY rules/tests/seed/auth changes only when requested.',
+  '  4. PROPOSE changes when the user asks for advice; APPLY rules/tests/seed/auth changes when needed to fulfill the requested model, demo, or evidence.',
   '  5. VERIFY with lint, simulation, traffic, or workspace tests where useful. Do not build App.tsx unless explicitly asked.',
 ].join('\n');
+
+export const FIRESTORE_SEEDING_POLICY = [
+  'FIRESTORE SEED ID POLICY:',
+  '  Live/demo/fixture state: call `seed_firestore_data_as_admin`; test-file `seed` blocks are hermetic only.',
+  '  Use `autoId: true` for addDoc-style user-created docs: posts, tasks, messages, orders, invites, games, and child docs.',
+  '  Use explicit IDs for semantic or stable docs: `users/{uid}`, profiles by UID, membership docs keyed by UID, config/singleton, lookup, and referenced rule-test paths.',
+  '  Mixed batches are normal; read `data.generated` after auto-ID writes.',
+].join('\n');
+
+export const FIRESTORE_DATA_MODELING_WORKFLOW = [
+  'RULES-FIRST FIRESTORE DATA MODELING WORKSHOP:',
+  '  Run the session as Lesson -> Decision -> Change -> Evidence. Teach the modeling process; do not merely narrate tool use.',
+  '  1. LESSON: explain that Firestore rules come first because the data model must expose the facts rules need to enforce.',
+  '  2. ACCESS CONTRACT: before editing files, write the actors, operations, paths, allowed cases, denied cases, and rule facts needed from request.auth, path params, resource.data, request.resource.data, or bounded get()/exists() calls.',
+  '  3. RULE-SHAPED MODEL: derive collections, document IDs, fields, membership/role docs, and query shapes from enforceability. Explain each shape decision before applying it.',
+  '  4. RULES: before writing firestore.rules, explain how each path/field supports a rule condition.',
+  '  5. FIXTURE EVIDENCE: after the rules shape is clear, call `seed_firestore_data_as_admin` for live representative docs using the Firestore seed ID policy, and seed Auth users when identity matters.',
+  '  6. VERIFY: prove at least one allowed behavior and one denied behavior with simulations, traffic, or tests. Close by explaining the cause and effect the user can see.',
+].join('\n');
+
+function lensWorkflowSections(lenses: ReturnType<typeof resolveAgentContext>['lenses']): string[] {
+  const ids = new Set(lenses.map((lens) => lens.id));
+  if (ids.has('firestore') && ids.has('data-modeling')) {
+    return [FIRESTORE_DATA_MODELING_WORKFLOW, ''];
+  }
+  return [];
+}
 
 // Injected by buildSystemPrompt ONLY when the workspace is new/empty
 // (rules + appSource both blank). Without it, the agent spends a whole
@@ -131,7 +159,7 @@ export const WORKSPACE_STATE_FRESH = [
 ].join('\n');
 
 export const WORKSPACE_STATE_FRESH_FIREBASE_TOOLING = [
-  'WORKSPACE STATE — NEW FIREBASE TOOLING SESSION: the workspace may be empty. Do not treat that as a reason to build an app. Inspect only the files or sandbox evidence needed for the requested Firebase audit, rules, seed, auth, or data-modeling task.',
+  'WORKSPACE STATE — NEW FIREBASE SESSION: the workspace may be empty. Do not treat that as a reason to build an app. Inspect only the files or sandbox evidence needed for the requested Firebase audit, rules, seed, auth, or data-modeling task.',
 ].join('\n');
 
 const RULES_STDLIB = [
@@ -152,7 +180,7 @@ export const AUTH_SHAPE = [
   '  RIGHT:   `sandbox.withAuth({ uid: "alice", token: { admin: true } })`',
   '  In rules, custom claims read as `request.auth.token.<name>` (NOT `request.auth.<name>`).',
   '  Anonymous identity: `sandbox.withAuth(null)`. Skips auth entirely; `request.auth` is null.',
-  'There are no real Firebase services — only the simulator.',
+  'There are no real Firebase services in local sandbox work — only Pyric\'s sandbox runtime.',
 ].join('\n');
 
 export const TOOL_TRUTHFULNESS = [
@@ -188,7 +216,7 @@ export const FIREBASE_TOOLING_FILE_REFERENCES = [
   'WORKSPACE FILES:',
   `  - ${RULES_PATH} — Firestore rules source; writing it auto-deploys to the sandbox.`,
   `  - ${DATABASE_RULES_PATH} — Realtime Database rules source; writing it auto-deploys when the selected runtime supports RTDB rules.`,
-  `  - ${APP_ENTRY_PATH} — optional preview entry. In Firebase tooling mode, edit this only when the user explicitly asks for an app or preview UI.`,
+  `  - ${APP_ENTRY_PATH} — optional preview entry. In Firebase expert mode, edit this only when the user explicitly asks for an app or preview UI.`,
   '  File bodies are intentionally omitted from this prompt. Use list_files, search_file, and ranged read_file to inspect current contents before editing existing files.',
 ].join('\n');
 
@@ -210,7 +238,7 @@ export function skillBriefSections(): string[] {
   return sections;
 }
 
-export function buildSystemPrompt({ diagnosticsEnabled }: BuildSystemPromptOpts): string {
+export function buildSystemPrompt({ diagnosticsEnabled, prompt = '' }: BuildSystemPromptOpts): string {
   // Read the store so prompt generation still reacts to workspace changes,
   // but do not inline large file bodies into every model request.
   const ws = useWorkspaceStore.getState();
@@ -225,16 +253,22 @@ export function buildSystemPrompt({ diagnosticsEnabled }: BuildSystemPromptOpts)
   const hasRealProject = useSessionStore.getState().currentProjectId !== null;
   const linkedGithubRepo = useGithubSessionStore.getState().linkedRepo;
   const intro = hasRealProject ? `${INTRO_BASE}\n${REAL_PROJECT_TOOLS}` : INTRO_BASE;
-  const activeSkills = resolveActiveSkills(useSkillsStore.getState().activeSkillIds);
-  const promptProfile = resolvePromptProfile(activeSkills);
+  const agentContext = resolveAgentContext({
+    prompt,
+    activeSkillIds: useSkillsStore.getState().activeSkillIds,
+  });
+  const promptProfile = agentContext.promptProfile;
   const profileSections =
-    promptProfile === 'firebase-tooling'
+    promptProfile === 'firebase'
       ? [
           ...(isFresh ? [WORKSPACE_STATE_FRESH_FIREBASE_TOOLING, ''] : []),
-          FIREBASE_TOOLING_PROFILE,
+          FIREBASE_PROFILE,
           '',
-          FIREBASE_TOOLING_WORKFLOW,
+          FIREBASE_WORKFLOW,
           '',
+          FIRESTORE_SEEDING_POLICY,
+          '',
+          ...lensWorkflowSections(agentContext.lenses),
           AUTH_SHAPE,
           '',
           RULES_STDLIB,
@@ -246,6 +280,8 @@ export function buildSystemPrompt({ diagnosticsEnabled }: BuildSystemPromptOpts)
       : [
           ...(isFresh ? [WORKSPACE_STATE_FRESH, ''] : []),
           WORKFLOW_PHASES,
+          '',
+          FIRESTORE_SEEDING_POLICY,
           '',
           SCOPE,
           '',

--- a/packages/playground/src/lib/agent/tool-profile.test.ts
+++ b/packages/playground/src/lib/agent/tool-profile.test.ts
@@ -13,6 +13,7 @@ describe('selectToolProfileForPrompt', () => {
         prompt: 'hello there',
         settings: SETTINGS,
         delegated: false,
+        promptProfile: 'app-builder',
       }),
     ).toBe('authoring');
     expect(
@@ -20,17 +21,18 @@ describe('selectToolProfileForPrompt', () => {
         prompt: 'Investigate security rules denials',
         settings: SETTINGS,
         delegated: false,
+        promptProfile: 'app-builder',
       }),
     ).toBe('diagnostic');
   });
 
-  test('Firebase tooling sessions prefer diagnostic tools', () => {
+  test('Firebase expert sessions prefer diagnostic tools', () => {
     expect(
       selectToolProfileForPrompt({
         prompt: 'Audit my rules',
         settings: SETTINGS,
         delegated: false,
-        promptProfile: 'firebase-tooling',
+        promptProfile: 'firebase',
       }),
     ).toBe('diagnostic');
   });
@@ -41,7 +43,7 @@ describe('selectToolProfileForPrompt', () => {
         prompt: 'Audit my rules',
         settings: SETTINGS,
         delegated: true,
-        promptProfile: 'firebase-tooling',
+        promptProfile: 'firebase',
       }),
     ).toBe('authoring');
   });

--- a/packages/playground/src/lib/agent/tool-profile.ts
+++ b/packages/playground/src/lib/agent/tool-profile.ts
@@ -12,7 +12,7 @@ export function selectToolProfileForPrompt({
   prompt,
   settings,
   delegated,
-  promptProfile = 'app-builder',
+  promptProfile = 'firebase',
   preference,
 }: {
   prompt: string;
@@ -23,7 +23,7 @@ export function selectToolProfileForPrompt({
 }): ToolProfile {
   if (delegated) return 'authoring';
   if (preference) return preference;
-  if (promptProfile === 'firebase-tooling') return 'diagnostic';
+  if (promptProfile === 'firebase') return 'diagnostic';
   if (!settings.pyricDiagnosticsEnabled) return 'authoring';
   const routedStrategy =
     settings.strategyMode === 'auto'

--- a/packages/playground/src/lib/session-host/index.ts
+++ b/packages/playground/src/lib/session-host/index.ts
@@ -99,7 +99,7 @@ import { buildSystemPrompt } from '~/lib/agent/system-prompt';
 import { makeDiagnosticsContext } from '~/lib/agent/diagnostics';
 import { resolveModelHistory } from './model-history';
 import { pruneToolHistoryWithStats, withPrunedHistory } from '~/lib/agent/prune-history';
-import { resolveActiveSkills, resolveWorkbenchIntent } from '~/lib/skills/registry';
+import { resolveAgentContext } from '~/lib/agent/context';
 import { useSkillsStore } from '~/lib/store/skills';
 import { logPage } from '~/lib/llm/inference/diagnostics';
 import { setServerJobProgressListener } from '~/lib/llm/inference';
@@ -225,10 +225,12 @@ export async function runOneTurn(
   // Phase 2: a real tool registry. Today contains `writeRules`. The
   // list grows as we add capabilities — agent sees them at function-
   // declaration time and can call any of them.
-  const workbenchIntent = resolveWorkbenchIntent(
-    resolveActiveSkills(useSkillsStore.getState().activeSkillIds),
-  );
-  const forceDiagnostics = workbenchIntent.promptProfile === 'firebase-tooling';
+  const agentContext = resolveAgentContext({
+    prompt,
+    activeSkillIds: useSkillsStore.getState().activeSkillIds,
+  });
+  const workbenchIntent = agentContext.workbenchIntent;
+  const forceDiagnostics = workbenchIntent.promptProfile === 'firebase';
   const registry = buildToolRegistry({ forceDiagnostics });
   const dispatch = createDispatch(registry);
   const toolProfile = selectToolProfileForPrompt({
@@ -411,10 +413,12 @@ export async function runOneTurn(
         ? buildClaudeLanePrompt({
             diagnosticsEnabled:
               useSettingsStore.getState().pyricDiagnosticsEnabled || forceDiagnostics,
+            prompt,
           })
         : buildSystemPrompt({
             diagnosticsEnabled:
               useSettingsStore.getState().pyricDiagnosticsEnabled || forceDiagnostics,
+            prompt,
           }),
     metrics,
     history: uiToCoreHistory(history),

--- a/packages/playground/src/lib/skills/firebase-tooling.ts
+++ b/packages/playground/src/lib/skills/firebase-tooling.ts
@@ -2,7 +2,7 @@ import type { SkillDefinition } from './registry';
 import { DATABASE_RULES_PATH, RULES_PATH } from '~/lib/store/files';
 
 const FIREBASE_TOOLING_DEFAULTS = {
-  promptProfile: 'firebase-tooling',
+  promptProfile: 'firebase',
   toolProfilePreference: 'diagnostic',
   strategyPreference: 'react',
 } as const;

--- a/packages/playground/src/lib/skills/registry.test.ts
+++ b/packages/playground/src/lib/skills/registry.test.ts
@@ -50,12 +50,12 @@ const TOOLING_SKILL: SkillDefinition = {
   id: 'fixture-tooling',
   label: 'Fixture tooling',
   icon: 'policy',
-  description: 'test-only Firebase tooling skill',
+  description: 'test-only Firebase expert skill',
   brief: 'FIXTURE TOOLING BRIEF',
   manTopic: 'fixture-tooling',
   manSummary: 'fixture tooling one-line summary',
   manBody: 'fixture tooling body',
-  promptProfile: 'firebase-tooling',
+  promptProfile: 'firebase',
   primarySurface: 'firebase',
   defaultFirebaseSubtab: 'sandbox',
   toolProfilePreference: 'diagnostic',
@@ -66,12 +66,12 @@ const FILE_TOOLING_SKILL: SkillDefinition = {
   id: 'fixture-file-tooling',
   label: 'Fixture file tooling',
   icon: 'rule',
-  description: 'test-only file-focused Firebase tooling skill',
+  description: 'test-only file-focused Firebase expert skill',
   brief: 'FIXTURE FILE TOOLING BRIEF',
   manTopic: 'fixture-file-tooling',
   manSummary: 'fixture file tooling one-line summary',
   manBody: 'fixture file tooling body',
-  promptProfile: 'firebase-tooling',
+  promptProfile: 'firebase',
   primarySurface: 'file',
   defaultFirebaseSubtab: 'traffic',
   defaultFilePath: '/workspace/firestore.rules',
@@ -141,13 +141,13 @@ describe('skill framework invariants', () => {
     expect(namesOn).toContain('fixture_skill_tool');
   });
 
-  test('active tooling skill switches prompt profile to Firebase tooling', () => {
-    expect(resolvePromptProfile(resolveActiveSkills([]))).toBe('app-builder');
+  test('Firebase is the default prompt profile and tooling skills keep it', () => {
+    expect(resolvePromptProfile(resolveActiveSkills([]))).toBe('firebase');
     useSkillsStore.getState().toggleSkill('fixture-tooling');
     const active = resolveActiveSkills(useSkillsStore.getState().activeSkillIds);
-    expect(resolvePromptProfile(active)).toBe('firebase-tooling');
+    expect(resolvePromptProfile(active)).toBe('firebase');
     expect(resolveWorkbenchIntent(active)).toMatchObject({
-      promptProfile: 'firebase-tooling',
+      promptProfile: 'firebase',
       primarySurface: 'firebase',
       defaultFirebaseSubtab: 'sandbox',
       toolProfilePreference: 'diagnostic',
@@ -176,7 +176,7 @@ describe('skill framework invariants', () => {
     expect(authSkill?.manBody).toContain('seed_auth_users');
     expect(authSkill?.manBody).not.toContain('Firebase Emulator');
     expect(resolveWorkbenchIntent([authSkill!])).toMatchObject({
-      promptProfile: 'firebase-tooling',
+      promptProfile: 'firebase',
       primarySurface: 'firebase',
       defaultFirebaseSubtab: 'auth',
       toolProfilePreference: 'diagnostic',
@@ -189,7 +189,7 @@ describe('skill framework invariants', () => {
     expect(querySkill?.manBody).toContain('zero shapes');
     expect(querySkill?.manBody).not.toContain('Firebase Emulator');
     expect(resolveWorkbenchIntent([querySkill!])).toMatchObject({
-      promptProfile: 'firebase-tooling',
+      promptProfile: 'firebase',
       primarySurface: 'firebase',
       defaultFirebaseSubtab: 'data',
       toolProfilePreference: 'diagnostic',

--- a/packages/playground/src/lib/skills/registry.ts
+++ b/packages/playground/src/lib/skills/registry.ts
@@ -10,8 +10,8 @@
  *   2. publishes its full `manBody` as a pull-based `man <topic>` page
  *      (visible only while the skill is active),
  *   3. registers its extra `tools` (if any) for the turn,
- *   4. (P4) contributes an `enhancerShape` that reshapes the prompt
- *      enhancer for the skill's domain.
+ *   4. (P4) contributes an `enhancerShape` used as lens guidance or
+ *      a specialist overlay in the prompt enhancer.
  *
  * Adding a skill = adding one definition file + a registry entry —
  * never new plumbing. Activation state lives in `store/skills.ts`
@@ -30,7 +30,7 @@ import {
 } from './firebase-tooling';
 import { firestoreGameRulesSkill } from './firestore-game-rules';
 
-export type AgentPromptProfile = 'app-builder' | 'firebase-tooling';
+export type AgentPromptProfile = 'firebase' | 'app-builder';
 export type WorkbenchSurface = 'preview' | 'firebase' | 'file';
 export type FirebaseWorkbenchSubtab = 'sandbox' | 'data' | 'auth' | 'traffic' | 'seed';
 export type SkillToolProfilePreference = 'authoring' | 'diagnostic';
@@ -73,8 +73,9 @@ export interface SkillDefinition {
   /** Strategy to prefer under this skill. */
   strategyPreference?: SkillStrategyPreference;
   /**
-   * (P4) Shape block for the prompt enhancer — replaces the default
-   * five-property app shape when this skill is active.
+   * (P4) Shape block for the prompt enhancer. General Firebase skills
+   * map into automatic context lenses; specialist skills add overlay
+   * requirements on top of always-on Firebase Expert guidance.
    */
   enhancerShape?: string;
 }
@@ -145,15 +146,15 @@ function latestIntentSkill(skills: readonly SkillDefinition[]): SkillDefinition 
   return undefined;
 }
 
-/** Resolve active skills to the session's prompt profile. App-building
- *  remains the default; any active Firebase tooling skill switches the
- *  base prompt out of App.tsx-first mode. */
+/** Resolve active skills to the session's prompt profile. Firebase
+ *  expertise is the product default; app-building is selected by
+ *  context when the user's prompt asks for an app or UI. */
 export function resolvePromptProfile(
   activeSkills: readonly SkillDefinition[],
 ): AgentPromptProfile {
-  return activeSkills.some((skill) => skill.promptProfile === 'firebase-tooling')
-    ? 'firebase-tooling'
-    : 'app-builder';
+  return activeSkills.some((skill) => skill.promptProfile === 'app-builder')
+    ? 'app-builder'
+    : 'firebase';
 }
 
 /** Resolve active skills to the workbench defaults used by the UI,
@@ -165,7 +166,7 @@ export function resolveWorkbenchIntent(
   const promptProfile = resolvePromptProfile(activeSkills);
   const latest = latestIntentSkill(activeSkills);
   const primarySurface =
-    latest?.primarySurface ?? (promptProfile === 'firebase-tooling' ? 'firebase' : 'preview');
+    latest?.primarySurface ?? (promptProfile === 'firebase' ? 'firebase' : 'preview');
   return {
     promptProfile,
     primarySurface,
@@ -173,12 +174,12 @@ export function resolveWorkbenchIntent(
     ...(latest?.defaultFilePath ? { defaultFilePath: latest.defaultFilePath } : {}),
     ...(latest?.toolProfilePreference
       ? { toolProfilePreference: latest.toolProfilePreference }
-      : promptProfile === 'firebase-tooling'
+      : promptProfile === 'firebase'
         ? { toolProfilePreference: 'diagnostic' as const }
         : {}),
     ...(latest?.strategyPreference
       ? { strategyPreference: latest.strategyPreference }
-      : promptProfile === 'firebase-tooling'
+      : promptProfile === 'firebase'
         ? { strategyPreference: 'react' as const }
         : {}),
   };

--- a/packages/playground/src/lib/tools/diagnostics/seed-firestore-data.ts
+++ b/packages/playground/src/lib/tools/diagnostics/seed-firestore-data.ts
@@ -85,7 +85,7 @@ export function buildSeedFirestoreDataHandler(): ToolHandler {
   return {
     name: 'seed_firestore_data_as_admin',
     description:
-      'Bulk-apply admin-bypass writes/deletes to the in-browser sandbox. Use this to set up fixture state BEFORE testing rule enforcement — e.g. seed a doc as if it were already written so a `read` rule can be probed against existing data. NOT for testing whether your rules ALLOW a write; for that, call `simulate_firestore_write` so the write evaluates against the ruleset. Method limited to `set` (default) and `delete`. For auto-generated document ids (like `addDoc`), set `autoId: true` and pass a COLLECTION path — the generated full paths are returned in `data.generated`. Max 100 operations per call — anything larger gets the whole call rejected. Per-entry failures are collected into `errors[]` and do NOT abort the batch (no atomicity guarantee). Seeded paths wake any active `onSnapshot` listener so the App preview reflects the change live.',
+      'Bulk-apply admin-bypass writes/deletes to the in-browser sandbox. Use this to set up LIVE sandbox fixture/demo state BEFORE testing rule enforcement — e.g. seed a doc as if it were already written so a `read` rule can be probed against existing data. NOT for testing whether your rules ALLOW a write; for that, call `simulate_firestore_write` so the write evaluates against the ruleset. Method limited to `set` (default) and `delete`. For addDoc-style user-created docs, set `autoId: true` and pass a COLLECTION path; use explicit document IDs for semantic/stable docs such as `users/{uid}`, membership docs keyed by UID, config/singleton docs, lookup docs, and rule-test paths that must be referenced directly. Mixed batches are expected. Generated full paths are returned in `data.generated`; use them for follow-up references. Max 100 operations per call — anything larger gets the whole call rejected. Per-entry failures are collected into `errors[]` and do NOT abort the batch (no atomicity guarantee). Seeded paths wake any active `onSnapshot` listener so the App preview reflects the change live.',
     parameters: {
       type: 'object',
       properties: {
@@ -104,7 +104,7 @@ export function buildSeedFirestoreDataHandler(): ToolHandler {
               autoId: {
                 type: 'boolean',
                 description:
-                  'When true, `path` is a COLLECTION path and a document id is auto-generated (like `addDoc`). Only valid for `set`; ignored for `delete`. The written full path is returned in `data.generated`.',
+                  'When true, `path` is a COLLECTION path and a document id is auto-generated (like `addDoc`). Use for user-created docs such as posts, comments, tasks, messages, orders, invites, game sessions, notifications, and nested child docs created by user action. Do NOT use for semantic/stable IDs such as `users/{uid}`, membership docs keyed by UID, config/singleton docs, lookup docs, or paths that tests/rules must reference directly. Only valid for `set`; ignored for `delete`. The written full path is returned in `data.generated`.',
               },
               data: {
                 type: 'object',

--- a/packages/playground/src/styles/global.css
+++ b/packages/playground/src/styles/global.css
@@ -65,6 +65,50 @@
   .custom-scrollbar::-webkit-scrollbar-thumb:hover {
     background: #444455;
   }
+
+  .prompt-signal-gradient-text {
+    /* Fallback first, then OKLCH interpolation for smoother, less muddy color travel. */
+    background-image: linear-gradient(
+      90deg,
+      #ff9100 0%,
+      #ffc400 30%,
+      #ff9100 62%,
+      #dd2c00 88%,
+      #ff9100 100%
+    );
+    background-image: linear-gradient(
+      90deg in oklch,
+      #ff9100 0%,
+      #ffc400 30%,
+      #ff9100 62%,
+      #dd2c00 88%,
+      #ff9100 100%
+    );
+    background-size: 240% 100%;
+    background-position: 0% 50%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    text-shadow: 0 0 0.18em rgba(255, 145, 0, 0.06);
+    animation: prompt-signal-gradient-drift 8s ease-in-out infinite alternate;
+  }
+
+  @keyframes prompt-signal-gradient-drift {
+    from {
+      background-position: 0% 50%;
+    }
+    to {
+      background-position: 120% 50%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prompt-signal-gradient-text {
+      animation: none;
+      background-position: 50% 50%;
+    }
+  }
 }
 
 /* ----------------------------------------------------------------


### PR DESCRIPTION
Summary:
- Make Firebase expertise the default Playground context instead of a manually selected general skill mode.
- Add deterministic context lenses for Firebase concepts, app-build intent, prompt enhancement, strategy routing, tool posture, and workbench defaults.
- Polish the prompt composer recognition effect and seed-data guidance, including nuanced Firestore auto-ID policy.

Tests:
- bun run --cwd packages/playground test
- git diff --check