### PR TITLE
Own equality semantics by domain

### DIFF
--- a/packages/pyric/src/database/replay.ts
+++ b/packages/pyric/src/database/replay.ts
@@ -14,6 +14,7 @@ import {
   update,
   sandbox as rtdbSandbox,
 } from './modular.js';
+import { isJsonObject, jsonValuesEqual } from './sandbox/data-tree.js';
 
 export interface RtdbReplayOptions {
   rules: { rules: Record<string, unknown> };
@@ -151,7 +152,7 @@ async function replayRtdbCommitWithDatabase(
       await remove(dbRef);
       break;
     case 'update':
-      if (!isRecord(commit.data)) {
+      if (!isJsonObject(commit.data)) {
         divergences.push({
           kind: 'unsupported',
           path,
@@ -189,8 +190,8 @@ function collectStateDrift(
   path: string,
   out: RtdbReplayDivergence[],
 ): void {
-  if (deepEqual(expected, actual)) return;
-  if (!isRecord(expected) || !isRecord(actual)) {
+  if (jsonValuesEqual(expected, actual)) return;
+  if (!isJsonObject(expected) || !isJsonObject(actual)) {
     out.push({
       kind: 'state-drift',
       path,
@@ -209,22 +210,4 @@ function collectStateDrift(
       out,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) return true;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b)) return false;
-    if (a.length !== b.length) return false;
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (!isRecord(a) || !isRecord(b)) return false;
-  const aKeys = Object.keys(a).sort();
-  const bKeys = Object.keys(b).sort();
-  if (aKeys.length !== bKeys.length) return false;
-  return aKeys.every((key, index) => key === bKeys[index] && deepEqual(a[key], b[key]));
 }

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -29,6 +29,7 @@ import {
 import {
   DataTree,
   cloneJson,
+  jsonValuesEqual,
   joinPath,
   pathSegments,
   type JsonValue,
@@ -939,7 +940,7 @@ export class RtdbBackend {
       // unchanged must NOT re-fire — RTDB's SyncTree dedups no-change.
       const snap = this.makeSnap(listener.path);
       const last = listener.lastValue;
-      if (last !== undefined && deepEqualJson(last, snap.val)) {
+      if (last !== undefined && jsonValuesEqual(last, snap.val)) {
         this.emitListener('suppressed', listener, listener.auth, {
           event: 'value',
           reason: 'no-op',
@@ -1355,7 +1356,7 @@ export class RtdbBackend {
    * For each listener, compute the diff between prior and current
    * children, then dispatch:
    *   - `child_added` when a key appears that wasn't in prior.
-   *   - `child_changed` when a key's value transitions (deep-not-equal).
+   *   - `child_changed` when a key's value transitions.
    *   - `child_removed` when a prior key is gone.
    */
   private fanOutChildren(priorByParent: Map<string, Map<string, JsonValue>>): void {
@@ -1382,7 +1383,7 @@ export class RtdbBackend {
       for (const [k, v] of next) {
         if (!prior.has(k)) {
           added.push({ key: k, val: v });
-        } else if (!deepEqualJson(prior.get(k)!, v)) {
+        } else if (!jsonValuesEqual(prior.get(k)!, v)) {
           changed.push({ key: k, val: v });
         }
       }
@@ -1444,37 +1445,6 @@ function canonicalPath(path: string): string {
 }
 
 /**
- * Structural JSON equality. Used by the child-event diff to tell
- * `child_changed` from "same value". RTDB's diff is value-based — a
- * write that lands the same JSON shape is a no-op for child events.
- */
-function deepEqualJson(a: JsonValue, b: JsonValue): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-  if (Array.isArray(a)) {
-    const bb = b as JsonValue[];
-    if (a.length !== bb.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqualJson(a[i]!, bb[i]!)) return false;
-    }
-    return true;
-  }
-  const ao = a as Record<string, JsonValue>;
-  const bo = b as Record<string, JsonValue>;
-  const ak = Object.keys(ao);
-  const bk = Object.keys(bo);
-  if (ak.length !== bk.length) return false;
-  for (const k of ak) {
-    if (!(k in bo)) return false;
-    if (!deepEqualJson(ao[k]!, bo[k]!)) return false;
-  }
-  return true;
-}
-
-/**
  * Transaction-specific denial constructor. Pinned by oracle observation
  * `rtdb-modular-runtransaction-on-rules-denied-path.json`:
  *
@@ -1516,18 +1486,18 @@ function rowsToVal(rows: QueryRow[]): JsonValue {
   return out;
 }
 
-/** Deep-equal compare for two windowed result lists. Used to decide
- *  whether a query listener should re-fire. Uses structural
- *  `deepEqualJson` (key-order-INsensitive) rather than `JSON.stringify`
- *  so a re-write that only reorders object keys is correctly treated as
- *  "no change" (DB-B11: RTDB treats objects as order-equal). */
+/** Compare two windowed result lists. Used to decide whether a query
+ *  listener should re-fire. Uses RTDB JSON value equality rather than
+ *  `JSON.stringify` so a re-write that only reorders object keys is
+ *  correctly treated as "no change" (DB-B11: RTDB treats objects as
+ *  order-equal). */
 function windowsEqual(a: QueryRow[], b: QueryRow[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     const ai = a[i]!;
     const bi = b[i]!;
     if (ai.key !== bi.key) return false;
-    if (!deepEqualJson(ai.value, bi.value)) return false;
+    if (!jsonValuesEqual(ai.value, bi.value)) return false;
   }
   return true;
 }

--- a/packages/pyric/src/database/sandbox/data-tree.ts
+++ b/packages/pyric/src/database/sandbox/data-tree.ts
@@ -95,6 +95,33 @@ export function cloneJson<T extends JsonValue>(v: T): T {
   return out as T;
 }
 
+/** True for RTDB JSON object nodes. Arrays are ordered values in RTDB,
+ *  not object patches or path maps. */
+export function isJsonObject(value: unknown): value is Record<string, JsonValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Structural RTDB JSON equality.
+ *
+ * Object key order is ignored, array order is preserved, and primitive
+ * leaves compare by value. This is the equality RTDB listener diffs and
+ * fixture replay use when deciding whether two JSON states are the same.
+ */
+export function jsonValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => jsonValuesEqual(value, b[index]));
+  }
+  if (!isJsonObject(a) || !isJsonObject(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && jsonValuesEqual(a[key], b[key]));
+}
+
 /**
  * In-memory JSON tree. One instance per sandbox.
  *

--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -13,7 +13,9 @@
  */
 import type { Expression, FunctionDef } from '../grammar/FirestoreAST.js';
 import { assembleExpression } from '../grammar/FirestoreAssembler.js';
-import { MapDiff, FirestoreSet } from './mapdiff.js';
+import { MapDiff } from './mapdiff.js';
+import { FirestoreSet } from './firestore-set.js';
+import { rulesValuesEqual } from './value-equality.js';
 import { RulesValue, NO_OP } from './wrappers/base.js';
 import { LatLng } from './wrappers/latlng.js';
 import { Duration } from './wrappers/duration.js';
@@ -419,14 +421,14 @@ function evaluateExpr(expr: Expression, ctx: SimulationContext, scope: Record<st
       const element = evaluate(expr.element, ctx, scope);
       const collection = evaluate(expr.collection, ctx, scope);
       if (collection === null || collection === undefined) return false;
-      // Use deepEqualsForRules instead of Array.includes so wrapper
+      // Use Rules value equality instead of Array.includes so wrapper
       // value-equality applies (Item 0.B hook 6). Without this,
       // `someTimestamp in [t1, t2]` is always false because `===`
       // doesn't see the wrappers as equal even when their contents
       // match. Map-key membership stays as a String() check — keys
       // are always strings in Firestore rules.
       if (Array.isArray(collection)) {
-        return collection.some(v => deepEqualsForRules(v, element));
+        return collection.some(v => rulesValuesEqual(v, element));
       }
       // RULES-B7: map-key membership must use OWN keys only. `in` walks the JS
       // prototype chain, so `'toString' in resource.data` wrongly returned
@@ -616,7 +618,7 @@ function evaluateBinaryOp(
   // to the generic numeric switch below.
   //
   // == and != intentionally bypass this hook — they route through
-  // deepEqualsForRules above, which already calls the wrapper's
+  // rulesValuesEqual above, which already calls the wrapper's
   // `equals()`. Splitting "value equality" from "operator dispatch"
   // keeps each wrapper's contract clean.
   if (op !== '==' && op !== '!=') {
@@ -678,8 +680,8 @@ function evaluateBinaryOp(
   }
 
   switch (op) {
-    case '==': return lv === rv || deepEqualsForRules(lv, rv);
-    case '!=': return !(lv === rv || deepEqualsForRules(lv, rv));
+    case '==': return lv === rv || rulesValuesEqual(lv, rv);
+    case '!=': return !(lv === rv || rulesValuesEqual(lv, rv));
     case '<': return (lv as number) < (rv as number);
     case '>': return (lv as number) > (rv as number);
     case '<=': return (lv as number) <= (rv as number);
@@ -722,38 +724,6 @@ function evaluateBinaryOp(
       return (lv as number) % (rv as number);
     default: throw new EvalError(`Unknown binary op: ${op}`);
   }
-}
-
-/** Firestore == uses value equality for maps and lists */
-function deepEqualsForRules(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  // RulesValue wrappers (Timestamp, Duration, Bytes, LatLng, Path)
-  // own value-equality. The 0.B failure mode: two `timestamp.value(1234)`
-  // calls return distinct instances so `a === b` is false; without this
-  // hook the function falls into the generic object branch and compares
-  // private state field-by-field, accidentally working for some types
-  // and silently failing for others. Routing through `equals()` keeps
-  // every wrapper consistent.
-  if (a instanceof RulesValue) return a.equals(b);
-  if (b instanceof RulesValue) return b.equals(a);
-  // FirestoreSet is not a RulesValue; without this hook it falls into
-  // the generic-object branch where two sets ALWAYS compare equal
-  // (their private JS Set has no enumerable keys) — false-permissive.
-  if (a instanceof FirestoreSet || b instanceof FirestoreSet) {
-    return a instanceof FirestoreSet && a.equals(b);
-  }
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((v, i) => deepEqualsForRules(v, b[i]));
-  }
-  if (Array.isArray(a) || Array.isArray(b)) return false;
-  const ao = a as Record<string, unknown>, bo = b as Record<string, unknown>;
-  const ak = Object.keys(ao), bk = Object.keys(bo);
-  if (ak.length !== bk.length) return false;
-  return ak.every(k => k in bo && deepEqualsForRules(ao[k], bo[k]));
 }
 
 // ═══ Type-conversion builtins (RULES-B5 / RULES-B6) ═══
@@ -1059,14 +1029,14 @@ function evaluateMethodCall(
       case 'size': return obj.length;
       // RULES-B9: list membership uses VALUE equality, not JS identity, so it
       // is consistent with `in` / `removeAll` (which already use
-      // deepEqualsForRules). Without this, `[t1].hasAll([t2])` for equal-valued
+      // rulesValuesEqual). Without this, `[t1].hasAll([t2])` for equal-valued
       // Timestamp/Bytes/Path wrappers wrongly returned false because the two
       // instances aren't `===`.
-      case 'hasAll': return (argValues[0] as unknown[]).every(v => obj.some(o => deepEqualsForRules(o, v)));
-      case 'hasAny': return (argValues[0] as unknown[]).some(v => obj.some(o => deepEqualsForRules(o, v)));
+      case 'hasAll': return (argValues[0] as unknown[]).every(v => obj.some(o => rulesValuesEqual(o, v)));
+      case 'hasAny': return (argValues[0] as unknown[]).some(v => obj.some(o => rulesValuesEqual(o, v)));
       case 'hasOnly': {
         const allowed = argValues[0] as unknown[];
-        return obj.every(v => allowed.some(o => deepEqualsForRules(o, v)));
+        return obj.every(v => allowed.some(o => rulesValuesEqual(o, v)));
       }
       case 'join': return obj.join(String(argValues[0] ?? ','));
       // ─── Item 5.2: List.concat / removeAll / toSet ─────────────────────
@@ -1079,7 +1049,7 @@ function evaluateMethodCall(
       }
       case 'removeAll': {
         // Returns a new list with all items from `other` removed (by value
-        // equality). Uses deepEqualsForRules so wrapper instances (Timestamp,
+        // equality). Uses rulesValuesEqual so wrapper instances (Timestamp,
         // Duration, etc.) compare by value, not by JS identity — without
         // this, `[t1].removeAll([t2])` where t1 and t2 are equal Timestamp
         // wrappers would not remove t1.
@@ -1087,7 +1057,7 @@ function evaluateMethodCall(
         if (!Array.isArray(other)) {
           throw new EvalError(`List.removeAll requires a list argument, got ${typeof other}`);
         }
-        return obj.filter(v => !other.some(o => deepEqualsForRules(v, o)));
+        return obj.filter(v => !other.some(o => rulesValuesEqual(v, o)));
       }
       case 'toSet': {
         // Convert to FirestoreSet. The class stores strings only — coerce

--- a/packages/pyric/src/rules/simulator/firestore-set.ts
+++ b/packages/pyric/src/rules/simulator/firestore-set.ts
@@ -1,0 +1,90 @@
+export class FirestoreSet {
+  private items: Set<string>;
+
+  constructor(items: Iterable<string>) {
+    this.items = new Set(items);
+  }
+
+  /** True if the set contains ONLY keys from the provided list/set (and no others). */
+  hasOnly(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const item of this.items) {
+      if (!arr.includes(item)) return false;
+    }
+    return true;
+  }
+
+  /** Value equality against another FirestoreSet (order-insensitive).
+   *  Production supports `set == set` (e.g. `diff.addedKeys() ==
+   *  [uid].toSet()`). */
+  equals(other: unknown): boolean {
+    if (!(other instanceof FirestoreSet)) return false;
+    if (other.items.size !== this.items.size) return false;
+    for (const item of this.items) {
+      if (!other.items.has(item)) return false;
+    }
+    return true;
+  }
+
+  /** True if the set contains ALL keys from the provided list/set. */
+  hasAll(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const key of arr) {
+      if (!this.items.has(key)) return false;
+    }
+    return true;
+  }
+
+  /** True if the set contains ANY key from the provided list/set. */
+  hasAny(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const key of arr) {
+      if (this.items.has(key)) return true;
+    }
+    return false;
+  }
+
+  /** Number of items in the set. */
+  size(): number {
+    return this.items.size;
+  }
+
+  /** Convert to array (for debugging). */
+  toArray(): string[] {
+    return [...this.items];
+  }
+
+  // Per REBUILD_PLAN type table for Set:
+  //   difference(other: Set) -> Set
+  //   union(other: Set) -> Set
+  //   intersection(other: Set) -> Set
+  // Mirroring hasOnly/hasAll/hasAny, we accept a List (string[]) too.
+
+  /** Items in this set but not in `other`. */
+  difference(other: string[] | FirestoreSet): FirestoreSet {
+    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
+    const result: string[] = [];
+    for (const item of this.items) {
+      if (!otherSet.has(item)) result.push(item);
+    }
+    return new FirestoreSet(result);
+  }
+
+  /** Items in either set. */
+  union(other: string[] | FirestoreSet): FirestoreSet {
+    const otherArr = other instanceof FirestoreSet ? other.toArray() : other;
+    const merged = new Set<string>(this.items);
+    for (const item of otherArr) merged.add(item);
+    return new FirestoreSet(merged);
+  }
+
+  /** Items in both sets. */
+  intersection(other: string[] | FirestoreSet): FirestoreSet {
+    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
+    const result: string[] = [];
+    for (const item of this.items) {
+      if (otherSet.has(item)) result.push(item);
+    }
+    return new FirestoreSet(result);
+  }
+}

--- a/packages/pyric/src/rules/simulator/handler.ts
+++ b/packages/pyric/src/rules/simulator/handler.ts
@@ -309,7 +309,7 @@ function isServerTimestampSentinel(value: unknown): boolean {
  * Recursively replace serverTimestamp sentinels with the actual server time.
  * Item 1.3: `serverTime` is now a Timestamp wrapper (was ISO string). The
  * SAME instance is reused across every sentinel hit so `data.createdAt ==
- * request.time` succeeds via deepEqualsForRules → Timestamp.equals (field
+ * request.time` succeeds via rulesValuesEqual -> Timestamp.equals (field
  * compare). Without instance reuse, two distinct Timestamp instances would
  * still equate via field compare — but the single-instance invariant is
  * documented here so future refactors don't break it accidentally.

--- a/packages/pyric/src/rules/simulator/mapdiff.ts
+++ b/packages/pyric/src/rules/simulator/mapdiff.ts
@@ -6,104 +6,14 @@
  *
  * Semantics derived from production Firestore behavior:
  * - Only compares top-level keys (nested map diff is unreliable in production)
- * - Values are compared with deep equality
+ * - Values are compared with Firestore Rules value equality
  * - Returns Set-like objects with hasOnly(), hasAll(), hasAny(), size()
  */
 
-export class FirestoreSet {
-  private items: Set<string>;
+import { FirestoreSet } from './firestore-set.js';
+import { rulesValuesEqual } from './value-equality.js';
 
-  constructor(items: Iterable<string>) {
-    this.items = new Set(items);
-  }
-
-  /** True if the set contains ONLY keys from the provided list/set (and no others). */
-  hasOnly(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const item of this.items) {
-      if (!arr.includes(item)) return false;
-    }
-    return true;
-  }
-
-  /** Value equality against another FirestoreSet (order-insensitive).
-   *  Production supports `set == set` (e.g. `diff.addedKeys() ==
-   *  [uid].toSet()`); without this the evaluator's deep-equals fell
-   *  into the generic-object branch, whose Object.keys() view of the
-   *  private JS Set is always [] — so ANY two sets compared EQUAL, a
-   *  false-PERMISSIVE divergence found by joining validation. */
-  equals(other: unknown): boolean {
-    if (!(other instanceof FirestoreSet)) return false;
-    if (other.items.size !== this.items.size) return false;
-    for (const item of this.items) {
-      if (!other.items.has(item)) return false;
-    }
-    return true;
-  }
-
-  /** True if the set contains ALL keys from the provided list/set. */
-  hasAll(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const key of arr) {
-      if (!this.items.has(key)) return false;
-    }
-    return true;
-  }
-
-  /** True if the set contains ANY key from the provided list/set. */
-  hasAny(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const key of arr) {
-      if (this.items.has(key)) return true;
-    }
-    return false;
-  }
-
-  /** Number of items in the set. */
-  size(): number {
-    return this.items.size;
-  }
-
-  /** Convert to array (for debugging). */
-  toArray(): string[] {
-    return [...this.items];
-  }
-
-  // ─── Set algebra (Item 5.1) ───────────────────────────────────────────
-  // Per REBUILD_PLAN type table for Set:
-  //   difference(other: Set) → Set
-  //   union(other: Set) → Set
-  //   intersection(other: Set) → Set
-  // Mirroring hasOnly/hasAll/hasAny, we accept a List (string[]) too.
-
-  /** Items in this set but not in `other`. */
-  difference(other: string[] | FirestoreSet): FirestoreSet {
-    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
-    const result: string[] = [];
-    for (const item of this.items) {
-      if (!otherSet.has(item)) result.push(item);
-    }
-    return new FirestoreSet(result);
-  }
-
-  /** Items in either set. */
-  union(other: string[] | FirestoreSet): FirestoreSet {
-    const otherArr = other instanceof FirestoreSet ? other.toArray() : other;
-    const merged = new Set<string>(this.items);
-    for (const item of otherArr) merged.add(item);
-    return new FirestoreSet(merged);
-  }
-
-  /** Items in both sets. */
-  intersection(other: string[] | FirestoreSet): FirestoreSet {
-    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
-    const result: string[] = [];
-    for (const item of this.items) {
-      if (otherSet.has(item)) result.push(item);
-    }
-    return new FirestoreSet(result);
-  }
-}
+export { FirestoreSet } from './firestore-set.js';
 
 export class MapDiff {
   private before: Record<string, unknown>;
@@ -136,7 +46,7 @@ export class MapDiff {
   changedKeys(): FirestoreSet {
     const changed: string[] = [];
     for (const key of Object.keys(this.after)) {
-      if (key in this.before && !deepEqual(this.before[key], this.after[key])) {
+      if (key in this.before && !rulesValuesEqual(this.before[key], this.after[key])) {
         changed.push(key);
       }
     }
@@ -148,7 +58,7 @@ export class MapDiff {
     const affected: string[] = [];
     const allKeys = new Set([...Object.keys(this.before), ...Object.keys(this.after)]);
     for (const key of allKeys) {
-      if (!(key in this.before) || !(key in this.after) || !deepEqual(this.before[key], this.after[key])) {
+      if (!(key in this.before) || !(key in this.after) || !rulesValuesEqual(this.before[key], this.after[key])) {
         affected.push(key);
       }
     }
@@ -159,32 +69,10 @@ export class MapDiff {
   unchangedKeys(): FirestoreSet {
     const unchanged: string[] = [];
     for (const key of Object.keys(this.before)) {
-      if (key in this.after && deepEqual(this.before[key], this.after[key])) {
+      if (key in this.after && rulesValuesEqual(this.before[key], this.after[key])) {
         unchanged.push(key);
       }
     }
     return new FirestoreSet(unchanged);
   }
-}
-
-/** Deep equality for Firestore field values. */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((val, i) => deepEqual(val, b[i]));
-  }
-
-  if (Array.isArray(a) || Array.isArray(b)) return false;
-
-  const aObj = a as Record<string, unknown>;
-  const bObj = b as Record<string, unknown>;
-  const aKeys = Object.keys(aObj);
-  const bKeys = Object.keys(bObj);
-  if (aKeys.length !== bKeys.length) return false;
-  return aKeys.every(key => key in bObj && deepEqual(aObj[key], bObj[key]));
 }

--- a/packages/pyric/src/rules/simulator/value-equality.ts
+++ b/packages/pyric/src/rules/simulator/value-equality.ts
@@ -1,0 +1,33 @@
+import { FirestoreSet } from './firestore-set.js';
+import { RulesValue } from './wrappers/base.js';
+
+/**
+ * Firestore Rules value equality.
+ *
+ * Rules wrappers and FirestoreSet own equality; lists and maps compare
+ * structurally, with map key order ignored.
+ */
+export function rulesValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof RulesValue) return a.equals(b);
+  if (b instanceof RulesValue) return b.equals(a);
+  if (a instanceof FirestoreSet || b instanceof FirestoreSet) {
+    return a instanceof FirestoreSet && a.equals(b);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => rulesValuesEqual(value, b[index]));
+  }
+  if (!isRulesMapValue(a) || !isRulesMapValue(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && rulesValuesEqual(a[key], b[key]));
+}
+
+function isRulesMapValue(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/pyric/src/rules/simulator/wrappers/base.ts
+++ b/packages/pyric/src/rules/simulator/wrappers/base.ts
@@ -3,7 +3,7 @@
  * REBUILD_PLAN.md Item 0.B + Item 1.
  *
  * Why an abstract base instead of duck typing: the evaluator dispatches
- * through six different code paths (deepEqualsForRules, memberAccess,
+ * through six different code paths (rulesValuesEqual, memberAccess,
  * bracketAccess, evaluateMethodCall, evaluateBinaryOp, isExpr, inExpr).
  * Without a single base class, every new wrapper would have to be
  * registered at six sites — and forgetting one is the exact failure mode
@@ -76,7 +76,7 @@ export abstract class RulesValue {
 
   /**
    * Value equality. THE single source of truth for `==` / `!=` /
-   * `deepEqualsForRules`. `===` reference equality is intentionally
+   * `rulesValuesEqual`. `===` reference equality is intentionally
    * insufficient (the 0.B failure: two `timestamp.value(1234)` calls
    * produce two distinct instances; `===` is false; rule denies).
    */
@@ -126,7 +126,7 @@ export abstract class RulesValue {
    *   Bytes < <= > >= Bytes → lexicographic byte compare
    *
    * `==` and `!=` do NOT route through this hook — they go through
-   * `deepEqualsForRules` which calls `equals()`. This split keeps the
+   * `rulesValuesEqual` which calls `equals()`. This split keeps the
    * "is this the same value?" question separate from "what does
    * `lhs OP rhs` evaluate to?".
    *

--- a/packages/pyric/src/rules/simulator/wrappers/latlng.ts
+++ b/packages/pyric/src/rules/simulator/wrappers/latlng.ts
@@ -112,5 +112,5 @@ export class LatLng extends RulesValue {
 
   // No binaryOp override — defaults to NO_OP, so arithmetic falls
   // through to the generic numeric switch which produces NaN. == / !=
-  // route through deepEqualsForRules → equals(). This is correct.
+  // route through rulesValuesEqual -> equals(). This is correct.
 }

--- a/packages/pyric/src/sandbox/branches/index.ts
+++ b/packages/pyric/src/sandbox/branches/index.ts
@@ -237,7 +237,7 @@ export function promote(branch: Branch, target: Sandbox): void {
       target.admin.deleteDocument(path);
       continue;
     }
-    if (before === undefined || !deepEqual(before, after)) {
+    if (before === undefined || !sandboxDocumentsEqual(before, after)) {
       // Branch added or changed this doc.
       target.admin.setDocument(path, after);
     }
@@ -343,13 +343,13 @@ function walkDoc(path: string, before: unknown, after: unknown, out: Divergence[
       return;
     }
 
-    if (deepEqual(a, b)) return;
+    if (sandboxDocumentsEqual(a, b)) return;
     out.push({ kind: 'real-divergence', path, field: fieldPath || undefined, before: a, after: b });
   }
 }
 
-/** Structural deep-equality on plain JSON-ish values. */
-function deepEqual(a: unknown, b: unknown): boolean {
+/** Structural equality on sandbox document snapshots. */
+function sandboxDocumentsEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a === null || b === null) return false;
   if (typeof a !== 'object' || typeof b !== 'object') return false;
@@ -359,7 +359,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (aArr && bArr) {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i], b[i])) return false;
+      if (!sandboxDocumentsEqual(a[i], b[i])) return false;
     }
     return true;
   }
@@ -370,7 +370,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (ak.length !== bk.length) return false;
   for (const k of ak) {
     if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
-    if (!deepEqual(ao[k], bo[k])) return false;
+    if (!sandboxDocumentsEqual(ao[k], bo[k])) return false;
   }
   return true;
 }

--- a/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
@@ -21,11 +21,8 @@
  *     number/string/boolean/bigint fields (the only types the corpus
  *     exercises today, per the design-doc inventory) and a deterministic
  *     fallback (`String(...)` comparison) for cross-type cases.
- *   - `deepEqual` keeps the bench's `JSON.stringify` shortcut for
- *     objects. Brittle on key order, but matches bench's behavior
- *     exactly so probe ports don't need to relax their assertions.
- *     Slice-5 tests will fail loudly if we ever need a real structural
- *     equality here.
+ *   - `firestoreValuesEqual` keeps query value matching aligned with
+ *     transform dedupe and Firestore value wrappers.
  *
  * Circular import note: `doc-ref.ts` imports `CollectionRefImpl` for
  * `.parent` / `.collection(name)`; this file imports `DocumentRefImpl`
@@ -44,6 +41,7 @@ import { DocumentRefImpl } from './doc-ref.js';
 // mis-ordered cross-type values + broke NaN. See `value-order.ts`.
 import { compareValues, typeOrderRank } from './value-order.js';
 import { topK } from '../topk.js';
+import { firestoreValuesEqual } from '../value-equality.js';
 // RULES-B11 — structured `where`/`limit`/`orderBy` view threaded into the
 // rule-enforced read paths so the query-proof gate ("rules are not
 // filters") can discharge per-doc rule predicates from the query's
@@ -157,16 +155,6 @@ function greaterOrEqual(a: unknown, b: unknown): boolean {
   return sameType(a, b) && compareValues(a, b) >= 0;
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a && b && typeof a === 'object') {
-    return JSON.stringify(a) === JSON.stringify(b);
-  }
-  return false;
-}
-
-
 // ─────────────────────────────────────────────────────────────────────────
 // Where / order / limit application.
 // ─────────────────────────────────────────────────────────────────────────
@@ -182,30 +170,30 @@ function matchesWhere(
   // short-circuits every operator to false.
   const present = value !== undefined;
   switch (op) {
-    case '==': return present && deepEqual(value, target);
+    case '==': return present && firestoreValuesEqual(value, target);
     case '!=':
       // != requires the field to EXIST and be non-null, then differ.
       // (clones/.../core/filter.ts FieldFilter.matches NOT_EQUAL branch.)
-      return present && value !== null && !deepEqual(value, target);
+      return present && value !== null && !firestoreValuesEqual(value, target);
     case '<': return present && lessThan(value, target);
     case '<=': return present && lessOrEqual(value, target);
     case '>': return present && greaterThan(value, target);
     case '>=': return present && greaterOrEqual(value, target);
     case 'in':
-      return present && Array.isArray(target) && target.some((t) => deepEqual(value, t));
+      return present && Array.isArray(target) && target.some((t) => firestoreValuesEqual(value, t));
     case 'not-in':
       // not-in requires existence + non-null; a null in the operand list
       // makes the filter match nothing (clones/.../core/filter.ts
       // NotInFilter.matches). Field must also not equal any operand.
       if (!Array.isArray(target)) return false;
       if (target.some((t) => t === null)) return false;
-      return present && value !== null && !target.some((t) => deepEqual(value, t));
+      return present && value !== null && !target.some((t) => firestoreValuesEqual(value, t));
     case 'array-contains':
-      return Array.isArray(value) && value.some((v) => deepEqual(v, target));
+      return Array.isArray(value) && value.some((v) => firestoreValuesEqual(v, target));
     case 'array-contains-any':
       return Array.isArray(value)
         && Array.isArray(target)
-        && target.some((t) => value.some((v) => deepEqual(v, t)));
+        && target.some((t) => value.some((v) => firestoreValuesEqual(v, t)));
   }
 }
 

--- a/packages/pyric/src/sandbox/firestore/converters/fieldvalue.ts
+++ b/packages/pyric/src/sandbox/firestore/converters/fieldvalue.ts
@@ -42,6 +42,7 @@
  *   (`computeTransformOperationBaseValue`, `coercedFieldValuesArray`).
  */
 import { KEEP, DELETE_MARKER, type ValueConverter, type ResolveContext } from '../value-resolver.js';
+import { firestoreValuesEqual } from '../value-equality.js';
 
 // ═══ Sentinel shapes ═══
 
@@ -143,12 +144,7 @@ export const arrayUnionConverter: ValueConverter = {
     // throwing (upstream `coercedFieldValuesArray`).
     const base: unknown[] = Array.isArray(prior) ? prior.slice() : [];
     for (const v of value.values) {
-      // Firestore's union dedups by deep value equality. JSON-string
-      // comparison covers the common cases (primitives, plain objects,
-      // arrays of primitives). Wrappers like Timestamp/Path/DocRef are
-      // compared by reference here — refine in Item 5+ once those
-      // wrappers carry value-equals.
-      const exists = base.some((b) => deepEqual(b, v));
+      const exists = base.some((b) => firestoreValuesEqual(b, v));
       if (!exists) base.push(v);
     }
     return base;
@@ -163,7 +159,7 @@ export const arrayRemoveConverter: ValueConverter = {
     // FS-B11 — a non-array (or absent) prior coerces to `[]` (so the result
     // is `[]`), rather than throwing.
     if (!Array.isArray(prior)) return [];
-    return prior.filter((b) => !value.values.some((v) => deepEqual(b, v)));
+    return prior.filter((b) => !value.values.some((v) => firestoreValuesEqual(b, v)));
   },
 };
 
@@ -174,21 +170,3 @@ export const deleteFieldConverter: ValueConverter = {
     return DELETE_MARKER;
   },
 };
-
-// ═══ Helpers ═══
-
-/**
- * Best-effort deep-equality for arrayUnion/arrayRemove dedup.
- * Handles primitives, arrays, and plain objects via JSON; class
- * instances (Date, Timestamp, etc.) fall back to reference equality.
- */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== 'object' || typeof b !== 'object') return false;
-  try {
-    return JSON.stringify(a) === JSON.stringify(b);
-  } catch {
-    return false;
-  }
-}

--- a/packages/pyric/src/sandbox/firestore/value-equality.ts
+++ b/packages/pyric/src/sandbox/firestore/value-equality.ts
@@ -1,0 +1,34 @@
+interface FirestoreValueComparable {
+  isEqual(other: unknown): boolean;
+}
+
+function hasFirestoreValueEquality(value: unknown): value is FirestoreValueComparable {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'isEqual' in value &&
+    typeof (value as { isEqual?: unknown }).isEqual === 'function'
+  );
+}
+
+function isFirestoreMapValue(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function firestoreValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (hasFirestoreValueEquality(a)) return a.isEqual(b);
+  if (hasFirestoreValueEquality(b)) return b.isEqual(a);
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => firestoreValuesEqual(value, b[index]));
+  }
+  if (!isFirestoreMapValue(a) || !isFirestoreMapValue(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && firestoreValuesEqual(a[key], b[key]));
+}

--- a/packages/pyric/test/database/json-value.test.ts
+++ b/packages/pyric/test/database/json-value.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { isJsonObject, jsonValuesEqual } from '../../src/database/sandbox/data-tree.js';
+
+describe('RTDB JSON value primitives', () => {
+  it('compares object values without depending on key order', () => {
+    expect(jsonValuesEqual(
+      { room: { title: 'Launch', members: { alice: true, bob: true } } },
+      { room: { members: { bob: true, alice: true }, title: 'Launch' } },
+    )).toBe(true);
+  });
+
+  it('keeps array order significant', () => {
+    expect(jsonValuesEqual(['alice', 'bob'], ['bob', 'alice'])).toBe(false);
+  });
+
+  it('recognizes RTDB JSON object nodes, not arrays or absent values', () => {
+    expect(isJsonObject({ patch: true })).toBe(true);
+    expect(isJsonObject(['patch'])).toBe(false);
+    expect(isJsonObject(null)).toBe(false);
+  });
+});

--- a/packages/pyric/test/rules/simulator/set-equality.test.ts
+++ b/packages/pyric/test/rules/simulator/set-equality.test.ts
@@ -3,8 +3,8 @@
  *
  * Production supports `set == set` (e.g.
  * `diff.addedKeys() == [request.auth.uid].toSet()`). Before the fix,
- * `FirestoreSet` was not a `RulesValue`, so `deepEqualsForRules` fell
- * into its generic-object branch — where the private JS `Set` exposes
+ * `FirestoreSet` did not have Rules-owned equality, so it fell into
+ * the plain object branch — where the private JS `Set` exposes
  * no enumerable keys, so ANY two sets compared EQUAL. That divergence
  * was false-PERMISSIVE (simulator ALLOWED what production DENIES):
  * caught by joining validation, whose 10 cases all pass in the production

--- a/packages/pyric/test/sandbox/firestore/admin-compat/compat.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/compat.test.ts
@@ -102,6 +102,26 @@ describe('admin-compat — Query', () => {
     expect(snap.docs[0]!.data().ownerId).toBe('alice');
   });
 
+  test('query.where(==) matches object values without depending on key order', async () => {
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES,
+      documents: {
+        'profiles/a': { prefs: { role: 'admin', active: true } },
+        'profiles/b': { prefs: { role: 'member', active: true } },
+      },
+    });
+    const db = createCompatFirestore(env, { auth: { uid: 'alice' } });
+
+    const snap = await db
+      .collection('profiles')
+      .where('prefs', '==', { active: true, role: 'admin' })
+      .get();
+
+    expect(snap.size).toBe(1);
+    expect(snap.docs[0]!.id).toBe('a');
+  });
+
   test('query.orderBy(desc).limit(1)', async () => {
     const { db } = freshDb();
     const snap = await db.collection('accounts').orderBy('balance', 'desc').limit(1).get();

--- a/packages/pyric/test/sandbox/firestore/simulator/converters/fieldvalue.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/converters/fieldvalue.test.ts
@@ -118,6 +118,14 @@ describe('arrayUnionConverter', () => {
     expect(out).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
+  test('dedups object values without depending on key order', () => {
+    const out = arrayUnionConverter.convert(
+      ARRAY_UNION({ active: true, role: 'admin' }),
+      baseCtx({ prior: { items: [{ role: 'admin', active: true }] }, fieldPath: 'items' }),
+    );
+    expect(out).toEqual([{ role: 'admin', active: true }]);
+  });
+
   test('treats absent prior as empty array', () => {
     const out = arrayUnionConverter.convert(
       ARRAY_UNION('x'),
@@ -148,6 +156,22 @@ describe('arrayRemoveConverter', () => {
       baseCtx({ prior: { tags: ['a', 'b', 'c'] }, fieldPath: 'tags' }),
     );
     expect(out).toEqual(['a', 'c']);
+  });
+
+  test('removes object values without depending on key order', () => {
+    const out = arrayRemoveConverter.convert(
+      ARRAY_REMOVE({ active: true, role: 'admin' }),
+      baseCtx({
+        prior: {
+          items: [
+            { role: 'admin', active: true },
+            { role: 'member', active: true },
+          ],
+        },
+        fieldPath: 'items',
+      }),
+    );
+    expect(out).toEqual([{ role: 'member', active: true }]);
   });
 
   test('returns empty array when prior is absent', () => {

--- a/packages/pyric/test/sandbox/firestore/simulator/mapdiff.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/mapdiff.test.ts
@@ -94,6 +94,14 @@ describe('MapDiff', () => {
       );
       expect(diff.changedKeys().size()).toBe(0);
     });
+
+    test('nested object unchanged regardless of key order', () => {
+      const diff = new MapDiff(
+        { a: { x: 1, y: 2 } },
+        { a: { y: 2, x: 1 } },
+      );
+      expect(diff.changedKeys().size()).toBe(0);
+    });
   });
 
   describe('affectedKeys', () => {
@@ -170,7 +178,7 @@ describe('MapDiff', () => {
     });
   });
 
-  describe('deep equality edge cases', () => {
+  describe('rules value equality edge cases', () => {
     test('null values', () => {
       const diff = new MapDiff({ a: null }, { a: null });
       expect(diff.changedKeys().size()).toBe(0);


### PR DESCRIPTION
## Summary

This PR replaces repeated local equality helpers with domain-owned primitives so the code reads in the language of the data being compared.

## What changes

- Adds RTDB JSON equality next to the RTDB JSON tree primitives and uses it for replay drift detection and RTDB listener/window comparisons.
- Adds Firestore value equality for array transform dedupe/removal and admin query matching.
- Adds Firestore Rules value equality for evaluator comparisons, list membership, list methods, and MapDiff changed/affected/unchanged key checks.
- Moves FirestoreSet into its own rules simulator primitive while preserving the existing rules export surface.
- Renames branch snapshot equality to describe sandbox document comparison directly.

## Why this matters

These comparisons are not interchangeable generic utilities. RTDB JSON equality, Firestore value equality, Rules value equality, and sandbox document equality each have different semantics. Naming them by domain makes those semantics visible at the callsite and reduces the chance that future code reaches for a vague local helper.

## Validation

- bun run build in packages/pyric
- bun run build in packages/pyric-tools, to satisfy package self-imports in the full pyric suite
- bun test focused RTDB/Firestore/Rules equality tests in packages/pyric
- bun test --only-failures in packages/pyric: 4211 pass, 21 skip, 0 fail