### PR TITLE
Remote sandbox transport: generic worker-relay over the bridge

### DIFF
--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -54,6 +54,13 @@
     "./serve/worker": {
       "types": "./dist/serve/worker/index.d.ts",
       "import": "./dist/serve/worker/index.js"
+    },
+    "./remote": {
+      "types": "./dist/remote/index.d.ts",
+      "node": {
+        "types": "./dist/remote/index.d.ts",
+        "import": "./dist/remote/index.js"
+      }
     }
   },
   "bin": {

--- a/packages/pyric-tools/src/bridge/client/bridge.ts
+++ b/packages/pyric-tools/src/bridge/client/bridge.ts
@@ -21,11 +21,16 @@ import type {
   HelloFromClient,
   ToolCallRequest,
   ToolCallResponse,
+  WorkerOpFrame,
+  WorkerSubFrame,
+  WorkerOpPayload,
+  WorkerSubPayload,
 } from '../protocol.js';
 import {
   isBridgeMessage,
   DEFAULT_BRIDGE_PORT,
   DEFAULT_SANDBOX_PATH,
+  WORKER_RELAY_CAPABILITY,
 } from '../protocol.js';
 import { dispatchSandboxTool, SANDBOX_TOOL_NAMES } from './dispatch.js';
 
@@ -63,6 +68,26 @@ export interface ConnectBridgeOptions {
   noReconnect?: boolean;
   /** Called whenever the client transitions connection state. */
   onStateChange?: (state: ConnectedBridgeState) => void;
+  /**
+   * Generic worker relay (remote sandbox, slice 1). When supplied, the
+   * client advertises the `worker-relay` capability in its hello and routes
+   * `worker-op` / `worker-sub` / `worker-unsub` frames through it — on the
+   * worker path this forwards them into the SharedWorker port
+   * (`relayWorkerOp` / `relayWorkerSub` in `serve/worker/client.ts`).
+   */
+  workerRelay?: WorkerRelay;
+}
+
+/** Host-supplied handlers that forward relay frames into the SharedWorker. */
+export interface WorkerRelay {
+  /** Dispatch one worker op; resolves with the worker's `res.value`. */
+  op(op: WorkerOpPayload): Promise<unknown>;
+  /**
+   * Register a worker subscription; `onValue` receives every snap value
+   * (including the `{ __error }` establishment-failure convention).
+   * Returns the unsubscribe function.
+   */
+  subscribe(sub: WorkerSubPayload, onValue: (value: unknown) => void): () => void;
 }
 
 export type ConnectedBridgeState =
@@ -107,11 +132,26 @@ export function connectBridge(
   const noReconnect = opts.noReconnect ?? false;
   const onStateChange = opts.onStateChange ?? (() => {});
 
+  const workerRelay = opts.workerRelay ?? null;
+
   let ws: WebSocket | null = null;
   let closed = false;
   let attempt = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let currentState: ConnectedBridgeState = { kind: 'connecting' };
+  /** Live relay subscriptions (bridge subId → worker unsubscribe). Torn down
+   *  on every socket close: the bridge re-issues its registry to the NEXT
+   *  registered peer, so keeping these would double-deliver. */
+  const relaySubs = new Map<string, () => void>();
+
+  function teardownRelaySubs() {
+    for (const unsubscribe of relaySubs.values()) {
+      try {
+        unsubscribe();
+      } catch {}
+    }
+    relaySubs.clear();
+  }
 
   function setState(next: ConnectedBridgeState) {
     currentState = next;
@@ -151,6 +191,7 @@ export function connectBridge(
         protocol: 1,
         tools: toolNames,
         sandboxId,
+        ...(workerRelay ? { capabilities: [WORKER_RELAY_CAPABILITY] } : {}),
       };
       send(hello);
     };
@@ -172,6 +213,24 @@ export function connectBridge(
         void handleToolCall(parsed);
         return;
       }
+      if (parsed.type === 'worker-op') {
+        void handleWorkerOp(parsed);
+        return;
+      }
+      if (parsed.type === 'worker-sub') {
+        handleWorkerSub(parsed);
+        return;
+      }
+      if (parsed.type === 'worker-unsub') {
+        const unsubscribe = relaySubs.get(parsed.subId);
+        if (unsubscribe) {
+          relaySubs.delete(parsed.subId);
+          try {
+            unsubscribe();
+          } catch {}
+        }
+        return;
+      }
       if (parsed.type === 'ping') {
         send({ type: 'pong', id: parsed.id });
         return;
@@ -183,6 +242,10 @@ export function connectBridge(
     socket.onclose = (event: CloseEvent) => {
       const reason = event.reason || `closed (code ${event.code})`;
       ws = null;
+      // Relay subs are per-connection: the bridge owns the durable registry
+      // and re-issues it after the next hello, so live worker listeners from
+      // THIS connection must go now (or the next connection double-delivers).
+      teardownRelaySubs();
       scheduleReconnect(reason);
     };
 
@@ -216,6 +279,48 @@ export function connectBridge(
     send(response);
   }
 
+  async function handleWorkerOp(req: WorkerOpFrame) {
+    if (!workerRelay) return; // capability not advertised — drop (wire drift)
+    try {
+      const value = await workerRelay.op(req.op);
+      send({ type: 'worker-res', id: req.id, ok: true, value });
+    } catch (err) {
+      send({
+        type: 'worker-res',
+        id: req.id,
+        ok: false,
+        error: {
+          code: (err as { code?: string }).code ?? 'unknown',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
+  function handleWorkerSub(req: WorkerSubFrame) {
+    if (!workerRelay) return; // capability not advertised — drop (wire drift)
+    if (relaySubs.has(req.subId)) return; // idempotent
+    try {
+      const unsubscribe = workerRelay.subscribe(req.sub, (value) => {
+        send({ type: 'worker-snap', subId: req.subId, value });
+      });
+      relaySubs.set(req.subId, unsubscribe);
+    } catch (err) {
+      // Synchronous establishment failure — relay it via the worker host's
+      // snap-error convention so the far side's subscribe can reject.
+      send({
+        type: 'worker-snap',
+        subId: req.subId,
+        value: {
+          __error: {
+            code: (err as { code?: string }).code ?? 'unknown',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        },
+      });
+    }
+  }
+
   function scheduleReconnect(reason: string) {
     if (closed) return;
     if (noReconnect) {
@@ -237,6 +342,7 @@ export function connectBridge(
   return {
     disconnect() {
       closed = true;
+      teardownRelaySubs();
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;

--- a/packages/pyric-tools/src/bridge/protocol.ts
+++ b/packages/pyric-tools/src/bridge/protocol.ts
@@ -15,6 +15,11 @@
  * environment.
  */
 
+// TYPE-ONLY imports (erased at build) — the wire payloads for the generic
+// worker relay are the SharedWorker protocol's own op/sub messages, minus
+// the port-level `t`/`id`/`subId` fields the relay re-mints per hop.
+import type { OpMessage, SubMessage } from '../serve/worker/protocol.js';
+
 /** Bridge mode set at process start. */
 export type BridgeMode = 'sandbox' | 'prod';
 
@@ -67,6 +72,13 @@ export interface HelloFromClient {
   tools: string[];
   /** Stable identifier for this sandbox session (for audit log). */
   sandboxId: string;
+  /**
+   * Optional peer capabilities (additive). The bridge only sends `worker-*`
+   * frames to a peer that declared {@link WORKER_RELAY_CAPABILITY} — an old
+   * peer that omits it simply never receives them, and worker ops against it
+   * fail fast with a clear error instead of timing out.
+   */
+  capabilities?: string[];
 }
 
 /** Bridge → browser: acknowledge connection. */
@@ -107,6 +119,96 @@ export interface ToolCallResponse {
   };
 }
 
+// ── Generic worker relay (remote sandbox, slice 1) ───────────────────
+//
+// Beyond `tool-call`, the bridge can relay ANY SharedWorker-protocol op or
+// (snap-delivering) subscription between a Node consumer and the browser
+// peer. The SAME frame shapes travel both legs:
+//
+//   Node consumer ──ws──> bridge ──ws──> browser tab ──port──> worker
+//
+// Correlation ids/subIds are re-minted per hop (consumer-minted on the
+// consumer leg, bridge-minted UUIDs on the peer leg, page-local ids on the
+// worker port) so each hop's pending/registry maps stay collision-free.
+
+/** Peer capability flag: "I can relay worker-op / worker-sub frames". */
+export const WORKER_RELAY_CAPABILITY = 'worker-relay';
+
+/** `Omit` distributed over a union (plain `Omit` collapses union members). */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/** A worker one-shot op, minus the port-level `t`/`id` the relay re-mints. */
+export type WorkerOpPayload = DistributiveOmit<OpMessage, 't' | 'id'>;
+
+/**
+ * A worker subscription, minus the port-level `t`/`subId`. Slice 1 relays
+ * snap-delivering subs (RTDB value, auth state, Firestore); the unified
+ * event stream (`target: 'events'`) is NOT relayable yet — it needs bounded
+ * backpressure first (slice 2).
+ */
+export type WorkerSubPayload = DistributiveOmit<SubMessage, 't' | 'subId'>;
+
+/** Node consumer → bridge: attach as a worker-relay consumer (NOT a peer —
+ *  a consumer never replaces the browser tab in last-connection-wins). */
+export interface AttachFromConsumer {
+  type: 'attach';
+  protocol: 1;
+}
+
+/** Bridge → Node consumer: attach acknowledged. */
+export interface AttachAckFromBridge {
+  type: 'attach-ack';
+  protocol: 1;
+  bridgeVersion: string;
+  /** Whether a browser tab is currently registered as the sandbox peer. */
+  peerConnected: boolean;
+}
+
+/** Toward the worker: dispatch this one-shot op. (consumer→bridge and
+ *  bridge→browser use the same shape; `id` is per-leg.) */
+export interface WorkerOpFrame {
+  type: 'worker-op';
+  /** Correlation id — echoed back in the matching `worker-res`. */
+  id: string;
+  op: WorkerOpPayload;
+}
+
+/** Away from the worker: the relayed op result. */
+export interface WorkerResFrame {
+  type: 'worker-res';
+  id: string;
+  /** When `ok === false`, `error` is populated and `value` omitted. */
+  ok: boolean;
+  value?: unknown;
+  error?: { code: string; message: string };
+}
+
+/** Toward the worker: register a subscription. Re-issued by the bridge to a
+ *  NEW peer on reconnect/replacement (value subs re-deliver a fresh initial
+ *  snapshot, so replay is cursor-free and last-value-wins-safe). */
+export interface WorkerSubFrame {
+  type: 'worker-sub';
+  subId: string;
+  sub: WorkerSubPayload;
+}
+
+/** Toward the worker: tear a subscription down. */
+export interface WorkerUnsubFrame {
+  type: 'worker-unsub';
+  subId: string;
+}
+
+/** Away from the worker: one streamed snapshot for a subscription. A failed
+ *  ESTABLISHMENT also arrives here as `value: { __error: { code, message } }`
+ *  (the worker host's snap-error convention) — relays forward it verbatim. */
+export interface WorkerSnapFrame {
+  type: 'worker-snap';
+  subId: string;
+  value: unknown;
+}
+
 /** Either direction: ping for keepalive / liveness detection. */
 export interface Ping {
   type: 'ping';
@@ -123,8 +225,15 @@ export interface Pong {
 export type BridgeMessage =
   | HelloFromClient
   | HelloFromBridge
+  | AttachFromConsumer
+  | AttachAckFromBridge
   | ToolCallRequest
   | ToolCallResponse
+  | WorkerOpFrame
+  | WorkerResFrame
+  | WorkerSubFrame
+  | WorkerUnsubFrame
+  | WorkerSnapFrame
   | Ping
   | Pong;
 
@@ -135,8 +244,15 @@ export function isBridgeMessage(value: unknown): value is BridgeMessage {
   return (
     t === 'hello' ||
     t === 'hello-ack' ||
+    t === 'attach' ||
+    t === 'attach-ack' ||
     t === 'tool-call' ||
     t === 'tool-result' ||
+    t === 'worker-op' ||
+    t === 'worker-res' ||
+    t === 'worker-sub' ||
+    t === 'worker-unsub' ||
+    t === 'worker-snap' ||
     t === 'ping' ||
     t === 'pong'
   );
@@ -145,3 +261,7 @@ export function isBridgeMessage(value: unknown): value is BridgeMessage {
 /** Error returned by MCP when no browser tab is currently connected. */
 export const NO_SANDBOX_ERROR_MESSAGE =
   'sandbox not connected. Open your dev server in a browser and refresh the page so the bridge client can register.';
+
+/** Error for worker ops against a peer that predates the worker relay. */
+export const NO_WORKER_RELAY_ERROR_MESSAGE =
+  'the connected browser tab does not support the worker relay — reload the tab (and update pyric if reloading does not help).';

--- a/packages/pyric-tools/src/bridge/server/bridge.ts
+++ b/packages/pyric-tools/src/bridge/server/bridge.ts
@@ -128,12 +128,19 @@ export interface Bridge {
    *
    * `capabilities` come from the peer's `hello` — the bridge only sends
    * `worker-*` frames to a peer that declared `'worker-relay'`.
+   *
+   * `onReplaced` fires when a NEWER registration displaces this peer. The
+   * transport MUST use it to close the old socket: the browser side's
+   * close handler tears down its relayed worker subscriptions — without
+   * this, a replaced tab's SharedWorker listeners would live until the tab
+   * closed, streaming snaps the bridge drops as stale-generation forever.
    */
   registerSandboxPeer(
     send: SendToPeer,
     tools: string[],
     sandboxId: string,
     capabilities?: string[],
+    onReplaced?: () => void,
   ): () => void;
 
   /** True if a sandbox peer is currently registered. */
@@ -196,6 +203,7 @@ interface ActivePeer {
   tools: Set<string>;
   sandboxId: string;
   capabilities: Set<string>;
+  onReplaced?: () => void;
 }
 
 interface PendingWorkerOp {
@@ -267,10 +275,21 @@ export function createBridge(opts: BridgeOptions): Bridge {
     tools: string[],
     sandboxId: string,
     capabilities: string[] = [],
+    onReplaced?: () => void,
   ): () => void {
     if (peer) {
       // Last-wins: kick the old peer and reject its pending calls.
       failAllPending('sandbox peer replaced by a newer connection');
+      // Tear the old peer down (the transport closes its socket). The
+      // browser's close handler tears down its relayed worker
+      // subscriptions — otherwise the replaced tab's SharedWorker
+      // listeners would keep posting snaps this bridge drops as
+      // stale-generation until the tab closed.
+      try {
+        peer.onReplaced?.();
+      } catch {
+        // A failing transport hook must not block the new registration.
+      }
     }
     generation += 1;
     const myPeer: ActivePeer = {
@@ -278,6 +297,7 @@ export function createBridge(opts: BridgeOptions): Bridge {
       tools: new Set(tools),
       sandboxId,
       capabilities: new Set(capabilities),
+      onReplaced,
     };
     peer = myPeer;
     // Re-issue every registered worker subscription to the new peer. RTDB

--- a/packages/pyric-tools/src/bridge/server/bridge.ts
+++ b/packages/pyric-tools/src/bridge/server/bridge.ts
@@ -22,8 +22,16 @@ import type {
   BridgeMode,
   HealthReport,
   ToolCallResponse,
+  WorkerOpPayload,
+  WorkerSubPayload,
+  WorkerResFrame,
+  WorkerSnapFrame,
 } from '../protocol.js';
-import { NO_SANDBOX_ERROR_MESSAGE } from '../protocol.js';
+import {
+  NO_SANDBOX_ERROR_MESSAGE,
+  NO_WORKER_RELAY_ERROR_MESSAGE,
+  WORKER_RELAY_CAPABILITY,
+} from '../protocol.js';
 import type { ConfirmHandler, ConfirmDecision } from './confirm.js';
 
 /** Subset of `@inbrowser/agent`'s `ToolResult` shape the bridge emits. */
@@ -117,11 +125,28 @@ export interface Bridge {
    * caller MUST invoke when the WS closes. Last-wins: a new
    * registration disconnects the previous peer (its pending calls
    * fail with a clear error).
+   *
+   * `capabilities` come from the peer's `hello` — the bridge only sends
+   * `worker-*` frames to a peer that declared `'worker-relay'`.
    */
-  registerSandboxPeer(send: SendToPeer, tools: string[], sandboxId: string): () => void;
+  registerSandboxPeer(
+    send: SendToPeer,
+    tools: string[],
+    sandboxId: string,
+    capabilities?: string[],
+  ): () => void;
 
   /** True if a sandbox peer is currently registered. */
   isSandboxConnected(): boolean;
+
+  /**
+   * Generation counter of the CURRENT peer registration (0 = no peer has
+   * ever registered). The transport captures this right after registering
+   * and tags every inbound message with it, so a frame arriving on a
+   * REPLACED peer's socket (tab refresh mid-flight) can never resolve a new
+   * peer's pending call or deliver a stale subscription snapshot.
+   */
+  peerGeneration(): number;
 
   /** Tool names the bridge currently exposes to MCP. */
   toolNames(): string[];
@@ -129,8 +154,31 @@ export interface Bridge {
   /** Dispatch a tool call. Forwards to peer in sandbox mode. */
   dispatch(name: string, args: Record<string, unknown>): Promise<BridgeToolResult>;
 
-  /** Handle a message from the sandbox peer (tool-result, pong, …). */
-  handleSandboxMessage(msg: BridgeMessage): void;
+  /**
+   * Relay a generic worker op to the peer's SharedWorker. Resolves with the
+   * worker's `res.value`; rejects with an Error carrying `.code` on worker
+   * failure, timeout, no peer, or a peer without the worker relay.
+   */
+  dispatchWorkerOp(op: WorkerOpPayload): Promise<unknown>;
+
+  /**
+   * Register a worker subscription. Ownership lives HERE: the registry
+   * survives peer churn, and every registered sub is re-issued to a new
+   * peer on registration (RTDB value / auth-state subs re-deliver a fresh
+   * initial snapshot, so replay is cursor-free). `onSnap` receives every
+   * relayed snap value verbatim — including the worker host's
+   * `{ __error: { code, message } }` establishment-failure convention.
+   * Returns the unsubscribe function.
+   */
+  subscribeWorker(sub: WorkerSubPayload, onSnap: (value: unknown) => void): () => void;
+
+  /**
+   * Handle a message from the sandbox peer (tool-result, pong, …).
+   * `generation` is the peer generation the transport captured at
+   * registration; when provided, `worker-res`/`worker-snap` frames from a
+   * stale generation are dropped.
+   */
+  handleSandboxMessage(msg: BridgeMessage, generation?: number): void;
 
   /** /health endpoint payload. */
   health(): HealthReport;
@@ -147,6 +195,26 @@ interface ActivePeer {
   send: SendToPeer;
   tools: Set<string>;
   sandboxId: string;
+  capabilities: Set<string>;
+}
+
+interface PendingWorkerOp {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  method: string;
+}
+
+interface WorkerSubEntry {
+  sub: WorkerSubPayload;
+  onSnap: (value: unknown) => void;
+}
+
+/** Build the typed Error worker-op rejections carry. */
+function workerOpError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
 }
 
 export function createBridge(opts: BridgeOptions): Bridge {
@@ -164,6 +232,15 @@ export function createBridge(opts: BridgeOptions): Bridge {
 
   let peer: ActivePeer | null = null;
   const pending = new Map<string, PendingCall>();
+  // ── worker relay state ──
+  // Generation counter: bumped on every peer registration. Inbound frames
+  // tagged with an older generation are stale (a replaced tab's socket) and
+  // must not resolve ops / deliver snaps registered under the new peer.
+  let generation = 0;
+  const workerPending = new Map<string, PendingWorkerOp>();
+  // Subscription ownership lives on the bridge: entries survive peer churn
+  // and are re-issued to every newly registered relay-capable peer.
+  const workerSubs = new Map<string, WorkerSubEntry>();
 
   function failAllPending(reason: string) {
     for (const call of pending.values()) {
@@ -174,23 +251,48 @@ export function createBridge(opts: BridgeOptions): Bridge {
       });
     }
     pending.clear();
+    for (const op of workerPending.values()) {
+      clearTimeout(op.timer);
+      op.reject(workerOpError('unavailable', reason));
+    }
+    workerPending.clear();
+  }
+
+  function peerHasRelay(): boolean {
+    return peer !== null && peer.capabilities.has(WORKER_RELAY_CAPABILITY);
   }
 
   function registerSandboxPeer(
     send: SendToPeer,
     tools: string[],
     sandboxId: string,
+    capabilities: string[] = [],
   ): () => void {
     if (peer) {
       // Last-wins: kick the old peer and reject its pending calls.
       failAllPending('sandbox peer replaced by a newer connection');
     }
+    generation += 1;
     const myPeer: ActivePeer = {
       send,
       tools: new Set(tools),
       sandboxId,
+      capabilities: new Set(capabilities),
     };
     peer = myPeer;
+    // Re-issue every registered worker subscription to the new peer. RTDB
+    // value / auth-state semantics make this safe and cursor-free: each
+    // (re)subscribe delivers a fresh initial snapshot and consumers are
+    // last-value-wins, so the Node side just sees one extra snapshot.
+    if (myPeer.capabilities.has(WORKER_RELAY_CAPABILITY)) {
+      for (const [subId, entry] of workerSubs) {
+        try {
+          myPeer.send({ type: 'worker-sub', subId, sub: entry.sub });
+        } catch {
+          // Socket failure surfaces via the transport's close handler.
+        }
+      }
+    }
     return () => {
       if (peer === myPeer) {
         failAllPending(NO_SANDBOX_ERROR_MESSAGE);
@@ -201,6 +303,10 @@ export function createBridge(opts: BridgeOptions): Bridge {
 
   function isSandboxConnected(): boolean {
     return peer !== null;
+  }
+
+  function peerGeneration(): number {
+    return generation;
   }
 
   function toolNames(): string[] {
@@ -301,7 +407,105 @@ export function createBridge(opts: BridgeOptions): Bridge {
     });
   }
 
-  function handleSandboxMessage(msg: BridgeMessage): void {
+  function dispatchWorkerOp(op: WorkerOpPayload): Promise<unknown> {
+    if (!peer) {
+      return Promise.reject(workerOpError('unavailable', NO_SANDBOX_ERROR_MESSAGE));
+    }
+    if (!peerHasRelay()) {
+      return Promise.reject(workerOpError('unimplemented', NO_WORKER_RELAY_ERROR_MESSAGE));
+    }
+    return new Promise<unknown>((resolve, reject) => {
+      const id = randomUUID();
+      const timer = setTimeout(() => {
+        if (workerPending.has(id)) {
+          workerPending.delete(id);
+          reject(
+            workerOpError(
+              'deadline-exceeded',
+              `sandbox worker op timed out after ${callTimeoutMs}ms (op: ${op.method})`,
+            ),
+          );
+        }
+      }, callTimeoutMs);
+      workerPending.set(id, { resolve, reject, timer, method: op.method });
+      try {
+        peer!.send({ type: 'worker-op', id, op });
+      } catch (err) {
+        clearTimeout(timer);
+        workerPending.delete(id);
+        reject(
+          workerOpError(
+            'unavailable',
+            `failed to send worker op to sandbox: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    });
+  }
+
+  function subscribeWorker(
+    sub: WorkerSubPayload,
+    onSnap: (value: unknown) => void,
+  ): () => void {
+    const subId = randomUUID();
+    workerSubs.set(subId, { sub, onSnap });
+    if (peerHasRelay()) {
+      try {
+        peer!.send({ type: 'worker-sub', subId, sub });
+      } catch {
+        // Socket failure surfaces via the transport's close handler; the
+        // registry entry replays on the next peer registration.
+      }
+    }
+    // No peer (or a relay-less peer) is NOT an error here: the registry is
+    // replayed on the next registration, mirroring RTDB's offline semantics.
+    return () => {
+      if (!workerSubs.delete(subId)) return;
+      if (peerHasRelay()) {
+        try {
+          peer!.send({ type: 'worker-unsub', subId });
+        } catch {}
+      }
+    };
+  }
+
+  function handleSandboxMessage(msg: BridgeMessage, msgGeneration?: number): void {
+    // Frames from a REPLACED peer's socket must not act on the current
+    // peer's state (subscriptions make stale delivery likely on tab
+    // refresh: the old tab's worker port keeps firing until its WS dies).
+    const stale = msgGeneration !== undefined && msgGeneration !== generation;
+    switch (msg.type) {
+      case 'worker-res': {
+        if (stale) return;
+        const res = msg as WorkerResFrame;
+        const op = workerPending.get(res.id);
+        if (!op) return; // late or unknown — drop silently
+        clearTimeout(op.timer);
+        workerPending.delete(res.id);
+        if (res.ok) {
+          op.resolve(res.value);
+        } else {
+          op.reject(
+            workerOpError(res.error?.code ?? 'unknown', res.error?.message ?? 'unknown sandbox error'),
+          );
+        }
+        return;
+      }
+      case 'worker-snap': {
+        if (stale) return;
+        const snap = msg as WorkerSnapFrame;
+        const entry = workerSubs.get(snap.subId);
+        if (!entry) return; // unsubscribed or unknown — drop silently
+        try {
+          entry.onSnap(snap.value);
+        } catch {
+          // Consumer callback failures must not break the relay loop.
+        }
+        return;
+      }
+      default:
+        break;
+    }
     switch (msg.type) {
       case 'tool-result': {
         const response = msg as ToolCallResponse;
@@ -377,8 +581,11 @@ export function createBridge(opts: BridgeOptions): Bridge {
     recordToolEvent,
     registerSandboxPeer,
     isSandboxConnected,
+    peerGeneration,
     toolNames,
     dispatch,
+    dispatchWorkerOp,
+    subscribeWorker,
     handleSandboxMessage,
     health,
   };

--- a/packages/pyric-tools/src/bridge/server/peer.ts
+++ b/packages/pyric-tools/src/bridge/server/peer.ts
@@ -62,9 +62,22 @@ export function attachPeer(
             ws.send(JSON.stringify(out));
           } catch {}
         },
-        msg.tools,
+        // Harden against a malformed hello: these fields come off the wire
+        // and feed `new Set(...)` in the bridge core — a non-array value
+        // (e.g. `capabilities: 42`) would throw inside this message
+        // listener, escape uncaught, and crash the serve process.
+        Array.isArray(msg.tools) ? msg.tools : [],
         msg.sandboxId,
-        msg.capabilities ?? [],
+        Array.isArray(msg.capabilities) ? msg.capabilities : [],
+        // On replacement, close THIS socket: the browser side's onclose
+        // handler tears down its relayed worker subscriptions, so a
+        // replaced tab's SharedWorker listeners don't keep streaming
+        // snaps the bridge drops as stale-generation until the tab closes.
+        () => {
+          try {
+            ws.close();
+          } catch {}
+        },
       );
       peerGen = bridge.peerGeneration();
       ws.send(

--- a/packages/pyric-tools/src/bridge/server/peer.ts
+++ b/packages/pyric-tools/src/bridge/server/peer.ts
@@ -1,9 +1,11 @@
 /**
  * Bridge transport helpers shared by the bridge mounts.
  *
- * `attachPeer` adapts a `ws` WebSocket into a registered sandbox peer (the
- * browser-side `connectBridge` is the other end); `collectBody` buffers a
- * Node request body into parsed JSON for the stateless MCP transport.
+ * `attachPeer` adapts a `ws` WebSocket into either a registered sandbox PEER
+ * (the browser-side `connectBridge` is the other end — first message
+ * `hello`) or a worker-relay CONSUMER (the Node-side `connectRemoteSandbox`
+ * — first message `attach`); `collectBody` buffers a Node request body into
+ * parsed JSON for the stateless MCP transport.
  *
  * Both are consumed by `serve/bridge-mount.ts` (the `pyric serve --bridge` and
  * `pyricSandbox({ bridge })` mount) and `serve/namespace.ts` (capture route).
@@ -12,7 +14,7 @@
  */
 import type { IncomingMessage } from 'node:http';
 import type { WebSocket } from 'ws';
-import { createBridge } from './bridge.js';
+import { createBridge, type Bridge } from './bridge.js';
 import { isBridgeMessage, type BridgeMessage } from '../protocol.js';
 
 export function attachPeer(
@@ -20,7 +22,12 @@ export function attachPeer(
   ws: WebSocket,
 ): void {
   let disconnect: (() => void) | null = null;
+  /** Peer generation captured at registration — tags every inbound frame so
+   *  a replaced tab's socket can't resolve the NEW peer's calls or deliver
+   *  stale subscription snaps (see Bridge.peerGeneration). */
+  let peerGen = 0;
   let helloed = false;
+  let consumer: ConsumerSession | null = null;
 
   ws.on('message', (raw) => {
     let msg: unknown;
@@ -30,6 +37,22 @@ export function attachPeer(
       return;
     }
     if (!isBridgeMessage(msg)) return;
+    if (msg.type === 'attach') {
+      // Worker-relay consumer (Node client). NOT a peer: attaching never
+      // kicks the browser tab out of last-connection-wins.
+      if (helloed || consumer) return;
+      consumer = createConsumerSession(bridge, (out: BridgeMessage) => {
+        try {
+          ws.send(JSON.stringify(out));
+        } catch {}
+      });
+      consumer.handleMessage(msg); // acks with attach-ack
+      return;
+    }
+    if (consumer) {
+      consumer.handleMessage(msg);
+      return;
+    }
     if (msg.type === 'hello') {
       if (helloed) return;
       helloed = true;
@@ -41,7 +64,9 @@ export function attachPeer(
         },
         msg.tools,
         msg.sandboxId,
+        msg.capabilities ?? [],
       );
+      peerGen = bridge.peerGeneration();
       ws.send(
         JSON.stringify({
           type: 'hello-ack',
@@ -52,14 +77,99 @@ export function attachPeer(
       return;
     }
     if (!helloed) return;
-    bridge.handleSandboxMessage(msg);
+    bridge.handleSandboxMessage(msg, peerGen);
   });
 
   ws.on('close', () => {
     if (disconnect) disconnect();
     disconnect = null;
+    if (consumer) consumer.dispose();
+    consumer = null;
   });
   ws.on('error', () => {});
+}
+
+// ── Worker-relay consumer session (transport-agnostic) ───────────────────
+
+/**
+ * One attached worker-relay consumer (the Node `connectRemoteSandbox`
+ * client). Transport-agnostic — `attachPeer` adapts it onto a `ws` socket;
+ * tests drive `handleMessage` directly.
+ */
+export interface ConsumerSession {
+  /** Handle one parsed message from the consumer. */
+  handleMessage(msg: BridgeMessage): void;
+  /** Tear down every subscription this consumer registered. */
+  dispose(): void;
+}
+
+/**
+ * Create a consumer session over `send`. Correlation ids/subIds on this leg
+ * are CONSUMER-minted and echoed verbatim; the bridge core mints its own ids
+ * for the peer leg (`dispatchWorkerOp` / `subscribeWorker`), so the two legs'
+ * id spaces never mix.
+ */
+export function createConsumerSession(
+  bridge: Bridge,
+  send: (msg: BridgeMessage) => void,
+): ConsumerSession {
+  /** consumer subId → bridge-side unsubscribe. */
+  const subs = new Map<string, () => void>();
+
+  return {
+    handleMessage(msg: BridgeMessage): void {
+      switch (msg.type) {
+        case 'attach': {
+          // Idempotent re-attach: just re-ack.
+          send({
+            type: 'attach-ack',
+            protocol: 1,
+            bridgeVersion: bridge.version,
+            peerConnected: bridge.isSandboxConnected(),
+          });
+          return;
+        }
+        case 'worker-op': {
+          bridge.dispatchWorkerOp(msg.op).then(
+            (value) => send({ type: 'worker-res', id: msg.id, ok: true, value }),
+            (err: Error & { code?: string }) =>
+              send({
+                type: 'worker-res',
+                id: msg.id,
+                ok: false,
+                error: { code: err.code ?? 'unknown', message: err.message },
+              }),
+          );
+          return;
+        }
+        case 'worker-sub': {
+          if (subs.has(msg.subId)) return; // idempotent
+          const unsubscribe = bridge.subscribeWorker(msg.sub, (value) =>
+            send({ type: 'worker-snap', subId: msg.subId, value }),
+          );
+          subs.set(msg.subId, unsubscribe);
+          return;
+        }
+        case 'worker-unsub': {
+          const unsubscribe = subs.get(msg.subId);
+          if (!unsubscribe) return;
+          subs.delete(msg.subId);
+          unsubscribe();
+          return;
+        }
+        case 'ping': {
+          send({ type: 'pong', id: msg.id });
+          return;
+        }
+        default:
+          return; // peer-only or unknown frames — ignore
+      }
+    },
+    dispose(): void {
+      for (const unsubscribe of subs.values()) unsubscribe();
+      subs.clear();
+    },
+  };
 }
 
 export async function collectBody(req: IncomingMessage): Promise<unknown> {

--- a/packages/pyric-tools/src/cli/mcp-proxy.ts
+++ b/packages/pyric-tools/src/cli/mcp-proxy.ts
@@ -36,18 +36,14 @@
  * window as a fallback. Degrades LEGIBLY: if no serve is found, or the pointed
  * server's identity can't be matched, we report it — never a silent hang.
  */
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { ParsedArgs } from './parse-args.js';
+import { discoverServe, SCAN_PORTS } from '../serve/discovery.js';
 
-/** Ports probed when the pointer is absent — serve's default scan window PLUS
- *  the vite-plugin default (5174), which the old 5000-5004 window missed (so a
- *  vite-only project was never found by scan). The standalone `pyric bridge`
- *  serves `/health` (not `/__pyric/health`) and writes no pointer, so it is
- *  registered directly via `claude mcp add`, not discovered here. */
-const SCAN_PORTS = [5000, 5001, 5002, 5003, 5004, 5174];
-const POINTER = join('.pyric', 'serve.json');
+// Discovery (pointer + identity-pinned health probing) lives in
+// `serve/discovery.ts` — shared with the Node remote-sandbox client
+// (`remote/index.ts`). Re-exported here for existing consumers.
+export { discoverServe } from '../serve/discovery.js';
 
 /** A relayed request with no response within this window is failed with a
  *  JSON-RPC error rather than hanging forever. Sits just above the bridge's
@@ -55,142 +51,6 @@ const POINTER = join('.pyric', 'serve.json');
 const REQUEST_TIMEOUT_MS = 35_000;
 /** JSON-RPC error code for proxy-synthesized failures (server-defined range). */
 const PROXY_ERROR_CODE = -32001;
-
-interface HealthLite {
-  mode?: string;
-  instanceId?: string;
-}
-interface Discovered {
-  mcpUrl: string;
-  url: string;
-  /** `http://<family>:<port>` the server actually answered on. */
-  base: string;
-  /** Identity pinned at discovery. Null only when talking to an older server
-   *  that predates the instanceId field (matching is then skipped). */
-  instanceId: string | null;
-  source: string;
-}
-
-/**
- * Probe BOTH loopback families on a port and return the base that answers.
- *
- * Hostname-based URLs are a trap here: serve writes `http://localhost:...`
- * for humans (browsers dual-stack fine), but `localhost` resolution differs
- * by runtime — node/undici prefers IPv6 `::1`, and a serve under one runtime
- * may bind `127.0.0.1`-only while under another binds `::1`-only. So the
- * proxy never trusts the hostname: it takes the PORT and tries explicit
- * `127.0.0.1` and `[::1]`, using whichever the server is actually on.
- */
-function basesForPort(port: number): string[] {
-  return [`http://127.0.0.1:${port}`, `http://[::1]:${port}`];
-}
-
-async function probeHealth(base: string): Promise<HealthLite | null> {
-  try {
-    const res = await fetch(`${base}/__pyric/health`, { signal: AbortSignal.timeout(1000) });
-    if (res.status !== 200) return null;
-    const body = (await res.json()) as HealthLite;
-    return body.mode === 'sandbox' ? body : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * First loopback base on `port` whose health reports a sandbox bridge. With an
- * `expectedInstanceId`, returns ONLY a family whose health identity matches —
- * so when two sandboxes collide on one port across families, the proxy locks
- * onto the one the pointer names, not merely the first to answer. (An older
- * server with no `instanceId` field can't be identity-checked; matching is
- * skipped in that case so the pointer still resolves.)
- */
-async function healthyBase(
-  port: number,
-  expectedInstanceId?: string | null,
-): Promise<{ base: string; instanceId: string | null } | null> {
-  for (const base of basesForPort(port)) {
-    const health = await probeHealth(base);
-    if (!health) continue;
-    const id = health.instanceId ?? null;
-    // Healthy but the WRONG server (the cross-family squatter): skip, try next.
-    if (expectedInstanceId && id !== expectedInstanceId) continue;
-    return { base, instanceId: id };
-  }
-  return null;
-}
-
-/** Best-effort port extraction from a pointer url/mcpUrl. */
-function portOf(u: string | undefined): number | null {
-  const m = u?.match(/:(\d{2,5})(?:\/|$)/);
-  return m ? Number(m[1]) : null;
-}
-
-/** Find the running serve: pointer first (in `cwd`), then a port scan. The
- *  pointer gives the PORT and (when present) the identity; the family is
- *  resolved by probing, so the returned base always uses the address the
- *  server is actually reachable on. */
-export async function discoverServe(
-  cwd: string,
-  log: (m: string) => void = () => {},
-  // Injectable so discovery can be tested hermetically — the default scan probes
-  // real localhost ports, which a test environment can't guarantee are free.
-  scanPorts: number[] = SCAN_PORTS,
-): Promise<Discovered | null> {
-  const pointerPath = join(cwd, POINTER);
-  if (existsSync(pointerPath)) {
-    try {
-      const p = JSON.parse(readFileSync(pointerPath, 'utf8')) as {
-        url?: string;
-        mcpUrl?: string;
-        port?: number;
-        instanceId?: string;
-      };
-      const port = p.port ?? portOf(p.mcpUrl) ?? portOf(p.url);
-      if (port) {
-        const expectedId = typeof p.instanceId === 'string' && p.instanceId ? p.instanceId : null;
-        const hit = await healthyBase(port, expectedId);
-        if (hit) {
-          return {
-            mcpUrl: `${hit.base}/__pyric/mcp`,
-            url: hit.base,
-            base: hit.base,
-            instanceId: hit.instanceId,
-            source: `pointer ${POINTER}`,
-          };
-        }
-        // The pointer named a specific identity we could NOT find on its port:
-        // a different sandbox may be squatting it (cross-family collision) or
-        // the server stopped. Do NOT scan into a possibly-wrong server — that
-        // split-brain is exactly what this identity check prevents. Fail legibly.
-        if (expectedId) {
-          log(
-            `pointer ${POINTER} names a server (instanceId ${expectedId.slice(0, 8)}…) ` +
-              `that isn't answering on port ${port} — another sandbox may be squatting the ` +
-              `port on the other loopback family, or the server stopped. Not falling back to ` +
-              `a blind port scan (it could hit the wrong sandbox). Restart your dev server, ` +
-              `and open http://127.0.0.1:${port} (NOT localhost) so a single family is used.`,
-          );
-          return null;
-        }
-      }
-    } catch {
-      /* stale/corrupt pointer — fall through to scan */
-    }
-  }
-  for (const port of scanPorts) {
-    const hit = await healthyBase(port);
-    if (hit) {
-      return {
-        mcpUrl: `${hit.base}/__pyric/mcp`,
-        url: hit.base,
-        base: hit.base,
-        instanceId: hit.instanceId,
-        source: `port scan (:${port})`,
-      };
-    }
-  }
-  return null;
-}
 
 // ── JSON-RPC shape helpers (relay-level; no SDK runtime import) ──────────────
 function msgId(m: JSONRPCMessage): string | number | null {

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -1,0 +1,562 @@
+/**
+ * `connectRemoteSandbox()` — Node-side client for the browser-hosted
+ * SharedWorker sandbox (remote sandbox, slice 1 / checkpoint 1).
+ *
+ * Server-side Node code (ultimately `pyric-admin`'s remote dispatch arm)
+ * reaches the ONE sandbox the app + Studio + agent share:
+ *
+ *   Node process ──ws──> `pyric serve --bridge` ──ws──> browser tab
+ *                 (attach/consumer leg)        (peer leg)
+ *                                        ──MessagePort──> SharedWorker
+ *
+ * DISCOVERY mirrors `pyric mcp-proxy` (`serve/discovery.ts`): the
+ * `.pyric/serve.json` pointer in cwd, health-probed across both loopback
+ * families with the pointer's `instanceId` pinned so a cross-family
+ * port-squatter can't split-brain the connection.
+ *
+ * FAIL-FAST, NEVER FALL BACK: when no browser tab is connected the connect
+ * (and every later op that races a closing tab) fails with a clear
+ * "open <serve url>" error. There is deliberately NO silent headless
+ * fallback — a silently split backend is exactly the failure this client
+ * exists to avoid.
+ *
+ * SUBSCRIPTION OWNERSHIP: the bridge process owns the durable sub registry
+ * and re-issues it to every newly registered peer (tab refresh/replacement),
+ * so a subscription made here survives peer churn — RTDB value semantics
+ * make the replay safe (each resubscribe re-delivers a fresh snapshot;
+ * consumers are last-value-wins).
+ *
+ * NODE-ONLY: uses `ws` and `node:fs` — exported via a `node`-conditional
+ * subpath (`pyric-tools/remote`), never bundled for the browser.
+ */
+import { WebSocket } from 'ws';
+import type { AuthUserRecord, CreateUserRequest, UpdateUserRequest } from 'pyric/auth';
+import type {
+  BridgeMessage,
+  WorkerOpPayload,
+  WorkerSubPayload,
+} from '../bridge/protocol.js';
+import { isBridgeMessage, NO_SANDBOX_ERROR_MESSAGE } from '../bridge/protocol.js';
+import { discoverServe } from '../serve/discovery.js';
+
+/** Sits just above the bridge's own 30s `callTimeoutMs` so a legitimately
+ *  slow worker op still completes (same layering as `mcp-proxy`'s 35s). */
+const DEFAULT_OP_TIMEOUT_MS = 35_000;
+
+/** How long the attach handshake may take before connect() fails. */
+const ATTACH_TIMEOUT_MS = 5_000;
+
+function remoteError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+function noTabError(serveUrl: string): Error & { code: string } {
+  return remoteError(
+    'unavailable',
+    `no browser tab is connected to the sandbox — open ${serveUrl} in a browser and retry.`,
+  );
+}
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+export interface ConnectRemoteSandboxOptions {
+  /** Project root for `.pyric/serve.json` discovery. Default: `process.cwd()`. */
+  cwd?: string;
+  /** Explicit serve base URL (e.g. `http://127.0.0.1:5000`) — skips discovery. */
+  url?: string;
+  /** Per-op timeout in ms on the Node side (default 35s, above the bridge's 30s). */
+  opTimeoutMs?: number;
+}
+
+/**
+ * The raw relay channel: any worker-protocol op or snap-delivering
+ * subscription, verbatim. The typed conveniences below are built on this;
+ * checkpoint 2's `pyric-admin` remote-dispatch arm consumes it directly.
+ */
+export interface RemoteSandboxChannel {
+  /** Dispatch one worker op. Resolves with the worker's `res.value`;
+   *  rejects with an Error carrying `.code`. NOTE: callers choose their own
+   *  `actAs` lens — nothing is pinned here. */
+  op(op: WorkerOpPayload): Promise<unknown>;
+  /**
+   * Register a worker subscription. `onSnap` receives each snap value;
+   * an establishment failure (the worker host's `{ __error }` snap) routes
+   * to `onError` instead. Returns the unsubscribe function.
+   */
+  subscribe(
+    sub: WorkerSubPayload,
+    onSnap: (value: unknown) => void,
+    onError?: (err: Error & { code: string }) => void,
+  ): () => void;
+}
+
+/** Wire shape of an RTDB snapshot as the worker host serializes it. */
+export interface RemoteRtdbSnapshot {
+  key: string | null;
+  exists: boolean;
+  value: unknown;
+  size: number;
+}
+
+/**
+ * Thin RTDB conveniences over the channel. Every call pins
+ * `actAs: { mode: 'admin' }` — firebase-admin's rules-bypass semantics,
+ * matching what `pyric-admin`'s database backend needs. Use the raw
+ * `channel` for lensed (rules-evaluated) access.
+ */
+export interface RemoteRtdb {
+  /** Read the value at `path` (null when absent). */
+  get(path: string): Promise<unknown>;
+  set(path: string, value: unknown): Promise<void>;
+  update(path: string, values: Record<string, unknown>): Promise<void>;
+  remove(path: string): Promise<void>;
+  /** Push `value` under a CLIENT-minted 20-char push id (the worker-protocol
+   *  contract: `rtdb.push` carries the key, so `.key` is known synchronously
+   *  on the pyric-admin side). Resolves with the minted key + full path. */
+  push(path: string, value?: unknown): Promise<{ key: string; path: string }>;
+  /** Subscribe to the value at `path` (initial snapshot + every change). */
+  onValue(
+    path: string,
+    callback: (snapshot: RemoteRtdbSnapshot) => void,
+    onError?: (err: Error & { code: string }) => void,
+  ): () => void;
+}
+
+/** Admin auth user-CRUD passthrough (never lensed — auth ops operate the
+ *  worker's user pool directly, mirroring `pyric/auth`'s sandbox ops). */
+export interface RemoteAuthAdmin {
+  listUsers(): Promise<AuthUserRecord[]>;
+  createUser(request: CreateUserRequest): Promise<AuthUserRecord>;
+  updateUser(uid: string, request: UpdateUserRequest): Promise<AuthUserRecord>;
+  deleteUser(uid: string): Promise<void>;
+  clearUsers(): Promise<void>;
+}
+
+export interface RemoteSandbox {
+  /** Base URL of the serve this handle is attached to (for error guidance). */
+  readonly serveUrl: string;
+  /** The raw worker op/sub relay channel. */
+  readonly channel: RemoteSandboxChannel;
+  /** RTDB conveniences (admin lens pinned). */
+  readonly rtdb: RemoteRtdb;
+  /** Admin auth user CRUD. */
+  readonly auth: RemoteAuthAdmin;
+  /** Close the connection. In-flight ops reject; subscriptions stop. */
+  close(): void;
+}
+
+// ─── Core (transport-injected — the test seam) ─────────────────────────────
+
+/** Minimal transport the core writes to. `connectRemoteSandbox` adapts a
+ *  `ws` socket; tests inject an in-process pipe to a `ConsumerSession`. */
+export interface RemoteTransport {
+  send(msg: BridgeMessage): void;
+}
+
+export interface RemoteSandboxCore {
+  /** Feed one parsed message from the transport into the core. */
+  handleMessage(msg: BridgeMessage): void;
+  /** Send the attach handshake. `ready` settles on the ack. */
+  start(): void;
+  /** Resolves on `attach-ack`; rejects when no browser tab is connected. */
+  ready: Promise<void>;
+  channel: RemoteSandboxChannel;
+  /** Fail everything in flight (transport closed). Idempotent. */
+  dispose(reason?: string): void;
+}
+
+/**
+ * Transport-agnostic client core: correlation ids/subIds are minted HERE
+ * (this leg's id space; the bridge re-mints for the peer leg), pending ops
+ * carry a Node-side timeout above the bridge's 30s, and `{ __error }` snap
+ * values are routed to the subscription's error handler.
+ */
+export function createRemoteSandboxCore(
+  transport: RemoteTransport,
+  opts: { serveUrl: string; opTimeoutMs?: number },
+): RemoteSandboxCore {
+  const serveUrl = opts.serveUrl;
+  const opTimeoutMs = opts.opTimeoutMs ?? DEFAULT_OP_TIMEOUT_MS;
+
+  let opCounter = 0;
+  let subCounter = 0;
+  let disposed: string | null = null;
+
+  const pending = new Map<
+    string,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >();
+  const subs = new Map<
+    string,
+    { onSnap: (value: unknown) => void; onError?: (err: Error & { code: string }) => void }
+  >();
+
+  let readyResolve!: () => void;
+  let readyReject!: (e: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  // `ready` may legitimately go unobserved after dispose — never unhandled.
+  ready.catch(() => {});
+
+  function send(msg: BridgeMessage): void {
+    transport.send(msg);
+  }
+
+  function op(payload: WorkerOpPayload): Promise<unknown> {
+    if (disposed) {
+      return Promise.reject(remoteError('unavailable', disposed));
+    }
+    return new Promise<unknown>((resolve, reject) => {
+      const id = `rop-${++opCounter}`;
+      const timer = setTimeout(() => {
+        if (pending.has(id)) {
+          pending.delete(id);
+          reject(
+            remoteError(
+              'deadline-exceeded',
+              `remote sandbox op timed out after ${opTimeoutMs}ms (op: ${payload.method}) — is the serve still running?`,
+            ),
+          );
+        }
+      }, opTimeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      try {
+        send({ type: 'worker-op', id, op: payload });
+      } catch (err) {
+        clearTimeout(timer);
+        pending.delete(id);
+        reject(
+          remoteError(
+            'unavailable',
+            `failed to send op to serve: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    });
+  }
+
+  function subscribe(
+    sub: WorkerSubPayload,
+    onSnap: (value: unknown) => void,
+    onError?: (err: Error & { code: string }) => void,
+  ): () => void {
+    if (disposed) throw remoteError('unavailable', disposed);
+    const subId = `rsub-${++subCounter}`;
+    subs.set(subId, { onSnap, onError });
+    send({ type: 'worker-sub', subId, sub });
+    return () => {
+      if (!subs.delete(subId)) return;
+      if (!disposed) {
+        try {
+          send({ type: 'worker-unsub', subId });
+        } catch {}
+      }
+    };
+  }
+
+  function handleMessage(msg: BridgeMessage): void {
+    if (!isBridgeMessage(msg)) return;
+    switch (msg.type) {
+      case 'attach-ack': {
+        if (msg.peerConnected) readyResolve();
+        else readyReject(noTabError(serveUrl));
+        return;
+      }
+      case 'worker-res': {
+        const call = pending.get(msg.id);
+        if (!call) return; // late (already timed out) — drop
+        clearTimeout(call.timer);
+        pending.delete(msg.id);
+        if (msg.ok) {
+          call.resolve(msg.value);
+        } else {
+          const code = msg.error?.code ?? 'unknown';
+          let message = msg.error?.message ?? 'unknown sandbox error';
+          // Enrich the bridge's generic no-peer error with actionable guidance.
+          if (message === NO_SANDBOX_ERROR_MESSAGE) {
+            message = noTabError(serveUrl).message;
+          }
+          call.reject(remoteError(code, message));
+        }
+        return;
+      }
+      case 'worker-snap': {
+        const sub = subs.get(msg.subId);
+        if (!sub) return; // unsubscribed — drop
+        const value = (msg.value ?? {}) as Record<string, unknown>;
+        if (value.__error) {
+          const payload = value.__error as { code: string; message: string };
+          const err = remoteError(payload.code, payload.message);
+          if (sub.onError) sub.onError(err);
+          else console.error('pyric remote sandbox: uncaught error in subscription:', err);
+          return;
+        }
+        try {
+          sub.onSnap(msg.value);
+        } catch {
+          // Consumer callback failures must not break the relay loop.
+        }
+        return;
+      }
+      case 'ping': {
+        send({ type: 'pong', id: msg.id });
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  function dispose(reason?: string): void {
+    if (disposed) return;
+    disposed = reason ?? 'remote sandbox connection closed';
+    const err = remoteError('unavailable', disposed);
+    for (const call of pending.values()) {
+      clearTimeout(call.timer);
+      call.reject(err);
+    }
+    pending.clear();
+    subs.clear();
+    readyReject(err); // no-op if already settled
+  }
+
+  return {
+    handleMessage,
+    start: () => send({ type: 'attach', protocol: 1 }),
+    ready,
+    channel: { op, subscribe },
+    dispose,
+  };
+}
+
+// ─── Typed conveniences over the raw channel ───────────────────────────────
+
+/** firebase-admin's rules-bypass lens, pinned on every RTDB convenience op. */
+const ADMIN_LENS = { mode: 'admin' } as const;
+
+export function buildRemoteRtdb(channel: RemoteSandboxChannel): RemoteRtdb {
+  return {
+    async get(path) {
+      const snap = (await channel.op({
+        method: 'rtdb.get',
+        path,
+        actAs: ADMIN_LENS,
+      })) as RemoteRtdbSnapshot;
+      return snap.value ?? null;
+    },
+    async set(path, value) {
+      await channel.op({ method: 'rtdb.set', path, value, actAs: ADMIN_LENS });
+    },
+    async update(path, values) {
+      await channel.op({ method: 'rtdb.update', path, values, actAs: ADMIN_LENS });
+    },
+    async remove(path) {
+      await channel.op({ method: 'rtdb.remove', path, actAs: ADMIN_LENS });
+    },
+    async push(path, value) {
+      const key = generatePushId();
+      const res = (await channel.op({
+        method: 'rtdb.push',
+        path,
+        key,
+        ...(value !== undefined ? { value } : {}),
+        actAs: ADMIN_LENS,
+      })) as { key: string; path: string };
+      return res;
+    },
+    onValue(path, callback, onError) {
+      return channel.subscribe(
+        { target: { service: 'rtdb', path }, actAs: ADMIN_LENS },
+        (value) => callback(value as RemoteRtdbSnapshot),
+        onError,
+      );
+    },
+  };
+}
+
+export function buildRemoteAuthAdmin(channel: RemoteSandboxChannel): RemoteAuthAdmin {
+  return {
+    async listUsers() {
+      return (await channel.op({ method: 'auth.listUsers' })) as AuthUserRecord[];
+    },
+    async createUser(request) {
+      return (await channel.op({
+        method: 'auth.adminCreateUser',
+        request: request as Record<string, unknown>,
+      })) as AuthUserRecord;
+    },
+    async updateUser(uid, request) {
+      return (await channel.op({
+        method: 'auth.adminUpdateUser',
+        uid,
+        request: request as Record<string, unknown>,
+      })) as AuthUserRecord;
+    },
+    async deleteUser(uid) {
+      await channel.op({ method: 'auth.adminDeleteUser', uid });
+    },
+    async clearUsers() {
+      await channel.op({ method: 'auth.adminClearUsers' });
+    },
+  };
+}
+
+// ─── connect ───────────────────────────────────────────────────────────────
+
+/**
+ * Discover the running `pyric serve --bridge`, attach to its bridge WS as a
+ * worker-relay CONSUMER (never a peer — attaching cannot kick the browser
+ * tab out of last-connection-wins), and return the typed remote handle.
+ *
+ * Fails fast when no serve is discoverable or no browser tab is connected —
+ * there is deliberately no headless fallback (see module doc).
+ */
+export async function connectRemoteSandbox(
+  options: ConnectRemoteSandboxOptions = {},
+): Promise<RemoteSandbox> {
+  const cwd = options.cwd ?? process.cwd();
+
+  let serveUrl: string;
+  if (options.url) {
+    serveUrl = options.url.replace(/\/$/, '');
+  } else {
+    const found = await discoverServe(cwd);
+    if (!found) {
+      throw remoteError(
+        'not-found',
+        'no running `pyric serve --bridge` found (looked for .pyric/serve.json in ' +
+          `${cwd} and the default ports) — start your dev server with the bridge enabled and retry.`,
+      );
+    }
+    serveUrl = found.base;
+  }
+
+  const wsUrl = `${serveUrl.replace(/^http/, 'ws')}/__pyric/sandbox`;
+  const ws = new WebSocket(wsUrl);
+
+  const core = createRemoteSandboxCore(
+    { send: (msg) => ws.send(JSON.stringify(msg)) },
+    { serveUrl, opTimeoutMs: options.opTimeoutMs },
+  );
+
+  ws.on('message', (raw) => {
+    let msg: unknown;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    if (isBridgeMessage(msg)) core.handleMessage(msg);
+  });
+  ws.on('close', () => core.dispose('remote sandbox connection closed (serve stopped or connection lost)'));
+  ws.on('error', (err) => core.dispose(`remote sandbox connection failed: ${err.message}`));
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(remoteError('deadline-exceeded', `timed out connecting to ${wsUrl}`)),
+      ATTACH_TIMEOUT_MS,
+    );
+    ws.once('open', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    ws.once('error', (err) => {
+      clearTimeout(timer);
+      reject(remoteError('unavailable', `failed to connect to ${wsUrl}: ${err.message}`));
+    });
+  });
+
+  core.start();
+  try {
+    await withTimeout(core.ready, ATTACH_TIMEOUT_MS, `timed out attaching to the bridge at ${wsUrl}`);
+  } catch (err) {
+    try {
+      ws.close();
+    } catch {}
+    throw err;
+  }
+
+  return {
+    serveUrl,
+    channel: core.channel,
+    rtdb: buildRemoteRtdb(core.channel),
+    auth: buildRemoteAuthAdmin(core.channel),
+    close() {
+      core.dispose('remote sandbox connection closed by the client');
+      try {
+        ws.close();
+      } catch {}
+    },
+  };
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(remoteError('deadline-exceeded', message)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
+// ─── RTDB push-id generator ────────────────────────────────────────────────
+// Client-minted push ids (the worker-protocol contract: `rtdb.push` carries
+// the key so `.key` is synchronously known to callers). Standard Firebase
+// algorithm — 8 chars of timestamp + 12 random, monotonic within one ms.
+// Inlined (like pyric-admin does) because pyric doesn't export its generator.
+
+const PUSH_CHARS =
+  '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+
+let lastPushTime = 0;
+const lastRandChars: number[] = new Array(12).fill(0);
+
+function generatePushId(now: number = Date.now()): string {
+  const duplicateTime = now === lastPushTime;
+  lastPushTime = now;
+
+  const timeStampChars: string[] = new Array(8);
+  let ts = now;
+  for (let i = 7; i >= 0; i--) {
+    timeStampChars[i] = PUSH_CHARS.charAt(ts % 64);
+    ts = Math.floor(ts / 64);
+  }
+  if (ts !== 0) {
+    throw new Error('RTDB push-id: timestamp overflow.');
+  }
+  let id = timeStampChars.join('');
+
+  if (!duplicateTime) {
+    for (let i = 0; i < 12; i++) {
+      lastRandChars[i] = Math.floor(Math.random() * 64);
+    }
+  } else {
+    let i: number;
+    for (i = 11; i >= 0 && lastRandChars[i] === 63; i--) {
+      lastRandChars[i] = 0;
+    }
+    if (i < 0) {
+      for (let j = 0; j < 12; j++) {
+        lastRandChars[j] = Math.floor(Math.random() * 64);
+      }
+    } else {
+      lastRandChars[i] = (lastRandChars[i] ?? 0) + 1;
+    }
+  }
+
+  for (let i = 0; i < 12; i++) {
+    id += PUSH_CHARS.charAt(lastRandChars[i]!);
+  }
+  return id;
+}

--- a/packages/pyric-tools/src/serve/discovery.ts
+++ b/packages/pyric-tools/src/serve/discovery.ts
@@ -1,0 +1,167 @@
+/**
+ * Discovery of a RUNNING `pyric serve --bridge` — shared by the stdio MCP
+ * proxy (`cli/mcp-proxy.ts`) and the Node remote-sandbox client
+ * (`remote/index.ts`). Extracted here so both speak the SAME pointer +
+ * identity-pinning rules instead of drifting copies.
+ *
+ * Strategy: the `.pyric/serve.json` pointer serve writes in the project cwd
+ * (exact + project-correct) first, then a health probe across the scan
+ * window as a fallback. Degrades LEGIBLY: if no serve is found, or the
+ * pointed server's identity can't be matched, callers get `null` (plus a
+ * `log` diagnostic) — never a silent wrong-server hit.
+ *
+ * IDENTITY — the discovery pointer records the bridge's `instanceId`; a
+ * server is accepted only if its `/__pyric/health` reports the SAME id. Two
+ * sandboxes can collide on one port across loopback families (IPv4 `*:P` +
+ * `[::1]:P`); without this, a client locks onto whichever family answers
+ * first while the browser is on the other — split-brain.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Ports probed when the pointer is absent — serve's default scan window PLUS
+ *  the vite-plugin default (5174), which the old 5000-5004 window missed (so a
+ *  vite-only project was never found by scan). The standalone `pyric bridge`
+ *  serves `/health` (not `/__pyric/health`) and writes no pointer, so it is
+ *  registered directly via `claude mcp add`, not discovered here. */
+export const SCAN_PORTS = [5000, 5001, 5002, 5003, 5004, 5174];
+export const POINTER = join('.pyric', 'serve.json');
+
+export interface HealthLite {
+  mode?: string;
+  instanceId?: string;
+  /** Whether a browser tab is currently connected as the sandbox peer. */
+  sandboxConnected?: boolean;
+}
+
+export interface Discovered {
+  mcpUrl: string;
+  url: string;
+  /** `http://<family>:<port>` the server actually answered on. */
+  base: string;
+  /** Identity pinned at discovery. Null only when talking to an older server
+   *  that predates the instanceId field (matching is then skipped). */
+  instanceId: string | null;
+  source: string;
+}
+
+/**
+ * Probe BOTH loopback families on a port and return the base that answers.
+ *
+ * Hostname-based URLs are a trap here: serve writes `http://localhost:...`
+ * for humans (browsers dual-stack fine), but `localhost` resolution differs
+ * by runtime — node/undici prefers IPv6 `::1`, and a serve under one runtime
+ * may bind `127.0.0.1`-only while under another binds `::1`-only. So a
+ * discovery client never trusts the hostname: it takes the PORT and tries
+ * explicit `127.0.0.1` and `[::1]`, using whichever the server is actually on.
+ */
+export function basesForPort(port: number): string[] {
+  return [`http://127.0.0.1:${port}`, `http://[::1]:${port}`];
+}
+
+export async function probeHealth(base: string): Promise<HealthLite | null> {
+  try {
+    const res = await fetch(`${base}/__pyric/health`, { signal: AbortSignal.timeout(1000) });
+    if (res.status !== 200) return null;
+    const body = (await res.json()) as HealthLite;
+    return body.mode === 'sandbox' ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * First loopback base on `port` whose health reports a sandbox bridge. With an
+ * `expectedInstanceId`, returns ONLY a family whose health identity matches —
+ * so when two sandboxes collide on one port across families, the client locks
+ * onto the one the pointer names, not merely the first to answer. (An older
+ * server with no `instanceId` field can't be identity-checked; matching is
+ * skipped in that case so the pointer still resolves.)
+ */
+export async function healthyBase(
+  port: number,
+  expectedInstanceId?: string | null,
+): Promise<{ base: string; instanceId: string | null } | null> {
+  for (const base of basesForPort(port)) {
+    const health = await probeHealth(base);
+    if (!health) continue;
+    const id = health.instanceId ?? null;
+    // Healthy but the WRONG server (the cross-family squatter): skip, try next.
+    if (expectedInstanceId && id !== expectedInstanceId) continue;
+    return { base, instanceId: id };
+  }
+  return null;
+}
+
+/** Best-effort port extraction from a pointer url/mcpUrl. */
+function portOf(u: string | undefined): number | null {
+  const m = u?.match(/:(\d{2,5})(?:\/|$)/);
+  return m ? Number(m[1]) : null;
+}
+
+/** Find the running serve: pointer first (in `cwd`), then a port scan. The
+ *  pointer gives the PORT and (when present) the identity; the family is
+ *  resolved by probing, so the returned base always uses the address the
+ *  server is actually reachable on. */
+export async function discoverServe(
+  cwd: string,
+  log: (m: string) => void = () => {},
+  // Injectable so discovery can be tested hermetically — the default scan probes
+  // real localhost ports, which a test environment can't guarantee are free.
+  scanPorts: number[] = SCAN_PORTS,
+): Promise<Discovered | null> {
+  const pointerPath = join(cwd, POINTER);
+  if (existsSync(pointerPath)) {
+    try {
+      const p = JSON.parse(readFileSync(pointerPath, 'utf8')) as {
+        url?: string;
+        mcpUrl?: string;
+        port?: number;
+        instanceId?: string;
+      };
+      const port = p.port ?? portOf(p.mcpUrl) ?? portOf(p.url);
+      if (port) {
+        const expectedId = typeof p.instanceId === 'string' && p.instanceId ? p.instanceId : null;
+        const hit = await healthyBase(port, expectedId);
+        if (hit) {
+          return {
+            mcpUrl: `${hit.base}/__pyric/mcp`,
+            url: hit.base,
+            base: hit.base,
+            instanceId: hit.instanceId,
+            source: `pointer ${POINTER}`,
+          };
+        }
+        // The pointer named a specific identity we could NOT find on its port:
+        // a different sandbox may be squatting it (cross-family collision) or
+        // the server stopped. Do NOT scan into a possibly-wrong server — that
+        // split-brain is exactly what this identity check prevents. Fail legibly.
+        if (expectedId) {
+          log(
+            `pointer ${POINTER} names a server (instanceId ${expectedId.slice(0, 8)}…) ` +
+              `that isn't answering on port ${port} — another sandbox may be squatting the ` +
+              `port on the other loopback family, or the server stopped. Not falling back to ` +
+              `a blind port scan (it could hit the wrong sandbox). Restart your dev server, ` +
+              `and open http://127.0.0.1:${port} (NOT localhost) so a single family is used.`,
+          );
+          return null;
+        }
+      }
+    } catch {
+      /* stale/corrupt pointer — fall through to scan */
+    }
+  }
+  for (const port of scanPorts) {
+    const hit = await healthyBase(port);
+    if (hit) {
+      return {
+        mcpUrl: `${hit.base}/__pyric/mcp`,
+        url: hit.base,
+        base: hit.base,
+        instanceId: hit.instanceId,
+        source: `port scan (:${port})`,
+      };
+    }
+  }
+  return null;
+}

--- a/packages/pyric-tools/src/serve/entries/runtime.ts
+++ b/packages/pyric-tools/src/serve/entries/runtime.ts
@@ -26,6 +26,8 @@ import {
   getFirestore as workerGetFirestore,
   getWorkerVersion,
   callTool as workerCallTool,
+  relayWorkerOp,
+  relayWorkerSub,
   getAuth as workerGetAuth,
   onAuthStateChanged as workerOnAuthStateChanged,
   restorePortSession as workerRestorePortSession,
@@ -512,6 +514,14 @@ async function connectBridgePeer(rawUrl: string): Promise<void> {
     connectBridge(sandbox, {
       url,
       dispatcher: (_sandbox, name, args) => workerCallTool(wdb, name, args),
+      // Generic worker relay (remote sandbox, slice 1): server-side Node code
+      // (`connectRemoteSandbox`) reaches THIS page's SharedWorker through the
+      // bridge — ops and snap-delivering subscriptions pass straight through
+      // to the one sandbox the app + Studio + agent share.
+      workerRelay: {
+        op: (op) => relayWorkerOp(wdb, op),
+        subscribe: (sub, onValue) => relayWorkerSub(wdb, sub, onValue),
+      },
     });
   } else {
     connectBridge(sandbox, { url });

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -84,6 +84,10 @@ import type {
 } from './protocol.js';
 import type { PolicyRequest } from './protocol.js';
 import { deserializeDocData, isSentinelMarker } from './protocol.js';
+// TYPE-ONLY — the generic worker-relay wire payloads (op/sub messages minus
+// the port-level ids this module re-mints). Erased at build; `bridge/
+// protocol.ts` itself has no runtime imports, so no engine code is pulled in.
+import type { WorkerOpPayload, WorkerSubPayload } from '../../bridge/protocol.js';
 // TYPE-ONLY — the auth-lens contract + the cross-service event envelope, shared
 // with the worker host + the sandbox's event provenance. Erased at build, so the
 // leaf client bundle stays engine-free.
@@ -420,6 +424,64 @@ export async function callTool(
     ok: boolean;
     summary: string;
     data?: unknown;
+  };
+}
+
+// ─── Generic worker relay (remote sandbox, slice 1) ────────────────────────
+//
+// The bridge peer forwards `worker-op` / `worker-sub` frames from the Node
+// side (`connectRemoteSandbox`) into the SharedWorker through these two
+// functions (see `workerRelay` in `bridge/client/bridge.ts` + the wiring in
+// `entries/runtime.ts`). Ids are re-minted LOCALLY (`nextId`/`nextSubId`) so
+// relayed traffic shares this page's pending/sub maps without any chance of
+// colliding with the page's own ids — the bridge correlates by ITS frame id.
+
+/**
+ * Relay one raw worker-protocol op into the SharedWorker. `op` is the op
+ * message minus `t`/`id` (the `WorkerOpPayload` wire shape); resolves with
+ * the worker's `res.value`, rejects with an Error carrying `.code`.
+ */
+export function relayWorkerOp(db: ClientDb, op: WorkerOpPayload): Promise<unknown> {
+  return rpc(db.port, { ...op, t: 'op', id: nextId() } as InboundMessage);
+}
+
+/**
+ * Relay a raw worker-protocol subscription into the SharedWorker. `sub` is
+ * the sub message minus `t`/`subId` (the `WorkerSubPayload` wire shape).
+ * `onValue` receives every snap value VERBATIM — including the worker host's
+ * `{ __error: { code, message } }` establishment-failure convention (listener
+ * errors are re-wrapped into the same shape so the far side sees one form).
+ * Returns the unsubscribe function.
+ *
+ * The unified event stream (`target: 'events'`) is NOT relayable yet — its
+ * history batches aren't coalescible, so it needs bounded backpressure first
+ * (slice 2).
+ */
+export function relayWorkerSub(
+  db: ClientDb,
+  sub: WorkerSubPayload,
+  onValue: (value: unknown) => void,
+): () => void {
+  if (sub.target === 'events') {
+    throw new Error(
+      'event-stream subscriptions cannot be relayed over the bridge yet (needs bounded backpressure — slice 2)',
+    );
+  }
+  const subId = nextSubId();
+  _snapSubs.set(subId, {
+    next: onValue,
+    error: (err) =>
+      onValue({
+        __error: {
+          code: (err as { code?: string }).code ?? 'unknown',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      }),
+  });
+  db.port.postMessage({ ...sub, t: 'sub', subId } as InboundMessage);
+  return () => {
+    _snapSubs.delete(subId);
+    db.port.postMessage({ t: 'unsub', subId } satisfies InboundMessage);
   };
 }
 

--- a/packages/pyric-tools/test/bridge/worker-relay.test.ts
+++ b/packages/pyric-tools/test/bridge/worker-relay.test.ts
@@ -25,7 +25,7 @@
 import 'fake-indexeddb/auto';
 import { describe, it, expect } from 'bun:test';
 import { createBridge, type Bridge } from '../../src/bridge/server/bridge.js';
-import { createConsumerSession } from '../../src/bridge/server/peer.js';
+import { createConsumerSession, attachPeer } from '../../src/bridge/server/peer.js';
 import {
   WORKER_RELAY_CAPABILITY,
   type BridgeMessage,
@@ -84,6 +84,10 @@ interface FakeTab {
   disconnect: () => void;
   /** This tab's worker-side port (a distinct port per tab, one shared ctx). */
   port: PortLike;
+  /** True once the bridge's onReplaced hook fired for this tab. */
+  wasReplaced: () => boolean;
+  /** SubIds currently relayed into the worker on this tab's behalf. */
+  activeSubIds: () => ReadonlySet<string>;
 }
 
 /**
@@ -93,13 +97,21 @@ interface FakeTab {
  * `worker-res` / `worker-snap`, tagged with the generation captured at
  * registration (like `attachPeer` does), so a replaced tab's late frames
  * are verifiably stale.
+ *
+ * On replacement the bridge fires `onReplaced` (the transport closes the
+ * old socket; the browser's close handler runs `teardownRelaySubs`) — the
+ * harness models that teardown by unsubscribing this tab's relayed worker
+ * subs. `keepAliveOnReplace` skips it, simulating the async window where
+ * the close hasn't landed yet and stale frames are still in flight.
  */
 function connectTab(
   bridge: Bridge,
   ctx: HostCtx,
-  opts: { dropOps?: boolean } = {},
+  opts: { dropOps?: boolean; keepAliveOnReplace?: boolean } = {},
 ): FakeTab {
   let gen = 0;
+  let replaced = false;
+  const activeSubIds = new Set<string>();
   const port: PortLike = {
     postMessage(raw: unknown) {
       const m = raw as OutboundMessage;
@@ -126,13 +138,36 @@ function connectTab(
       if (opts.dropOps) return; // simulate a hung tab (timeout tests)
       void handleMessage(ctx, port, { ...msg.op, t: 'op', id: msg.id } as InboundMessage);
     } else if (msg.type === 'worker-sub') {
+      activeSubIds.add(msg.subId);
       void handleMessage(ctx, port, { ...msg.sub, t: 'sub', subId: msg.subId } as InboundMessage);
     } else if (msg.type === 'worker-unsub') {
+      activeSubIds.delete(msg.subId);
       void handleMessage(ctx, port, { t: 'unsub', subId: msg.subId } as InboundMessage);
     }
   };
-  const disconnect = bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
-  return { disconnect, port };
+  const onReplaced = (): void => {
+    replaced = true;
+    if (opts.keepAliveOnReplace) return; // simulate in-flight staleness window
+    // The browser's WS close handler (`teardownRelaySubs`) unsubscribes every
+    // relayed worker listener for this connection.
+    for (const subId of [...activeSubIds]) {
+      activeSubIds.delete(subId);
+      void handleMessage(ctx, port, { t: 'unsub', subId } as InboundMessage);
+    }
+  };
+  const disconnect = bridge.registerSandboxPeer(
+    send,
+    [],
+    'fake-tab',
+    [WORKER_RELAY_CAPABILITY],
+    onReplaced,
+  );
+  return {
+    disconnect,
+    port,
+    wasReplaced: () => replaced,
+    activeSubIds: () => activeSubIds,
+  };
 }
 
 /** Wire a Node client core to the bridge through a real ConsumerSession. */
@@ -155,6 +190,36 @@ function connectNode(bridge: Bridge, opts: { opTimeoutMs?: number } = {}) {
 
 function makeRelayBridge(callTimeoutMs?: number): Bridge {
   return createBridge({ mode: 'sandbox', version: 'test', callTimeoutMs });
+}
+
+/** Minimal fake of the `ws` WebSocket surface `attachPeer` consumes. */
+function fakeWs() {
+  const handlers = new Map<string, (...args: unknown[]) => void>();
+  const sent: unknown[] = [];
+  const self = {
+    sent,
+    closed: false,
+    on(event: string, cb: (...args: unknown[]) => void) {
+      handlers.set(event, cb);
+      return self;
+    },
+    send(data: string) {
+      sent.push(JSON.parse(data));
+    },
+    close() {
+      if (self.closed) return;
+      self.closed = true;
+      handlers.get('close')?.();
+    },
+    emitMessage(msg: unknown) {
+      handlers.get('message')?.(JSON.stringify(msg));
+    },
+    emitRaw(raw: string) {
+      handlers.get('message')?.(raw);
+    },
+    asWebSocket: () => self as unknown as Parameters<typeof attachPeer>[1],
+  };
+  return self;
 }
 
 // ─── Op round-trips ───────────────────────────────────────────────────────
@@ -323,7 +388,7 @@ describe('worker relay — no peer / timeout', () => {
     const bridge = makeRelayBridge();
     const node = connectNode(bridge);
     // attach-ack reports peerConnected: false → ready rejects with guidance.
-    expect(node.core.ready).rejects.toThrow(/open http:\/\/localhost:5000/);
+    await expect(node.core.ready).rejects.toThrow(/open http:\/\/localhost:5000/);
 
     // Per-op failures carry the same enriched guidance (fast — no 30s wait).
     const started = Date.now();
@@ -375,7 +440,10 @@ describe('worker relay — peer replacement and reconnect', () => {
   it('replacement mid-subscription: stale-generation snaps dropped, sub re-issued to the new peer', async () => {
     const bridge = makeRelayBridge();
     const ctx = await makeWorkerCtx(); // ONE SharedWorker shared by both tabs
-    connectTab(bridge, ctx);
+    // keepAliveOnReplace: simulate the async window where the replaced tab's
+    // socket close hasn't landed yet, so its worker port KEEPS firing — those
+    // frames are tagged with the OLD generation and MUST be dropped.
+    connectTab(bridge, ctx, { keepAliveOnReplace: true });
     const node = connectNode(bridge);
     await node.core.ready;
 
@@ -387,9 +455,8 @@ describe('worker relay — peer replacement and reconnect', () => {
     expect(snaps).toHaveLength(1); // initial via tab A
 
     // Tab "refresh": a NEW tab registers (last-connection-wins). The bridge
-    // re-issues the sub registry to tab B. Tab A's worker port stays live in
-    // the shared ctx (its WS just died mid-flight in the real world) — its
-    // deliveries are tagged with the OLD generation and MUST be dropped.
+    // re-issues the sub registry to tab B; tab A's still-live deliveries are
+    // stale-generation and must not reach the consumer.
     connectTab(bridge, ctx);
     await tick();
     expect(snaps).toHaveLength(2); // exactly ONE extra initial snap (tab B); tab A delivers nothing
@@ -399,6 +466,38 @@ describe('worker relay — peer replacement and reconnect', () => {
     // Both tabs' worker ports fire; only tab B's (current generation) lands.
     expect(snaps).toHaveLength(3);
     expect(snaps[2]!.value).toEqual({ round: 2 });
+  });
+
+  it('replacement tears the old peer down: onReplaced fires and its relayed worker subs unsubscribe', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    const tabA = connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const snaps: RemoteRtdbSnapshot[] = [];
+    node.rtdb.onValue('game/state', (snap) => snaps.push(snap));
+    await tick();
+    expect(snaps).toHaveLength(1);
+    expect(tabA.activeSubIds().size).toBe(1);
+    expect(ctx.subs.get(tabA.port)?.size).toBe(1); // live listener in the worker
+
+    // A new tab replaces tab A: the bridge MUST notify the old peer so the
+    // transport closes its socket and the browser tears its relay subs down
+    // — otherwise tab A's SharedWorker listeners would stream snaps the
+    // bridge drops as stale until the tab closed.
+    const tabB = connectTab(bridge, ctx);
+    await tick();
+    expect(tabA.wasReplaced()).toBe(true);
+    expect(tabB.wasReplaced()).toBe(false);
+    expect(tabA.activeSubIds().size).toBe(0);
+    expect(ctx.subs.get(tabA.port)?.size ?? 0).toBe(0); // worker listener gone
+
+    // Delivery continues via tab B only.
+    await node.rtdb.set('game/state', { round: 2 });
+    await tick();
+    expect(snaps[snaps.length - 1]!.value).toEqual({ round: 2 });
+    expect(ctx.subs.get(tabB.port)?.size).toBe(1);
   });
 
   it('reconnect: in-flight ops fail on peer loss; subs resume on the next peer', async () => {
@@ -423,7 +522,7 @@ describe('worker relay — peer replacement and reconnect', () => {
     }
 
     // Ops while no peer is connected fail fast with the same guidance.
-    expect(node.rtdb.get('doc')).rejects.toThrow(/open http:\/\/localhost:5000/);
+    await expect(node.rtdb.get('doc')).rejects.toThrow(/open http:\/\/localhost:5000/);
 
     // A new tab connects: the bridge re-issues the sub; ops work again.
     connectTab(bridge, ctx);
@@ -434,6 +533,25 @@ describe('worker relay — peer replacement and reconnect', () => {
     await tick();
     expect(snaps[snaps.length - 1]!.value).toEqual({ alive: true });
     expect(await node.rtdb.get('doc')).toEqual({ alive: true });
+  });
+
+  it('attachPeer closes the replaced peer\'s socket (onReplaced → ws.close)', async () => {
+    const bridge = makeRelayBridge();
+    const wsA = fakeWs();
+    const wsB = fakeWs();
+    attachPeer(bridge, wsA.asWebSocket());
+    attachPeer(bridge, wsB.asWebSocket());
+
+    wsA.emitMessage({ type: 'hello', protocol: 1, tools: [], sandboxId: 'a' });
+    expect(bridge.isSandboxConnected()).toBe(true);
+    expect(wsA.closed).toBe(false);
+
+    // Tab B's hello replaces tab A → the bridge's onReplaced hook must close
+    // tab A's socket (whose browser-side close handler tears its subs down).
+    wsB.emitMessage({ type: 'hello', protocol: 1, tools: [], sandboxId: 'b' });
+    expect(wsA.closed).toBe(true);
+    expect(wsB.closed).toBe(false);
+    expect(bridge.isSandboxConnected()).toBe(true); // tab B is the peer
   });
 
   it('consumer disposal tears its subscriptions out of the bridge registry', async () => {
@@ -455,5 +573,45 @@ describe('worker relay — peer replacement and reconnect', () => {
     await node.rtdb.set('x', 1).catch(() => {}); // channel still up in-process
     await tick();
     expect(snaps).toHaveLength(1); // no delivery after disposal
+  });
+});
+
+// ─── attachPeer hardening ─────────────────────────────────────────────────
+
+describe('attachPeer — malformed hello', () => {
+  it('non-array tools/capabilities cannot crash the serve process', async () => {
+    const bridge = makeRelayBridge();
+    const ws = fakeWs();
+    attachPeer(bridge, ws.asWebSocket());
+
+    // `tools`/`capabilities` come off the wire — a non-array used to reach
+    // `new Set(...)` in the bridge core and throw inside the ws message
+    // listener (uncaught → process crash). Must register cleanly instead.
+    ws.emitMessage({
+      type: 'hello',
+      protocol: 1,
+      tools: 42,
+      sandboxId: 'x',
+      capabilities: 42,
+    });
+
+    expect(bridge.isSandboxConnected()).toBe(true);
+    expect(bridge.toolNames()).toEqual([]); // coerced to empty
+    expect((ws.sent[0] as { type: string }).type).toBe('hello-ack');
+
+    // Worker ops fail legibly (no relay capability), not with a crash.
+    await expect(bridge.dispatchWorkerOp({ method: 'getVersion' })).rejects.toThrow(
+      /does not support the worker relay/,
+    );
+  });
+
+  it('unparseable and non-bridge messages are ignored', () => {
+    const bridge = makeRelayBridge();
+    const ws = fakeWs();
+    attachPeer(bridge, ws.asWebSocket());
+    ws.emitRaw('this is not json {{');
+    ws.emitMessage({ type: 'not-a-bridge-frame' });
+    expect(bridge.isSandboxConnected()).toBe(false);
+    expect(ws.sent).toHaveLength(0);
   });
 });

--- a/packages/pyric-tools/test/bridge/worker-relay.test.ts
+++ b/packages/pyric-tools/test/bridge/worker-relay.test.ts
@@ -1,0 +1,459 @@
+/**
+ * End-to-end characterization of the generic worker relay (remote sandbox,
+ * slice 1 / checkpoint 1) — fully in-process, no browser, no real WS.
+ *
+ * The whole chain is wired with the documented seams:
+ *
+ *   Node client core (`createRemoteSandboxCore`, injected transport)
+ *     ⇄ consumer session (`createConsumerSession`)
+ *     ⇄ bridge core (`createBridge` — pending ops, sub registry, generations)
+ *     ⇄ fake browser peer (a `send` function playing `connectBridge`'s
+ *        worker-relay role)
+ *     ⇄ REAL worker host (`handleMessage` + fake `{ postMessage }` ports —
+ *        the same harness style as test/serve/worker/host.test.ts)
+ *
+ * Coverage (per the checkpoint-1 spec):
+ *   - op round-trip (RTDB conveniences + raw channel + auth admin CRUD)
+ *   - subscription snap delivery (initial + updates), unsub stops delivery
+ *   - fail-fast when no peer; timeout when the peer never responds
+ *   - peer replacement mid-subscription: stale-generation snaps dropped,
+ *     registry re-issued to the new peer
+ *   - reconnect: in-flight ops fail on peer loss, subs resume on new peer
+ *   - subscription establishment errors relay as rejections (`__error` snap)
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { createBridge, type Bridge } from '../../src/bridge/server/bridge.js';
+import { createConsumerSession } from '../../src/bridge/server/peer.js';
+import {
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../src/bridge/protocol.js';
+import {
+  createRemoteSandboxCore,
+  buildRemoteRtdb,
+  buildRemoteAuthAdmin,
+  type RemoteSandboxCore,
+  type RemoteRtdbSnapshot,
+} from '../../src/remote/index.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../src/serve/worker/protocol.js';
+import { initializeSandbox, attachPersistence, createMemoryBackend } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import type { AuthUserRecord } from 'pyric/auth';
+
+// ─── Harness ──────────────────────────────────────────────────────────────
+
+const PERMISSIVE_RULES = `
+  rules_version = '2';
+  service cloud.firestore {
+    match /databases/{database}/documents {
+      match /{document=**} {
+        allow read, write: if true;
+      }
+    }
+  }
+`;
+
+/** Build a REAL worker host ctx (in-memory sandbox) — one per "SharedWorker". */
+async function makeWorkerCtx(): Promise<HostCtx> {
+  const sandbox = initializeSandbox();
+  const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
+  getAdminFirestore(sandbox.withAuth(null)).setRules(PERMISSIVE_RULES);
+  await attachPersistence(sandbox, {
+    key: `relay-test-${Math.random()}`,
+    injectedBackend: createMemoryBackend(),
+  });
+  return { db: getFirestore(sandbox), sandbox, instanceId: 'relay-test', subs: new Map() };
+}
+
+function tick(ms = 10): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+interface FakeTab {
+  /** Unregister, as the transport would on WS close. */
+  disconnect: () => void;
+  /** This tab's worker-side port (a distinct port per tab, one shared ctx). */
+  port: PortLike;
+}
+
+/**
+ * Register a fake browser tab as the bridge's sandbox peer. Plays exactly
+ * the role `connectBridge`'s `workerRelay` plays: worker frames from the
+ * bridge go into the REAL worker host; the fake port's posts come back as
+ * `worker-res` / `worker-snap`, tagged with the generation captured at
+ * registration (like `attachPeer` does), so a replaced tab's late frames
+ * are verifiably stale.
+ */
+function connectTab(
+  bridge: Bridge,
+  ctx: HostCtx,
+  opts: { dropOps?: boolean } = {},
+): FakeTab {
+  let gen = 0;
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      const m = raw as OutboundMessage;
+      if (m.t === 'res') {
+        bridge.handleSandboxMessage(
+          m.ok
+            ? { type: 'worker-res', id: m.id, ok: true, value: m.value }
+            : { type: 'worker-res', id: m.id, ok: false, error: m.error },
+          gen,
+        );
+      } else if (m.t === 'snap') {
+        bridge.handleSandboxMessage(
+          { type: 'worker-snap', subId: m.subId, value: m.value },
+          gen,
+        );
+      }
+    },
+  };
+  const send = (msg: BridgeMessage): void => {
+    // First send happens inside registerSandboxPeer (sub replay) — the
+    // generation is already bumped by then, so capture it lazily.
+    if (gen === 0) gen = bridge.peerGeneration();
+    if (msg.type === 'worker-op') {
+      if (opts.dropOps) return; // simulate a hung tab (timeout tests)
+      void handleMessage(ctx, port, { ...msg.op, t: 'op', id: msg.id } as InboundMessage);
+    } else if (msg.type === 'worker-sub') {
+      void handleMessage(ctx, port, { ...msg.sub, t: 'sub', subId: msg.subId } as InboundMessage);
+    } else if (msg.type === 'worker-unsub') {
+      void handleMessage(ctx, port, { t: 'unsub', subId: msg.subId } as InboundMessage);
+    }
+  };
+  const disconnect = bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
+  return { disconnect, port };
+}
+
+/** Wire a Node client core to the bridge through a real ConsumerSession. */
+function connectNode(bridge: Bridge, opts: { opTimeoutMs?: number } = {}) {
+  let core: RemoteSandboxCore;
+  const session = createConsumerSession(bridge, (msg) => core.handleMessage(msg));
+  core = createRemoteSandboxCore(
+    { send: (msg) => session.handleMessage(msg) },
+    { serveUrl: 'http://localhost:5000', opTimeoutMs: opts.opTimeoutMs },
+  );
+  core.start();
+  return {
+    core,
+    session,
+    channel: core.channel,
+    rtdb: buildRemoteRtdb(core.channel),
+    auth: buildRemoteAuthAdmin(core.channel),
+  };
+}
+
+function makeRelayBridge(callTimeoutMs?: number): Bridge {
+  return createBridge({ mode: 'sandbox', version: 'test', callTimeoutMs });
+}
+
+// ─── Op round-trips ───────────────────────────────────────────────────────
+
+describe('worker relay — op round-trip', () => {
+  it('relays a raw worker op end-to-end (getVersion)', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const version = (await node.channel.op({ method: 'getVersion' })) as {
+      version: string;
+      instanceId: string;
+    };
+    expect(version.version).toBe('dev');
+    expect(version.instanceId).toBe('relay-test');
+  });
+
+  it('RTDB set/get/update/remove round-trip through the real worker host', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await node.rtdb.set('rooms/lobby', { name: 'Lobby', open: true });
+    expect(await node.rtdb.get('rooms/lobby')).toEqual({ name: 'Lobby', open: true });
+
+    await node.rtdb.update('rooms/lobby', { open: false });
+    expect(await node.rtdb.get('rooms/lobby')).toEqual({ name: 'Lobby', open: false });
+
+    await node.rtdb.remove('rooms/lobby');
+    expect(await node.rtdb.get('rooms/lobby')).toBeNull();
+  });
+
+  it('push mints the key client-side and writes the value there', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const { key, path } = await node.rtdb.push('messages', { text: 'hi' });
+    expect(key).toHaveLength(20);
+    expect(path).toBe(`/messages/${key}`);
+    expect(await node.rtdb.get(`messages/${key}`)).toEqual({ text: 'hi' });
+  });
+
+  it('worker errors relay with their code', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    // A one-segment doc path is invalid — the worker host's typed error
+    // (code + message) must survive both relay legs.
+    try {
+      await node.channel.op({ method: 'getDoc', path: 'only-one-segment' });
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBeTruthy();
+      expect((err as Error).message).toContain('only-one-segment');
+    }
+  });
+});
+
+// ─── Auth admin CRUD passthrough ──────────────────────────────────────────
+
+describe('worker relay — auth admin user CRUD', () => {
+  it('createUser / listUsers / updateUser / deleteUser / clearUsers', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const created = await node.auth.createUser({
+      email: 'ada@example.com',
+      password: 'correct-horse',
+      displayName: 'Ada',
+    });
+    expect(created.uid).toBeTruthy();
+    expect(created.email).toBe('ada@example.com');
+
+    let users: AuthUserRecord[] = await node.auth.listUsers();
+    expect(users.map((u) => u.email)).toEqual(['ada@example.com']);
+
+    const updated = await node.auth.updateUser(created.uid, {
+      displayName: 'Ada Lovelace',
+      customClaims: { admin: true },
+    });
+    expect(updated.displayName).toBe('Ada Lovelace');
+    expect(updated.customClaims).toEqual({ admin: true });
+
+    await node.auth.deleteUser(created.uid);
+    users = await node.auth.listUsers();
+    expect(users).toHaveLength(0);
+
+    await node.auth.createUser({ email: 'b@example.com', password: 'pw-123456' });
+    await node.auth.clearUsers();
+    expect(await node.auth.listUsers()).toHaveLength(0);
+  });
+});
+
+// ─── Subscriptions ────────────────────────────────────────────────────────
+
+describe('worker relay — RTDB value subscription', () => {
+  it('delivers the initial snapshot and every update; unsub stops delivery', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await node.rtdb.set('counter', { n: 1 });
+
+    const snaps: RemoteRtdbSnapshot[] = [];
+    const unsubscribe = node.rtdb.onValue('counter', (snap) => snaps.push(snap));
+    await tick();
+    expect(snaps).toHaveLength(1);
+    expect(snaps[0]!.value).toEqual({ n: 1 });
+
+    await node.rtdb.set('counter', { n: 2 });
+    await tick();
+    expect(snaps).toHaveLength(2);
+    expect(snaps[1]!.value).toEqual({ n: 2 });
+
+    unsubscribe();
+    await tick();
+    await node.rtdb.set('counter', { n: 3 });
+    await tick();
+    expect(snaps).toHaveLength(2); // no delivery after unsub
+  });
+
+  it('relays a failed subscription establishment as an error (__error snap)', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const errors: Array<Error & { code: string }> = [];
+    const snaps: unknown[] = [];
+    // A one-segment doc path is invalid — resolveTarget throws synchronously
+    // in the worker host, which posts the `{ __error }` snap the relay
+    // forwards; the Node side routes it to onError, never onSnap.
+    node.channel.subscribe(
+      { target: { __ref: 'doc', path: 'only-one-segment' } },
+      (s) => snaps.push(s),
+      (e) => errors.push(e),
+    );
+    await tick();
+    expect(snaps).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.message.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── Failure modes ────────────────────────────────────────────────────────
+
+describe('worker relay — no peer / timeout', () => {
+  it('fails fast with "open <url>" guidance when no browser tab is connected', async () => {
+    const bridge = makeRelayBridge();
+    const node = connectNode(bridge);
+    // attach-ack reports peerConnected: false → ready rejects with guidance.
+    expect(node.core.ready).rejects.toThrow(/open http:\/\/localhost:5000/);
+
+    // Per-op failures carry the same enriched guidance (fast — no 30s wait).
+    const started = Date.now();
+    try {
+      await node.rtdb.get('anything');
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as Error).message).toContain('open http://localhost:5000');
+      expect((err as { code?: string }).code).toBe('unavailable');
+    }
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('times out when the peer never responds (bridge callTimeoutMs)', async () => {
+    const bridge = makeRelayBridge(50); // 50ms bridge-side op budget
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx, { dropOps: true }); // hung tab: ops vanish
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const started = Date.now();
+    try {
+      await node.rtdb.get('anything');
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as Error).message).toContain('timed out after 50ms');
+      expect((err as { code?: string }).code).toBe('deadline-exceeded');
+    }
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  it('rejects worker ops against a peer that lacks the worker-relay capability', async () => {
+    const bridge = makeRelayBridge();
+    // An OLD peer: registered without capabilities (pre-relay hello).
+    bridge.registerSandboxPeer(() => {}, [], 'old-tab');
+    const node = connectNode(bridge);
+    try {
+      await node.channel.op({ method: 'getVersion' });
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as Error).message).toContain('does not support the worker relay');
+    }
+  });
+});
+
+// ─── Peer replacement + reconnect ─────────────────────────────────────────
+
+describe('worker relay — peer replacement and reconnect', () => {
+  it('replacement mid-subscription: stale-generation snaps dropped, sub re-issued to the new peer', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx(); // ONE SharedWorker shared by both tabs
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await node.rtdb.set('game/state', { round: 1 });
+
+    const snaps: RemoteRtdbSnapshot[] = [];
+    node.rtdb.onValue('game/state', (snap) => snaps.push(snap));
+    await tick();
+    expect(snaps).toHaveLength(1); // initial via tab A
+
+    // Tab "refresh": a NEW tab registers (last-connection-wins). The bridge
+    // re-issues the sub registry to tab B. Tab A's worker port stays live in
+    // the shared ctx (its WS just died mid-flight in the real world) — its
+    // deliveries are tagged with the OLD generation and MUST be dropped.
+    connectTab(bridge, ctx);
+    await tick();
+    expect(snaps).toHaveLength(2); // exactly ONE extra initial snap (tab B); tab A delivers nothing
+
+    await node.rtdb.set('game/state', { round: 2 });
+    await tick();
+    // Both tabs' worker ports fire; only tab B's (current generation) lands.
+    expect(snaps).toHaveLength(3);
+    expect(snaps[2]!.value).toEqual({ round: 2 });
+  });
+
+  it('reconnect: in-flight ops fail on peer loss; subs resume on the next peer', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    const tabA = connectTab(bridge, ctx, { dropOps: true }); // ops hang → in-flight on disconnect
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const snaps: RemoteRtdbSnapshot[] = [];
+    node.rtdb.onValue('doc', (snap) => snaps.push(snap));
+    await tick();
+    expect(snaps).toHaveLength(1); // initial (null) via tab A — subs are not dropped
+
+    const inFlight = node.rtdb.get('doc');
+    tabA.disconnect(); // WS close → in-flight ops fail with the no-tab error
+    try {
+      await inFlight;
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as Error).message).toContain('open http://localhost:5000');
+    }
+
+    // Ops while no peer is connected fail fast with the same guidance.
+    expect(node.rtdb.get('doc')).rejects.toThrow(/open http:\/\/localhost:5000/);
+
+    // A new tab connects: the bridge re-issues the sub; ops work again.
+    connectTab(bridge, ctx);
+    await tick();
+    expect(snaps).toHaveLength(2); // fresh initial snapshot from the new peer
+
+    await node.rtdb.set('doc', { alive: true });
+    await tick();
+    expect(snaps[snaps.length - 1]!.value).toEqual({ alive: true });
+    expect(await node.rtdb.get('doc')).toEqual({ alive: true });
+  });
+
+  it('consumer disposal tears its subscriptions out of the bridge registry', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const snaps: unknown[] = [];
+    node.rtdb.onValue('x', (s) => snaps.push(s));
+    await tick();
+    expect(snaps).toHaveLength(1);
+
+    // Node WS closed: attachPeer would dispose the session — all bridge-side
+    // subs for this consumer unsubscribe (and relay the unsub to the worker).
+    node.session.dispose();
+    await tick();
+    await node.rtdb.set('x', 1).catch(() => {}); // channel still up in-process
+    await tick();
+    expect(snaps).toHaveLength(1); // no delivery after disposal
+  });
+});


### PR DESCRIPTION
Checkpoint 1 of the remote sandbox (slice 1): lets a Node process drive the browser-hosted SharedWorker sandbox over the existing bridge WS — the transport layer under the upcoming `pyric-admin` remote-dispatch PR (first-user unblock: server-side RTDB + Auth).

- **Bridge frames** (`bridge/protocol.ts`): `worker-op`/`worker-res` (correlated request/response), `worker-sub`/`worker-unsub`/`worker-snap`, and an explicit `attach`/`attach-ack` consumer handshake so a Node client can join `/__pyric/sandbox` without registering as a peer (which would kick the browser tab via last-connection-wins). `hello.capabilities` advertises `worker-relay`; gating fails closed for legacy tabs with a reload-guidance error.
- **Bridge core** (`server/bridge.ts`, `server/peer.ts`): correlated dispatch reusing the 30s timeout pattern; peer-generation tagging drops stale `worker-res`/`worker-snap` from replaced tabs; a bridge-owned durable subscription registry re-issues consumer subs to each newly connected peer (subscriptions survive tab refresh); on replacement the old peer is torn down (`onReplaced` → socket close) so its SharedWorker listeners don't leak.
- **Browser relay** (`client/bridge.ts`, `serve/worker/client.ts`, `serve/entries/runtime.ts`): generic op/sub passthrough into the SharedWorker port with locally re-minted ids; `{__error}` snap convention preserved end-to-end.
- **Node client** (`pyric-tools/remote`, node-condition-only export): `connectRemoteSandbox()` — discovery via `.pyric/serve.json` (extracted to `serve/discovery.ts`; `mcp-proxy` re-exports, behavior-preserving), raw op/sub channel, RTDB conveniences (get/set/update/remove/push with client-minted key so `.key` stays sync; `onValue`) pinned to `actAs: {mode:'admin'}`, auth admin CRUD passthrough, fail-fast "no browser tab is connected — open <serve url>" errors, 35s timeout backstopping the bridge's 30s.
- **Tests**: 17 headless end-to-end tests (real bridge core + real worker host over fake ports): op round-trip, typed errors, push keys, auth CRUD, sub lifecycle, no-peer fail-fast, hung-tab timeout, legacy-peer rejection, peer replacement with stale-generation snaps verifiably dropped + old-peer teardown, reconnect, consumer disposal, malformed-hello hardening (crash fix), garbage-frame tolerance.

Adversarially reviewed pre-PR; confirmed findings (replaced-peer subscription leak, malformed-`hello` process crash, two un-awaited async assertions) are fixed in the final commit. Known deferred nits: stale-peer `ping` answered via new socket (harmless, pre-existing pattern); `dispose()` doesn't notify sub `onError` (deferred to avoid conflict with the stacked checkpoint-2 branch); event-stream relay (`target:'events'`) is slice 2.

Full `test/bridge`: 105 pass / 0 fail. `tsc --noEmit` and `lint:manifest` (publint + attw + exports↔dist) clean. Headless-harness gap to cover in the manual e2e before release: the browser-leg wiring (`attachPeer` + page relay handlers) is simulated by the test harness.