### PR TITLE
Own object boundary parsing by feature

### DIFF
--- a/packages/playground/src/components/RtdbTab.tsx
+++ b/packages/playground/src/components/RtdbTab.tsx
@@ -1,73 +1,21 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useToast } from '@pyric/ui/primitives';
 import {
+  formatRtdbJson,
+  joinRtdbPath,
+  parentRtdbPath,
+  parseRtdbJson,
+  previewRtdbValue,
+  rtdbChildEntries,
+  rtdbPathSegments,
+  rtdbValueAt,
+  rtdbValueKind,
+} from '@pyric/ui/rtdb';
+import {
   adminDeleteDatabaseValue,
   adminSetDatabaseValue,
   readDatabaseState,
 } from '~/lib/sandbox/runtime';
-
-function normalizePath(path: string): string {
-  const segments = path.split('/').filter(Boolean);
-  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
-}
-
-function pathSegments(path: string): string[] {
-  return normalizePath(path).split('/').filter(Boolean);
-}
-
-function joinPath(base: string, child: string): string {
-  return normalizePath([...pathSegments(base), ...child.split('/').filter(Boolean)].join('/'));
-}
-
-function parentPath(path: string): string {
-  const segments = pathSegments(path);
-  if (segments.length <= 1) return '/';
-  return `/${segments.slice(0, -1).join('/')}`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function childEntries(value: unknown): Array<[string, unknown]> {
-  if (value === null || typeof value !== 'object') return [];
-  return Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
-}
-
-function valueAt(root: unknown, path: string): unknown {
-  let value = root ?? null;
-  for (const segment of pathSegments(path)) {
-    if (value === null || typeof value !== 'object') return null;
-    value = (value as Record<string, unknown>)[segment] ?? null;
-  }
-  return value;
-}
-
-function formatJson(value: unknown): string {
-  return JSON.stringify(value ?? null, null, 2);
-}
-
-function parseJson(value: string): unknown {
-  const text = value.trim();
-  return text.length === 0 ? null : JSON.parse(text);
-}
-
-function valueKind(value: unknown): string {
-  if (value === null || value === undefined) return 'null';
-  if (Array.isArray(value)) return 'array';
-  return typeof value;
-}
-
-function previewValue(value: unknown): string {
-  if (value === null || value === undefined) return 'null';
-  if (Array.isArray(value)) return `${value.length} items`;
-  if (isRecord(value)) {
-    const count = Object.keys(value).length;
-    return count === 1 ? '1 child' : `${count} children`;
-  }
-  if (typeof value === 'string') return JSON.stringify(value);
-  return String(value);
-}
 
 export function RtdbTab() {
   const { toast } = useToast();
@@ -107,18 +55,18 @@ export function RtdbTab() {
     };
   }, [tick]);
 
-  const selectedValue = useMemo(() => valueAt(snapshot, path), [path, snapshot]);
-  const children = useMemo(() => childEntries(selectedValue), [selectedValue]);
+  const selectedValue = useMemo(() => rtdbValueAt(snapshot, path), [path, snapshot]);
+  const children = useMemo(() => rtdbChildEntries(selectedValue), [selectedValue]);
 
   useEffect(() => {
-    if (!editing) setDraft(formatJson(selectedValue));
+    if (!editing) setDraft(formatRtdbJson(selectedValue));
   }, [editing, selectedValue]);
 
   const refresh = () => setTick((n) => n + 1);
 
   const saveValue = async () => {
     try {
-      await adminSetDatabaseValue(path, parseJson(draft));
+      await adminSetDatabaseValue(path, parseRtdbJson(draft));
       toast({ title: `Saved ${path}`, kind: 'success' });
       setEditing(false);
       refresh();
@@ -136,7 +84,7 @@ export function RtdbTab() {
     try {
       await adminDeleteDatabaseValue(path);
       toast({ title: `Deleted ${path}`, kind: 'success' });
-      setPath(parentPath(path));
+      setPath(parentRtdbPath(path));
       setEditing(false);
       refresh();
     } catch (e) {
@@ -153,8 +101,8 @@ export function RtdbTab() {
     const key = childKey.trim();
     if (!key) return;
     try {
-      const nextPath = joinPath(path, key);
-      await adminSetDatabaseValue(nextPath, parseJson(childDraft));
+      const nextPath = joinRtdbPath(path, key);
+      await adminSetDatabaseValue(nextPath, parseRtdbJson(childDraft));
       toast({ title: `Added ${nextPath}`, kind: 'success' });
       setChildKey('');
       setChildDraft('{}');
@@ -194,7 +142,7 @@ export function RtdbTab() {
               {path !== '/' ? (
                 <button
                   type="button"
-                  onClick={() => setPath(parentPath(path))}
+                  onClick={() => setPath(parentRtdbPath(path))}
                   className="rounded border border-[#2a2a35] px-2.5 py-1 text-[11px] text-slate-gray hover:text-soft-white hover:border-[#3a3a48]"
                 >
                   Back
@@ -209,7 +157,7 @@ export function RtdbTab() {
                     key={key}
                     type="button"
                     onClick={() => {
-                      setPath(joinPath(path, key));
+                      setPath(joinRtdbPath(path, key));
                       setEditing(false);
                     }}
                     className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-[#2a2a35] px-3 py-3 text-left last:border-b-0 hover:bg-[#20202c]"
@@ -219,11 +167,11 @@ export function RtdbTab() {
                         {key}
                       </span>
                       <span className="block truncate text-[11px] text-slate-gray">
-                        {previewValue(value)}
+                        {previewRtdbValue(value)}
                       </span>
                     </span>
                     <span className="rounded-full border border-[#2a2a35] px-2 py-0.5 font-mono text-[9px] uppercase tracking-wider text-slate-gray">
-                      {valueKind(value)}
+                      {rtdbValueKind(value)}
                     </span>
                   </button>
                 ))}
@@ -268,7 +216,7 @@ export function RtdbTab() {
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
                 <h3 className="truncate font-mono text-[13px] text-soft-white">{path}</h3>
-                <p className="text-[11px] text-slate-gray">{valueKind(selectedValue)}</p>
+                <p className="text-[11px] text-slate-gray">{rtdbValueKind(selectedValue)}</p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 {editing ? (
@@ -277,7 +225,7 @@ export function RtdbTab() {
                       type="button"
                       onClick={() => {
                         setEditing(false);
-                        setDraft(formatJson(selectedValue));
+                        setDraft(formatRtdbJson(selectedValue));
                       }}
                       className="rounded border border-[#2a2a35] px-2.5 py-1 text-[11px] text-slate-gray hover:text-soft-white"
                     >
@@ -321,7 +269,7 @@ export function RtdbTab() {
               />
             ) : (
               <pre className="min-h-[320px] overflow-auto rounded-md border border-[#2a2a35] bg-[#111116] p-3 font-mono text-[12px] leading-relaxed text-soft-white custom-scrollbar">
-                {formatJson(selectedValue)}
+                {formatRtdbJson(selectedValue)}
               </pre>
             )}
           </section>
@@ -338,7 +286,7 @@ function RtdbBreadcrumb({
   path: string;
   onNavigate: (path: string) => void;
 }) {
-  const segments = pathSegments(path);
+  const segments = rtdbPathSegments(path);
   return (
     <div className="shrink-0 border-b border-[#2a2a35] px-4 py-3 font-mono text-[12px]">
       <button

--- a/packages/playground/src/lib/store/trace.ts
+++ b/packages/playground/src/lib/store/trace.ts
@@ -293,7 +293,7 @@ function summarize(): TraceSnapshotSummary {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isTraceObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
@@ -306,7 +306,7 @@ function coerceBoolean(value: unknown): boolean | undefined {
 }
 
 function coerceHostCtx(raw: unknown): HostCtx | null {
-  if (!isRecord(raw)) return null;
+  if (!isTraceObject(raw)) return null;
   const providerId = coerceString(raw.providerId);
   const providerLabel = coerceString(raw.providerLabel);
   const modelLabel = coerceString(raw.modelLabel);
@@ -342,9 +342,9 @@ function coerceHostCtx(raw: unknown): HostCtx | null {
 /** Hydrate a legacy v1 snapshot: coerce each full trace, then intern its
  *  requests so the in-memory form is deduped like live-captured traces. */
 function hydrateV1(tracesByTurn: unknown): void {
-  if (!isRecord(tracesByTurn)) return;
+  if (!isTraceObject(tracesByTurn)) return;
   for (const rawTrace of Object.values(tracesByTurn)) {
-    if (!isRecord(rawTrace)) continue;
+    if (!isTraceObject(rawTrace)) continue;
     const turnId = coerceString(rawTrace.turnId);
     const hostCtx = coerceHostCtx(rawTrace.hostCtx);
     if (!turnId || !hostCtx) continue;
@@ -354,7 +354,7 @@ function hydrateV1(tracesByTurn: unknown): void {
     payloadByTurn.set(turnId, {
       turnId,
       requests: rawRequests
-        .filter((r) => isRecord(r) && typeof r.systemPrompt === 'string' && Array.isArray(r.messages))
+        .filter((r) => isTraceObject(r) && typeof r.systemPrompt === 'string' && Array.isArray(r.messages))
         .map((r) => internRequest(r)),
       responses: Array.isArray(rawTrace.responses)
         ? (rawTrace.responses as LlmResponseTrace[])
@@ -368,7 +368,7 @@ function hydrateV1(tracesByTurn: unknown): void {
  *  instances by construction), re-register it in the intern tables, then
  *  rebuild requests from refs. Malformed turns/requests are skipped. */
 function hydrateV2(snapshot: PersistedTraceTelemetry): void {
-  if (!isRecord(snapshot.content) || !isRecord(snapshot.tracesByTurn)) return;
+  if (!isTraceObject(snapshot.content) || !isTraceObject(snapshot.tracesByTurn)) return;
   const valueByRef = new Map<number, unknown>();
   for (const [key, json] of Object.entries(snapshot.content)) {
     const id = Number(key);
@@ -391,13 +391,13 @@ function hydrateV2(snapshot: PersistedTraceTelemetry): void {
     }
   }
   for (const rawTrace of Object.values(snapshot.tracesByTurn)) {
-    if (!isRecord(rawTrace)) continue;
+    if (!isTraceObject(rawTrace)) continue;
     const turnId = coerceString(rawTrace.turnId);
     const hostCtx = coerceHostCtx(rawTrace.hostCtx);
     if (!turnId || !hostCtx) continue;
     const requests: LlmRequestTrace[] = [];
     for (const rawReq of Array.isArray(rawTrace.requests) ? rawTrace.requests : []) {
-      if (!isRecord(rawReq)) continue;
+      if (!isTraceObject(rawReq)) continue;
       const { systemPromptRef, toolsRef, messageRefs, ...rest } = rawReq as PersistedRequestV2;
       const systemPrompt = valueByRef.get(systemPromptRef);
       if (typeof systemPrompt !== 'string' || !Array.isArray(messageRefs)) {
@@ -512,7 +512,7 @@ export const useTraceStore = create<TraceState>()((set) => ({
   },
   hydrate: (snapshot) => {
     resetPayloadStore();
-    if (isRecord(snapshot)) {
+    if (isTraceObject(snapshot)) {
       if (snapshot.version === 2) hydrateV2(snapshot as PersistedTraceTelemetry);
       else if (snapshot.version === 1) hydrateV1(snapshot.tracesByTurn);
     }

--- a/packages/pyric-tools/src/cli/verify.ts
+++ b/packages/pyric-tools/src/cli/verify.ts
@@ -18,6 +18,7 @@ import {
 import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
 import type { FlagValue, ParsedArgs } from './parse-args.js';
 import { resolveScope } from './scope.js';
+import { parseRtdbRulesJson } from '../rtdb/rules-json.js';
 
 export type Fixture = PyricVerifyFixture;
 
@@ -361,10 +362,10 @@ function parseRtdbRulesFile(path: string): { rules: Record<string, unknown> } {
   } catch (e) {
     throw new Error(`failed to parse RTDB rules JSON at ${path}: ${messageOf(e)}`);
   }
-  if (!isRecord(parsed) || !isRecord(parsed.rules)) {
-    throw new Error(`RTDB rules file must contain a top-level "rules" object: ${path}`);
-  }
-  return parsed as { rules: Record<string, unknown> };
+  return parseRtdbRulesJson(
+    parsed,
+    () => new Error(`RTDB rules file must contain a top-level "rules" object: ${path}`),
+  );
 }
 
 function toVerifiableService(raw: string): VerifiableService {
@@ -412,8 +413,4 @@ function formatDivergence(divergence: VerifyDivergence): string {
 
 function messageOf(value: unknown): string {
   return value instanceof Error ? value.message : String(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/rtdb/rules-json.ts
+++ b/packages/pyric-tools/src/rtdb/rules-json.ts
@@ -1,0 +1,19 @@
+export interface RtdbRulesJson {
+  rules: Record<string, unknown>;
+}
+
+export function isRtdbRulesJson(value: unknown): value is RtdbRulesJson {
+  return isRtdbRulesObject(value) && isRtdbRulesObject(value.rules);
+}
+
+export function parseRtdbRulesJson(
+  value: unknown,
+  onInvalid: () => Error,
+): RtdbRulesJson {
+  if (!isRtdbRulesJson(value)) throw onInvalid();
+  return value;
+}
+
+function isRtdbRulesObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/pyric-tools/src/serve/rules.ts
+++ b/packages/pyric-tools/src/serve/rules.ts
@@ -15,6 +15,7 @@ import { readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { lintFirestoreRules, resolveModulesBrowser } from 'pyric/rules';
 import type { FirebaseJson } from '../cli/firebase-json.js';
+import { parseRtdbRulesJson } from '../rtdb/rules-json.js';
 
 export interface LoadedRules {
   /** Plain-v2 source ready for the sandbox, or null when the project has no
@@ -129,12 +130,13 @@ export async function loadProjectDatabaseRules(
   } catch (e) {
     throw new Error(`pyric serve: ${path} failed to parse as RTDB rules JSON: ${e instanceof Error ? e.message : String(e)}`);
   }
-  if (!isRecord(parsed) || !isRecord(parsed.rules)) {
-    throw new Error(`pyric serve: ${path} must contain a top-level "rules" object.`);
-  }
+  const rules = parseRtdbRulesJson(
+    parsed,
+    () => new Error(`pyric serve: ${path} must contain a top-level "rules" object.`),
+  );
 
   return {
-    rules: parsed as { rules: Record<string, unknown> },
+    rules,
     rulesHash: rulesHashOf(raw),
     sourcePath: path,
     databaseUrl: config?.database?.url ?? null,
@@ -171,8 +173,4 @@ export function watchProjectRules(
       );
     }, debounceMs);
   });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/verify/cases.ts
+++ b/packages/pyric-tools/src/verify/cases.ts
@@ -126,7 +126,7 @@ export function deriveRulesTestCases(
 }
 
 function isFirestoreRequestEvent(event: unknown): event is RequestEvent {
-  if (!isRecord(event) || event.kind !== 'request') return false;
+  if (!isCapturedRequestEvent(event) || event.kind !== 'request') return false;
   const service = event.service;
   return service === undefined || service === 'firestore';
 }
@@ -162,7 +162,7 @@ function buildTestCase(
   if (isWriteMethod(method)) {
     if (method !== 'delete') {
       const data = event.resourceAfter?.data ?? event.request?.resourceData;
-      if (isRecord(data)) testCase.data = data;
+      if (isFirestoreWriteData(data)) testCase.data = data;
     }
     testCase.writeMode = writeModeFor(method);
   }
@@ -199,13 +199,13 @@ function extractFunctionMocks(event: RequestEvent): FunctionMock[] | null {
 }
 
 function isFunctionMock(value: unknown): value is FunctionMock {
-  if (!isRecord(value)) return false;
+  if (!isFunctionMockCandidate(value)) return false;
   if (value.function !== 'get' && value.function !== 'exists') return false;
   return typeof value.path === 'string' && 'result' in value;
 }
 
 function isListQuery(value: unknown): value is NonNullable<TestCase['query']> {
-  if (!isRecord(value)) return false;
+  if (!isListQueryCandidate(value)) return false;
   if ('limit' in value && value.limit !== undefined && typeof value.limit !== 'number') return false;
   if ('offset' in value && value.offset !== undefined && typeof value.offset !== 'number') return false;
   if ('orderBy' in value && value.orderBy !== undefined && typeof value.orderBy !== 'string') return false;
@@ -216,6 +216,18 @@ function eventMayNeedFunctionMocks(event: RequestEvent): boolean {
   return event.reasons.some((reason) => /\b(get|exists)\s*\(/.test(reason));
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isCapturedRequestEvent(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFirestoreWriteData(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFunctionMockCandidate(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isListQueryCandidate(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/verify/fixture.ts
+++ b/packages/pyric-tools/src/verify/fixture.ts
@@ -1,4 +1,5 @@
 import type { EventService, Sandbox, SandboxEvent } from 'pyric/sandbox';
+import { isRtdbRulesJson } from '../rtdb/rules-json.js';
 
 export const VERIFY_FIXTURE_SCHEMA = 'pyric.verify.fixture.v1' as const;
 
@@ -111,7 +112,7 @@ export function buildVerifyFixture(input: BuildVerifyFixtureInput): PyricVerifyF
 }
 
 export function parseVerifyFixture(value: unknown): PyricVerifyFixture {
-  if (!isRecord(value)) {
+  if (!isVerifyFixtureObject(value)) {
     throw new Error('fixture must be a JSON object.');
   }
   if (value.schema !== VERIFY_FIXTURE_SCHEMA) {
@@ -120,7 +121,7 @@ export function parseVerifyFixture(value: unknown): PyricVerifyFixture {
   if (!Array.isArray(value.events)) {
     throw new Error('fixture.events must be an array.');
   }
-  if (!isRecord(value.services)) {
+  if (!isVerifyFixtureObject(value.services)) {
     throw new Error('fixture.services must be an object.');
   }
 
@@ -131,7 +132,7 @@ export function parseVerifyFixture(value: unknown): PyricVerifyFixture {
   if (services.rtdb !== undefined) {
     assertRtdbService(services.rtdb);
   }
-  if (services.auth !== undefined && !isRecord(services.auth)) {
+  if (services.auth !== undefined && !isVerifyFixtureObject(services.auth)) {
     throw new Error('fixture.services.auth must be an object.');
   }
 
@@ -148,26 +149,25 @@ export function fixtureVerifiableServices(
 }
 
 function assertFirestoreService(value: unknown): void {
-  if (!isRecord(value)) throw new Error('fixture.services.firestore must be an object.');
-  if (!isRecord(value.rules) || value.rules.format !== 'firestore.rules' || typeof value.rules.source !== 'string') {
+  if (!isVerifyFixtureObject(value)) throw new Error('fixture.services.firestore must be an object.');
+  if (!isVerifyFixtureObject(value.rules) || value.rules.format !== 'firestore.rules' || typeof value.rules.source !== 'string') {
     throw new Error('fixture.services.firestore.rules must contain firestore.rules source.');
   }
-  if (!isRecord(value.state) || !isRecord(value.state.documents)) {
+  if (!isVerifyFixtureObject(value.state) || !isVerifyFixtureObject(value.state.documents)) {
     throw new Error('fixture.services.firestore.state.documents must be an object.');
   }
 }
 
 function assertRtdbService(value: unknown): void {
-  if (!isRecord(value)) throw new Error('fixture.services.rtdb must be an object.');
+  if (!isVerifyFixtureObject(value)) throw new Error('fixture.services.rtdb must be an object.');
   if (
-    !isRecord(value.rules) ||
+    !isVerifyFixtureObject(value.rules) ||
     value.rules.format !== 'rtdb.rules.json' ||
-    !isRecord(value.rules.json) ||
-    !isRecord(value.rules.json.rules)
+    !isRtdbRulesJson(value.rules.json)
   ) {
     throw new Error('fixture.services.rtdb.rules must contain RTDB rules JSON.');
   }
-  if (!isRecord(value.state) || !('tree' in value.state)) {
+  if (!isVerifyFixtureObject(value.state) || !('tree' in value.state)) {
     throw new Error('fixture.services.rtdb.state.tree is required.');
   }
 }
@@ -179,6 +179,6 @@ function eventService(event: SandboxEvent): EventService {
   return 'firestore';
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isVerifyFixtureObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'pyric/rules';
 import type { RtdbRulesDocument } from 'pyric/rules/rtdb';
 import type { ProjectScope } from '../deploy/index.js';
+import { parseRtdbRulesJson, type RtdbRulesJson } from '../rtdb/rules-json.js';
 import {
   fixtureVerifiableServices,
   parseVerifyFixture,
@@ -440,10 +441,20 @@ function requireFirestoreRules(input: VerifyRulesInput): string {
   throw new VerifyInputError('missing candidate Firestore rules. Pass rules.firestore.');
 }
 
-function requireRtdbRules(input: VerifyRulesInput): { rules: Record<string, unknown> } {
+function requireRtdbRules(input: VerifyRulesInput): RtdbRulesJson {
   const rules = input.rtdb;
-  if (isRtdbRulesDocument(rules)) return rules.toJSON();
-  if (isRtdbRulesJson(rules)) return rules;
+  if (isRtdbRulesDocument(rules)) {
+    return parseRtdbRulesJson(
+      rules.toJSON(),
+      () => new VerifyInputError('candidate RTDB rules document must compile to { rules: object }.'),
+    );
+  }
+  if (rules !== undefined) {
+    return parseRtdbRulesJson(
+      rules,
+      () => new VerifyInputError('candidate RTDB rules must be { rules: object }.'),
+    );
+  }
   throw new VerifyInputError('missing candidate RTDB rules. Pass rules.rtdb.');
 }
 
@@ -453,15 +464,6 @@ function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
     value !== null &&
     'toJSON' in value &&
     typeof (value as { toJSON?: unknown }).toJSON === 'function'
-  );
-}
-
-function isRtdbRulesJson(value: unknown): value is { rules: Record<string, unknown> } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'rules' in value &&
-    isRecord((value as { rules?: unknown }).rules)
   );
 }
 
@@ -517,8 +519,4 @@ function mapRtdbReplayDivergence(divergence: RtdbReplayDivergence): VerifyDiverg
 
 function isInformational(divergence: VerifyDivergence): boolean {
   return divergence.kind === 'expected-drift';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/pyric-tools/test/rtdb/rules-json.test.ts
+++ b/packages/pyric-tools/test/rtdb/rules-json.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isRtdbRulesJson,
+  parseRtdbRulesJson,
+} from '../../src/rtdb/rules-json.js';
+
+describe('RTDB rules JSON parser', () => {
+  test('accepts a top-level rules object', () => {
+    const rules = { rules: { '.read': true } };
+    expect(isRtdbRulesJson(rules)).toBe(true);
+    expect(parseRtdbRulesJson(rules, () => new Error('invalid'))).toBe(rules);
+  });
+
+  test('rejects absent, null, or array rules blocks', () => {
+    expect(isRtdbRulesJson(null)).toBe(false);
+    expect(isRtdbRulesJson({})).toBe(false);
+    expect(isRtdbRulesJson({ rules: null })).toBe(false);
+    expect(isRtdbRulesJson({ rules: [] })).toBe(false);
+    expect(() =>
+      parseRtdbRulesJson({ rules: [] }, () => new Error('caller-specific message')),
+    ).toThrow('caller-specific message');
+  });
+});

--- a/packages/pyric/src/database/replay.ts
+++ b/packages/pyric/src/database/replay.ts
@@ -14,6 +14,7 @@ import {
   update,
   sandbox as rtdbSandbox,
 } from './modular.js';
+import { isJsonObject, jsonValuesEqual } from './sandbox/data-tree.js';
 
 export interface RtdbReplayOptions {
   rules: { rules: Record<string, unknown> };
@@ -151,7 +152,7 @@ async function replayRtdbCommitWithDatabase(
       await remove(dbRef);
       break;
     case 'update':
-      if (!isRecord(commit.data)) {
+      if (!isJsonObject(commit.data)) {
         divergences.push({
           kind: 'unsupported',
           path,
@@ -189,8 +190,8 @@ function collectStateDrift(
   path: string,
   out: RtdbReplayDivergence[],
 ): void {
-  if (deepEqual(expected, actual)) return;
-  if (!isRecord(expected) || !isRecord(actual)) {
+  if (jsonValuesEqual(expected, actual)) return;
+  if (!isJsonObject(expected) || !isJsonObject(actual)) {
     out.push({
       kind: 'state-drift',
       path,
@@ -209,22 +210,4 @@ function collectStateDrift(
       out,
     );
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) return true;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b)) return false;
-    if (a.length !== b.length) return false;
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (!isRecord(a) || !isRecord(b)) return false;
-  const aKeys = Object.keys(a).sort();
-  const bKeys = Object.keys(b).sort();
-  if (aKeys.length !== bKeys.length) return false;
-  return aKeys.every((key, index) => key === bKeys[index] && deepEqual(a[key], b[key]));
 }

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -29,6 +29,7 @@ import {
 import {
   DataTree,
   cloneJson,
+  jsonValuesEqual,
   joinPath,
   pathSegments,
   type JsonValue,
@@ -939,7 +940,7 @@ export class RtdbBackend {
       // unchanged must NOT re-fire — RTDB's SyncTree dedups no-change.
       const snap = this.makeSnap(listener.path);
       const last = listener.lastValue;
-      if (last !== undefined && deepEqualJson(last, snap.val)) {
+      if (last !== undefined && jsonValuesEqual(last, snap.val)) {
         this.emitListener('suppressed', listener, listener.auth, {
           event: 'value',
           reason: 'no-op',
@@ -1355,7 +1356,7 @@ export class RtdbBackend {
    * For each listener, compute the diff between prior and current
    * children, then dispatch:
    *   - `child_added` when a key appears that wasn't in prior.
-   *   - `child_changed` when a key's value transitions (deep-not-equal).
+   *   - `child_changed` when a key's value transitions.
    *   - `child_removed` when a prior key is gone.
    */
   private fanOutChildren(priorByParent: Map<string, Map<string, JsonValue>>): void {
@@ -1382,7 +1383,7 @@ export class RtdbBackend {
       for (const [k, v] of next) {
         if (!prior.has(k)) {
           added.push({ key: k, val: v });
-        } else if (!deepEqualJson(prior.get(k)!, v)) {
+        } else if (!jsonValuesEqual(prior.get(k)!, v)) {
           changed.push({ key: k, val: v });
         }
       }
@@ -1444,37 +1445,6 @@ function canonicalPath(path: string): string {
 }
 
 /**
- * Structural JSON equality. Used by the child-event diff to tell
- * `child_changed` from "same value". RTDB's diff is value-based — a
- * write that lands the same JSON shape is a no-op for child events.
- */
-function deepEqualJson(a: JsonValue, b: JsonValue): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-  if (Array.isArray(a)) {
-    const bb = b as JsonValue[];
-    if (a.length !== bb.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqualJson(a[i]!, bb[i]!)) return false;
-    }
-    return true;
-  }
-  const ao = a as Record<string, JsonValue>;
-  const bo = b as Record<string, JsonValue>;
-  const ak = Object.keys(ao);
-  const bk = Object.keys(bo);
-  if (ak.length !== bk.length) return false;
-  for (const k of ak) {
-    if (!(k in bo)) return false;
-    if (!deepEqualJson(ao[k]!, bo[k]!)) return false;
-  }
-  return true;
-}
-
-/**
  * Transaction-specific denial constructor. Pinned by oracle observation
  * `rtdb-modular-runtransaction-on-rules-denied-path.json`:
  *
@@ -1516,18 +1486,18 @@ function rowsToVal(rows: QueryRow[]): JsonValue {
   return out;
 }
 
-/** Deep-equal compare for two windowed result lists. Used to decide
- *  whether a query listener should re-fire. Uses structural
- *  `deepEqualJson` (key-order-INsensitive) rather than `JSON.stringify`
- *  so a re-write that only reorders object keys is correctly treated as
- *  "no change" (DB-B11: RTDB treats objects as order-equal). */
+/** Compare two windowed result lists. Used to decide whether a query
+ *  listener should re-fire. Uses RTDB JSON value equality rather than
+ *  `JSON.stringify` so a re-write that only reorders object keys is
+ *  correctly treated as "no change" (DB-B11: RTDB treats objects as
+ *  order-equal). */
 function windowsEqual(a: QueryRow[], b: QueryRow[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     const ai = a[i]!;
     const bi = b[i]!;
     if (ai.key !== bi.key) return false;
-    if (!deepEqualJson(ai.value, bi.value)) return false;
+    if (!jsonValuesEqual(ai.value, bi.value)) return false;
   }
   return true;
 }

--- a/packages/pyric/src/database/sandbox/data-tree.ts
+++ b/packages/pyric/src/database/sandbox/data-tree.ts
@@ -95,6 +95,33 @@ export function cloneJson<T extends JsonValue>(v: T): T {
   return out as T;
 }
 
+/** True for RTDB JSON object nodes. Arrays are ordered values in RTDB,
+ *  not object patches or path maps. */
+export function isJsonObject(value: unknown): value is Record<string, JsonValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Structural RTDB JSON equality.
+ *
+ * Object key order is ignored, array order is preserved, and primitive
+ * leaves compare by value. This is the equality RTDB listener diffs and
+ * fixture replay use when deciding whether two JSON states are the same.
+ */
+export function jsonValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => jsonValuesEqual(value, b[index]));
+  }
+  if (!isJsonObject(a) || !isJsonObject(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && jsonValuesEqual(a[key], b[key]));
+}
+
 /**
  * In-memory JSON tree. One instance per sandbox.
  *

--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -13,7 +13,9 @@
  */
 import type { Expression, FunctionDef } from '../grammar/FirestoreAST.js';
 import { assembleExpression } from '../grammar/FirestoreAssembler.js';
-import { MapDiff, FirestoreSet } from './mapdiff.js';
+import { MapDiff } from './mapdiff.js';
+import { FirestoreSet } from './firestore-set.js';
+import { rulesValuesEqual } from './value-equality.js';
 import { RulesValue, NO_OP } from './wrappers/base.js';
 import { LatLng } from './wrappers/latlng.js';
 import { Duration } from './wrappers/duration.js';
@@ -419,14 +421,14 @@ function evaluateExpr(expr: Expression, ctx: SimulationContext, scope: Record<st
       const element = evaluate(expr.element, ctx, scope);
       const collection = evaluate(expr.collection, ctx, scope);
       if (collection === null || collection === undefined) return false;
-      // Use deepEqualsForRules instead of Array.includes so wrapper
+      // Use Rules value equality instead of Array.includes so wrapper
       // value-equality applies (Item 0.B hook 6). Without this,
       // `someTimestamp in [t1, t2]` is always false because `===`
       // doesn't see the wrappers as equal even when their contents
       // match. Map-key membership stays as a String() check — keys
       // are always strings in Firestore rules.
       if (Array.isArray(collection)) {
-        return collection.some(v => deepEqualsForRules(v, element));
+        return collection.some(v => rulesValuesEqual(v, element));
       }
       // RULES-B7: map-key membership must use OWN keys only. `in` walks the JS
       // prototype chain, so `'toString' in resource.data` wrongly returned
@@ -616,7 +618,7 @@ function evaluateBinaryOp(
   // to the generic numeric switch below.
   //
   // == and != intentionally bypass this hook — they route through
-  // deepEqualsForRules above, which already calls the wrapper's
+  // rulesValuesEqual above, which already calls the wrapper's
   // `equals()`. Splitting "value equality" from "operator dispatch"
   // keeps each wrapper's contract clean.
   if (op !== '==' && op !== '!=') {
@@ -678,8 +680,8 @@ function evaluateBinaryOp(
   }
 
   switch (op) {
-    case '==': return lv === rv || deepEqualsForRules(lv, rv);
-    case '!=': return !(lv === rv || deepEqualsForRules(lv, rv));
+    case '==': return lv === rv || rulesValuesEqual(lv, rv);
+    case '!=': return !(lv === rv || rulesValuesEqual(lv, rv));
     case '<': return (lv as number) < (rv as number);
     case '>': return (lv as number) > (rv as number);
     case '<=': return (lv as number) <= (rv as number);
@@ -722,38 +724,6 @@ function evaluateBinaryOp(
       return (lv as number) % (rv as number);
     default: throw new EvalError(`Unknown binary op: ${op}`);
   }
-}
-
-/** Firestore == uses value equality for maps and lists */
-function deepEqualsForRules(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  // RulesValue wrappers (Timestamp, Duration, Bytes, LatLng, Path)
-  // own value-equality. The 0.B failure mode: two `timestamp.value(1234)`
-  // calls return distinct instances so `a === b` is false; without this
-  // hook the function falls into the generic object branch and compares
-  // private state field-by-field, accidentally working for some types
-  // and silently failing for others. Routing through `equals()` keeps
-  // every wrapper consistent.
-  if (a instanceof RulesValue) return a.equals(b);
-  if (b instanceof RulesValue) return b.equals(a);
-  // FirestoreSet is not a RulesValue; without this hook it falls into
-  // the generic-object branch where two sets ALWAYS compare equal
-  // (their private JS Set has no enumerable keys) — false-permissive.
-  if (a instanceof FirestoreSet || b instanceof FirestoreSet) {
-    return a instanceof FirestoreSet && a.equals(b);
-  }
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((v, i) => deepEqualsForRules(v, b[i]));
-  }
-  if (Array.isArray(a) || Array.isArray(b)) return false;
-  const ao = a as Record<string, unknown>, bo = b as Record<string, unknown>;
-  const ak = Object.keys(ao), bk = Object.keys(bo);
-  if (ak.length !== bk.length) return false;
-  return ak.every(k => k in bo && deepEqualsForRules(ao[k], bo[k]));
 }
 
 // ═══ Type-conversion builtins (RULES-B5 / RULES-B6) ═══
@@ -1059,14 +1029,14 @@ function evaluateMethodCall(
       case 'size': return obj.length;
       // RULES-B9: list membership uses VALUE equality, not JS identity, so it
       // is consistent with `in` / `removeAll` (which already use
-      // deepEqualsForRules). Without this, `[t1].hasAll([t2])` for equal-valued
+      // rulesValuesEqual). Without this, `[t1].hasAll([t2])` for equal-valued
       // Timestamp/Bytes/Path wrappers wrongly returned false because the two
       // instances aren't `===`.
-      case 'hasAll': return (argValues[0] as unknown[]).every(v => obj.some(o => deepEqualsForRules(o, v)));
-      case 'hasAny': return (argValues[0] as unknown[]).some(v => obj.some(o => deepEqualsForRules(o, v)));
+      case 'hasAll': return (argValues[0] as unknown[]).every(v => obj.some(o => rulesValuesEqual(o, v)));
+      case 'hasAny': return (argValues[0] as unknown[]).some(v => obj.some(o => rulesValuesEqual(o, v)));
       case 'hasOnly': {
         const allowed = argValues[0] as unknown[];
-        return obj.every(v => allowed.some(o => deepEqualsForRules(o, v)));
+        return obj.every(v => allowed.some(o => rulesValuesEqual(o, v)));
       }
       case 'join': return obj.join(String(argValues[0] ?? ','));
       // ─── Item 5.2: List.concat / removeAll / toSet ─────────────────────
@@ -1079,7 +1049,7 @@ function evaluateMethodCall(
       }
       case 'removeAll': {
         // Returns a new list with all items from `other` removed (by value
-        // equality). Uses deepEqualsForRules so wrapper instances (Timestamp,
+        // equality). Uses rulesValuesEqual so wrapper instances (Timestamp,
         // Duration, etc.) compare by value, not by JS identity — without
         // this, `[t1].removeAll([t2])` where t1 and t2 are equal Timestamp
         // wrappers would not remove t1.
@@ -1087,7 +1057,7 @@ function evaluateMethodCall(
         if (!Array.isArray(other)) {
           throw new EvalError(`List.removeAll requires a list argument, got ${typeof other}`);
         }
-        return obj.filter(v => !other.some(o => deepEqualsForRules(v, o)));
+        return obj.filter(v => !other.some(o => rulesValuesEqual(v, o)));
       }
       case 'toSet': {
         // Convert to FirestoreSet. The class stores strings only — coerce

--- a/packages/pyric/src/rules/simulator/firestore-set.ts
+++ b/packages/pyric/src/rules/simulator/firestore-set.ts
@@ -1,0 +1,90 @@
+export class FirestoreSet {
+  private items: Set<string>;
+
+  constructor(items: Iterable<string>) {
+    this.items = new Set(items);
+  }
+
+  /** True if the set contains ONLY keys from the provided list/set (and no others). */
+  hasOnly(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const item of this.items) {
+      if (!arr.includes(item)) return false;
+    }
+    return true;
+  }
+
+  /** Value equality against another FirestoreSet (order-insensitive).
+   *  Production supports `set == set` (e.g. `diff.addedKeys() ==
+   *  [uid].toSet()`). */
+  equals(other: unknown): boolean {
+    if (!(other instanceof FirestoreSet)) return false;
+    if (other.items.size !== this.items.size) return false;
+    for (const item of this.items) {
+      if (!other.items.has(item)) return false;
+    }
+    return true;
+  }
+
+  /** True if the set contains ALL keys from the provided list/set. */
+  hasAll(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const key of arr) {
+      if (!this.items.has(key)) return false;
+    }
+    return true;
+  }
+
+  /** True if the set contains ANY key from the provided list/set. */
+  hasAny(keys: string[] | FirestoreSet): boolean {
+    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
+    for (const key of arr) {
+      if (this.items.has(key)) return true;
+    }
+    return false;
+  }
+
+  /** Number of items in the set. */
+  size(): number {
+    return this.items.size;
+  }
+
+  /** Convert to array (for debugging). */
+  toArray(): string[] {
+    return [...this.items];
+  }
+
+  // Per REBUILD_PLAN type table for Set:
+  //   difference(other: Set) -> Set
+  //   union(other: Set) -> Set
+  //   intersection(other: Set) -> Set
+  // Mirroring hasOnly/hasAll/hasAny, we accept a List (string[]) too.
+
+  /** Items in this set but not in `other`. */
+  difference(other: string[] | FirestoreSet): FirestoreSet {
+    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
+    const result: string[] = [];
+    for (const item of this.items) {
+      if (!otherSet.has(item)) result.push(item);
+    }
+    return new FirestoreSet(result);
+  }
+
+  /** Items in either set. */
+  union(other: string[] | FirestoreSet): FirestoreSet {
+    const otherArr = other instanceof FirestoreSet ? other.toArray() : other;
+    const merged = new Set<string>(this.items);
+    for (const item of otherArr) merged.add(item);
+    return new FirestoreSet(merged);
+  }
+
+  /** Items in both sets. */
+  intersection(other: string[] | FirestoreSet): FirestoreSet {
+    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
+    const result: string[] = [];
+    for (const item of this.items) {
+      if (otherSet.has(item)) result.push(item);
+    }
+    return new FirestoreSet(result);
+  }
+}

--- a/packages/pyric/src/rules/simulator/handler.ts
+++ b/packages/pyric/src/rules/simulator/handler.ts
@@ -309,7 +309,7 @@ function isServerTimestampSentinel(value: unknown): boolean {
  * Recursively replace serverTimestamp sentinels with the actual server time.
  * Item 1.3: `serverTime` is now a Timestamp wrapper (was ISO string). The
  * SAME instance is reused across every sentinel hit so `data.createdAt ==
- * request.time` succeeds via deepEqualsForRules → Timestamp.equals (field
+ * request.time` succeeds via rulesValuesEqual -> Timestamp.equals (field
  * compare). Without instance reuse, two distinct Timestamp instances would
  * still equate via field compare — but the single-instance invariant is
  * documented here so future refactors don't break it accidentally.

--- a/packages/pyric/src/rules/simulator/mapdiff.ts
+++ b/packages/pyric/src/rules/simulator/mapdiff.ts
@@ -6,104 +6,14 @@
  *
  * Semantics derived from production Firestore behavior:
  * - Only compares top-level keys (nested map diff is unreliable in production)
- * - Values are compared with deep equality
+ * - Values are compared with Firestore Rules value equality
  * - Returns Set-like objects with hasOnly(), hasAll(), hasAny(), size()
  */
 
-export class FirestoreSet {
-  private items: Set<string>;
+import { FirestoreSet } from './firestore-set.js';
+import { rulesValuesEqual } from './value-equality.js';
 
-  constructor(items: Iterable<string>) {
-    this.items = new Set(items);
-  }
-
-  /** True if the set contains ONLY keys from the provided list/set (and no others). */
-  hasOnly(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const item of this.items) {
-      if (!arr.includes(item)) return false;
-    }
-    return true;
-  }
-
-  /** Value equality against another FirestoreSet (order-insensitive).
-   *  Production supports `set == set` (e.g. `diff.addedKeys() ==
-   *  [uid].toSet()`); without this the evaluator's deep-equals fell
-   *  into the generic-object branch, whose Object.keys() view of the
-   *  private JS Set is always [] — so ANY two sets compared EQUAL, a
-   *  false-PERMISSIVE divergence found by joining validation. */
-  equals(other: unknown): boolean {
-    if (!(other instanceof FirestoreSet)) return false;
-    if (other.items.size !== this.items.size) return false;
-    for (const item of this.items) {
-      if (!other.items.has(item)) return false;
-    }
-    return true;
-  }
-
-  /** True if the set contains ALL keys from the provided list/set. */
-  hasAll(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const key of arr) {
-      if (!this.items.has(key)) return false;
-    }
-    return true;
-  }
-
-  /** True if the set contains ANY key from the provided list/set. */
-  hasAny(keys: string[] | FirestoreSet): boolean {
-    const arr = keys instanceof FirestoreSet ? keys.toArray() : keys;
-    for (const key of arr) {
-      if (this.items.has(key)) return true;
-    }
-    return false;
-  }
-
-  /** Number of items in the set. */
-  size(): number {
-    return this.items.size;
-  }
-
-  /** Convert to array (for debugging). */
-  toArray(): string[] {
-    return [...this.items];
-  }
-
-  // ─── Set algebra (Item 5.1) ───────────────────────────────────────────
-  // Per REBUILD_PLAN type table for Set:
-  //   difference(other: Set) → Set
-  //   union(other: Set) → Set
-  //   intersection(other: Set) → Set
-  // Mirroring hasOnly/hasAll/hasAny, we accept a List (string[]) too.
-
-  /** Items in this set but not in `other`. */
-  difference(other: string[] | FirestoreSet): FirestoreSet {
-    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
-    const result: string[] = [];
-    for (const item of this.items) {
-      if (!otherSet.has(item)) result.push(item);
-    }
-    return new FirestoreSet(result);
-  }
-
-  /** Items in either set. */
-  union(other: string[] | FirestoreSet): FirestoreSet {
-    const otherArr = other instanceof FirestoreSet ? other.toArray() : other;
-    const merged = new Set<string>(this.items);
-    for (const item of otherArr) merged.add(item);
-    return new FirestoreSet(merged);
-  }
-
-  /** Items in both sets. */
-  intersection(other: string[] | FirestoreSet): FirestoreSet {
-    const otherSet = new Set(other instanceof FirestoreSet ? other.toArray() : other);
-    const result: string[] = [];
-    for (const item of this.items) {
-      if (otherSet.has(item)) result.push(item);
-    }
-    return new FirestoreSet(result);
-  }
-}
+export { FirestoreSet } from './firestore-set.js';
 
 export class MapDiff {
   private before: Record<string, unknown>;
@@ -136,7 +46,7 @@ export class MapDiff {
   changedKeys(): FirestoreSet {
     const changed: string[] = [];
     for (const key of Object.keys(this.after)) {
-      if (key in this.before && !deepEqual(this.before[key], this.after[key])) {
+      if (key in this.before && !rulesValuesEqual(this.before[key], this.after[key])) {
         changed.push(key);
       }
     }
@@ -148,7 +58,7 @@ export class MapDiff {
     const affected: string[] = [];
     const allKeys = new Set([...Object.keys(this.before), ...Object.keys(this.after)]);
     for (const key of allKeys) {
-      if (!(key in this.before) || !(key in this.after) || !deepEqual(this.before[key], this.after[key])) {
+      if (!(key in this.before) || !(key in this.after) || !rulesValuesEqual(this.before[key], this.after[key])) {
         affected.push(key);
       }
     }
@@ -159,32 +69,10 @@ export class MapDiff {
   unchangedKeys(): FirestoreSet {
     const unchanged: string[] = [];
     for (const key of Object.keys(this.before)) {
-      if (key in this.after && deepEqual(this.before[key], this.after[key])) {
+      if (key in this.after && rulesValuesEqual(this.before[key], this.after[key])) {
         unchanged.push(key);
       }
     }
     return new FirestoreSet(unchanged);
   }
-}
-
-/** Deep equality for Firestore field values. */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((val, i) => deepEqual(val, b[i]));
-  }
-
-  if (Array.isArray(a) || Array.isArray(b)) return false;
-
-  const aObj = a as Record<string, unknown>;
-  const bObj = b as Record<string, unknown>;
-  const aKeys = Object.keys(aObj);
-  const bKeys = Object.keys(bObj);
-  if (aKeys.length !== bKeys.length) return false;
-  return aKeys.every(key => key in bObj && deepEqual(aObj[key], bObj[key]));
 }

--- a/packages/pyric/src/rules/simulator/value-equality.ts
+++ b/packages/pyric/src/rules/simulator/value-equality.ts
@@ -1,0 +1,33 @@
+import { FirestoreSet } from './firestore-set.js';
+import { RulesValue } from './wrappers/base.js';
+
+/**
+ * Firestore Rules value equality.
+ *
+ * Rules wrappers and FirestoreSet own equality; lists and maps compare
+ * structurally, with map key order ignored.
+ */
+export function rulesValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof RulesValue) return a.equals(b);
+  if (b instanceof RulesValue) return b.equals(a);
+  if (a instanceof FirestoreSet || b instanceof FirestoreSet) {
+    return a instanceof FirestoreSet && a.equals(b);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => rulesValuesEqual(value, b[index]));
+  }
+  if (!isRulesMapValue(a) || !isRulesMapValue(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && rulesValuesEqual(a[key], b[key]));
+}
+
+function isRulesMapValue(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/pyric/src/rules/simulator/wrappers/base.ts
+++ b/packages/pyric/src/rules/simulator/wrappers/base.ts
@@ -3,7 +3,7 @@
  * REBUILD_PLAN.md Item 0.B + Item 1.
  *
  * Why an abstract base instead of duck typing: the evaluator dispatches
- * through six different code paths (deepEqualsForRules, memberAccess,
+ * through six different code paths (rulesValuesEqual, memberAccess,
  * bracketAccess, evaluateMethodCall, evaluateBinaryOp, isExpr, inExpr).
  * Without a single base class, every new wrapper would have to be
  * registered at six sites — and forgetting one is the exact failure mode
@@ -76,7 +76,7 @@ export abstract class RulesValue {
 
   /**
    * Value equality. THE single source of truth for `==` / `!=` /
-   * `deepEqualsForRules`. `===` reference equality is intentionally
+   * `rulesValuesEqual`. `===` reference equality is intentionally
    * insufficient (the 0.B failure: two `timestamp.value(1234)` calls
    * produce two distinct instances; `===` is false; rule denies).
    */
@@ -126,7 +126,7 @@ export abstract class RulesValue {
    *   Bytes < <= > >= Bytes → lexicographic byte compare
    *
    * `==` and `!=` do NOT route through this hook — they go through
-   * `deepEqualsForRules` which calls `equals()`. This split keeps the
+   * `rulesValuesEqual` which calls `equals()`. This split keeps the
    * "is this the same value?" question separate from "what does
    * `lhs OP rhs` evaluate to?".
    *

--- a/packages/pyric/src/rules/simulator/wrappers/latlng.ts
+++ b/packages/pyric/src/rules/simulator/wrappers/latlng.ts
@@ -112,5 +112,5 @@ export class LatLng extends RulesValue {
 
   // No binaryOp override — defaults to NO_OP, so arithmetic falls
   // through to the generic numeric switch which produces NaN. == / !=
-  // route through deepEqualsForRules → equals(). This is correct.
+  // route through rulesValuesEqual -> equals(). This is correct.
 }

--- a/packages/pyric/src/sandbox/branches/index.ts
+++ b/packages/pyric/src/sandbox/branches/index.ts
@@ -237,7 +237,7 @@ export function promote(branch: Branch, target: Sandbox): void {
       target.admin.deleteDocument(path);
       continue;
     }
-    if (before === undefined || !deepEqual(before, after)) {
+    if (before === undefined || !sandboxDocumentsEqual(before, after)) {
       // Branch added or changed this doc.
       target.admin.setDocument(path, after);
     }
@@ -343,13 +343,13 @@ function walkDoc(path: string, before: unknown, after: unknown, out: Divergence[
       return;
     }
 
-    if (deepEqual(a, b)) return;
+    if (sandboxDocumentsEqual(a, b)) return;
     out.push({ kind: 'real-divergence', path, field: fieldPath || undefined, before: a, after: b });
   }
 }
 
-/** Structural deep-equality on plain JSON-ish values. */
-function deepEqual(a: unknown, b: unknown): boolean {
+/** Structural equality on sandbox document snapshots. */
+function sandboxDocumentsEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a === null || b === null) return false;
   if (typeof a !== 'object' || typeof b !== 'object') return false;
@@ -359,7 +359,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (aArr && bArr) {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i], b[i])) return false;
+      if (!sandboxDocumentsEqual(a[i], b[i])) return false;
     }
     return true;
   }
@@ -370,7 +370,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (ak.length !== bk.length) return false;
   for (const k of ak) {
     if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
-    if (!deepEqual(ao[k], bo[k])) return false;
+    if (!sandboxDocumentsEqual(ao[k], bo[k])) return false;
   }
   return true;
 }

--- a/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
@@ -21,11 +21,8 @@
  *     number/string/boolean/bigint fields (the only types the corpus
  *     exercises today, per the design-doc inventory) and a deterministic
  *     fallback (`String(...)` comparison) for cross-type cases.
- *   - `deepEqual` keeps the bench's `JSON.stringify` shortcut for
- *     objects. Brittle on key order, but matches bench's behavior
- *     exactly so probe ports don't need to relax their assertions.
- *     Slice-5 tests will fail loudly if we ever need a real structural
- *     equality here.
+ *   - `firestoreValuesEqual` keeps query value matching aligned with
+ *     transform dedupe and Firestore value wrappers.
  *
  * Circular import note: `doc-ref.ts` imports `CollectionRefImpl` for
  * `.parent` / `.collection(name)`; this file imports `DocumentRefImpl`
@@ -44,6 +41,7 @@ import { DocumentRefImpl } from './doc-ref.js';
 // mis-ordered cross-type values + broke NaN. See `value-order.ts`.
 import { compareValues, typeOrderRank } from './value-order.js';
 import { topK } from '../topk.js';
+import { firestoreValuesEqual } from '../value-equality.js';
 // RULES-B11 — structured `where`/`limit`/`orderBy` view threaded into the
 // rule-enforced read paths so the query-proof gate ("rules are not
 // filters") can discharge per-doc rule predicates from the query's
@@ -157,16 +155,6 @@ function greaterOrEqual(a: unknown, b: unknown): boolean {
   return sameType(a, b) && compareValues(a, b) >= 0;
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a && b && typeof a === 'object') {
-    return JSON.stringify(a) === JSON.stringify(b);
-  }
-  return false;
-}
-
-
 // ─────────────────────────────────────────────────────────────────────────
 // Where / order / limit application.
 // ─────────────────────────────────────────────────────────────────────────
@@ -182,30 +170,30 @@ function matchesWhere(
   // short-circuits every operator to false.
   const present = value !== undefined;
   switch (op) {
-    case '==': return present && deepEqual(value, target);
+    case '==': return present && firestoreValuesEqual(value, target);
     case '!=':
       // != requires the field to EXIST and be non-null, then differ.
       // (clones/.../core/filter.ts FieldFilter.matches NOT_EQUAL branch.)
-      return present && value !== null && !deepEqual(value, target);
+      return present && value !== null && !firestoreValuesEqual(value, target);
     case '<': return present && lessThan(value, target);
     case '<=': return present && lessOrEqual(value, target);
     case '>': return present && greaterThan(value, target);
     case '>=': return present && greaterOrEqual(value, target);
     case 'in':
-      return present && Array.isArray(target) && target.some((t) => deepEqual(value, t));
+      return present && Array.isArray(target) && target.some((t) => firestoreValuesEqual(value, t));
     case 'not-in':
       // not-in requires existence + non-null; a null in the operand list
       // makes the filter match nothing (clones/.../core/filter.ts
       // NotInFilter.matches). Field must also not equal any operand.
       if (!Array.isArray(target)) return false;
       if (target.some((t) => t === null)) return false;
-      return present && value !== null && !target.some((t) => deepEqual(value, t));
+      return present && value !== null && !target.some((t) => firestoreValuesEqual(value, t));
     case 'array-contains':
-      return Array.isArray(value) && value.some((v) => deepEqual(v, target));
+      return Array.isArray(value) && value.some((v) => firestoreValuesEqual(v, target));
     case 'array-contains-any':
       return Array.isArray(value)
         && Array.isArray(target)
-        && target.some((t) => value.some((v) => deepEqual(v, t)));
+        && target.some((t) => value.some((v) => firestoreValuesEqual(v, t)));
   }
 }
 

--- a/packages/pyric/src/sandbox/firestore/converters/fieldvalue.ts
+++ b/packages/pyric/src/sandbox/firestore/converters/fieldvalue.ts
@@ -42,6 +42,7 @@
  *   (`computeTransformOperationBaseValue`, `coercedFieldValuesArray`).
  */
 import { KEEP, DELETE_MARKER, type ValueConverter, type ResolveContext } from '../value-resolver.js';
+import { firestoreValuesEqual } from '../value-equality.js';
 
 // ═══ Sentinel shapes ═══
 
@@ -143,12 +144,7 @@ export const arrayUnionConverter: ValueConverter = {
     // throwing (upstream `coercedFieldValuesArray`).
     const base: unknown[] = Array.isArray(prior) ? prior.slice() : [];
     for (const v of value.values) {
-      // Firestore's union dedups by deep value equality. JSON-string
-      // comparison covers the common cases (primitives, plain objects,
-      // arrays of primitives). Wrappers like Timestamp/Path/DocRef are
-      // compared by reference here — refine in Item 5+ once those
-      // wrappers carry value-equals.
-      const exists = base.some((b) => deepEqual(b, v));
+      const exists = base.some((b) => firestoreValuesEqual(b, v));
       if (!exists) base.push(v);
     }
     return base;
@@ -163,7 +159,7 @@ export const arrayRemoveConverter: ValueConverter = {
     // FS-B11 — a non-array (or absent) prior coerces to `[]` (so the result
     // is `[]`), rather than throwing.
     if (!Array.isArray(prior)) return [];
-    return prior.filter((b) => !value.values.some((v) => deepEqual(b, v)));
+    return prior.filter((b) => !value.values.some((v) => firestoreValuesEqual(b, v)));
   },
 };
 
@@ -174,21 +170,3 @@ export const deleteFieldConverter: ValueConverter = {
     return DELETE_MARKER;
   },
 };
-
-// ═══ Helpers ═══
-
-/**
- * Best-effort deep-equality for arrayUnion/arrayRemove dedup.
- * Handles primitives, arrays, and plain objects via JSON; class
- * instances (Date, Timestamp, etc.) fall back to reference equality.
- */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== 'object' || typeof b !== 'object') return false;
-  try {
-    return JSON.stringify(a) === JSON.stringify(b);
-  } catch {
-    return false;
-  }
-}

--- a/packages/pyric/src/sandbox/firestore/value-equality.ts
+++ b/packages/pyric/src/sandbox/firestore/value-equality.ts
@@ -1,0 +1,34 @@
+interface FirestoreValueComparable {
+  isEqual(other: unknown): boolean;
+}
+
+function hasFirestoreValueEquality(value: unknown): value is FirestoreValueComparable {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'isEqual' in value &&
+    typeof (value as { isEqual?: unknown }).isEqual === 'function'
+  );
+}
+
+function isFirestoreMapValue(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function firestoreValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (hasFirestoreValueEquality(a)) return a.isEqual(b);
+  if (hasFirestoreValueEquality(b)) return b.isEqual(a);
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => firestoreValuesEqual(value, b[index]));
+  }
+  if (!isFirestoreMapValue(a) || !isFirestoreMapValue(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => key in b && firestoreValuesEqual(a[key], b[key]));
+}

--- a/packages/pyric/test/database/json-value.test.ts
+++ b/packages/pyric/test/database/json-value.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { isJsonObject, jsonValuesEqual } from '../../src/database/sandbox/data-tree.js';
+
+describe('RTDB JSON value primitives', () => {
+  it('compares object values without depending on key order', () => {
+    expect(jsonValuesEqual(
+      { room: { title: 'Launch', members: { alice: true, bob: true } } },
+      { room: { members: { bob: true, alice: true }, title: 'Launch' } },
+    )).toBe(true);
+  });
+
+  it('keeps array order significant', () => {
+    expect(jsonValuesEqual(['alice', 'bob'], ['bob', 'alice'])).toBe(false);
+  });
+
+  it('recognizes RTDB JSON object nodes, not arrays or absent values', () => {
+    expect(isJsonObject({ patch: true })).toBe(true);
+    expect(isJsonObject(['patch'])).toBe(false);
+    expect(isJsonObject(null)).toBe(false);
+  });
+});

--- a/packages/pyric/test/rules/simulator/set-equality.test.ts
+++ b/packages/pyric/test/rules/simulator/set-equality.test.ts
@@ -3,8 +3,8 @@
  *
  * Production supports `set == set` (e.g.
  * `diff.addedKeys() == [request.auth.uid].toSet()`). Before the fix,
- * `FirestoreSet` was not a `RulesValue`, so `deepEqualsForRules` fell
- * into its generic-object branch — where the private JS `Set` exposes
+ * `FirestoreSet` did not have Rules-owned equality, so it fell into
+ * the plain object branch — where the private JS `Set` exposes
  * no enumerable keys, so ANY two sets compared EQUAL. That divergence
  * was false-PERMISSIVE (simulator ALLOWED what production DENIES):
  * caught by joining validation, whose 10 cases all pass in the production

--- a/packages/pyric/test/sandbox/firestore/admin-compat/compat.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/compat.test.ts
@@ -102,6 +102,26 @@ describe('admin-compat — Query', () => {
     expect(snap.docs[0]!.data().ownerId).toBe('alice');
   });
 
+  test('query.where(==) matches object values without depending on key order', async () => {
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES,
+      documents: {
+        'profiles/a': { prefs: { role: 'admin', active: true } },
+        'profiles/b': { prefs: { role: 'member', active: true } },
+      },
+    });
+    const db = createCompatFirestore(env, { auth: { uid: 'alice' } });
+
+    const snap = await db
+      .collection('profiles')
+      .where('prefs', '==', { active: true, role: 'admin' })
+      .get();
+
+    expect(snap.size).toBe(1);
+    expect(snap.docs[0]!.id).toBe('a');
+  });
+
   test('query.orderBy(desc).limit(1)', async () => {
     const { db } = freshDb();
     const snap = await db.collection('accounts').orderBy('balance', 'desc').limit(1).get();

--- a/packages/pyric/test/sandbox/firestore/simulator/converters/fieldvalue.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/converters/fieldvalue.test.ts
@@ -118,6 +118,14 @@ describe('arrayUnionConverter', () => {
     expect(out).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
+  test('dedups object values without depending on key order', () => {
+    const out = arrayUnionConverter.convert(
+      ARRAY_UNION({ active: true, role: 'admin' }),
+      baseCtx({ prior: { items: [{ role: 'admin', active: true }] }, fieldPath: 'items' }),
+    );
+    expect(out).toEqual([{ role: 'admin', active: true }]);
+  });
+
   test('treats absent prior as empty array', () => {
     const out = arrayUnionConverter.convert(
       ARRAY_UNION('x'),
@@ -148,6 +156,22 @@ describe('arrayRemoveConverter', () => {
       baseCtx({ prior: { tags: ['a', 'b', 'c'] }, fieldPath: 'tags' }),
     );
     expect(out).toEqual(['a', 'c']);
+  });
+
+  test('removes object values without depending on key order', () => {
+    const out = arrayRemoveConverter.convert(
+      ARRAY_REMOVE({ active: true, role: 'admin' }),
+      baseCtx({
+        prior: {
+          items: [
+            { role: 'admin', active: true },
+            { role: 'member', active: true },
+          ],
+        },
+        fieldPath: 'items',
+      }),
+    );
+    expect(out).toEqual([{ role: 'member', active: true }]);
   });
 
   test('returns empty array when prior is absent', () => {

--- a/packages/pyric/test/sandbox/firestore/simulator/mapdiff.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/mapdiff.test.ts
@@ -94,6 +94,14 @@ describe('MapDiff', () => {
       );
       expect(diff.changedKeys().size()).toBe(0);
     });
+
+    test('nested object unchanged regardless of key order', () => {
+      const diff = new MapDiff(
+        { a: { x: 1, y: 2 } },
+        { a: { y: 2, x: 1 } },
+      );
+      expect(diff.changedKeys().size()).toBe(0);
+    });
   });
 
   describe('affectedKeys', () => {
@@ -170,7 +178,7 @@ describe('MapDiff', () => {
     });
   });
 
-  describe('deep equality edge cases', () => {
+  describe('rules value equality edge cases', () => {
     test('null values', () => {
       const diff = new MapDiff({ a: null }, { a: null });
       expect(diff.changedKeys().size()).toBe(0);

--- a/packages/studio/src/features/rtdb/RtdbSurface.tsx
+++ b/packages/studio/src/features/rtdb/RtdbSurface.tsx
@@ -1,69 +1,17 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  formatRtdbJson,
+  joinRtdbPath,
+  parentRtdbPath,
+  parseRtdbJson,
+  previewRtdbValue,
+  rtdbChildEntries,
+  rtdbPathSegments,
+  rtdbValueAt,
+  rtdbValueKind,
+} from '@pyric/ui/rtdb';
 import { useEnvironment } from '../../shell/environment.js';
 import type { WorkerLivePlane } from '../../clients/worker-live.js';
-
-function normalizePath(path: string): string {
-  const segments = path.split('/').filter(Boolean);
-  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
-}
-
-function pathSegments(path: string): string[] {
-  return normalizePath(path).split('/').filter(Boolean);
-}
-
-function joinPath(base: string, child: string): string {
-  return normalizePath([...pathSegments(base), ...child.split('/').filter(Boolean)].join('/'));
-}
-
-function parentPath(path: string): string {
-  const segments = pathSegments(path);
-  if (segments.length <= 1) return '/';
-  return `/${segments.slice(0, -1).join('/')}`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function childEntries(value: unknown): Array<[string, unknown]> {
-  if (value === null || typeof value !== 'object') return [];
-  return Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
-}
-
-function valueAt(root: unknown, path: string): unknown {
-  let value = root ?? null;
-  for (const segment of pathSegments(path)) {
-    if (value === null || typeof value !== 'object') return null;
-    value = (value as Record<string, unknown>)[segment] ?? null;
-  }
-  return value;
-}
-
-function formatJson(value: unknown): string {
-  return JSON.stringify(value ?? null, null, 2);
-}
-
-function parseJson(value: string): unknown {
-  const text = value.trim();
-  return text.length === 0 ? null : JSON.parse(text);
-}
-
-function valueKind(value: unknown): string {
-  if (value === null || value === undefined) return 'null';
-  if (Array.isArray(value)) return 'array';
-  return typeof value;
-}
-
-function previewValue(value: unknown): string {
-  if (value === null || value === undefined) return 'null';
-  if (Array.isArray(value)) return `${value.length} items`;
-  if (isRecord(value)) {
-    const count = Object.keys(value).length;
-    return count === 1 ? '1 child' : `${count} children`;
-  }
-  if (typeof value === 'string') return JSON.stringify(value);
-  return String(value);
-}
 
 export function RtdbSurface() {
   const env = useEnvironment();
@@ -127,11 +75,11 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
     });
   }, [live, refresh]);
 
-  const selectedValue = useMemo(() => valueAt(snapshot, path), [path, snapshot]);
-  const children = useMemo(() => childEntries(selectedValue), [selectedValue]);
+  const selectedValue = useMemo(() => rtdbValueAt(snapshot, path), [path, snapshot]);
+  const children = useMemo(() => rtdbChildEntries(selectedValue), [selectedValue]);
 
   useEffect(() => {
-    if (!editing) setDraft(formatJson(selectedValue));
+    if (!editing) setDraft(formatRtdbJson(selectedValue));
   }, [editing, selectedValue]);
 
   const navigate = (nextPath: string) => {
@@ -143,7 +91,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
 
   const saveValue = async () => {
     try {
-      await live.setRtdbValue(path, parseJson(draft));
+      await live.setRtdbValue(path, parseRtdbJson(draft));
       setMessage(`Saved ${path}`);
       setError(null);
       setEditing(false);
@@ -159,7 +107,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
       await live.deleteRtdbValue(path);
       setMessage(`Deleted ${path}`);
       setError(null);
-      setPath(parentPath(path));
+      setPath(parentRtdbPath(path));
       setEditing(false);
       await refresh();
     } catch (e) {
@@ -172,8 +120,8 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
     const key = childKey.trim();
     if (!key) return;
     try {
-      const nextPath = joinPath(path, key);
-      await live.setRtdbValue(nextPath, parseJson(childDraft));
+      const nextPath = joinRtdbPath(path, key);
+      await live.setRtdbValue(nextPath, parseRtdbJson(childDraft));
       setMessage(`Added ${nextPath}`);
       setError(null);
       setChildKey('');
@@ -214,7 +162,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
               </p>
             </div>
             {path !== '/' ? (
-              <button type="button" className="studio-button" onClick={() => navigate(parentPath(path))}>
+              <button type="button" className="studio-button" onClick={() => navigate(parentRtdbPath(path))}>
                 Back
               </button>
             ) : null}
@@ -226,15 +174,15 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
                 <button
                   key={key}
                   type="button"
-                  onClick={() => navigate(joinPath(path, key))}
+                  onClick={() => navigate(joinRtdbPath(path, key))}
                   className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-line bg-transparent px-3 py-3 text-left last:border-b-0 hover:bg-elevated"
                 >
                   <span className="min-w-0">
                     <span className="block truncate font-mono text-sm text-ink">{key}</span>
-                    <span className="block truncate text-xs text-muted">{previewValue(value)}</span>
+                    <span className="block truncate text-xs text-muted">{previewRtdbValue(value)}</span>
                   </span>
                   <span className="rounded-full border border-line px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted">
-                    {valueKind(value)}
+                    {rtdbValueKind(value)}
                   </span>
                 </button>
               ))}
@@ -279,7 +227,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
               <h2 className="m-0 truncate font-mono text-sm text-ink">{path}</h2>
-              <p className="m-0 text-xs text-muted">{valueKind(selectedValue)}</p>
+              <p className="m-0 text-xs text-muted">{rtdbValueKind(selectedValue)}</p>
             </div>
             <div className="flex shrink-0 items-center gap-2">
               {editing ? (
@@ -289,7 +237,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
                     className="studio-button"
                     onClick={() => {
                       setEditing(false);
-                      setDraft(formatJson(selectedValue));
+                      setDraft(formatRtdbJson(selectedValue));
                     }}
                   >
                     Cancel
@@ -324,7 +272,7 @@ function LiveRtdbBrowser({ live }: { live: WorkerLivePlane }) {
             />
           ) : (
             <pre className="min-h-[320px] overflow-auto rounded-md border border-line bg-bg p-3 font-mono text-sm leading-relaxed text-ink">
-              {formatJson(selectedValue)}
+              {formatRtdbJson(selectedValue)}
             </pre>
           )}
         </section>
@@ -340,7 +288,7 @@ function RtdbBreadcrumb({
   path: string;
   onNavigate: (path: string) => void;
 }) {
-  const segments = pathSegments(path);
+  const segments = rtdbPathSegments(path);
   return (
     <div className="border-b border-line px-4 py-3 font-mono text-sm">
       <button type="button" onClick={() => onNavigate('/')} className="text-muted hover:text-ink">

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/firestore/hooks/index.d.ts",
       "import": "./dist/firestore/hooks/index.js"
     },
+    "./rtdb": {
+      "types": "./dist/rtdb/index.d.ts",
+      "import": "./dist/rtdb/index.js"
+    },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js"
@@ -68,7 +72,7 @@
   "scripts": {
     "build": "tsc",
     "test": "bun run test:no-dom && bun run test:dom",
-    "test:no-dom": "bun test test/auth/claims test/auth/controller test/auth/hooks test/firestore/hooks test/firestore/inference test/firestore/reducers test/storage/hooks test/traffic/hooks test/rules/hooks test/rules/logic test/events/hooks",
+    "test:no-dom": "bun test test/auth/claims test/auth/controller test/auth/hooks test/firestore/hooks test/firestore/inference test/firestore/reducers test/storage/hooks test/traffic/hooks test/rules/hooks test/rules/logic test/events/hooks test/rtdb",
     "test:dom": "bun test test/auth/components test/firestore/components test/primitives test/storage/components test/traffic/components test/rules/components test/events/components test/agents",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit"
   },

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,6 +2,7 @@
 //   @pyric/ui/primitives
 //   @pyric/ui/firestore
 //   @pyric/ui/firestore/hooks
+//   @pyric/ui/rtdb
 //
 // This forces deliberate dependency choices — a consumer that only
 // uses `useFirestoreDoc` doesn't pull in any primitive components,

--- a/packages/ui/src/rtdb/index.ts
+++ b/packages/ui/src/rtdb/index.ts
@@ -1,0 +1,62 @@
+export function normalizeRtdbPath(path: string): string {
+  const segments = path.split('/').filter(Boolean);
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+export function rtdbPathSegments(path: string): string[] {
+  return normalizeRtdbPath(path).split('/').filter(Boolean);
+}
+
+export function joinRtdbPath(base: string, child: string): string {
+  return normalizeRtdbPath([...rtdbPathSegments(base), ...child.split('/').filter(Boolean)].join('/'));
+}
+
+export function parentRtdbPath(path: string): string {
+  const segments = rtdbPathSegments(path);
+  if (segments.length <= 1) return '/';
+  return `/${segments.slice(0, -1).join('/')}`;
+}
+
+export function isRtdbObjectValue(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function rtdbChildEntries(value: unknown): Array<[string, unknown]> {
+  if (value === null || typeof value !== 'object') return [];
+  return Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function rtdbValueAt(root: unknown, path: string): unknown {
+  let value = root ?? null;
+  for (const segment of rtdbPathSegments(path)) {
+    if (value === null || typeof value !== 'object') return null;
+    value = (value as Record<string, unknown>)[segment] ?? null;
+  }
+  return value;
+}
+
+export function formatRtdbJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+export function parseRtdbJson(value: string): unknown {
+  const text = value.trim();
+  return text.length === 0 ? null : JSON.parse(text);
+}
+
+export function rtdbValueKind(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export function previewRtdbValue(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) return `${value.length} items`;
+  if (isRtdbObjectValue(value)) {
+    const count = Object.keys(value).length;
+    return count === 1 ? '1 child' : `${count} children`;
+  }
+  if (typeof value === 'string') return JSON.stringify(value);
+  return String(value);
+}

--- a/packages/ui/test/rtdb/browser-values.test.ts
+++ b/packages/ui/test/rtdb/browser-values.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  formatRtdbJson,
+  isRtdbObjectValue,
+  joinRtdbPath,
+  normalizeRtdbPath,
+  parentRtdbPath,
+  parseRtdbJson,
+  previewRtdbValue,
+  rtdbChildEntries,
+  rtdbPathSegments,
+  rtdbValueAt,
+  rtdbValueKind,
+} from '../../src/rtdb/index.js';
+
+describe('RTDB browser value helpers', () => {
+  test('normalizes and joins RTDB paths', () => {
+    expect(normalizeRtdbPath('///rooms/r1//messages/')).toBe('/rooms/r1/messages');
+    expect(rtdbPathSegments('/rooms/r1/messages')).toEqual(['rooms', 'r1', 'messages']);
+    expect(joinRtdbPath('/rooms/r1', '/messages/m1')).toBe('/rooms/r1/messages/m1');
+    expect(parentRtdbPath('/rooms/r1/messages')).toBe('/rooms/r1');
+    expect(parentRtdbPath('/rooms')).toBe('/');
+  });
+
+  test('reads values and sorted child entries from a tree', () => {
+    const tree = {
+      rooms: {
+        b: { title: 'Beta' },
+        a: { title: 'Alpha' },
+      },
+    };
+    expect(rtdbValueAt(tree, '/rooms/a/title')).toBe('Alpha');
+    expect(rtdbValueAt(tree, '/rooms/missing')).toBeNull();
+    expect(rtdbChildEntries(rtdbValueAt(tree, '/rooms')).map(([key]) => key)).toEqual(['a', 'b']);
+  });
+
+  test('formats, parses, and previews RTDB values', () => {
+    expect(parseRtdbJson('')).toBeNull();
+    expect(parseRtdbJson('{"ready":true}')).toEqual({ ready: true });
+    expect(formatRtdbJson(undefined)).toBe('null');
+    expect(rtdbValueKind(['a'])).toBe('array');
+    expect(previewRtdbValue({ child: true })).toBe('1 child');
+    expect(previewRtdbValue(['a', 'b'])).toBe('2 items');
+  });
+
+  test('recognizes RTDB object values without treating arrays as objects', () => {
+    expect(isRtdbObjectValue({})).toBe(true);
+    expect(isRtdbObjectValue([])).toBe(false);
+    expect(isRtdbObjectValue(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This stacked PR removes the remaining generic object-boundary helper tells from source code by replacing them with feature-owned parsing and value-boundary concepts.

## What changes

- Adds a single RTDB rules JSON parser in `pyric-tools` for the `{ rules: object }` boundary.
- Uses that RTDB parser from `pyric serve`, `pyric verify` CLI rule loading, and programmatic `verifyFixture()` RTDB candidate normalization while preserving caller-specific error messages.
- Keeps fixture validation inside `parseVerifyFixture()` but renames its object boundary to `isVerifyFixtureObject`.
- Keeps Rules Test API case derivation validation inside `deriveRulesTestCases()` with derivation-specific names for captured request events, write data, function mocks, and list queries.
- Extracts duplicated RTDB browser path/value helpers from Playground and Studio into `@pyric/ui/rtdb`, including `isRtdbObjectValue`.
- Renames trace hydration's persistence guard to `isTraceObject`.

## Why this matters

The important distinction is ownership. These checks are not reusable object trivia; they are boundaries where a feature accepts unknown data and turns it into a domain shape. RTDB rules JSON, verify fixtures, Rules Test API cases, RTDB browser values, and trace telemetry each now name their own boundary.

## Validation

- Source scan: no exact `isRecord`, `deepEqual`, or `deepEqualJson` occurrences remain in `packages/**/src`.
- `bun test test/rtdb/rules-json.test.ts test/verify/verify.test.ts test/cli/verify.test.ts test/serve/rules.test.ts` in `packages/pyric-tools`.
- `bun test test/rtdb/browser-values.test.ts` in `packages/ui`.
- `bun test src/lib/store/trace.test.ts` in `packages/playground`.
- `bun run typecheck` in `packages/studio`.
- `bun run build` at the repo root.

## Known local test limitation

`npm run test` reaches `pyric-tools` and fails in existing serve/bridge/loopback/watch tests because this local sandbox rejects HTTP server `listen(0)` and related process/watch flows. The non-socket tests relevant to this PR pass, and the full repo build passes.
