### PR TITLE
Adoption stack: ambient init, register loader, and the pyric dev runner

### DIFF
--- a/packages/pyric-admin/src/app/index.ts
+++ b/packages/pyric-admin/src/app/index.ts
@@ -1,5 +1,6 @@
 /**
- * `pyric-admin/app` — Phase 3 initializeApp surface (ADR-001 D6).
+ * `pyric-admin/app` — Phase 3 initializeApp surface (ADR-001 D6) plus the
+ * default-app registry and AMBIENT INIT (adoption experience, layer 3).
  *
  * Mirror shape: at cutover this becomes `pyric-admin/app` and is the
  * single entry point where the sandbox-vs-prod choice is made for the
@@ -10,15 +11,71 @@
  *   - `initializeApp({ credential, ... })` — prod-backed (live;
  *     delegates to `firebase-admin/app.initializeApp`).
  *   - `initializeApp({ sandbox })` — sandbox-backed (live).
+ *   - `initializeApp()` — BARE, zero pyric identifiers in app code. The
+ *     environment decides the backend (see "Ambient init" below).
  *   - Per-subpath adapter dispatch via the brand: implemented in
  *     `pyric-admin/{auth,database,storage}` via structural
  *     checks on the `app` argument. Phase 4 commits use property
  *     probing today; cutover swaps to brand-symbol reads.
+ *
+ * ── Default-app registry ──────────────────────────────────────────────
+ *
+ * Mirrors `firebase-admin/app`'s lifecycle exactly (oracle:
+ * `firebase-admin/lib/app/lifecycle.js`):
+ *
+ *   - `initializeApp(config?, name?)` registers under `'[DEFAULT]'` when
+ *     unnamed; `getApp(name?)` / `getApps()` / `deleteApp(app)` read it.
+ *   - Duplicate-name errors carry firebase-admin's codes and message
+ *     text: `app/duplicate-app` for a config'd re-init with a different
+ *     configuration, `app/invalid-app-options` for a bare-vs-config'd
+ *     mismatch (firebase-admin's autoInit mismatch), `app/no-app` from
+ *     `getApp` on a missing name, `app/invalid-app-name` for a
+ *     non-string/empty name. Errors are {@link PyricAdminAppError} —
+ *     plain `Error`s with a firebase-admin-shaped `.code` (the closest
+ *     the existing pyric-admin error style gets to `FirebaseAppError`).
+ *   - Idempotency mirror: a bare `initializeApp()` repeated for the same
+ *     name returns the existing auto-initialized app (firebase-admin's
+ *     autoInit path); `initializeApp({ sandbox })` repeated with the
+ *     SAME `Sandbox` reference returns the existing app (the reference
+ *     is our deep-equal analog — sandboxes have identity, not value
+ *     equality); prod re-inits delegate the equality decision to
+ *     firebase-admin itself (deep-equal options → same app; credential /
+ *     httpAgent present → `app/invalid-app-options`, exactly upstream).
+ *
+ * ── Ambient init (bare `initializeApp()`) ─────────────────────────────
+ *
+ * The user's server code contains ZERO pyric identifiers — bare
+ * `initializeApp()` + no-arg `getDatabase()` / `getAuth()`. The
+ * environment picks the backend:
+ *
+ *   - `PYRIC_SANDBOX` unset → exactly firebase-admin's behavior:
+ *     delegate to `firebase-admin/app.initializeApp()` (FIREBASE_CONFIG
+ *     env + application-default credentials), register the prod arm.
+ *   - `PYRIC_SANDBOX=remote` or `remote:<url>` → obtain a remote sandbox
+ *     handle from the factory installed by `pyric-tools/register` at
+ *     `globalThis[REMOTE_SANDBOX_FACTORY]`
+ *     (`Symbol.for('pyric.remote.sandboxFactory')`) and register the
+ *     sandbox arm. One activation line is logged to stderr. If the env
+ *     is set but no factory is installed, throw with remediation (run
+ *     under `pyric dev`, or add `--import pyric-tools/register` to
+ *     NODE_OPTIONS).
+ *   - Production guard: refuses to route to a sandbox when
+ *     `NODE_ENV === 'production'`, unless `PYRIC_SANDBOX_FORCE=1`.
+ *
+ * Ambient resolution happens ONLY on the bare call — any explicit
+ * config (`{ sandbox }` or prod `AppOptions`, even `{}`) bypasses the
+ * env entirely, so pyric-aware code keeps full control.
  */
 
-import type { Sandbox } from 'pyric/sandbox';
+import {
+  REMOTE_SANDBOX_FACTORY,
+  type RemoteSandboxFactory,
+  type RemoteSandboxFactoryOptions,
+  type Sandbox,
+} from 'pyric/sandbox';
 import {
   initializeApp as initializeFirebaseAdminApp,
+  deleteApp as deleteFirebaseAdminApp,
   type App as AdminApp,
   type AppOptions,
 } from 'firebase-admin/app';
@@ -32,14 +89,21 @@ export const ADMIN_APP_TARGET = Symbol.for('pyric.admin.app.target');
 
 export type PyricAdminAppTarget = 'sandbox' | 'prod';
 
+/** firebase-admin's default app name — `'[DEFAULT]'`. */
+export const DEFAULT_APP_NAME = '[DEFAULT]';
+
 export interface SandboxAdminApp {
   readonly [ADMIN_APP_TARGET]: 'sandbox';
   readonly sandbox: Sandbox;
+  /** Registry name (mirrors firebase-admin `App.name`). */
+  readonly name: string;
 }
 
 export interface ProdAdminApp {
   readonly [ADMIN_APP_TARGET]: 'prod';
   readonly adminApp: AdminApp;
+  /** Registry name (mirrors firebase-admin `App.name`). */
+  readonly name: string;
 }
 
 export type PyricAdminApp = SandboxAdminApp | ProdAdminApp;
@@ -47,12 +111,61 @@ export type PyricAdminApp = SandboxAdminApp | ProdAdminApp;
 export type InitializeAdminAppConfig = { sandbox: Sandbox } | AppOptions;
 
 /**
- * Initialize a Pyric admin app.
+ * App-lifecycle error, mirroring `firebase-admin`'s `FirebaseAppError`:
+ * a plain `Error` whose `.code` is the `app/`-prefixed error code
+ * (`app/no-app`, `app/duplicate-app`, `app/invalid-app-options`,
+ * `app/invalid-app-name`, `app/invalid-argument`) and whose message text
+ * matches upstream's word for word where a direct mirror exists.
+ */
+export class PyricAdminAppError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'PyricAdminAppError';
+    this.code = `app/${code}`;
+  }
+}
+
+// ─── Registry ───────────────────────────────────────────────────────────
+//
+// Module-level, matching firebase-admin's `defaultAppStore` (one store per
+// module instance). `autoInitApps` tracks which registered apps came from a
+// BARE `initializeApp()` — firebase-admin's `autoInit` flag — so the
+// bare-vs-config'd mismatch throws exactly like upstream.
+
+const appRegistry = new Map<string, PyricAdminApp>();
+const autoInitApps = new WeakSet<PyricAdminApp>();
+
+/** firebase-admin's app-name validation, verbatim message. */
+function validateAppName(name: unknown): asserts name is string {
+  if (typeof name !== 'string' || name === '') {
+    throw new PyricAdminAppError(
+      'invalid-app-name',
+      `Invalid Firebase app name "${String(name)}" provided. App name must be a non-empty string.`,
+    );
+  }
+}
+
+/** firebase-admin's message for every same-name/different-config case. */
+function alreadyExists(name: string, code: 'duplicate-app' | 'invalid-app-options'): PyricAdminAppError {
+  return new PyricAdminAppError(
+    code,
+    `A Firebase app named "${name}" already exists with a different configuration.`,
+  );
+}
+
+/**
+ * Initialize a Pyric admin app and register it under `name`
+ * (default `'[DEFAULT]'`), mirroring `firebase-admin/app.initializeApp`.
  *
  * @example
  * ```ts
- * // Prod-backed
+ * // Ambient (zero pyric identifiers — environment decides)
  * import { initializeApp } from 'pyric-admin/app';
+ * const app = initializeApp();
+ *
+ * // Prod-backed
  * import { applicationDefault } from 'firebase-admin/app';
  * const app = initializeApp({ credential: applicationDefault() });
  *
@@ -61,19 +174,203 @@ export type InitializeAdminAppConfig = { sandbox: Sandbox } | AppOptions;
  * const app = initializeApp({ sandbox: initializeSandbox() });
  * ```
  */
-export function initializeApp(config: InitializeAdminAppConfig): PyricAdminApp {
+export function initializeApp(
+  config?: InitializeAdminAppConfig,
+  name: string = DEFAULT_APP_NAME,
+): PyricAdminApp {
+  validateAppName(name);
+  const existing = appRegistry.get(name);
+
+  // ── Bare call: ambient resolution ────────────────────────────────────
+  if (config === undefined) {
+    if (existing !== undefined) {
+      // firebase-admin: two autoInit calls return the same app; an
+      // autoInit call against a config'd app is an options mismatch.
+      if (autoInitApps.has(existing)) return existing;
+      throw alreadyExists(name, 'invalid-app-options');
+    }
+    const app = initializeAmbientApp(name);
+    appRegistry.set(name, app);
+    autoInitApps.add(app);
+    return app;
+  }
+
+  // ── Explicit sandbox config ──────────────────────────────────────────
   if (isSandboxConfig(config)) {
-    return {
+    if (existing !== undefined) {
+      // Reference identity is the deep-equal analog for sandboxes.
+      if (
+        !autoInitApps.has(existing) &&
+        existing[ADMIN_APP_TARGET] === 'sandbox' &&
+        existing.sandbox === config.sandbox
+      ) {
+        return existing;
+      }
+      throw alreadyExists(
+        name,
+        autoInitApps.has(existing) ? 'invalid-app-options' : 'duplicate-app',
+      );
+    }
+    const app: SandboxAdminApp = {
       [ADMIN_APP_TARGET]: 'sandbox',
       sandbox: config.sandbox,
+      name,
     };
+    appRegistry.set(name, app);
+    return app;
   }
-  const adminApp = initializeFirebaseAdminApp(config);
-  return {
-    [ADMIN_APP_TARGET]: 'prod',
-    adminApp,
-  };
+
+  // ── Explicit prod options ────────────────────────────────────────────
+  if (existing !== undefined) {
+    if (existing[ADMIN_APP_TARGET] === 'prod' && !autoInitApps.has(existing)) {
+      // Delegate the equality decision to firebase-admin itself: deep-
+      // equal options return the same AdminApp; credential / httpAgent
+      // re-inits throw app/invalid-app-options; different options throw
+      // app/duplicate-app — all with upstream's exact messages.
+      const adminApp = initializeFirebaseAdminApp(config, name);
+      if (adminApp === existing.adminApp) return existing;
+    }
+    throw alreadyExists(
+      name,
+      autoInitApps.has(existing) ? 'invalid-app-options' : 'duplicate-app',
+    );
+  }
+  const adminApp = initializeFirebaseAdminApp(config, name);
+  const app: ProdAdminApp = { [ADMIN_APP_TARGET]: 'prod', adminApp, name };
+  appRegistry.set(name, app);
+  return app;
 }
+
+/**
+ * Return the registered app for `name` (default `'[DEFAULT]'`).
+ * Mirrors `firebase-admin/app.getApp` — including the exact `app/no-app`
+ * error text on a miss.
+ */
+export function getApp(name: string = DEFAULT_APP_NAME): PyricAdminApp {
+  validateAppName(name);
+  const app = appRegistry.get(name);
+  if (app === undefined) {
+    const lead =
+      name === DEFAULT_APP_NAME
+        ? 'The default Firebase app does not exist. '
+        : `Firebase app named "${name}" does not exist. `;
+    throw new PyricAdminAppError(
+      'no-app',
+      lead + 'Make sure you call initializeApp() before using any of the Firebase services.',
+    );
+  }
+  return app;
+}
+
+/**
+ * A copy of the list of all registered apps.
+ * Mirrors `firebase-admin/app.getApps`.
+ */
+export function getApps(): PyricAdminApp[] {
+  return Array.from(appRegistry.values());
+}
+
+/**
+ * Remove `app` from the registry, mirroring `firebase-admin/app.deleteApp`.
+ * Prod-backed apps also delete the underlying firebase-admin app (freeing
+ * its resources and its slot in firebase-admin's own registry, so the
+ * name can be re-initialized). Sandbox-backed apps only deregister — the
+ * `Sandbox` handle's lifetime belongs to its creator.
+ */
+export function deleteApp(app: PyricAdminApp): Promise<void> {
+  if (typeof app !== 'object' || app === null || !(ADMIN_APP_TARGET in app)) {
+    throw new PyricAdminAppError('invalid-argument', 'Invalid app argument.');
+  }
+  // Make sure the given app is actually registered (throws app/no-app).
+  const existing = getApp(app.name);
+  appRegistry.delete(existing.name);
+  if (existing[ADMIN_APP_TARGET] === 'prod') {
+    return deleteFirebaseAdminApp(existing.adminApp);
+  }
+  return Promise.resolve();
+}
+
+// ─── Ambient init ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a bare `initializeApp()` from the environment. See the
+ * module-level "Ambient init" docs for the full contract.
+ */
+function initializeAmbientApp(name: string): PyricAdminApp {
+  const env = process.env.PYRIC_SANDBOX;
+  if (env === undefined || env.trim() === '') {
+    // Unset → exactly today's prod behavior: firebase-admin's autoInit
+    // (FIREBASE_CONFIG env options + application-default credentials).
+    const adminApp = initializeFirebaseAdminApp(undefined, name);
+    return { [ADMIN_APP_TARGET]: 'prod', adminApp, name };
+  }
+
+  const opts = parsePyricSandboxEnv(env);
+
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.PYRIC_SANDBOX_FORCE !== '1'
+  ) {
+    throw new Error(
+      'pyric-admin: PYRIC_SANDBOX is set but NODE_ENV is "production" — ' +
+        'refusing to route firebase-admin to a development sandbox. ' +
+        'Unset PYRIC_SANDBOX in production, or set PYRIC_SANDBOX_FORCE=1 ' +
+        'if this routing is intentional.',
+    );
+  }
+
+  const factory = (
+    globalThis as { [REMOTE_SANDBOX_FACTORY]?: RemoteSandboxFactory }
+  )[REMOTE_SANDBOX_FACTORY];
+  if (typeof factory !== 'function') {
+    throw new Error(
+      `pyric-admin: PYRIC_SANDBOX=${env} is set but no remote sandbox ` +
+        'factory is installed (globalThis[Symbol.for(' +
+        "'pyric.remote.sandboxFactory')] is absent). Run your server " +
+        'under `pyric dev`, or add `--import pyric-tools/register` to ' +
+        'NODE_OPTIONS.',
+    );
+  }
+
+  const sandbox = factory(opts);
+  process.stderr.write(
+    `pyric: firebase-admin routed to sandbox${opts.url !== undefined ? ` at ${opts.url}` : ''}\n`,
+  );
+  return { [ADMIN_APP_TARGET]: 'sandbox', sandbox, name };
+}
+
+/**
+ * Parse the `PYRIC_SANDBOX` activator value.
+ *
+ *   - `remote`        → `{}` (factory discovers the running `pyric dev`)
+ *   - `remote:<url>`  → `{ url }` (everything after the FIRST colon —
+ *     URLs contain colons, so only the mode prefix is split off)
+ *
+ * Anything else throws: an unrecognized activator must never silently
+ * fall through to prod (mode-by-side-effect in the failure direction).
+ */
+function parsePyricSandboxEnv(env: string): RemoteSandboxFactoryOptions {
+  const value = env.trim();
+  if (value === 'remote') return {};
+  if (value.startsWith('remote:')) {
+    const url = value.slice('remote:'.length).trim();
+    if (url === '') {
+      throw new Error(
+        'pyric-admin: PYRIC_SANDBOX=remote: has an empty url. Use ' +
+          'PYRIC_SANDBOX=remote to auto-discover the running `pyric dev`, ' +
+          'or PYRIC_SANDBOX=remote:<url> with the host url.',
+      );
+    }
+    return { url };
+  }
+  throw new Error(
+    `pyric-admin: unrecognized PYRIC_SANDBOX value "${env}". Supported ` +
+      'values: "remote" (auto-discover the running `pyric dev`) or ' +
+      '"remote:<url>".',
+  );
+}
+
+// ─── Guards ─────────────────────────────────────────────────────────────
 
 function isSandboxConfig(
   config: InitializeAdminAppConfig,

--- a/packages/pyric-admin/src/auth/auth.test.ts
+++ b/packages/pyric-admin/src/auth/auth.test.ts
@@ -14,19 +14,31 @@
  *     `not implemented in pyric-admin/auth sandbox backend` message.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, it, expect } from 'bun:test';
 
 import { initializeSandbox } from 'pyric/sandbox';
 
-import { initializeApp, ADMIN_APP_TARGET } from '../app/index.js';
+import { initializeApp, deleteApp, getApps, ADMIN_APP_TARGET } from '../app/index.js';
 import { getAuth, SANDBOX_TOKEN_PREFIX } from './index.js';
+
+// The app registry is module-global (mirror of firebase-admin's
+// defaultAppStore) — deregister every app after each test so unnamed
+// `initializeApp({ sandbox })` calls don't collide across tests.
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
 
 describe('getAuth — Phase 3 dispatch', () => {
   it('rejects values that are not PyricAdminApp with a clear TypeError', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => getAuth(null as any)).toThrow(TypeError);
+    // `undefined` is the no-arg mirror: it resolves the default app from
+    // the registry and (with none initialized) throws firebase-admin's
+    // app/no-app error, not the entry-guard TypeError.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => getAuth(undefined as any)).toThrow(TypeError);
+    expect(() => getAuth(undefined as any)).toThrow(
+      /The default Firebase app does not exist/,
+    );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => getAuth({} as any)).toThrow(/ADMIN_APP_TARGET brand/);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,6 +73,7 @@ describe('getAuth — Phase 3 dispatch', () => {
         options: { projectId: 'test-project' },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
+      name: 'auth-test-prod',
     };
     let err: unknown;
     try {

--- a/packages/pyric-admin/src/auth/index.ts
+++ b/packages/pyric-admin/src/auth/index.ts
@@ -96,6 +96,7 @@ import type {
 } from 'pyric/auth';
 import {
   ADMIN_APP_TARGET,
+  getApp,
   type PyricAdminApp,
   type ProdAdminApp,
   type SandboxAdminApp,
@@ -835,7 +836,12 @@ function isSandboxAdminApp(app: PyricAdminApp): app is SandboxAdminApp {
 }
 
 /**
- * Return an `Auth` handle for the given app.
+ * Return an `Auth` handle for the given app — or for the DEFAULT app when
+ * called with no argument (mirrors firebase-admin's no-arg `getAuth()`:
+ * resolves `'[DEFAULT]'` through `pyric-admin/app`'s registry and throws
+ * `app/no-app` when nothing has been initialized). Works on all three
+ * arms — local sandbox, remote sandbox, prod — since dispatch happens on
+ * whatever brand the resolved app carries.
  *
  * Dispatches on the brand symbol set by `pyric-admin/app`'s
  * `initializeApp`:
@@ -869,7 +875,12 @@ function isSandboxAdminApp(app: PyricAdminApp): app is SandboxAdminApp {
  * console.log(decoded.uid, decoded.role); // 'alice' 'admin'
  * ```
  */
-export function getAuth(app: PyricAdminApp): Auth {
+export function getAuth(app?: PyricAdminApp): Auth {
+  if (app === undefined) {
+    // No-arg mirror of firebase-admin's `getAuth()` — resolve the
+    // '[DEFAULT]' app from the registry (throws app/no-app on a miss).
+    app = getApp();
+  }
   if (app === null || typeof app !== 'object' || !(ADMIN_APP_TARGET in app)) {
     throw new TypeError(
       'pyric-admin/auth: getAuth expected a PyricAdminApp (from pyric-admin/app#initializeApp). ' +

--- a/packages/pyric-admin/src/database/database.test.ts
+++ b/packages/pyric-admin/src/database/database.test.ts
@@ -33,6 +33,7 @@ function sandboxApp(sandbox: Sandbox): PyricAdminApp {
   return {
     [ADMIN_APP_TARGET]: 'sandbox',
     sandbox,
+    name: 'database-test',
   };
 }
 

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -107,6 +107,7 @@ import {
 
 import {
   ADMIN_APP_TARGET,
+  getApp,
   type PyricAdminApp,
 } from '../app/index.js';
 
@@ -128,9 +129,15 @@ export type {
 /**
  * Returns the {@link AdminDatabase} service for the supplied app.
  *
- * Signature mirrors `firebase-admin/database`'s `getDatabase(app)` and
+ * Signature mirrors `firebase-admin/database`'s `getDatabase(app?)` and
  * `getDatabaseWithUrl(url, app)` collapsed into a single function:
  *
+ *   - `getDatabase()` — default database for the DEFAULT app (resolved
+ *     through `pyric-admin/app`'s registry, exactly like firebase-admin's
+ *     no-arg `getDatabase()`; throws `app/no-app` when no default app has
+ *     been initialized). Works on all three arms — local sandbox, remote
+ *     sandbox, and prod — since it dispatches on whatever brand the
+ *     registered default app carries.
  *   - `getDatabase(app)` — default database for the app.
  *   - `getDatabase(app, url)` — database at the explicit URL (delegates
  *     to firebase-admin's `getDatabaseWithUrl` on the prod path; the
@@ -149,9 +156,14 @@ export type {
  *     the per-`Sandbox` state described in the module-level docs.
  */
 export function getDatabase(
-  app: PyricAdminApp,
+  app?: PyricAdminApp,
   url?: string,
 ): AdminDatabase {
+  if (app === undefined) {
+    // No-arg mirror of firebase-admin's `getDatabase()` — resolve the
+    // '[DEFAULT]' app from the registry (throws app/no-app on a miss).
+    app = getApp();
+  }
   if (app[ADMIN_APP_TARGET] === 'prod') {
     return url === undefined
       ? adminGetDatabase(app.adminApp)

--- a/packages/pyric-admin/src/storage/storage.test.ts
+++ b/packages/pyric-admin/src/storage/storage.test.ts
@@ -35,6 +35,7 @@ function sandboxAdminApp(): SandboxAdminApp {
   return {
     [ADMIN_APP_TARGET]: 'sandbox',
     sandbox,
+    name: 'storage-test',
   };
 }
 
@@ -45,6 +46,7 @@ function prodAdminApp(): ProdAdminApp {
     [ADMIN_APP_TARGET]: 'prod',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     adminApp: { name: '[DEFAULT]', options: { projectId: 'test-project' } } as any,
+    name: 'storage-test-prod',
   };
 }
 

--- a/packages/pyric-admin/test/app/ambient-init.test.ts
+++ b/packages/pyric-admin/test/app/ambient-init.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Ambient init — bare `initializeApp()` + environment (adoption
+ * experience, layer 3). The user's server code contains zero pyric
+ * identifiers; `PYRIC_SANDBOX` decides the backend, and the remote
+ * handle comes from the factory `pyric-tools/register` installs at
+ * `globalThis[Symbol.for('pyric.remote.sandboxFactory')]`.
+ *
+ * These tests install a FAKE factory (the real one is `pyric-tools`'
+ * concern — the global symbol is the seam) and cover:
+ *   - env unset → prod arm, factory never consulted
+ *   - `remote` / `remote:<url>` parsing (url after the FIRST colon)
+ *   - the one-line stderr activation log (with and without url)
+ *   - missing-factory remediation message
+ *   - production guard (`NODE_ENV=production`) + `PYRIC_SANDBOX_FORCE=1`
+ *   - explicit configs bypass the env entirely
+ *   - unrecognized activator values throw (never silently fall to prod)
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from 'bun:test';
+
+import {
+  REMOTE_SANDBOX_FACTORY,
+  initializeSandbox,
+  type RemoteSandbox,
+  type RemoteSandboxFactoryOptions,
+} from 'pyric/sandbox';
+
+import {
+  deleteApp,
+  getApps,
+  initializeApp,
+  isProdAdminApp,
+  isSandboxAdminApp,
+} from '../../src/app/index.js';
+
+// ─── Environment / global scaffolding ───────────────────────────────────
+
+type FactoryGlobal = { [REMOTE_SANDBOX_FACTORY]?: unknown };
+
+const savedEnv: Record<string, string | undefined> = {};
+let savedFactory: unknown;
+let savedStderrWrite: typeof process.stderr.write;
+let stderrLines: string[];
+
+beforeEach(() => {
+  for (const key of ['PYRIC_SANDBOX', 'PYRIC_SANDBOX_FORCE', 'NODE_ENV']) {
+    savedEnv[key] = process.env[key];
+  }
+  delete process.env.PYRIC_SANDBOX;
+  delete process.env.PYRIC_SANDBOX_FORCE;
+  savedFactory = (globalThis as FactoryGlobal)[REMOTE_SANDBOX_FACTORY];
+  delete (globalThis as FactoryGlobal)[REMOTE_SANDBOX_FACTORY];
+  // Capture the activation log without polluting test output.
+  stderrLines = [];
+  savedStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: unknown) => {
+    stderrLines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+});
+
+afterEach(async () => {
+  process.stderr.write = savedStderrWrite;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  if (savedFactory === undefined) {
+    delete (globalThis as FactoryGlobal)[REMOTE_SANDBOX_FACTORY];
+  } else {
+    (globalThis as FactoryGlobal)[REMOTE_SANDBOX_FACTORY] = savedFactory;
+  }
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+/** Install a fake factory; returns the calls it received and the handle
+ *  it mints. The handle is a plain sentinel object — ambient init must
+ *  register it verbatim as the app's `sandbox`, without touching it. */
+function installFakeFactory(): {
+  calls: Array<RemoteSandboxFactoryOptions | undefined>;
+  handle: RemoteSandbox;
+} {
+  const handle = { __fake: 'remote-sandbox' } as unknown as RemoteSandbox;
+  const calls: Array<RemoteSandboxFactoryOptions | undefined> = [];
+  (globalThis as FactoryGlobal)[REMOTE_SANDBOX_FACTORY] = (
+    opts?: RemoteSandboxFactoryOptions,
+  ) => {
+    calls.push(opts);
+    return handle;
+  };
+  return { calls, handle };
+}
+
+// ─── Env unset: exactly today's prod behavior ───────────────────────────
+
+describe('ambient init — PYRIC_SANDBOX unset', () => {
+  it('bare initializeApp() takes the prod arm and never consults the factory', () => {
+    const { calls } = installFakeFactory(); // installed but must be ignored
+    const app = initializeApp();
+    expect(isProdAdminApp(app)).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(stderrLines).toHaveLength(0); // no activation log on prod
+  });
+
+  it('empty-string PYRIC_SANDBOX is treated as unset', () => {
+    const { calls } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = '';
+    const app = initializeApp();
+    expect(isProdAdminApp(app)).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ─── Activation + env parsing ───────────────────────────────────────────
+
+describe('ambient init — PYRIC_SANDBOX set', () => {
+  it('remote → factory called with {}, sandbox arm registered, one log line', () => {
+    const { calls, handle } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+
+    const app = initializeApp();
+    expect(isSandboxAdminApp(app)).toBe(true);
+    if (isSandboxAdminApp(app)) expect(app.sandbox).toBe(handle);
+    expect(calls).toEqual([{}]);
+    expect(stderrLines).toEqual(['pyric: firebase-admin routed to sandbox\n']);
+  });
+
+  it('remote:<url> → factory called with { url }, url in the log line', () => {
+    const { calls } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote:http://localhost:5179';
+
+    initializeApp();
+    // Split on the FIRST colon only — the url itself contains colons.
+    expect(calls).toEqual([{ url: 'http://localhost:5179' }]);
+    expect(stderrLines).toEqual([
+      'pyric: firebase-admin routed to sandbox at http://localhost:5179\n',
+    ]);
+  });
+
+  it('repeated bare calls return the existing app and log only once', () => {
+    const { calls } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    const first = initializeApp();
+    expect(initializeApp()).toBe(first);
+    expect(calls).toHaveLength(1);
+    expect(stderrLines).toHaveLength(1);
+  });
+
+  it('remote: with an empty url throws', () => {
+    installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote:';
+    expect(() => initializeApp()).toThrow(/empty url/);
+  });
+
+  it('unrecognized values throw instead of silently falling through to prod', () => {
+    installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'local';
+    expect(() => initializeApp()).toThrow(
+      /unrecognized PYRIC_SANDBOX value "local".*"remote".*"remote:<url>"/s,
+    );
+    expect(getApps()).toHaveLength(0); // nothing half-registered
+  });
+
+  it('explicit configs bypass the env entirely (no factory call, no log)', () => {
+    const { calls } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+
+    const sandbox = initializeSandbox();
+    const app = initializeApp({ sandbox });
+    expect(isSandboxAdminApp(app) && app.sandbox === sandbox).toBe(true);
+    const prod = initializeApp({ projectId: 'demo-explicit' }, 'explicit-prod');
+    expect(isProdAdminApp(prod)).toBe(true);
+
+    expect(calls).toHaveLength(0);
+    expect(stderrLines).toHaveLength(0);
+  });
+});
+
+// ─── Missing factory ────────────────────────────────────────────────────
+
+describe('ambient init — factory global absent', () => {
+  it('throws with the pyric dev / --import pyric-tools/register remediation', () => {
+    process.env.PYRIC_SANDBOX = 'remote';
+    expect(() => initializeApp()).toThrow(
+      /pyric\.remote\.sandboxFactory.*pyric dev.*--import pyric-tools\/register.*NODE_OPTIONS/s,
+    );
+    expect(getApps()).toHaveLength(0); // nothing half-registered
+    expect(stderrLines).toHaveLength(0); // no activation log on failure
+  });
+});
+
+// ─── Production guard ───────────────────────────────────────────────────
+
+describe('ambient init — production guard', () => {
+  it('NODE_ENV=production + PYRIC_SANDBOX refuses to route', () => {
+    installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    process.env.NODE_ENV = 'production';
+    expect(() => initializeApp()).toThrow(
+      /NODE_ENV is "production".*refusing to route.*PYRIC_SANDBOX_FORCE=1/s,
+    );
+    expect(getApps()).toHaveLength(0);
+  });
+
+  it('PYRIC_SANDBOX_FORCE=1 overrides the guard', () => {
+    const { handle } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    process.env.NODE_ENV = 'production';
+    process.env.PYRIC_SANDBOX_FORCE = '1';
+    const app = initializeApp();
+    expect(isSandboxAdminApp(app)).toBe(true);
+    if (isSandboxAdminApp(app)) expect(app.sandbox).toBe(handle);
+    expect(stderrLines).toEqual(['pyric: firebase-admin routed to sandbox\n']);
+  });
+
+  it('other PYRIC_SANDBOX_FORCE values do not override', () => {
+    installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    process.env.NODE_ENV = 'production';
+    process.env.PYRIC_SANDBOX_FORCE = 'true';
+    expect(() => initializeApp()).toThrow(/refusing to route/);
+  });
+
+  it('non-production NODE_ENV values route normally', () => {
+    installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    process.env.NODE_ENV = 'development';
+    const app = initializeApp();
+    expect(isSandboxAdminApp(app)).toBe(true);
+  });
+});

--- a/packages/pyric-admin/test/app/registry.test.ts
+++ b/packages/pyric-admin/test/app/registry.test.ts
@@ -1,0 +1,258 @@
+/**
+ * `pyric-admin/app` default-app registry — mirror conformance against
+ * `firebase-admin/app`'s lifecycle (oracle:
+ * `firebase-admin/lib/app/lifecycle.js`).
+ *
+ * Covers:
+ *   - register/get semantics: unnamed `initializeApp` registers
+ *     `'[DEFAULT]'`; `getApp(name?)` / `getApps()` read the registry.
+ *   - error mirror: `app/no-app` (exact upstream message text, default
+ *     and named variants), `app/duplicate-app`,
+ *     `app/invalid-app-options` (bare-vs-config'd autoInit mismatch),
+ *     `app/invalid-app-name`, `app/invalid-argument` (deleteApp).
+ *   - idempotency mirror: repeated bare calls return the same app;
+ *     repeated `{ sandbox }` calls with the SAME Sandbox reference
+ *     return the same app; prod re-inits with deep-equal options return
+ *     the same app (decided by firebase-admin itself).
+ *   - no-arg `getDatabase()` / `getAuth()` resolving the default app on
+ *     the LOCAL SANDBOX and PROD arms (the remote arm reuses the
+ *     headless harness in `../remote/remote-dispatch.test.ts`).
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from 'bun:test';
+
+import { initializeSandbox } from 'pyric/sandbox';
+
+import {
+  DEFAULT_APP_NAME,
+  PyricAdminAppError,
+  deleteApp,
+  getApp,
+  getApps,
+  initializeApp,
+  isProdAdminApp,
+  isSandboxAdminApp,
+} from '../../src/app/index.js';
+import { getDatabase } from '../../src/database/index.js';
+import { getAuth } from '../../src/auth/index.js';
+
+// The registry is module-global (mirror of firebase-admin's
+// defaultAppStore) — start every test from an empty registry, and make
+// sure no ambient-activation env leaks in from other suites.
+beforeEach(() => {
+  delete process.env.PYRIC_SANDBOX;
+  delete process.env.PYRIC_SANDBOX_FORCE;
+});
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+function expectAppError(fn: () => unknown, code: string, message: RegExp): void {
+  let err: unknown;
+  try {
+    fn();
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(Error);
+  expect((err as { code?: string }).code).toBe(code);
+  expect((err as Error).message).toMatch(message);
+}
+
+describe('app registry — register / get', () => {
+  it("unnamed initializeApp registers '[DEFAULT]'", () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+    expect(app.name).toBe('[DEFAULT]');
+    expect(DEFAULT_APP_NAME).toBe('[DEFAULT]');
+    expect(getApp()).toBe(app);
+    expect(getApp('[DEFAULT]')).toBe(app);
+  });
+
+  it('named initializeApp registers under the name; getApps lists all', () => {
+    const def = initializeApp({ sandbox: initializeSandbox() });
+    const other = initializeApp({ sandbox: initializeSandbox() }, 'other');
+    expect(other.name).toBe('other');
+    expect(getApp('other')).toBe(other);
+    expect(getApps()).toEqual([def, other]);
+    // getApps returns a copy — mutating it must not touch the registry.
+    getApps().pop();
+    expect(getApps()).toHaveLength(2);
+  });
+
+  it('getApp throws app/no-app with the exact firebase-admin message (default)', () => {
+    expectAppError(
+      () => getApp(),
+      'app/no-app',
+      /^The default Firebase app does not exist\. Make sure you call initializeApp\(\) before using any of the Firebase services\.$/,
+    );
+  });
+
+  it('getApp throws app/no-app with the exact firebase-admin message (named)', () => {
+    expectAppError(
+      () => getApp('missing'),
+      'app/no-app',
+      /^Firebase app named "missing" does not exist\. Make sure you call initializeApp\(\) before using any of the Firebase services\.$/,
+    );
+  });
+
+  it('empty / non-string names throw app/invalid-app-name (both init and get)', () => {
+    expectAppError(() => getApp(''), 'app/invalid-app-name', /non-empty string/);
+    expectAppError(
+      () => initializeApp({ sandbox: initializeSandbox() }, ''),
+      'app/invalid-app-name',
+      /Invalid Firebase app name "" provided\. App name must be a non-empty string\./,
+    );
+    expectAppError(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => getApp(42 as any),
+      'app/invalid-app-name',
+      /non-empty string/,
+    );
+  });
+});
+
+describe('app registry — duplicate semantics (firebase-admin mirror)', () => {
+  it('re-initializing a name with a DIFFERENT sandbox throws app/duplicate-app', () => {
+    initializeApp({ sandbox: initializeSandbox() });
+    expectAppError(
+      () => initializeApp({ sandbox: initializeSandbox() }),
+      'app/duplicate-app',
+      /^A Firebase app named "\[DEFAULT\]" already exists with a different configuration\.$/,
+    );
+  });
+
+  it('re-initializing with the SAME Sandbox reference returns the existing app', () => {
+    const sandbox = initializeSandbox();
+    const first = initializeApp({ sandbox });
+    expect(initializeApp({ sandbox })).toBe(first);
+  });
+
+  it('different names never collide', () => {
+    const a = initializeApp({ sandbox: initializeSandbox() }, 'a');
+    const b = initializeApp({ sandbox: initializeSandbox() }, 'b');
+    expect(a).not.toBe(b);
+    expect(getApp('a')).toBe(a);
+    expect(getApp('b')).toBe(b);
+  });
+
+  it("config'd init after a bare init throws app/invalid-app-options (autoInit mismatch)", () => {
+    // PYRIC_SANDBOX is unset — the bare call takes today's prod path.
+    initializeApp();
+    expectAppError(
+      () => initializeApp({ sandbox: initializeSandbox() }),
+      'app/invalid-app-options',
+      /already exists with a different configuration/,
+    );
+  });
+
+  it('bare init after a config’d init throws app/invalid-app-options (autoInit mismatch)', () => {
+    initializeApp({ sandbox: initializeSandbox() });
+    expectAppError(
+      () => initializeApp(),
+      'app/invalid-app-options',
+      /already exists with a different configuration/,
+    );
+  });
+
+  it('prod re-init with deep-equal options returns the same app (firebase-admin decides)', () => {
+    const first = initializeApp({ projectId: 'demo-registry' }, 'prod-dup');
+    expect(initializeApp({ projectId: 'demo-registry' }, 'prod-dup')).toBe(first);
+  });
+
+  it('prod re-init with different options throws firebase-admin’s app/duplicate-app', () => {
+    initializeApp({ projectId: 'demo-registry' }, 'prod-dup2');
+    expectAppError(
+      () => initializeApp({ projectId: 'something-else' }, 'prod-dup2'),
+      'app/duplicate-app',
+      /already exists with a different configuration/,
+    );
+  });
+});
+
+describe('app registry — bare initializeApp() (prod arm, PYRIC_SANDBOX unset)', () => {
+  it('delegates to firebase-admin autoInit and is idempotent', () => {
+    const app = initializeApp();
+    expect(isProdAdminApp(app)).toBe(true);
+    expect(app.name).toBe('[DEFAULT]');
+    // firebase-admin's own registry holds the delegated app under the
+    // same name.
+    if (isProdAdminApp(app)) {
+      expect(app.adminApp.name).toBe('[DEFAULT]');
+    }
+    // Repeat bare call → the SAME app (firebase-admin autoInit mirror).
+    expect(initializeApp()).toBe(app);
+    expect(getApps()).toHaveLength(1);
+  });
+});
+
+describe('app registry — deleteApp', () => {
+  it('removes the app so the name can be re-initialized', async () => {
+    const sandbox = initializeSandbox();
+    const app = initializeApp({ sandbox });
+    await deleteApp(app);
+    expect(getApps()).toHaveLength(0);
+    expectAppError(() => getApp(), 'app/no-app', /does not exist/);
+    // Name is free again — a different sandbox no longer collides.
+    const again = initializeApp({ sandbox: initializeSandbox() });
+    expect(again).not.toBe(app);
+  });
+
+  it('deleting a prod app frees firebase-admin’s slot too', async () => {
+    const app = initializeApp({ projectId: 'demo-delete' }, 'prod-del');
+    await deleteApp(app);
+    // Re-init with DIFFERENT options succeeds — proof the underlying
+    // firebase-admin app was deleted, not just our wrapper.
+    const again = initializeApp({ projectId: 'demo-delete-2' }, 'prod-del');
+    expect(isProdAdminApp(again)).toBe(true);
+  });
+
+  it('unregistered app throws app/no-app; non-app values throw app/invalid-argument', async () => {
+    const sandbox = initializeSandbox();
+    const app = initializeApp({ sandbox });
+    await deleteApp(app);
+    expectAppError(() => deleteApp(app), 'app/no-app', /does not exist/);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expectAppError(() => deleteApp({} as any), 'app/invalid-argument', /^Invalid app argument\.$/);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expectAppError(() => deleteApp(null as any), 'app/invalid-argument', /^Invalid app argument\.$/);
+    expect(new PyricAdminAppError('no-app', 'x').code).toBe('app/no-app');
+  });
+});
+
+describe('no-arg getDatabase() / getAuth() — default-app resolution', () => {
+  it('throws app/no-app when no default app exists', () => {
+    expectAppError(() => getDatabase(), 'app/no-app', /The default Firebase app does not exist/);
+    expectAppError(() => getAuth(), 'app/no-app', /The default Firebase app does not exist/);
+  });
+
+  it('local sandbox arm: no-arg handles hit the default app’s in-memory backends', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+    expect(isSandboxAdminApp(app)).toBe(true);
+
+    const db = getDatabase(); // no-arg — resolves '[DEFAULT]'
+    await db.ref('ambient/local').set({ ok: true });
+    expect((await db.ref('ambient/local').get()).val()).toEqual({ ok: true });
+    // Same backend as the explicit-app handle (singleton per sandbox).
+    expect((await getDatabase(app).ref('ambient/local').get()).val()).toEqual({ ok: true });
+
+    const auth = getAuth(); // no-arg — resolves '[DEFAULT]'
+    await auth.createUser({ uid: 'ambient-user', email: 'ambient@example.com' });
+    expect((await getAuth(app).getUser('ambient-user')).email).toBe('ambient@example.com');
+  });
+
+  it('prod arm: no-arg handles delegate to firebase-admin for the default app', () => {
+    const app = initializeApp({
+      projectId: 'demo-prod-noarg',
+      databaseURL: 'https://demo-prod-noarg.firebaseio.com',
+    });
+    // No-arg resolves '[DEFAULT]' — the same firebase-admin service
+    // instance the explicit-app call returns. (Identity, not shape:
+    // database.test.ts mock.module's firebase-admin/database process-
+    // wide, so shape assertions here would be order-dependent.)
+    expect(getDatabase()).toBe(getDatabase(app));
+    const auth = getAuth();
+    expect(auth).toBe(getAuth(app));
+    expect(auth.app.name).toBe('[DEFAULT]');
+    expect(auth.app.options.projectId).toBe('demo-prod-noarg');
+  });
+});

--- a/packages/pyric-admin/test/database/proto-pollution.test.ts
+++ b/packages/pyric-admin/test/database/proto-pollution.test.ts
@@ -10,10 +10,16 @@
  * rejects `__proto__`/`prototype`/`constructor`, and the walks read
  * own-only.
  */
-import { describe, test, expect } from 'bun:test';
+import { afterEach, describe, test, expect } from 'bun:test';
 import { initializeSandbox } from 'pyric/sandbox';
-import { initializeApp } from '../../src/app/index.js';
+import { initializeApp, deleteApp, getApps } from '../../src/app/index.js';
 import { getDatabase } from '../../src/database/index.js';
+
+// Deregister the unnamed default app after each test (the registry is
+// module-global, mirroring firebase-admin's defaultAppStore).
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
 
 function makeDb() {
   const app = initializeApp({ sandbox: initializeSandbox() });

--- a/packages/pyric-admin/test/remote/remote-dispatch.test.ts
+++ b/packages/pyric-admin/test/remote/remote-dispatch.test.ts
@@ -26,8 +26,8 @@
  *   - the local in-process arm still selected for plain sandboxes
  */
 
-import { describe, it, expect } from 'bun:test';
-import { initializeSandbox } from 'pyric/sandbox';
+import { afterEach, describe, it, expect } from 'bun:test';
+import { REMOTE_SANDBOX_FACTORY, initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
 import type { AuthUserRecord } from 'pyric/auth';
 
@@ -52,13 +52,20 @@ import type {
   OutboundMessage,
 } from '../../../pyric-tools/src/serve/worker/protocol.js';
 
-import { initializeApp } from '../../src/app/index.js';
+import { initializeApp, deleteApp, getApps } from '../../src/app/index.js';
 import { getDatabase } from '../../src/database/index.js';
 import { getAuth } from '../../src/auth/index.js';
 
 // ─── Harness (checkpoint 1's, minus persistence — not needed here) ─────────
 
 const SERVE_URL = 'http://localhost:5000';
+
+// The app registry is module-global (mirror of firebase-admin's
+// defaultAppStore) — deregister every app after each test so repeated
+// unnamed `initializeApp({ sandbox })` calls don't collide.
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
 
 function makeWorkerCtx(): HostCtx {
   const sandbox = initializeSandbox();
@@ -467,6 +474,61 @@ describe('remote sandbox handle — sync-only Sandbox members', () => {
 });
 
 // ─── No-peer failure mode through the admin API ─────────────────────────────
+
+// ─── Ambient init on the remote arm (adoption experience, layer 3) ──────────
+
+describe('remote dispatch — ambient init (bare initializeApp + no-arg handles)', () => {
+  it('routes no-arg getDatabase()/getAuth() through the worker via the factory global', async () => {
+    // Same headless stack, but the app comes from a BARE initializeApp():
+    // PYRIC_SANDBOX activates, and the factory global (here: a fake
+    // installed the way `pyric-tools/register` would) mints the real
+    // branded remote handle.
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    const ctx = makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const remote = connectRemote(bridge);
+
+    const g = globalThis as { [REMOTE_SANDBOX_FACTORY]?: unknown };
+    const prevFactory = g[REMOTE_SANDBOX_FACTORY];
+    const prevEnv = process.env.PYRIC_SANDBOX;
+    const prevWrite = process.stderr.write.bind(process.stderr);
+    const logged: string[] = [];
+    process.stderr.write = ((chunk: unknown) => {
+      logged.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      process.env.PYRIC_SANDBOX = 'remote';
+      g[REMOTE_SANDBOX_FACTORY] = () => remote;
+
+      const app = initializeApp(); // ZERO pyric identifiers needed
+      expect(logged).toEqual(['pyric: firebase-admin routed to sandbox\n']);
+
+      // No-arg getDatabase resolves '[DEFAULT]' and takes the REMOTE arm:
+      // the write lands in the worker's tree (independent direct port).
+      const db = getDatabase();
+      await db.ref('ambient/probe').set({ via: 'ambient-remote' });
+      expect(await workerRtdbGet(ctx, 'ambient/probe')).toEqual({
+        via: 'ambient-remote',
+      });
+      expect(getDatabase()).toBe(getDatabase(app)); // same singleton handle
+
+      // No-arg getAuth relays to the worker's ONE user pool.
+      const auth = getAuth();
+      const created = await auth.createUser({ email: 'ambient@example.com' });
+      const workerUsers = (await workerOp(ctx, {
+        method: 'auth.listUsers',
+      })) as AuthUserRecord[];
+      expect(workerUsers.map((u) => u.uid)).toEqual([created.uid]);
+    } finally {
+      process.stderr.write = prevWrite;
+      if (prevEnv === undefined) delete process.env.PYRIC_SANDBOX;
+      else process.env.PYRIC_SANDBOX = prevEnv;
+      if (prevFactory === undefined) delete g[REMOTE_SANDBOX_FACTORY];
+      else g[REMOTE_SANDBOX_FACTORY] = prevFactory;
+    }
+  });
+});
 
 describe('remote dispatch — no browser tab connected', () => {
   it('RTDB and Auth calls fail fast with the "open <serve url>" guidance', async () => {

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -61,6 +61,13 @@
         "types": "./dist/remote/index.d.ts",
         "import": "./dist/remote/index.js"
       }
+    },
+    "./register": {
+      "types": "./dist/register/index.d.ts",
+      "node": {
+        "types": "./dist/register/index.d.ts",
+        "import": "./dist/register/index.js"
+      }
     }
   },
   "bin": {
@@ -107,7 +114,7 @@
     }
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.15"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pyric-tools/src/cli/dev-runner.ts
+++ b/packages/pyric-tools/src/cli/dev-runner.ts
@@ -1,0 +1,229 @@
+/**
+ * The `pyric dev` child runner — "one command, not two" (adoption design):
+ * after the host is up, run the user's OWN dev command with the environment
+ * activated so their unchanged firebase-admin/firebase imports resolve to the
+ * pyric sandbox:
+ *
+ *   PYRIC_SANDBOX=remote:<serve url>          (the activator)
+ *   NODE_OPTIONS += --import pyric-tools/register   (the substitution seam)
+ *
+ * Child-command precedence: explicit `pyric dev -- <cmd>` wins; else the
+ * project package.json `dev` script (via the detected package manager); else
+ * host-only (today's behavior). `--no-run` forces host-only; `--json`
+ * defaults to host-only (an explicit `--` still wins — agents can opt in).
+ *
+ * Everything decision-shaped here is pure and exported for the unit suite;
+ * only `spawnDevChild` touches the process table.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ─── Child-command resolution (pure) ───────────────────────────────────────
+
+export type PackageManager = 'bun' | 'pnpm' | 'yarn' | 'npm';
+
+/** Lockfile sniff, mirroring how init/vendor pick their install hints. */
+export function detectPackageManager(cwd: string): PackageManager {
+  if (existsSync(join(cwd, 'bun.lock')) || existsSync(join(cwd, 'bun.lockb'))) return 'bun';
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
+  return 'npm';
+}
+
+/** The project's `dev` script, or null (no package.json / no script). */
+export function readDevScript(cwd: string): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, unknown>;
+    };
+    const dev = pkg.scripts?.dev;
+    return typeof dev === 'string' && dev.trim().length > 0 ? dev : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface DevChildPlan {
+  /** argv to spawn — argv[0] is the executable, no shell. */
+  argv: string[];
+  /** Human-readable command for the pre-spawn line. */
+  label: string;
+}
+
+/**
+ * Decide what (if anything) to run after the host is up.
+ *
+ * Matrix:
+ *   --no-run                → null, always
+ *   `-- <cmd>`              → that command (wins over everything else)
+ *   --json (no `--`)        → null (machine mode defaults to host-only)
+ *   package.json dev script → `<pm> run dev`
+ *   none of the above       → null (host-only, today's behavior)
+ *
+ * A `dev` script that itself invokes `pyric dev` is treated as absent —
+ * running it would recurse forever (pyric dev → npm run dev → pyric dev …).
+ */
+export function resolveDevChild(opts: {
+  passthrough: string[];
+  noRun: boolean;
+  json: boolean;
+  devScript: string | null;
+  packageManager: PackageManager;
+}): DevChildPlan | null {
+  if (opts.noRun) return null;
+  if (opts.passthrough.length > 0) {
+    return { argv: [...opts.passthrough], label: opts.passthrough.join(' ') };
+  }
+  if (opts.json) return null;
+  if (opts.devScript && !/(^|[\s;&|])pyric\s+dev\b/.test(opts.devScript)) {
+    const label = `${opts.packageManager} run dev`;
+    return { argv: [opts.packageManager, 'run', 'dev'], label };
+  }
+  return null;
+}
+
+// ─── Environment for the child (pure) ──────────────────────────────────────
+
+/**
+ * The absolute `file:` URL of the register module, resolved from
+ * pyric-tools' OWN installed location — `import.meta.resolve` walks this
+ * package's `exports` (self-reference), so it lands on the right file no
+ * matter how the user's node_modules are laid out (hoisted, pnpm-isolated,
+ * vendored). Fallback: relative to this compiled file (dist/cli/ →
+ * dist/register/), for runtimes without a usable import.meta.resolve.
+ */
+export function registerModuleUrl(): string {
+  try {
+    const url = import.meta.resolve('pyric-tools/register');
+    if (typeof url === 'string' && url.length > 0) return url;
+  } catch {
+    // fall through
+  }
+  return new URL('../register/index.js', import.meta.url).href;
+}
+
+/**
+ * Child env: sets the activator and APPENDS the loader to NODE_OPTIONS —
+ * never replaces it (the user's own --inspect / --max-old-space-size etc.
+ * must survive). `file:` URLs are percent-encoded, so no quoting is needed
+ * even for paths with spaces.
+ */
+export function buildChildEnv(
+  base: NodeJS.ProcessEnv,
+  opts: { serveUrl: string; registerUrl: string },
+): NodeJS.ProcessEnv {
+  const importFlag = `--import ${opts.registerUrl}`;
+  return {
+    ...base,
+    PYRIC_SANDBOX: `remote:${opts.serveUrl}`,
+    NODE_OPTIONS: base.NODE_OPTIONS ? `${base.NODE_OPTIONS} ${importFlag}` : importFlag,
+  };
+}
+
+// ─── Line prefixing (pure core) ────────────────────────────────────────────
+
+/**
+ * Incremental line prefixer: every child output line gets `[dev] `, partial
+ * lines are buffered until their newline (or flush at stream end).
+ */
+export function createLinePrefixer(
+  prefix: string,
+  write: (line: string) => void,
+): { push(chunk: string): void; flush(): void } {
+  let buffer = '';
+  return {
+    push(chunk: string): void {
+      buffer += chunk;
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        write(`${prefix}${buffer.slice(0, nl)}\n`);
+        buffer = buffer.slice(nl + 1);
+      }
+    },
+    flush(): void {
+      if (buffer.length > 0) {
+        write(`${prefix}${buffer}\n`);
+        buffer = '';
+      }
+    },
+  };
+}
+
+// ─── Spawn + lifecycle ─────────────────────────────────────────────────────
+
+export interface DevChildHandle {
+  /** Resolves with the exit code to propagate once the child is gone. */
+  exited: Promise<number>;
+  /** Forward a signal (Ctrl-C / SIGTERM). Marks the exit as user-initiated
+   *  so the propagated code is 0, and SIGKILLs a child that lingers. */
+  signal(sig: NodeJS.Signals): void;
+  child: ChildProcess;
+}
+
+/** How long a signalled child may linger before SIGKILL. */
+const FORCE_KILL_AFTER_MS = 2_000;
+
+/**
+ * Spawn the child with inherited stdin and `[dev]`-prefixed stdout/stderr.
+ * In `--json` mode ALL child output goes to stderr — stdout carries exactly
+ * the one machine line (the serve --json contract).
+ */
+export function spawnDevChild(
+  plan: DevChildPlan,
+  opts: { cwd: string; env: NodeJS.ProcessEnv; json: boolean },
+): DevChildHandle {
+  const [command, ...args] = plan.argv;
+  const child = spawn(command!, args, {
+    cwd: opts.cwd,
+    env: opts.env,
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+
+  const outTarget = opts.json ? process.stderr : process.stdout;
+  const out = createLinePrefixer('[dev] ', (line) => outTarget.write(line));
+  const err = createLinePrefixer('[dev] ', (line) => process.stderr.write(line));
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => out.push(chunk));
+  child.stderr?.on('data', (chunk: string) => err.push(chunk));
+
+  let signalled = false;
+  let forceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const exited = new Promise<number>((resolve) => {
+    child.once('error', (e) => {
+      process.stderr.write(`pyric dev: failed to run \`${plan.label}\`: ${e.message}\n`);
+      resolve(1);
+    });
+    child.once('exit', (code, signal) => {
+      out.flush();
+      err.flush();
+      if (forceTimer) clearTimeout(forceTimer);
+      // User-initiated stop (Ctrl-C forwarded) is a clean shutdown → 0.
+      if (signalled) resolve(0);
+      else if (typeof code === 'number') resolve(code);
+      else resolve(signal ? 1 : 0);
+    });
+  });
+
+  return {
+    exited,
+    child,
+    signal(sig: NodeJS.Signals): void {
+      if (child.exitCode !== null || signalled) return;
+      signalled = true;
+      try {
+        child.kill(sig);
+      } catch {
+        return;
+      }
+      forceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {}
+      }, FORCE_KILL_AFTER_MS);
+      forceTimer.unref();
+    },
+  };
+}

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -4,7 +4,7 @@
  *
  * Subcommands:
  *   pyric bridge [--mode sandbox|prod] [--port N] [--project ID] …
- *   pyric dev [--port N] [--host H] [--no-cache] [--bridge] [--ui] [--seed FILE] [--no-watch] [--no-open] [--no-capture] [--json] [--persist] [--fresh]
+ *   pyric dev [--port N] [--host H] [--no-cache] [--bridge] [--ui] [--seed FILE] [--no-watch] [--no-open] [--no-capture] [--no-run] [--json] [--persist] [--fresh] [-- <cmd>]
  *   pyric init [dir] [--template web|node] [--name N] [--force] [--json]
  *   pyric vendor [dir] [--json]
  *   pyric snapshot [--out FILE] [--port N] [--force] [--json] [--include-passwords]
@@ -74,7 +74,7 @@ project) to external MCP clients (Claude Code, Cursor, ...).
 
 USAGE
   pyric bridge [flags]
-  pyric dev [flags]
+  pyric dev [flags] [-- <cmd>]
   pyric init [dir] [--template=web|node]
   pyric snapshot [--out=FILE]
   pyric verify [fixture|dir] [--engine sandbox|rules-test-api|both]
@@ -100,7 +100,10 @@ COMMANDS
   bridge                     Start the HTTP+WebSocket bridge external MCP clients point at.
   dev                        Serve the app locally with the pyric sandbox standing in for
                              Firebase — unmodified firebase/* imports hit an in-page sandbox
-                             with your firestore.rules deployed.
+                             with your firestore.rules deployed. Also runs your own dev
+                             command (\`-- <cmd>\`, else the package.json \`dev\` script) with
+                             unchanged firebase-admin/firebase imports routed to the
+                             sandbox (PYRIC_SANDBOX + \`--import pyric-tools/register\`).
   init [dir]                 Scaffold a pyric project. --template=web (default; canonical
                              firebase/* app served by \`pyric dev\`) or node (script-style).
                              --name=NAME --force (overwrite scaffold files) --json (machine
@@ -201,6 +204,14 @@ CORE FLAGS (dev)
   --fresh            With --persist: discard the existing state file and
                      re-seed from scratch (escape hatch when you've edited
                      seed.json).
+  -- <cmd>           Run <cmd> once the host is up, with PYRIC_SANDBOX set and
+                     NODE_OPTIONS extended with --import pyric-tools/register
+                     so firebase-admin/firebase resolve to the sandbox. When
+                     omitted, the package.json \`dev\` script runs (via the
+                     detected package manager); no script → host-only.
+  --no-run           Never run a child command (host-only, for users with
+                     their own process manager). --json implies --no-run
+                     unless a \`-- <cmd>\` is given explicitly.
   --json             One machine-readable line on stdout ({url, port, mcpUrl,
                      rulesHash, persist, restoredDocs, restoredUsers}); the
                      banner moves to stderr. Readiness probe:

--- a/packages/pyric-tools/src/cli/parse-args.ts
+++ b/packages/pyric-tools/src/cli/parse-args.ts
@@ -12,6 +12,9 @@ export interface ParsedArgs {
   subcommand: string | null;
   flags: Map<string, FlagValue>;
   positional: string[];
+  /** Everything after a bare `--`, verbatim (e.g. `pyric dev -- npm start`).
+   *  Optional so hand-built ParsedArgs literals stay valid. */
+  passthrough?: string[];
 }
 
 export type FlagValue = string | boolean | Array<string | boolean>;
@@ -19,6 +22,7 @@ export type FlagValue = string | boolean | Array<string | boolean>;
 export function parseArgs(argv: string[]): ParsedArgs {
   const flags = new Map<string, FlagValue>();
   const positional: string[] = [];
+  const passthrough: string[] = [];
   let subcommand: string | null = null;
   let i = 0;
   while (i < argv.length) {
@@ -26,6 +30,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
     if (arg === undefined) {
       i += 1;
       continue;
+    }
+    if (arg === '--') {
+      // Everything after a bare `--` belongs to the child command, verbatim
+      // — never parsed as flags (`pyric dev -- npm start --port 3000`).
+      passthrough.push(...argv.slice(i + 1).filter((a): a is string => a !== undefined));
+      break;
     }
     if (arg.startsWith('--')) {
       const eq = arg.indexOf('=');
@@ -49,7 +59,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     i += 1;
   }
-  return { subcommand, flags, positional };
+  return { subcommand, flags, positional, passthrough };
 }
 
 function setFlag(flags: Map<string, FlagValue>, key: string, value: string | boolean): void {

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -30,6 +30,15 @@ import { createCaptureStore } from '../serve/capture-store.js';
 import { consoleServeLogger, startStaticServer, stderrServeLogger, type ServeHandle } from '../serve/server.js';
 import { createBridgeMount } from '../serve/bridge-mount.js';
 import { openBrowser, shouldAutoOpen } from '../serve/open-browser.js';
+import {
+  buildChildEnv,
+  detectPackageManager,
+  readDevScript,
+  registerModuleUrl,
+  resolveDevChild,
+  spawnDevChild,
+  type DevChildHandle,
+} from './dev-runner.js';
 
 interface HostingConfig {
   public?: string;
@@ -545,15 +554,59 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     void openBrowser(runtime.uiUrl ?? runtime.handle.url);
   }
 
+  // The child runner ("one command, not two"): run the user's own dev
+  // command with the sandbox environment injected. Precedence: `-- <cmd>`
+  // wins; else the package.json dev script; else host-only. --no-run forces
+  // host-only; --json defaults to host-only (explicit `--` still wins).
+  const cwd = process.cwd();
+  const plan = resolveDevChild({
+    passthrough: parsed.passthrough ?? [],
+    noRun: Boolean(parsed.flags.get('no-run')),
+    json,
+    devScript: readDevScript(cwd),
+    packageManager: detectPackageManager(cwd),
+  });
+
+  let devChild: DevChildHandle | null = null;
+  if (plan) {
+    const info = json ? process.stderr : process.stdout;
+    info.write(
+      `✔ run      \`${plan.label}\` — firebase-admin/firebase imports are routed to the sandbox at ${runtime.handle.url}\n`,
+    );
+    devChild = spawnDevChild(plan, {
+      cwd,
+      json,
+      env: buildChildEnv(process.env, {
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+    });
+  }
+
   return await new Promise<number>((resolveExit) => {
-    const shutdown = (): void => {
-      (json ? process.stderr : process.stdout).write('\nShutting down...\n');
+    let settled = false;
+    const finish = (code: number): void => {
+      if (settled) return;
+      settled = true;
       void runtime.handle.stop().then(
-        () => resolveExit(0),
-        () => resolveExit(0),
+        () => resolveExit(code),
+        () => resolveExit(code),
       );
     };
-    process.once('SIGINT', shutdown);
-    process.once('SIGTERM', shutdown);
+    const shutdown = (signal: NodeJS.Signals): void => {
+      (json ? process.stderr : process.stdout).write('\nShutting down...\n');
+      if (devChild && devChild.child.exitCode === null) {
+        // Forward the signal; the child's exit (below) closes the host.
+        // (The terminal delivers Ctrl-C to the whole group too — the
+        // forward makes non-TTY / programmatic signals behave the same.)
+        devChild.signal(signal);
+      } else {
+        finish(0);
+      }
+    };
+    // Child exits → close the host and propagate its code (Ctrl-C → 0).
+    if (devChild) void devChild.exited.then((code) => finish(code));
+    process.once('SIGINT', () => shutdown('SIGINT'));
+    process.once('SIGTERM', () => shutdown('SIGTERM'));
   });
 }

--- a/packages/pyric-tools/src/register/esm-exports.ts
+++ b/packages/pyric-tools/src/register/esm-exports.ts
@@ -1,0 +1,63 @@
+/**
+ * Minimal `exports`-field walker for the CJS→ESM seam in
+ * `pyric-tools/register`.
+ *
+ * Why it exists: a rewritten CJS `require('firebase-admin/app')` resolves
+ * `pyric-admin/app` under the `require` condition, but the pyric mirrors are
+ * ESM-only (`import`-condition exports) — Node's CJS resolver throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED and ignores hook-supplied condition
+ * overrides. `require(esm)` (Node ≥ 22.12) can LOAD the module fine once we
+ * hand it the file, so the register hook locates the package
+ * (`Module.findPackageJSON`) and resolves the subpath here under import
+ * conditions.
+ *
+ * Deliberately narrow, matching what the pyric packages actually publish:
+ * literal subpaths only (no `*` patterns), string targets, and nested
+ * condition objects tried in `node` → `import` → `default` order (`types`
+ * and unknown conditions are skipped).
+ */
+
+type ExportsValue = string | { [key: string]: ExportsValue } | null;
+
+const CONDITION_ORDER = ['node', 'import', 'default'] as const;
+
+/** Resolve one condition object/string to its file target, or null. */
+function resolveTarget(value: ExportsValue): string | null {
+  if (typeof value === 'string') return value;
+  if (value === null || typeof value !== 'object') return null;
+  for (const condition of CONDITION_ORDER) {
+    if (condition in value) {
+      const resolved = resolveTarget(value[condition] ?? null);
+      if (resolved !== null) return resolved;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve `subpath` (e.g. `'./app'`, or `'.'` for the root) against a
+ * package's `exports` field under import conditions. Returns the relative
+ * file target (e.g. `'./dist/app/index.js'`) or null when the subpath is
+ * not exported.
+ */
+export function resolveEsmOnlySubpath(
+  exportsField: unknown,
+  subpath: string,
+): string | null {
+  if (exportsField === null || exportsField === undefined) return null;
+  if (typeof exportsField === 'string') {
+    return subpath === '.' ? exportsField : null;
+  }
+  if (typeof exportsField !== 'object') return null;
+  const map = exportsField as Record<string, ExportsValue>;
+
+  const keys = Object.keys(map);
+  const isSubpathMap = keys.every((k) => k === '.' || k.startsWith('./'));
+  if (!isSubpathMap) {
+    // Bare conditions object — describes the root subpath only.
+    return subpath === '.' ? resolveTarget(map as ExportsValue) : null;
+  }
+  const entry = map[subpath];
+  if (entry === undefined) return null;
+  return resolveTarget(entry);
+}

--- a/packages/pyric-tools/src/register/exempt.ts
+++ b/packages/pyric-tools/src/register/exempt.ts
@@ -1,0 +1,74 @@
+/**
+ * Mirror-package exemption for the register hooks.
+ *
+ * The pyric mirrors THEMSELVES import Firebase — that's their prod arm
+ * (e.g. pyric-admin/database's `import { getDatabaseWithUrl } from
+ * 'firebase-admin/database'`). Rewriting those would turn them into
+ * self-imports and break the mirror (missing exports, infinite mirrors),
+ * so a specifier is only rewritten when the REQUESTING module lives
+ * outside the pyric packages.
+ *
+ * Identity is the OWNING PACKAGE NAME — the `name` in the nearest named
+ * package.json above the requesting file — never a path substring (repo
+ * checkouts and worktrees have 'pyric' in every path). Nameless
+ * package.json files (`{"type": "module"}` markers in dist dirs) are
+ * skipped: they set the module format, not the package identity.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mapFirebaseSpecifier } from './mapping.js';
+
+/** The packages whose own Firebase imports must stay Firebase. */
+const EXEMPT_PACKAGES: ReadonlySet<string> = new Set(['pyric', 'pyric-admin', 'pyric-tools']);
+
+/** dir → owning package name (null = none found up to the fs root).
+ *  Resolution runs on every import in the child process — cache it. */
+const ownerCache = new Map<string, string | null>();
+
+function owningPackageNameOfDir(dir: string): string | null {
+  const cached = ownerCache.get(dir);
+  if (cached !== undefined) return cached;
+  let name: string | null = null;
+  try {
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      name?: unknown;
+    };
+    if (typeof pkg.name === 'string' && pkg.name.length > 0) {
+      name = pkg.name;
+    }
+  } catch {
+    // no/unreadable package.json here — keep walking
+  }
+  if (name === null) {
+    const parent = dirname(dir);
+    name = parent === dir ? null : owningPackageNameOfDir(parent);
+  }
+  ownerCache.set(dir, name);
+  return name;
+}
+
+/** The `name` of the package that owns `fileUrl` (a `file:` URL), or null
+ *  (entry point, data:/node: parents, no named package.json above it). */
+export function owningPackageName(fileUrl: string | undefined): string | null {
+  if (!fileUrl || !fileUrl.startsWith('file:')) return null;
+  try {
+    return owningPackageNameOfDir(dirname(fileURLToPath(fileUrl)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The one rewrite decision both hook paths (`module.registerHooks` and the
+ * `module.register` fallback) share: map the specifier, unless the
+ * requesting module is owned by a pyric mirror package. Returns the mapped
+ * specifier or null (leave resolution alone).
+ */
+export function rewriteSpecifier(specifier: string, parentURL: string | undefined): string | null {
+  const mapped = mapFirebaseSpecifier(specifier);
+  if (mapped === null) return null;
+  const owner = owningPackageName(parentURL);
+  if (owner !== null && EXEMPT_PACKAGES.has(owner)) return null;
+  return mapped;
+}

--- a/packages/pyric-tools/src/register/hooks.ts
+++ b/packages/pyric-tools/src/register/hooks.ts
@@ -8,7 +8,7 @@
  * a warning saying exactly that). Keep this module free of side effects and
  * heavy imports: the loader thread re-instantiates it in isolation.
  */
-import { mapFirebaseSpecifier } from './mapping.js';
+import { rewriteSpecifier } from './exempt.js';
 
 interface ResolveContext {
   parentURL?: string;
@@ -26,5 +26,5 @@ export function resolve(
   context: ResolveContext,
   nextResolve: (specifier: string, context?: ResolveContext) => Promise<ResolveResult>,
 ): Promise<ResolveResult> {
-  return nextResolve(mapFirebaseSpecifier(specifier) ?? specifier, context);
+  return nextResolve(rewriteSpecifier(specifier, context.parentURL) ?? specifier, context);
 }

--- a/packages/pyric-tools/src/register/hooks.ts
+++ b/packages/pyric-tools/src/register/hooks.ts
@@ -1,0 +1,30 @@
+/**
+ * `module.register()` fallback hooks — the ASYNC (loader-thread) variant of
+ * the specifier rewrite, used only on Node 22.x older than 22.15 where the
+ * sync `module.registerHooks` API doesn't exist yet.
+ *
+ * Runs on Node's loader thread, so it intercepts ESM `import` ONLY — CJS
+ * `require('firebase-admin')` is NOT rewritten on this path (index.ts logs
+ * a warning saying exactly that). Keep this module free of side effects and
+ * heavy imports: the loader thread re-instantiates it in isolation.
+ */
+import { mapFirebaseSpecifier } from './mapping.js';
+
+interface ResolveContext {
+  parentURL?: string;
+  conditions: string[];
+  importAttributes: Record<string, string>;
+}
+interface ResolveResult {
+  url: string;
+  format?: string | null;
+  shortCircuit?: boolean;
+}
+
+export function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: (specifier: string, context?: ResolveContext) => Promise<ResolveResult>,
+): Promise<ResolveResult> {
+  return nextResolve(mapFirebaseSpecifier(specifier) ?? specifier, context);
+}

--- a/packages/pyric-tools/src/register/index.ts
+++ b/packages/pyric-tools/src/register/index.ts
@@ -1,0 +1,142 @@
+/**
+ * `pyric-tools/register` — the Node substitution seam (adoption layer 2).
+ *
+ * Loaded via `node --import pyric-tools/register` (which `pyric dev` injects
+ * through NODE_OPTIONS), it makes the user's UNCHANGED `firebase-admin` /
+ * `firebase` imports resolve to `pyric-admin` / `pyric`, every subpath 1:1,
+ * and installs the sandbox-factory global that `pyric-admin`'s ambient
+ * `initializeApp()` consumes.
+ *
+ * ACTIVATOR, NOT LOCATOR (adoption-experience design): activation is purely
+ * the `PYRIC_SANDBOX` env var injected at invocation — never file presence,
+ * never app code. Without it this module is INERT (import it freely; nothing
+ * happens). Under `NODE_ENV=production` it REFUSES with one stderr line
+ * unless `PYRIC_SANDBOX_FORCE=1`. On activation it logs one stderr line.
+ *
+ * Hooks API: `module.registerHooks` (sync, Node ≥ 22.15) intercepts BOTH
+ * `require()` and `import`. On older 22.x it falls back to
+ * `module.register()` (ESM-only) with a warning that CJS require() is not
+ * rewritten.
+ */
+import Module from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { mapFirebaseSpecifier } from './mapping.js';
+import { resolveEsmOnlySubpath } from './esm-exports.js';
+import { remoteSandbox } from '../remote/index.js';
+
+/** The shared seam with pyric-admin's ambient init: a synchronous factory
+ *  returning the lazy branded handle. `Symbol.for` so both packages agree
+ *  without importing each other's types. */
+const SANDBOX_FACTORY = Symbol.for('pyric.remote.sandboxFactory');
+
+interface SyncResolveContext {
+  parentURL?: string;
+  conditions?: string[];
+}
+interface SyncResolveResult {
+  url: string;
+  format?: string | null;
+  shortCircuit?: boolean;
+}
+type SyncResolve = (
+  specifier: string,
+  context: SyncResolveContext,
+  nextResolve: (specifier: string, context?: SyncResolveContext) => SyncResolveResult,
+) => SyncResolveResult;
+
+/** `module.registerHooks` landed in Node 22.15 / 23.5 — feature-detect
+ *  (typed locally: the repo's ambient node types predate it). */
+const moduleApi = Module as unknown as {
+  registerHooks?: (hooks: { resolve: SyncResolve }) => void;
+  register?: (specifier: string | URL) => void;
+  findPackageJSON?: (specifier: string, base: string | URL) => string | undefined;
+};
+
+/**
+ * CJS→ESM seam: a rewritten `require()` fails against the pyric mirrors'
+ * `import`-condition-only exports (the CJS resolver ignores hook-supplied
+ * condition overrides), even though `require(esm)` can load them fine.
+ * Locate the package from the REQUIRING module and resolve the subpath under
+ * import conditions ourselves. Returns the resolved file URL, or null to
+ * rethrow the original error.
+ */
+function resolveEsmOnlyForRequire(mapped: string, parentURL: string | undefined): string | null {
+  if (typeof moduleApi.findPackageJSON !== 'function') return null;
+  const slash = mapped.indexOf('/');
+  const pkgName = slash === -1 ? mapped : mapped.slice(0, slash);
+  const subpath = slash === -1 ? '.' : `.${mapped.slice(slash)}`;
+  let pkgJsonPath: string | undefined;
+  try {
+    pkgJsonPath = moduleApi.findPackageJSON(
+      pkgName,
+      parentURL ?? pathToFileURL(join(process.cwd(), 'noop.js')),
+    );
+  } catch {
+    return null;
+  }
+  if (!pkgJsonPath) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as { exports?: unknown };
+    const target = resolveEsmOnlySubpath(pkg.exports, subpath);
+    if (!target) return null;
+    return pathToFileURL(join(dirname(pkgJsonPath), target)).href;
+  } catch {
+    return null;
+  }
+}
+
+function activate(): void {
+  if (typeof moduleApi.registerHooks === 'function') {
+    moduleApi.registerHooks({
+      resolve(specifier, context, nextResolve) {
+        const mapped = mapFirebaseSpecifier(specifier);
+        if (mapped === null) return nextResolve(specifier, context);
+        try {
+          return nextResolve(mapped, context);
+        } catch (err) {
+          // CJS `require('firebase-admin/app')` resolves under the `require`
+          // condition, but the pyric mirrors are ESM-only. Resolve the file
+          // under import conditions ourselves — require(esm) (Node ≥ 22.12)
+          // loads it fine once given the URL.
+          if ((err as { code?: string }).code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+            const url = resolveEsmOnlyForRequire(mapped, context.parentURL);
+            if (url) return { url, shortCircuit: true };
+          }
+          throw err;
+        }
+      },
+    });
+  } else {
+    process.stderr.write(
+      'pyric-tools/register: this Node version lacks module.registerHooks (needs >= 22.15) — ' +
+        'falling back to module.register: ESM imports of firebase-admin/firebase are rewritten, ' +
+        "but CJS require('firebase-admin') is NOT intercepted. Upgrade Node to >= 22.15 for full coverage.\n",
+    );
+    moduleApi.register?.(new URL('./hooks.js', import.meta.url));
+  }
+
+  // The factory global — exact contract shared with pyric-admin's ambient
+  // init: synchronous, returns the lazy branded handle.
+  (globalThis as Record<symbol, unknown>)[SANDBOX_FACTORY] = (opts?: { url?: string }) =>
+    remoteSandbox(opts);
+
+  process.stderr.write(
+    `pyric-tools/register: active — firebase-admin/firebase imports now resolve to the ` +
+      `pyric sandbox (PYRIC_SANDBOX=${process.env.PYRIC_SANDBOX}).\n`,
+  );
+}
+
+if (process.env.PYRIC_SANDBOX) {
+  if (process.env.NODE_ENV === 'production' && process.env.PYRIC_SANDBOX_FORCE !== '1') {
+    process.stderr.write(
+      'pyric-tools/register: refusing to activate under NODE_ENV=production — ' +
+        'firebase-admin/firebase imports are NOT rewritten. ' +
+        'Set PYRIC_SANDBOX_FORCE=1 to override (dev/CI only).\n',
+    );
+  } else {
+    activate();
+  }
+}
+// No PYRIC_SANDBOX → inert by design: importing this module does nothing.

--- a/packages/pyric-tools/src/register/index.ts
+++ b/packages/pyric-tools/src/register/index.ts
@@ -22,7 +22,7 @@ import Module from 'node:module';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { mapFirebaseSpecifier } from './mapping.js';
+import { rewriteSpecifier } from './exempt.js';
 import { resolveEsmOnlySubpath } from './esm-exports.js';
 import { remoteSandbox } from '../remote/index.js';
 
@@ -91,7 +91,11 @@ function activate(): void {
   if (typeof moduleApi.registerHooks === 'function') {
     moduleApi.registerHooks({
       resolve(specifier, context, nextResolve) {
-        const mapped = mapFirebaseSpecifier(specifier);
+        // The rewrite decision includes the mirror-package exemption:
+        // Firebase imports made FROM WITHIN pyric/pyric-admin/pyric-tools
+        // are their prod arms and must keep resolving to real Firebase
+        // (see exempt.ts).
+        const mapped = rewriteSpecifier(specifier, context.parentURL);
         if (mapped === null) return nextResolve(specifier, context);
         try {
           return nextResolve(mapped, context);

--- a/packages/pyric-tools/src/register/mapping.ts
+++ b/packages/pyric-tools/src/register/mapping.ts
@@ -1,0 +1,30 @@
+/**
+ * The specifier map behind `pyric-tools/register`: unmodified Firebase
+ * imports resolve to their pyric mirrors, 1:1 including every subpath
+ * (`firebase-admin/app` → `pyric-admin/app`, `firebase/firestore` →
+ * `pyric/firestore`, …).
+ *
+ * Pure — the resolution hooks (index.ts / hooks.ts) call this and the unit
+ * suite exercises it directly. Deliberately narrow: only the two package
+ * roots match. `@firebase/*` internals, `firebase-functions`, and anything
+ * merely *containing* "firebase" pass through untouched.
+ */
+
+const MAPPINGS: ReadonlyArray<readonly [from: string, to: string]> = [
+  // firebase-admin first — `firebase-admin` must never match the bare
+  // `firebase` root (it can't today, but the order documents the intent).
+  ['firebase-admin', 'pyric-admin'],
+  ['firebase', 'pyric'],
+];
+
+/**
+ * Map a Firebase specifier to its pyric mirror, or return `null` when the
+ * specifier is not a Firebase package (leave it for the default resolver).
+ */
+export function mapFirebaseSpecifier(specifier: string): string | null {
+  for (const [from, to] of MAPPINGS) {
+    if (specifier === from) return to;
+    if (specifier.startsWith(`${from}/`)) return to + specifier.slice(from.length);
+  }
+  return null;
+}

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -635,6 +635,139 @@ export async function connectRemoteSandbox(
   });
 }
 
+// ─── Lazy connect (`remoteSandbox`) ────────────────────────────────────────
+
+/**
+ * {@link remoteSandbox}'s return type: the branded handle plus `ready` for
+ * eager checkers. `ready` kicks off the connection when first accessed and
+ * settles with the same fail-fast errors {@link connectRemoteSandbox} throws
+ * (no serve discovered / no browser tab connected).
+ */
+export interface LazyRemoteSandbox extends RemoteSandbox {
+  readonly ready: Promise<void>;
+}
+
+/**
+ * Synchronous construction, lazy connection — the ambient-init seam.
+ *
+ * `pyric-tools/register` installs this behind the
+ * `Symbol.for('pyric.remote.sandboxFactory')` global so `pyric-admin`'s bare
+ * `initializeApp()` can mint a full branded handle without awaiting anything.
+ * The wire connection (discovery → WS attach) happens on the FIRST op (or
+ * `ready` access), so the existing fail-fast — "no browser tab is connected —
+ * open <url>" — surfaces on first use instead of at construction. A failed
+ * connect is NOT latched: the next op retries, matching the error's own
+ * "…and retry" guidance. `connectRemoteSandbox` (eager) is unchanged.
+ */
+export function remoteSandbox(options: ConnectRemoteSandboxOptions = {}): LazyRemoteSandbox {
+  return createLazyRemoteSandbox(() => connectRemoteSandbox(options), options);
+}
+
+/**
+ * The lazy wrapper with the connect function injected — the test seam
+ * (tests inject a fake connect; production injects `connectRemoteSandbox`).
+ */
+export function createLazyRemoteSandbox(
+  connect: () => Promise<RemoteSandbox>,
+  options: { url?: string } = {},
+): LazyRemoteSandbox {
+  let inner: Promise<RemoteSandbox> | null = null;
+  let closed = false;
+
+  function ensure(): Promise<RemoteSandbox> {
+    if (closed) {
+      return Promise.reject(
+        remoteError('unavailable', 'remote sandbox connection closed by the client'),
+      );
+    }
+    if (!inner) {
+      inner = connect().then(
+        (h) => {
+          if (closed) {
+            h.close();
+            throw remoteError('unavailable', 'remote sandbox connection closed by the client');
+          }
+          // Discovery resolved the real URL — reflect it on the outer handle.
+          (handle as { serveUrl: string }).serveUrl = h.serveUrl;
+          return h;
+        },
+        (err) => {
+          // Fail-fast surfaces on this op, but don't latch: the remediation
+          // is "open <url> and retry", so the next op re-attempts the connect.
+          inner = null;
+          throw err;
+        },
+      );
+    }
+    return inner;
+  }
+
+  const channel: RemoteSandboxChannel = {
+    op: (payload) => ensure().then((h) => h.channel.op(payload)),
+    subscribe(sub, onSnap, onError) {
+      let cancelled = false;
+      let innerUnsub: (() => void) | null = null;
+      ensure().then(
+        (h) => {
+          if (cancelled) return;
+          innerUnsub = h.channel.subscribe(sub, onSnap, onError);
+        },
+        (err) => {
+          if (cancelled) return;
+          const e =
+            err instanceof Error && 'code' in err
+              ? (err as Error & { code: string })
+              : remoteError('unavailable', String(err));
+          if (onError) onError(e);
+          else console.error('pyric remote sandbox: subscription failed to connect:', e);
+        },
+      );
+      return () => {
+        cancelled = true;
+        if (innerUnsub) {
+          innerUnsub();
+          innerUnsub = null;
+        }
+      };
+    },
+  };
+
+  const handle = createRemoteSandboxHandle({
+    channel,
+    // Before discovery the URL is unknown; op-level errors always carry the
+    // real URL (they come from the inner connect), and `serveUrl` is patched
+    // to the discovered value as soon as the first connect succeeds.
+    serveUrl: options.url?.replace(/\/$/, '') ?? '<pyric dev url (pending discovery)>',
+    close() {
+      if (closed) return;
+      closed = true;
+      const settled = inner;
+      inner = null;
+      if (settled) {
+        settled.then(
+          (h) => h.close(),
+          () => {},
+        );
+      }
+    },
+  }) as RemoteSandbox & { ready: Promise<void> };
+
+  // `ready` — the eager checker: accessing it starts the connection. Marked
+  // handled (same pattern as the core's `ready`) so a mere existence check
+  // (`handle.ready instanceof Promise`) never surfaces an unhandled rejection.
+  Object.defineProperty(handle, 'ready', {
+    get: (): Promise<void> => {
+      const p = ensure().then(() => undefined);
+      p.catch(() => {});
+      return p;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  return handle as LazyRemoteSandbox;
+}
+
 function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(remoteError('deadline-exceeded', message)), ms);

--- a/packages/pyric-tools/test/cli/dev-runner.test.ts
+++ b/packages/pyric-tools/test/cli/dev-runner.test.ts
@@ -1,0 +1,150 @@
+/**
+ * `pyric dev` child-runner decisions: `--` passthrough parsing, the
+ * command-precedence matrix (`--` > dev script > none; --no-run / --json),
+ * the child environment (activator + APPENDED NODE_OPTIONS), the register
+ * module URL, and the `[dev]` line prefixer.
+ */
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from '../../src/cli/parse-args.js';
+import {
+  buildChildEnv,
+  createLinePrefixer,
+  detectPackageManager,
+  readDevScript,
+  registerModuleUrl,
+  resolveDevChild,
+} from '../../src/cli/dev-runner.js';
+
+describe('parseArgs `--` passthrough', () => {
+  it('collects everything after -- verbatim, never as flags', () => {
+    const parsed = parseArgs(['dev', '--bridge', '--', 'npm', 'start', '--port', '3000']);
+    expect(parsed.subcommand).toBe('dev');
+    expect(parsed.flags.get('bridge')).toBe(true);
+    expect(parsed.passthrough).toEqual(['npm', 'start', '--port', '3000']);
+    expect(parsed.flags.has('port')).toBe(false);
+  });
+
+  it('is empty without --', () => {
+    expect(parseArgs(['dev', '--json']).passthrough).toEqual([]);
+  });
+
+  it('handles a trailing bare --', () => {
+    expect(parseArgs(['dev', '--']).passthrough).toEqual([]);
+  });
+});
+
+describe('resolveDevChild precedence', () => {
+  const base = {
+    passthrough: [] as string[],
+    noRun: false,
+    json: false,
+    devScript: null as string | null,
+    packageManager: 'npm' as const,
+  };
+
+  it('explicit -- command wins over the dev script', () => {
+    const plan = resolveDevChild({ ...base, passthrough: ['node', 'server.js'], devScript: 'vite' });
+    expect(plan).toEqual({ argv: ['node', 'server.js'], label: 'node server.js' });
+  });
+
+  it('falls back to the dev script via the detected package manager', () => {
+    const plan = resolveDevChild({ ...base, devScript: 'vite dev', packageManager: 'bun' });
+    expect(plan).toEqual({ argv: ['bun', 'run', 'dev'], label: 'bun run dev' });
+  });
+
+  it('no -- and no dev script → host-only', () => {
+    expect(resolveDevChild(base)).toBeNull();
+  });
+
+  it('--no-run forces host-only, even with -- and a dev script', () => {
+    expect(
+      resolveDevChild({ ...base, noRun: true, passthrough: ['npm', 'start'], devScript: 'vite' }),
+    ).toBeNull();
+  });
+
+  it('--json defaults to host-only (skips the dev script)', () => {
+    expect(resolveDevChild({ ...base, json: true, devScript: 'vite' })).toBeNull();
+  });
+
+  it('--json with an explicit -- command still runs it', () => {
+    const plan = resolveDevChild({ ...base, json: true, passthrough: ['node', 'x.js'] });
+    expect(plan?.argv).toEqual(['node', 'x.js']);
+  });
+
+  it('a dev script that itself runs pyric dev is skipped (no recursion)', () => {
+    expect(resolveDevChild({ ...base, devScript: 'pyric dev --bridge' })).toBeNull();
+    expect(resolveDevChild({ ...base, devScript: 'rimraf dist && pyric dev' })).toBeNull();
+  });
+});
+
+describe('detectPackageManager / readDevScript', () => {
+  it('sniffs lockfiles, defaulting to npm', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-pm-'));
+    try {
+      expect(detectPackageManager(dir)).toBe('npm');
+      writeFileSync(join(dir, 'yarn.lock'), '');
+      expect(detectPackageManager(dir)).toBe('yarn');
+      writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
+      expect(detectPackageManager(dir)).toBe('pnpm');
+      writeFileSync(join(dir, 'bun.lock'), '');
+      expect(detectPackageManager(dir)).toBe('bun');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads scripts.dev, tolerating missing/invalid package.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-devscript-'));
+    try {
+      expect(readDevScript(dir)).toBeNull();
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { dev: 'vite dev' } }));
+      expect(readDevScript(dir)).toBe('vite dev');
+      writeFileSync(join(dir, 'package.json'), '{not json');
+      expect(readDevScript(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildChildEnv', () => {
+  it('sets the activator and appends --import to an existing NODE_OPTIONS', () => {
+    const env = buildChildEnv(
+      { NODE_OPTIONS: '--max-old-space-size=4096', PATH: '/bin' },
+      { serveUrl: 'http://localhost:5000', registerUrl: 'file:///x/register/index.js' },
+    );
+    expect(env.PYRIC_SANDBOX).toBe('remote:http://localhost:5000');
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size=4096 --import file:///x/register/index.js');
+    expect(env.PATH).toBe('/bin');
+  });
+
+  it('creates NODE_OPTIONS when absent', () => {
+    const env = buildChildEnv({}, { serveUrl: 'http://h:1', registerUrl: 'file:///r.js' });
+    expect(env.NODE_OPTIONS).toBe('--import file:///r.js');
+  });
+});
+
+describe('registerModuleUrl', () => {
+  it('resolves to an absolute file URL of the register module', () => {
+    const url = registerModuleUrl();
+    expect(url.startsWith('file://')).toBe(true);
+    expect(url).toContain('register/index');
+  });
+});
+
+describe('createLinePrefixer', () => {
+  it('prefixes complete lines and buffers partials until flush', () => {
+    const out: string[] = [];
+    const p = createLinePrefixer('[dev] ', (line) => out.push(line));
+    p.push('hello\nwor');
+    p.push('ld\ntail');
+    expect(out).toEqual(['[dev] hello\n', '[dev] world\n']);
+    p.flush();
+    expect(out).toEqual(['[dev] hello\n', '[dev] world\n', '[dev] tail\n']);
+    p.flush(); // idempotent
+    expect(out).toHaveLength(3);
+  });
+});

--- a/packages/pyric-tools/test/register/mapping.test.ts
+++ b/packages/pyric-tools/test/register/mapping.test.ts
@@ -1,10 +1,17 @@
 /**
  * Unit coverage for the register seam's pure pieces: the specifier map
- * (firebase → pyric, all subpaths 1:1, non-Firebase untouched) and the
- * ESM-only exports walker behind the CJS require() fallback.
+ * (firebase → pyric, all subpaths 1:1, non-Firebase untouched), the
+ * mirror-package exemption (Firebase imports FROM WITHIN the pyric mirrors
+ * stay Firebase — their prod arms), and the ESM-only exports walker behind
+ * the CJS require() fallback.
  */
 import { describe, it, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { mapFirebaseSpecifier } from '../../src/register/mapping.js';
+import { owningPackageName, rewriteSpecifier } from '../../src/register/exempt.js';
 import { resolveEsmOnlySubpath } from '../../src/register/esm-exports.js';
 
 describe('mapFirebaseSpecifier', () => {
@@ -46,6 +53,69 @@ describe('mapFirebaseSpecifier', () => {
   it('does not double-map pyric specifiers', () => {
     expect(mapFirebaseSpecifier('pyric-admin/app')).toBeNull();
     expect(mapFirebaseSpecifier('pyric/firestore')).toBeNull();
+  });
+});
+
+describe('rewriteSpecifier (mirror-package exemption)', () => {
+  const repoRoot = resolve(import.meta.dir, '../../../..');
+  const pyricAdminParent = pathToFileURL(
+    join(repoRoot, 'packages/pyric-admin/src/database/index.ts'),
+  ).href;
+  const pyricParent = pathToFileURL(join(repoRoot, 'packages/pyric/src/app/index.ts')).href;
+  const pyricToolsParent = pathToFileURL(
+    join(repoRoot, 'packages/pyric-tools/src/deploy/index.ts'),
+  ).href;
+
+  it('does NOT rewrite Firebase imports made from within the pyric mirrors', () => {
+    // The repro: pyric-admin/database's own prod-arm import — a rewrite
+    // turns it into a self-import missing getDatabaseWithUrl.
+    expect(rewriteSpecifier('firebase-admin/database', pyricAdminParent)).toBeNull();
+    expect(rewriteSpecifier('firebase-admin/app', pyricAdminParent)).toBeNull();
+    expect(rewriteSpecifier('firebase/app', pyricParent)).toBeNull();
+    expect(rewriteSpecifier('firebase-admin/firestore', pyricToolsParent)).toBeNull();
+  });
+
+  it('rewrites from user modules, entry points, and non-file parents', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-exempt-'));
+    try {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'user-app' }));
+      const userParent = pathToFileURL(join(dir, 'server.mjs')).href;
+      expect(rewriteSpecifier('firebase-admin/database', userParent)).toBe('pyric-admin/database');
+      expect(rewriteSpecifier('firebase/app', userParent)).toBe('pyric/app');
+      expect(rewriteSpecifier('firebase-admin/app', undefined)).toBe('pyric-admin/app');
+      expect(rewriteSpecifier('firebase-admin/app', 'data:text/javascript,')).toBe(
+        'pyric-admin/app',
+      );
+      // Non-Firebase specifiers stay null regardless of parent.
+      expect(rewriteSpecifier('express', userParent)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('identifies the owner by package NAME, skipping nameless format-marker package.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-owner-'));
+    try {
+      // A copy under an arbitrary 'pyric'-flavored path: identity must come
+      // from the package.json name, never from a path substring.
+      const pkgDir = join(dir, 'some-pyric-worktree/node_modules/pyric-admin');
+      mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+      writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'pyric-admin' }));
+      // Nameless format marker inside dist — skipped, not the owner.
+      writeFileSync(join(pkgDir, 'dist', 'package.json'), JSON.stringify({ type: 'module' }));
+      const parent = pathToFileURL(join(pkgDir, 'dist', 'database.js')).href;
+      expect(owningPackageName(parent)).toBe('pyric-admin');
+      expect(rewriteSpecifier('firebase-admin/database', parent)).toBeNull();
+
+      // A user package on a path CONTAINING 'pyric' still gets rewritten.
+      const userDir = join(dir, 'my-pyric-app');
+      mkdirSync(userDir, { recursive: true });
+      writeFileSync(join(userDir, 'package.json'), JSON.stringify({ name: 'my-pyric-app' }));
+      const userParent = pathToFileURL(join(userDir, 'index.mjs')).href;
+      expect(rewriteSpecifier('firebase-admin/database', userParent)).toBe('pyric-admin/database');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/pyric-tools/test/register/mapping.test.ts
+++ b/packages/pyric-tools/test/register/mapping.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for the register seam's pure pieces: the specifier map
+ * (firebase → pyric, all subpaths 1:1, non-Firebase untouched) and the
+ * ESM-only exports walker behind the CJS require() fallback.
+ */
+import { describe, it, expect } from 'bun:test';
+import { mapFirebaseSpecifier } from '../../src/register/mapping.js';
+import { resolveEsmOnlySubpath } from '../../src/register/esm-exports.js';
+
+describe('mapFirebaseSpecifier', () => {
+  it('maps the bare package roots', () => {
+    expect(mapFirebaseSpecifier('firebase-admin')).toBe('pyric-admin');
+    expect(mapFirebaseSpecifier('firebase')).toBe('pyric');
+  });
+
+  it('maps every subpath 1:1', () => {
+    expect(mapFirebaseSpecifier('firebase-admin/app')).toBe('pyric-admin/app');
+    expect(mapFirebaseSpecifier('firebase-admin/firestore')).toBe('pyric-admin/firestore');
+    expect(mapFirebaseSpecifier('firebase-admin/auth')).toBe('pyric-admin/auth');
+    expect(mapFirebaseSpecifier('firebase-admin/database')).toBe('pyric-admin/database');
+    expect(mapFirebaseSpecifier('firebase-admin/storage')).toBe('pyric-admin/storage');
+    expect(mapFirebaseSpecifier('firebase/app')).toBe('pyric/app');
+    expect(mapFirebaseSpecifier('firebase/firestore')).toBe('pyric/firestore');
+    expect(mapFirebaseSpecifier('firebase/auth')).toBe('pyric/auth');
+  });
+
+  it('maps nested subpaths verbatim', () => {
+    expect(mapFirebaseSpecifier('firebase/database/modular')).toBe('pyric/database/modular');
+  });
+
+  it('leaves non-Firebase specifiers untouched', () => {
+    expect(mapFirebaseSpecifier('express')).toBeNull();
+    expect(mapFirebaseSpecifier('node:fs')).toBeNull();
+    expect(mapFirebaseSpecifier('./firebase')).toBeNull();
+    expect(mapFirebaseSpecifier('/abs/firebase')).toBeNull();
+  });
+
+  it('does not match packages that merely contain "firebase"', () => {
+    expect(mapFirebaseSpecifier('firebase-functions')).toBeNull();
+    expect(mapFirebaseSpecifier('firebase-functions/v2')).toBeNull();
+    expect(mapFirebaseSpecifier('firebase-tools')).toBeNull();
+    expect(mapFirebaseSpecifier('@firebase/app')).toBeNull();
+    expect(mapFirebaseSpecifier('my-firebase')).toBeNull();
+  });
+
+  it('does not double-map pyric specifiers', () => {
+    expect(mapFirebaseSpecifier('pyric-admin/app')).toBeNull();
+    expect(mapFirebaseSpecifier('pyric/firestore')).toBeNull();
+  });
+});
+
+describe('resolveEsmOnlySubpath', () => {
+  const exportsField = {
+    './app': { types: './dist/app/index.d.ts', import: './dist/app/index.js' },
+    './auth': {
+      types: './dist/auth/index.d.ts',
+      node: { types: './dist/auth/index.d.ts', import: './dist/auth/node.js' },
+      default: './dist/auth/index.js',
+    },
+  };
+
+  it('resolves an import-condition-only subpath', () => {
+    expect(resolveEsmOnlySubpath(exportsField, './app')).toBe('./dist/app/index.js');
+  });
+
+  it('prefers node over default and skips types', () => {
+    expect(resolveEsmOnlySubpath(exportsField, './auth')).toBe('./dist/auth/node.js');
+  });
+
+  it('returns null for unexported subpaths (incl. the root)', () => {
+    expect(resolveEsmOnlySubpath(exportsField, './nope')).toBeNull();
+    expect(resolveEsmOnlySubpath(exportsField, '.')).toBeNull();
+  });
+
+  it('handles string and bare-conditions exports for the root', () => {
+    expect(resolveEsmOnlySubpath('./index.js', '.')).toBe('./index.js');
+    expect(resolveEsmOnlySubpath({ import: './index.js' }, '.')).toBe('./index.js');
+    expect(resolveEsmOnlySubpath({ import: './index.js' }, './x')).toBeNull();
+  });
+
+  it('handles missing exports fields', () => {
+    expect(resolveEsmOnlySubpath(undefined, './app')).toBeNull();
+    expect(resolveEsmOnlySubpath(null, '.')).toBeNull();
+  });
+});

--- a/packages/pyric-tools/test/register/register-child.test.ts
+++ b/packages/pyric-tools/test/register/register-child.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Child-process integration for `pyric-tools/register`: real `node --import`
+ * runs against fixture scripts in a temp project whose node_modules symlinks
+ * the workspace's built pyric packages (plus the real firebase/firebase-admin
+ * for the inertness check). No browser, no server — resolution + activation
+ * gating only.
+ *
+ * Requires the packages to be BUILT (`bun run build`) — the child loads
+ * dist/register/index.js and the pyric mirrors' dist output.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const toolsRoot = resolve(import.meta.dir, '../..');
+const repoRoot = resolve(toolsRoot, '../..');
+const registerDist = join(toolsRoot, 'dist/register/index.js');
+const registerUrl = pathToFileURL(registerDist).href;
+
+/** The sync-hooks API needs Node ≥ 22.15; skip the CJS leg without it. */
+const hasRegisterHooks =
+  spawnSync('node', ['-p', "typeof require('node:module').registerHooks"], {
+    encoding: 'utf8',
+  }).stdout?.trim() === 'function';
+
+let fixtureDir: string;
+
+function runNode(
+  script: string,
+  env: Record<string, string | undefined>,
+): { status: number | null; stdout: string; stderr: string } {
+  const res = spawnSync('node', ['--import', registerUrl, script], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+    env: { ...process.env, NODE_ENV: undefined, PYRIC_SANDBOX: undefined, PYRIC_SANDBOX_FORCE: undefined, ...env },
+    timeout: 30_000,
+  });
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+beforeAll(() => {
+  if (!existsSync(registerDist)) {
+    throw new Error(`dist/register/index.js missing — run \`bun run build\` first (${registerDist})`);
+  }
+  // node --version guard: the suite itself needs a node on PATH.
+  execFileSync('node', ['--version']);
+
+  fixtureDir = mkdtempSync(join(tmpdir(), 'pyric-register-'));
+  const nm = join(fixtureDir, 'node_modules');
+  mkdirSync(nm);
+  // The pyric mirrors (workspace builds) + the real Firebase packages, so
+  // the fixture resolves BOTH the mapped and the unmapped specifiers.
+  symlinkSync(join(repoRoot, 'packages/pyric-admin'), join(nm, 'pyric-admin'));
+  symlinkSync(join(repoRoot, 'packages/pyric'), join(nm, 'pyric'));
+  symlinkSync(join(repoRoot, 'node_modules/firebase-admin'), join(nm, 'firebase-admin'));
+  symlinkSync(join(repoRoot, 'node_modules/firebase'), join(nm, 'firebase'));
+  writeFileSync(join(fixtureDir, 'package.json'), JSON.stringify({ name: 'register-fixture', type: 'commonjs' }));
+
+  // ESM fixture: env is set, firebase-admin/app IS pyric-admin (its
+  // ADMIN_APP_TARGET symbol is pyric-admin-only), and the factory global
+  // mints the lazy branded handle synchronously.
+  writeFileSync(
+    join(fixtureDir, 'main.mjs'),
+    `import assert from 'node:assert';
+assert.ok(process.env.PYRIC_SANDBOX, 'PYRIC_SANDBOX must be set in the child');
+const app = await import('firebase-admin/app');
+assert.strictEqual(app.ADMIN_APP_TARGET, Symbol.for('pyric.admin.app.target'), 'firebase-admin/app must be pyric-admin/app');
+const factory = globalThis[Symbol.for('pyric.remote.sandboxFactory')];
+assert.strictEqual(typeof factory, 'function', 'sandbox factory global must be installed');
+const handle = factory({ url: 'http://127.0.0.1:9' });
+assert.strictEqual(handle[Symbol.for('pyric.remote.sandbox')], true, 'factory must return the branded handle');
+assert.strictEqual(typeof handle.channel.op, 'function');
+assert.ok(handle.ready instanceof Promise, 'handle.ready must be a promise');
+handle.ready.catch(() => {});
+handle.close();
+console.log('ESM_OK');
+`,
+  );
+
+  // CJS fixture: require() interception (sync hooks + the ESM-only exports
+  // fallback → require(esm)).
+  writeFileSync(
+    join(fixtureDir, 'main.cjs'),
+    `const assert = require('node:assert');
+assert.ok(process.env.PYRIC_SANDBOX, 'PYRIC_SANDBOX must be set in the child');
+const app = require('firebase-admin/app');
+assert.strictEqual(app.ADMIN_APP_TARGET, Symbol.for('pyric.admin.app.target'), 'require(firebase-admin/app) must be pyric-admin/app');
+assert.strictEqual(typeof globalThis[Symbol.for('pyric.remote.sandboxFactory')], 'function');
+console.log('CJS_OK');
+`,
+  );
+
+  // Inertness probe: reports whether the rewrite happened + factory presence.
+  writeFileSync(
+    join(fixtureDir, 'probe.mjs'),
+    `const app = await import('firebase-admin/app');
+const factory = globalThis[Symbol.for('pyric.remote.sandboxFactory')];
+console.log(JSON.stringify({
+  rewritten: app.ADMIN_APP_TARGET === Symbol.for('pyric.admin.app.target'),
+  factory: typeof factory,
+}));
+`,
+  );
+});
+
+afterAll(() => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe('pyric-tools/register (child process)', () => {
+  it('rewrites ESM imports and installs the factory global when PYRIC_SANDBOX is set', () => {
+    const res = runNode('main.mjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
+    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stdout).toContain('ESM_OK');
+    expect(res.status).toBe(0);
+  });
+
+  it.skipIf(!hasRegisterHooks)('rewrites CJS require() via the sync hooks', () => {
+    const res = runNode('main.cjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
+    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stdout).toContain('CJS_OK');
+    expect(res.status).toBe(0);
+  });
+
+  it('is inert without PYRIC_SANDBOX — real firebase-admin, no factory, no log', () => {
+    const res = runNode('probe.mjs', {});
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual({ rewritten: false, factory: 'undefined' });
+    expect(res.stderr).not.toContain('pyric-tools/register');
+  });
+
+  it('refuses under NODE_ENV=production (logs, stays inert)', () => {
+    const res = runNode('probe.mjs', {
+      PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000',
+      NODE_ENV: 'production',
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('refusing to activate under NODE_ENV=production');
+    expect(JSON.parse(res.stdout)).toEqual({ rewritten: false, factory: 'undefined' });
+  });
+
+  it('PYRIC_SANDBOX_FORCE=1 overrides the production refusal', () => {
+    const res = runNode('probe.mjs', {
+      PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000',
+      NODE_ENV: 'production',
+      PYRIC_SANDBOX_FORCE: '1',
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(JSON.parse(res.stdout)).toEqual({ rewritten: true, factory: 'function' });
+  });
+});

--- a/packages/pyric-tools/test/register/register-child.test.ts
+++ b/packages/pyric-tools/test/register/register-child.test.ts
@@ -93,6 +93,25 @@ console.log('CJS_OK');
 `,
   );
 
+  // Mirror-exemption fixture (the merged-stack repro, scoped to this
+  // branch): a USER import of firebase-admin/database is rewritten to
+  // pyric-admin/database, whose OWN prod-arm import of
+  // firebase-admin/database (getDatabaseWithUrl et al.) must resolve to
+  // REAL firebase-admin — without the exemption that import self-rewrites
+  // and the load crashes with "does not provide an export named
+  // 'getDatabaseWithUrl'".
+  writeFileSync(
+    join(fixtureDir, 'prod-arm.mjs'),
+    `import assert from 'node:assert';
+const db = await import('firebase-admin/database');
+const direct = await import('pyric-admin/database');
+assert.strictEqual(db, direct, 'user import of firebase-admin/database must BE pyric-admin/database');
+assert.strictEqual(db.getDatabaseWithUrl, undefined, 'surface must be pyric-admin, not real firebase-admin');
+assert.strictEqual(typeof db.getDatabase, 'function');
+console.log('PROD_ARM_OK');
+`,
+  );
+
   // Inertness probe: reports whether the rewrite happened + factory presence.
   writeFileSync(
     join(fixtureDir, 'probe.mjs'),
@@ -115,6 +134,15 @@ describe('pyric-tools/register (child process)', () => {
     const res = runNode('main.mjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
     expect(res.stderr).toContain('pyric-tools/register: active');
     expect(res.stdout).toContain('ESM_OK');
+    expect(res.status).toBe(0);
+  });
+
+  it("rewrites user imports but EXEMPTS the mirrors' own prod-arm imports", () => {
+    const res = runNode('prod-arm.mjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
+    expect(res.stderr).toContain('pyric-tools/register: active');
+    // The success line is only reachable when pyric-admin/database loaded,
+    // i.e. its internal firebase-admin/database import stayed unrewritten.
+    expect(res.stdout).toContain('PROD_ARM_OK');
     expect(res.status).toBe(0);
   });
 

--- a/packages/pyric-tools/test/remote/lazy.test.ts
+++ b/packages/pyric-tools/test/remote/lazy.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `remoteSandbox()` — the lazy handle. Construction is synchronous and never
+ * touches the wire; the connect (injected via `createLazyRemoteSandbox`, the
+ * test seam) runs on the first op / `ready` access, fail-fast errors surface
+ * there, and a failed connect is retried by the next op.
+ */
+import { describe, it, expect } from 'bun:test';
+import { REMOTE_SANDBOX } from 'pyric/sandbox';
+import {
+  createLazyRemoteSandbox,
+  createRemoteSandboxHandle,
+  remoteSandbox,
+  type RemoteSandbox,
+  type RemoteSandboxChannel,
+} from '../../src/remote/index.js';
+import type { WorkerOpPayload } from '../../src/bridge/protocol.js';
+
+/** A fake inner handle over a recording channel. */
+function fakeInner(serveUrl = 'http://127.0.0.1:5000'): {
+  handle: RemoteSandbox;
+  ops: WorkerOpPayload[];
+  subs: Array<{ unsubscribed: boolean }>;
+  closed: () => boolean;
+} {
+  const ops: WorkerOpPayload[] = [];
+  const subs: Array<{ unsubscribed: boolean }> = [];
+  let closed = false;
+  const channel: RemoteSandboxChannel = {
+    op: (op) => {
+      ops.push(op);
+      return Promise.resolve({ ok: true, op: op.method });
+    },
+    subscribe: (_sub, _onSnap) => {
+      const record = { unsubscribed: false };
+      subs.push(record);
+      return () => {
+        record.unsubscribed = true;
+      };
+    },
+  };
+  const handle = createRemoteSandboxHandle({ channel, serveUrl, close: () => (closed = true) });
+  return { handle, ops, subs, closed: () => closed };
+}
+
+describe('createLazyRemoteSandbox', () => {
+  it('returns the branded handle synchronously without connecting', () => {
+    let connects = 0;
+    const lazy = createLazyRemoteSandbox(async () => {
+      connects += 1;
+      return fakeInner().handle;
+    });
+    expect(lazy[REMOTE_SANDBOX]).toBe(true);
+    expect(typeof lazy.channel.op).toBe('function');
+    expect(typeof lazy.rtdb.get).toBe('function');
+    expect(typeof lazy.auth.listUsers).toBe('function');
+    expect(connects).toBe(0);
+  });
+
+  it('connects once on the first op and reuses the connection', async () => {
+    let connects = 0;
+    const inner = fakeInner();
+    const lazy = createLazyRemoteSandbox(async () => {
+      connects += 1;
+      return inner.handle;
+    });
+    await lazy.rtdb.get('users/a');
+    await lazy.rtdb.set('users/b', { x: 1 });
+    expect(connects).toBe(1);
+    expect(inner.ops.map((o) => o.method)).toEqual(['rtdb.get', 'rtdb.set']);
+  });
+
+  it('surfaces the connect failure on the first op (not at construction)', async () => {
+    const lazy = createLazyRemoteSandbox(async () => {
+      throw Object.assign(new Error('no browser tab is connected to the sandbox — open http://x and retry.'), {
+        code: 'unavailable',
+      });
+    });
+    expect(lazy.channel.op({ method: 'getSnapshot' })).rejects.toThrow('no browser tab is connected');
+  });
+
+  it('retries the connect on the next op after a failure', async () => {
+    let connects = 0;
+    const inner = fakeInner();
+    const lazy = createLazyRemoteSandbox(async () => {
+      connects += 1;
+      if (connects === 1) throw new Error('serve not up yet');
+      return inner.handle;
+    });
+    await expect(lazy.channel.op({ method: 'getSnapshot' })).rejects.toThrow('serve not up yet');
+    await lazy.channel.op({ method: 'getSnapshot' });
+    expect(connects).toBe(2);
+    expect(inner.ops).toHaveLength(1);
+  });
+
+  it('ready connects eagerly and resolves / rejects with the connect outcome', async () => {
+    let connects = 0;
+    const lazy = createLazyRemoteSandbox(async () => {
+      connects += 1;
+      return fakeInner().handle;
+    });
+    await lazy.ready;
+    expect(connects).toBe(1);
+
+    const failing = createLazyRemoteSandbox(async () => {
+      throw new Error('no tab');
+    });
+    expect(failing.ready).rejects.toThrow('no tab');
+  });
+
+  it('subscribe before connect attaches after connect; unsubscribe works both sides', async () => {
+    const inner = fakeInner();
+    const lazy = createLazyRemoteSandbox(async () => inner.handle);
+
+    // Unsubscribe BEFORE the connect settles → never attaches.
+    const unsubEarly = lazy.channel.subscribe(
+      { target: { service: 'rtdb', path: 'a' }, actAs: { mode: 'admin' } },
+      () => {},
+    );
+    unsubEarly();
+    await lazy.ready;
+    expect(inner.subs).toHaveLength(0);
+
+    // Normal flow: attaches, then the returned unsubscribe reaches through.
+    const unsub = lazy.channel.subscribe(
+      { target: { service: 'rtdb', path: 'b' }, actAs: { mode: 'admin' } },
+      () => {},
+    );
+    await lazy.ready;
+    expect(inner.subs).toHaveLength(1);
+    unsub();
+    expect(inner.subs[0]!.unsubscribed).toBe(true);
+  });
+
+  it('routes a connect failure under a subscription to onError', async () => {
+    const lazy = createLazyRemoteSandbox(async () => {
+      throw Object.assign(new Error('no tab'), { code: 'unavailable' });
+    });
+    const err = await new Promise<Error & { code: string }>((resolve) => {
+      lazy.channel.subscribe(
+        { target: { service: 'rtdb', path: 'a' }, actAs: { mode: 'admin' } },
+        () => {},
+        resolve,
+      );
+    });
+    expect(err.code).toBe('unavailable');
+    expect(err.message).toContain('no tab');
+  });
+
+  it('close() closes an established inner connection and fails later ops', async () => {
+    const inner = fakeInner();
+    const lazy = createLazyRemoteSandbox(async () => inner.handle);
+    await lazy.ready;
+    lazy.close();
+    await Bun.sleep(0);
+    expect(inner.closed()).toBe(true);
+    expect(lazy.channel.op({ method: 'getSnapshot' })).rejects.toThrow('closed by the client');
+  });
+
+  it('adopts the discovered serveUrl once connected', async () => {
+    const lazy = createLazyRemoteSandbox(async () => fakeInner('http://127.0.0.1:5050').handle);
+    expect(lazy.serveUrl).toContain('pending discovery');
+    await lazy.ready;
+    expect(lazy.serveUrl).toBe('http://127.0.0.1:5050');
+  });
+});
+
+describe('remoteSandbox', () => {
+  it('is synchronous and fails fast on the first op when nothing is listening', async () => {
+    const lazy = remoteSandbox({ url: 'http://127.0.0.1:1' });
+    expect(lazy[REMOTE_SANDBOX]).toBe(true);
+    expect(lazy.serveUrl).toBe('http://127.0.0.1:1');
+    expect(lazy.channel.op({ method: 'getSnapshot' })).rejects.toThrow(/failed to connect|timed out/);
+  });
+});

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -53,8 +53,13 @@ export { SandboxContextImpl } from './sandbox-context.js';
 // lets `pyric-admin` recognize a Node-side handle onto the browser-hosted
 // worker sandbox (constructed by `pyric-tools`' `connectRemoteSandbox`)
 // and route its RTDB/Auth ops over the wire instead of into local state.
-export { REMOTE_SANDBOX, isRemoteSandbox } from './remote.js';
-export type { RemoteSandbox, RemoteSandboxChannel } from './remote.js';
+export { REMOTE_SANDBOX, REMOTE_SANDBOX_FACTORY, isRemoteSandbox } from './remote.js';
+export type {
+  RemoteSandbox,
+  RemoteSandboxChannel,
+  RemoteSandboxFactory,
+  RemoteSandboxFactoryOptions,
+} from './remote.js';
 
 // Replay engine — capture a session via `sandbox.history()` and re-
 // issue every write against a fresh sandbox. See

--- a/packages/pyric/src/sandbox/remote.ts
+++ b/packages/pyric/src/sandbox/remote.ts
@@ -86,6 +86,38 @@ export interface RemoteSandbox extends Sandbox {
 }
 
 /**
+ * Well-known global key under which `pyric-tools/register` installs the
+ * remote-sandbox factory: `globalThis[REMOTE_SANDBOX_FACTORY]`.
+ *
+ * This is the AMBIENT-INIT seam (adoption experience, layer 3): when
+ * `pyric-admin/app`'s bare `initializeApp()` sees `PYRIC_SANDBOX=remote[:url]`
+ * it reads this global and calls the installed {@link RemoteSandboxFactory}
+ * to obtain the branded handle — without importing `pyric-tools` (which is
+ * a devDependency of the app, not of `pyric-admin`). `Symbol.for` so the
+ * installer and the reader agree even across duplicated copies of `pyric`.
+ */
+export const REMOTE_SANDBOX_FACTORY = Symbol.for('pyric.remote.sandboxFactory');
+
+/** Options accepted by the ambient remote-sandbox factory. */
+export interface RemoteSandboxFactoryOptions {
+  /** Explicit `pyric dev` base URL (from `PYRIC_SANDBOX=remote:<url>`).
+   *  When omitted the factory discovers the running host itself (the
+   *  `.pyric/serve.json` locator protocol). */
+  url?: string;
+}
+
+/**
+ * The factory `pyric-tools/register` installs at
+ * `globalThis[`{@link REMOTE_SANDBOX_FACTORY}`]`. SYNCHRONOUS by contract:
+ * `initializeApp()` is sync in firebase-admin, so the factory must return
+ * the branded handle without awaiting (connection establishment may be
+ * lazy inside the handle's channel).
+ */
+export type RemoteSandboxFactory = (
+  opts?: RemoteSandboxFactoryOptions,
+) => RemoteSandbox;
+
+/**
  * Is this sandbox a remote handle? Backend dispatch guard for consumers
  * (e.g. `pyric-admin`'s RTDB/Auth sandbox backends) that must route a
  * remote sandbox's operations through {@link RemoteSandbox.channel} rather


### PR DESCRIPTION
Stacked on #26. The publish-gating adoption stack: a user's server code contains ZERO pyric identifiers — the bridge stays inside the box.

```bash
pyric dev        # runs your package.json dev script with the sandbox wired in
```
```js
// your server — unchanged firebase-admin code
import { initializeApp } from 'firebase-admin/app';
import { getDatabase } from 'firebase-admin/database';
initializeApp();
const db = getDatabase();
```

Four layers, each composable without the one above:

- **Default-app registry** (`pyric-admin/app`, mirror conformance): `initializeApp(config?, name?)` with `'[DEFAULT]'`, `getApp`/`getApps`/`deleteApp`, error codes/messages mirroring `firebase-admin` lifecycle word-for-word; no-arg `getDatabase()`/`getAuth()` on all three arms. Deliberate divergences documented in-code (Sandbox reference identity for duplicate detection; `PyricAdminAppError` class; `getAuth(undefined)` now throws `app/no-app` instead of a TypeError — one test updated).
- **Ambient init**: bare `initializeApp()` + `PYRIC_SANDBOX=remote[:url]` → lazy remote handle via the factory global (`Symbol.for('pyric.remote.sandboxFactory')`, declared with types in `pyric/sandbox`); one stderr activation line; missing-factory error names both remediations; production guard unless `PYRIC_SANDBOX_FORCE=1`; unrecognized activator values throw rather than silently falling through to prod.
- **`pyric-tools/register`** (new `./register` export, node-only): module hooks mapping `firebase-admin/*`→`pyric-admin/*`, `firebase/*`→`pyric/*`. `module.registerHooks` (CJS + ESM) with `module.register` ESM-only fallback + warning below 22.15 — **pyric-tools engines raised to `>=22.15`**. Inert without the env; production refusal. Two hard-won edges: CJS `require()` into ESM-only mirror exports (findPackageJSON + exports-walker fallback), and the **mirror self-rewrite exemption** — requesting modules owned by `pyric`/`pyric-admin`/`pyric-tools` are never rewritten (owning package NAME identity, not path substrings), found by cross-stream integration smoke: without it, pyric-admin's own prod-arm `firebase-admin/database` import rewrote into a self-import and crashed the load.
- **Runner in `pyric dev`**: child = `-- <cmd>` > package.json `dev` script (lockfile-sniffed pm, self-recursion guarded) > host-only; `--no-run`; `--json` defaults host-only. Injects `PYRIC_SANDBOX=remote:<url>` + `NODE_OPTIONS` (appended) `--import <import.meta.resolve('pyric-tools/register')>`; `[dev]`-prefixed output; signals forwarded; exit code propagated.
- **`remoteSandbox()`**: sync lazy variant of `connectRemoteSandbox()` (connect on first op, `.ready` for eager checks, failures retry rather than latch).

Verified: cross-stream integration smoke (unchanged firebase-admin code under `node --import pyric-tools/register` → activation log → lazy handle → correct "no running pyric dev" guidance); pyric-admin 499/0; pyric 4334/0; pyric-tools 1139/0 (48 new tests incl. ESM+CJS child-process integrations); root test script green; `lint:manifest` PASS with the new export.

Review notes: the engines bump to 22.15 is a published constraint worth ratifying; the factory-global seam keeps pyric-admin free of any pyric-tools dependency.