### PR TITLE
Treat Firestore admin writes as verify setup

### DIFF
--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -309,6 +309,7 @@ export function sdkImportMap(): Record<string, string> {
   return {
     'firebase/app': '/__pyric/sdk/app.js',
     'firebase/auth': '/__pyric/sdk/auth.js',
+    'firebase/database': '/__pyric/sdk/database.js',
     'firebase/firestore': '/__pyric/sdk/firestore.js',
   };
 }

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -148,9 +148,13 @@ function verifyFirestore(
   return {
     service: 'firestore',
     ok: mapped.every(isInformational),
-    checkedEvents: fixture.events.filter((event) => event.kind === 'write').length,
+    checkedEvents: fixture.events.filter(isProtectedFirestoreWrite).length,
     divergences: mapped,
   };
+}
+
+function isProtectedFirestoreWrite(event: SandboxEvent): boolean {
+  return event.kind === 'write' && event.detail?.admin !== true;
 }
 
 async function verifyRtdb(

--- a/packages/pyric-tools/test/serve/integration.test.ts
+++ b/packages/pyric-tools/test/serve/integration.test.ts
@@ -72,11 +72,12 @@ describe('pyric serve end-to-end (HTTP)', () => {
     expect(mapAt).toBeGreaterThan(-1);
     expect(mapAt).toBeLessThan(appAt);
     expect(html).toContain('"firebase/firestore":"/__pyric/sdk/firestore.js"');
+    expect(html).toContain('"firebase/database":"/__pyric/sdk/database.js"');
     expect(html).toContain('"firebase/app":"/__pyric/sdk/app.js"');
     expect(html).toContain('/__pyric/sdk/init.js');
 
     // 2. the mapped SDK files are served, browser-standalone
-    for (const mod of ['app', 'auth', 'firestore', 'init']) {
+    for (const mod of ['app', 'auth', 'firestore', 'database', 'init']) {
       const res = await fetch(`${base}/__pyric/sdk/${mod}.js`);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('javascript');

--- a/packages/pyric-tools/test/serve/namespace.test.ts
+++ b/packages/pyric-tools/test/serve/namespace.test.ts
@@ -13,6 +13,7 @@ function fixture() {
   for (const d of [site, sdk]) require('node:fs').mkdirSync(d);
   writeFileSync(join(site, 'index.html'), '<!doctype html><html><head><title>t</title></head><body></body></html>');
   writeFileSync(join(sdk, 'auth.js'), 'export const getAuth = 1;');
+  writeFileSync(join(sdk, 'database.js'), 'export const getDatabase = 1;');
   writeFileSync(join(sdk, 'init.js'), '// init');
   return { site, sdk };
 }
@@ -64,6 +65,7 @@ describe('injectServeTags', () => {
     expect(Object.keys(sdkImportMap()).sort()).toEqual([
       'firebase/app',
       'firebase/auth',
+      'firebase/database',
       'firebase/firestore',
     ]);
   });
@@ -108,6 +110,9 @@ describe('namespace over the real server', () => {
     const auth = await fetch(h.url + '/__pyric/sdk/auth.js');
     expect(auth.status).toBe(200);
     expect(auth.headers.get('content-type')).toContain('javascript');
+    const database = await fetch(h.url + '/__pyric/sdk/database.js');
+    expect(database.status).toBe(200);
+    expect(database.headers.get('content-type')).toContain('javascript');
     expect((await fetch(h.url + '/__pyric/sdk/../../etc/passwd')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/sdk/nope.js')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/unknown')).status).toBe(404);

--- a/packages/pyric-tools/test/verify/verify.test.ts
+++ b/packages/pyric-tools/test/verify/verify.test.ts
@@ -10,6 +10,7 @@ import {
 } from 'pyric/database';
 import { defineRtdbRules, allow, deny } from 'pyric/rules/rtdb';
 import { initializeSandbox } from 'pyric/sandbox';
+import { getAdminFirestore, getFirestore } from 'pyric/sandbox/admin-firestore';
 import {
   buildVerifyFixture,
   parseVerifyFixture,
@@ -19,6 +20,17 @@ import {
 
 const ALLOW_ALL_RTDB = { rules: { '.read': true, '.write': true } };
 const DENY_ALL_RTDB = { rules: { '.read': false, '.write': false } };
+const FIRESTORE_SETUP_RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /setup/{id} {
+      allow read, write: if false;
+    }
+    match /notes/{id} {
+      allow read, write: if request.auth.uid == 'alice';
+    }
+  }
+}`;
 
 async function captureRtdbJourney(): Promise<PyricVerifyFixture> {
   const sandbox = initializeSandbox();
@@ -71,6 +83,33 @@ describe('verifyFixture', () => {
 
     expect(result.ok).toBe(true);
     expect(result.services.rtdb?.checkedEvents).toBe(4);
+  });
+
+  it('uses Firestore admin setup writes as replay context, not protected behavior', async () => {
+    const sandbox = initializeSandbox();
+    const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
+    const adminDb = getAdminFirestore(sandbox);
+    db.setRules(FIRESTORE_SETUP_RULES);
+
+    await adminDb.doc('setup/seed').set({ enabled: true });
+    await db.doc('notes/n1').set({ title: 'hello' });
+
+    const fixture = buildVerifyFixture({
+      sandbox,
+      firestoreRules: FIRESTORE_SETUP_RULES,
+    });
+    const setupWrite = fixture.events.find(
+      (event) => event.kind === 'write' && event.path === 'setup/seed',
+    );
+
+    expect(setupWrite?.detail?.admin).toBe(true);
+
+    const result = await verifyFixture(fixture, {
+      rules: { firestore: FIRESTORE_SETUP_RULES },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.services.firestore?.checkedEvents).toBe(1);
   });
 
   it('reports now-denied when RTDB candidate rules reject captured writes', async () => {

--- a/packages/pyric/src/sandbox/firestore/local-environment.ts
+++ b/packages/pyric/src/sandbox/firestore/local-environment.ts
@@ -210,6 +210,7 @@ interface EmitRequestInput {
   origin: 'user' | 'listener' | 'transaction' | 'batch';
   groupId?: string;
   triggeredBy?: { method: string; path: string };
+  detail?: { admin?: boolean } & Record<string, unknown>;
 }
 
 let _requestEventSeq = 0;
@@ -281,6 +282,7 @@ function buildRequestEvent(input: EmitRequestInput): import('../types.js').Reque
     else if (input.origin === 'transaction') out.groupKind = 'transaction';
   }
   if (input.triggeredBy !== undefined) out.triggeredBy = input.triggeredBy;
+  if (input.detail !== undefined) out.detail = input.detail;
   return out;
 }
 
@@ -656,6 +658,7 @@ export class LocalEnvironment {
      *  replay engine uses this to re-issue the same Date.now() value
      *  when re-resolving serverTimestamp() sentinels. */
     requestTime: Timestamp;
+    detail?: { admin?: boolean } & Record<string, unknown>;
   }): void {
     if (this.writeListeners.size === 0) return;
     const event: import('../types.js').WriteSandboxEvent = {
@@ -675,6 +678,7 @@ export class LocalEnvironment {
       ...(input.sentinels && input.sentinels.length > 0 ? { sentinels: input.sentinels } : {}),
       ...(input.autoId !== undefined ? { autoId: input.autoId } : {}),
       requestTime: { seconds: input.requestTime.seconds, nanoseconds: input.requestTime.nanos },
+      ...(input.detail !== undefined ? { detail: input.detail } : {}),
     };
     for (const cb of this.writeListeners) {
       try {
@@ -1847,6 +1851,7 @@ export class LocalEnvironment {
    *  listeners behave exactly as a rule-allowed op would. */
   execute(operation: Operation): OperationResult {
     const { method, path, auth, data, autoId, requestTime: pinnedRequestTime, merge, bypassRules } = operation;
+    const detail = bypassRules ? { admin: true } : undefined;
 
     // Reads — evaluate rules (denied reads return no data)
     if (method === 'get' || method === 'list') {
@@ -1871,6 +1876,7 @@ export class LocalEnvironment {
           at: evalAt, evalMs, method, path, auth, result: 'deny',
           debugMessages: [`Simulation error: ${simResult.error.message}`],
           origin: 'user',
+          ...(detail ? { detail } : {}),
         });
         return { allowed: false, debugMessages: [simResult.error.message], event };
       }
@@ -1882,6 +1888,7 @@ export class LocalEnvironment {
         this.emitRequest({
           at: evalAt, evalMs, method, path, auth, result: 'unsupported',
           debugMessages: renderLegacyDebugMessages(result), origin: 'user',
+          ...(detail ? { detail } : {}),
         });
         throw new SimulatorUnsupportedError(
           unsupportedMessage(method, path, renderLegacyDebugMessages(result)),
@@ -1938,6 +1945,7 @@ export class LocalEnvironment {
         ...(method === 'get'
           ? { resourceBefore: { data: this.state.get(path), exists: this.state.get(path) !== null } }
           : {}),
+        ...(detail ? { detail } : {}),
       });
       return out;
     }
@@ -1999,6 +2007,7 @@ export class LocalEnvironment {
         ...(resolvedData ? { resourceData: resolvedData } : data ? { resourceData: data } : {}),
         resourceBefore: { data: snapshot[path] ?? null, exists: (snapshot[path] ?? null) !== null },
         origin: 'user',
+        ...(detail ? { detail } : {}),
       });
       // Item 6: a sentinel-resolution throw maps to `invalid-argument`.
       // The admin SDK throws the same code when a FieldValue is malformed
@@ -2030,6 +2039,7 @@ export class LocalEnvironment {
         ...(data ? { resourceData: data } : {}),
         resourceBefore: { data: snapshot[path] ?? null, exists: (snapshot[path] ?? null) !== null },
         origin: 'user',
+        ...(detail ? { detail } : {}),
       });
       // Item 6: a simulator-internal failure isn't a rules denial — map
       // it to invalid-argument so callers can distinguish "the rule
@@ -2050,6 +2060,7 @@ export class LocalEnvironment {
         ...(data ? { resourceData: data } : {}),
         resourceBefore: { data: snapshot[path] ?? null, exists: (snapshot[path] ?? null) !== null },
         origin: 'user',
+        ...(detail ? { detail } : {}),
       });
       throw new SimulatorUnsupportedError(
         unsupportedMessage(method, path, renderLegacyDebugMessages(result)),
@@ -2132,6 +2143,7 @@ export class LocalEnvironment {
         ? { resourceAfter: { data: finalDoc, exists: finalDoc !== null } }
         : { resourceAfter: { data: null, exists: false } }),
       origin: 'user',
+      ...(detail ? { detail } : {}),
     });
 
     // Issue #307 — emit a committed-write event for the post-apply state.
@@ -2158,6 +2170,7 @@ export class LocalEnvironment {
         ...(sentinels && sentinels.length > 0 ? { sentinels } : {}),
         ...(mintedAutoId ? { autoId: mintedAutoId } : {}),
         requestTime: serverTime,
+        ...(detail ? { detail } : {}),
       });
     }
 
@@ -2221,6 +2234,7 @@ export class LocalEnvironment {
     auth: Operation['auth'],
     bypassRules?: boolean,
   ): BatchResult {
+    const detail = bypassRules ? { admin: true } : undefined;
     // Capture priors for just the operations' paths (undo is O(affected)).
     const snapshot = this.capturePriors(operations.map((o) => o.path));
     const results: BatchResult['results'] = [];
@@ -2276,6 +2290,7 @@ export class LocalEnvironment {
           ...(op.data ? { resourceData: op.data } : {}),
           resourceBefore: { data: snapshot[op.path] ?? null, exists: (snapshot[op.path] ?? null) !== null },
           origin: 'batch', groupId,
+          ...(detail ? { detail } : {}),
         });
         // Item 6: same code as the single-op resolver throw —
         // invalid-argument is the admin-SDK signal for malformed
@@ -2327,6 +2342,7 @@ export class LocalEnvironment {
           ...(preData ? { resourceData: preData } : {}),
           resourceBefore: { data: snapshot[op.path] ?? null, exists: (snapshot[op.path] ?? null) !== null },
           origin: 'batch', groupId,
+          ...(detail ? { detail } : {}),
         });
         allAllowed = false;
         continue;
@@ -2341,6 +2357,7 @@ export class LocalEnvironment {
           ...(preData ? { resourceData: preData } : {}),
           resourceBefore: { data: snapshot[op.path] ?? null, exists: (snapshot[op.path] ?? null) !== null },
           origin: 'batch', groupId,
+          ...(detail ? { detail } : {}),
         });
         throw new SimulatorUnsupportedError(
           unsupportedMessage(op.method, op.path, renderLegacyDebugMessages(r)),
@@ -2386,6 +2403,7 @@ export class LocalEnvironment {
         ...(preData ? { resourceData: preData } : {}),
         resourceBefore: { data: snapshot[op.path] ?? null, exists: (snapshot[op.path] ?? null) !== null },
         origin: 'batch', groupId,
+        ...(detail ? { detail } : {}),
       });
       results.push(entry);
     }
@@ -2485,6 +2503,7 @@ export class LocalEnvironment {
           ...(e.groupId ? { groupId: e.groupId, groupKind: 'batch' as const } : {}),
           ...(sentinels && sentinels.length > 0 ? { sentinels } : {}),
           requestTime: serverTime,
+          ...(detail ? { detail } : {}),
         });
       }
     }
@@ -2617,6 +2636,7 @@ export class LocalEnvironment {
     returnValue: R,
   ): TransactionResult<R> {
     const { reads, writes } = ctx.consume();
+    const detail = options.bypassRules ? { admin: true } : undefined;
     // Issue #307 — shared groupId so consumers can fold tx sub-ops
     // together the same way they fold batch sub-ops.
     const txId = `tx-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
@@ -2725,6 +2745,7 @@ export class LocalEnvironment {
           ...(op.data && opRuleMethod !== 'delete' ? { resourceData: op.data } : {}),
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
+          ...(detail ? { detail } : {}),
         });
         return {
           allowed: false,
@@ -2796,6 +2817,7 @@ export class LocalEnvironment {
           ...(preData && ruleMethod !== 'delete' ? { resourceData: preData } : {}),
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
+          ...(detail ? { detail } : {}),
         });
         allAllowed = false;
         continue;
@@ -2811,6 +2833,7 @@ export class LocalEnvironment {
           ...(preData && ruleMethod !== 'delete' ? { resourceData: preData } : {}),
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
+          ...(detail ? { detail } : {}),
         });
         throw new SimulatorUnsupportedError(
           unsupportedMessage(ruleMethod, op.path, renderLegacyDebugMessages(r)),
@@ -2837,6 +2860,7 @@ export class LocalEnvironment {
         ...(preData && ruleMethod !== 'delete' ? { resourceData: preData } : {}),
         resourceBefore: { data: priorDoc, exists: priorDoc !== null },
         origin: 'transaction', groupId: txId,
+        ...(detail ? { detail } : {}),
       });
       if (!isAllowed) {
         // Per-op `request`/`resource` captured against pre-tx snapshot
@@ -2947,6 +2971,7 @@ export class LocalEnvironment {
           ...(e.groupId ? { groupId: e.groupId, groupKind: 'transaction' as const } : {}),
           ...(sentinels && sentinels.length > 0 ? { sentinels } : {}),
           requestTime: serverTime,
+          ...(detail ? { detail } : {}),
         });
       }
     }

--- a/packages/pyric/src/sandbox/replay/index.ts
+++ b/packages/pyric/src/sandbox/replay/index.ts
@@ -126,6 +126,7 @@ export function replay(
   // own `data` (post-resolution) when the request event isn't
   // available.
   for (const wEv of writes) {
+    const bypassRules = isAdminWrite(wEv);
     const data = preResolutionDataFor(wEv, events) ?? wEv.data;
     const requestTime = pinRequestTime
       ? new Timestamp(wEv.requestTime.seconds, wEv.requestTime.nanoseconds)
@@ -134,7 +135,12 @@ export function replay(
     if (wEv.autoId) {
       // Auto-id create: split path, mint a fresh id, record the alias.
       const collection = wEv.path.slice(0, wEv.path.lastIndexOf('/'));
-      const { path: mintedPath } = env.createWithAutoId(collection, (data ?? {}) as DocData, wEv.auth);
+      const { path: mintedPath } = env.createWithAutoId(
+        collection,
+        (data ?? {}) as DocData,
+        wEv.auth,
+        bypassRules,
+      );
       pathAliases.set(wEv.path, mintedPath);
       continue;
     }
@@ -146,6 +152,7 @@ export function replay(
         auth: wEv.auth,
         ...(data !== undefined ? { data: data as DocData } : {}),
         ...(requestTime ? { requestTime } : {}),
+        ...(bypassRules ? { bypassRules: true } : {}),
       });
     } catch {
       // Replay denials surface as state divergence below; keep going
@@ -159,6 +166,10 @@ export function replay(
     : [];
 
   return { sandbox, divergences, pathAliases };
+}
+
+function isAdminWrite(event: WriteSandboxEvent): boolean {
+  return event.detail?.admin === true;
 }
 
 /**

--- a/packages/pyric/src/sandbox/types.ts
+++ b/packages/pyric/src/sandbox/types.ts
@@ -509,6 +509,10 @@ export interface RequestEvent {
   /** For listener re-evals: the originating user op that triggered this
    *  re-evaluation. Absent on the initial-snapshot fire. */
   triggeredBy?: { method: string; path: string };
+  /** Free-form operation metadata. `admin: true` marks a rules-bypassing
+   *  setup/admin operation so fixture tooling can exclude it from protected
+   *  behavior while still preserving it as replay context. */
+  detail?: { admin?: boolean } & Record<string, unknown>;
 }
 
 /**
@@ -568,6 +572,10 @@ export interface WriteSandboxEvent {
    *  on replay. Shape mirrors the Firestore Web SDK Timestamp
    *  (`{ seconds, nanoseconds }`). */
   requestTime: { seconds: number; nanoseconds: number };
+  /** Free-form write metadata. `admin: true` marks a rules-bypassing
+   *  setup/admin commit so replay can apply it as context without asking
+   *  candidate rules to permit it. */
+  detail?: { admin?: boolean } & Record<string, unknown>;
 }
 
 /**

--- a/packages/pyric/test/sandbox/replay.test.ts
+++ b/packages/pyric/test/sandbox/replay.test.ts
@@ -9,7 +9,14 @@
  * not a subpath.
  */
 import { describe, it, expect } from 'bun:test';
-import { initializeSandbox, replay, type Divergence, type Sandbox } from '../../src/sandbox/index.js';
+import {
+  initializeSandbox,
+  replay,
+  type Divergence,
+  type RequestEvent,
+  type Sandbox,
+  type WriteSandboxEvent,
+} from '../../src/sandbox/index.js';
 import { getInternalEnv } from '../../src/sandbox/internal/sandbox-impl.js';
 
 const RULES = `rules_version = '2';
@@ -134,6 +141,41 @@ service cloud.firestore {
     // replayed sandbox → the diff surfaces as real-divergence.
     const real = result.divergences.filter((d) => d.kind === 'real-divergence');
     expect(real.length).toBeGreaterThan(0);
+  });
+
+  it('replays admin setup writes as context without requiring candidate rules to allow them', () => {
+    const { sandbox, env } = setup();
+    env.execute({
+      method: 'set',
+      path: 'things/setup',
+      auth: null,
+      data: { seeded: true },
+      bypassRules: true,
+    });
+    env.execute({
+      method: 'set',
+      path: 'things/user',
+      auth: { uid: 'alice' },
+      data: { value: 1 },
+    });
+
+    const events = sandbox.history();
+    const setupRequest = events.find(
+      (event): event is RequestEvent => event.kind === 'request' && event.path === 'things/setup',
+    );
+    const setupWrite = events.find(
+      (event): event is WriteSandboxEvent => event.kind === 'write' && event.path === 'things/setup',
+    );
+
+    expect(setupRequest?.detail?.admin).toBe(true);
+    expect(setupWrite?.detail?.admin).toBe(true);
+
+    const originalState = sandbox.snapshot().firestore;
+    const result = replay(events, RULES, {}, originalState);
+
+    expect(result.divergences).toHaveLength(0);
+    expect(result.sandbox.snapshot().firestore['things/setup']).toEqual({ seeded: true });
+    expect(result.sandbox.snapshot().firestore['things/user']).toEqual({ value: 1 });
   });
 
   it('captures sentinels across batch sub-ops and re-issues on replay', () => {


### PR DESCRIPTION
## Setup writes stay setup

Captured Firestore admin traffic now behaves as fixture context during verification. Candidate rules no longer have to allow writes that originally bypassed rules, while user writes are still replayed as protected behavior.

```ts
const result = await verifyFixture(fixture, {
  rules: {
    firestore: candidateRules,
  },
});

// Admin seed writes rebuild the captured starting point.
// User writes are checked against the candidate rules.
```

## API surface

- Firestore sandbox events can carry `detail.admin` metadata.
- Admin Firestore writes emitted through the sandbox are marked when they bypass rules.
- Firestore replay applies admin/setup writes with bypass semantics.
- `verifyFixture()` excludes admin/setup writes from protected checked-event counts.

## Why this matters

A captured session often contains setup data written by an admin lens before the user action being protected. Verification should preserve that context, then ask whether the candidate rules still allow or deny the user-visible behavior.

## Tests

- Firestore replay proves admin setup data is applied even when candidate rules deny setup writes.
- Verify tests prove setup writes do not inflate protected checked-event counts.
- Existing verify CLI coverage remains green.