### PR TITLE
Update stale public package references

### DIFF
--- a/packages/pyric-admin/docs/firestore/how-to/seed-and-set-rules.md
+++ b/packages/pyric-admin/docs/firestore/how-to/seed-and-set-rules.md
@@ -24,7 +24,7 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 }
 ```
 
-`setRules` returns the `LintResult` from `pyric/firestore-rules`. Check warnings before treating the deploy as successful. If the source has parse errors, the rules are *not* swapped — `setRules` is consistent with `LocalEnvironment.deployRules` on that point.
+`setRules` returns the `LintResult` from `pyric/rules`. Check warnings before treating the deploy as successful. If the source has parse errors, the rules are *not* swapped — `setRules` is consistent with `LocalEnvironment.deployRules` on that point.
 
 ## Seed initial data
 
@@ -92,5 +92,5 @@ adminDb.seed({ documents: before });
 
 ## Where to look next
 
-- For lint warning shapes, see [`pyric/firestore-rules` lint rules](../../../firestore-rules/docs/reference/lint-rules.md).
+- For lint warning shapes, see [`pyric/rules` lint rules](../../../../pyric/docs/rules/reference/lint-rules.md).
 - For why these methods live on the data-plane handle rather than the sandbox itself, see [Why mirror the admin SDK shape](../explanation/why-mirror-admin-shape.md).

--- a/packages/pyric-admin/docs/firestore/reference/sandbox-firestore.md
+++ b/packages/pyric-admin/docs/firestore/reference/sandbox-firestore.md
@@ -34,7 +34,7 @@ These have no production analog and use sandbox-specific verbs so they can't be 
 
 ### `setRules(rules: string): LintResult`
 
-Replace the active ruleset. Returns the lint result from `pyric/firestore-rules` — surface the warnings if any. If the source has parse-level errors, the rules are not swapped (consistent with `LocalEnvironment.deployRules`).
+Replace the active ruleset. Returns the lint result from `pyric/rules` — surface the warnings if any. If the source has parse-level errors, the rules are not swapped (consistent with `LocalEnvironment.deployRules`).
 
 After a successful `setRules`, every active snapshot listener is re-evaluated under the new rules. See [Listener re-evaluation on `deployRules`](../../../sandbox/docs/explanation/listener-re-evaluation.md) in `pyric/sandbox`.
 

--- a/packages/pyric-admin/src/auth/index.ts
+++ b/packages/pyric-admin/src/auth/index.ts
@@ -549,7 +549,7 @@ function isSandboxAdminApp(app: PyricAdminApp): app is SandboxAdminApp {
  * The firebase-admin import is dynamic (`require` at call time) so the
  * module's top-level evaluation stays cheap and so sandbox-only
  * consumers do not pay the firebase-admin initialization cost. Mirrors
- * how `@pyric/firestore` defers its firebase init: backends are
+ * how `pyric/firestore` defers its firebase init: backends are
  * pay-for-what-you-use.
  *
  * @example

--- a/packages/pyric-admin/test/firestore/scenarios/01-kanban.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/01-kanban.test.ts
@@ -1,5 +1,5 @@
 /**
- * Scenario 1: Task Management (Kanban) — migrated through @pyric/sandbox.
+ * Scenario 1: Task Management (Kanban) — migrated through pyric/sandbox.
  *
  * Identical assertions to the SDK-side `scenarios/01-kanban.test.ts`,
  * but operations dispatch through `getFirestore(sandbox)` instead of

--- a/packages/pyric-admin/test/firestore/scenarios/02-multitenant.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/02-multitenant.test.ts
@@ -6,7 +6,7 @@
  *
  * Rules: examples/scenarios/02-multitenant.rules
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/03-ecommerce.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/03-ecommerce.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: examples/scenarios/03-ecommerce.rules
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/04-publishing.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/04-publishing.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: examples/scenarios/04-publishing.rules
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/05-chat.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/05-chat.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: examples/scenarios/05-chat.rules
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/06-social.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/06-social.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: inline
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/07-inventory.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/07-inventory.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: inline
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/08-booking.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/08-booking.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: inline
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/09-rookchess.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/09-rookchess.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: inline
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/10-cardgame.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/10-cardgame.test.ts
@@ -7,7 +7,7 @@
  *
  * Rules: inline
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/11-enrollment.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/11-enrollment.test.ts
@@ -5,7 +5,7 @@
  * get() to verify teacherId, MapDiff to constrain which fields change.
  * Stdlib: auth, validation, lifecycle, membership
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/12-iot.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/12-iot.test.ts
@@ -5,7 +5,7 @@
  * device active check via get(), range validation for sensor data.
  * Stdlib: auth, lifecycle, validation
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/13-finance.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/13-finance.test.ts
@@ -5,7 +5,7 @@
  * balances and receiver existence, self-transfer blocked, immutable transfers.
  * Stdlib: auth, lifecycle, validation
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/14-medical.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/14-medical.test.ts
@@ -6,7 +6,7 @@
  * only admin can delete records.
  * Stdlib: auth, membership, lifecycle, validation
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/15-checkers-jumps.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/15-checkers-jumps.test.ts
@@ -6,7 +6,7 @@
  * Config doc built programmatically for the 4x4 board.
  * Stdlib: geometry, turns, state, auth
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/16-workflow.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/16-workflow.test.ts
@@ -5,7 +5,7 @@
  * immutable approval records, and batch operations.
  * Stdlib: auth, transitions, validation, lifecycle
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  *
  * NOTE: 3 batch tests from the original suite are skipped here because

--- a/packages/pyric-admin/test/firestore/scenarios/17-supplychain.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/17-supplychain.test.ts
@@ -5,7 +5,7 @@
  * role-based claims for admin vs logistics, capacity enforcement.
  * Stdlib: auth, membership, validation, lifecycle
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/18-allstdlib.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/18-allstdlib.test.ts
@@ -5,7 +5,7 @@
  * turns, state, membership, lifecycle, transitions, geometry.
  * Stdlib: auth, validation, lobby, turns, state, membership, lifecycle, transitions, geometry
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  *
  * NOTE: Lobby tests are stateful — they share `lobbyRoot` so that 'create',

--- a/packages/pyric-admin/test/firestore/scenarios/19-highrules.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/19-highrules.test.ts
@@ -6,7 +6,7 @@
  * paths, and denial conditions.
  * Stdlib: auth, transitions, lifecycle
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/20-nested.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/20-nested.test.ts
@@ -5,7 +5,7 @@
  * role-based access at each level, and field immutability.
  * Stdlib: auth, membership, lifecycle, validation
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric-admin/test/firestore/scenarios/21-tax-brackets.test.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/21-tax-brackets.test.ts
@@ -5,7 +5,7 @@
  * verify each intermediate step against a config document with pre-computed
  * bracket data. Same approach that made chess work — lookup document + verify.
  *
- * Migrated through `@pyric/sandbox` — operations dispatch through
+ * Migrated through `pyric/sandbox` — operations dispatch through
  * `getFirestore(sandbox)` instead of `LocalEnvironment.execute`.
  *
  * NOTE: Test #24 ('owner can read own return') from the original suite is

--- a/packages/pyric-admin/test/firestore/scenarios/_helpers.ts
+++ b/packages/pyric-admin/test/firestore/scenarios/_helpers.ts
@@ -3,7 +3,7 @@
  * "given rules + seed, this op is allowed/denied" without the
  * try/catch/withAuth ceremony at every callsite.
  *
- * Why migrate scenario tests through `@pyric/sandbox` at all (rather
+ * Why migrate scenario tests through `pyric/sandbox` at all (rather
  * than continue using `LocalEnvironment.execute` directly):
  *
  *   - Scenario tests double as the largest corpus of "does this rule

--- a/packages/pyric-tools/docs/deploy/README.md
+++ b/packages/pyric-tools/docs/deploy/README.md
@@ -47,7 +47,7 @@ Documentation is organised under [`docs/`](./) following the [Diataxis](https://
 
 ## Position in the Pyric stack
 
-`pyric-tools/deploy` is the **control plane**. It mutates project configuration (deploys rules, creates indexes, uploads functions). It does not read or write Firestore documents — that's `pyric/firestore` (data plane) and `pyric/firestore-rules` (rules tooling). The three packages plus `pyric/sandbox` form a loose hexagon; each depends on a small surface of the others.
+`pyric-tools/deploy` is the **control plane**. It mutates project configuration (deploys rules, creates indexes, uploads functions). It does not read or write Firestore documents — that's `pyric/firestore` (data plane) and `pyric/rules` (rules tooling). The three packages plus `pyric/sandbox` form a loose hexagon; each depends on a small surface of the others.
 
 See [Why this package exists](./explanation/why-this-package-exists.md) for the longer story.
 

--- a/packages/pyric-tools/docs/deploy/explanation/why-this-package-exists.md
+++ b/packages/pyric-tools/docs/deploy/explanation/why-this-package-exists.md
@@ -54,7 +54,7 @@ You don't need a translation layer between "deploy primitives" and "tool handler
 ## What stays out
 
 - **Data plane** (read / write documents) — that's `pyric/firestore` and `pyric-admin`.
-- **Rules tooling** (parse, lint, simulate) — that's `pyric/firestore-rules`.
+- **Rules tooling** (parse, lint, simulate) — that's `pyric/rules`.
 - **Auth admin** (user management, custom claims) — not yet implemented; will live here when it lands.
 - **Realtime Database deploy** — deferred until a consumer asks.
 - **Storage upload** — `pyric/storage` covers the storage data plane; the storage admin surface (CORS, bucket creation) will live here when needed.

--- a/packages/pyric-tools/docs/deploy/how-to/deploy-firestore-rules.md
+++ b/packages/pyric-tools/docs/deploy/how-to/deploy-firestore-rules.md
@@ -114,4 +114,4 @@ Returns `null` for greenfield projects.
 
 - For the `EnsureRuleOutcome` and `RuleCheckResult` shapes, see [`firestore` namespace](../reference/firestore-namespace.md#firestorerules).
 - For why `ensure` is an orchestrator (returns `Outcome`) while `deploy` is a primitive (throws), see [Primitives throw, orchestrators return](../explanation/primitives-vs-orchestrators.md).
-- For linting rules before deploying them, see [`pyric/firestore-rules`](../../../firestore-rules/README.md).
+- For linting rules before deploying them, see [`pyric/rules`](../../../../pyric/docs/rules/README.md).

--- a/packages/pyric-tools/docs/reference/cli.md
+++ b/packages/pyric-tools/docs/reference/cli.md
@@ -196,11 +196,11 @@ These wrap the rules toolchain documented in
 
 ### `pyric rules:lint <path>`
 
-Run the firestore-rules linter against a file.
+Run the Firestore rules linter against a file.
 
 ### `pyric rules:validate <path>`
 
-Validate firestore-rules structure against a file.
+Validate Firestore rules structure against a file.
 
 ### `pyric rules:simulate [--stdin]`
 

--- a/packages/pyric-tools/src/auth/index.ts
+++ b/packages/pyric-tools/src/auth/index.ts
@@ -1,7 +1,7 @@
 /**
- * `@pyric/auth/admin` — Identity Toolkit-driven auth tooling.
+ * `pyric/auth/admin` — Identity Toolkit-driven auth tooling.
  *
- * Sibling subpath to `@pyric/auth` (the modular Web-SDK adapter).
+ * Sibling subpath to `pyric/auth` (the modular Web-SDK adapter).
  * Control-plane surface lives here so the swap-in namespace doesn't
  * pull in Identity Toolkit REST clients for browser bundles that just
  * want `getAuth` / `signInAnonymously` / etc.

--- a/packages/pyric-tools/src/auth/types.ts
+++ b/packages/pyric-tools/src/auth/types.ts
@@ -1,10 +1,10 @@
 /**
- * Types for the auth control-plane surface (`@pyric/auth/admin`).
+ * Types for the auth control-plane surface (`pyric/auth/admin`).
  *
  * Pairs with mapper.ts +
  * resolver.ts + provider/ + domains/ — the Identity Toolkit-driven
  * tooling that's distinct from the modular Web-SDK adapter that
- * @pyric/auth's root entry provides.
+ * pyric/auth's root entry provides.
  */
 
 // 1. Strict provider-id union to prevent hallucinations.

--- a/packages/pyric-tools/src/bridge/server/json-schema-to-zod.ts
+++ b/packages/pyric-tools/src/bridge/server/json-schema-to-zod.ts
@@ -8,7 +8,7 @@
  * The MCP SDK's `server.tool()` / `server.registerTool()` insist on
  * Zod schemas for input validation. Pyric's tool definitions are
  * plain JSON Schema (matching the inline shape in
- * `packages/firestore-rules/src/tools.ts`), so the bridge converts
+ * `packages/pyric/src/rules/tools.ts`), so the bridge converts
  * just-in-time when registering each tool with the MCP server.
  */
 

--- a/packages/pyric-tools/src/bridge/server/tool-metadata.ts
+++ b/packages/pyric-tools/src/bridge/server/tool-metadata.ts
@@ -1,6 +1,6 @@
 /**
  * Extract tool metadata (name + description + parameters) from the
- * existing `@pyric/firestore-rules` factories without running any
+ * existing `pyric/rules` factories without running any
  * tool logic. Used by the bridge to register MCP tools whose actual
  * dispatch happens against the connected browser peer.
  *
@@ -83,7 +83,7 @@ export function getSandboxToolMetadata(): ToolMetadata[] {
  * need a `ProjectScope` work in prod-mode bridges too.
  */
 export function getRulesToolHandlers(scope?: unknown): ToolHandler[] {
-  // Factory accepts { scope } per packages/firestore-rules/src/tools.ts.
+  // Factory accepts { scope } per packages/pyric/src/rules/tools.ts.
   // The cast is because pyric/rules's ProjectScope type is re-exported
   // from pyric-tools/deploy and we'd otherwise force a type-only import
   // here. Bridge level we don't need the type.

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -150,8 +150,8 @@ COMMANDS
                              database.url, then default instance discovery.
   hosting:channel:deploy     Mirror of \`deploy hosting --channel <channelId>\`
                              (firebase-tools spelling) — identical behavior.
-  rules:lint                 Run firestore-rules linter against a file.
-  rules:validate             Validate firestore-rules structure against a file.
+  rules:lint                 Run Firestore rules linter against a file.
+  rules:validate             Validate Firestore rules structure against a file.
   rules:simulate             Local rules simulator (smoke-test or --stdin scripted).
   database:rules:lint        Run Realtime Database rules JSON expression linter.
   database:rules:validate    Validate Realtime Database rules JSON expressions.

--- a/packages/pyric-tools/src/serve/entries/auth-helper-core.ts
+++ b/packages/pyric-tools/src/serve/entries/auth-helper-core.ts
@@ -1,7 +1,7 @@
 /**
  * Sign-in helper core for `pyric serve` — the framework-free controller
  * behind the account-picker dialog (the emulator's sign-in widget analog,
- * and the second consumer of `@pyric/auth`'s `AuthFlowResolver` seam after
+ * and the second consumer of `pyric/auth`'s `AuthFlowResolver` seam after
  * the playground; same settle/seed semantics, zero DOM).
  *
  * `resolver()` parks the SDK's popup/redirect promise; `pick`/`add`/`cancel`

--- a/packages/pyric-tools/src/serve/state-store.ts
+++ b/packages/pyric-tools/src/serve/state-store.ts
@@ -3,7 +3,7 @@
  * flow doc section 3c ("persistence = an autosaved seed").
  *
  * The file is an ENVELOPE around two sections:
- *   - `firestore`: the `@pyric/sandbox` persistence controller's own blob
+ *   - `firestore`: the `pyric/sandbox` persistence controller's own blob
  *     (`{version, savedAt, firestore: {path: fields}}`), stored verbatim as
  *     parsed JSON. The page's controller wrote it and will read it back
  *     through its own (de)serializer — wrapper types (Timestamp, Bytes, …)

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -244,7 +244,7 @@ function wirePort(port: MessagePort): void {
         // worker-path twin of the in-page default (a denied listener after a
         // rules change / sign-out must not fail silently on the page console).
         if (sub.error) sub.error(err);
-        else console.error('@pyric/firestore: Uncaught Error in snapshot listener:', err);
+        else console.error('pyric/firestore: Uncaught Error in snapshot listener:', err);
         return;
       }
       sub.next(msg.value);

--- a/packages/pyric-tools/test/deploy/firestore.test.ts
+++ b/packages/pyric-tools/test/deploy/firestore.test.ts
@@ -1,7 +1,6 @@
 /**
- * `pyric-tools/deploy.firestore` unit tests. Moved from
- * `packages/firestore/test/admin.test.ts` (Slice 4) and reshaped
- * to take `ProjectScope` per F3.
+ * `pyric-tools/deploy` Firestore unit tests. Reshaped to take
+ * `ProjectScope` per F3.
  *
  * Network calls are stubbed via `fetch` mocks. Integration against
  * the live REST APIs is a separate test pass that needs OAuth tokens.

--- a/packages/pyric/docs/firestore/README.md
+++ b/packages/pyric/docs/firestore/README.md
@@ -68,7 +68,7 @@ Two named exports sit alongside the production-shaped surface:
 
 ## Position in the Pyric stack
 
-`pyric/firestore` is the **modular-shape data-plane adapter**. Sibling to `pyric-admin` (admin-shape). Both run on top of `pyric/sandbox`. Rules tooling lives in `pyric/firestore-rules`; deploy primitives in `@pyric/deploy`.
+`pyric/firestore` is the **modular-shape data-plane adapter**. Sibling to `pyric-admin` (admin-shape). Both run on top of `pyric/sandbox`. Rules tooling lives in `pyric/rules`; deploy primitives in `pyric-tools/deploy`.
 
 ## Licence
 

--- a/packages/pyric/docs/firestore/explanation/rules-tooling-is-separate.md
+++ b/packages/pyric/docs/firestore/explanation/rules-tooling-is-separate.md
@@ -1,12 +1,12 @@
 # Why rules tooling lives in a sibling package
 
-`pyric/firestore` is the data plane. It doesn't ship the rules parser, the linter, the simulator, the validator, the modules resolver, or the value wrappers. Those live in `pyric/firestore-rules`. The split looks bureaucratic; the reason is the swap-in contract.
+`pyric/firestore` is the data plane. It doesn't ship the rules parser, the linter, the simulator, the validator, the modules resolver, or the value wrappers. Those live in `pyric/rules`. The split looks bureaucratic; the reason is the swap-in contract.
 
 ## The principle
 
 `pyric/firestore` is meant to be a drop-in for `firebase/firestore`. The upstream package's surface is the data plane — reads, writes, queries, listeners. It does not include rules tooling. If `pyric/firestore` exposed rules tooling, the swap-in would have a wider surface than the package it replaces, and the migration story would no longer be "rename the import".
 
-By keeping rules tooling in `pyric/firestore-rules`, the swap-in surface stays bit-faithful to the upstream. Code that imports from `pyric/firestore` looks exactly like code that imports from `firebase/firestore`. Code that needs rules tooling reaches one folder over.
+By keeping rules tooling in `pyric/rules`, the swap-in surface stays bit-faithful to the upstream. Code that imports from `pyric/firestore` looks exactly like code that imports from `firebase/firestore`. Code that needs rules tooling reaches one folder over.
 
 ## What lives where
 
@@ -15,12 +15,12 @@ By keeping rules tooling in `pyric/firestore-rules`, the swap-in surface stays b
 | `getDoc`, `setDoc`, `collection`, `query`, `onSnapshot`, ... | `pyric/firestore` |
 | `FieldValue`, `Timestamp`, sentinels | `pyric/firestore` (re-exported from `pyric-admin`) |
 | Sandbox-only ops (`sandbox.setRules`, `sandbox.seedDocuments`) | `pyric/firestore` (sandbox-only namespace) |
-| `parseToAST`, `lintFirestoreRules`, `validateFirestoreRules` | `pyric/firestore-rules` |
-| `SimulateFirestoreRulesHandler`, `TestFirestoreRulesHandler` | `pyric/firestore-rules` |
-| Stdlib (`auth`, `validation`, ... modules) | `pyric/firestore-rules` |
-| `Timestamp`, `Path`, `Bytes` (rules wrapper classes) | `pyric/firestore-rules` |
-| Tool factories for lint / simulate / test | `pyric/firestore-rules` |
-| `firestore.rules.deploy(scope, source)` | `@pyric/deploy` |
+| `parseToAST`, `lintFirestoreRules`, `validateFirestoreRules` | `pyric/rules` |
+| `SimulateFirestoreRulesHandler`, `TestFirestoreRulesHandler` | `pyric/rules` |
+| Stdlib (`auth`, `validation`, ... modules) | `pyric/rules` |
+| `Timestamp`, `Path`, `Bytes` (rules wrapper classes) | `pyric/rules` |
+| Tool factories for lint / simulate / test | `pyric/rules` |
+| `firestore.rules.deploy(scope, source)` | `pyric-tools/deploy` |
 
 There's some name overlap: `Timestamp` is both a sentinel value (data plane) and a wrapper class (rules engine). The two share a wire format but are distinct types. Each package exports its own; converters bridge them when needed.
 
@@ -28,7 +28,7 @@ There's some name overlap: `Timestamp` is both a sentinel value (data plane) and
 
 Three common cases:
 
-- **Linting before deploy.** `lintFirestoreRules(source)` returns warnings and metrics. The deploy path in `@pyric/deploy` runs this internally; consumers running their own deploy gate run it explicitly.
+- **Linting before deploy.** `lintFirestoreRules(source)` returns warnings and metrics. The deploy path in `pyric-tools/deploy` runs this internally; consumers running their own deploy gate run it explicitly.
 - **Testing rules locally.** `SimulateFirestoreRulesHandler.simulate(source, testCases)` runs rules against synthetic requests without deploying or hitting the network. Useful for unit tests of complex rule logic.
 - **Inspecting rules programmatically.** `parseToAST(source)` returns a typed tree consumers can walk for custom analysis.
 
@@ -41,24 +41,24 @@ These belong to a different audience than the data-plane consumers. A web app ra
 ```ts
 sandbox.setRules(db, source) → pyric-admin's handle.setRules(source)
                                → LocalEnvironment.deployRules(source)
-                               → lintFirestoreRules(source) (from pyric/firestore-rules)
+                               → lintFirestoreRules(source) (from pyric/rules)
 ```
 
-The lint result returned to the consumer comes from `pyric/firestore-rules`. The data-plane package depends on the rules-tooling package transitively — but doesn't re-export it.
+The lint result returned to the consumer comes from `pyric/rules`. The data-plane package depends on the rules-tooling package transitively — but doesn't re-export it.
 
 ## When the cycle matters
 
-`pyric/sandbox` imports the rules simulator from `pyric/firestore-rules` to evaluate rules against operations. `pyric/firestore-rules` imports `LocalEnvironment` (type-only) from `pyric/sandbox` for its tool-factory shape. A runtime cycle.
+`pyric/sandbox` imports the rules simulator from `pyric/rules` to evaluate rules against operations. `pyric/rules` imports `LocalEnvironment` (type-only) from `pyric/sandbox` for its tool-factory shape. A runtime cycle.
 
-`pyric/firestore` sits on top of both. It depends on `pyric-admin` (which depends on `pyric/sandbox`) and indirectly on `pyric/firestore-rules` (through `pyric/sandbox`). It doesn't depend on `pyric/firestore-rules` directly — the sandbox-only namespace's lint output is whatever the underlying `LocalEnvironment.deployRules` returns.
+`pyric/firestore` sits on top of both. It depends on `pyric-admin` (which depends on `pyric/sandbox`) and indirectly on `pyric/rules` (through `pyric/sandbox`). It doesn't depend on `pyric/rules` directly — the sandbox-only namespace's lint output is whatever the underlying `LocalEnvironment.deployRules` returns.
 
-The cycle is benign. Documented loudly. Build order is `firestore-rules` → `sandbox` → `admin` → `firestore`.
+The cycle is benign. Documented loudly. The module direction is `rules` → `sandbox` → `admin` → `firestore`.
 
 ## What we get from the split
 
 - `pyric/firestore` is small. The package wraps a few hundred functions over two backends; its dependency graph is bounded.
-- `pyric/firestore-rules` can evolve independently. New lint rules, new simulator features, new validator codes — none affect `pyric/firestore`'s surface.
-- `@pyric/deploy` deploys rules without depending on the data plane. CI pipelines pull only what they need.
+- `pyric/rules` can evolve independently. New lint rules, new simulator features, new validator codes — none affect `pyric/firestore`'s surface.
+- `pyric-tools/deploy` deploys rules without depending on the data plane. CI pipelines pull only what they need.
 - Consumers reach for exactly the surface they want by package name. The package name is the documentation.
 
-The downside is exactly one: a beginner asking "where is the linter?" has to learn it lives in a different package. That's a one-time cost — the README and docs point at it explicitly — versus the recurring cost of a kitchen-sink package that complicates every other consumer's bundle.
+The downside is exactly one: a beginner asking "where is the linter?" has to learn it lives in a different public subpath. That's a one-time cost — the README and docs point at it explicitly — versus the recurring cost of a kitchen-sink surface that complicates every other consumer's bundle.

--- a/packages/pyric/docs/firestore/how-to/use-sandbox-ops.md
+++ b/packages/pyric/docs/firestore/how-to/use-sandbox-ops.md
@@ -21,7 +21,7 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 }
 ```
 
-`setRules` returns the `LintResult` from `pyric/firestore-rules`. Source with parse errors is not swapped — check warnings.
+`setRules` returns the `LintResult` from `pyric/rules`. Source with parse errors is not swapped — check warnings.
 
 ## Seed data
 
@@ -75,9 +75,9 @@ sandbox.seedDocuments(db, {}); // throws
 sandbox.snapshotState(db);     // throws
 ```
 
-On prod, deploy rules through `@pyric/deploy.firestore.rules.deploy`. There's no equivalent for `seedDocuments` (populate via writes) or `snapshotState` (no efficient bulk-read API).
+On prod, import `firestore` from `pyric-tools/deploy` and call `firestore.rules.deploy(...)`. There's no equivalent for `seedDocuments` (populate via writes) or `snapshotState` (no efficient bulk-read API).
 
 ## Where to look next
 
 - For the reference page covering all three operations, see [Sandbox-only operations](../reference/sandbox-ops.md).
-- For prod rule deploys, see [`@pyric/deploy`'s firestore namespace](../../../deploy/docs/reference/firestore-namespace.md).
+- For prod rule deploys, see [`pyric-tools/deploy`'s firestore namespace](../../../../pyric-tools/docs/deploy/reference/firestore-namespace.md).

--- a/packages/pyric/docs/firestore/reference/feature-matrix.md
+++ b/packages/pyric/docs/firestore/reference/feature-matrix.md
@@ -178,7 +178,7 @@ called against a prod-backed handle.
 
 | Symbol | Status | Note | Use in `appSource`? |
 |---|---|---|---|
-| `sandbox.setRules(db, rulesSource)` | ✅ | Sandbox-only; use `@pyric/deploy` for prod | **No** — never appears in deployed app code |
+| `sandbox.setRules(db, rulesSource)` | ✅ | Sandbox-only; use `pyric-tools/deploy` for prod | **No** — never appears in deployed app code |
 | `sandbox.seedDocuments(db, docs)` | ✅ | Sandbox-only; bulk-load bypassing rules | **No** — same |
 | `sandbox.snapshotState(db)` | ✅ | Sandbox-only; dump of all stored docs | **No** — same |
 | `TARGET_SYMBOL` | ✅ | Internal brand; agents should not read it | No |

--- a/packages/pyric/docs/firestore/reference/sandbox-ops.md
+++ b/packages/pyric/docs/firestore/reference/sandbox-ops.md
@@ -21,11 +21,11 @@ service cloud.firestore {
 }`);
 ```
 
-Returns the `LintResult` from `pyric/firestore-rules`. Source with parse-level errors is not swapped; check the warnings.
+Returns the `LintResult` from `pyric/rules`. Source with parse-level errors is not swapped; check the warnings.
 
 After a successful swap, every active snapshot listener re-evaluates under the new rules. See [Listener re-evaluation on `deployRules`](../../../sandbox/docs/explanation/listener-re-evaluation.md).
 
-On prod, deploy rules through `@pyric/deploy.firestore.rules.deploy` — that hits Firebase's rules API.
+On prod, import `firestore` from `pyric-tools/deploy` and call `firestore.rules.deploy(...)` — that hits Firebase's rules API.
 
 ## `sandbox.seedDocuments(db, documents): LintResult`
 
@@ -82,5 +82,5 @@ Both styles work. The chosen tradeoff in `pyric/firestore` is "stay shape-faithf
 
 ## Where to look next
 
-- For the lint result shape, see [`pyric/firestore-rules` lint rules reference](../../../firestore-rules/docs/reference/lint-rules.md).
-- For prod rule deploys, see [`@pyric/deploy`'s firestore namespace](../../../deploy/docs/reference/firestore-namespace.md).
+- For the lint result shape, see [`pyric/rules` lint rules reference](../../rules/reference/lint-rules.md).
+- For prod rule deploys, see [`pyric-tools/deploy`'s firestore namespace](../../../../pyric-tools/docs/deploy/reference/firestore-namespace.md).

--- a/packages/pyric/docs/firestore/tutorials/02-swap-to-prod-backend.md
+++ b/packages/pyric/docs/firestore/tutorials/02-swap-to-prod-backend.md
@@ -49,10 +49,10 @@ sandboxOps.seedDocuments(db, ...); // throws 'failed-precondition'
 sandboxOps.snapshotState(db);     // throws 'failed-precondition'
 ```
 
-The sandbox namespace operations are sandbox-only by design. On prod, deploy rules through `@pyric/deploy`:
+The sandbox namespace operations are sandbox-only by design. On prod, deploy rules through `pyric-tools/deploy`:
 
 ```ts
-import { fromServiceAccount, firestore } from '@pyric/deploy';
+import { fromServiceAccount, firestore } from 'pyric-tools/deploy';
 
 const scope = await fromServiceAccount('./service-account.json');
 await firestore.rules.deploy(scope, `rules_version = '2'; ...`);
@@ -77,7 +77,7 @@ The CLI reads your local `firestore.rules` and pushes it.
 If you're running the demo as part of a larger script:
 
 ```ts
-import { fromServiceAccount, firestore } from '@pyric/deploy';
+import { fromServiceAccount, firestore } from 'pyric-tools/deploy';
 
 const scope = await fromServiceAccount('./service-account.json');
 await firestore.rules.deploy(scope, `rules_version = '2';
@@ -135,6 +135,6 @@ There's no proxy, no wrapper, no overhead. The package is mostly the dispatch la
 
 ## Where to go next
 
-- For deploying rules to prod, see [`@pyric/deploy`'s firestore namespace](../../../deploy/docs/reference/firestore-namespace.md).
+- For deploying rules to prod, see [`pyric-tools/deploy`'s firestore namespace](../../../../pyric-tools/docs/deploy/reference/firestore-namespace.md).
 - For why the two-backend story works, see [Why two backends behind one surface](../explanation/two-backends-one-surface.md).
 - For a real migration from `firebase/firestore`, see [Migrate from `firebase/firestore`](../how-to/migrate-from-firebase-firestore.md).

--- a/packages/pyric/docs/rules/README.md
+++ b/packages/pyric/docs/rules/README.md
@@ -1,4 +1,4 @@
-# `pyric/firestore-rules`
+# `pyric/rules`
 
 Pyric-native Firestore Security Rules tooling. A browser-safe parser, linter, modules resolver, in-process simulator, and Rules Test API client — packaged so the data-plane swap-in (`pyric/firestore`) stays minimal.
 
@@ -12,14 +12,14 @@ The surface is grouped around the things you can do with a rules source:
 - **Test** it against the live Firebase Rules Test API.
 - **Wrap** it in agent-tool factories for `@inbrowser/agent` registries.
 
-Parse, Lint, Validate, Simulate, and Test are on the browser-safe root entry. **Resolve** and **Wrap** are Node-only and live on the `pyric/firestore-rules/node` subpath — `resolveModules`, `createFirestoreRulesTools`, and `createFirestoreSimulatorTools` are not exported from the root.
+Parse, Lint, Validate, Simulate, and Test are on the browser-safe root entry. **Resolve** and **Wrap** are Node-only and live on the `pyric/rules/node` subpath — `resolveModules`, `createFirestoreRulesTools`, and `createFirestoreSimulatorTools` are not exported from the root.
 
 ## Install
 
 ```bash
-bun add pyric/firestore-rules
+bun add pyric
 # or
-npm install pyric/firestore-rules
+npm install pyric
 ```
 
 ## A 30-second example
@@ -28,7 +28,7 @@ npm install pyric/firestore-rules
 import {
   lintFirestoreRules,
   SimulateFirestoreRulesHandler,
-} from 'pyric/firestore-rules';
+} from 'pyric/rules';
 
 const source = `rules_version = '2';
 service cloud.firestore {
@@ -64,7 +64,7 @@ import {
   resolveModules,
   createFirestoreRulesTools,
   createFirestoreSimulatorTools,
-} from 'pyric/firestore-rules/node';
+} from 'pyric/rules/node';
 ```
 
 ## Where to go next
@@ -87,7 +87,7 @@ Documentation is organised under [`docs/`](./docs/) following the [Diataxis](htt
 
 ## Position in the Pyric stack
 
-`pyric/firestore-rules` is the **rules-tooling** sibling of `pyric/firestore` (the modular Web-SDK swap-in). The split is deliberate: the data-plane swap-in must mirror the production Firestore surface and nothing more. Anything that is *about* rules — parsing them, linting them, simulating them — lives here. See [Why this package exists](./docs/explanation/why-this-package-exists.md) for the longer story.
+`pyric/rules` is the **rules-tooling** sibling of `pyric/firestore` (the modular Web-SDK swap-in). The split is deliberate: the data-plane swap-in must mirror the production Firestore surface and nothing more. Anything that is *about* rules — parsing them, linting them, simulating them — lives here. See [Why this package exists](./docs/explanation/why-this-package-exists.md) for the longer story.
 
 ## Licence
 

--- a/packages/pyric/docs/rules/explanation/runtime-budget-and-shared-gates.md
+++ b/packages/pyric/docs/rules/explanation/runtime-budget-and-shared-gates.md
@@ -70,6 +70,6 @@ A separate hard limit applies to document reads from rules — `get(...)` and `e
 
 ## Why the linter sometimes blocks the deploy
 
-Most lint warnings are advisory. A handful are not — `SOURCE_SIZE`, `CHAIN_DEPTH` (above the band), `LET_LIMIT`, `GET_COUNT` (above 10), `PERMISSIVE_RULE`, `RECURSIVE_WILDCARD_OPEN`, `HALLUCINATED_METHOD`, `INVALID_OPERATOR`. The `@pyric/deploy` path refuses to swap a ruleset that contains any `severity: 'error'` warning. The choice is deliberate: these are the categories where the cost of shipping the bad rule is high (a deploy that fails compilation; a publicly-readable database) and the cost of demanding a fix is low (the linter tells you exactly what's wrong).
+Most lint warnings are advisory. A handful are not — `SOURCE_SIZE`, `CHAIN_DEPTH` (above the band), `LET_LIMIT`, `GET_COUNT` (above 10), `PERMISSIVE_RULE`, `RECURSIVE_WILDCARD_OPEN`, `HALLUCINATED_METHOD`, `INVALID_OPERATOR`. The `pyric-tools/deploy` path refuses to swap a ruleset that contains any `severity: 'error'` warning. The choice is deliberate: these are the categories where the cost of shipping the bad rule is high (a deploy that fails compilation; a publicly-readable database) and the cost of demanding a fix is low (the linter tells you exactly what's wrong).
 
 `RULES_WEAKENED` is `warning`, not `error`. There are legitimate reasons to remove a predicate — a refactor, a dedupe, an intentional broadening. The signal is "review this", not "block the deploy".

--- a/packages/pyric/docs/rules/explanation/the-2-plus-modules-extension.md
+++ b/packages/pyric/docs/rules/explanation/the-2-plus-modules-extension.md
@@ -50,7 +50,7 @@ This is deliberate. We did not want to extend the rules language in any way that
 6. **Rewrite** the version to `'2'` and clear the import list.
 7. **Assemble** the AST back to a rules source string.
 
-The output is a standard `'2'` rules source with the imports gone and the relevant helpers inlined. You feed that to `firebase deploy` (or to `@pyric/deploy`'s release primitive) and Firebase is none the wiser.
+The output is a standard `'2'` rules source with the imports gone and the relevant helpers inlined. You feed that to `firebase deploy` (or to `pyric-tools/deploy`'s release primitive) and Firebase is none the wiser.
 
 ## Why prefix only private functions
 

--- a/packages/pyric/docs/rules/explanation/value-wrappers-design.md
+++ b/packages/pyric/docs/rules/explanation/value-wrappers-design.md
@@ -73,7 +73,7 @@ The handler resolves every `{ __type: 'serverTimestamp' }` sentinel in your test
 
 The sandbox in `pyric/sandbox` also needs `Timestamp`, `Vector`, `Reference` — when it reads a document containing a timestamp field, it needs to return a `Timestamp` instance that `instanceof Timestamp` is true for. If the wrapper classes lived in the sandbox, the rules simulator couldn't use them without depending on the sandbox; if they lived in both packages, `instanceof Timestamp` would lie depending on which copy was imported.
 
-The wrappers live in `pyric/firestore-rules` because:
+The wrappers live in `pyric/rules` because:
 
 - This is the package that defines what `is timestamp` means.
 - This is the package that evaluates expressions, which is where most wrapper code is exercised.

--- a/packages/pyric/docs/rules/explanation/why-this-package-exists.md
+++ b/packages/pyric/docs/rules/explanation/why-this-package-exists.md
@@ -4,7 +4,7 @@ Firestore Security Rules is a small DSL that sits between every read and write y
 
 1. A **data-plane** for the app code — `getDoc`, `setDoc`, `onSnapshot`, the modular Web SDK shape — that can be swapped between production Firestore and an in-process sandbox. This lives in `pyric/firestore`.
 
-2. **Tooling around the rules themselves** — parsing them, linting them, simulating them, testing them. This is `pyric/firestore-rules`.
+2. **Tooling around the rules themselves** — parsing them, linting them, simulating them, testing them. This is `pyric/rules`.
 
 The split looks bureaucratic at first. Why not put both in one package? Two reasons:
 
@@ -16,7 +16,7 @@ By the time you have `lintFirestoreRules`, `SimulateFirestoreRulesHandler`, `par
 
 ## The audiences are different
 
-Most apps using `pyric/firestore` will never call any function in `pyric/firestore-rules`. The data-plane is consumed by feature code — components, hooks, server actions. The rules tooling is consumed by tooling code — CI scripts, lint hooks, deploy pipelines, agent runtimes. These audiences have different bundle-size sensitivities (a feature-code package has to pay for every dependency in every consumer's bundle; a tooling package only loads in CI) and different release cadences (the data plane changes when the Firestore Web SDK does; the rules tooling changes when we discover a new agent failure mode).
+Most apps using `pyric/firestore` will never call any function in `pyric/rules`. The data-plane is consumed by feature code — components, hooks, server actions. The rules tooling is consumed by tooling code — CI scripts, lint hooks, deploy pipelines, agent runtimes. These audiences have different bundle-size sensitivities (a feature-code package has to pay for every dependency in every consumer's bundle; a tooling package only loads in CI) and different release cadences (the data plane changes when the Firestore Web SDK does; the rules tooling changes when we discover a new agent failure mode).
 
 A clean split lets each side evolve at its own speed without burdening the other.
 
@@ -36,8 +36,8 @@ Anything *about* rules:
 
 ## What stays out
 
-The Firestore Web SDK surface stays in `pyric/firestore`. The control-plane primitives (deploy, scope) stay in `@pyric/deploy`. The sandbox itself (the `LocalEnvironment` that holds documents and listeners) stays in `pyric/sandbox`. These three packages and this one form a loose hexagon: data plane, rules tooling, control plane, sandbox. Each depends on a small surface of the others; none of them depends on a kitchen-sink package.
+The Firestore Web SDK surface stays in `pyric/firestore`. The control-plane primitives (deploy, scope) stay in `pyric-tools/deploy`. The sandbox itself (the `LocalEnvironment` that holds documents and listeners) stays in `pyric/sandbox`. These three packages and this one form a loose hexagon: data plane, rules tooling, control plane, sandbox. Each depends on a small surface of the others; none of them depends on a kitchen-sink package.
 
 ## Tradeoffs
 
-The cost of the split is duplication risk: a value wrapper used by both the sandbox (for type coercion at read-time) and the rules simulator (for expression evaluation) has to live in exactly one of the two packages — and the other has to import it. We chose to put the wrappers here because the rules simulator is the source of truth for "what does Firestore think this value is". The sandbox imports `Timestamp`, `Vector`, `Reference` from `pyric/firestore-rules` as a result, which creates a runtime cycle in workspace terms. The cycle is benign at build time (the two packages export non-overlapping symbols and TypeScript handles the resolution), but it does mean both have to be built in a specific order. We accepted that complexity over the alternative of either (a) duplicating the wrapper classes — which would make `instanceof Timestamp` start lying — or (b) shipping a third `pyric/firestore-values` package — which would split the wrappers from their evaluator and make the evaluation logic harder to reason about.
+The cost of the split is duplication risk: a value wrapper used by both the sandbox (for type coercion at read-time) and the rules simulator (for expression evaluation) has to live in exactly one of the two packages — and the other has to import it. We chose to put the wrappers here because the rules simulator is the source of truth for "what does Firestore think this value is". The sandbox imports `Timestamp`, `Vector`, `Reference` from `pyric/rules` as a result, which creates a runtime cycle in workspace terms. The cycle is benign at build time (the two packages export non-overlapping symbols and TypeScript handles the resolution), but it does mean both have to be built in a specific order. We accepted that complexity over the alternative of either (a) duplicating the wrapper classes — which would make `instanceof Timestamp` start lying — or (b) shipping a third `pyric/firestore-values` package — which would split the wrappers from their evaluator and make the evaluation logic harder to reason about.

--- a/packages/pyric/docs/rules/how-to/compare-rulesets-for-weakening.md
+++ b/packages/pyric/docs/rules/how-to/compare-rulesets-for-weakening.md
@@ -7,7 +7,7 @@ When you ship a rules change, the most dangerous mistake is silently removing a 
 Pass the previously-deployed source as `options.previousSource`:
 
 ```ts
-import { lintFirestoreRules } from 'pyric/firestore-rules';
+import { lintFirestoreRules } from 'pyric/rules';
 
 const result = lintFirestoreRules(newSource, { previousSource: oldSource });
 
@@ -48,7 +48,7 @@ Then in your check script:
 
 ```ts
 import { readFileSync } from 'node:fs';
-import { lintFirestoreRules } from 'pyric/firestore-rules';
+import { lintFirestoreRules } from 'pyric/rules';
 
 const previousSource = readFileSync('previous.rules', 'utf-8');
 const newSource = readFileSync('firestore.rules', 'utf-8');

--- a/packages/pyric/docs/rules/how-to/inspect-rules-via-the-ast.md
+++ b/packages/pyric/docs/rules/how-to/inspect-rules-via-the-ast.md
@@ -7,7 +7,7 @@ This guide shows you how to parse rules into a typed AST and walk the tree for c
 `parseToASTOrError` returns either the AST or a structured failure. Use it when you want a diagnostic on parse failure:
 
 ```ts
-import { parseToASTOrError } from 'pyric/firestore-rules';
+import { parseToASTOrError } from 'pyric/rules';
 
 const result = parseToASTOrError(source);
 if (!result.ok) {
@@ -20,7 +20,7 @@ const ast = result.ast;
 When `null` is sufficient signal:
 
 ```ts
-import { parseToAST } from 'pyric/firestore-rules';
+import { parseToAST } from 'pyric/rules';
 
 const ast = parseToAST(source);
 if (!ast) throw new Error('parse failed');
@@ -31,7 +31,7 @@ if (!ast) throw new Error('parse failed');
 `FirestoreRules.service.match` is the root match (always `/databases/{db}/documents`). Walk its `children` recursively to enumerate every nested match block:
 
 ```ts
-import type { MatchBlock } from 'pyric/firestore-rules';
+import type { MatchBlock } from 'pyric/rules';
 
 function walk(block: MatchBlock, parentPath = ''): void {
   const path = parentPath + block.path.raw;
@@ -67,7 +67,7 @@ for (const seg of block.path.segments) {
 `Expression` is a discriminated union. The discriminator is `type`:
 
 ```ts
-import type { Expression } from 'pyric/firestore-rules';
+import type { Expression } from 'pyric/rules';
 
 function walkExpr(expr: Expression, visit: (e: Expression) => void): void {
   visit(expr);
@@ -95,7 +95,7 @@ See [AST reference](../reference/ast.md) for every node shape.
 If your custom checks overlap with security or quality concerns, run the bundled validator and union the findings into your output:
 
 ```ts
-import { validateFirestoreRules } from 'pyric/firestore-rules';
+import { validateFirestoreRules } from 'pyric/rules';
 
 const findings = validateFirestoreRules(ast);
 for (const f of findings) {
@@ -110,7 +110,7 @@ The validator covers public-write detection, default-deny audit, duplicate funct
 Useful for editor pop-ups or function-level lint hooks:
 
 ```ts
-import { parseFunctions } from 'pyric/firestore-rules';
+import { parseFunctions } from 'pyric/rules';
 
 const fns = parseFunctions(`
   function isAdmin() { return request.auth.token.role == 'admin'; }

--- a/packages/pyric/docs/rules/how-to/lint-rules-source.md
+++ b/packages/pyric/docs/rules/how-to/lint-rules-source.md
@@ -5,7 +5,7 @@ This guide shows you how to lint a Firestore rules source and act on the result.
 ## Lint a string
 
 ```ts
-import { lintFirestoreRules } from 'pyric/firestore-rules';
+import { lintFirestoreRules } from 'pyric/rules';
 
 const result = lintFirestoreRules(source);
 ```
@@ -32,7 +32,7 @@ Pre-parse syntax hints (JS-isms like `===`, `?.`, `??`, backtick strings) fire e
 
 ## Block deploys on errors only
 
-`warnings` mixes severities. The deploy path in `@pyric/deploy` refuses to swap a ruleset when any warning has `severity: 'error'`. Mirror that behaviour:
+`warnings` mixes severities. The deploy path in `pyric-tools/deploy` refuses to swap a ruleset when any warning has `severity: 'error'`. Mirror that behaviour:
 
 ```ts
 const errors = result.warnings.filter((w) => w.severity === 'error');

--- a/packages/pyric/docs/rules/how-to/pin-request-time.md
+++ b/packages/pyric/docs/rules/how-to/pin-request-time.md
@@ -36,7 +36,7 @@ The same ISO string is forwarded to the Firebase Rules Test API when you run via
 Pass the test suite to the linter and look for `REQUEST_TIME_NOT_PINNED`:
 
 ```ts
-import { lintFirestoreRules } from 'pyric/firestore-rules';
+import { lintFirestoreRules } from 'pyric/rules';
 
 const result = lintFirestoreRules(source, { testCases });
 const unpinned = result.warnings.filter((w) => w.rule === 'REQUEST_TIME_NOT_PINNED');

--- a/packages/pyric/docs/rules/how-to/register-tools-with-an-agent.md
+++ b/packages/pyric/docs/rules/how-to/register-tools-with-an-agent.md
@@ -7,7 +7,7 @@ This guide shows you how to expose the rules surface as tool handlers for an `@i
 `createFirestoreRulesTools()` returns three handlers:
 
 ```ts
-import { createFirestoreRulesTools } from 'pyric/firestore-rules';
+import { createFirestoreRulesTools } from 'pyric/rules/node';
 import { createToolRegistry } from '@inbrowser/agent';
 
 const registry = createToolRegistry();
@@ -26,7 +26,7 @@ These are pure-local: no network, no credentials, safe to expose anywhere.
 Pass a `ProjectScope` and a fourth handler appears: `firestore_test_rules`, which calls Google's Rules Test API.
 
 ```ts
-import { fromServiceAccount } from '@pyric/deploy';
+import { fromServiceAccount } from 'pyric-tools/deploy';
 
 const scope = await fromServiceAccount('./service-account.json');
 
@@ -70,7 +70,7 @@ The `ToolResult` shape is uniform across handlers: `{ ok, summary, data }`. Look
 `createFirestoreSimulatorTools({ resolveSandbox })` is the entry point for the seven-tool simulator family that operates against a session-scoped `LocalEnvironment` from `pyric/sandbox`. It currently returns an empty array — the full implementation lands as consumers ask for it. The factory shape and dependency contract are stable; only the handlers are pending.
 
 ```ts
-import { createFirestoreSimulatorTools } from 'pyric/firestore-rules';
+import { createFirestoreSimulatorTools } from 'pyric/rules/node';
 
 // Today: returns [] — placeholder
 const tools = createFirestoreSimulatorTools({

--- a/packages/pyric/docs/rules/how-to/resolve-module-imports.md
+++ b/packages/pyric/docs/rules/how-to/resolve-module-imports.md
@@ -30,7 +30,7 @@ service cloud.firestore {
 ## Resolve to standard rules
 
 ```ts
-import { resolveModules } from 'pyric/firestore-rules';
+import { resolveModules } from 'pyric/rules/node';
 
 const result = resolveModules(source);
 if (!result.success) {

--- a/packages/pyric/docs/rules/how-to/simulate-rules-locally.md
+++ b/packages/pyric/docs/rules/how-to/simulate-rules-locally.md
@@ -8,7 +8,7 @@ This guide shows you how to evaluate Firestore rules in-process against a list o
 import {
   SimulateFirestoreRulesHandler,
   type TestCase,
-} from 'pyric/firestore-rules';
+} from 'pyric/rules';
 
 const handler = new SimulateFirestoreRulesHandler();
 const result = handler.simulate(source, testCases);

--- a/packages/pyric/docs/rules/how-to/test-rules-against-firebase.md
+++ b/packages/pyric/docs/rules/how-to/test-rules-against-firebase.md
@@ -6,10 +6,10 @@ The Rules Test API does not deploy the rules — it evaluates them against your 
 
 ## You need a `ProjectScope`
 
-`TestFirestoreRulesHandler.execute` takes a `ProjectScope` from `@pyric/deploy` — a `{ projectId, resolveToken }` pair. Build it from a service-account file:
+`TestFirestoreRulesHandler.execute` takes a `ProjectScope` from `pyric-tools/deploy` — a `{ projectId, resolveToken }` pair. Build it from a service-account file:
 
 ```ts
-import { fromServiceAccount } from '@pyric/deploy';
+import { fromServiceAccount } from 'pyric-tools/deploy';
 
 const scope = await fromServiceAccount('./service-account.json');
 ```
@@ -17,7 +17,7 @@ const scope = await fromServiceAccount('./service-account.json');
 Or build one by hand from any OAuth source — for example, the current Firebase Auth user in a browser host:
 
 ```ts
-import type { ProjectScope } from '@pyric/deploy';
+import type { ProjectScope } from 'pyric-tools/deploy';
 
 const scope: ProjectScope = {
   projectId: 'your-project-id',
@@ -31,7 +31,7 @@ const scope: ProjectScope = {
 import {
   TestFirestoreRulesHandler,
   type TestCase,
-} from 'pyric/firestore-rules';
+} from 'pyric/rules';
 
 const handler = new TestFirestoreRulesHandler();
 const result = await handler.execute(scope, source, testCases);
@@ -69,7 +69,7 @@ Two common patterns:
 import {
   SimulateFirestoreRulesHandler,
   TestFirestoreRulesHandler,
-} from 'pyric/firestore-rules';
+} from 'pyric/rules';
 
 const sim = new SimulateFirestoreRulesHandler();
 const local = sim.simulate(source, testCases);
@@ -101,5 +101,5 @@ Each `execute` call is one HTTP round-trip plus rule evaluation on Google's serv
 ## Where to look next
 
 - For the tradeoffs between local and live evaluation, see [Simulator vs Rules Test API](../explanation/simulator-vs-rules-test-api.md).
-- For the `ProjectScope` contract and `fromServiceAccount`, see the [`@pyric/deploy` package](../../../deploy/README.md).
+- For the `ProjectScope` contract and `fromServiceAccount`, see the [`pyric-tools/deploy` package](../../../../pyric-tools/docs/deploy/README.md).
 - For all error codes the handler can return, see [Errors](../reference/errors.md).

--- a/packages/pyric/docs/rules/reference/api.md
+++ b/packages/pyric/docs/rules/reference/api.md
@@ -1,6 +1,6 @@
 # Public API
 
-This page describes every symbol re-exported from `pyric/firestore-rules`. Symbols are grouped by submodule and listed alphabetically within each group.
+This page describes every symbol re-exported from `pyric/rules`. Symbols are grouped by submodule and listed alphabetically within each group.
 
 ## Parser and AST
 
@@ -142,7 +142,7 @@ Calls Google's Firebase Rules Test API.
 
 - `execute(scope: ProjectScope, source: string, testCases: TestCase[]): Promise<TestFirestoreRulesResult>`
 
-`ProjectScope` comes from `@pyric/deploy`.
+`ProjectScope` comes from `pyric-tools/deploy`.
 
 ### Types
 

--- a/packages/pyric/docs/rules/reference/ast.md
+++ b/packages/pyric/docs/rules/reference/ast.md
@@ -1,6 +1,6 @@
 # AST
 
-The AST is the typed tree produced by `parseToAST` / `parseToASTOrError`. Every shape is exported from `pyric/firestore-rules`.
+The AST is the typed tree produced by `parseToAST` / `parseToASTOrError`. Every shape is exported from `pyric/rules`.
 
 ## Root: `FirestoreRules`
 

--- a/packages/pyric/docs/rules/reference/lint-rules.md
+++ b/packages/pyric/docs/rules/reference/lint-rules.md
@@ -4,7 +4,7 @@ This page lists every lint rule emitted by `lintFirestoreRules`. Each entry give
 
 Severities have two values:
 
-- `error` — blocks deploys in `@pyric/deploy`.
+- `error` — blocks deploys in `pyric-tools/deploy`.
 - `warning` — advisory; does not block.
 
 Some rules adjust severity by threshold band; those entries note the bands explicitly.

--- a/packages/pyric/docs/rules/reference/stdlib-modules.md
+++ b/packages/pyric/docs/rules/reference/stdlib-modules.md
@@ -1,6 +1,6 @@
 # Standard library modules
 
-Fifteen modules ship with `pyric/firestore-rules`. Each module is a `.rules` file living under `src/rules/modules/stdlib/`; imports resolve automatically without any configuration.
+Fifteen modules ship with `pyric/rules`. Each module is a `.rules` file living under `src/rules/modules/stdlib/`; imports resolve automatically without any configuration.
 
 Use them by setting `rules_version = '2+modules'` and adding import statements:
 

--- a/packages/pyric/docs/rules/reference/test-case-schema.md
+++ b/packages/pyric/docs/rules/reference/test-case-schema.md
@@ -93,7 +93,7 @@ type WriteMode =
 When your write payload contains a server-timestamp sentinel — exactly `{ __type: 'serverTimestamp' }` — the simulator resolves every occurrence to the same `Timestamp` instance (matching `request.time`). Use the exported `SERVER_TIMESTAMP` constant for clarity:
 
 ```ts
-import { SERVER_TIMESTAMP } from 'pyric/firestore-rules';
+import { SERVER_TIMESTAMP } from 'pyric/rules';
 
 const tc: TestCase = {
   description: 'create stamps createdAt = request.time',
@@ -111,7 +111,7 @@ The single-instance invariant matters because `data.createdAt == request.time` s
 ## Validation
 
 ```ts
-import { TestCaseSchema } from 'pyric/firestore-rules';
+import { TestCaseSchema } from 'pyric/rules';
 
 const parsed = TestCaseSchema.parse(input);  // throws on schema mismatch
 ```

--- a/packages/pyric/docs/rules/tutorials/01-lint-your-first-rules-file.md
+++ b/packages/pyric/docs/rules/tutorials/01-lint-your-first-rules-file.md
@@ -1,6 +1,6 @@
 # Lint your first rules file
 
-In this tutorial you will install `pyric/firestore-rules`, write a small rules file with a deliberate problem in it, and use the linter to find that problem. By the end you will have seen the parse → lint cycle end-to-end, and you will know what a `LintWarning` looks like in practice.
+In this tutorial you will install `pyric/rules`, write a small rules file with a deliberate problem in it, and use the linter to find that problem. By the end you will have seen the parse → lint cycle end-to-end, and you will know what a `LintWarning` looks like in practice.
 
 This tutorial assumes you have Node.js 18+ or Bun 1.x available. No Firebase project is required — everything runs in-process.
 
@@ -18,10 +18,10 @@ cd rules-lint-tutorial
 bun init -y
 ```
 
-Add `pyric/firestore-rules`:
+Add `pyric/rules`:
 
 ```bash
-bun add pyric/firestore-rules
+bun add pyric/rules
 ```
 
 You now have a working project. Let's write a rules file.
@@ -61,7 +61,7 @@ Create a file called `lint.ts`:
 
 ```ts
 import { readFileSync } from 'node:fs';
-import { lintFirestoreRules } from 'pyric/firestore-rules';
+import { lintFirestoreRules } from 'pyric/rules';
 
 const source = readFileSync('./firestore.rules', 'utf-8');
 const result = lintFirestoreRules(source);

--- a/packages/pyric/docs/rules/tutorials/02-write-a-test-suite-for-your-rules.md
+++ b/packages/pyric/docs/rules/tutorials/02-write-a-test-suite-for-your-rules.md
@@ -46,7 +46,7 @@ import { readFileSync } from 'node:fs';
 import {
   SimulateFirestoreRulesHandler,
   type TestCase,
-} from 'pyric/firestore-rules';
+} from 'pyric/rules';
 
 const source = readFileSync('./firestore.rules', 'utf-8');
 

--- a/packages/pyric/docs/sandbox/README.md
+++ b/packages/pyric/docs/sandbox/README.md
@@ -62,7 +62,7 @@ Documentation is organised under [`docs/`](./docs/) following the [Diataxis](htt
 
 ## Position in the Pyric stack
 
-`pyric/sandbox` is the **runtime substrate**. It does not depend on `pyric-admin`, `pyric/firestore`, or any other adapter — they depend on it. Rules tooling lives in `pyric/firestore-rules` (imported by the sandbox for `SimulateFirestoreRulesHandler`). Control-plane operations live in `@pyric/deploy`. See [Why this package exists](./docs/explanation/why-this-package-exists.md).
+`pyric/sandbox` is the **runtime substrate**. It does not depend on `pyric-admin`, `pyric/firestore`, or any other adapter — they depend on it. Rules tooling lives in `pyric/rules` (imported by the sandbox for `SimulateFirestoreRulesHandler`). Control-plane operations live in `pyric-tools/deploy`. See [Why this package exists](./docs/explanation/why-this-package-exists.md).
 
 ## Licence
 

--- a/packages/pyric/docs/sandbox/explanation/every-op-is-a-request.md
+++ b/packages/pyric/docs/sandbox/explanation/every-op-is-a-request.md
@@ -151,7 +151,7 @@ A few things in this v1 shape that we'd reconsider once consumers exist:
 
 - **Inner per-doc filter visibility.** Opt-in flag for the "why was doc X filtered out" use case.
 - **Transaction reads.** Plumb the transaction read path through the request channel.
-- **Rule source positions.** `matchedRule.line` and `matchedRule.column` — requires upstream AST work in `pyric/firestore-rules`. The biggest single ergonomic win available, and the most invasive.
+- **Rule source positions.** `matchedRule.line` and `matchedRule.column` — requires upstream AST work in `pyric/rules`. The biggest single ergonomic win available, and the most invasive.
 - **`getCalls` runtime tracing.** If a consumer says "I need to see the actual paths the rule visited," this is mechanical to add — patch the simulator's `resolveGet` to thread an array through `SimulationContext`. Currently skipped because no consumer asked.
 
 None of these are blocking. They're notes for when someone needs them.

--- a/packages/pyric/docs/sandbox/explanation/why-adapters-are-siblings.md
+++ b/packages/pyric/docs/sandbox/explanation/why-adapters-are-siblings.md
@@ -60,16 +60,16 @@ This is what makes "the substrate is shared" workable. Both adapters bottom out 
 | `LocalEnvironment` (raw substrate) | `pyric/sandbox/internal` |
 | Admin-SDK-shaped Firestore API | `pyric-admin` |
 | Modular Web SDK-shaped Firestore API | `pyric/firestore` |
-| Rules parser, linter, simulator | `pyric/firestore-rules` |
-| Deploy primitives (rules, indexes, hosting, functions) | `@pyric/deploy` |
+| Rules parser, linter, simulator | `pyric/rules` |
+| Deploy primitives (rules, indexes, hosting, functions) | `pyric-tools/deploy` |
 
 The rule of thumb: anything *shape-agnostic* (the data, the rules, the lifecycle) lives in the substrate; anything *shape-specific* lives in an adapter.
 
 ## The runtime cycle
 
-`pyric/sandbox` imports the rules simulator from `pyric/firestore-rules`. `pyric/firestore-rules` imports `LocalEnvironment` (type-only) from `pyric/sandbox/internal`. This is a workspace cycle.
+`pyric/sandbox` imports the rules simulator from `pyric/rules`. `pyric/rules` imports `LocalEnvironment` (type-only) from `pyric/sandbox/internal`. This is a module cycle inside the package graph.
 
-The cycle is benign: the import from `firestore-rules` into `sandbox` is value (the `SimulateFirestoreRulesHandler` class and a handful of wrappers); the import from `sandbox` back into `firestore-rules` is type-only (the `LocalEnvironment` interface for `createFirestoreSimulatorTools`'s `resolveSandbox` dep). The two packages have to build in a specific order, but neither is in the other's runtime call graph beyond what's documented.
+The cycle is benign: the import from `pyric/rules` into `pyric/sandbox` is value (the `SimulateFirestoreRulesHandler` class and a handful of wrappers); the import from `pyric/sandbox` back into `pyric/rules` is type-only (the `LocalEnvironment` interface for `createFirestoreSimulatorTools`'s `resolveSandbox` dep). Neither side is in the other's runtime call graph beyond what's documented.
 
 We accepted the cycle because the alternative — duplicating wrapper classes in both packages — would make `instanceof Timestamp` start lying depending on which copy was imported. The substrate consuming the simulator's wrapper types is the canonical path.
 
@@ -84,6 +84,6 @@ The same pattern extends to other services. Hypothetical `pyric/auth` would:
 
 The substrate would need a multi-service split inside `LocalEnvironment` (currently Firestore-only) and the adapter would slot in.
 
-Same for `pyric/database` (Realtime Database) and `pyric/storage` (Cloud Storage). `pyric/storage` already exists for the storage data plane; its admin surface (CORS, bucket lifecycle) will eventually land in `@pyric/deploy`.
+Same for `pyric/database` (Realtime Database) and `pyric/storage` (Cloud Storage). `pyric/storage` already exists for the storage data plane; its admin surface (CORS, bucket lifecycle) will eventually land in `pyric-tools/deploy`.
 
 The point of the sibling-package shape is that each new adapter is a contained addition. Nobody who already uses `pyric-admin` cares when `pyric/database` lands; the substrate gets a new service slot but the existing adapter surface doesn't move.

--- a/packages/pyric/docs/sandbox/explanation/why-this-package-exists.md
+++ b/packages/pyric/docs/sandbox/explanation/why-this-package-exists.md
@@ -24,14 +24,14 @@ For each of these, `pyric/sandbox` is the alternative. In-process, browser-safe,
 A re-implementation of the data + rules portion of Firestore, in TypeScript, sized to fit the agent / playground / unit-test use cases:
 
 - The document store is an in-memory `LocalState` map.
-- The rules engine is `pyric/firestore-rules`' `SimulateFirestoreRulesHandler` — also browser-safe.
+- The rules engine is `pyric/rules`' `SimulateFirestoreRulesHandler` — also browser-safe.
 - The transaction system tracks reads and writes per-tx, detects read-after-write violations, projects post-write state for `getAfter()`.
 - Snapshot listeners are first-class: doc and query listeners both implemented, including the production behaviour where stream errors silently terminate the listener.
 - Field-value sentinels (`increment`, `serverTimestamp`, `arrayUnion`) are honoured by the rules engine and the data plane.
 
 What it isn't:
 
-- It isn't bit-for-bit production. The simulator has gaps (some namespace methods on wrapper types aren't modelled yet). It returns `'unsupported'` on those, distinct from `'denied'` — see the `UnsupportedError` discussion in `pyric/firestore-rules`.
+- It isn't bit-for-bit production. The simulator has gaps (some namespace methods on wrapper types aren't modelled yet). It returns `'unsupported'` on those, distinct from `'denied'` — see the `UnsupportedError` discussion in `pyric/rules`.
 - It isn't a network. There's no transport, no quota, no concurrent-connection model. Tests that need to exercise transport-level error codes (`'unavailable'`, `'aborted'` from contention) belong on the emulator or live Firestore.
 - It isn't multi-service yet. Firestore is the only data plane today. Auth state is modelled (because rules need it) but no Auth API is exposed. Realtime Database, Storage, and Functions emulation are out of scope.
 

--- a/packages/pyric/docs/sandbox/how-to/reset-between-tests.md
+++ b/packages/pyric/docs/sandbox/how-to/reset-between-tests.md
@@ -76,7 +76,7 @@ Resubscribing on every reset works too, but isn't required.
 
 Where parallel tests *do* need care:
 
-- **Shared resources** (a single Firebase project, a single set of credentials) — sandboxes don't talk to Firebase, so this is rare. Only relevant if your tests also exercise `@pyric/deploy` or other live-cloud surfaces.
+- **Shared resources** (a single Firebase project, a single set of credentials) — sandboxes don't talk to Firebase, so this is rare. Only relevant if your tests also exercise `pyric-tools/deploy` or other live-cloud surfaces.
 - **Shared output streams** — log noise from one test can confuse another's assertions if both subscribe to the same console. Subscribers are per-sandbox, so this doesn't happen automatically; only worry about it if you wire global logging.
 
 ## What `reset` does *not* do

--- a/packages/pyric/docs/sandbox/how-to/seed-data-and-rules.md
+++ b/packages/pyric/docs/sandbox/how-to/seed-data-and-rules.md
@@ -73,7 +73,7 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 }
 ```
 
-`seed` returns the `LintResult` from `pyric/firestore-rules`. Check it before treating the seed as successful — a ruleset with errors leaves the sandbox in default-deny.
+`seed` returns the `LintResult` from `pyric/rules`. Check it before treating the seed as successful — a ruleset with errors leaves the sandbox in default-deny.
 
 `/internal` is documented as adapter-only. Tooling that uses it accepts that the surface may change between minor versions.
 
@@ -118,5 +118,5 @@ Rules first, then documents. If you write documents before rules, the writes eva
 
 ## Where to look next
 
-- For rules linting and the lint result shape, see [`pyric/firestore-rules`](../../../firestore-rules/docs/reference/lint-rules.md).
+- For rules linting and the lint result shape, see [`pyric/rules`](../../rules/reference/lint-rules.md).
 - For resetting between tests, see [Reset between tests](./reset-between-tests.md).

--- a/packages/pyric/docs/sandbox/reference/api.md
+++ b/packages/pyric/docs/sandbox/reference/api.md
@@ -130,4 +130,4 @@ The concrete `SandboxContext` class. Exported so service factories can `instance
 
 - `LocalEnvironment` and other adapter primitives live at `pyric/sandbox/internal`. See [The `/internal` adapter protocol](./internal-protocol.md).
 - Data-plane APIs (`getDoc`, `setDoc`, `collection`, transactions, etc.) live in `pyric-admin` and `pyric/firestore`.
-- Rules tooling (parser, linter, simulator) lives in `pyric/firestore-rules`.
+- Rules tooling (parser, linter, simulator) lives in `pyric/rules`.

--- a/packages/pyric/docs/sandbox/reference/error-codes.md
+++ b/packages/pyric/docs/sandbox/reference/error-codes.md
@@ -73,7 +73,7 @@ These don't have a production analog. They exist so callers can distinguish "the
 
 ### `'unimplemented'`
 
-The sandbox doesn't yet model a feature your rule uses. Returned from the simulator's `UnsupportedError` channel surfaced through this code. For most agent workflows the right response is to route the offending case to the live Firebase Rules Test API — see [`pyric/firestore-rules`](../../../firestore-rules/docs/explanation/simulator-vs-rules-test-api.md).
+The sandbox doesn't yet model a feature your rule uses. Returned from the simulator's `UnsupportedError` channel surfaced through this code. For most agent workflows the right response is to route the offending case to the live Firebase Rules Test API — see [`pyric/rules`](../../rules/explanation/simulator-vs-rules-test-api.md).
 
 ### `'not-seeded'`
 

--- a/packages/pyric/docs/sandbox/reference/sandbox-and-context.md
+++ b/packages/pyric/docs/sandbox/reference/sandbox-and-context.md
@@ -113,7 +113,7 @@ type AuthState =
 - `{ uid }` → authenticated; `request.auth.uid` carries the value.
 - `{ uid, token }` → authenticated with custom claims; `request.auth.token.<key>` carries each entry.
 
-The same shape feeds the rules simulator's `TestCase.auth` field (`pyric/firestore-rules`), so test data written against one surface works with the other.
+The same shape feeds the rules simulator's `TestCase.auth` field (`pyric/rules`), so test data written against one surface works with the other.
 
 ## Lifecycle in pictures
 

--- a/packages/pyric/docs/sandbox/reference/snapshot-and-admin.md
+++ b/packages/pyric/docs/sandbox/reference/snapshot-and-admin.md
@@ -80,7 +80,7 @@ const rooms = sandbox.admin.listDocuments('rooms');
 // ]
 ```
 
-The `phantom: true` flag lets test code distinguish "this doc was explicitly written and is empty" from "this doc exists only because something underneath it was written". The discover crawler in `pyric/firestore-rules` uses this signal to walk structure without confusing the two cases.
+The `phantom: true` flag lets test code distinguish "this doc was explicitly written and is empty" from "this doc exists only because something underneath it was written". The discover crawler in `pyric/rules` uses this signal to walk structure without confusing the two cases.
 
 ## Why this surface is on the root sandbox
 

--- a/packages/pyric/docs/storage/README.md
+++ b/packages/pyric/docs/storage/README.md
@@ -58,9 +58,9 @@ This documentation follows the [Diataxis](https://diataxis.fr/) framework:
 
 ## Position in the Pyric stack
 
-`pyric/storage` is the **storage data-plane adapter** (plus a thin control plane). It depends on `pyric/sandbox` for identity (and lifecycle on the sandbox backend), `@pyric/deploy` for the bucket-provisioning calls, and `@inbrowser/agent` for the tool-factory contract. It exposes the modular Web SDK's Storage surface. Sibling to `pyric/firestore` and `pyric-admin` on the Firestore side.
+`pyric/storage` is the **storage data-plane adapter** (plus a thin control plane). It depends on `pyric/sandbox` for identity (and lifecycle on the sandbox backend), `pyric-tools/deploy` for the bucket-provisioning calls, and `@inbrowser/agent` for the tool-factory contract. It exposes the modular Web SDK's Storage surface. Sibling to `pyric/firestore` and `pyric-admin` on the Firestore side.
 
-The package's rules engine is local to the package — Storage rules use a different DSL from Firestore rules, so unlike `pyric/firestore` (which depends on `pyric/firestore-rules`), this package keeps the Storage-specific parser and evaluator in-tree.
+The package's rules engine is local to the package — Storage rules use a different DSL from Firestore rules, so unlike `pyric/firestore` (which depends on `pyric/rules`), this package keeps the Storage-specific parser and evaluator in-tree.
 
 ## Licence
 

--- a/packages/pyric/docs/storage/explanation/session-archive-use-case.md
+++ b/packages/pyric/docs/storage/explanation/session-archive-use-case.md
@@ -51,7 +51,7 @@ These were the *real* rules used in production. Tested locally first means the e
 
 ## Why the rule engine is local to this package
 
-`pyric/firestore-rules` is a sibling-package answer to the same problem for Firestore — parse, lint, simulate. We didn't reuse it because the Storage rules grammar is different from the Firestore rules grammar. Different identifiers (`request.resource.contentType` doesn't exist in Firestore), different verbs (`read` / `write` vs `read` / `write` / `get` / `list` / `create` / `update` / `delete`), different evaluation contexts.
+`pyric/rules` is a sibling-package answer to the same problem for Firestore — parse, lint, simulate. We didn't reuse it because the Storage rules grammar is different from the Firestore rules grammar. Different identifiers (`request.resource.contentType` doesn't exist in Firestore), different verbs (`read` / `write` vs `read` / `write` / `get` / `list` / `create` / `update` / `delete`), different evaluation contexts.
 
 A separate parser + evaluator for Storage rules avoided the headache of multiplexing two grammars in one package. It also kept the rule subset small — the Storage rules v1 scope covers what session archives needed, nothing more.
 

--- a/packages/pyric/docs/storage/how-to/switch-backends.md
+++ b/packages/pyric/docs/storage/how-to/switch-backends.md
@@ -45,7 +45,7 @@ The dispatch is hidden inside each function. Same call sites; the backend choice
 
 ## What only the sandbox does
 
-- **`rules` option** at config time. Prod deploys rules separately, via `firebase deploy --only storage:rules` or `@pyric/deploy`'s control plane (when Storage admin support lands).
+- **`rules` option** at config time. Prod deploys rules separately, via `firebase deploy --only storage:rules` or `pyric-tools/deploy`'s control plane (when Storage admin support lands).
 - **`dbName` option** for IndexedDB partition. Doesn't apply on prod.
 - **Synchronous rule changes**. The sandbox enforces rules from the `rules` option immediately. Prod has propagation time.
 

--- a/packages/pyric/scripts/inline-stdlib.ts
+++ b/packages/pyric/scripts/inline-stdlib.ts
@@ -22,7 +22,7 @@
  * edits without manual remembering.
  *
  * Run:
- *   bun packages/firestore-rules/scripts/inline-stdlib.ts
+ *   bun packages/pyric/scripts/inline-stdlib.ts
  */
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';

--- a/packages/pyric/src/app/index.ts
+++ b/packages/pyric/src/app/index.ts
@@ -12,7 +12,7 @@
  *   - `initializeApp(firebaseConfig)` — prod-backed app handle (live).
  *   - Adapter dispatch (the `getFirestore(app)` etc. wrappers) is
  *     **deferred to cutover**: the adapter subpaths still re-export
- *     from `@pyric/firestore` / `@pyric/auth` / etc., which take their
+ *     from `pyric/firestore` / `pyric/auth` / etc., which take their
  *     own per-backend handles. Implementing the wrap requires hiding
  *     the existing `getFirestore` overloads behind the unified
  *     handle, which lands cleanly when source folds into
@@ -28,7 +28,7 @@ import { initializeApp as initializeFirebaseApp, type FirebaseApp, type Firebase
 /**
  * Brand symbol on every PyricApp. Adapter dispatch reads this to
  * route between sandbox and prod backends. Mirrors the
- * `TARGET_SYMBOL` pattern that `@pyric/firestore` uses internally.
+ * `TARGET_SYMBOL` pattern that `pyric/firestore` uses internally.
  */
 export const APP_TARGET = Symbol.for('pyric.app.target');
 

--- a/packages/pyric/src/auth/index.ts
+++ b/packages/pyric/src/auth/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/auth` — modular Web-SDK Auth adapter for the Pyric
+ * `pyric/auth` — modular Web-SDK Auth adapter for the Pyric
  * sandbox.
  *
  * Mirrors `firebase/auth`'s tree-shakable free-function surface
@@ -16,19 +16,19 @@
  * Same call surface across both. Agent code that writes against the
  * sandbox during iteration runs unmodified against prod at deploy.
  *
- * Dual-target dispatch follows the same pattern as `@pyric/firestore`:
+ * Dual-target dispatch follows the same pattern as `pyric/firestore`:
  *   - {@link TARGET_SYMBOL} brands every {@link Auth} handle.
  *   - {@link targetOf} (internal) reads it and switches on
  *     `target.kind`.
  *
  * Sandbox-only test driver lives under {@link sandbox}, mirroring
- * `@pyric/firestore`'s `sandbox.setRules` etc. — each method throws
+ * `pyric/firestore`'s `sandbox.setRules` etc. — each method throws
  * `failed-precondition` if called against a prod-backed handle.
  *
  * v0 scope is deliberately minimal. The deny-list is documented in
  * `docs/reference/feature-matrix.md`; agent `appSource` that imports
  * any of those will fail to bundle once the playground's
- * `firebase/auth` → `@pyric/auth` alias swap lands.
+ * `firebase/auth` → `pyric/auth` alias swap lands.
  */
 
 import { SandboxError, type Sandbox } from 'pyric/sandbox';
@@ -600,7 +600,7 @@ export async function updateProfile(
 /**
  * Sandbox-only lifecycle / test-driver surface. Throws
  * `failed-precondition` on prod-backed handles — mirrors the
- * `@pyric/firestore` `sandbox.*` pattern.
+ * `pyric/firestore` `sandbox.*` pattern.
  *
  * **Naming note:** the `sandbox` export name collides with the
  * common `const sandbox = initializeSandbox()` local. Alias on

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -1,5 +1,5 @@
 /**
- * Sandbox backend for `@pyric/auth`.
+ * Sandbox backend for `pyric/auth`.
  *
  * Owns four pieces of per-sandbox state:
  *   1. In-memory user database — emails / passwords / customClaims

--- a/packages/pyric/src/auth/target.ts
+++ b/packages/pyric/src/auth/target.ts
@@ -1,10 +1,10 @@
 /**
- * Dispatch routing for `@pyric/auth`.
+ * Dispatch routing for `pyric/auth`.
  *
  * Each {@link Auth} handle carries a hidden {@link Target} discriminator
  * via {@link TARGET_SYMBOL}. Free functions read it through
  * {@link targetOf} and switch on `target.kind`, mirroring the same
- * pattern `@pyric/firestore` uses (see
+ * pattern `pyric/firestore` uses (see
  * `packages/firestore/src/index.ts`).
  *
  * Sandbox-side state (the in-memory user DB, listener set,
@@ -47,7 +47,7 @@ export function targetOf(auth: Auth): Target {
   const t = (auth as { [TARGET_SYMBOL]?: Target })[TARGET_SYMBOL];
   if (!t) {
     throw new TypeError(
-      '@pyric/auth: unrecognized Auth handle — was it produced by getAuth(...)?',
+      'pyric/auth: unrecognized Auth handle — was it produced by getAuth(...)?',
     );
   }
   return t;

--- a/packages/pyric/src/auth/types.ts
+++ b/packages/pyric/src/auth/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public types for `@pyric/auth`. Backend-opaque shapes that mirror
+ * Public types for `pyric/auth`. Backend-opaque shapes that mirror
  * `firebase/auth`'s modular surface at the type level. Sandbox and
  * prod targets both satisfy these interfaces — consumer code stays
  * agnostic.
@@ -17,7 +17,7 @@ import type { Target } from './target.js';
  *  {@link getAuth}; consumers don't read it. Exposed only so the
  *  dispatch helpers in this package can recover routing without a
  *  WeakMap lookup. */
-export const TARGET_SYMBOL: unique symbol = Symbol('@pyric/auth/target');
+export const TARGET_SYMBOL: unique symbol = Symbol('pyric/auth/target');
 
 /**
  * Result of `getIdTokenResult()`. Mirrors the `firebase/auth` shape.

--- a/packages/pyric/src/database/host.ts
+++ b/packages/pyric/src/database/host.ts
@@ -2,7 +2,7 @@
  * The `RtdbHost` contract — what `@pyric/rtdb` needs from its caller
  * to talk to a Realtime Database.
  *
- * Unlike `@pyric/storage`'s `ProjectScope` (admin-token-only),
+ * Unlike `pyric/storage`'s `ProjectScope` (admin-token-only),
  * RTDB needs four things:
  *
  *   - `projectId` + `databaseUrl` — identity

--- a/packages/pyric/src/database/modular.ts
+++ b/packages/pyric/src/database/modular.ts
@@ -11,12 +11,12 @@
  *     plus the existing `@pyric/rtdb` rule simulator). Identity is the
  *     `SandboxContext`'s frozen `auth`.
  *   - **Sandbox-live target** — same backend, but identity is read
- *     per-op from `sandbox.currentUser` so a `@pyric/auth`-driven
+ *     per-op from `sandbox.currentUser` so a `pyric/auth`-driven
  *     sign-in flips the next op's `request.auth` without re-binding.
  *   - **Prod target** — wraps `firebase/database` against a real
  *     Firebase project.
  *
- * Dispatch machinery mirrors `@pyric/firestore`:
+ * Dispatch machinery mirrors `pyric/firestore`:
  *   - {@link TARGET_SYMBOL} brand on every {@link Database} handle.
  *   - {@link refToTarget} WeakMap from refs to their owning target so
  *     chained calls (`child(ref, 'sub')`, `get(ref)`) recover routing.
@@ -1369,7 +1369,7 @@ export function connectDatabaseEmulator(
 
 // ─── Sandbox-only ops ───────────────────────────────────────────────
 //
-// Mirrors `@pyric/firestore`'s `sandbox` namespace — explicit
+// Mirrors `pyric/firestore`'s `sandbox` namespace — explicit
 // per-package sandbox lifecycle that the prod target doesn't ship.
 // Calling against a prod handle throws.
 

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -130,7 +130,7 @@ export class RulesEvaluator {
     // The simulator's SimulationInputSchema requires `auth` to be
     // either `null` or `{ uid: string, token: Record<string, unknown> }` —
     // `token` is mandatory, not optional. `AuthState` from
-    // `@pyric/sandbox` makes `token` optional. Normalise here so an
+    // `pyric/sandbox` makes `token` optional. Normalise here so an
     // auth identity without custom claims (`{ uid: 'alice' }`) still
     // satisfies the schema and the rule sees `auth.token = {}`.
     const normalisedAuth =

--- a/packages/pyric/src/firestore/index.ts
+++ b/packages/pyric/src/firestore/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/firestore` — modular Web-SDK Firestore adapter for the
+ * `pyric/firestore` — modular Web-SDK Firestore adapter for the
  * Pyric sandbox.
  *
  * Mirrors `firebase/firestore`'s tree-shakable free-function shape:
@@ -7,8 +7,8 @@
  * `onSnapshot`, `runTransaction`, etc. All operations route to one of
  * two backends, picked at init time:
  *
- *   - **Sandbox target** — wraps `@pyric/admin`'s chainable adapter,
- *     which sits on `@pyric/sandbox`'s `LocalEnvironment`. No
+ *   - **Sandbox target** — wraps `pyric-admin`'s chainable adapter,
+ *     which sits on `pyric/sandbox`'s `LocalEnvironment`. No
  *     network. Identity comes from a `SandboxContext`.
  *   - **Prod target** — wraps `firebase/firestore` against a real
  *     Firebase project. Identity comes from `firebase/auth`'s
@@ -81,7 +81,7 @@ import { APP_TARGET, type PyricApp } from 'pyric/app';
  * between sandbox and prod backends so free functions can route
  * without consumer-visible API differences.
  */
-export const TARGET_SYMBOL: unique symbol = Symbol('@pyric/firestore/target');
+export const TARGET_SYMBOL: unique symbol = Symbol('pyric/firestore/target');
 
 type SandboxTarget = { kind: 'sandbox'; db: SandboxFirestore; sandbox: Sandbox };
 /**
@@ -94,7 +94,7 @@ type SandboxTarget = { kind: 'sandbox'; db: SandboxFirestore; sandbox: Sandbox }
  * obtains a chainable handle bound to that ctx.
  *
  * Wired into the modular surface so app code that uses both
- * `@pyric/auth` and `@pyric/firestore` against the same `Sandbox` sees
+ * `pyric/auth` and `pyric/firestore` against the same `Sandbox` sees
  * live auth-state changes: a `signInAnonymously` / `setUser` call on
  * the auth side mutates `sandbox.currentUser`, and the next Firestore
  * op evaluates rules under the new identity.
@@ -146,7 +146,7 @@ function tag<T extends object>(obj: T, target: Target): T {
  * *current* `currentUser` rather than the auth that was active when
  * the ref was first built.
  *
- * Necessary because `@pyric/admin`'s chainable refs capture auth at
+ * Necessary because `pyric-admin`'s chainable refs capture auth at
  * construction time — calling `chainRef.get()` on a held ref runs
  * under the auth from when the ref was built, not from when the op
  * fires. For sandbox-live, every op must construct a fresh chainable
@@ -182,7 +182,7 @@ function chainDocFor(
   const rebuild = sandboxLiveRebuild.get(underlying);
   if (!rebuild) {
     throw new TypeError(
-      '@pyric/firestore: live ref missing rebuild closure — was it produced by a factory in this package?',
+      'pyric/firestore: live ref missing rebuild closure — was it produced by a factory in this package?',
     );
   }
   return rebuild(sandboxDb(target)) as ChainDocRef;
@@ -198,7 +198,7 @@ function chainCollFor(
   const rebuild = sandboxLiveRebuild.get(underlying);
   if (!rebuild) {
     throw new TypeError(
-      '@pyric/firestore: live collection ref missing rebuild closure.',
+      'pyric/firestore: live collection ref missing rebuild closure.',
     );
   }
   return rebuild(sandboxDb(target)) as ChainCollRef;
@@ -214,7 +214,7 @@ function chainQueryFor(
   const rebuild = sandboxLiveRebuild.get(underlying);
   if (!rebuild) {
     throw new TypeError(
-      '@pyric/firestore: live query missing rebuild closure.',
+      'pyric/firestore: live query missing rebuild closure.',
     );
   }
   return rebuild(sandboxDb(target)) as ChainQuery;
@@ -251,7 +251,7 @@ function parentRebuild(parent: object): (db: SandboxFirestore) => object {
   if (fn) return fn;
   // Frozen-ctx target. The chainable parent ref is bound to the same
   // ctx for life; returning it as-is is correct because frozen-ctx
-  // chaining is what `@pyric/admin`'s adapter already supports.
+  // chaining is what `pyric-admin`'s adapter already supports.
   return () => underlying;
 }
 
@@ -262,7 +262,7 @@ function targetOf(refOrDb: object): Target {
   const t = refToTarget.get(refOrDb);
   if (!t) {
     throw new TypeError(
-      '@pyric/firestore: unrecognized reference — was it produced by a factory in this package?',
+      'pyric/firestore: unrecognized reference — was it produced by a factory in this package?',
     );
   }
   return t;
@@ -360,7 +360,7 @@ export interface Firestore {
  *     scenario.
  *   - `Sandbox` → sandbox-backed Firestore that reads
  *     `sandbox.currentUser` per-call. Best for app code that drives
- *     identity through `@pyric/auth` — every Firestore op evaluates
+ *     identity through `pyric/auth` — every Firestore op evaluates
  *     rules under whatever user is currently signed in.
  *   - `FirebaseApp` → prod-backed Firestore (delegates to
  *     `firebase/firestore`'s `getFirestore(app)`).
@@ -373,7 +373,7 @@ export interface Firestore {
  * const sandbox = initializeSandbox();
  * const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
  *
- * // Sandbox, live identity (app code paired with @pyric/auth).
+ * // Sandbox, live identity (app code paired with pyric/auth).
  * import { initializeSandbox } from 'pyric/sandbox';
  * import { getAuth, signInAnonymously } from 'pyric/auth';
  * const sandbox = initializeSandbox();
@@ -535,12 +535,12 @@ function isSandboxContext(target: SandboxContext | Sandbox | FirebaseApp): targe
 
 /**
  * Structural test for the `Sandbox` overload. The class is internal
- * to `@pyric/sandbox` (not exported), so we recognize it by the
+ * to `pyric/sandbox` (not exported), so we recognize it by the
  * presence of `currentUser` + `onCurrentUserChanged` + `withAuth` +
  * `admin` — the four members that distinguish `Sandbox` from
  * `SandboxContext` (which has `withAuth` only) and `FirebaseApp`
  * (which has none). Tightening to a brand symbol would require an
- * `@pyric/sandbox` change; structural recognition is safe here
+ * `pyric/sandbox` change; structural recognition is safe here
  * because every member of this set has been on `Sandbox` since v0
  * and `FirebaseApp` would have to grow all four to collide.
  */
@@ -558,10 +558,10 @@ function isSandbox(target: SandboxContext | Sandbox | FirebaseApp): target is Sa
 /**
  * Build the per-call ctx-resolver for a `sandbox-live` target. Each
  * call reads `sandbox.currentUser` (the source of truth that
- * `@pyric/auth` writes through to), constructs a fresh
+ * `pyric/auth` writes through to), constructs a fresh
  * `SandboxContext`, and returns the chainable Firestore handle bound
  * to it. Constructing per-call is cheap — `SandboxContext` is a tiny
- * object — and `@pyric/admin`'s `getFirestore(ctx)` caches by ctx
+ * object — and `pyric-admin`'s `getFirestore(ctx)` caches by ctx
  * identity via WeakMap, so the chainable is collected once the ctx
  * is.
  *
@@ -697,7 +697,7 @@ function targetMatch(a: object, b: object): Target {
   const bSandbox = isSandboxKind(tb);
   if (aSandbox !== bSandbox) {
     throw new TypeError(
-      '@pyric/firestore: cannot compare references / queries / snapshots across different targets.',
+      'pyric/firestore: cannot compare references / queries / snapshots across different targets.',
     );
   }
   return ta;
@@ -929,8 +929,8 @@ function vectorValuesOf(value: unknown): number[] | null {
 /**
  * Final read-path translation for sandbox-target snapshots.
  *
- * The admin-compat read-path walker (in `@pyric/sandbox`'s admin-compat
- * `snapshots.ts`) leaves `@pyric/firestore-rules` wrappers (`Bytes`,
+ * The admin-compat read-path walker (in `pyric/sandbox`'s admin-compat
+ * `snapshots.ts`) leaves `pyric/rules` wrappers (`Bytes`,
  * `LatLng`) as identity — it can't translate them to
  * `firebase/firestore`'s `Bytes` / `GeoPoint` because the admin-compat
  * layer doesn't depend on `firebase/firestore`.
@@ -1047,7 +1047,7 @@ export async function getDoc<T = DocumentData>(ref: DocumentReference<T>): Promi
     // Normalize `.exists` to method form + tag the snap's ref so
     // consumers get Firebase-modular-SDK shape uniformly.
     tagSnapshotRefs(snap, target);
-    // Wrap .data() to translate `@pyric/firestore-rules` wrappers
+    // Wrap .data() to translate `pyric/rules` wrappers
     // (Bytes / LatLng) into `firebase/firestore` types so reads match
     // prod's instanceof semantics. Closes firestore #109 + #110.
     return wrapSandboxDocSnap<T>(snap as object);
@@ -1372,7 +1372,7 @@ function composite(
 ): QueryConstraint {
   if (filters.length === 0) {
     throw new TypeError(
-      `@pyric/firestore: ${kind}() requires at least one filter argument.`,
+      `pyric/firestore: ${kind}() requires at least one filter argument.`,
     );
   }
   const sandboxSubs: ChainFilter[] = [];
@@ -1380,7 +1380,7 @@ function composite(
   for (const c of filters) {
     if (c._sandboxFilter === undefined || c._fbFilter === undefined) {
       throw new TypeError(
-        `@pyric/firestore: ${kind}() received a non-filter constraint (orderBy / limit are not valid here).`,
+        `pyric/firestore: ${kind}() received a non-filter constraint (orderBy / limit are not valid here).`,
       );
     }
     sandboxSubs.push(c._sandboxFilter);
@@ -1707,7 +1707,7 @@ export function onSnapshot(
     // ever sees it. Without this, `snap.ref` / `snap.docs[i].ref`
     // come back from the chainable adapter untagged, and the next
     // `onSnapshot(ref, …)` / `setDoc(ref, …)` throws
-    // "@pyric/firestore: unrecognized reference."
+    // "pyric/firestore: unrecognized reference."
     const wrappedArgs = tagSandboxSnapshotArgs(arg2, arg3, arg4, target);
     // Thread the live-vs-frozen marker down to the chainable adapter so
     // it can set `addSnapshotListener`'s `followsCurrentUser` flag. The
@@ -1759,7 +1759,7 @@ function resolveSandboxListenable(
   const rebuild = sandboxLiveRebuild.get(underlying);
   if (!rebuild) {
     throw new TypeError(
-      '@pyric/firestore: live ref missing rebuild closure for onSnapshot.',
+      'pyric/firestore: live ref missing rebuild closure for onSnapshot.',
     );
   }
   return rebuild(sandboxDb(target)) as unknown as { onSnapshot: (...args: unknown[]) => Unsubscribe };
@@ -1889,7 +1889,7 @@ function finalizeSandboxSnapshot(snap: unknown, target: Target): unknown {
  */
 function defaultSnapshotErrorHandler(error: unknown): void {
   // eslint-disable-next-line no-console
-  console.error('@pyric/firestore: Uncaught Error in snapshot listener:', error);
+  console.error('pyric/firestore: Uncaught Error in snapshot listener:', error);
 }
 
 function wrapNext(
@@ -2098,7 +2098,7 @@ export const sandbox = {
     if (!isSandboxKind(target)) {
       throw new SandboxError(
         'failed-precondition',
-        'sandbox.setRules is sandbox-only; use @pyric/deploy.firestore.rules.deploy for prod targets.',
+        'sandbox.setRules is sandbox-only; use firestore.rules.deploy from pyric-tools/deploy for prod targets.',
       );
     }
     return sandboxDb(target).setRules(rules);
@@ -2238,7 +2238,7 @@ function inspectSandbox(sandbox: Sandbox, recentLimit: number): SandboxInspect {
 
 // ─── Sentinels + scalar types ─────────────────────────────────────────
 //
-// Sentinels in pyric ride on `@pyric/admin`'s sentinel objects, which
+// Sentinels in pyric ride on `pyric-admin`'s sentinel objects, which
 // are structurally identical to `firebase/firestore`'s — the simulator
 // recognizes them by `__type` discriminator, and so does production
 // Firestore (their wire format normalizes through the same path). One
@@ -2268,4 +2268,3 @@ export function deleteField(): FieldValueSentinel {
 // ─── Tool factories (Slice 10) ────────────────────────────────────────
 export { createFirestoreDataTools, createFirestoreInspectTools } from './tools.js';
 export type { FirestoreDataToolDeps, UserAuth, As } from './tools.js';
-

--- a/packages/pyric/src/firestore/tools.ts
+++ b/packages/pyric/src/firestore/tools.ts
@@ -1,5 +1,5 @@
 /**
- * Tool factories for `@pyric/firestore` per F1.
+ * Tool factories for `pyric/firestore` per F1.
  *
  * `createFirestoreDataTools({ resolveDb })` wraps the modular
  * Web-SDK Firestore data plane as `ToolHandler[]`. The resolver

--- a/packages/pyric/src/rules/extract.ts
+++ b/packages/pyric/src/rules/extract.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/firestore-rules/extract`: composite-index extractor entry.
+ * `pyric/rules/extract`: composite-index extractor entry.
  *
  * The extractor statically analyzes JS/TS source (via the TypeScript compiler)
  * for the modular Firestore client's `query(collection(...), where(...),

--- a/packages/pyric/src/rules/index.ts
+++ b/packages/pyric/src/rules/index.ts
@@ -1,7 +1,7 @@
 /**
- * `@pyric/firestore-rules` — Pyric-native Firestore rules tooling.
+ * `pyric/rules` — Pyric-native Firestore rules tooling.
  *
- * Sibling to `@pyric/firestore` (the modular Web-SDK swap-in). Rules
+ * Sibling to `pyric/firestore` (the modular Web-SDK swap-in). Rules
  * tooling lives here so non-standard surface (linter, parser, etc.)
  * doesn't pollute the swap-in namespace.
  *
@@ -48,7 +48,7 @@ export type {
 
 // ─── Modules resolver — Node-only ────────────────────────────────────
 // The resolver reads stdlib files off disk and so can't ship to the
-// browser. Its value exports live on `@pyric/firestore-rules/node`;
+// browser. Its value exports live on `pyric/rules/node`;
 // only the (erasable) types stay on the universal root entry.
 export type { ResolveResult, ResolveOptions } from './modules/resolver.js';
 
@@ -108,7 +108,7 @@ export {
 // ─── Tool factories (Slice 8) — Node-only ────────────────────────────
 // `createFirestoreRulesTools` wraps the resolver (Node-only) into
 // agent tools, so the factory itself is Node-only. Values live on
-// `@pyric/firestore-rules/node`; types stay here so consumers in
+// `pyric/rules/node`; types stay here so consumers in
 // either environment can describe tool deps without dragging Node
 // imports along.
 export type {
@@ -136,7 +136,7 @@ export { createFirestoreRulesStdlibTools } from './stdlib-tools.js';
 
 // Browser-safe `2+modules` resolver — pre-supplies the inlined stdlib
 // content so it works without `node:fs`. Node consumers should keep
-// importing `resolveModules` from `@pyric/firestore-rules/node`,
+// importing `resolveModules` from `pyric/rules/node`,
 // which falls back to disk reads for stdlib modules and picks up
 // `.rules` edits between builds without re-running the inliner.
 export { resolveModulesBrowser, STDLIB_INLINE } from './modules/resolver-browser.js';

--- a/packages/pyric/src/rules/node.ts
+++ b/packages/pyric/src/rules/node.ts
@@ -4,7 +4,7 @@
  * Anything that imports `node:fs` / `node:path` / `node:url` at
  * module-init lives here, so the browser-facing root entry stays
  * free of Node builtins. Consumers running in Node (admin tools,
- * SDK agent definitions, tests) import from `@pyric/firestore-rules/node`.
+ * SDK agent definitions, tests) import from `pyric/rules/node`.
  *
  * Today the only Node-only surface is the modules resolver — it
  * reads stdlib files off disk via `readFileSync`.

--- a/packages/pyric/src/rules/simulator-tools-impl.ts
+++ b/packages/pyric/src/rules/simulator-tools-impl.ts
@@ -5,11 +5,11 @@
  * browser bundle.
  *
  * The factory takes `resolveModulesFn` as an injected dep:
- *  - `@pyric/firestore-rules` (root) wires `resolveModules` from
- *    `./modules/resolver.js` — Node's disk-reading version.
- *  - `@pyric/firestore-rules/simulator` (browser entry) wires
- *    `resolveModulesBrowser` from `./modules/resolver-browser.js`,
- *    which pre-supplies the stdlib content inlined at build time.
+ *  - `pyric/rules/node` wires `resolveModules` from `./modules/resolver.js`
+ *    — Node's disk-reading version.
+ *  - `./simulator.ts` wires `resolveModulesBrowser` from
+ *    `./modules/resolver-browser.js`, which pre-supplies the stdlib content
+ *    inlined at build time.
  *  - When the dep is absent, the `firestore_simulator_create` tool
  *    returns a clear error if a caller seeds `'2+modules'` rules.
  *
@@ -107,7 +107,7 @@ export function createFirestoreSimulatorTools(
             return {
               ok: false,
               summary:
-                'Module resolve unavailable: this builder was not wired with `resolveModulesFn`. Use the @pyric/firestore-rules root entry (Node) or /simulator entry (browser) instead of importing the impl directly.',
+                'Module resolve unavailable: this builder was not wired with `resolveModulesFn`. Use a package entry that wires module resolution, such as pyric/rules/node, instead of importing the impl directly.',
               data: { code: 'NO_MODULE_RESOLVER' },
             };
           }

--- a/packages/pyric/src/rules/simulator.ts
+++ b/packages/pyric/src/rules/simulator.ts
@@ -1,23 +1,17 @@
 /**
  * Browser-safe entry for the simulator tool factory.
  *
- * Consumers building MCP / agent tool surfaces that run in a browser
- * (e.g. `@pyric/dev`'s in-page bridge client) import from here:
- *
- * ```ts
- * import { createFirestoreSimulatorTools } from '@pyric/firestore-rules/simulator';
- * const tools = createFirestoreSimulatorTools({ resolveSandbox });
- * ```
+ * Hosts building MCP / agent tool surfaces that run in a browser can bundle
+ * this source entry to avoid pulling the Node-only resolver into the browser.
  *
  * The factory wires the browser-safe `resolveModulesBrowser` so
  * `firestore_simulator_create` accepts `rules_version = '2+modules'`
  * sources without a disk dependency.
  *
- * The Node entry (`@pyric/firestore-rules/node`) re-exports the same
- * factory wired with the disk-reading `resolveModules`. The two
- * factories share `./simulator-tools-impl.ts` — drift between
- * browser dispatch and Node MCP advertisement is impossible by
- * construction.
+ * The public Node entry (`pyric/rules/node`) re-exports the same factory wired
+ * with the disk-reading `resolveModules`. The two factories share
+ * `./simulator-tools-impl.ts` so browser dispatch and Node MCP advertisement
+ * stay in lockstep.
  */
 
 import { resolveModulesBrowser } from './modules/resolver-browser.js';

--- a/packages/pyric/src/rules/stdlib-modules.ts
+++ b/packages/pyric/src/rules/stdlib-modules.ts
@@ -16,7 +16,7 @@
  *       request-time and existing-doc state. Accessed as paths
  *       (`request.auth.uid`), not callables.
  *   `user-module` — reusable libraries shipped under
- *       `packages/firestore-rules/src/modules/stdlib/` (auth,
+ *       `packages/pyric/src/rules/modules/stdlib/` (auth,
  *       validation, lobby, …). Imported via
  *       `import { isAuthenticated } from 'auth';` after
  *       `rules_version = '2+modules';`. Functions called bare after

--- a/packages/pyric/src/rules/stdlib-tools.ts
+++ b/packages/pyric/src/rules/stdlib-tools.ts
@@ -3,10 +3,10 @@
  *
  * Why a separate file: `createFirestoreRulesTools` lives in `./tools.ts`
  * alongside the Node-only resolver — so the whole factory ships from
- * `@pyric/firestore-rules/node`. The stdlib tools are pure data (no
+ * `pyric/rules/node`. The stdlib tools are pure data (no
  * fs, no network) and useful to browser consumers (the playground
  * imports them straight into its tool registry). Keeping the data +
- * tool factory together in this file lets the main `@pyric/firestore-
+ * tool factory together in this file lets the main `pyric/firestore-
  * rules` entry export them without dragging in `node:fs`.
  *
  * The Node-only `createFirestoreRulesTools` factory still bundles

--- a/packages/pyric/src/rules/tools.ts
+++ b/packages/pyric/src/rules/tools.ts
@@ -1,5 +1,5 @@
 /**
- * Tool factories for `@pyric/firestore-rules` per F1.
+ * Tool factories for `pyric/rules` per F1.
  *
  *   - `createFirestoreRulesTools()`: pure-local rules tooling
  *     (lint, parse, resolve-modules, simulate) + the Rules Test API
@@ -31,7 +31,7 @@ import {
 } from './simulator-tools-impl.js';
 
 // Re-exported for back-compat with consumers that imported the type
-// from `@pyric/firestore-rules/node` (where this file is exposed).
+// from `pyric/rules/node` (where this file is exposed).
 export type FirestoreSimulatorToolDeps = Pick<
   FirestoreSimulatorToolDepsImpl,
   'resolveSandbox'
@@ -103,12 +103,12 @@ export function createFirestoreRulesTools(
 
   if (deps.scope) {
     const scope = deps.scope;
-    // Note: `firestore_get_rules` is NOT added here. `@pyric/deploy`'s
+    // Note: `firestore_get_rules` is NOT added here. `pyric-tools/deploy`'s
     // `createFirestoreDeployTools` already exposes a tool with that
     // name (returning raw rules source); composeMcpRegistry would
     // reject the duplicate. Browser callers that want the parsed
     // inspect (AST + summary + findings) wire `createFirestoreInspectTool`
-    // directly from `@pyric/firestore-rules` — see playground's
+    // directly from `pyric/rules` — see playground's
     // `firestore-rules-inspect.ts`.
     handlers.push({
       name: 'firestore_test_rules',

--- a/packages/pyric/src/sandbox/admin-compat.ts
+++ b/packages/pyric/src/sandbox/admin-compat.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/sandbox/admin-compat` — chainable Admin-shaped Firestore
+ * `pyric/sandbox/admin-compat` — chainable Admin-shaped Firestore
  * wrapper backed by `LocalEnvironment`.
  *
  * This is the surface that mirrors `firebase-admin/firestore` (the
@@ -7,7 +7,7 @@
  * chainable Admin shape — `db.collection('x').doc('y').get()` etc. —
  * can run unmodified against the in-process sandbox.
  *
- * `@pyric/admin` imports from here directly rather than reaching across
+ * `pyric-admin` imports from here directly rather than reaching across
  * packages for its substrate.
  *
  * Exported as a separate subpath (not via `/internal`) because the
@@ -21,7 +21,7 @@ export * from './firestore/admin-compat/index.js';
 // Web-SDK-shaped snapshot aliases — what onSnapshot listener callbacks
 // receive. Re-exported here with `Live*` prefixes to disambiguate from
 // admin-compat's own DocumentSnapshot / QuerySnapshot (chainable Admin
-// shape). Consumers (e.g. `@pyric/admin`) augment THIS module's
+// shape). Consumers (e.g. `pyric-admin`) augment THIS module's
 // LiveDocumentSnapshot / LiveQuerySnapshot to attach `onSnapshot` methods.
 export type {
   DocumentSnapshot as LiveDocumentSnapshot,

--- a/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
@@ -45,7 +45,7 @@ import {
  * `db.collection(path)` regardless of how many contexts share the
  * underlying sandbox. Symbol so it never collides with a real property.
  */
-export const CONTEXT_SYMBOL: unique symbol = Symbol('@pyric/sandbox/context');
+export const CONTEXT_SYMBOL: unique symbol = Symbol('pyric/sandbox/context');
 
 /**
  * Late-bound reference to the free `onSnapshot(ref, ...args)` function

--- a/packages/pyric/src/sandbox/admin-firestore/index.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/admin` — Admin-SDK-shaped chainable Firestore adapter for
+ * `pyric-admin` — Admin-SDK-shaped chainable Firestore adapter for
  * the Pyric sandbox.
  *
  * `getFirestore(ctx)` returns a `SandboxFirestore` whose operations
@@ -7,7 +7,7 @@
  * `LocalEnvironment` of the context's sandbox. Idempotent — a second
  * call with the same `SandboxContext` returns the same wrapper.
  *
- * Wraps the `@pyric/sandbox/admin-compat` implementation.
+ * Wraps the `pyric/sandbox/admin-compat` implementation.
  * Per-operation methods construct a fresh delegate so a
  * `sandbox.reset()` (which swaps the underlying environment) is
  * picked up on the next operation. Refs returned from the wrapper
@@ -37,8 +37,8 @@ import { getInternalEnv } from 'pyric/sandbox/internal';
 import { CONTEXT_SYMBOL, registerOnSnapshotImpl, wrapWithErrorTranslation } from './error-translation.js';
 
 // Re-export commonly-needed foundation types so most consumers can
-// import everything from `@pyric/admin`. Anyone needing more reaches
-// into `@pyric/sandbox` directly.
+// import everything from `pyric-admin`. Anyone needing more reaches
+// into `pyric/sandbox` directly.
 export type {
   AuthState,
   Sandbox,
@@ -47,7 +47,7 @@ export type {
 export { SandboxError } from 'pyric/sandbox';
 
 // Re-export the production-shaped types so consumers can spell them
-// with a `@pyric/admin` import path.
+// with a `pyric-admin` import path.
 //
 // `DocumentSnapshot`, `QueryDocumentSnapshot`, `QuerySnapshot` are
 // re-exported from the Web-SDK-shaped snapshot-listener types — that's
@@ -105,7 +105,7 @@ export type {
 export type SnapshotListenOptions = SnapshotListenerOptions;
 
 /**
- * Internal channel for the modular `@pyric/firestore` layer to mark a
+ * Internal channel for the modular `pyric/firestore` layer to mark a
  * listener as live (identity follows `sandbox.currentUser`) vs frozen
  * (`getFirestore(ctx)`, pinned identity). The chainable adapter sees only
  * a `SandboxContext` per call and can't tell the two apart on its own — the
@@ -117,7 +117,7 @@ export type SnapshotListenOptions = SnapshotListenerOptions;
  * Symbol-keyed (not a named field) so it never collides with a real
  * `SnapshotListenOptions` field and never leaks to consumer code.
  */
-export const FOLLOWS_CURRENT_USER: unique symbol = Symbol('@pyric/firestore/followsCurrentUser');
+export const FOLLOWS_CURRENT_USER: unique symbol = Symbol('pyric/firestore/followsCurrentUser');
 
 /**
  * Returned from `onSnapshot`. Calling it deregisters the listener and
@@ -382,7 +382,7 @@ function isSandboxContext(target: SandboxContext | Sandbox): target is SandboxCo
  *
  * Read it via a structural lookup rather than `instanceof` so this
  * adapter never has to import the compat impl class (which would create
- * a circular dependency through `@pyric/sandbox/admin-compat`).
+ * a circular dependency through `pyric/sandbox/admin-compat`).
  *
  * Returns `null` for refs we cannot route (anonymous/foreign Query
  * implementations); the caller throws a clear remediation error.
@@ -633,7 +633,7 @@ function contextFromRef(ref: unknown): SandboxContext {
 // ─── Chainable `.onSnapshot(...)` shim ─────────────────────────────────
 //
 // The free `onSnapshot(ref, observer)` function above mirrors
-// `firebase/firestore`'s modular shape. The rest of `@pyric/admin` is
+// `firebase/firestore`'s modular shape. The rest of `pyric-admin` is
 // chainable-method-shaped, though, and agents reach for
 // `db.collection(path).where(...).onSnapshot(cb)` more often than the
 // free form. To eliminate the asymmetry without losing the modular

--- a/packages/pyric/src/sandbox/firestore/admin-compat/index.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/index.ts
@@ -67,7 +67,7 @@ export interface CreateCompatFirestoreOptions {
    * treated as ALLOW (the modular-shaped equivalent of `sandbox.admin.*`).
    * Storage preconditions and the event/listener path are unchanged; only
    * rule evaluation is skipped. Default `false` → rules enforced under
-   * `auth`. Used by `getAdminFirestore` (see `@pyric/admin` and
+   * `auth`. Used by `getAdminFirestore` (see `pyric-admin` and
    * `pyric/firestore`).
    */
   bypassRules?: boolean;

--- a/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/query.ts
@@ -76,7 +76,7 @@ import {
 // Composite filters: Each query carries an array of `Filter` values.
 // Multiple filters AND together (matching multiple `where()` calls).
 // Composite OR / AND filters are introduced by `Query.applyFilter`
-// (which `@pyric/firestore`'s `or()` / `and()` modular factories
+// (which `pyric/firestore`'s `or()` / `and()` modular factories
 // route through).
 // ─────────────────────────────────────────────────────────────────────────
 

--- a/packages/pyric/src/sandbox/firestore/admin-compat/read-translation.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/read-translation.ts
@@ -27,11 +27,11 @@ function translateValue(value: unknown): unknown {
     return new CompatTimestamp(value.seconds, value.nanos);
   }
   // Bytes + LatLng wrappers (rules-internal) ride through the read path
-  // as their instance form. The `@pyric/firestore` modular layer does
+  // as their instance form. The `pyric/firestore` modular layer does
   // the final conversion to `firebase/firestore`'s `Bytes` / `GeoPoint`
   // for its consumers; the admin-compat read path here leaves them as
   // the wrapper so downstream layers can identify the type via
-  // `instanceof` against `@pyric/firestore-rules`. Without these
+  // `instanceof` against `pyric/rules`. Without these
   // short-circuits, the generic object walk below would destructure the
   // class instance into a plain `{...}` and erase the type.
   if (value instanceof InternalBytes) return value;

--- a/packages/pyric/src/sandbox/firestore/admin-compat/types.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/types.ts
@@ -123,7 +123,7 @@ export interface Query {
    * already on the query — same implicit-AND semantics as multiple
    * `where()` calls. To OR multiple predicates, wrap them with
    * `{ kind: 'or', filters: [...] }` before calling. Backs the
-   * modular `or()` / `and()` constraints in `@pyric/firestore`.
+   * modular `or()` / `and()` constraints in `pyric/firestore`.
    */
   applyFilter(filter: Filter): Query;
   orderBy(field: string, direction?: OrderDirection): Query;
@@ -369,7 +369,7 @@ export class FirestoreCompatError extends Error {
   readonly code: FirestoreErrorCode;
   /**
    * The structured `FirestoreSimError` this throw was built from. Kept
-   * as a back-channel so downstream wrappers (`@pyric/sandbox`) can
+   * as a back-channel so downstream wrappers (`pyric/sandbox`) can
    * read the eval-time `request`/`resource` context without re-parsing
    * the message string. Production Admin SDK has no equivalent — this
    * field is sandbox-only and intentionally not surfaced on `Error`'s

--- a/packages/pyric/src/sandbox/firestore/converters/bytes-geopoint.ts
+++ b/packages/pyric/src/sandbox/firestore/converters/bytes-geopoint.ts
@@ -10,7 +10,7 @@
  * Two problems with that:
  *
  *   1. Rules evaluator detects these types via `instanceof
- *      `@pyric/firestore-rules`.Bytes` / `instanceof LatLng` — a
+ *      `pyric/rules`.Bytes` / `instanceof LatLng` — a
  *      `fb.Bytes` instance fails both checks, so `data.b is bytes`
  *      returns false.
  *   2. The admin-compat read-path walker in `snapshots.ts` walks any
@@ -39,7 +39,7 @@
  *      `instanceof`.
  *
  * Idempotency: each converter rejects its own output (our
- * `@pyric/firestore-rules` wrapper) by `instanceof` check, so a second
+ * `pyric/rules` wrapper) by `instanceof` check, so a second
  * resolver pass is a no-op.
  */
 import { KEEP, type ValueConverter } from '../value-resolver.js';

--- a/packages/pyric/src/sandbox/firestore/local-environment.ts
+++ b/packages/pyric/src/sandbox/firestore/local-environment.ts
@@ -228,7 +228,7 @@ function nextRequestEventId(): string {
  * Parse `Rule #N (ops...) → ALLOW/deny` lines out of the simulator's
  * debug messages. The simulator emits one such line per evaluated rule
  * in the matched match block (see `evaluateRules` in
- * `@pyric/firestore-rules/simulator/handler.ts`). For allowed outcomes
+ * `pyric/rules/handler.ts`). For allowed outcomes
  * the last `→ ALLOW` rule wins; for denials we surface the first rule
  * that even tried to match this op-set.
  */

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -1,15 +1,15 @@
 /**
- * `@pyric/sandbox` — sandbox host (foundation). Provides the
+ * `pyric/sandbox` — sandbox host (foundation). Provides the
  * `Sandbox` type, the `SandboxContext` identity handle, the
  * `initializeSandbox` factory, and the `SandboxError` family.
  *
- * Service handles live in sibling packages (`@pyric/admin` for the
+ * Service handles live in sibling packages (`pyric-admin` for the
  * Admin-SDK-shaped chainable Firestore adapter, future
- * `@pyric/firestore` for the modular Web SDK adapter,
- * `@pyric/auth`/`@pyric/database`/`@pyric/storage` later) and consume
+ * `pyric/firestore` for the modular Web SDK adapter,
+ * `pyric/auth`/`pyric/database`/`pyric/storage` later) and consume
  * `SandboxContext` from here.
  *
- * Adapter packages also reach into `@pyric/sandbox/internal` for the
+ * Adapter packages also reach into `pyric/sandbox/internal` for the
  * non-public protocol (`getInternalEnv`, etc.). See
  * the design rationale and
  * the design rationale for the design rationale.

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -1,13 +1,13 @@
 /**
- * `@pyric/sandbox/internal` — adapter-only protocol surface.
+ * `pyric/sandbox/internal` — adapter-only protocol surface.
  *
- * Service adapter packages (`@pyric/admin`, future `@pyric/firestore`,
- * `@pyric/auth`, etc.) consume this subpath to reach the underlying
+ * Service adapter packages (`pyric-admin`, future `pyric/firestore`,
+ * `pyric/auth`, etc.) consume this subpath to reach the underlying
  * `LocalEnvironment` and any other primitives that need to flow
  * through the sandbox boundary.
  *
  * **Not part of the public API.** The shape is subject to change
- * without breaking-change semantics across `@pyric/sandbox` versions.
+ * without breaking-change semantics across `pyric/sandbox` versions.
  * External adapter authors shouldn't rely on this — when the protocol
  * stabilizes (post-multi-service architecture) it'll be promoted.
  *
@@ -75,7 +75,7 @@ export * from '../firestore/converters/bytes-geopoint.js';
 export * from '../firestore/snapshot-listeners.js';
 // Wire-encoder: produces Firestore JSON wire-format from sandbox
 // values. Used by the discover crawler's sandbox adapter (in
-// @pyric/firestore/discover) to bridge LocalEnvironment ↔ the wire
+// pyric/firestore/discover) to bridge LocalEnvironment ↔ the wire
 // decoder.
 export * from '../firestore/wire-encoder.js';
 

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -119,7 +119,7 @@ export class SandboxImpl implements Sandbox {
   private eventHistory: SandboxEvent[] = [];
 
   /**
-   * Currently authenticated user. Mutated by `@pyric/auth` (and any
+   * Currently authenticated user. Mutated by `pyric/auth` (and any
    * future stateful identity bridge). Read per-call by service
    * factories that want to see auth changes without re-binding.
    * Defaults to `null` (anonymous / signed out).
@@ -313,7 +313,7 @@ export class SandboxImpl implements Sandbox {
    * returned array doesn't affect future history() calls.
    *
    * Replay engine consumes this: hand the array to
-   * `replay(events, rules)` from `@pyric/sandbox` and the
+   * `replay(events, rules)` from `pyric/sandbox` and the
    * engine re-issues every captured write against a fresh sandbox.
    *
    * `reset()` clears the history AFTER emitting the closing
@@ -451,7 +451,7 @@ export class SandboxImpl implements Sandbox {
 
   /**
    * Current authenticated user across the sandbox. See the doc on
-   * {@link Sandbox.currentUser} — used by `@pyric/auth` to thread
+   * {@link Sandbox.currentUser} — used by `pyric/auth` to thread
    * identity through stateful Auth handles.
    */
   get currentUser(): AuthState {
@@ -657,10 +657,10 @@ export function getInternalEnv(sandbox: Sandbox): LocalEnvironment {
  * than bending into Firestore's rule-eval-shaped `request`/`write` kinds.
  * Wired emit sites:
  *   - auth:    user create/update/delete, users-clear, sign-in, sign-out
- *              (`SandboxBackend` in `@pyric/auth`).
- *   - storage: object put / delete / metadata-update (`@pyric/storage`).
+ *              (`SandboxBackend` in `pyric/auth`).
+ *   - storage: object put / delete / metadata-update (`pyric/storage`).
  *   - rtdb:    set / update / remove / transaction-commit
- *              (`RtdbBackend` in `@pyric/database`, via the modular surface).
+ *              (`RtdbBackend` in `pyric/database`, via the modular surface).
  * Firestore still rides the env→sandbox fan-out and is unchanged. See
  * the design rationale.
  *

--- a/packages/pyric/src/sandbox/persistence/types.ts
+++ b/packages/pyric/src/sandbox/persistence/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public types for `@pyric/sandbox` persistence. The sandbox itself is
+ * Public types for `pyric/sandbox` persistence. The sandbox itself is
  * an in-memory dev Firestore; persistence lets a host (browser
  * playground, agent harness) snapshot the sandbox's data to a backend
  * and restore it on next init — turning the sandbox into the local

--- a/packages/pyric/src/sandbox/replay/index.ts
+++ b/packages/pyric/src/sandbox/replay/index.ts
@@ -3,7 +3,7 @@
  * every write against a fresh sandbox; the engine classifies any
  * divergences.
  *
- * Exported from the main `@pyric/sandbox` entry. The file lives at
+ * Exported from the main `pyric/sandbox` entry. The file lives at
  * `src/replay/index.ts` as an organizational unit; importers use
  * the public bare-package import path.
  *

--- a/packages/pyric/src/sandbox/types.ts
+++ b/packages/pyric/src/sandbox/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public type surface for `@pyric/sandbox`.
+ * Public type surface for `pyric/sandbox`.
  *
  * Kept service-agnostic on purpose: `/app` is the host the rest of the
  * library plugs into. Service modules (`/firestore`, future `/storage`,
@@ -1002,7 +1002,7 @@ export interface Sandbox {
    * the last `reset()`. Returns a defensive copy.
    *
    * Use this for replay: hand the array to `replay(events, rules)`
-   * from `@pyric/sandbox` and the engine re-issues every
+   * from `pyric/sandbox` and the engine re-issues every
    * captured write against a fresh sandbox.
    *
    * Unlike {@link onEvent} (live stream from the moment of subscribe),
@@ -1073,7 +1073,7 @@ export interface Sandbox {
   /**
    * Current authenticated user across the sandbox.
    *
-   * Mutated by `@pyric/auth`'s `signInAnonymously` /
+   * Mutated by `pyric/auth`'s `signInAnonymously` /
    * `signInWithEmailAndPassword` / `signOut` / `sandbox.setUser`. Read
    * per-call by service factories (e.g. a future
    * `getFirestore(sandbox)` overload) so they see auth state changes
@@ -1083,7 +1083,7 @@ export interface Sandbox {
    * **Independent of `withAuth({uid})`** — `withAuth` still produces a
    * frozen {@link SandboxContext} that carries its own identity for
    * the runner's test code (the existing pattern: explicit identity
-   * per service call). `currentUser` exists for the `@pyric/auth`
+   * per service call). `currentUser` exists for the `pyric/auth`
    * mirror, where consumer app code drives identity through a
    * stateful `Auth` handle rather than naming it per call.
    */
@@ -1212,7 +1212,7 @@ export interface Sandbox {
  *
  * Constructed via `Sandbox.withAuth(auth)` or chained via
  * `SandboxContext.withAuth(auth)`. The concrete class is exported
- * from `@pyric/sandbox` for `instanceof` routing in service
+ * from `pyric/sandbox` for `instanceof` routing in service
  * factories; consumers don't construct it directly.
  */
 export interface SandboxContext {

--- a/packages/pyric/src/storage/admin/handler.ts
+++ b/packages/pyric/src/storage/admin/handler.ts
@@ -2,7 +2,7 @@
  * Handlers wrapping the pure-fetch `api.ts` provisioning functions
  * with a structured outcome shape. They take a `ProjectScope`
  * (`{ projectId, resolveToken }`) — the same credential value the
- * `@pyric/deploy` factories accept — so the storage tools share the
+ * `pyric-tools/deploy` factories accept — so the storage tools share the
  * resolver contract with the rest of the control plane.
  *
  * Note on permissions: `resolveToken()` typically yields a Firebase

--- a/packages/pyric/src/storage/admin/tools.ts
+++ b/packages/pyric/src/storage/admin/tools.ts
@@ -4,7 +4,7 @@
  * `createStorageAdminTools({ scope })` returns the two
  * provisioning/status tools as `ToolHandler[]`, consumable by
  * `@inbrowser/agent`'s registry — including by `composeMcpRegistry`.
- * Mirrors the `createFirestoreRulesTools` / `@pyric/deploy` factory
+ * Mirrors the `createFirestoreRulesTools` / `pyric-tools/deploy` factory
  * shape: a `ProjectScope` in, JSON-Schema-typed `ToolHandler`s out.
  */
 import type { ToolHandler } from '@inbrowser/agent';
@@ -14,7 +14,7 @@ import type { ProvisionStorageInput } from './spec.js';
 import type { ProvisionProgress } from './api.js';
 
 export interface StorageAdminToolDeps {
-  /** Project identity + token resolver. Same shape `@pyric/deploy`'s
+  /** Project identity + token resolver. Same shape `pyric-tools/deploy`'s
    *  factories take. */
   scope: ProjectScope;
 }

--- a/packages/pyric/src/storage/index.ts
+++ b/packages/pyric/src/storage/index.ts
@@ -1,9 +1,9 @@
 /**
- * `@pyric/storage` — Firebase Storage adapter for the Pyric sandbox.
+ * `pyric/storage` — Firebase Storage adapter for the Pyric sandbox.
  *
  * Sibling-package layout mirrors Firebase:
  *   `firebase/app`     ↔ `firebase/storage`
- *   `@pyric/sandbox`   ↔ `@pyric/storage`
+ *   `pyric/sandbox`   ↔ `pyric/storage`
  *
  * Public surface lands incrementally through the slices in
  * the design rationale:

--- a/packages/pyric/src/storage/persistence.ts
+++ b/packages/pyric/src/storage/persistence.ts
@@ -1,5 +1,5 @@
 /**
- * IndexedDB persistence layer for `@pyric/storage`.
+ * IndexedDB persistence layer for `pyric/storage`.
  *
  * One database (`pyric-storage` by default), two object stores —
  * `blobs` for the file content and `metadata` for the descriptive

--- a/packages/pyric/src/storage/reference.ts
+++ b/packages/pyric/src/storage/reference.ts
@@ -50,7 +50,7 @@ export function fbRefOf(ref: StorageReference): fb.StorageReference {
   const r = PROD_FB_REF.get(ref);
   if (!r) {
     throw new Error(
-      '@pyric/storage: expected a prod-target reference but the WeakMap had no entry. ' +
+      'pyric/storage: expected a prod-target reference but the WeakMap had no entry. ' +
       'Mixing sandbox + prod refs in the same call?',
     );
   }

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -1,7 +1,7 @@
 /**
  * Service module — handles, factories, and target-discriminated
- * routing. Mirrors `@pyric/firestore`'s dual-target shape so the same
- * playground (or any consumer) can switch from a `@pyric/sandbox`-
+ * routing. Mirrors `pyric/firestore`'s dual-target shape so the same
+ * playground (or any consumer) can switch from a `pyric/sandbox`-
  * backed IDB store to a real Firebase Storage bucket by swapping the
  * factory call.
  *
@@ -47,7 +47,7 @@ const DEFAULT_BUCKET = 'pyric-default';
  * the target discriminator so free functions can route between
  * sandbox + prod backends without consumer-visible API differences.
  */
-export const TARGET_SYMBOL: unique symbol = Symbol('@pyric/storage/target');
+export const TARGET_SYMBOL: unique symbol = Symbol('pyric/storage/target');
 
 /**
  * Sandbox target — IDB-backed, identity from `SandboxContext`, rules
@@ -246,7 +246,7 @@ export function targetOf(storage: FirebaseStorage): Target {
   const t = (storage as { [TARGET_SYMBOL]?: Target })[TARGET_SYMBOL];
   if (!t) {
     throw new TypeError(
-      '@pyric/storage: not a FirebaseStorage handle — was it produced by getStorageSandbox or getStorageProd?',
+      'pyric/storage: not a FirebaseStorage handle — was it produced by getStorageSandbox or getStorageProd?',
     );
   }
   return t;

--- a/packages/pyric/test/auth/types.test.ts
+++ b/packages/pyric/test/auth/types.test.ts
@@ -1,5 +1,5 @@
 /**
- * Type-level checks — the `@pyric/auth` public surface should be
+ * Type-level checks — the `pyric/auth` public surface should be
  * shape-compatible with `firebase/auth`'s modular surface for the
  * v0 subset.
  *

--- a/packages/pyric/test/firestore/prod-target.test.ts
+++ b/packages/pyric/test/firestore/prod-target.test.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/firestore` prod target — smoke + routing tests.
+ * `pyric/firestore` prod target — smoke + routing tests.
  *
  * These tests don't hit a real Firestore (that's emulator/integration
  * territory). They verify:

--- a/packages/pyric/test/firestore/sandbox-live-identity.test.ts
+++ b/packages/pyric/test/firestore/sandbox-live-identity.test.ts
@@ -5,17 +5,17 @@
  * `sandbox.currentUser` per-op. Counterpart to the frozen-ctx
  * `getFirestore(ctx)` overload (covered in `sandbox-target.test.ts`).
  *
- * The integration seam: `@pyric/auth`'s sandbox backend writes
+ * The integration seam: `pyric/auth`'s sandbox backend writes
  * through to `sandbox.currentUser`. App code that uses both
- * `@pyric/auth` and `@pyric/firestore` against the same `Sandbox`
+ * `pyric/auth` and `pyric/firestore` against the same `Sandbox`
  * should see auth-state changes live — every Firestore op evaluates
  * rules under whatever user is currently signed in, without
  * re-binding the Firestore handle.
  *
- * These tests don't depend on `@pyric/auth`; they mutate
+ * These tests don't depend on `pyric/auth`; they mutate
  * `sandbox.currentUser` directly to simulate what `signIn*` /
  * `setUser` would do. That keeps the test surface focused on the
- * `@pyric/firestore` behavior and avoids a cross-package
+ * `pyric/firestore` behavior and avoids a cross-package
  * dependency cycle.
  */
 import { describe, it, expect } from 'bun:test';

--- a/packages/pyric/test/firestore/sandbox-target.test.ts
+++ b/packages/pyric/test/firestore/sandbox-target.test.ts
@@ -1,8 +1,8 @@
 /**
- * `@pyric/firestore` sandbox target — smoke + parity tests.
+ * `pyric/firestore` sandbox target — smoke + parity tests.
  *
  * Verifies the modular Web-SDK surface routes correctly through to
- * `@pyric/admin`'s chainable adapter on top of `@pyric/sandbox`.
+ * `pyric-admin`'s chainable adapter on top of `pyric/sandbox`.
  * Same operations should produce the same observable outcomes
  * regardless of which adapter (modular vs. chainable) the consumer
  * picks — this is the load-bearing claim for the dual-target design.

--- a/packages/pyric/test/sandbox/branches.test.ts
+++ b/packages/pyric/test/sandbox/branches.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the branches primitive exported from `@pyric/sandbox`.
+ * Tests for the branches primitive exported from `pyric/sandbox`.
  *
  * Branches compose on top of `snapshot()` + `replay()`: `fork(snapshot)`
  * seeds a fresh isolated sandbox from a `SandboxSnapshot`, `apply` re-

--- a/packages/pyric/test/sandbox/browser-bundle/probe-entry.ts
+++ b/packages/pyric/test/sandbox/browser-bundle/probe-entry.ts
@@ -16,7 +16,7 @@ import {
 // Side-import so the bundle's node:* gate covers the hosting core
 // too. Reachable graph: core.ts → gzip.ts (CompressionStream) +
 // hash.ts (crypto.subtle). Both universal — should be zero node:*.
-// (Hosting moved to @pyric/deploy 2026-05-24; import path updated.)
+// (Hosting moved to pyric-tools/deploy 2026-05-24; import path updated.)
 import { deployHostingFiles } from 'pyric-tools/deploy';
 // Touch the symbol so tree-shaking can't drop it before the gate runs.
 void deployHostingFiles;

--- a/packages/pyric/test/sandbox/firestore/simulator/unsupported.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/unsupported.test.ts
@@ -148,7 +148,7 @@ service cloud.firestore {
   // `results[]` for the UNSUPPORTED case but the handler short-circuits
   // before it materializes. Was tolerated previously via a
   // `continue-on-error: true` CI step; the tests now run under
-  // @pyric/sandbox where the test gate is strict, so
+  // pyric/sandbox where the test gate is strict, so
   // explicit skip preserves the rest of the suite while the underlying
   // bug stays in the queue.
   test.skip('debug message includes "unsupported:" prefix for the failing rule', () => {

--- a/packages/pyric/test/sandbox/firestore/wire-encoder-bytes-geopoint.test.ts
+++ b/packages/pyric/test/sandbox/firestore/wire-encoder-bytes-geopoint.test.ts
@@ -6,23 +6,23 @@
  *
  *   1. **Converter unit:** `bytesConverter` / `geoPointConverter`
  *      duck-type-detect `firebase/firestore`'s `Bytes` / `GeoPoint`
- *      shapes and substitute the `@pyric/firestore-rules` wrappers
+ *      shapes and substitute the `pyric/rules` wrappers
  *      (`Bytes`, `LatLng`). KEEP on idempotency, on plain shapes that
  *      lack the duck-type, and on non-objects.
  *
  *   2. **Storage round-trip:** writing a doc with the rules-wrapper
  *      forms through `LocalEnvironment.execute({ method: 'create' })`
  *      and reading it back via `getDocument` returns the same wrapper
- *      instances — so the final `@pyric/firestore` translation hop
+ *      instances — so the final `pyric/firestore` translation hop
  *      (rules wrapper → `firebase/firestore.Bytes` / `.GeoPoint`) has
  *      a stable source. The end-to-end fb.Bytes → fb.Bytes round-trip
  *      through setDoc / getDoc is verified at
  *      `packages/firestore/test/sandbox-target.test.ts`.
  *
  * The `firebase/firestore` shape is faked with a minimal duck-typed
- * object — `@pyric/sandbox` deliberately doesn't depend on `firebase`,
+ * object — `pyric/sandbox` deliberately doesn't depend on `firebase`,
  * matching the converter's duck-typing approach. The integration test
- * at the `@pyric/firestore` layer uses the real `firebase/firestore`
+ * at the `pyric/firestore` layer uses the real `firebase/firestore`
  * exports.
  */
 import { describe, test, expect } from 'bun:test';

--- a/packages/pyric/test/sandbox/on-request.test.ts
+++ b/packages/pyric/test/sandbox/on-request.test.ts
@@ -3,7 +3,7 @@
  *
  * Drives `LocalEnvironment.execute` / `batch` / `addSnapshotListener`
  * directly via `getInternalEnv()` so the test doesn't depend on the
- * data-plane adapter packages — keeps `@pyric/sandbox` self-contained.
+ * data-plane adapter packages — keeps `pyric/sandbox` self-contained.
  * The admin/firestore packages will exercise the same surface
  * end-to-end in their own integration tests.
  */
@@ -90,9 +90,9 @@ describe('Sandbox.onRequest', () => {
   });
 
   it('pins the simulator debug-message format that matchedRule parsing depends on', () => {
-    // Cross-package contract: @pyric/firestore-rules's simulator
+    // Cross-package contract: pyric/rules's simulator
     // emits "Rule #N (op1,op2) → ALLOW/deny/unsupported: ..." and
-    // @pyric/sandbox's parseMatchedRule regex consumes it. If the
+    // pyric/sandbox's parseMatchedRule regex consumes it. If the
     // simulator changes the format silently (different arrow,
     // different capitalisation, parentheses gone) matchedRule becomes
     // undefined for every event — no test would notice unless we pin

--- a/packages/pyric/test/sandbox/replay.test.ts
+++ b/packages/pyric/test/sandbox/replay.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the replay engine exported from `@pyric/sandbox`.
+ * Tests for the replay engine exported from `pyric/sandbox`.
  *
  * Each test captures an event stream via `sandbox.history()`, then
  * hands it to `replay(events, rules)` and asserts the classification

--- a/packages/pyric/test/storage/prod-target.test.ts
+++ b/packages/pyric/test/storage/prod-target.test.ts
@@ -1,5 +1,5 @@
 /**
- * `@pyric/storage` prod target — surface + routing tests.
+ * `pyric/storage` prod target — surface + routing tests.
  *
  * These tests don't hit a real Firebase Storage bucket (that's
  * emulator/integration territory). They verify:

--- a/packages/ui/bunfig.toml
+++ b/packages/ui/bunfig.toml
@@ -3,7 +3,7 @@
 #   1. `test/firestore/*.test.tsx` — drive React hooks via
 #      `react-test-renderer` (no DOM needed). Keeping the realm
 #      clean avoids a known cross-realm breakage in
-#      `@pyric/firestore-rules`' OHM parser that fires when JSDOM
+#      `pyric/rules`' OHM parser that fires when JSDOM
 #      or happy-dom installs replacement globals.
 #
 #   2. `test/primitives/*.test.tsx` — install JSDOM locally at the

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pyric/ui",
   "version": "0.0.0",
-  "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (@pyric/firestore against @pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling — consumers bring their own design system via className + data-* attributes.",
+  "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (pyric/firestore against pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling — consumers bring their own design system via className + data-* attributes.",
   "type": "module",
   "exports": {
     "./auth": {

--- a/packages/ui/src/firestore/components/DeleteWithConfirm.tsx
+++ b/packages/ui/src/firestore/components/DeleteWithConfirm.tsx
@@ -13,7 +13,7 @@ export interface DeleteWithConfirmProps {
   /** The doc / collection to delete. */
   target: DocumentReference | CollectionReference;
   /** Implementation that walks the tree + deletes. Consumer-supplied.
-   *  Sandbox-backed apps usually wire `@pyric/sandbox` introspection;
+   *  Sandbox-backed apps usually wire `pyric/sandbox` introspection;
    *  production apps usually call a Cloud Function. */
   impl: RecursiveDeleteImpl;
   /** Confirm-dialog title. Defaults to a sensible derivation from

--- a/packages/ui/src/firestore/components/DocumentList.tsx
+++ b/packages/ui/src/firestore/components/DocumentList.tsx
@@ -4,7 +4,7 @@ import { VirtualList } from '../../primitives/VirtualList.js';
 
 /**
  * Both backends carry `.ref` on snapshots at runtime, but the
- * `@pyric/firestore` modular interface omits it. Pull it through
+ * `pyric/firestore` modular interface omits it. Pull it through
  * a structural cast — safe because the property is guaranteed by
  * the underlying SDKs.
  */

--- a/packages/ui/src/firestore/components/DocumentPreview.tsx
+++ b/packages/ui/src/firestore/components/DocumentPreview.tsx
@@ -19,7 +19,7 @@ import {
 /**
  * `DocumentSnapshot.exists` is a method on the firebase/firestore
  * `QueryDocumentSnapshot` (`.exists()`) and a getter/property on the
- * Admin chainable adapter. `@pyric/firestore` unions the two; this
+ * Admin chainable adapter. `pyric/firestore` unions the two; this
  * helper handles either.
  */
 function snapshotExists(snapshot: DocumentSnapshot): boolean {
@@ -66,7 +66,7 @@ export interface DocumentPreviewProps {
   /**
    * Injected lister for the document's subcollections. The modular Web
    * SDK has no client-side `listCollections`; sandbox-backed apps wire
-   * `@pyric/sandbox`'s in-process listing, production apps pass a known
+   * `pyric/sandbox`'s in-process listing, production apps pass a known
    * list or a server proxy. Same shape `ReferencePicker` /
    * `useCollectionList` use. Omit to hide the Subcollections section.
    */

--- a/packages/ui/src/firestore/fieldEditors/reference.tsx
+++ b/packages/ui/src/firestore/fieldEditors/reference.tsx
@@ -61,7 +61,7 @@ function ReferenceEdit({ value, onChange, error, path }: FieldEditProps<Document
           // Preserve the existing firestore handle if the current
           // value already carries one (so it can be wired back when
           // the M5 picker arrives). Cast through `unknown` because
-          // the @pyric/firestore type union doesn't expose
+          // the pyric/firestore type union doesn't expose
           // `.firestore` uniformly across chainable + modular.
           const existingFirestore =
             (value as unknown as { firestore?: unknown }).firestore ?? {};

--- a/packages/ui/src/firestore/hooks/useCollectionList.ts
+++ b/packages/ui/src/firestore/hooks/useCollectionList.ts
@@ -16,7 +16,7 @@ export interface UseCollectionListOptions {
    * Injected collection-listing function. The library doesn't ship
    * a default — the modular Web SDK doesn't expose `listCollections`
    * on the client. Sandbox-backed apps usually wire
-   * `@pyric/sandbox`'s in-process listing; production apps either
+   * `pyric/sandbox`'s in-process listing; production apps either
    * pass a known list (e.g. from a schema) or call a server proxy.
    */
   listCollections: (

--- a/packages/ui/src/firestore/hooks/useFirestoreCollection.ts
+++ b/packages/ui/src/firestore/hooks/useFirestoreCollection.ts
@@ -8,7 +8,7 @@ import { coerceError } from './coerceError.js';
 import type { SubscriptionState } from './useFirestoreDoc.js';
 
 /**
- * Subscribe to a Firestore query (a `Query` from `@pyric/firestore`'s
+ * Subscribe to a Firestore query (a `Query` from `pyric/firestore`'s
  * modular surface, including any `CollectionReference`, which extends
  * `Query`). Returns `{ data, error, isLoading }`.
  *

--- a/packages/ui/src/firestore/hooks/useRecursiveDelete.ts
+++ b/packages/ui/src/firestore/hooks/useRecursiveDelete.ts
@@ -10,7 +10,7 @@ export interface RecursiveDeleteProgress {
 
 /**
  * Implementation injected by the consumer. The library doesn't ship
- * one — sandbox-backed apps usually walk `@pyric/sandbox`'s in-process
+ * one — sandbox-backed apps usually walk `pyric/sandbox`'s in-process
  * tree; production apps usually call a Cloud Function. Either way,
  * `start` returns an async iterator emitting progress.
  */

--- a/packages/ui/src/firestore/types.ts
+++ b/packages/ui/src/firestore/types.ts
@@ -51,7 +51,7 @@ export function inferType(value: unknown): FieldType {
   if (Array.isArray(value)) return 'array';
 
   // Firestore SDK value types — these are class instances at runtime.
-  // `instanceof` works against the same import @pyric/firestore
+  // `instanceof` works against the same import pyric/firestore
   // re-exports (Bytes / GeoPoint from firebase/firestore directly;
   // Timestamp from either backend's compatible class).
   if (value instanceof Timestamp) return 'timestamp';

--- a/packages/ui/src/storage/folderPlaceholder.ts
+++ b/packages/ui/src/storage/folderPlaceholder.ts
@@ -8,7 +8,7 @@ import { ref as refFn, type FirebaseStorage, type StorageReference } from 'pyric
  * refs with the same `(storage, fullPath)` are equal), so a plain
  * object is a legal reference — the only way to express a `<path>/`
  * name past `ref()`'s slash normalization. Sandbox targets accept
- * it; prod targets throw (the `@pyric/storage` follow-up routes prod
+ * it; prod targets throw (the `pyric/storage` follow-up routes prod
  * through the REST `name=<path>/` channel — see the P2 step-00 doc).
  */
 export function folderPlaceholderRef(

--- a/packages/ui/src/storage/hooks/useMetadataEditor.ts
+++ b/packages/ui/src/storage/hooks/useMetadataEditor.ts
@@ -174,7 +174,7 @@ export interface UseMetadataEditorResult {
    * Serialize the draft to an `updateMetadata` patch. Empty
    * `contentType`/`cacheControl` become `undefined` — which LEAVES
    * the previous value (the sandbox doesn't model null-clears; see
-   * `@pyric/storage`'s `updateMetadata` doc). `customMetadata` is
+   * `pyric/storage`'s `updateMetadata` doc). `customMetadata` is
    * always included and replaces wholesale, so row removal works.
    */
   toPatch: () => SettableMetadata;

--- a/packages/ui/src/storage/hooks/useObjectUpload.ts
+++ b/packages/ui/src/storage/hooks/useObjectUpload.ts
@@ -17,7 +17,7 @@ export type UploadTaskStatus = 'running' | 'success' | 'error';
  * byte counters and the `onProgress` callback are in the type NOW so
  * a future `uploadBytesResumable`-backed implementation emits real
  * intermediate snapshots without a breaking change. Today
- * (`@pyric/storage` has no resumable uploads — COMPAT) a task
+ * (`pyric/storage` has no resumable uploads — COMPAT) a task
  * completes in one tick: `onProgress` fires once at 0 bytes and once
  * at `totalBytes`.
  */
@@ -97,7 +97,7 @@ export interface UseObjectUploadResult {
    * Sandbox-only today: the JS-SDK-shaped `ref()` normalizes the
    * trailing slash away, so the placeholder is written through a
    * structural value-object reference the sandbox accepts; prod
-   * targets reject it (the `@pyric/storage` follow-up is a
+   * targets reject it (the `pyric/storage` follow-up is a
    * first-class placeholder API routing prod through the REST
    * `name=<path>/` upload). Throws the underlying error after
    * rolling back the optimistic prefix insert.

--- a/packages/ui/src/storage/hooks/usePathState.ts
+++ b/packages/ui/src/storage/hooks/usePathState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 /** Strip leading/trailing slashes and collapse repeats — mirrors
- *  `@pyric/storage`'s reference normalization so `usePathState` and
+ *  `pyric/storage`'s reference normalization so `usePathState` and
  *  `useStorageList` always agree on what a path is. */
 export function normalizeStoragePath(path: string): string {
   return path.split('/').filter(Boolean).join('/');

--- a/packages/ui/src/storage/hooks/useStorageObject.ts
+++ b/packages/ui/src/storage/hooks/useStorageObject.ts
@@ -24,7 +24,7 @@ export interface UseStorageObjectResult {
   blob: Blob | undefined;
   /**
    * `URL.createObjectURL` handle for the loaded blob, the preview
-   * channel (no `getDownloadURL` in `@pyric/storage`; blob URLs work
+   * channel (no `getDownloadURL` in `pyric/storage`; blob URLs work
    * identically sandbox/prod). Revoked automatically when the blob
    * is replaced, the path changes, or the hook unmounts.
    */

--- a/packages/ui/src/storage/hooks/useStorageRulesGate.ts
+++ b/packages/ui/src/storage/hooks/useStorageRulesGate.ts
@@ -19,13 +19,13 @@ export type StorageRulesGateStatus = 'idle' | 'loading' | 'ready' | 'error';
  *   (`getStorageSandbox(ctx, { rules })`), read off the handle's
  *   `StorageService`.
  * - `'none'` — no rules reachable. Every verdict allows
- *   (open-by-default, the same semantics `@pyric/storage`'s
+ *   (open-by-default, the same semantics `pyric/storage`'s
  *   enforcement layer applies when no rules are configured).
  */
 export type StorageRulesSource = 'option' | 'sandbox' | 'none';
 
 /**
- * Per-path verdict. `@pyric/storage`'s rules subset has exactly two
+ * Per-path verdict. `pyric/storage`'s rules subset has exactly two
  * verbs (`read` | `write` — the granular get/list/create/update/
  * delete forms are a parser follow-up), so `delete` and `upload` are
  * DERIVED aliases of `write`: Firebase Storage's `write` permission
@@ -146,7 +146,7 @@ interface RulesState {
  * `identity` explicitly and treat verdicts as advisory (`advisory:
  * true` — the server is authoritative).
  *
- * Evaluation contract (mirrors `@pyric/storage`'s own enforcement):
+ * Evaluation contract (mirrors `pyric/storage`'s own enforcement):
  * `resource` (the existing object) is bound as `null` — the gate
  * pre-evaluates without fetching per-path metadata, matching how the
  * sandbox enforces `listAll`. Rules conditioned on existing-object

--- a/packages/ui/src/traffic/hooks/useTrafficMonitor.ts
+++ b/packages/ui/src/traffic/hooks/useTrafficMonitor.ts
@@ -49,7 +49,7 @@ export interface UseTrafficMonitorResult {
 
 /**
  * Buffers a traffic stream into a capped ring buffer with
- * pause/resume/clear. Decoupled from `@pyric/sandbox` — `source` is
+ * pause/resume/clear. Decoupled from `pyric/sandbox` — `source` is
  * just a `(cb) => unsubscribe` function.
  *
  * Pause is consumer-side: while paused, the subscription stays

--- a/packages/ui/src/traffic/types.ts
+++ b/packages/ui/src/traffic/types.ts
@@ -1,8 +1,8 @@
 /**
  * The traffic domain types. `TrafficEvent` is structurally identical
- * to `@pyric/sandbox`'s `RequestEvent` (locked in
+ * to `pyric/sandbox`'s `RequestEvent` (locked in
  * the design rationale) — but the library defines its
- * own copy so it never imports `@pyric/sandbox`. `sandbox.onRequest`
+ * own copy so it never imports `pyric/sandbox`. `sandbox.onRequest`
  * is assignable as a `TrafficSource` with zero adapter code; a prod
  * log feed can satisfy the same shape.
  */
@@ -77,7 +77,7 @@ export interface TrafficEvent {
 
 /**
  * A subscription function: register a callback, get back an
- * unsubscribe. `@pyric/sandbox`'s `Sandbox.onRequest` matches this
+ * unsubscribe. `pyric/sandbox`'s `Sandbox.onRequest` matches this
  * signature exactly.
  */
 export type TrafficSource = (

--- a/packages/ui/test/firestore/components/ReferencePicker.test.tsx
+++ b/packages/ui/test/firestore/components/ReferencePicker.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => cleanup());
 
 // Shared sandbox + Firestore handle. The hook calls `doc()` to
 // parse text input and `query()` to fetch a collection's first
-// page — both refuse refs that didn't come from a @pyric/firestore
+// page — both refuse refs that didn't come from a pyric/firestore
 // factory. Initialize once + reuse so the multi-init upstream bug
 // (M1 note) doesn't apply.
 const sandbox = initializeSandbox();

--- a/packages/ui/test/firestore/hooks/useFirestoreDoc.test.tsx
+++ b/packages/ui/test/firestore/hooks/useFirestoreDoc.test.tsx
@@ -31,7 +31,7 @@ function makeFirestore() {
 // Minimal repro (no React, no hooks):
 //   test('a', () => { … setDoc(...) });
 //   test('b', () => { … setDoc(...) }); // <- fails
-// Reproduces against the *built* `@pyric/firestore` dist. The
+// Reproduces against the *built* `pyric/firestore` dist. The
 // existing `packages/firestore/test/sandbox-target.test.ts` avoids
 // the issue by seeding via `sandboxOps.seedDocuments` and rarely
 // calling `setDoc` directly across tests — a workaround, not a fix.

--- a/packages/ui/test/firestore/hooks/useQueryBuilder.test.tsx
+++ b/packages/ui/test/firestore/hooks/useQueryBuilder.test.tsx
@@ -10,7 +10,7 @@ import { renderHook, act, waitFor } from '../../helpers/render-hook.js';
 
 // Shared sandbox + Firestore handle. `buildQuery` calls `query()`
 // and `where()` against the input — both refuse refs not produced
-// by @pyric/firestore factories.
+// by pyric/firestore factories.
 const sandbox = initializeSandbox();
 const firestore = getFirestore(sandbox.withAuth({ uid: 'tester' }));
 const baseColl = collFn(firestore, 'users');

--- a/packages/ui/test/firestore/hooks/useReferencePicker.test.tsx
+++ b/packages/ui/test/firestore/hooks/useReferencePicker.test.tsx
@@ -12,7 +12,7 @@ import { renderHook, act, waitFor } from '../../helpers/render-hook.js';
 
 // One sandbox + one Firestore handle shared by every test in the
 // file. `useReferencePicker` calls `doc(firestore, path)` and
-// `query(coll, limit)` — both check the @pyric/firestore brand on
+// `query(coll, limit)` — both check the pyric/firestore brand on
 // the input ref. Plain `{ path, id, firestore }` literals don't
 // pass that check; refs must come from the real factories. We
 // initialize one sandbox + handle and reuse, so the multi-

--- a/packages/ui/test/helpers/render-hook.tsx
+++ b/packages/ui/test/helpers/render-hook.tsx
@@ -11,7 +11,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer';
  *
  * `@testing-library/react`'s `renderHook` mounts to a real DOM
  * container, which requires JSDOM globals on `globalThis`. Installing
- * those globals fights `@pyric/firestore-rules`' OHM parser (the
+ * those globals fights `pyric/rules`' OHM parser (the
  * rules parser hits cross-realm checks and fails with
  * `Failed to parse rules source`). `react-test-renderer` runs hooks
  * the same way React does internally but doesn't need a DOM at all,

--- a/packages/ui/test/rules/components/DenialInspector.test.tsx
+++ b/packages/ui/test/rules/components/DenialInspector.test.tsx
@@ -1,5 +1,5 @@
 // Build the REAL denial fixtures BEFORE installing JSDOM globals.
-// `@pyric/firestore-rules`' OHM parser hits cross-realm checks that fail
+// `pyric/rules`' OHM parser hits cross-realm checks that fail
 // once JSDOM replaces `globalThis` (see bunfig.toml note + render-hook
 // helper). Running the simulator here, pre-JSDOM, sidesteps that — the
 // component itself never touches the parser, so DOM rendering is safe.

--- a/packages/ui/test/storage/components/ObjectBrowser.test.tsx
+++ b/packages/ui/test/storage/components/ObjectBrowser.test.tsx
@@ -16,7 +16,7 @@ g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 g.IS_REACT_ACT_ENVIRONMENT = true;
 
 // Real sandbox behind the rules-gate probes. Storage rules use the
-// hand-rolled `@pyric/storage` parser (NOT the firestore OHM one that
+// hand-rolled `pyric/storage` parser (NOT the firestore OHM one that
 // fights JSDOM globals), so deploying rules in a DOM test is safe.
 // Assign the IDB fakes explicitly onto globalThis — see
 // ObjectInspector.test.tsx for why `fake-indexeddb/auto` isn't enough

--- a/packages/ui/test/storage/components/UploadDropzone.test.tsx
+++ b/packages/ui/test/storage/components/UploadDropzone.test.tsx
@@ -16,7 +16,7 @@ g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 g.IS_REACT_ACT_ENVIRONMENT = true;
 
 // Real sandbox behind the rules-gate probe. Storage rules use the
-// hand-rolled `@pyric/storage` parser (NOT the firestore OHM one), so
+// hand-rolled `pyric/storage` parser (NOT the firestore OHM one), so
 // deploying rules in a DOM test is safe. Explicit global assignment —
 // see ObjectInspector.test.tsx for the shared-process rationale.
 import { indexedDB as fakeIndexedDB, IDBKeyRange as fakeIDBKeyRange } from 'fake-indexeddb';


### PR DESCRIPTION
## Documentation now uses the package names users actually install

This removes stale public-package references from docs, examples, comments, and explanatory text so the repository consistently points at the current package surface.

```sh
bun add pyric pyric-tools pyric-admin
```

```ts
import { rulesTest } from 'pyric/rules/node';
import { verifyFixture } from 'pyric-tools/verify';
import { rtdb } from 'pyric-tools/deploy';
```

The change is intentionally about public naming only. Stable oracle IDs and internal fixtures that are identifiers rather than package names are left alone.

## What changes

- Replaces stale `@pyric/*` package examples with current package names.
- Updates old `pyric/firestore-rules` examples to current `pyric/rules` and `pyric/rules/node` imports.
- Updates deploy examples to use `pyric-tools/deploy`.
- Refreshes comments that still referred to old package folder names.
- Keeps stable test IDs unchanged where the old wording is part of an oracle identifier.

## Other usage

Node-only rule helpers should be imported through the Node-specific rules entry:

```ts
import { parseRules } from 'pyric/rules/node';
```

Deploy helpers should come from the tools package:

```ts
import { firestore, rtdb } from 'pyric-tools/deploy';
```

## Testing

- `bun run build`
- `bun run test`
