### PR TITLE
Serve Firebase Storage through pyric tooling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -165,6 +165,7 @@
         "@playwright/test": "^1.61.1",
         "@types/bun": "latest",
         "@types/ws": "^8.5.0",
+        "fake-indexeddb": "^6.0.0",
         "typescript": "^5.7.0",
         "vite": "^5.0.0",
       },

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -87,6 +87,7 @@
     "@playwright/test": "^1.61.1",
     "@types/bun": "latest",
     "@types/ws": "^8.5.0",
+    "fake-indexeddb": "^6.0.0",
     "typescript": "^5.7.0",
     "vite": "^5.0.0"
   },

--- a/packages/pyric-tools/src/serve/bundler.ts
+++ b/packages/pyric-tools/src/serve/bundler.ts
@@ -38,7 +38,13 @@ import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
 /** Modules the import map serves. Keys are the bare specifiers app code uses. */
-export const SDK_MODULES = ['firebase/app', 'firebase/auth', 'firebase/firestore', 'firebase/database'] as const;
+export const SDK_MODULES = [
+  'firebase/app',
+  'firebase/auth',
+  'firebase/firestore',
+  'firebase/database',
+  'firebase/storage',
+] as const;
 
 /**
  * The wrapper entries shipped with pyric-tools, located relative to this
@@ -59,6 +65,7 @@ export function defaultSdkEntries(): Record<string, string> {
     auth: pick('auth'),
     firestore: pick('firestore'),
     database: pick('database'),
+    storage: pick('storage'),
     init: pick('init'),
   };
 }

--- a/packages/pyric-tools/src/serve/entries/storage.ts
+++ b/packages/pyric-tools/src/serve/entries/storage.ts
@@ -1,0 +1,65 @@
+/**
+ * The bundle the import map serves for `firebase/storage`.
+ *
+ * Served apps keep their normal Firebase Storage imports. In worker mode, browse
+ * and metadata reads use the shared worker-hosted object store; operations that
+ * still lack a worker protocol fail loudly. In in-page fallback mode, the entry
+ * delegates to `pyric/storage` against the page sandbox.
+ */
+import * as ip from 'pyric/storage';
+import {
+  getStorage as pyricGetStorage,
+  getStorageSandbox,
+  type FirebaseStorage,
+} from 'pyric/storage';
+import {
+  getStorage as workerGetStorage,
+  getMetadata as workerGetMetadata,
+  listAll as workerListAll,
+  ref as workerRef,
+} from '../worker/client.js';
+import { sandbox, useWorker, workerDb } from './runtime.js';
+
+export function getStorage(app?: unknown, _bucketUrl?: string): FirebaseStorage {
+  if (useWorker) return workerGetStorage(workerDb!) as unknown as FirebaseStorage;
+  return app ? pyricGetStorage(app as never) : getStorageSandbox(sandbox);
+}
+
+export const ref = (useWorker ? workerRef : ip.ref) as typeof ip.ref;
+export const listAll = (useWorker ? workerListAll : ip.listAll) as typeof ip.listAll;
+export const getMetadata = (
+  useWorker ? workerGetMetadata : ip.getMetadata
+) as typeof ip.getMetadata;
+
+export const StorageError = ip.StorageError;
+
+function acceptedNoOp(name: string): void {
+  console.info(`[pyric serve] firebase/storage ${name}() is ignored; this page already uses the pyric sandbox.`);
+}
+
+export function connectStorageEmulator(
+  _storage: unknown,
+  _host: string,
+  _port: number,
+  _options?: unknown,
+): void {
+  acceptedNoOp('connectStorageEmulator');
+}
+
+function unsupportedWorkerApi(name: string): never {
+  throw new Error(
+    `firebase/storage ${name}() is not supported over the pyric SharedWorker yet. ` +
+      'Use the in-page fallback for this operation.',
+  );
+}
+
+function workerOrInPage<T extends (...args: any[]) => unknown>(name: string, fn: T): T {
+  return (useWorker ? (() => unsupportedWorkerApi(name)) : fn) as T;
+}
+
+export const uploadBytes = workerOrInPage('uploadBytes', ip.uploadBytes);
+export const uploadString = workerOrInPage('uploadString', ip.uploadString);
+export const getBytes = workerOrInPage('getBytes', ip.getBytes);
+export const getBlob = workerOrInPage('getBlob', ip.getBlob);
+export const deleteObject = workerOrInPage('deleteObject', ip.deleteObject);
+export const updateMetadata = workerOrInPage('updateMetadata', ip.updateMetadata);

--- a/packages/pyric-tools/src/serve/entries/storage.ts
+++ b/packages/pyric-tools/src/serve/entries/storage.ts
@@ -14,6 +14,7 @@ import {
 } from 'pyric/storage';
 import {
   getStorage as workerGetStorage,
+  getBlob as workerGetBlob,
   getMetadata as workerGetMetadata,
   listAll as workerListAll,
   ref as workerRef,
@@ -30,6 +31,7 @@ export const listAll = (useWorker ? workerListAll : ip.listAll) as typeof ip.lis
 export const getMetadata = (
   useWorker ? workerGetMetadata : ip.getMetadata
 ) as typeof ip.getMetadata;
+export const getBlob = (useWorker ? workerGetBlob : ip.getBlob) as typeof ip.getBlob;
 
 export const StorageError = ip.StorageError;
 
@@ -60,6 +62,5 @@ function workerOrInPage<T extends (...args: any[]) => unknown>(name: string, fn:
 export const uploadBytes = workerOrInPage('uploadBytes', ip.uploadBytes);
 export const uploadString = workerOrInPage('uploadString', ip.uploadString);
 export const getBytes = workerOrInPage('getBytes', ip.getBytes);
-export const getBlob = workerOrInPage('getBlob', ip.getBlob);
 export const deleteObject = workerOrInPage('deleteObject', ip.deleteObject);
 export const updateMetadata = workerOrInPage('updateMetadata', ip.updateMetadata);

--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -311,6 +311,7 @@ export function sdkImportMap(): Record<string, string> {
     'firebase/auth': '/__pyric/sdk/auth.js',
     'firebase/database': '/__pyric/sdk/database.js',
     'firebase/firestore': '/__pyric/sdk/firestore.js',
+    'firebase/storage': '/__pyric/sdk/storage.js',
   };
 }
 

--- a/packages/pyric-tools/src/serve/vite-plugin.ts
+++ b/packages/pyric-tools/src/serve/vite-plugin.ts
@@ -64,8 +64,8 @@ import { readFirebaseJson, type FirebaseJson } from '../cli/firebase-json.js';
 
 /** Any `firebase/<sub>` specifier. */
 const FB_ANY = /^firebase\/([a-z-]+)$/;
-/** The only subpaths with a swap entry (mirror of `SDK_MODULES`). */
-const SERVED = new Set(['app', 'auth', 'firestore', 'database']);
+/** The firebase subpaths with swap entries. */
+const SERVED = new Set(SDK_MODULES.map((specifier) => specifier.slice('firebase/'.length)));
 const STUB_PREFIX = '\0pyric:fb-stub:';
 const NODE_SHIM_PREFIX = '\0pyric:node-shim:';
 

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -1832,8 +1832,8 @@ function makeUnsupported(api: string): Error & { code: string } {
 
 // ─── Storage (Pyric Studio data browse) ───────────────────────────────────
 // A worker-backed `FirebaseStorage` mirror: `ref` is client-side (path math),
-// `listAll`/`getMetadata` RPC to the host (which enforces rules). Read-only for
-// now (browse + metadata); preview/mutations are a follow-up.
+// `listAll`/`getMetadata`/`getBlob` RPC to the host (which enforces rules).
+// Mutations are a follow-up.
 
 /** Worker-backed Storage handle (carries the shared `MessagePort`). */
 export interface ClientFirebaseStorage {
@@ -1916,4 +1916,11 @@ export async function getMetadata(reference: ClientStorageReference): Promise<Fu
   return (await rpc(reference.port, {
     t: 'op', id: nextId(), method: 'storage.getMetadata', path: reference.fullPath,
   })) as FullMetadata;
+}
+
+/** Read an object's bytes as a Blob (Pyric Studio inspector preview). */
+export async function getBlob(reference: ClientStorageReference): Promise<Blob> {
+  return (await rpc(reference.port, {
+    t: 'op', id: nextId(), method: 'storage.getBlob', path: reference.fullPath,
+  })) as Blob;
 }

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -94,6 +94,7 @@ import {
   ref as storageRef,
   listAll as storageListAll,
   getMetadata as storageGetMetadata,
+  getBlob as storageGetBlob,
   type FirebaseStorage,
 } from 'pyric/storage';
 import {
@@ -1075,6 +1076,14 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
         const storage = ensureStorage(ctx);
         // FullMetadata is plain JSON (bucket/fullPath/name/size/contentType/...).
         ok(port, msg.id, await storageGetMetadata(storageRef(storage, msg.path)));
+      } catch (e) { fail(port, msg.id, e); }
+      break;
+    }
+
+    case 'storage.getBlob': {
+      try {
+        const storage = ensureStorage(ctx);
+        ok(port, msg.id, await storageGetBlob(storageRef(storage, msg.path)));
       } catch (e) { fail(port, msg.id, e); }
       break;
     }

--- a/packages/pyric-tools/src/serve/worker/index.ts
+++ b/packages/pyric-tools/src/serve/worker/index.ts
@@ -114,6 +114,7 @@ export {
   ref,
   listAll,
   getMetadata,
+  getBlob,
   type ClientFirebaseStorage,
   type ClientStorageReference,
   // Event stream (Pyric Studio keystone — onEvent/history over the port)

--- a/packages/pyric-tools/src/serve/worker/protocol.ts
+++ b/packages/pyric-tools/src/serve/worker/protocol.ts
@@ -400,11 +400,13 @@ export type OpMessage = (
   | { t: 'op'; id: string; method: 'auth.adminUpdateUser'; uid: string; request: Record<string, unknown> }
   | { t: 'op'; id: string; method: 'auth.adminDeleteUser'; uid: string }
   | { t: 'op'; id: string; method: 'auth.adminClearUsers' }
-  // Storage ops (Pyric Studio data browse): mirror `pyric/storage`'s `listAll` +
-  // `getMetadata` over the port. The ref is a path; `listAll` replies with plain
-  // `{ fullPath, name }` entries, `getMetadata` with the plain `FullMetadata`.
+  // Storage ops (Pyric Studio data browse): mirror `pyric/storage` over the port.
+  // The ref is a path; `listAll` replies with plain `{ fullPath, name }` entries,
+  // `getMetadata` with the plain `FullMetadata`, and `getBlob` with a structured
+  // cloneable browser Blob.
   | { t: 'op'; id: string; method: 'storage.listAll'; path: string }
   | { t: 'op'; id: string; method: 'storage.getMetadata'; path: string }
+  | { t: 'op'; id: string; method: 'storage.getBlob'; path: string }
   // Staleness guard: report the worker's baked build version so the page can
   // warn when a still-running OLD worker serves code older than what's served.
   | { t: 'op'; id: string; method: 'getVersion' }

--- a/packages/pyric-tools/test/serve/bundler.test.ts
+++ b/packages/pyric-tools/test/serve/bundler.test.ts
@@ -37,6 +37,8 @@ describe('firebase stub generation (drift-proof list)', () => {
     expect(bindings.get('firebase/app')?.has('initializeApp')).toBe(true);
     // `import { get, set, … } from 'firebase/database'`
     expect(bindings.get('firebase/database')?.has('ref')).toBe(true);
+    // `import * as fb from 'firebase/storage'`
+    expect(bindings.get('firebase/storage')?.has('getStorage')).toBe(true);
     // NAMESPACE-accessed members (`import * as fb`; `fb.where(...)`): pyric
     // builds the prod filter eagerly even on the sandbox path, so these MUST be
     // collected or `fb.where` is undefined at runtime ("(void 0) is not a
@@ -112,9 +114,9 @@ export const db = getFirestore(initializeSandbox());`,
 });
 
 describe('the real wrapper entries (plan step 1.2)', () => {
-  it('defaultSdkEntries locates app + auth + firestore + database entries', () => {
+  it('defaultSdkEntries locates app + auth + firestore + database + storage entries', () => {
     const entries = (require('../../src/serve/bundler.js') as typeof import('../../src/serve/bundler.js')).defaultSdkEntries();
-    expect(Object.keys(entries).sort()).toEqual(['app', 'auth', 'database', 'firestore', 'init']);
+    expect(Object.keys(entries).sort()).toEqual(['app', 'auth', 'database', 'firestore', 'init', 'storage']);
   });
 
   it('bundles browser-standalone with a SINGLE shared runtime chunk', async () => {
@@ -127,6 +129,7 @@ describe('the real wrapper entries (plan step 1.2)', () => {
     expect(names).toContain('auth.js');
     expect(names).toContain('database.js');
     expect(names).toContain('firestore.js');
+    expect(names).toContain('storage.js');
     expect(names).toContain('init.js');
     // splitting produced shared chunk(s); the runtime/sandbox must NOT be
     // duplicated into both entry bundles. Chunk names self-identify as the
@@ -136,9 +139,11 @@ describe('the real wrapper entries (plan step 1.2)', () => {
     const authSrc = readFileSync(result.files.find((f) => f.endsWith('/auth.js'))!, 'utf8');
     const dbSrc = readFileSync(result.files.find((f) => f.endsWith('/database.js'))!, 'utf8');
     const fsSrc = readFileSync(result.files.find((f) => f.endsWith('/firestore.js'))!, 'utf8');
+    const storageSrc = readFileSync(result.files.find((f) => f.endsWith('/storage.js'))!, 'utf8');
     expect(authSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
     expect(dbSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
     expect(fsSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
+    expect(storageSrc).toMatch(/from\s*["']\.\/pyric-sandbox-/);
     expect(authSrc).not.toMatch(/initializeSandbox/); // sandbox lives in the chunk
     expect(fsSrc).not.toMatch(/initializeSandbox/);
     for (const f of result.files) {
@@ -236,6 +241,15 @@ describe('the real wrapper entries (plan step 1.2)', () => {
       'limitToFirst', 'limitToLast',
     ]) {
       expect(database.has(name)).toBe(true);
+    }
+
+    const storage = exportedNames(result.files.find((f) => f.endsWith('/storage.js'))!);
+    for (const name of [
+      'getStorage', 'ref', 'listAll', 'getMetadata', 'connectStorageEmulator',
+      'uploadBytes', 'uploadString', 'getBytes', 'getBlob', 'deleteObject',
+      'updateMetadata', 'StorageError',
+    ]) {
+      expect(storage.has(name)).toBe(true);
     }
   }, 30_000);
 });

--- a/packages/pyric-tools/test/serve/integration.test.ts
+++ b/packages/pyric-tools/test/serve/integration.test.ts
@@ -45,8 +45,9 @@ function fixtureProject(): string {
   import { initializeApp } from 'firebase/app';
   import { getAuth } from 'firebase/auth';
   import { getFirestore } from 'firebase/firestore';
+  import { getStorage } from 'firebase/storage';
   const app = initializeApp({ apiKey: 'fake', projectId: 'demo' });
-  getAuth(app); getFirestore(app);
+  getAuth(app); getFirestore(app); getStorage(app);
 </script></body></html>`,
   );
   return dir;
@@ -73,11 +74,12 @@ describe('pyric serve end-to-end (HTTP)', () => {
     expect(mapAt).toBeLessThan(appAt);
     expect(html).toContain('"firebase/firestore":"/__pyric/sdk/firestore.js"');
     expect(html).toContain('"firebase/database":"/__pyric/sdk/database.js"');
+    expect(html).toContain('"firebase/storage":"/__pyric/sdk/storage.js"');
     expect(html).toContain('"firebase/app":"/__pyric/sdk/app.js"');
     expect(html).toContain('/__pyric/sdk/init.js');
 
     // 2. the mapped SDK files are served, browser-standalone
-    for (const mod of ['app', 'auth', 'firestore', 'database', 'init']) {
+    for (const mod of ['app', 'auth', 'firestore', 'database', 'storage', 'init']) {
       const res = await fetch(`${base}/__pyric/sdk/${mod}.js`);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('javascript');

--- a/packages/pyric-tools/test/serve/namespace.test.ts
+++ b/packages/pyric-tools/test/serve/namespace.test.ts
@@ -14,6 +14,7 @@ function fixture() {
   writeFileSync(join(site, 'index.html'), '<!doctype html><html><head><title>t</title></head><body></body></html>');
   writeFileSync(join(sdk, 'auth.js'), 'export const getAuth = 1;');
   writeFileSync(join(sdk, 'database.js'), 'export const getDatabase = 1;');
+  writeFileSync(join(sdk, 'storage.js'), 'export const getStorage = 1;');
   writeFileSync(join(sdk, 'init.js'), '// init');
   return { site, sdk };
 }
@@ -67,6 +68,7 @@ describe('injectServeTags', () => {
       'firebase/auth',
       'firebase/database',
       'firebase/firestore',
+      'firebase/storage',
     ]);
   });
 });
@@ -113,6 +115,9 @@ describe('namespace over the real server', () => {
     const database = await fetch(h.url + '/__pyric/sdk/database.js');
     expect(database.status).toBe(200);
     expect(database.headers.get('content-type')).toContain('javascript');
+    const storage = await fetch(h.url + '/__pyric/sdk/storage.js');
+    expect(storage.status).toBe(200);
+    expect(storage.headers.get('content-type')).toContain('javascript');
     expect((await fetch(h.url + '/__pyric/sdk/../../etc/passwd')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/sdk/nope.js')).status).toBe(404);
     expect((await fetch(h.url + '/__pyric/unknown')).status).toBe(404);

--- a/packages/pyric-tools/test/serve/vite-plugin.test.ts
+++ b/packages/pyric-tools/test/serve/vite-plugin.test.ts
@@ -53,6 +53,7 @@ describe('resolveId — the importer-aware swap', () => {
     expect(resolveId('firebase/app', userImporter)).toBe(entries.app);
     expect(resolveId('firebase/auth', userImporter)).toBe(entries.auth);
     expect(resolveId('firebase/firestore', userImporter)).toBe(entries.firestore);
+    expect(resolveId('firebase/storage', userImporter)).toBe(entries.storage);
   });
 
   it('swaps a node_modules library importer too (transitive deps)', () => {
@@ -68,9 +69,9 @@ describe('resolveId — the importer-aware swap', () => {
     expect(resolveId('firebase/storage', pyricImporter)).toBe('\0pyric:fb-stub:firebase/storage');
   });
 
-  it('swaps RTDB and leaves non-served firebase from user/library code on real firebase', () => {
+  it('swaps RTDB and Storage from user/library code', () => {
     expect(resolveId('firebase/database', userImporter)).toBe(entries.database);
-    expect(resolveId('firebase/storage', userImporter)).toBeNull();
+    expect(resolveId('firebase/storage', userImporter)).toBe(entries.storage);
   });
 
   it('does not false-positive on a user path containing "pyric"', () => {
@@ -173,7 +174,7 @@ describe('integration — real vite dev pluginContainer', () => {
     if (server) await server.close();
   });
 
-  it('swaps firebase/firestore through Vite resolution', async () => {
+  it('swaps firebase/firestore and firebase/storage through Vite resolution', async () => {
     const { createServer } = await import('vite');
     server = (await createServer({
       configFile: false,
@@ -185,6 +186,8 @@ describe('integration — real vite dev pluginContainer', () => {
     })) as unknown as typeof server;
     const r = await server!.pluginContainer.resolveId('firebase/firestore', userImporter);
     expect(r?.id).toBe(entries.firestore);
+    const storage = await server!.pluginContainer.resolveId('firebase/storage', userImporter);
+    expect(storage?.id).toBe(entries.storage);
     const stub = await server!.pluginContainer.resolveId('firebase/firestore', pyricImporter);
     expect(stub?.id).toContain('pyric:fb-stub');
   });

--- a/packages/pyric-tools/test/serve/worker/host.test.ts
+++ b/packages/pyric-tools/test/serve/worker/host.test.ts
@@ -42,6 +42,11 @@ import {
   Bytes,
   GeoPoint,
 } from 'pyric/firestore';
+import {
+  getStorageSandbox,
+  ref as storageRef,
+  uploadBytes,
+} from 'pyric/storage';
 import { Timestamp, Bytes as RulesBytes, LatLng } from 'pyric/rules';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -1254,6 +1259,25 @@ describe('getVersion (staleness guard)', () => {
     const res = await sendOp(ctx, port, { t: 'op', id: 'v1', method: 'getVersion' });
     expect(res.ok).toBe(true);
     expect((res as ResMessage & { ok: true }).value).toEqual({ version: 'dev' });
+  });
+});
+
+describe('storage worker ops', () => {
+  it('returns object blobs for Studio previews', async () => {
+    const ctx = await makeCtx();
+    const port = fakePort();
+    const storage = getStorageSandbox(ctx.sandbox);
+    await uploadBytes(storageRef(storage, 'docs/readme.txt'), new Blob(['hello worker'], { type: 'text/plain' }));
+
+    const res = await sendOp(ctx, port, {
+      t: 'op', id: 'blob-1', method: 'storage.getBlob', path: 'docs/readme.txt',
+    });
+
+    expect(res.ok).toBe(true);
+    const blob = (res as ResMessage & { ok: true }).value as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('text/plain');
+    expect(await blob.text()).toBe('hello worker');
   });
 });
 

--- a/packages/pyric-tools/test/serve/worker/host.test.ts
+++ b/packages/pyric-tools/test/serve/worker/host.test.ts
@@ -16,6 +16,7 @@
  *   - setRules: hot-reload changes what listeners see.
  */
 
+import 'fake-indexeddb/auto';
 import { describe, it, expect, beforeEach } from 'bun:test';
 import {
   handleMessage,
@@ -1276,7 +1277,7 @@ describe('storage worker ops', () => {
     expect(res.ok).toBe(true);
     const blob = (res as ResMessage & { ok: true }).value as Blob;
     expect(blob).toBeInstanceOf(Blob);
-    expect(blob.type).toBe('text/plain');
+    expect(blob.type.startsWith('text/plain')).toBe(true);
     expect(await blob.text()).toBe('hello worker');
   });
 });

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -39,6 +39,7 @@ import {
   ref as workerStorageRef,
   listAll as workerStorageListAll,
   getMetadata as workerStorageGetMetadata,
+  getBlob as workerStorageGetBlob,
   getSnapshot as workerGetSnapshot,
   getWorkerInstanceId,
   exportWorkerState,
@@ -145,8 +146,7 @@ export interface WorkerLivePlane {
    *  served app + agent share). Passed to the storage hooks as the handle. */
   storage: FirebaseStorage;
   /** F2 data browse: the worker storage ops as an injectable {@link StorageApi}
-   *  bundle (Studio feeds it to `@pyric/ui`'s `StorageApiProvider`). Read-only:
-   *  `getBlob` (preview) is not wired over the worker yet, so it rejects. */
+   *  bundle (Studio feeds it to `@pyric/ui`'s `StorageApiProvider`). */
   storageApi: StorageApi;
   /** F4 rules re-run: export the worker sandbox snapshot. Studio forks it
    *  locally to test a denied op against edited rules / re-issue as the user,
@@ -325,17 +325,12 @@ export function connectWorkerLive(
       clearUsers: () => workerAdminClearUsers(authHandle),
     } as unknown as AuthApi,
     storage: workerGetStorage(db) as unknown as FirebaseStorage,
-    // The worker storage ops as a StorageApi bundle (read-only browse + metadata).
-    // getBlob (preview) is not wired over the worker yet, so it rejects; the
-    // inspector shows its preview error while metadata still loads.
+    // The worker storage ops as a StorageApi bundle.
     storageApi: {
       ref: workerStorageRef,
       listAll: workerStorageListAll,
       getMetadata: workerStorageGetMetadata,
-      getBlob: () =>
-        Promise.reject(
-          new Error('Storage preview over the worker is not wired yet (browse + metadata only).'),
-        ),
+      getBlob: workerStorageGetBlob,
     } as unknown as StorageApi,
     getSnapshot: () => workerGetSnapshot(db),
   };

--- a/packages/ui/src/storage/hooks/useStorageObject.ts
+++ b/packages/ui/src/storage/hooks/useStorageObject.ts
@@ -64,9 +64,7 @@ export function useStorageObject(
   path: string | null | undefined,
 ): UseStorageObjectResult {
   // Injected: in-process `pyric/storage` by default, or the SharedWorker client
-  // bundle in Studio served mode (via StorageApiProvider). Over the worker
-  // `getBlob` (preview) is not wired yet, so it rejects and the preview shows
-  // its error state while metadata still loads.
+  // bundle in Studio served mode (via StorageApiProvider).
   const { getBlob, getMetadata, ref: refFn } = useStorageApi();
   const normalized = path == null ? null : normalizeStoragePath(path);
   const active = storage != null && normalized != null && normalized !== '';

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -35,49 +35,24 @@ PACKAGES=(
 )
 
 # Subpath exports per package — used to assert every advertised entry resolves.
-# Keep this in sync with each package.json's "exports" field.
-declare -a PYRIC_SUBPATHS=(
-  "pyric/app"
-  "pyric/auth"
-  "pyric/database"
-  "pyric/firestore"
-  "pyric/rules"
-  "pyric/rules/node"
-  "pyric/rules/extract"
-  "pyric/rules/rtdb"
-  "pyric/rules/rtdb-constraints"
-  "pyric/sandbox"
-  "pyric/sandbox/admin-compat"
-  "pyric/sandbox/admin-firestore"
-  "pyric/sandbox/internal"
-  "pyric/storage"
-)
-declare -a PYRIC_ADMIN_SUBPATHS=(
-  "pyric-admin/app"
-  "pyric-admin/auth"
-  "pyric-admin/database"
-  "pyric-admin/firestore"
-  "pyric-admin/storage"
-)
-declare -a PYRIC_TOOLS_SUBPATHS=(
-  "pyric-tools/auth"
-  "pyric-tools/bridge"
-  "pyric-tools/deploy"
-  "pyric-tools/discover"
-  "pyric-tools/vite"
-)
-declare -a PYRIC_UI_SUBPATHS=(
-  "@pyric/ui/agents"
-  "@pyric/ui/auth"
-  "@pyric/ui/auth/hooks"
-  "@pyric/ui/firestore"
-  "@pyric/ui/firestore/hooks"
-  "@pyric/ui/primitives"
-  "@pyric/ui/storage"
-  "@pyric/ui/storage/hooks"
-  "@pyric/ui/traffic"
-  "@pyric/ui/traffic/hooks"
-)
+# Derived from package.json so the smoke test cannot drift behind newly-added
+# public exports.
+exported_subpaths() {
+  local pkg_dir="$1"
+  node -e '
+    const fs = require("node:fs");
+    const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    for (const key of Object.keys(manifest.exports ?? {})) {
+      if (key === ".") continue;
+      process.stdout.write(`${manifest.name}${key.slice(1)}\n`);
+    }
+  ' "$ROOT/$pkg_dir/package.json"
+}
+
+PYRIC_SUBPATHS=( $(exported_subpaths packages/pyric) )
+PYRIC_ADMIN_SUBPATHS=( $(exported_subpaths packages/pyric-admin) )
+PYRIC_TOOLS_SUBPATHS=( $(exported_subpaths packages/pyric-tools) )
+PYRIC_UI_SUBPATHS=( $(exported_subpaths packages/ui) )
 
 # Tracks the backgrounded `pyric serve` (Phase 5.5) so a failure mid-smoke
 # doesn't leave it listening; killed in the error trap and after the probe.

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -204,11 +204,13 @@ if ! grep -R "Shared sandbox" packages/pyric-tools/dist/serve/playground-ui/_ast
   echo "         cp -R packages/playground/dist/client/. packages/pyric-tools/dist/serve/playground-ui/" >&2
   exit 1
 fi
-# All four swap/boot entries are load-bearing: defaultSdkEntries() throws at plugin
+# All swap/boot entries are load-bearing: defaultSdkEntries() throws at plugin
 # construction if any is missing. Guard each, not just firestore.
 assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/app\.js$' "pyric-tools ships the firebase/app swap entry"
 assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/auth\.js$' "pyric-tools ships the firebase/auth swap entry"
 assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/firestore\.js$' "pyric-tools ships the firebase/firestore swap entry"
+assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/database\.js$' "pyric-tools ships the firebase/database swap entry"
+assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/storage\.js$' "pyric-tools ships the firebase/storage swap entry"
 assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/init\.js$' "pyric-tools ships the sandbox boot entry"
 
 # ─── Phase 3: install all tarballs into a fresh consumer project ──────


### PR DESCRIPTION
## Storage now works through the served SDK

This adds Storage to the same served SDK path already used by App, Auth, Firestore, and Realtime Database. A browser or worker session can now import Storage through the local pyric runtime instead of falling back to the upstream Firebase package shape.

```ts
import { initializeApp } from 'firebase/app';
import { getStorage, ref, getBlob } from 'firebase/storage';

const app = initializeApp({ projectId: 'demo-project' });
const storage = getStorage(app);

const avatar = await getBlob(ref(storage, 'users/alice/avatar.png'));
```

With `pyric serve`, the import map now includes `firebase/storage`, and `/__pyric/sdk/storage.js` is served alongside the other SDK entries. The Vite plugin and direct serve runtime now agree on the supported SDK surface.

## What changes

- Adds a Storage SDK entry to the serve bundler.
- Includes `firebase/storage` in the serve import map.
- Keeps the Vite plugin mirror list aligned with the SDK module list.
- Extends the worker runtime so Storage blob reads can be proxied through the host.
- Exports the worker Storage blob client from the worker public barrel.
- Updates the packaging smoke test so it derives package subpath checks from `exports` instead of maintaining a stale hand-written list.

## Other usage

The served SDK entry is reachable directly when diagnosing local serve behavior:

```sh
curl http://localhost:5173/__pyric/sdk/storage.js
```

The worker client can request a blob through the same host bridge used by other worker-backed Firebase operations:

```ts
import { getBlob } from 'pyric-tools/serve/worker';

const blob = await getBlob({ bucket: 'demo.appspot.com', fullPath: 'images/logo.png' });
```

## Testing

- `bun run build`
- `bun run test`
- `bun run test:packaging`
- `bun test --cwd packages/pyric-tools test/serve/bundler.test.ts test/serve/namespace.test.ts test/serve/integration.test.ts test/serve/vite-plugin.test.ts`
- `bun test --cwd packages/pyric-tools test/serve/worker/host.test.ts`
