### PR TITLE
Lockstep alpha versions and alpha-honest package READMEs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -134,7 +134,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.0.0",
+      "version": "0.1.0-alpha.7",
       "dependencies": {
         "firebase-admin": "^13.0.0",
         "pyric": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.0.0",
+      "version": "0.1.0-alpha.7",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/pyric-admin/README.md
+++ b/packages/pyric-admin/README.md
@@ -6,6 +6,11 @@ real Firebase Admin SDK backends.
 Use `pyric-admin` when you want server/admin ergonomics while keeping the same
 backend-selection model as the client package.
 
+> **Alpha.** This package is an early alpha. The admin-shaped subpaths are
+> best-effort mirror contracts of `firebase-admin` — not guaranteed parity.
+> Any exported surface beyond the mirrored shapes is experimental public-alpha
+> and may change without notice.
+
 ## Subpaths
 
 | Subpath | Surface |

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.0.0",
+  "version": "0.1.0-alpha.7",
   "description": "Pyric admin-shape adapters (firestore, auth, database, storage) with swappable sandbox/prod backends. Mirrors firebase-admin.",
   "type": "module",
   "exports": {

--- a/packages/pyric-tools/README.md
+++ b/packages/pyric-tools/README.md
@@ -3,6 +3,14 @@
 The Pyric CLI + programmatic helpers for `firebase-tools`-shaped work
 (deploy, bridge, discover, identity-toolkit configuration).
 
+> **Alpha.** This package is an early alpha. The `firebase-tools`-mirrored
+> surfaces (deploy, discover, auth configuration) are best-effort mirror
+> contracts; non-mirrored exports (e.g. `pyric-tools/serve/worker`,
+> `pyric-tools/verify`, `pyric-tools/credentials`) are experimental
+> public-alpha surfaces that may change without notice. The MCP tool surface
+> (tool names and shapes) will consolidate during early alpha — do not treat
+> tool names as stable.
+
 ## CLI subcommands
 
 | Command | What it does |

--- a/packages/pyric/README.md
+++ b/packages/pyric/README.md
@@ -3,6 +3,13 @@
 Firebase-shaped client SDK adapters with a swappable in-process sandbox
 backend, plus Pyric's rules tooling and sandbox runtime.
 
+> **Alpha.** This package is an early alpha. The Firebase-mirrored subpaths
+> (`pyric/app`, `pyric/firestore`, `pyric/auth`, `pyric/database`,
+> `pyric/storage`) are best-effort mirror contracts of the modular Web SDK —
+> not guaranteed parity. Non-mirrored exports (e.g. `pyric/sandbox/internal`,
+> the rules tooling subpaths) are experimental public-alpha surfaces that may
+> change without notice.
+
 `pyric` mirrors Firebase's modular Web SDK subpaths:
 
 | Subpath | Surface |

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -3,6 +3,11 @@
 Headless React components and hooks for Firebase/Pyric admin surfaces. The
 components ship behavior and structural `data-*` hooks, but no visual styling.
 
+> **Alpha.** This package is an early alpha. Components and hooks built over
+> mirrored Firebase surfaces track those best-effort mirror contracts; the
+> rest of the exported API (components, hooks, `data-*` contracts) is an
+> experimental public-alpha surface that may change without notice.
+
 The same components can run against:
 
 - a Pyric sandbox in local development;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.0.0",
+  "version": "0.1.0-alpha.7",
   "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (pyric/firestore against pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling — consumers bring their own design system via className + data-* attributes.",
   "type": "module",
   "exports": {

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -3,7 +3,7 @@
 # testing, side-by-side comparison, or local-install workflows.
 #
 # Output: `dist/packages/<name>-<version>.tgz` (npm's default tarball
-# naming, scoped names flattened — e.g. `@pyric/ui` → `pyric-ui-0.0.0.tgz`).
+# naming, scoped names flattened — e.g. `@pyric/ui` → `pyric-ui-0.1.0-alpha.7.tgz`).
 #
 # Default behavior: rebuilds before packing so dist/ is fresh. Pass
 # `--skip-build` to pack the current dist/ contents (useful when


### PR DESCRIPTION
Pre-npm Gate A packaging changes:

- **Lockstep versions**: `pyric-admin` and `@pyric/ui` move `0.0.0` → `0.1.0-alpha.7`, matching `pyric` and `pyric-tools`. All four publishables now release on one version train (cross-deps are `workspace:*`, rewritten to `^0.1.0-alpha.7` at pack time — verified in the packaging gate).
- **Alpha-honest READMEs**: each shipped README states alpha status — mirrored Firebase surfaces are best-effort mirror contracts; non-mirrored exports are experimental public-alpha. `pyric-tools` additionally notes the MCP tool surface (names/shapes) will consolidate during early alpha.
- **Cosmetic**: stale example tarball name in a `pack-packages.sh` comment.

Release gates run green from this tree: `scripts/build.sh`, `lint:manifest` (publint + attw + exports check), `test:packaging` (incl. embedded studio-ui/playground-ui asset checks), `test:install-matrix` for npm/pnpm/bun (47/47 subpaths), and the root `test` script (0 failures).

Notes for the release runner:
- Use the root `test` **script**, not bare `bun test` (the latter sweeps the excluded playground suites with known node-vs-browser failures).
- `test:install-matrix` requires the package-manager argument.
- If `test:packaging` fails on `@inbrowser/agent` "no matching version", clear the stale local cache at `$TMPDIR/npm-cache-pyric-packaging-test` (offline-preferred cache predating the 0.4.1 publish).