### PR TITLE
Centralize RTDB rules input handling

### DIFF
--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -564,7 +564,7 @@ describe('runDeploy', () => {
     }
   });
 
-  it('--schema on a not-yet-wired target is a usage error naming the rollout', async () => {
+  it('deploy rules --schema prints the provider tool parameters without credentials or firebase.json', async () => {
     const io = bufferIo();
     const code = await runDeploy(parseArgs(['deploy', 'rules', '--schema']), {
       ...io,
@@ -572,8 +572,15 @@ describe('runDeploy', () => {
       readFirebaseJson: neverCalled('readFirebaseJson') as never,
       resolveScope: neverCalled('resolveScope') as never,
     });
-    expect(code).toBe(1);
-    expect(io.getErr()).toContain('hosting only');
+    expect(code).toBe(0);
+    const schema = JSON.parse(io.getOut()) as {
+      type: string;
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.type).toBe('object');
+    expect(schema.required).toEqual(['source']);
+    expect(Object.keys(schema.properties)).toContain('source');
   });
 
   it("deploy hosting --json '<payload>' feeds the handler DIRECTLY and skips firebase.json", async () => {
@@ -646,6 +653,27 @@ describe('runDeploy', () => {
     expect((JSON.parse(errLine) as { ok: boolean }).ok).toBe(false);
   });
 
+  it("deploy rules --json '<payload>' feeds the provider handler directly", async () => {
+    const io = bufferIo();
+    const tool = makeFakeTool(
+      'firestore_deploy_rules',
+      { ok: true, summary: 'rules ok' },
+      { type: 'object', properties: { source: { type: 'string' } }, required: ['source'] },
+    );
+    const payload = { source: 'rules_version = "2";' };
+    const code = await runDeploy(parseArgs(['deploy', 'rules', '--json', JSON.stringify(payload)]), {
+      ...io,
+      cwd: '/tmp/nope',
+      readFirebaseJson: neverCalled('readFirebaseJson') as never,
+      readFirebaseRc: async () => null,
+      resolveScope: async () => ({ scope: makeScope(), source: 'FIREBASE_SA_BASE64' }),
+      createFirestoreDeployTools: mock(() => [tool.handler]),
+    });
+    expect(code).toBe(0);
+    expect(tool.calls[0]?.args).toEqual(payload);
+    expect(JSON.parse(io.getOut())).toEqual({ ok: true, summary: 'rules ok' });
+  });
+
   it('--json payload with an unknown key warns (typo guard) but still executes', async () => {
     const io = bufferIo();
     const tool = makeFakeTool('hosting_deploy', { ok: true, summary: 'ok' });
@@ -696,16 +724,22 @@ describe('runDeploy', () => {
     expect(io.getErr()).toContain('using project');
   });
 
-  it('bare --json on a not-yet-wired target is a usage error', async () => {
+  it('bare --json on rules uses the resolved provider deploy flow', async () => {
     const io = bufferIo();
+    const tool = makeFakeTool('firestore_deploy_rules', { ok: true, summary: 'rules ok' });
     const code = await runDeploy(parseArgs(['deploy', 'rules', '--json']), {
       ...io,
-      cwd: '/tmp/nope',
-      readFirebaseJson: neverCalled('readFirebaseJson') as never,
-      resolveScope: neverCalled('resolveScope') as never,
+      cwd: '/tmp',
+      readFirebaseJson: async () => ({ firestore: { rules: 'firestore.rules' } }),
+      readFirebaseRc: async () => null,
+      readFile: (async () => 'rules_version = "2";') as never,
+      resolveScope: async () => ({ scope: makeScope(), source: 'FIREBASE_SA_BASE64' }),
+      createFirestoreDeployTools: mock(() => [tool.handler]),
     });
-    expect(code).toBe(1);
-    expect(io.getErr()).toContain('hosting only');
+    expect(code).toBe(0);
+    expect((tool.calls[0]?.args as { source: string }).source).toBe('rules_version = "2";');
+    expect(JSON.parse(io.getOut())).toEqual({ ok: true, summary: 'rules ok' });
+    expect(io.getErr()).toContain('using project');
   });
 });
 

--- a/packages/pyric-tools/src/cli/deploy.ts
+++ b/packages/pyric-tools/src/cli/deploy.ts
@@ -5,7 +5,8 @@
  * `PYRIC_PROJECT` / `.firebaserc`; resolves a service-account scope
  * from env.
  *
- * Supported targets: `rules`, `indexes`, `database`, `hosting`, `functions`.
+ * Supported targets come from the deploy provider registry (`rules`, `indexes`,
+ * `database`, `hosting`, `functions`, `storage`, ...).
  * `functions` requires `--source <dir>` and a JSON-formatted
  * `--config` (FunctionDeployConfig[]); this is the minimum to make
  * the CLI a real handle on the library — extras (multi-function
@@ -21,12 +22,12 @@
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import type { ToolHandler } from '@inbrowser/agent';
-import {
+import type {
   createFirestoreDeployTools,
   createRtdbDeployTools,
   createHostingDeployTools,
   createFunctionsDeployTools,
-  type ProjectScope,
+  ProjectScope,
 } from '../deploy/index.js';
 import type { ParsedArgs } from './parse-args.js';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from './firebase-json.js';
@@ -86,21 +87,6 @@ export interface DeployDeps {
 //   --json             (bare) machine output for a normal resolved deploy
 //                      (mirror of firebase-tools' global -j/--json,
 //                      clones/firebase-tools/src/index.ts:16)
-// Every deploy target wraps a ToolHandler, so adding one = one entry
-// here. Hosting is wired today; rules/indexes/database/functions are follow-ups.
-interface AgentIoEntry {
-  toolName: string;
-  tools(deps: DeployDeps, scope: ProjectScope): ToolHandler[];
-}
-
-const AGENT_IO: Record<string, AgentIoEntry | undefined> = {
-  hosting: {
-    toolName: 'hosting_deploy',
-    tools: (deps, scope) =>
-      (deps.createHostingDeployTools ?? createHostingDeployTools)({ scope }),
-  },
-};
-
 export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Promise<number> {
   const out = deps.stdout ?? process.stdout;
   const err = deps.stderr ?? process.stderr;
@@ -122,20 +108,12 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
     return 1;
   }
 
-  // ── Agent I/O (A6) ──
-  const agentIo = AGENT_IO[target];
   const flagJson = parsed.flags.get('json');
   const machineOutput = flagJson !== undefined;
   const jsonPayload = typeof flagJson === 'string' ? flagJson : undefined;
 
   if (parsed.flags.get('schema') !== undefined) {
-    return printToolSchema(target, agentIo, deps, out, err);
-  }
-  if (machineOutput && !agentIo) {
-    err.write(
-      `pyric deploy ${target}: --json is not wired for '${target}' yet (hosting only; rules/indexes/database/functions are follow-ups).\n`,
-    );
-    return 1;
+    return printToolSchema(provider, deps, out, err);
   }
 
   // A direct payload bypasses firebase.json entirely — the payload is
@@ -181,8 +159,8 @@ export async function runDeploy(parsed: ParsedArgs, deps: DeployDeps = {}): Prom
     return 1;
   }
 
-  if (jsonPayload !== undefined && agentIo) {
-    return executeJsonPayload(jsonPayload, agentIo, scope, deps, out, err);
+  if (jsonPayload !== undefined) {
+    return executeJsonPayload(jsonPayload, provider, scope, deps, out, err);
   }
 
   // Scope-upgrade preflight (logged-in users only; a service account is 'all').
@@ -250,6 +228,10 @@ function singleValueFlags(flags: ParsedArgs['flags']): ReadonlyMap<string, strin
 
 type Sink = { write(s: string): void };
 
+function defaultOperation(provider: DeployProvider) {
+  return provider.operations.find((o) => o.default) ?? provider.operations[0];
+}
+
 /**
  * Resolve a provider's tools, honoring the per-target test-injection overrides
  * the CLI suite uses (`deps.createXxxDeployTools`). Production passes none, so the
@@ -288,7 +270,7 @@ async function runProviderDeploy(
   machineOutput: boolean,
   isTTY: boolean,
 ): Promise<number> {
-  const op = provider.operations.find((o) => o.default) ?? provider.operations[0];
+  const op = defaultOperation(provider);
   if (!op) {
     err.write(`pyric deploy ${provider.target}: provider exposes no operations.\n`);
     return 2;
@@ -354,17 +336,15 @@ async function runProviderDeploy(
  * tries to execute.
  */
 function printToolSchema(
-  target: string,
-  agentIo: AgentIoEntry | undefined,
+  provider: DeployProvider,
   deps: DeployDeps,
   out: Sink,
   err: Sink,
 ): number {
-  if (!agentIo) {
-    err.write(
-      `pyric deploy ${target}: --schema is not wired for '${target}' yet (hosting only; rules/indexes/database/functions are follow-ups).\n`,
-    );
-    return 1;
+  const op = defaultOperation(provider);
+  if (!op) {
+    err.write(`pyric deploy ${provider.target}: provider exposes no operations.\n`);
+    return 2;
   }
   const stubScope: ProjectScope = {
     projectId: '(schema-introspection)',
@@ -372,9 +352,9 @@ function printToolSchema(
       throw new Error('schema introspection never mints tokens');
     },
   };
-  const handler = agentIo.tools(deps, stubScope).find((t) => t.name === agentIo.toolName);
+  const handler = resolveDeployTools(provider, stubScope, deps).find((t) => t.name === op.toolName);
   if (!handler) {
-    err.write(`pyric deploy ${target}: ${agentIo.toolName} tool not found.\n`);
+    err.write(`pyric deploy ${provider.target}: ${op.toolName} tool not found.\n`);
     return 2;
   }
   out.write(`${JSON.stringify(handler.parameters, null, 2)}\n`);
@@ -390,7 +370,7 @@ function printToolSchema(
  */
 async function executeJsonPayload(
   raw: string,
-  agentIo: AgentIoEntry,
+  provider: DeployProvider,
   scope: ProjectScope,
   deps: DeployDeps,
   out: Sink,
@@ -407,15 +387,20 @@ async function executeJsonPayload(
     writeJsonError(err, '--json payload must be a JSON object (the tool input)');
     return 1;
   }
-  const handler = agentIo.tools(deps, scope).find((t) => t.name === agentIo.toolName);
+  const op = defaultOperation(provider);
+  if (!op) {
+    writeJsonError(err, `pyric deploy ${provider.target}: provider exposes no operations`);
+    return 2;
+  }
+  const handler = resolveDeployTools(provider, scope, deps).find((t) => t.name === op.toolName);
   if (!handler) {
-    writeJsonError(err, `${agentIo.toolName} tool not found`);
+    writeJsonError(err, `${op.toolName} tool not found`);
     return 2;
   }
   const schema = handler.parameters as SchemaNode;
   const problems = validateAgainstSchema(payload, schema, 'input');
   if (problems.length > 0) {
-    writeJsonError(err, `--json payload does not match the ${agentIo.toolName} schema`, problems);
+    writeJsonError(err, `--json payload does not match the ${op.toolName} schema`, problems);
     return 1;
   }
   // Typo guard: JSON Schema permits unknown keys (the handler ignores

--- a/packages/pyric-tools/src/deploy/rtdb/rules.ts
+++ b/packages/pyric-tools/src/deploy/rtdb/rules.ts
@@ -7,6 +7,7 @@ import {
   type RtdbRulesDocument,
 } from 'pyric/rules/rtdb';
 import { AdminApiError, type ProjectScope } from '../scope.js';
+import { isRtdbRulesDocument } from '../../rtdb/rules-json.js';
 
 const RTDB_ADMIN_API = 'https://firebasedatabase.googleapis.com/v1beta';
 
@@ -61,14 +62,6 @@ function extractDatabaseUrl(instance: unknown): string | null {
   if (typeof name !== 'string') return null;
   const instanceId = name.split('/').filter(Boolean).at(-1);
   return instanceId ? `https://${instanceId}.firebaseio.com` : null;
-}
-
-function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { toJSON?: unknown }).toJSON === 'function'
-  );
 }
 
 function rulesJsonFromInput(input: RtdbDeployRulesInput): unknown {

--- a/packages/pyric-tools/src/rtdb/rules-json.ts
+++ b/packages/pyric-tools/src/rtdb/rules-json.ts
@@ -1,3 +1,5 @@
+import type { RtdbRulesDocument } from 'pyric/rules/rtdb';
+
 export interface RtdbRulesJson {
   rules: Record<string, unknown>;
 }
@@ -12,6 +14,14 @@ export function parseRtdbRulesJson(
 ): RtdbRulesJson {
   if (!isRtdbRulesJson(value)) throw onInvalid();
   return value;
+}
+
+export function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toJSON?: unknown }).toJSON === 'function'
+  );
 }
 
 function isRtdbRulesObject(value: unknown): value is Record<string, unknown> {

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -16,7 +16,11 @@ import {
 } from 'pyric/rules';
 import type { RtdbRulesDocument } from 'pyric/rules/rtdb';
 import type { ProjectScope } from '../deploy/index.js';
-import { parseRtdbRulesJson, type RtdbRulesJson } from '../rtdb/rules-json.js';
+import {
+  isRtdbRulesDocument,
+  parseRtdbRulesJson,
+  type RtdbRulesJson,
+} from '../rtdb/rules-json.js';
 import {
   fixtureVerifiableServices,
   parseVerifyFixture,
@@ -456,15 +460,6 @@ function requireRtdbRules(input: VerifyRulesInput): RtdbRulesJson {
     );
   }
   throw new VerifyInputError('missing candidate RTDB rules. Pass rules.rtdb.');
-}
-
-function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'toJSON' in value &&
-    typeof (value as { toJSON?: unknown }).toJSON === 'function'
-  );
 }
 
 function mapFirestoreDivergence(divergence: Divergence): VerifyDivergence {

--- a/packages/pyric-tools/test/rtdb/rules-json.test.ts
+++ b/packages/pyric-tools/test/rtdb/rules-json.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  isRtdbRulesDocument,
   isRtdbRulesJson,
   parseRtdbRulesJson,
 } from '../../src/rtdb/rules-json.js';
@@ -19,5 +20,11 @@ describe('RTDB rules JSON parser', () => {
     expect(() =>
       parseRtdbRulesJson({ rules: [] }, () => new Error('caller-specific message')),
     ).toThrow('caller-specific message');
+  });
+
+  test('recognizes RTDB rules document objects by their compiler method', () => {
+    expect(isRtdbRulesDocument({ toJSON: () => ({ rules: {} }) })).toBe(true);
+    expect(isRtdbRulesDocument({ toJSON: 'not a function' })).toBe(false);
+    expect(isRtdbRulesDocument(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Deploy and verify now share the same RTDB rules boundary

This tightens the rules input path used by deploy and verify so RTDB rules JSON is recognized in one feature-owned place instead of through separate local guards.

```ts
import { rtdb } from 'pyric-tools/deploy';
import { verifyFixture } from 'pyric-tools/verify';

const rulesJson = {
  rules: {
    '.read': false,
    '.write': false,
    rooms: {
      '$roomId': {
        messages: {
          '$messageId': {
            '.read': "root.child('members').child($roomId).child(auth.uid).exists()",
          },
        },
      },
    },
  },
};

await rtdb.rules.deploy(scope, {
  databaseUrl: 'https://demo-default-rtdb.firebaseio.com',
  rulesJson,
});

await verifyFixture(fixture, {
  rules: { rtdb: rulesJson },
});
```

The public behavior stays the same, but the implementation now has one RTDB rules-document concept that both deploy and verify use.

## What changes

- Adds a centralized `isRtdbRulesDocument()` guard in the RTDB rules JSON module.
- Updates RTDB deploy input normalization to use the shared guard.
- Updates verify RTDB candidate normalization to use the shared guard.
- Routes machine-readable deploy CLI IO through the same provider registry as human-facing deploy operations.
- Adds CLI coverage for direct machine schema and JSON output paths.

## Other usage

Machine-readable deploy commands can now ask the selected provider for its schema and JSON behavior directly:

```sh
pyric deploy rtdb:rules --schema
pyric deploy rtdb:rules --json
```

This matters because deploy command behavior now comes from the provider that owns the operation rather than a parallel CLI-only path.

## Testing

- `bun run build`
- `bun run test`
- `bun test --cwd packages/pyric-tools test/rtdb/rules-json.test.ts src/cli/cli.test.ts`
