### PR TITLE
Route pyric-admin RTDB + Auth through remote sandboxes

### DIFF
--- a/packages/pyric-admin/src/auth/index.ts
+++ b/packages/pyric-admin/src/auth/index.ts
@@ -23,6 +23,15 @@
  *     `createCustomToken` / `verifyIdToken`, not enough to model a
  *     real identity platform.
  *
+ *   - **Remote sandbox arm** — when the sandbox carries `pyric/sandbox`'s
+ *     remote brand (a Node-side handle onto the browser-hosted
+ *     SharedWorker sandbox from `pyric-tools`' `connectRemoteSandbox()`),
+ *     user CRUD relays over the handle's worker channel instead of the
+ *     in-memory store, so server-created users land in the ONE user pool
+ *     the browser app + Studio share. See the "Remote sandbox arm"
+ *     section below for the details (including the extra methods it
+ *     supports: `updateUser`, `listUsers`).
+ *
  * Surface scope on the sandbox backend (what works):
  *
  *   - {@link getAuth}
@@ -69,10 +78,22 @@ import type {
   Auth as AdminAuth,
   CreateRequest,
   DecodedIdToken,
+  ListUsersResult,
+  UpdateRequest,
   UserRecord,
 } from 'firebase-admin/auth';
 import type { App } from 'firebase-admin/app';
-import type { Sandbox, SandboxEvent } from 'pyric/sandbox';
+import {
+  isRemoteSandbox,
+  type RemoteSandbox,
+  type Sandbox,
+  type SandboxEvent,
+} from 'pyric/sandbox';
+import type {
+  AuthUserRecord,
+  CreateUserRequest as SandboxCreateUserRequest,
+  UpdateUserRequest as SandboxUpdateUserRequest,
+} from 'pyric/auth';
 import {
   ADMIN_APP_TARGET,
   type PyricAdminApp,
@@ -194,6 +215,87 @@ function storeFor(sandbox: Sandbox): AuthStore {
 export const SANDBOX_TOKEN_PREFIX = 'pyric-sandbox-custom';
 
 /**
+ * Mint a deterministic sandbox token (the {@link SANDBOX_TOKEN_PREFIX}
+ * format). Stateless — shared verbatim by the local and remote sandbox
+ * arms, so a token minted against either round-trips through
+ * {@link verifySandboxIdToken} on the other.
+ */
+function mintSandboxCustomToken(uid: string, developerClaims?: object): Promise<string> {
+  const claims = developerClaims ?? {};
+  const token = `${SANDBOX_TOKEN_PREFIX}:${uid}:${JSON.stringify(claims)}`;
+  return Promise.resolve(token);
+}
+
+/**
+ * Parse a token minted by {@link mintSandboxCustomToken}. Returns a
+ * `DecodedIdToken`-shaped object — every required field is filled with a
+ * sandbox-appropriate placeholder (`iss`/`aud` = `pyric-sandbox`, time
+ * fields = now), and the developer claims are spread onto the result so
+ * `decoded.role` etc. work the same way they do in prod.
+ *
+ * Throws on any token that doesn't match the
+ * `${SANDBOX_TOKEN_PREFIX}:${uid}:${json}` shape — including real JWTs
+ * that another verifier would parse. The sandbox backends are
+ * intentionally not drop-ins for production token verification.
+ */
+function verifySandboxIdToken(idToken: string): Promise<DecodedIdToken> {
+  if (typeof idToken !== 'string' || !idToken.startsWith(`${SANDBOX_TOKEN_PREFIX}:`)) {
+    return Promise.reject(
+      new Error(
+        'pyric-admin/auth: verifyIdToken on the sandbox backend only ' +
+          'accepts tokens minted by this sandbox\'s createCustomToken. ' +
+          `Token prefix must be "${SANDBOX_TOKEN_PREFIX}:".`,
+      ),
+    );
+  }
+  // The token is `prefix:uid:json`. Split on the first two colons
+  // only — the JSON payload may itself contain colons (e.g. inside
+  // a string value) so `split(':')` with no limit would corrupt it.
+  const firstColon = idToken.indexOf(':');
+  const secondColon = idToken.indexOf(':', firstColon + 1);
+  if (secondColon < 0) {
+    return Promise.reject(
+      new Error(
+        `pyric-admin/auth: verifyIdToken received a malformed sandbox token (missing claims segment): ${idToken}`,
+      ),
+    );
+  }
+  const uid = idToken.slice(firstColon + 1, secondColon);
+  const jsonClaims = idToken.slice(secondColon + 1);
+  let claims: Record<string, unknown>;
+  try {
+    claims = JSON.parse(jsonClaims) as Record<string, unknown>;
+  } catch (e) {
+    return Promise.reject(
+      new Error(
+        `pyric-admin/auth: verifyIdToken failed to parse sandbox token claims as JSON: ${(e as Error).message}`,
+      ),
+    );
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  // `DecodedIdToken` requires `aud`/`iss`/`sub`/`uid`/`auth_time`/
+  // `exp`/`iat`/`firebase` to be present; the sandbox fills them
+  // with placeholders so consumers that read them get sensible
+  // values rather than `undefined`. Developer claims are spread on
+  // top so they shadow nothing critical.
+  const decoded: DecodedIdToken = {
+    aud: 'pyric-sandbox',
+    auth_time: nowSec,
+    exp: nowSec + 3600,
+    firebase: {
+      identities: {},
+      sign_in_provider: 'custom',
+    },
+    iat: nowSec,
+    iss: 'pyric-sandbox',
+    sub: uid,
+    uid,
+    ...claims,
+  };
+  return Promise.resolve(decoded);
+}
+
+/**
  * Build the in-memory `Auth` handle for a sandbox app. Returns an
  * object structurally compatible with `firebase-admin/auth`'s `Auth`
  * (cast at the boundary) where the documented method subset is wired
@@ -271,82 +373,19 @@ function makeSandboxAuth(sandbox: Sandbox): Auth {
      * Mint a deterministic sandbox token. Format is fixed at
      * `${SANDBOX_TOKEN_PREFIX}:${uid}:${JSON.stringify(claims ?? {})}`.
      * Round-trips through {@link verifyIdToken} on the same sandbox
-     * backend; rejected by every other token verifier.
+     * backend; rejected by every other token verifier. Shared
+     * implementation: {@link mintSandboxCustomToken}.
      */
     createCustomToken(uid: string, developerClaims?: object): Promise<string> {
-      const claims = developerClaims ?? {};
-      const token = `${SANDBOX_TOKEN_PREFIX}:${uid}:${JSON.stringify(claims)}`;
-      return Promise.resolve(token);
+      return mintSandboxCustomToken(uid, developerClaims);
     },
 
     /**
-     * Parse a token minted by {@link createCustomToken}. Returns a
-     * `DecodedIdToken`-shaped object — every required field is filled
-     * with a sandbox-appropriate placeholder (`iss`/`aud` =
-     * `pyric-sandbox`, time fields = now), and the developer claims are
-     * spread onto the result so `decoded.role` etc. work the same way
-     * they do in prod.
-     *
-     * Throws on any token that doesn't match the
-     * `${SANDBOX_TOKEN_PREFIX}:${uid}:${json}` shape — including real
-     * JWTs that another verifier would parse. The sandbox backend is
-     * intentionally not a drop-in for production token verification.
+     * Parse a token minted by {@link createCustomToken}. Shared
+     * implementation: {@link verifySandboxIdToken}.
      */
     verifyIdToken(idToken: string, _checkRevoked?: boolean): Promise<DecodedIdToken> {
-      if (typeof idToken !== 'string' || !idToken.startsWith(`${SANDBOX_TOKEN_PREFIX}:`)) {
-        return Promise.reject(
-          new Error(
-            'pyric-admin/auth: verifyIdToken on the sandbox backend only ' +
-              'accepts tokens minted by this sandbox\'s createCustomToken. ' +
-              `Token prefix must be "${SANDBOX_TOKEN_PREFIX}:".`,
-          ),
-        );
-      }
-      // The token is `prefix:uid:json`. Split on the first two colons
-      // only — the JSON payload may itself contain colons (e.g. inside
-      // a string value) so `split(':')` with no limit would corrupt it.
-      const firstColon = idToken.indexOf(':');
-      const secondColon = idToken.indexOf(':', firstColon + 1);
-      if (secondColon < 0) {
-        return Promise.reject(
-          new Error(
-            `pyric-admin/auth: verifyIdToken received a malformed sandbox token (missing claims segment): ${idToken}`,
-          ),
-        );
-      }
-      const uid = idToken.slice(firstColon + 1, secondColon);
-      const jsonClaims = idToken.slice(secondColon + 1);
-      let claims: Record<string, unknown>;
-      try {
-        claims = JSON.parse(jsonClaims) as Record<string, unknown>;
-      } catch (e) {
-        return Promise.reject(
-          new Error(
-            `pyric-admin/auth: verifyIdToken failed to parse sandbox token claims as JSON: ${(e as Error).message}`,
-          ),
-        );
-      }
-      const nowSec = Math.floor(Date.now() / 1000);
-      // `DecodedIdToken` requires `aud`/`iss`/`sub`/`uid`/`auth_time`/
-      // `exp`/`iat`/`firebase` to be present; the sandbox fills them
-      // with placeholders so consumers that read them get sensible
-      // values rather than `undefined`. Developer claims are spread on
-      // top so they shadow nothing critical.
-      const decoded: DecodedIdToken = {
-        aud: 'pyric-sandbox',
-        auth_time: nowSec,
-        exp: nowSec + 3600,
-        firebase: {
-          identities: {},
-          sign_in_provider: 'custom',
-        },
-        iat: nowSec,
-        iss: 'pyric-sandbox',
-        sub: uid,
-        uid,
-        ...claims,
-      };
-      return Promise.resolve(decoded);
+      return verifySandboxIdToken(idToken);
     },
 
     /**
@@ -515,6 +554,268 @@ function makeSandboxAuth(sandbox: Sandbox): Auth {
   return handle as Auth;
 }
 
+// ─── Remote sandbox arm (remote sandbox, slice 1) ───────────────────────
+//
+// The app's `Sandbox` is a Node-side handle onto the browser-hosted
+// SharedWorker sandbox (`pyric/sandbox`'s remote brand). User CRUD relays
+// over the handle's worker channel as the existing admin auth ops
+// (`auth.adminCreateUser` / `auth.adminUpdateUser` / `auth.adminDeleteUser`
+// / `auth.listUsers`) so server-created users land in the ONE user pool
+// the browser app + Studio + agents share — an in-memory `AuthStore` keyed
+// off a remote handle would be a private user table the browser never
+// sees. Auth ops are never lensed (they operate the worker's user pool
+// directly), so no `actAs` is pinned here, unlike the RTDB arm.
+//
+// Single-user lookups (`getUser` / `getUserByEmail`) go through
+// `auth.listUsers` + a client-side filter: the worker protocol has no
+// dedicated single-lookup op, and O(n) over the wire is fine at sandbox
+// scale (per the design spike — add an op if it ever matters).
+//
+// Tokens stay stateless and local: `createCustomToken` / `verifyIdToken`
+// are the same string transforms as the local arm
+// ({@link mintSandboxCustomToken} / {@link verifySandboxIdToken}), so a
+// token minted server-side verifies against any pyric-admin backend.
+
+/** Map a firebase-admin `CreateRequest` onto the worker's sandbox
+ *  create-user request. `null`s (upstream "clear") become "unset" — a
+ *  fresh user has nothing to clear. `multiFactor` isn't modeled. */
+function toSandboxCreateRequest(props: CreateRequest): SandboxCreateUserRequest {
+  return {
+    uid: props.uid,
+    email: props.email,
+    password: props.password,
+    displayName: props.displayName ?? undefined,
+    phoneNumber: props.phoneNumber ?? undefined,
+    photoUrl: props.photoURL ?? undefined,
+    disabled: props.disabled,
+    emailVerified: props.emailVerified,
+  };
+}
+
+/** Convert the worker's `AuthUserRecord` (emulator-REST-shaped, from
+ *  `pyric/auth`) into a firebase-admin `UserRecord`-shaped object — the
+ *  same field set the local arm's `toUserRecord` fills. */
+function fromAuthUserRecord(r: AuthUserRecord): UserRecord {
+  const metadata = {
+    creationTime: r.createdAt,
+    lastSignInTime: r.lastLoginAt ?? '',
+    toJSON: () => ({ creationTime: r.createdAt, lastSignInTime: r.lastLoginAt ?? '' }),
+  } as UserRecord['metadata'];
+  const record: Partial<UserRecord> = {
+    uid: r.uid,
+    email: r.email ?? undefined,
+    emailVerified: r.emailVerified,
+    displayName: r.displayName ?? undefined,
+    photoURL: r.photoUrl ?? undefined,
+    phoneNumber: r.phoneNumber ?? undefined,
+    disabled: r.disabled,
+    metadata,
+    providerData: r.providerUserInfo.map((p) => ({
+      providerId: p.providerId,
+      uid: r.uid,
+      displayName: r.displayName ?? undefined,
+      email: r.email ?? undefined,
+      photoURL: r.photoUrl ?? undefined,
+      phoneNumber: r.phoneNumber ?? undefined,
+      toJSON: () => ({ providerId: p.providerId, uid: r.uid }),
+    })) as unknown as UserRecord['providerData'],
+    customClaims:
+      Object.keys(r.customClaims).length > 0
+        ? (r.customClaims as Record<string, unknown>)
+        : undefined,
+    tenantId: null,
+    toJSON: () => ({ uid: r.uid, email: r.email ?? undefined }),
+  };
+  return record as UserRecord;
+}
+
+/**
+ * Build the remote `Auth` handle: the documented CRUD subset relays over
+ * the worker channel; tokens are the shared stateless transforms; the
+ * rest of the surface throws the canonical "not implemented" error (same
+ * cast-at-the-boundary rationale as {@link makeSandboxAuth}).
+ *
+ * Differences from the local in-memory arm, all deliberate:
+ *   - `updateUser` and `listUsers` WORK (the worker has the ops; the
+ *     local arm predates them and still throws).
+ *   - User mutations emit auth `SandboxEvent`s in the worker (visible to
+ *     Studio/agents) and are visible to the browser app immediately.
+ */
+function makeRemoteAuth(sandbox: RemoteSandbox): Auth {
+  const channel = sandbox.channel;
+
+  const notImplemented = (method: string): Error =>
+    new Error(
+      `pyric-admin/auth: ${method} is not implemented in pyric-admin/auth remote sandbox backend`,
+    );
+
+  const listRecords = async (): Promise<AuthUserRecord[]> =>
+    (await channel.op({ method: 'auth.listUsers' })) as AuthUserRecord[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handle: any = {
+    get app() {
+      throw notImplemented('auth.app');
+    },
+
+    /** Stateless mint — identical to the local arm; needs no relay. */
+    createCustomToken(uid: string, developerClaims?: object): Promise<string> {
+      return mintSandboxCustomToken(uid, developerClaims);
+    },
+
+    /** Stateless parse — identical to the local arm; needs no relay. */
+    verifyIdToken(idToken: string, _checkRevoked?: boolean): Promise<DecodedIdToken> {
+      return verifySandboxIdToken(idToken);
+    },
+
+    /** Relays `auth.adminCreateUser`. Uid conflicts / invalid emails /
+     *  weak passwords reject with the worker backend's `auth/*` error. */
+    async createUser(properties: CreateRequest): Promise<UserRecord> {
+      const record = await channel.op({
+        method: 'auth.adminCreateUser',
+        request: toSandboxCreateRequest(properties) as unknown as Record<string, unknown>,
+      });
+      return fromAuthUserRecord(record as AuthUserRecord);
+    },
+
+    /** `auth.listUsers` + client-side filter (see module note). */
+    async getUser(uid: string): Promise<UserRecord> {
+      const record = (await listRecords()).find((u) => u.uid === uid);
+      if (!record) {
+        throw new Error(`pyric-admin/auth: getUser failed — no user with uid "${uid}"`);
+      }
+      return fromAuthUserRecord(record);
+    },
+
+    /** `auth.listUsers` + client-side filter (see module note). */
+    async getUserByEmail(email: string): Promise<UserRecord> {
+      const record = (await listRecords()).find((u) => u.email === email);
+      if (!record) {
+        throw new Error(
+          `pyric-admin/auth: getUserByEmail failed — no user with email "${email}"`,
+        );
+      }
+      return fromAuthUserRecord(record);
+    },
+
+    /** Relays `auth.listUsers`. The whole pool fits one page at sandbox
+     *  scale, so `pageToken` is never set; `maxResults` is honored. */
+    async listUsers(maxResults?: number, _pageToken?: string): Promise<ListUsersResult> {
+      let records = await listRecords();
+      if (maxResults !== undefined) records = records.slice(0, maxResults);
+      return { users: records.map(fromAuthUserRecord) } as ListUsersResult;
+    },
+
+    /**
+     * Relays `auth.adminUpdateUser` for the fields the worker models
+     * (`displayName` / `email` / `password` / `disabled` /
+     * `emailVerified`). Fields it can't express (`photoURL`,
+     * `phoneNumber`, `multiFactor`, provider links) throw rather than
+     * silently dropping a requested change.
+     */
+    async updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord> {
+      const unsupported = (['photoURL', 'phoneNumber', 'multiFactor', 'providerToLink', 'providersToUnlink'] as const).filter(
+        (k) => (properties as Record<string, unknown>)[k] !== undefined,
+      );
+      if (unsupported.length > 0) {
+        throw notImplemented(`updateUser({ ${unsupported.join(', ')} })`);
+      }
+      const request: SandboxUpdateUserRequest = {
+        displayName: properties.displayName,
+        email: properties.email,
+        password: properties.password,
+        disabled: properties.disabled,
+        emailVerified: properties.emailVerified,
+      };
+      const record = await channel.op({
+        method: 'auth.adminUpdateUser',
+        uid,
+        request: request as unknown as Record<string, unknown>,
+      });
+      return fromAuthUserRecord(record as AuthUserRecord);
+    },
+
+    /** Relays `auth.adminDeleteUser`. A missing uid rejects with the
+     *  worker backend's `auth/user-not-found` error (matches upstream's
+     *  strict delete contract, like the local arm). */
+    async deleteUser(uid: string): Promise<void> {
+      await channel.op({ method: 'auth.adminDeleteUser', uid });
+    },
+
+    /** Relays `auth.adminUpdateUser` with a `customClaims` replacement —
+     *  `null` clears (the worker's UpdateUserRequest.customClaims
+     *  replaces the whole map, admin `setCustomUserClaims` semantics). */
+    async setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void> {
+      await channel.op({
+        method: 'auth.adminUpdateUser',
+        uid,
+        request: { customClaims: customUserClaims ?? {} },
+      });
+    },
+
+    // ─── Explicitly-not-implemented surface (parity with local) ──────
+
+    getUserByPhoneNumber(): Promise<UserRecord> {
+      return Promise.reject(notImplemented('getUserByPhoneNumber'));
+    },
+    getUserByProviderUid(): Promise<UserRecord> {
+      return Promise.reject(notImplemented('getUserByProviderUid'));
+    },
+    getUsers(): Promise<unknown> {
+      return Promise.reject(notImplemented('getUsers'));
+    },
+    deleteUsers(): Promise<unknown> {
+      return Promise.reject(notImplemented('deleteUsers'));
+    },
+    importUsers(): Promise<unknown> {
+      return Promise.reject(notImplemented('importUsers'));
+    },
+    revokeRefreshTokens(): Promise<void> {
+      return Promise.reject(notImplemented('revokeRefreshTokens'));
+    },
+    createSessionCookie(): Promise<string> {
+      return Promise.reject(notImplemented('createSessionCookie'));
+    },
+    verifySessionCookie(): Promise<DecodedIdToken> {
+      return Promise.reject(notImplemented('verifySessionCookie'));
+    },
+    generatePasswordResetLink(): Promise<string> {
+      return Promise.reject(notImplemented('generatePasswordResetLink'));
+    },
+    generateEmailVerificationLink(): Promise<string> {
+      return Promise.reject(notImplemented('generateEmailVerificationLink'));
+    },
+    generateSignInWithEmailLink(): Promise<string> {
+      return Promise.reject(notImplemented('generateSignInWithEmailLink'));
+    },
+    generateVerifyAndChangeEmailLink(): Promise<string> {
+      return Promise.reject(notImplemented('generateVerifyAndChangeEmailLink'));
+    },
+    createProviderConfig(): Promise<unknown> {
+      return Promise.reject(notImplemented('createProviderConfig'));
+    },
+    getProviderConfig(): Promise<unknown> {
+      return Promise.reject(notImplemented('getProviderConfig'));
+    },
+    listProviderConfigs(): Promise<unknown> {
+      return Promise.reject(notImplemented('listProviderConfigs'));
+    },
+    updateProviderConfig(): Promise<unknown> {
+      return Promise.reject(notImplemented('updateProviderConfig'));
+    },
+    deleteProviderConfig(): Promise<void> {
+      return Promise.reject(notImplemented('deleteProviderConfig'));
+    },
+    get tenantManager(): never {
+      throw notImplemented('tenantManager');
+    },
+    get projectConfigManager(): never {
+      throw notImplemented('projectConfigManager');
+    },
+  };
+  return handle as Auth;
+}
+
 // ─── Dispatch ────────────────────────────────────────────────────────────
 
 /**
@@ -577,6 +878,13 @@ export function getAuth(app: PyricAdminApp): Auth {
     );
   }
   if (isSandboxAdminApp(app)) {
+    // Remote-branded sandboxes dispatch BEFORE the local arm: the local
+    // in-memory store would be a private server-side user table the
+    // browser never sees (and its `sandbox.onEvent` reset wiring throws
+    // on remote handles by design).
+    if (isRemoteSandbox(app.sandbox)) {
+      return makeRemoteAuth(app.sandbox);
+    }
     return makeSandboxAuth(app.sandbox);
   }
   if (isProdAdminApp(app)) {

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -58,6 +58,30 @@
  *     Successive `getDatabase(app)` calls for the same sandbox return
  *     handles that share data (matches firebase-admin's
  *     singleton-per-app semantics).
+ *
+ *   - **Remote sandbox arm** (sandbox target whose `Sandbox` carries the
+ *     `pyric/sandbox` remote brand — a Node-side handle onto the
+ *     browser-hosted SharedWorker sandbox, built by `pyric-tools`'
+ *     `connectRemoteSandbox()`) — every `Reference` data operation routes
+ *     through the handle's worker-relay channel (`rtdb.get/set/update/
+ *     remove/push` ops with `actAs: { mode: 'admin' }` pinned — firebase-
+ *     admin's rules-bypass semantics), NOT into the process-local tree:
+ *     a local tree on a remote handle would be private server-side data
+ *     the browser never sees. Differences from the local arm, both
+ *     deliberate upgrades:
+ *
+ *       - `on('value')` / `once('value')` WORK (routed through the
+ *         channel's RTDB value subscription; other event types still
+ *         throw "not implemented").
+ *       - `update()` relays to the worker's full multi-path update
+ *         (`pyric/database/modular` semantics) rather than the local
+ *         arm's shallow per-key merge.
+ *       - Server-side writes run through the real worker RTDB backend,
+ *         so they emit `SandboxEvent`s into the unified stream (visible
+ *         to Studio/agents) and fire the app's live listeners.
+ *
+ *     `push()` keeps its sync `.key`: the client mints the push id and
+ *     sends it with the `rtdb.push` op (the worker-protocol contract).
  */
 
 import type { App } from 'firebase-admin/app';
@@ -74,7 +98,12 @@ import type {
   OnDisconnect as AdminOnDisconnect,
   EventType as AdminEventType,
 } from 'firebase-admin/database';
-import type { Sandbox } from 'pyric/sandbox';
+import {
+  isRemoteSandbox,
+  type RemoteSandbox,
+  type RemoteSandboxChannel,
+  type Sandbox,
+} from 'pyric/sandbox';
 
 import {
   ADMIN_APP_TARGET,
@@ -188,23 +217,42 @@ function getOrCreateState(sandbox: Sandbox): SandboxState {
   return state;
 }
 
-/** Build (or reuse) the sandbox Database handle for `sandbox`. */
+/** Build (or reuse) the sandbox Database handle for `sandbox`.
+ *
+ *  REMOTE handles dispatch here, BEFORE any local state is touched: a
+ *  remote sandbox must never get a `SandboxState` (a private local tree)
+ *  or a `sandbox.onEvent` wire-up (which throws on remote handles). */
 function getSandboxDatabase(sandbox: Sandbox): AdminDatabase {
+  if (isRemoteSandbox(sandbox)) {
+    return getRemoteDatabase(sandbox);
+  }
   const state = getOrCreateState(sandbox);
   return buildSandboxDatabase(state);
 }
 
 function buildSandboxDatabase(state: SandboxState): AdminDatabase {
+  return buildDatabaseShell((db, path) => buildSandboxRef(state, db, path));
+}
+
+/**
+ * The `Database`-level shell shared by the local and remote sandbox arms —
+ * everything except how a `Reference` is built. Rules metadata isn't
+ * modeled on either arm; connection toggles are no-ops (the sandbox IS the
+ * local emulator).
+ */
+function buildDatabaseShell(
+  refFactory: (db: AdminDatabase, path: string) => AdminReference,
+): AdminDatabase {
   const db = {
     ref(path?: string): AdminReference {
-      return buildSandboxRef(state, db as unknown as AdminDatabase, path ?? '/');
+      return refFactory(db as unknown as AdminDatabase, path ?? '/');
     },
     refFromURL(url: string): AdminReference {
       // Best-effort: strip the `https://<host>` prefix and treat the
       // remainder as a path. The sandbox has no notion of multi-database
       // hosts, so the host portion is ignored.
       const u = url.replace(/^https?:\/\/[^/]+/, '');
-      return buildSandboxRef(state, db as unknown as AdminDatabase, u || '/');
+      return refFactory(db as unknown as AdminDatabase, u || '/');
     },
     // Admin-only metadata methods — not modeled in the sandbox. The
     // sandbox is rule-bypass by construction; surfacing rule JSON would
@@ -495,7 +543,7 @@ function buildSandboxRef(
     /** Read this path. Resolves to a {@link DataSnapshot}-shaped value. */
     async get(): Promise<AdminDataSnapshot> {
       const val = readPath(state.root, canonical);
-      return buildSandboxSnap(state, db, canonical, val);
+      return buildSandboxSnap((p) => buildSandboxRef(state, db, p), canonical, val);
     },
 
     /** `once(eventType)` — admin-shape one-shot read. Only `'value'` is
@@ -512,7 +560,7 @@ function buildSandboxRef(
         throw notImplemented(`once('${eventType}')`);
       }
       const val = readPath(state.root, canonical);
-      return buildSandboxSnap(state, db, canonical, val);
+      return buildSandboxSnap((p) => buildSandboxRef(state, db, p), canonical, val);
     },
 
     /** Shallow merge: each key in `values` replaces the corresponding
@@ -555,14 +603,18 @@ function buildSandboxRef(
       // ThenableReference: the ref plus a `.then()` that resolves to it.
       // Returning a Reference with a tacked-on `.then` satisfies the
       // firebase-admin shape for the common `push(value).key` usage.
+      // CRITICAL: the promise must resolve with a PLAIN (non-thenable)
+      // ref — resolving with the thenable itself would make promise
+      // resolution unwrap it forever (`await push(...)` would spin).
+      const resolvedRef = buildSandboxRef(state, db, childPath);
       const thenable = childRef as AdminReference & PromiseLike<AdminReference>;
       (thenable as unknown as { then: PromiseLike<AdminReference>['then'] }).then = (
         onFulfilled,
         onRejected,
-      ) => Promise.resolve(childRef).then(onFulfilled, onRejected);
+      ) => Promise.resolve(resolvedRef).then(onFulfilled, onRejected);
       (thenable as unknown as { catch: <U>(onRejected: (reason: unknown) => U | PromiseLike<U>) => Promise<AdminReference | U> }).catch = (
         onRejected,
-      ) => Promise.resolve(childRef).catch(onRejected);
+      ) => Promise.resolve(resolvedRef).catch(onRejected);
       return thenable as AdminThenableReference;
     },
 
@@ -659,10 +711,12 @@ function buildSandboxRef(
 // ─── DataSnapshot ─────────────────────────────────────────────────────
 
 /** Build a sandbox `DataSnapshot` for the value at `path`. Implements
- *  the load-bearing subset of firebase-admin's `DataSnapshot` shape. */
+ *  the load-bearing subset of firebase-admin's `DataSnapshot` shape.
+ *  Backend-agnostic: the snapshot is a pure (path, value) view; `refAt`
+ *  supplies backend-appropriate `Reference`s (local tree or remote), so
+ *  the local and remote arms share one snapshot implementation. */
 function buildSandboxSnap(
-  state: SandboxState,
-  db: AdminDatabase,
+  refAt: (path: string) => AdminReference,
   path: string,
   val: JsonValue,
 ): AdminDataSnapshot {
@@ -672,7 +726,7 @@ function buildSandboxSnap(
   const snap = {
     key,
     get ref(): AdminReference {
-      return buildSandboxRef(state, db, path);
+      return refAt(path);
     },
     exists(): boolean {
       return exists;
@@ -690,7 +744,7 @@ function buildSandboxSnap(
         }
         cur = (cur as Record<string, JsonValue>)[s] ?? null;
       }
-      return buildSandboxSnap(state, db, joinPath([...segs, ...childSegs]), cur);
+      return buildSandboxSnap(refAt, joinPath([...segs, ...childSegs]), cur);
     },
     hasChild(p: string): boolean {
       return snap.child(p).exists();
@@ -710,7 +764,7 @@ function buildSandboxSnap(
     forEach(cb: (child: AdminDataSnapshot) => boolean | void): boolean {
       if (val === null || typeof val !== 'object' || Array.isArray(val)) return false;
       for (const [k, v] of Object.entries(val as Record<string, JsonValue>)) {
-        const childSnap = buildSandboxSnap(state, db, joinPath([...segs, k]), v);
+        const childSnap = buildSandboxSnap(refAt, joinPath([...segs, k]), v);
         if (cb(childSnap) === true) return true;
       }
       return false;
@@ -730,4 +784,380 @@ function buildSandboxSnap(
     },
   };
   return snap as unknown as AdminDataSnapshot;
+}
+
+// ─── Remote sandbox arm (remote sandbox, slice 1) ─────────────────────
+//
+// The app's `Sandbox` is a Node-side handle onto the browser-hosted
+// SharedWorker sandbox (`pyric/sandbox`'s remote brand). Every data
+// operation relays over the handle's worker channel with
+// `actAs: { mode: 'admin' }` pinned — firebase-admin's rules-bypass
+// semantics against the ONE tree the app + Studio + agents share. There
+// is deliberately NO local state here: a `WeakMap` tree keyed off a
+// remote handle would be private server-side data the browser never sees
+// (exactly the failure the remote sandbox exists to avoid). No
+// `session_boundary` wiring either — there is nothing local to wipe, and
+// `onEvent` throws on remote handles by design.
+
+/** firebase-admin's rules-bypass lens, pinned on every relayed operation. */
+const REMOTE_ADMIN_LENS = { mode: 'admin' } as const;
+
+/** Wire shape of an RTDB snapshot as the worker host serializes it. */
+interface RemoteWireSnapshot {
+  key: string | null;
+  exists: boolean;
+  value: unknown;
+  size: number;
+}
+
+/**
+ * Per-remote-handle state: the relay channel plus the `on('value')`
+ * listener registry (`path → callback → detach`) that `off()` consults.
+ */
+interface RemoteDbState {
+  channel: RemoteSandboxChannel;
+  listeners: Map<string, Map<unknown, () => void>>;
+}
+
+/** One `Database` per remote handle — successive `getDatabase(app)` calls
+ *  share the listener registry (matches the local arm's singleton-per-
+ *  sandbox semantics). Keyed off the handle object; the data itself lives
+ *  in the browser worker. */
+const remoteDbBySandbox = new WeakMap<Sandbox, AdminDatabase>();
+
+function getRemoteDatabase(sandbox: RemoteSandbox): AdminDatabase {
+  let db = remoteDbBySandbox.get(sandbox);
+  if (db !== undefined) return db;
+  const state: RemoteDbState = {
+    channel: sandbox.channel,
+    listeners: new Map(),
+  };
+  db = buildDatabaseShell((dbHandle, path) => buildRemoteRef(state, dbHandle, path));
+  remoteDbBySandbox.set(sandbox, db);
+  return db;
+}
+
+/**
+ * Build a remote `Reference` at `path`. Same load-bearing surface as the
+ * local arm's {@link buildSandboxRef} — plus working `on('value')` /
+ * `off()` (the channel relays the worker's RTDB value subscription).
+ * Transactions / queries / priorities / `onDisconnect` throw the same
+ * "not implemented" sentinel as the local arm.
+ */
+function buildRemoteRef(
+  state: RemoteDbState,
+  db: AdminDatabase,
+  path: string,
+): AdminReference {
+  const canonical = joinPath(pathSegments(path));
+  const segs = pathSegments(canonical);
+  const key = segs.length === 0 ? null : segs[segs.length - 1]!;
+  const refAt = (p: string): AdminReference => buildRemoteRef(state, db, p);
+  const snapFromWire = (wire: RemoteWireSnapshot): AdminDataSnapshot =>
+    buildSandboxSnap(refAt, canonical, (wire.value ?? null) as JsonValue);
+
+  const ref = {
+    key,
+    get parent(): AdminReference | null {
+      if (segs.length === 0) return null;
+      return refAt(joinPath(segs.slice(0, -1)));
+    },
+    get root(): AdminReference {
+      return refAt('/');
+    },
+    get path(): string {
+      return canonical;
+    },
+    toString(): string {
+      return `sandbox://rtdb${canonical}`;
+    },
+
+    // ─── Data-plane methods (relayed worker ops) ─────────────────────
+
+    /** Set `value` at this path. `null` deletes. Relays `rtdb.set`. */
+    async set(value: unknown): Promise<void> {
+      await state.channel.op({
+        method: 'rtdb.set',
+        path: canonical,
+        value: value ?? null,
+        actAs: REMOTE_ADMIN_LENS,
+      });
+    },
+
+    /** Read this path (`rtdb.get`). Resolves to a `DataSnapshot`. */
+    async get(): Promise<AdminDataSnapshot> {
+      const wire = (await state.channel.op({
+        method: 'rtdb.get',
+        path: canonical,
+        actAs: REMOTE_ADMIN_LENS,
+      })) as RemoteWireSnapshot;
+      return snapFromWire(wire);
+    },
+
+    /** One-shot read via the channel's value subscription: the initial
+     *  snapshot resolves the promise, then the subscription detaches.
+     *  Only `'value'` is supported (parity with the local arm). */
+    once(
+      eventType: AdminEventType,
+      _successCb?: unknown,
+      _failureCb?: unknown,
+      _context?: unknown,
+    ): Promise<AdminDataSnapshot> {
+      if (eventType !== 'value') {
+        throw notImplemented(`once('${eventType}')`);
+      }
+      return new Promise<AdminDataSnapshot>((resolve, reject) => {
+        let detach: (() => void) | null = null;
+        let settled = false;
+        detach = state.channel.subscribe(
+          { target: { service: 'rtdb', path: canonical }, actAs: REMOTE_ADMIN_LENS },
+          (value) => {
+            if (settled) return;
+            settled = true;
+            resolve(snapFromWire(value as RemoteWireSnapshot));
+            if (detach) detach();
+          },
+          (err) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+            if (detach) detach();
+          },
+        );
+        if (settled) detach();
+      });
+    },
+
+    /** Relays `rtdb.update` — the worker applies the FULL multi-path
+     *  update semantics (`pyric/database/modular`), an upgrade over the
+     *  local arm's shallow per-key merge. `null` values delete. */
+    async update(values: object): Promise<void> {
+      if (values === null || typeof values !== 'object') {
+        throw new TypeError(
+          'pyric-admin/database sandbox: update expected an object.',
+        );
+      }
+      await state.channel.op({
+        method: 'rtdb.update',
+        path: canonical,
+        values: values as Record<string, unknown>,
+        actAs: REMOTE_ADMIN_LENS,
+      });
+    },
+
+    /** Delete the subtree at this path (`rtdb.remove`). */
+    async remove(): Promise<void> {
+      await state.channel.op({
+        method: 'rtdb.remove',
+        path: canonical,
+        actAs: REMOTE_ADMIN_LENS,
+      });
+    },
+
+    /**
+     * Mint a 20-char push id CLIENT-side and relay `rtdb.push` carrying it
+     * (the worker-protocol contract) — so the returned
+     * `ThenableReference.key` is available synchronously, exactly like the
+     * local arm and firebase-admin. `.then()` settles when the relayed
+     * write commits (or immediately when no value was supplied — a bare
+     * `push()` performs no write, matching upstream); a write failure
+     * rejects the thenable and reaches `onComplete`.
+     */
+    push(value?: unknown, onComplete?: (err: Error | null) => void): AdminThenableReference {
+      const id = generatePushId();
+      const childPath = joinPath([...segs, id]);
+      const write: Promise<void> =
+        value === undefined
+          ? Promise.resolve()
+          : state.channel
+              .op({
+                method: 'rtdb.push',
+                path: canonical,
+                key: id,
+                value,
+                actAs: REMOTE_ADMIN_LENS,
+              })
+              .then(() => undefined);
+      // Surface completion without forcing the caller to await: `.then`'s
+      // rejection handler also keeps a fire-and-forget push from becoming
+      // an unhandled rejection (the failure still reaches `onComplete` and
+      // any `.then()`/`await` on the returned thenable).
+      write.then(
+        () => {
+          if (onComplete) onComplete(null);
+        },
+        (err: Error) => {
+          if (onComplete) onComplete(err);
+        },
+      );
+      const childRef = refAt(childPath);
+      // CRITICAL: settle with a PLAIN (non-thenable) ref — resolving with
+      // the thenable itself would make promise resolution unwrap it
+      // forever (`await push(...)` would spin). Same guard as local arm.
+      const resolvedRef = refAt(childPath);
+      const thenable = childRef as AdminReference & PromiseLike<AdminReference>;
+      (thenable as unknown as { then: PromiseLike<AdminReference>['then'] }).then = (
+        onFulfilled,
+        onRejected,
+      ) => write.then(() => resolvedRef).then(onFulfilled, onRejected);
+      (thenable as unknown as { catch: <U>(onRejected: (reason: unknown) => U | PromiseLike<U>) => Promise<AdminReference | U> }).catch = (
+        onRejected,
+      ) => write.then(() => resolvedRef).catch(onRejected);
+      return thenable as AdminThenableReference;
+    },
+
+    /** Relative ref builder — pure local path manipulation. */
+    child(p: string): AdminReference {
+      return refAt(joinPath([...segs, ...pathSegments(p)]));
+    },
+
+    // ─── Value listeners (relayed worker subscription) ────────────────
+
+    /**
+     * `on('value', callback)` — routed through the channel's RTDB value
+     * subscription: the callback fires with the initial snapshot and on
+     * every subsequent change (including changes made by the browser app,
+     * Studio, or agents — one shared tree). A subscription-establishment
+     * failure routes to `cancelCallback` when one is supplied. Other
+     * event types (`child_added`, …) still throw "not implemented" —
+     * the worker relays only value subscriptions today.
+     */
+    on(
+      eventType: AdminEventType,
+      callback: (snap: AdminDataSnapshot, prevChildKey?: string | null) => unknown,
+      cancelCallbackOrContext?: ((err: Error) => unknown) | object | null,
+      _context?: object | null,
+    ): (snap: AdminDataSnapshot, prevChildKey?: string | null) => unknown {
+      if (eventType !== 'value') {
+        throw notImplemented(`on('${eventType}')`);
+      }
+      const cancelCallback =
+        typeof cancelCallbackOrContext === 'function'
+          ? (cancelCallbackOrContext as (err: Error) => unknown)
+          : undefined;
+      const detach = state.channel.subscribe(
+        { target: { service: 'rtdb', path: canonical }, actAs: REMOTE_ADMIN_LENS },
+        (value) => {
+          callback(snapFromWire(value as RemoteWireSnapshot));
+        },
+        (err) => {
+          detachListener(state, canonical, callback);
+          if (cancelCallback) cancelCallback(err);
+          else console.error(`pyric-admin/database: on('value') subscription failed at ${canonical}:`, err);
+        },
+      );
+      let atPath = state.listeners.get(canonical);
+      if (atPath === undefined) {
+        atPath = new Map();
+        state.listeners.set(canonical, atPath);
+      }
+      // Re-registering the same callback replaces the prior registration
+      // (detach it first so the old worker subscription doesn't leak).
+      atPath.get(callback)?.();
+      atPath.set(callback, detach);
+      return callback;
+    },
+
+    /**
+     * Detach value listeners at this path: `off('value', callback)` removes
+     * that registration; `off()` / `off('value')` removes all of them.
+     * Unknown callbacks and other event types are no-ops (nothing else can
+     * be registered on the remote arm).
+     */
+    off(
+      eventType?: AdminEventType,
+      callback?: (snap: AdminDataSnapshot, prevChildKey?: string | null) => unknown,
+      _context?: object | null,
+    ): void {
+      if (eventType !== undefined && eventType !== 'value') return;
+      if (callback !== undefined) {
+        detachListener(state, canonical, callback);
+        return;
+      }
+      const atPath = state.listeners.get(canonical);
+      if (atPath === undefined) return;
+      for (const detach of atPath.values()) detach();
+      state.listeners.delete(canonical);
+    },
+
+    // ─── Not implemented on the remote arm (parity with local) ────────
+
+    onDisconnect(): never {
+      throw notImplemented('onDisconnect');
+    },
+    transaction(..._args: unknown[]): never {
+      throw notImplemented('transaction');
+    },
+    setPriority(..._args: unknown[]): never {
+      throw notImplemented('setPriority');
+    },
+    setWithPriority(..._args: unknown[]): never {
+      throw notImplemented('setWithPriority');
+    },
+    orderByChild(..._args: unknown[]): never {
+      throw notImplemented('orderByChild');
+    },
+    orderByKey(..._args: unknown[]): never {
+      throw notImplemented('orderByKey');
+    },
+    orderByValue(..._args: unknown[]): never {
+      throw notImplemented('orderByValue');
+    },
+    orderByPriority(..._args: unknown[]): never {
+      throw notImplemented('orderByPriority');
+    },
+    startAt(..._args: unknown[]): never {
+      throw notImplemented('startAt');
+    },
+    startAfter(..._args: unknown[]): never {
+      throw notImplemented('startAfter');
+    },
+    endAt(..._args: unknown[]): never {
+      throw notImplemented('endAt');
+    },
+    endBefore(..._args: unknown[]): never {
+      throw notImplemented('endBefore');
+    },
+    equalTo(..._args: unknown[]): never {
+      throw notImplemented('equalTo');
+    },
+    limitToFirst(..._args: unknown[]): never {
+      throw notImplemented('limitToFirst');
+    },
+    limitToLast(..._args: unknown[]): never {
+      throw notImplemented('limitToLast');
+    },
+    isEqual(other: unknown): boolean {
+      return (
+        other !== null &&
+        typeof other === 'object' &&
+        (other as { path?: string }).path === canonical
+      );
+    },
+    toJSON(): object {
+      return { path: canonical };
+    },
+    get database(): AdminDatabase {
+      return db;
+    },
+    get ref(): AdminReference {
+      return ref as unknown as AdminReference;
+    },
+  };
+
+  return ref as unknown as AdminReference;
+}
+
+/** Remove one `on('value')` registration (and its worker subscription). */
+function detachListener(
+  state: RemoteDbState,
+  path: string,
+  callback: unknown,
+): void {
+  const atPath = state.listeners.get(path);
+  const detach = atPath?.get(callback);
+  if (atPath === undefined || detach === undefined) return;
+  atPath.delete(callback);
+  if (atPath.size === 0) state.listeners.delete(path);
+  detach();
 }

--- a/packages/pyric-admin/test/remote/remote-dispatch.test.ts
+++ b/packages/pyric-admin/test/remote/remote-dispatch.test.ts
@@ -1,0 +1,493 @@
+/**
+ * `pyric-admin` remote-dispatch arm — end-to-end, fully in-process
+ * (remote sandbox, slice 1 / checkpoint 2).
+ *
+ * Extends checkpoint 1's headless harness (see
+ * `pyric-tools/test/bridge/worker-relay.test.ts`): the REAL worker host
+ * (`handleMessage` + fake `{ postMessage }` ports) behind the REAL bridge
+ * core and consumer session, fronted by the EXACT branded handle
+ * `connectRemoteSandbox()` returns (`createRemoteSandboxHandle`) — no
+ * browser, no WS. `pyric-admin`'s `initializeApp({ sandbox })` receives
+ * that handle unchanged, and `getDatabase` / `getAuth` must dispatch to
+ * the remote arm: every operation relays to the worker (verified by
+ * reading the worker's state through an independent direct port), and no
+ * process-local tree/store is ever created (the handle's `onEvent`
+ * throws — the local arms would trip it immediately).
+ *
+ * Coverage (per the checkpoint-2 spec):
+ *   - RTDB set/get/update/remove/push round-trip, incl. sync `.key`
+ *   - value listeners: `once('value')`, `on('value')` initial + update +
+ *     detach (`off`), cross-visibility with browser-side writes
+ *   - auth CRUD + custom claims + `getUser`/`getUserByEmail` via
+ *     listUsers-filter + stateless token round-trip
+ *   - the remediating throws on sync-only `Sandbox` members
+ *   - the no-peer error ("open <serve url>") surfacing through the
+ *     admin API
+ *   - the local in-process arm still selected for plain sandboxes
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import type { AuthUserRecord } from 'pyric/auth';
+
+import { createBridge, type Bridge } from '../../../pyric-tools/src/bridge/server/bridge.js';
+import { createConsumerSession } from '../../../pyric-tools/src/bridge/server/peer.js';
+import {
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../../pyric-tools/src/bridge/protocol.js';
+import {
+  createRemoteSandboxCore,
+  createRemoteSandboxHandle,
+  type RemoteSandbox,
+} from '../../../pyric-tools/src/remote/index.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../pyric-tools/src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../../pyric-tools/src/serve/worker/protocol.js';
+
+import { initializeApp } from '../../src/app/index.js';
+import { getDatabase } from '../../src/database/index.js';
+import { getAuth } from '../../src/auth/index.js';
+
+// ─── Harness (checkpoint 1's, minus persistence — not needed here) ─────────
+
+const SERVE_URL = 'http://localhost:5000';
+
+function makeWorkerCtx(): HostCtx {
+  const sandbox = initializeSandbox();
+  return {
+    db: getFirestore(sandbox),
+    sandbox,
+    instanceId: 'admin-remote-test',
+    subs: new Map(),
+  };
+}
+
+function tick(ms = 10): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Register a fake browser tab as the bridge's sandbox peer, backed by the
+ *  REAL worker host (same shape as worker-relay.test.ts's connectTab). */
+function connectTab(bridge: Bridge, ctx: HostCtx): void {
+  let gen = 0;
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      const m = raw as OutboundMessage;
+      if (m.t === 'res') {
+        bridge.handleSandboxMessage(
+          m.ok
+            ? { type: 'worker-res', id: m.id, ok: true, value: m.value }
+            : { type: 'worker-res', id: m.id, ok: false, error: m.error },
+          gen,
+        );
+      } else if (m.t === 'snap') {
+        bridge.handleSandboxMessage(
+          { type: 'worker-snap', subId: m.subId, value: m.value },
+          gen,
+        );
+      }
+    },
+  };
+  const send = (msg: BridgeMessage): void => {
+    if (gen === 0) gen = bridge.peerGeneration();
+    if (msg.type === 'worker-op') {
+      void handleMessage(ctx, port, { ...msg.op, t: 'op', id: msg.id } as InboundMessage);
+    } else if (msg.type === 'worker-sub') {
+      void handleMessage(ctx, port, { ...msg.sub, t: 'sub', subId: msg.subId } as InboundMessage);
+    } else if (msg.type === 'worker-unsub') {
+      void handleMessage(ctx, port, { t: 'unsub', subId: msg.subId } as InboundMessage);
+    }
+  };
+  bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
+}
+
+/** Build the EXACT production remote handle over an in-process transport. */
+function connectRemote(bridge: Bridge): RemoteSandbox {
+  let handleMsg: (msg: BridgeMessage) => void = () => {};
+  const session = createConsumerSession(bridge, (msg) => handleMsg(msg));
+  const core = createRemoteSandboxCore(
+    { send: (msg) => session.handleMessage(msg) },
+    { serveUrl: SERVE_URL },
+  );
+  handleMsg = core.handleMessage;
+  core.start();
+  return createRemoteSandboxHandle({
+    channel: core.channel,
+    serveUrl: SERVE_URL,
+    close: () => core.dispose('remote sandbox connection closed by the client'),
+  });
+}
+
+/** Drive one worker op through an INDEPENDENT direct port — the oracle
+ *  proving admin-API operations really landed in the worker's sandbox
+ *  (and letting "the browser app" write from its side). */
+let directOpSeq = 0;
+function workerOp(ctx: HostCtx, op: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const port: PortLike = {
+      postMessage(raw: unknown) {
+        const m = raw as OutboundMessage;
+        if (m.t !== 'res') return;
+        if (m.ok) resolve(m.value);
+        else reject(new Error(m.error.message));
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...op,
+      t: 'op',
+      id: `direct-${++directOpSeq}`,
+    } as InboundMessage);
+  });
+}
+
+async function workerRtdbGet(ctx: HostCtx, path: string): Promise<unknown> {
+  const wire = (await workerOp(ctx, {
+    method: 'rtdb.get',
+    path,
+    actAs: { mode: 'admin' },
+  })) as { value: unknown };
+  return wire.value ?? null;
+}
+
+/** Fresh full stack: worker ctx + bridge + tab + remote-branded admin app. */
+function makeStack() {
+  const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+  const ctx = makeWorkerCtx();
+  connectTab(bridge, ctx);
+  const remote = connectRemote(bridge);
+  const app = initializeApp({ sandbox: remote });
+  return { bridge, ctx, remote, app };
+}
+
+// ─── Dispatch selection ─────────────────────────────────────────────────────
+
+describe('pyric-admin remote dispatch — arm selection', () => {
+  it('routes a remote-branded sandbox to the remote arm (never local state)', async () => {
+    const { ctx, app } = makeStack();
+    // The handle's `onEvent` throws — the local arms subscribe to it when
+    // creating their WeakMap state, so merely getting working handles
+    // proves the remote arm was selected before any local state existed.
+    const db = getDatabase(app);
+    const auth = getAuth(app);
+    expect(db).toBeDefined();
+    expect(auth).toBeDefined();
+
+    // And the write lands in the WORKER's tree (independent direct port),
+    // not in a private server-side tree.
+    await db.ref('dispatch/probe').set({ via: 'remote-arm' });
+    expect(await workerRtdbGet(ctx, 'dispatch/probe')).toEqual({ via: 'remote-arm' });
+  });
+
+  it('still routes a plain in-process sandbox to the local arm', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+    const db = getDatabase(app);
+    await db.ref('local/probe').set({ via: 'local-arm' });
+    expect((await db.ref('local/probe').get()).val()).toEqual({ via: 'local-arm' });
+    // Local-arm signature: listeners are still not implemented there.
+    expect(() => db.ref('local/probe').on('value', () => {})).toThrow(/not implemented/);
+    // Awaiting a local ThenableReference resolves (regression for the
+    // self-resolving-thenable unwrap loop fixed alongside the remote arm).
+    const pushed = await db.ref('local/list').push({ v: 1 });
+    expect(pushed.key).toHaveLength(20);
+  });
+
+  it('getDatabase(app) is a singleton per remote handle (shared listener registry)', () => {
+    const { app } = makeStack();
+    expect(getDatabase(app)).toBe(getDatabase(app));
+  });
+});
+
+// ─── RTDB data plane ────────────────────────────────────────────────────────
+
+describe('pyric-admin remote dispatch — RTDB', () => {
+  it('set / get / update / remove round-trip through the worker', async () => {
+    const { ctx, app } = makeStack();
+    const db = getDatabase(app);
+
+    await db.ref('rooms/lobby').set({ name: 'Lobby', open: true });
+    const snap = await db.ref('rooms/lobby').get();
+    expect(snap.exists()).toBe(true);
+    expect(snap.key).toBe('lobby');
+    expect(snap.val()).toEqual({ name: 'Lobby', open: true });
+    expect(snap.child('name').val()).toBe('Lobby');
+
+    await db.ref('rooms/lobby').update({ open: false, topic: 'welcome' });
+    expect(await workerRtdbGet(ctx, 'rooms/lobby')).toEqual({
+      name: 'Lobby',
+      open: false,
+      topic: 'welcome',
+    });
+
+    await db.ref('rooms/lobby').remove();
+    const gone = await db.ref('rooms/lobby').get();
+    expect(gone.exists()).toBe(false);
+    expect(gone.val()).toBeNull();
+  });
+
+  it('set(null) deletes (relayed rtdb.set with null)', async () => {
+    const { ctx, app } = makeStack();
+    const db = getDatabase(app);
+    await db.ref('tmp/x').set(1);
+    await db.ref('tmp/x').set(null);
+    expect(await workerRtdbGet(ctx, 'tmp/x')).toBeNull();
+  });
+
+  it('child()/parent/root are pure local path manipulation', async () => {
+    const { app } = makeStack();
+    const db = getDatabase(app);
+    const ref = db.ref('a').child('b/c');
+    expect(ref.key).toBe('c');
+    expect(ref.parent!.key).toBe('b');
+    expect(ref.root.key).toBeNull();
+    expect(ref.toString()).toBe('sandbox://rtdb/a/b/c');
+  });
+
+  it('push() has a synchronous 20-char .key and commits the value remotely', async () => {
+    const { ctx, app } = makeStack();
+    const db = getDatabase(app);
+
+    const thenable = db.ref('messages').push({ text: 'hi' });
+    // `.key` is available SYNCHRONOUSLY — the client mints the push id.
+    expect(thenable.key).toHaveLength(20);
+    const ref = await thenable; // resolves once the relayed write commits
+    expect(ref.key).toBe(thenable.key);
+    expect(await workerRtdbGet(ctx, `messages/${thenable.key}`)).toEqual({ text: 'hi' });
+
+    // Bare push() performs no write (upstream semantics) but still mints.
+    const empty = db.ref('messages').push();
+    expect(empty.key).toHaveLength(20);
+    await empty;
+    expect(await workerRtdbGet(ctx, `messages/${empty.key}`)).toBeNull();
+  });
+
+  it("once('value') resolves the current snapshot and detaches", async () => {
+    const { app } = makeStack();
+    const db = getDatabase(app);
+    await db.ref('counter').set({ n: 1 });
+    const snap = await db.ref('counter').once('value');
+    expect(snap.val()).toEqual({ n: 1 });
+    // A later write must not re-fire anything (detached) — just verify the
+    // one-shot value was point-in-time.
+    await db.ref('counter').set({ n: 2 });
+    expect(snap.val()).toEqual({ n: 1 });
+  });
+
+  it("on('value') delivers initial + updates (incl. browser-side writes); off() detaches", async () => {
+    const { ctx, app } = makeStack();
+    const db = getDatabase(app);
+    await db.ref('game/state').set({ round: 1 });
+
+    const values: unknown[] = [];
+    const cb = db.ref('game/state').on('value', (snap) => {
+      values.push(snap.val());
+    });
+    await tick();
+    expect(values).toEqual([{ round: 1 }]);
+
+    // Server-side write → listener fires.
+    await db.ref('game/state').set({ round: 2 });
+    await tick();
+    expect(values).toEqual([{ round: 1 }, { round: 2 }]);
+
+    // BROWSER-side write (direct worker port — the app's own SDK) is
+    // visible to the server listener: one shared tree.
+    await workerOp(ctx, {
+      method: 'rtdb.set',
+      path: 'game/state',
+      value: { round: 3 },
+      actAs: { mode: 'admin' },
+    });
+    await tick();
+    expect(values).toEqual([{ round: 1 }, { round: 2 }, { round: 3 }]);
+
+    db.ref('game/state').off('value', cb);
+    await db.ref('game/state').set({ round: 4 });
+    await tick();
+    expect(values).toHaveLength(3); // no delivery after off()
+  });
+
+  it("off() with no callback detaches every listener at the path", async () => {
+    const { app } = makeStack();
+    const db = getDatabase(app);
+    const a: unknown[] = [];
+    const b: unknown[] = [];
+    db.ref('multi').on('value', (s) => a.push(s.val()));
+    db.ref('multi').on('value', (s) => b.push(s.val()));
+    await tick();
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+
+    db.ref('multi').off();
+    await db.ref('multi').set({ x: 1 });
+    await tick();
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it('non-value listeners / transactions / queries keep throwing "not implemented"', () => {
+    const { app } = makeStack();
+    const db = getDatabase(app);
+    const ref = db.ref('x');
+    expect(() => ref.on('child_added', () => {})).toThrow(/not implemented/);
+    expect(() => ref.transaction(() => null)).toThrow(/not implemented/);
+    expect(() => ref.orderByChild('y')).toThrow(/not implemented/);
+    expect(() => ref.onDisconnect()).toThrow(/not implemented/);
+  });
+});
+
+// ─── Auth ───────────────────────────────────────────────────────────────────
+
+describe('pyric-admin remote dispatch — Auth', () => {
+  it('createUser / getUser / getUserByEmail / listUsers relay to the worker pool', async () => {
+    const { ctx, app } = makeStack();
+    const auth = getAuth(app);
+
+    const created = await auth.createUser({
+      email: 'ada@example.com',
+      password: 'correct-horse',
+      displayName: 'Ada',
+    });
+    expect(created.uid).toBeTruthy();
+    expect(created.email).toBe('ada@example.com');
+    expect(created.displayName).toBe('Ada');
+
+    // The user exists in the WORKER's pool (independent direct port).
+    const workerUsers = (await workerOp(ctx, { method: 'auth.listUsers' })) as AuthUserRecord[];
+    expect(workerUsers.map((u) => u.email)).toEqual(['ada@example.com']);
+
+    const byUid = await auth.getUser(created.uid);
+    expect(byUid.email).toBe('ada@example.com');
+    const byEmail = await auth.getUserByEmail('ada@example.com');
+    expect(byEmail.uid).toBe(created.uid);
+
+    const listed = await auth.listUsers();
+    expect(listed.users.map((u) => u.uid)).toEqual([created.uid]);
+  });
+
+  it('getUser / getUserByEmail reject clearly on a miss (list + filter)', async () => {
+    const { app } = makeStack();
+    const auth = getAuth(app);
+    expect(auth.getUser('nope')).rejects.toThrow(/no user with uid "nope"/);
+    expect(auth.getUserByEmail('nope@example.com')).rejects.toThrow(
+      /no user with email "nope@example.com"/,
+    );
+  });
+
+  it('updateUser and setCustomUserClaims relay auth.adminUpdateUser', async () => {
+    const { app } = makeStack();
+    const auth = getAuth(app);
+    const created = await auth.createUser({ uid: 'ada', email: 'ada@example.com' });
+
+    const updated = await auth.updateUser(created.uid, { displayName: 'Ada Lovelace' });
+    expect(updated.displayName).toBe('Ada Lovelace');
+
+    await auth.setCustomUserClaims('ada', { admin: true });
+    expect((await auth.getUser('ada')).customClaims).toEqual({ admin: true });
+
+    // `null` clears the claims map.
+    await auth.setCustomUserClaims('ada', null);
+    expect((await auth.getUser('ada')).customClaims).toBeUndefined();
+
+    // Fields the worker can't express throw instead of silently dropping.
+    expect(auth.updateUser('ada', { photoURL: 'https://x/y.png' })).rejects.toThrow(
+      /photoURL/,
+    );
+  });
+
+  it('deleteUser relays; worker errors (missing uid, dup uid) surface with their message', async () => {
+    const { app } = makeStack();
+    const auth = getAuth(app);
+    await auth.createUser({ uid: 'gone', email: 'gone@example.com' });
+    await auth.deleteUser('gone');
+    expect(auth.getUser('gone')).rejects.toThrow(/no user with uid/);
+    expect(auth.deleteUser('gone')).rejects.toThrow(/gone/);
+
+    await auth.createUser({ uid: 'dup' });
+    expect(auth.createUser({ uid: 'dup' })).rejects.toThrow(/dup/);
+  });
+
+  it('createCustomToken / verifyIdToken are stateless and need no relay', async () => {
+    const { bridge, app } = makeStack();
+    void bridge;
+    const auth = getAuth(app);
+    const token = await auth.createCustomToken('alice', { role: 'admin' });
+    expect(token.startsWith('pyric-sandbox-custom:')).toBe(true);
+    const decoded = await auth.verifyIdToken(token);
+    expect(decoded.uid).toBe('alice');
+    expect((decoded as Record<string, unknown>).role).toBe('admin');
+  });
+
+  it('unmodeled surface throws the canonical remote "not implemented" error', () => {
+    const { app } = makeStack();
+    const auth = getAuth(app);
+    expect(auth.createSessionCookie('x', { expiresIn: 1 })).rejects.toThrow(
+      /not implemented in pyric-admin\/auth remote sandbox backend/,
+    );
+    expect(() => auth.tenantManager()).toThrow(/not implemented/);
+  });
+});
+
+// ─── Remediating throws on the handle's sync-only Sandbox members ──────────
+
+describe('remote sandbox handle — sync-only Sandbox members', () => {
+  it('admin / snapshot / history / onEvent / currentUser throw with remediation', () => {
+    const { remote } = makeStack();
+    expect(() => remote.admin).toThrow(/not available on a remote sandbox/);
+    expect(() => remote.snapshot()).toThrow(/getSnapshot/);
+    expect(() => remote.history()).toThrow(/not available on a remote sandbox/);
+    expect(() => remote.onEvent(() => {})).toThrow(/not available on a remote sandbox/);
+    expect(() => remote.currentUser).toThrow(/auth\.getCurrentUser/);
+    expect(() => remote.reset()).toThrow(/not available on a remote sandbox/);
+    expect(() => remote.loadSnapshot({} as never)).toThrow(/importState/);
+  });
+
+  it('withAuth works (pure local pair construction)', () => {
+    const { remote } = makeStack();
+    const ctx = remote.withAuth({ uid: 'alice' });
+    expect(ctx.sandbox).toBe(remote);
+    expect(ctx.auth).toEqual({ uid: 'alice' });
+    expect(ctx.withAuth(null).auth).toBeNull();
+  });
+
+  it('dispose() closes the connection; later admin ops fail fast', async () => {
+    const { remote, app } = makeStack();
+    const db = getDatabase(app);
+    await db.ref('pre').set(1);
+    remote.dispose();
+    expect(db.ref('pre').get()).rejects.toThrow(/connection closed/);
+  });
+});
+
+// ─── No-peer failure mode through the admin API ─────────────────────────────
+
+describe('remote dispatch — no browser tab connected', () => {
+  it('RTDB and Auth calls fail fast with the "open <serve url>" guidance', async () => {
+    // A bridge with NO tab registered: ops fail immediately, not after 30s.
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    const remote = connectRemote(bridge);
+    const app = initializeApp({ sandbox: remote });
+
+    const started = Date.now();
+    expect(getDatabase(app).ref('x').get()).rejects.toThrow(
+      /open http:\/\/localhost:5000/,
+    );
+    expect(getAuth(app).createUser({ uid: 'x' })).rejects.toThrow(
+      /open http:\/\/localhost:5000/,
+    );
+    try {
+      await getDatabase(app).ref('x').set(1);
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('unavailable');
+    }
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -31,6 +31,13 @@
  */
 import { WebSocket } from 'ws';
 import type { AuthUserRecord, CreateUserRequest, UpdateUserRequest } from 'pyric/auth';
+import {
+  REMOTE_SANDBOX,
+  SandboxContextImpl,
+  type RemoteSandbox as RemoteSandboxBase,
+  type AuthState,
+  type SandboxContext,
+} from 'pyric/sandbox';
 import type {
   BridgeMessage,
   WorkerOpPayload,
@@ -134,10 +141,20 @@ export interface RemoteAuthAdmin {
   clearUsers(): Promise<void>;
 }
 
-export interface RemoteSandbox {
-  /** Base URL of the serve this handle is attached to (for error guidance). */
-  readonly serveUrl: string;
-  /** The raw worker op/sub relay channel. */
+/**
+ * The Node-side remote sandbox handle. Extends `pyric/sandbox`'s branded
+ * {@link RemoteSandboxBase} — structurally a full `Sandbox`, so it can be
+ * passed to `pyric-admin/app`'s `initializeApp({ sandbox })`, whose RTDB and
+ * Auth backends dispatch on the brand and route through {@link channel}.
+ *
+ * Sandbox members that are genuinely sync-only (`admin`, `snapshot()`,
+ * `history()`, `onEvent`, `currentUser`, …) cannot be mirrored over the
+ * wire in slice 1 and throw a remediating `unimplemented` error naming
+ * what to do instead. Implemented members: `withAuth` (pure local pair
+ * construction) and `dispose` (aliases {@link close}).
+ */
+export interface RemoteSandbox extends RemoteSandboxBase {
+  /** The raw worker op/sub relay channel (narrowed to the wire payload types). */
   readonly channel: RemoteSandboxChannel;
   /** RTDB conveniences (admin lens pinned). */
   readonly rtdb: RemoteRtdb;
@@ -405,6 +422,132 @@ export function buildRemoteAuthAdmin(channel: RemoteSandboxChannel): RemoteAuthA
   };
 }
 
+// ─── Handle construction ────────────────────────────────────────────────────
+
+/** A member of `Sandbox` that slice 1 cannot express over the wire throws
+ *  this branded, remediating error instead of silently misbehaving. */
+function notAvailableRemotely(member: string, remedy: string): Error & { code: string } {
+  return remoteError(
+    'unimplemented',
+    `${member} is not available on a remote sandbox — ${remedy}`,
+  );
+}
+
+/**
+ * Build the branded remote sandbox handle over an established channel.
+ *
+ * Split out of {@link connectRemoteSandbox} so the in-process test harness
+ * (fake ports + `createConsumerSession`, no WS) constructs the EXACT handle
+ * production hands to `pyric-admin`.
+ *
+ * The handle satisfies `Sandbox` structurally:
+ *   - `withAuth` / `dispose` are real (pure local construction / teardown).
+ *   - Everything whose contract is sync-only or worker-owned (`admin`,
+ *     `snapshot`, `loadSnapshot`, `history`, `onEvent`, `reset`,
+ *     `currentUser`, `onCurrentUserChanged`, tab sync, persistence) throws
+ *     a remediating `unimplemented` error. Notably `onEvent`: the unified
+ *     event stream (`target: 'events'`) is not relayable until slice 2's
+ *     bounded backpressure lands, and no remote dispatch arm may depend on
+ *     it — a throw (not a silent no-op) keeps a subscriber from believing
+ *     it is observing events that will never arrive.
+ */
+export function createRemoteSandboxHandle(opts: {
+  channel: RemoteSandboxChannel;
+  serveUrl: string;
+  close: () => void;
+}): RemoteSandbox {
+  const { channel, serveUrl, close } = opts;
+  const throwMember = (member: string, remedy: string): never => {
+    throw notAvailableRemotely(member, remedy);
+  };
+  const handle: RemoteSandbox = {
+    [REMOTE_SANDBOX]: true as const,
+    serveUrl,
+    channel,
+    rtdb: buildRemoteRtdb(channel),
+    auth: buildRemoteAuthAdmin(channel),
+    close,
+
+    // ── Implemented Sandbox members ─────────────────────────────────────
+    withAuth(auth: AuthState): SandboxContext {
+      // Pure local pair construction — contexts carry identity, the data
+      // stays behind the channel.
+      return new SandboxContextImpl(handle, auth);
+    },
+    dispose(): void {
+      close();
+    },
+
+    // ── Sync-only / worker-owned members: remediating throws ───────────
+    onEvent: () =>
+      throwMember(
+        'onEvent',
+        'the unified event stream is not relayed over the bridge yet (slice 2); ' +
+          `observe activity in the browser tab at ${serveUrl} or in Pyric Studio instead`,
+      ),
+    history: () =>
+      throwMember(
+        'history()',
+        'the event log lives in the browser worker; inspect it in Pyric Studio ' +
+          'or subscribe from the page that hosts the sandbox',
+      ),
+    get admin(): never {
+      return throwMember(
+        'admin',
+        'the sync Firestore admin plane cannot span the wire; dispatch async worker ops ' +
+          "through the handle's channel instead (e.g. channel.op({ method: 'admin.getDocument', path }))",
+      );
+    },
+    reset: () =>
+      throwMember(
+        'reset()',
+        `reset the sandbox from the browser tab at ${serveUrl} or from Pyric Studio`,
+      ),
+    snapshot: () =>
+      throwMember(
+        'snapshot()',
+        "use the async worker op instead: channel.op({ method: 'getSnapshot' })",
+      ),
+    loadSnapshot: () =>
+      throwMember(
+        'loadSnapshot()',
+        "use the async worker ops instead: channel.op({ method: 'importState', bundle })",
+      ),
+    get currentUser(): never {
+      return throwMember(
+        'currentUser',
+        'the browser tab owns the auth session; ' +
+          "read it asynchronously via channel.op({ method: 'auth.getCurrentUser' })",
+      );
+    },
+    onCurrentUserChanged: () =>
+      throwMember(
+        'onCurrentUserChanged',
+        'the browser tab owns the auth session; subscribe there instead',
+      ),
+    enableTabSync: () =>
+      throwMember('enableTabSync', 'tab sync is a browser concern; enable it in the page'),
+    enablePersistence: () =>
+      throwMember(
+        'enablePersistence',
+        'the browser worker owns persistence; it is already enabled by `pyric serve`',
+      ),
+    flush: () =>
+      throwMember('flush()', 'the browser worker owns persistence and flushes itself'),
+    clearPersistence: () =>
+      throwMember(
+        'clearPersistence()',
+        'clear the persisted state from the browser tab or Pyric Studio',
+      ),
+    registerPersistableService: () =>
+      throwMember(
+        'registerPersistableService',
+        'the browser worker owns persistence; services register there',
+      ),
+  };
+  return handle;
+}
+
 // ─── connect ───────────────────────────────────────────────────────────────
 
 /**
@@ -480,18 +623,16 @@ export async function connectRemoteSandbox(
     throw err;
   }
 
-  return {
+  return createRemoteSandboxHandle({
     serveUrl,
     channel: core.channel,
-    rtdb: buildRemoteRtdb(core.channel),
-    auth: buildRemoteAuthAdmin(core.channel),
     close() {
       core.dispose('remote sandbox connection closed by the client');
       try {
         ws.close();
       } catch {}
     },
-  };
+  });
 }
 
 function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -49,6 +49,13 @@ export type {
 export { SandboxError } from './types.js';
 export { SandboxContextImpl } from './sandbox-context.js';
 
+// Remote sandbox (slice 1) — the brand + minimal channel contract that
+// lets `pyric-admin` recognize a Node-side handle onto the browser-hosted
+// worker sandbox (constructed by `pyric-tools`' `connectRemoteSandbox`)
+// and route its RTDB/Auth ops over the wire instead of into local state.
+export { REMOTE_SANDBOX, isRemoteSandbox } from './remote.js';
+export type { RemoteSandbox, RemoteSandboxChannel } from './remote.js';
+
 // Replay engine — capture a session via `sandbox.history()` and re-
 // issue every write against a fresh sandbox. See
 // `docs/how-to/replay-events.md`.

--- a/packages/pyric/src/sandbox/remote.ts
+++ b/packages/pyric/src/sandbox/remote.ts
@@ -1,0 +1,100 @@
+/**
+ * Remote-sandbox brand + channel contract (remote sandbox, slice 1).
+ *
+ * A REMOTE sandbox is a Node-side handle onto the browser-hosted
+ * SharedWorker sandbox, constructed by `pyric-tools`'s
+ * `connectRemoteSandbox()`. It satisfies {@link Sandbox} structurally, but
+ * its data plane lives in the browser worker — so consumers that keep
+ * process-local state keyed off the `Sandbox` object (`pyric-admin`'s RTDB
+ * and Auth sandbox backends) must NOT treat it like an in-process sandbox:
+ * doing so would create a private server-side data store that never reaches
+ * the browser.
+ *
+ * This module is the dependency seam that lets `pyric-admin` (which depends
+ * only on `pyric` + `firebase-admin`) recognize a handle constructed by
+ * `pyric-tools` (which depends on `pyric`):
+ *
+ *   - {@link REMOTE_SANDBOX} — a `Symbol.for` brand, so the stamp and the
+ *     check agree across package boundaries and duplicated module graphs.
+ *   - {@link RemoteSandboxChannel} — a STRUCTURALLY-typed minimal op/sub
+ *     relay interface matching `pyric-tools/remote`'s channel shape. The
+ *     concrete op/sub payload types live in `pyric-tools`' worker protocol;
+ *     this contract deliberately types them loosely (`method` + open
+ *     fields) so `pyric` carries no dependency on `pyric-tools`.
+ *
+ * No runtime imports beyond this package's own types — the only runtime
+ * export is the brand symbol and its guard.
+ */
+
+import type { Sandbox } from './types.js';
+
+/**
+ * Brand stamped (value `true`) on every remote sandbox handle.
+ * `Symbol.for` — registered globally so `pyric-admin`'s check matches the
+ * stamp even if two copies of `pyric` end up in one process.
+ */
+export const REMOTE_SANDBOX = Symbol.for('pyric.remote.sandbox');
+
+/**
+ * The minimal worker-relay channel a remote sandbox handle carries.
+ *
+ * Structural mirror of `pyric-tools/remote`'s `RemoteSandboxChannel`: one
+ * method to dispatch any SharedWorker-protocol op, one to register a
+ * snap-delivering subscription. Payloads are typed openly here (the real
+ * discriminated unions live in `pyric-tools`' worker protocol); callers in
+ * `pyric-admin` spell the concrete op objects (`rtdb.set`, `auth.listUsers`,
+ * …) and pin their own `actAs` lens — nothing is pinned by the channel.
+ */
+export interface RemoteSandboxChannel {
+  /**
+   * Dispatch one worker op. Resolves with the worker's result value;
+   * rejects with an `Error` carrying a `.code` (including the fail-fast
+   * "no browser tab is connected — open <serve url>" guidance when no
+   * peer is registered).
+   */
+  op(op: { method: string } & Record<string, unknown>): Promise<unknown>;
+
+  /**
+   * Register a worker subscription (e.g. an RTDB value listener:
+   * `{ target: { service: 'rtdb', path } }`). `onSnap` receives every snap
+   * value (initial + updates — and re-delivered fresh after peer
+   * replacement); an establishment failure routes to `onError` instead.
+   * Returns the unsubscribe function.
+   */
+  subscribe(
+    sub: { target: unknown } & Record<string, unknown>,
+    onSnap: (value: unknown) => void,
+    onError?: (err: Error & { code: string }) => void,
+  ): () => void;
+}
+
+/**
+ * A branded remote sandbox handle. Structurally a {@link Sandbox} — it can
+ * be passed anywhere a `Sandbox` is accepted (notably
+ * `pyric-admin/app`'s `initializeApp({ sandbox })`) — but sync-only members
+ * that cannot be mirrored over the wire (`admin`, `snapshot()`,
+ * `history()`, …) throw a remediating error. Consumers with a remote arm
+ * dispatch on {@link isRemoteSandbox} and use {@link channel} instead.
+ */
+export interface RemoteSandbox extends Sandbox {
+  readonly [REMOTE_SANDBOX]: true;
+  /** Base URL of the `pyric serve` this handle is attached to (used in
+   *  error guidance: "open <serveUrl> in a browser and retry"). */
+  readonly serveUrl: string;
+  /** The raw worker op/sub relay channel. */
+  readonly channel: RemoteSandboxChannel;
+}
+
+/**
+ * Is this sandbox a remote handle? Backend dispatch guard for consumers
+ * (e.g. `pyric-admin`'s RTDB/Auth sandbox backends) that must route a
+ * remote sandbox's operations through {@link RemoteSandbox.channel} rather
+ * than into process-local state.
+ */
+export function isRemoteSandbox(sandbox: Sandbox): sandbox is RemoteSandbox {
+  return (
+    (sandbox as Partial<Record<typeof REMOTE_SANDBOX, unknown>>)[
+      REMOTE_SANDBOX
+    ] === true
+  );
+}


### PR DESCRIPTION
Checkpoint 2 of the remote sandbox (slice 1), stacked on #23. With this, server-side `pyric-admin` code drives the browser-hosted sandbox — the first-user unblock (RTDB + Auth app on the RTDB Admin SDK).

- **Brand + channel contract in `pyric/sandbox`** (`packages/pyric/src/sandbox/remote.ts`): `Symbol.for('pyric.remote.sandbox')` brand (survives duplicated module graphs), `isRemoteSandbox()`, structural `RemoteSandboxChannel` with open payload types — pyric keeps zero dependency on pyric-tools' worker protocol; pyric-admin only depends on `pyric`.
- **Branded handle** (`pyric-tools/remote`): `connectRemoteSandbox()` now returns a full-`Sandbox`-satisfying handle; sync-only members (`admin.*`, `snapshot()`, `history()`, `enableTabSync`, `onEvent`) throw branded remediating errors pointing at the browser tab/Studio (throw over silent no-op: subscribers must not believe they observe events that never arrive).
- **Remote dispatch arms**: both pyric-admin backends check `isRemoteSandbox()` before any WeakMap state or `onEvent` wiring exists, so a remote handle can never grow a private server-side tree/user table (the spike's headline finding). RTDB relays get/set/update/remove/push (`actAs: admin` pinned; client-minted push key keeps `.key` sync); `on('value')`/`once` route through the channel subscription — an upgrade over the local arm, which throws on listeners. Auth relays user CRUD + custom claims; `getUser`/`getUserByEmail` are `listUsers` + filter (no new worker op); `updateUser` throws on fields the worker can't express instead of dropping them; token mint/verify stay stateless local transforms shared with the local arm.
- **Pre-existing bug fixed in both arms**: `push()`'s `ThenableReference` resolved with itself — a self-resolving thenable, so `await ref.push(v)` unwrapped forever at 100% CPU. Both arms now settle with a plain ref; local-arm regression test included.
- **Tests**: 21 new end-to-end in-process tests (real worker host; worker-side state verified via an independent direct port): RTDB round-trips incl. sync `.key`, value listeners incl. a browser-side write observed remotely, auth CRUD/claims/lookups/token round-trip, relayed worker errors, remediating throws, and the no-peer fast-fail with "open <serve url>" guidance.

Suites: pyric-admin 466/466 (local arms untouched in behavior), pyric 4221 pass / 21 skip, pyric-tools 1087 pass / 6 skip (incl. #23's relay suite). `tsc --noEmit`, `bun run build`, `lint:manifest` clean. No new exports/subpaths.

Remaining before release: the manual e2e against a live `pyric serve --bridge` + browser tab (the browser-leg wiring is the one thing the headless harness simulates).

https://claude.ai/code/session_019Kbqv5Ta2DMdFT4VoeRnn7