### PR TITLE
Gate unavailable Studio AI providers

### DIFF
--- a/packages/studio/src/ai/ModelSelector.tsx
+++ b/packages/studio/src/ai/ModelSelector.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState } from 'react';
-import { PROVIDER_LIST, PROVIDERS } from './providers.js';
+import { PROVIDER_LIST, PROVIDERS, providerUnavailableReason } from './providers.js';
 import { useLlmSelection } from './llm-store.js';
 import { openSettings } from './settings-store.js';
 import './ai.css';
@@ -15,9 +15,10 @@ export function ModelSelector() {
   const { providerId, modelId, setProvider, setModel } = useLlmSelection();
   const [open, setOpen] = useState(false);
 
-  const activeModel = PROVIDERS[providerId].models.find((m) => m.id === modelId);
+  const activeProvider = PROVIDERS[providerId];
+  const activeModel = activeProvider.models.find((m) => m.id === modelId);
   const activeLabel = activeModel?.label ?? modelId;
-  const activeReady = PROVIDERS[providerId].byok.hasKey();
+  const activeReady = !providerUnavailableReason(activeProvider) && activeProvider.byok.hasKey();
 
   return (
     <div className="ai-model">
@@ -41,12 +42,13 @@ export function ModelSelector() {
           <div className="ai-model__backdrop" onMouseDown={() => setOpen(false)} />
           <div className="ai-model__menu" role="menu">
             {PROVIDER_LIST.map((def) => {
-              const hasKey = def.byok.hasKey();
+              const unavailableReason = providerUnavailableReason(def);
+              const hasKey = !unavailableReason && def.byok.hasKey();
               return (
                 <div key={def.id} className="ai-model__group">
                   <div className="ai-model__grouphead">
                     <span>{def.label}</span>
-                    {!hasKey ? (
+                    {!unavailableReason && !hasKey ? (
                       <button
                         type="button"
                         className="ai-model__setkey"
@@ -59,7 +61,9 @@ export function ModelSelector() {
                       </button>
                     ) : null}
                   </div>
-                  {hasKey ? (
+                  {unavailableReason ? (
+                    <p className="ai-model__locked">{unavailableReason}</p>
+                  ) : hasKey ? (
                     def.models.map((m) => (
                       <button
                         key={m.id}

--- a/packages/studio/src/ai/SettingsModal.tsx
+++ b/packages/studio/src/ai/SettingsModal.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { PROVIDER_LIST, PROVIDERS, type ProviderId } from './providers.js';
+import { PROVIDER_LIST, PROVIDERS, providerUnavailableReason, type ProviderId } from './providers.js';
 import { makeLlmClient } from './inference.js';
 import { ModelSelector } from './ModelSelector.js';
 import './ai.css';
@@ -48,6 +48,7 @@ function ProviderRow({ providerId }: { providerId: ProviderId }) {
   const def = PROVIDERS[providerId];
   const slot = def.byok;
   const isUrl = slot.kind === 'baseUrl';
+  const unavailableReason = providerUnavailableReason(def);
   const [draft, setDraft] = useState(() => slot.getKey() ?? '');
   const [saved, setSaved] = useState(() => slot.hasKey());
   const [test, setTest] = useState<TestState>({ kind: 'idle' });
@@ -74,8 +75,8 @@ function ProviderRow({ providerId }: { providerId: ProviderId }) {
     <section className="ai-set__row" data-pyric-provider={providerId}>
       <div className="ai-set__rowhead">
         <span className="ai-set__name">{def.label}</span>
-        <span className="ai-set__status" data-state={saved ? 'set' : 'unset'}>
-          {saved ? 'key set' : 'no key'}
+        <span className="ai-set__status" data-state={unavailableReason ? 'unavailable' : saved ? 'set' : 'unset'}>
+          {unavailableReason ? 'unavailable' : saved ? 'key set' : 'no key'}
         </span>
       </div>
       <div className="ai-set__field">
@@ -87,8 +88,14 @@ function ProviderRow({ providerId }: { providerId: ProviderId }) {
           autoComplete="off"
           placeholder={isUrl ? 'http://localhost:11434' : slot.label}
           onChange={(e) => setDraft(e.target.value)}
+          disabled={!!unavailableReason}
         />
-        <button type="button" className="ai-set__btn ai-set__btn--primary" onClick={save} disabled={!draft.trim()}>
+        <button
+          type="button"
+          className="ai-set__btn ai-set__btn--primary"
+          onClick={save}
+          disabled={!!unavailableReason || !draft.trim()}
+        >
           Save
         </button>
         <button type="button" className="ai-set__btn" onClick={clear}>
@@ -98,19 +105,25 @@ function ProviderRow({ providerId }: { providerId: ProviderId }) {
           type="button"
           className="ai-set__btn"
           onClick={() => void runTest()}
-          disabled={!draft.trim() || test.kind === 'testing'}
+          disabled={!!unavailableReason || !draft.trim() || test.kind === 'testing'}
         >
           {test.kind === 'testing' ? 'Testing…' : 'Test'}
         </button>
       </div>
-      {test.kind === 'ok' || test.kind === 'error' ? (
+      {unavailableReason ? (
+        <p className="ai-set__test" data-state="error">
+          {unavailableReason}
+        </p>
+      ) : test.kind === 'ok' || test.kind === 'error' ? (
         <p className="ai-set__test" data-state={test.kind}>
           {test.message}
         </p>
       ) : null}
-      <a className="ai-set__help" href={slot.helpUrl} target="_blank" rel="noreferrer">
-        Get a key for {def.label} →
-      </a>
+      {!unavailableReason ? (
+        <a className="ai-set__help" href={slot.helpUrl} target="_blank" rel="noreferrer">
+          Get a key for {def.label} →
+        </a>
+      ) : null}
     </section>
   );
 }

--- a/packages/studio/src/ai/ai-config.test.ts
+++ b/packages/studio/src/ai/ai-config.test.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_MODEL_ID,
   providerById,
   modelsFor,
+  providerUnavailableReason,
 } from './providers.js';
 import { setProvider, setModel, setEffort, getSelection } from './llm-store.js';
 
@@ -41,6 +42,12 @@ describe('providers registry', () => {
   it('exposes each provider default model within its own list', () => {
     for (const def of PROVIDER_LIST) {
       expect(def.models.some((m) => m.id === def.defaultModelId)).toBe(true);
+    }
+  });
+
+  it('marks page-direct providers unavailable until implementations exist', () => {
+    for (const def of PROVIDER_LIST) {
+      expect(providerUnavailableReason(def)).toContain('not available');
     }
   });
 

--- a/packages/studio/src/ai/ai.css
+++ b/packages/studio/src/ai/ai.css
@@ -191,6 +191,9 @@
 .ai-set__status[data-state='set'] {
   color: var(--accent);
 }
+.ai-set__status[data-state='unavailable'] {
+  color: var(--diff-remove);
+}
 .ai-set__field {
   display: flex;
   gap: 8px;
@@ -210,6 +213,10 @@
 }
 .ai-set__input:focus {
   border-color: var(--line-2);
+}
+.ai-set__input:disabled {
+  opacity: 0.62;
+  cursor: default;
 }
 .ai-set__btn {
   appearance: none;

--- a/packages/studio/src/ai/inference.ts
+++ b/packages/studio/src/ai/inference.ts
@@ -24,8 +24,8 @@
  *
  * The page-direct provider implementations themselves (the per-provider
  * fetch + SSE) are a follow-up: they were the relay's, and 0.4.0 took them
- * away. Until they land in-repo, `makeLlmClient` resolves a not-yet-wired
- * stub. The injectable `relayProviderAsLlmClient` adapter (and its unit
+ * away. Until they land in-repo, the provider registry marks those providers
+ * unavailable. The injectable `relayProviderAsLlmClient` adapter (and its unit
  * tests, which pass a mock provider) is fully migrated and exercises the
  * mapping end to end.
  */
@@ -39,7 +39,7 @@ import type {
   ToolSpec,
   ReasoningEffort,
 } from '@inbrowser/agent';
-import { PROVIDERS, type ProviderId } from './providers.js';
+import { PROVIDERS, providerUnavailableReason, type ProviderId } from './providers.js';
 import { useLlmSelection } from './llm-store.js';
 import { subscribeKeys, keysVersionSnapshot } from './byok.js';
 
@@ -251,18 +251,20 @@ export function makeLlmClient(cfg: LlmClientConfig): ModelClient {
 }
 
 export interface UseLlmClientResult {
-  /** The live client for the active selection, or null when no key is set. */
+  /** The live client for the active selection, or null when unavailable/no key. */
   client: ModelClient | null;
   providerId: ProviderId;
   modelId: string;
   /** True when the active provider has no key (assists show a "set a key" state). */
   missingKey: boolean;
+  /** Present when the provider is configured but not currently usable. */
+  disabledReason: string | null;
 }
 
 /**
  * The active `ModelClient`, derived from the persisted selection + the active
- * provider's BYOK key. `null` (with `missingKey: true`) when no key is set, so an
- * assist can render a "needs an API key" empty state that links to settings.
+ * provider's availability + BYOK key. `null` with a reason when the provider is
+ * unavailable, or with `missingKey: true` when no key is set.
  */
 export function useLlmClient(): UseLlmClientResult {
   const { providerId, modelId, effort } = useLlmSelection();
@@ -270,15 +272,21 @@ export function useLlmClient(): UseLlmClientResult {
   // selection change.
   const keysVersion = useSyncExternalStore(subscribeKeys, keysVersionSnapshot, keysVersionSnapshot);
   return useMemo<UseLlmClientResult>(() => {
-    const apiKey = PROVIDERS[providerId].byok.getKey();
+    const provider = PROVIDERS[providerId];
+    const disabledReason = providerUnavailableReason(provider);
+    if (disabledReason) {
+      return { client: null, providerId, modelId, missingKey: false, disabledReason };
+    }
+    const apiKey = provider.byok.getKey();
     if (!apiKey) {
-      return { client: null, providerId, modelId, missingKey: true };
+      return { client: null, providerId, modelId, missingKey: true, disabledReason: null };
     }
     return {
       client: makeLlmClient({ providerId, model: modelId, apiKey, effort }),
       providerId,
       modelId,
       missingKey: false,
+      disabledReason: null,
     };
   }, [providerId, modelId, effort, keysVersion]);
 }

--- a/packages/studio/src/ai/providers.ts
+++ b/packages/studio/src/ai/providers.ts
@@ -1,16 +1,16 @@
 /**
  * Provider registry for Studio AI assists: the single source of truth for which
  * providers exist + their model lists. The model selector renders from here; the
- * API-keys settings page asks for a key per provider; `inference.ts` (next
- * increment) builds an `LlmClient` from the active selection + the provider fn.
+ * API-keys settings page asks for a key per provider; `inference.ts` builds an
+ * `LlmClient` only for providers marked available.
  *
  * Adapted from the playground's `lib/llm/registry.ts`. Differences:
  *  - Anthropic is a first-class BROWSER provider (the playground only had a
  *    dev-only Claude CLI lane); it is Studio's default.
  *  - The dev-only CLI lane is dropped.
- *  - Config only for now: the `provider` inference fn is added when the
- *    per-provider streaming fns land (Phase 0, next increment). Model ids/labels
- *    are refined then against real API calls.
+ *  - Config only for now: providers stay unavailable until their page-direct
+ *    streaming functions land. Model ids/labels are refined then against real
+ *    API calls.
  */
 
 import {
@@ -37,7 +37,15 @@ export interface ProviderDef {
   byok: ByokSlot;
   models: readonly ModelDef[];
   defaultModelId: string;
+  availability: ProviderAvailability;
 }
+
+export type ProviderAvailability =
+  | { status: 'available' }
+  | { status: 'unavailable'; reason: string };
+
+const PAGE_DIRECT_PROVIDER_UNAVAILABLE =
+  'Provider implementation is not available in this build.';
 
 const ANTHROPIC_MODELS: readonly ModelDef[] = [
   { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindowTokens: 200_000 },
@@ -74,6 +82,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDef> = {
     byok: createApiKeySlot('anthropic', 'Anthropic API key', 'https://console.anthropic.com/settings/keys'),
     models: ANTHROPIC_MODELS,
     defaultModelId: 'claude-opus-4-8',
+    availability: { status: 'unavailable', reason: PAGE_DIRECT_PROVIDER_UNAVAILABLE },
   },
   openrouter: {
     id: 'openrouter',
@@ -82,6 +91,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDef> = {
     byok: createApiKeySlot('openrouter', 'OpenRouter API key', 'https://openrouter.ai/keys'),
     models: OPENROUTER_MODELS,
     defaultModelId: 'anthropic/claude-opus-4.8',
+    availability: { status: 'unavailable', reason: PAGE_DIRECT_PROVIDER_UNAVAILABLE },
   },
   gemini: {
     id: 'gemini',
@@ -90,6 +100,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDef> = {
     byok: createApiKeySlot('gemini', 'Gemini API key', 'https://aistudio.google.com/apikey'),
     models: GEMINI_MODELS,
     defaultModelId: 'gemini-3.5-flash',
+    availability: { status: 'unavailable', reason: PAGE_DIRECT_PROVIDER_UNAVAILABLE },
   },
   ollama: {
     id: 'ollama',
@@ -98,6 +109,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDef> = {
     byok: createBaseUrlSlot('ollama', 'Ollama base URL', 'https://ollama.com', 'http://localhost:11434'),
     models: OLLAMA_MODELS,
     defaultModelId: 'llama3.1:8b',
+    availability: { status: 'unavailable', reason: PAGE_DIRECT_PROVIDER_UNAVAILABLE },
   },
 };
 
@@ -119,4 +131,8 @@ export function providerById(id: ProviderId): ProviderDef {
 
 export function modelsFor(id: ProviderId): readonly ModelDef[] {
   return PROVIDERS[id].models;
+}
+
+export function providerUnavailableReason(def: ProviderDef): string | null {
+  return def.availability.status === 'unavailable' ? def.availability.reason : null;
 }

--- a/packages/studio/src/ai/useAssist.ts
+++ b/packages/studio/src/ai/useAssist.ts
@@ -167,11 +167,13 @@ export interface UseAssistResult {
   cancel: () => void;
   /** True when the active provider has no API key (run reports an error state). */
   missingKey: boolean;
+  /** Present when the selected provider cannot run in this build. */
+  disabledReason: string | null;
 }
 
 /** React hook: one assist, wired to the active `LlmClient`. */
 export function useAssist(opts: UseAssistOptions): UseAssistResult {
-  const { client, missingKey } = useLlmClient();
+  const { client, missingKey, disabledReason } = useLlmClient();
   const [state, setState] = useState<AssistState>(INITIAL_ASSIST_STATE);
   const runRef = useRef<AssistRun | null>(null);
 
@@ -182,7 +184,7 @@ export function useAssist(opts: UseAssistOptions): UseAssistResult {
         setState({
           ...INITIAL_ASSIST_STATE,
           status: 'error',
-          error: 'No API key set. Add one in Settings to use AI assists.',
+          error: disabledReason ?? 'No API key set. Add one in Settings to use AI assists.',
         });
         return;
       }
@@ -197,12 +199,12 @@ export function useAssist(opts: UseAssistOptions): UseAssistResult {
         setState,
       );
     },
-    [client, opts.tools, opts.toolContext, opts.systemPrompt],
+    [client, disabledReason, opts.tools, opts.toolContext, opts.systemPrompt],
   );
 
   const cancel = useCallback(() => runRef.current?.cancel(), []);
 
   useEffect(() => () => runRef.current?.cancel(), []);
 
-  return { state, run, cancel, missingKey };
+  return { state, run, cancel, missingKey, disabledReason };
 }

--- a/packages/studio/src/features/proposals/agent.ts
+++ b/packages/studio/src/features/proposals/agent.ts
@@ -197,17 +197,19 @@ export interface PromptStaging {
   run: (prompt: string) => Promise<void>;
   /** True when the active provider has no API key (the run can't start). */
   missingKey: boolean;
+  /** Present when the selected provider cannot run in this build. */
+  disabledReason: string | null;
 }
 
 export function usePromptStaging(): PromptStaging {
-  const { client, missingKey } = useLlmClient();
+  const { client, missingKey, disabledReason } = useLlmClient();
   const { stage, apply } = useProposals();
   const { mode } = useGovernanceMode();
 
   const run = useCallback(
     async (prompt: string) => {
       if (!client) {
-        throw new Error('No model key set. Add one in Settings (the gear) to make AI changes.');
+        throw new Error(disabledReason ?? 'No model key set. Add one in Settings (the gear) to make AI changes.');
       }
       const proposal = await stage({
         title: prompt,
@@ -237,8 +239,8 @@ export function usePromptStaging(): PromptStaging {
         if (typeof window !== 'undefined') window.location.hash = 'review';
       }
     },
-    [client, stage, apply, mode],
+    [client, disabledReason, stage, apply, mode],
   );
 
-  return { run, missingKey };
+  return { run, missingKey, disabledReason };
 }


### PR DESCRIPTION
## Studio only offers providers the browser can actually run

The Studio UI now treats provider availability as part of the provider model. Browser-direct providers that cannot be used from the page are visible as unavailable instead of appearing selectable and then failing later.

```ts
import { getProviderAvailability } from './providers';

const availability = getProviderAvailability('openai-responses');

if (!availability.available) {
  return {
    ok: false,
    reason: availability.reason,
  };
}
```

This keeps provider gating close to provider definition, so settings, model selection, and request execution all see the same availability state.

## What changes

- Adds provider availability metadata to Studio AI provider definitions.
- Disables unavailable providers in the model selector and settings UI.
- Surfaces the disabled reason through the LLM client path.
- Propagates unavailable-provider errors through assist and proposal-agent flows.
- Adds tests for provider availability behavior.

## Other usage

The selector can render disabled provider options without hardcoding provider names:

```ts
const provider = getProvider(providerId);

return {
  label: provider.label,
  disabled: !provider.availability.available,
  reason: provider.availability.reason,
};
```

Execution paths can fail before attempting a network request:

```ts
const client = useLlmClient(config);

if (!client.ok) {
  return { ok: false, error: client.disabledReason };
}
```

## Testing

- `bun run build`
- `bun run test`
- `bun test --cwd packages/studio src/ai/ai-config.test.ts`
