### PR TITLE
Default the dev server port to 3473

### DIFF
--- a/docs/design/PRINCIPLES.md
+++ b/docs/design/PRINCIPLES.md
@@ -1,0 +1,105 @@
+# Studio Design Principles
+
+Normative rules for all Studio UI. Every rule has an ID so specs, reviews,
+and lint findings can cite it. MUST rules are checkable and enforced; SHOULD
+rules require written justification in the view spec to break.
+
+## Model (M)
+
+Derived from the assists post-mortem (`TOOL-SYSTEM.md` failure ledger).
+These outrank everything below: a view that satisfies L/C/N but violates M
+is still wrong.
+
+- **M1** The system is mechanical tools producing typed results (one
+  registry). Every view is either a dedicated home for a dataset/workbench
+  or a dynamic layout of result renderers. A feature that can't be named as
+  tool + result + surface doesn't ship.
+- **M2** No ambient or global modes. Identity, policy, and other
+  cross-cutting parameters are explicit inputs of the specific operation
+  that needs them, set where used and shown where set.
+- **M3** Data views are always admin. "What can user X see/do" is a
+  filter/query or a simulation — never a viewing mode.
+- **M4** One concern per surface. Settings, prompts, and results never
+  share a control surface; a command input's results contain actions and
+  routes, never configuration.
+- **M5** Every result type has exactly one renderer, shared by mechanical
+  and AI paths. AI adds narration around renderers, never replacement UI —
+  so every AI feature's mechanical fallback is automatic.
+- **M6** Rendered results are actionable or silent: a result offers derived
+  next actions (at most one primary) or presents nothing interactive. No
+  heaps of standing controls; controls exist only as parameters of the
+  stage they belong to.
+- **M7** Governance applies only to agent-initiated mutations and surfaces
+  at the moment it fires (on the staged item or blocked call), never as a
+  standing mode indicator.
+- **M8** Tool exposure is a per-caller decision (MCP, in-browser agent,
+  mechanical UI) recorded in the exposure matrix (`TOOL-SYSTEM.md`). A tool
+  absent from a caller without a recorded reason is a defect, not a
+  default.
+- **M9** No surface is grandfathered. "Already built" is not a tier;
+  every existing tab re-enters through a spec and must prove its worth
+  against C1–C4 or be reworked/retired.
+
+## Layout (L)
+
+- **L1** Foundation layouts MUST use modern intrinsic CSS: grid/flex with
+  `auto-fit`/`auto-fill`, `minmax()`, `fit-content`, `min()`/`max()`/`clamp()`.
+  Layouts adapt by intrinsic sizing first; media/container queries are a
+  refinement, not the mechanism.
+- **L2** Spacing between siblings MUST come from `gap` (or grid track
+  definitions). `margin` MUST NOT be used to nudge position between siblings.
+  `padding` is for a container's internal breathing room only.
+- **L3** Components MUST NOT style their own external geometry: no outer
+  margins, no self-imposed widths on the root. The root fills its container;
+  the parent decides placement and sizing.
+- **L4** Component-local layouts MUST be container-agnostic: they organize
+  their own content with their own grid/flex and adapt to available width
+  intrinsically (or via container queries), never by knowing where they are
+  mounted.
+- **L5** One scroll owner per region. Content wider than its region scrolls
+  inside its own container; the foundation never scrolls horizontally.
+- **L6** Unbounded collections (event logs, document lists, user lists)
+  MUST render through virtualization. A view never mounts an unbounded DOM
+  list.
+
+## Content (C)
+
+- **C1** Every view and every component MUST have a written content inventory
+  classifying each content item as **primary**, **secondary**, or
+  **tertiary** (see `specs/TEMPLATE.md`).
+- **C2** The default render shows primary and secondary content only.
+- **C3** Tertiary content is reached through interactive disclosure, in order
+  of preference: drill-in (route change), detail pane, popover, expandable
+  row. A modal is a last resort and MUST carry a written justification in the
+  spec.
+- **C4** A view has exactly one visible primary action. Additional actions
+  are secondary (visible but subordinate) or tertiary (disclosed).
+- **C5** Empty, loading, dense, and narrow states MUST be specified. Empty
+  states teach the primary action; they are onboarding, not apology.
+
+## Navigation (N)
+
+- **N1** One header bar. No stacked or secondary bars, ever.
+- **N2** The bar contains only load-bearing, always-relevant items:
+  navigation and global status. Contextual actions and controls live in the
+  surface they act on, never in the bar.
+- **N3** The bar is sacred space: nothing enters it without an amendment to
+  `specs/shell.md`. Default answer is no.
+- **N4** Every navigable state has a clean History-API URL (no hash
+  routing). Views, selections, and disclosed drill-ins that a user would
+  share or reload into MUST be addressable.
+
+## Process (P)
+
+- **P1** Spec before implementation: a view's spec (`docs/design/specs/`) is
+  written and agreed before its UI is built or reworked.
+- **P2** No parallel mock artifacts. Design iteration happens in the real app
+  (dev-seed build), behind a dev flag when exploratory. Promotion is removing
+  the flag, not porting a mock.
+- **P3** Reality wins, then the spec catches up: any PR that changes a view
+  MUST update its spec or state why no update is needed.
+- **P4** Ideas from the removed assists layer re-enter only through the
+  `TOOL-SYSTEM.md` failure ledger's stated door and a new spec. Assist-era
+  forms, names, and concepts-as-framed (assist, lens, dial, proposals
+  queue) are not starting points; treat their UI as harmful until
+  re-derived from the tool model.

--- a/docs/design/TOOL-SYSTEM.md
+++ b/docs/design/TOOL-SYSTEM.md
@@ -1,0 +1,211 @@
+# The Tool System: Studio's Mental Model
+
+Status: draft. This is the root document of the redesign — views, AI
+features, and specs all derive from this model. If a proposed feature can't
+be expressed in this model, the feature (or the model) is wrong, and that
+gets resolved before any UI is designed.
+
+## Why this document exists
+
+The "assist" layer was UI-first design: AI features each got a bespoke
+surface (palette, proposals queue, lens toggle, permission dial, sessions
+digest, denial inspector) with no underlying system model. Each surface
+invented its own relationship to data, identity, and action, so they were
+individually confusing and collectively incoherent. The corrective is
+model-first design: the system is **mechanical tools producing typed
+results**, and all UI — dedicated views, search results, AI output — is
+layout over those results. AI is a *caller* of the system, never a concept
+in it.
+
+## Failure ledger (assists post-mortem)
+
+Binding design input. Each row: the idea worth keeping, why the form
+failed, and the only door through which the idea may re-enter.
+
+| Assist-era feature | The good idea | Why the form failed | Where the idea re-enters |
+|---|---|---|---|
+| ⌘K palette | An NL/keyboard entry point to actions | Mixed settings and prompts in one list; no model of what it operated on | A command input that only routes and stages tool runs; settings are reachable only as navigation to Settings, never inline results (M4) |
+| Admin/app lens | "What does a user experience?" | A *global viewing mode*. Wrong model: a data viewer is not an authenticated user — a data viewer is always admin | Data views are always admin (M3). "What can user X see" is a filter/query or a simulation sweep. Impersonation exists only as an explicit parameter of the specific operation that needs it (simulate, preview), visible at the point of use (M2) |
+| Proposals / Review UI | Staged, reviewable agent writes | A disconnected queue of diffs with no source context; "made no sense" | A staged change is a typed result (`StagedChange`) rendered *where the data lives* (pending marker on the doc/row) with the queue as a secondary index into those, not the primary residence |
+| Sessions UI | Visibility into activity over time | A mishmash of data that was rarely actionable | Activity renders as provenance-stamped events, each carrying at most one derived action; anything non-actionable is disclosure-only (M6) |
+| Permission dial | Governance over agent writes | Ambient mode with no visible moment of application; incomprehensible next to the lens | Policy applies only to agent-initiated mutations and surfaces exactly where it fires — on the staged item / blocked call — never as a standing mode indicator (M7) |
+| Denial inspector | Denial debugging is the killer feature | A heap of controls piled on each other; no sequence | Denial debugging is a *pipeline* of tool results (below): each stage renders a result and derives the next action; controls appear only as parameters of the stage they belong to |
+
+## The model
+
+Three kinds of things:
+
+1. **Tools.** Deterministic operations with typed inputs and one typed
+   result. One registry (converging on `pyric-tools/registry`), four
+   callers: mechanical forms, composition flows, external agents over MCP,
+   and the in-browser agent. A caller never gets a capability the registry
+   doesn't define.
+2. **Results.** Typed values. **Every result type has exactly one
+   renderer** — a container-agnostic component with the shape: subject
+   header, result body, derived actions (at most one primary). Mechanical
+   and AI invocations of the same tool render identically; AI adds only
+   narration around renderers, never replacement UI (M5).
+3. **Surfaces.** Two layout kinds:
+   - **Dedicated views** — standing homes for a dataset or workbench
+     (Firestore browser, Rules workbench, Traffic). Their specs live in
+     `specs/`.
+   - **Dynamic layouts** — runtime compositions of result renderers,
+     produced by a search, a multi-step mechanical flow, or an AI turn: a
+     gap-spaced stack of renderers, each collapsible, tertiary detail
+     disclosed per C3. An agent turn is *not special*: it is a sequence of
+     tool results rendered by the same renderers, interleaved with prose.
+
+**The with/without-AI symmetry, stated once:** mechanical path = user fills
+a form → tool → renderer. AI path = model chooses tools and arguments →
+same tools → same renderers. Therefore AI can never have UI that mechanical
+use lacks, and every AI feature's fallback is automatic: expose the form.
+
+**Identity in the model:** there is no viewing identity. Data surfaces are
+admin, always. Identity appears only as a *parameter chip* on operations
+that take one (simulate as `alice`, preview as `alice`, coverage sweep over
+[anon, alice, bob]) — set where used, shown where set.
+
+## Tool inventory (initial)
+
+| Tool | Input | Result type | Surfaces |
+|---|---|---|---|
+| `simulate_write` | op, path, data, identity | `Verdict` (allow/deny + trace) | Rules workbench form; denial pipeline; audit sweep |
+| rules lint / validate | ruleset | `Findings` | Rules editor, inline |
+| `try_rules_edit` (traffic replay) | edited ruleset + captured events | `RegressionTable` (op × old × new verdict) | Rules workbench |
+| `inspect_denial` | event ref | `DenialDetail` (op, identity, rule trace) | Traffic drill-in → denial pipeline |
+| `discover_paths` | sandbox | `PathTree` | Structure view; seeds audit sweep |
+| `extract_indexes` | rules + observed queries | `IndexSet` (diffed vs repo file) | Rules workbench; repo write-back |
+| seed data / seed users | seed spec | `SeedReport` / `SeedProposal` | Seed builder (form); AI proposal renders the same proposal type |
+| fixture from session | session capture | `Fixture` (repo file) | Traffic/Home derived action |
+| snapshot / branch / export | — | `StateRef` | Settings |
+| staged mutation | write set | `StagedChange` (diff) | Inline pending markers + Review index |
+| visibility query | path/query + identity set | `AccessReport` | Data-view filter; audit sweep |
+| audit sweep (composed) | `PathTree` × ops × identities | `CoverageMatrix` | Audit view; AI narrates the same matrix |
+
+## Composition
+
+Tools compose when one's result type is another's input. Canonical chains —
+these are the product, with or without AI:
+
+- **Denial pipeline:** `TrafficEvent(denied)` → `DenialDetail` →
+  `Verdict` (re-simulate, parameters editable) → edit rules →
+  `RegressionTable` (replay all captured traffic) → deploy to sandbox /
+  save to repo.
+- **Modeling loop:** `PathTree` → `SeedProposal` → `SeedReport` →
+  `CoverageMatrix` → `IndexSet` → repo write-back.
+- **Audit:** `discover_paths` × identity set × ops → `simulate_write` sweep
+  → `CoverageMatrix`.
+
+An AI "skill" is a named composition plus narration. A mechanical "flow" is
+the same composition driven by forms. Both render the same chain of
+results, which is why the website demo and the keyless dev experience are
+the same product.
+
+## Session identity and provenance
+
+One idea from the assists era survives on its merits: **naming the sandbox
+session so it is identifiable across tools.** The running sandbox session
+gets a stable id plus a human-readable name, and that identity is stamped
+everywhere work is recorded: every `TrafficEvent`, fixture, capture file,
+branch, audit-log line, and MCP tool response tag (`_pyric:{...}`). Home's
+status strip shows it; `pyric verify` reports cite it; "captured from
+session <name>" makes fixtures and replays traceable. Provenance on an
+event is therefore two facts, both mechanical: *which session* and *which
+caller* (app, Studio, in-browser agent, MCP client name) — never a mode.
+
+**Engineering requirement — addressable events.** Every `TrafficEvent`
+needs a stable id that survives the worker feed, so events are deep-linkable
+(`/traffic/<eventId>`) and cross-linkable: an event links to its *subject*
+(the Firestore/RTDB/Storage path or Auth user it touched) and to its
+*consequence* (a denial links into the denial pipeline; a write links to
+the record it produced). An event that can't be linked can't be composed.
+
+## Traffic is a projection, not the substrate
+
+The sandbox thinks in **events**; users think in **traffic**. Traffic is
+the user-facing projection of the unified event stream — the actionable
+subset, service-tagged. There is deliberately **no raw events view**: an
+events UI would be an internals debugger nobody asked for, and every
+legitimate use ("what touched this path," "why was this denied") is a
+traffic question. The event stream remains the substrate (it is what the
+worker fans out and what renderers subscribe to), and if an internals view
+is ever needed it is a disclosure inside Traffic, not a surface.
+
+Traffic is **multi-service by design**: Firestore and RTDB emit traffic
+today; Auth and Storage must join. Service is therefore a first-class
+dimension of the `TrafficEvent` result type (a tag on the row, a filter on
+the view) — never a reason for parallel per-service traffic surfaces or
+per-service traffic tools.
+
+## Tool API design (T rules)
+
+The current tool inventory was grown by a mixture of behavior-first design
+(preferred) and mechanical granularity (often necessary, never preferred).
+Models pay a real tax per tool for discovery and composition; models are
+simultaneously getting better at richer parameter APIs, and tools can
+validate input and return corrective errors. That shifts the design toward
+**fewer, behavior-named tools with well-typed parameters**. Pre-npm is the
+moment: renames are free today and get progressively more expensive.
+
+- **T1** Consolidate by behavior (the verb), discriminate by parameter.
+  When two tools do the same behavior over different services and share a
+  result type, they are one tool with a `service` parameter
+  (`inspect_traffic`, not `firestore_*` + `rtdb_*` twins). Split only when
+  parameters stop sharing meaning — a discriminated union that degenerates
+  into per-service conditional mazes is the signal to split (e.g.
+  Firestore structured queries vs RTDB tree reads may earn separate tools;
+  path-level read/write may not).
+- **T2** The MCP surface is a curated façade, not a dump of the internal
+  registry. Granular tools may live on as programmatic APIs; what a model
+  sees is the consolidated set. Target roughly a dozen tools; every
+  addition must justify itself against consolidation first.
+- **T3** Tools validate input and return corrective, teachable errors
+  (what was wrong, what valid looks like). This is what makes richer
+  parameter APIs safe for models and forms alike.
+- **T4** Result types are service-tagged, never service-named, wherever
+  semantics are shared (`TrafficEvent{service}`, not
+  `FirestoreTrafficEvent`).
+
+### Candidate consolidated MCP façade (to be finalized early-alpha)
+
+`inspect_traffic` (cross-service query; `eventId` returns full detail incl.
+rules trace — absorbing `firestore_simulator_events`, playground
+inspect-traffic/denial), `simulate_access` ({service, op, path, data,
+identity} — absorbing `firestore_simulate_rules` + `rtdb_simulate_access`),
+`lint_rules`/`validate_rules` (service param), `replay_traffic`
+(try_rules_edit), `discover_structure` (absorbing discovery +
+`rtdb_crawl_structure`), `extract_indexes`, `seed_data`, `seed_users`,
+`save_fixture`, `sandbox_inspect`, data read/write/query (per-service split
+is the open T1 judgment call), deploy gates.
+
+## Exposure matrix (per M8)
+
+Every tool declares, per caller, exposed-or-not **with a reason**. Current
+known state — `gap` rows are defects to fix, `deliberate` rows are design:
+
+| Tool | MCP | In-browser agent | Mechanical UI | Status / reason |
+|---|---|---|---|---|
+| `inspect_firestore_traffic` | ✗ → ✓ | ✓ | Traffic view | **gap** — an external agent debugging rules needs the same visibility the playground agent has |
+| `inspect_denial` | ✗ → ✓ | ✓ | denial pipeline | **gap** — the killer feature must be reachable from Claude Code |
+| `simulate_firestore_write` | ✓ (bridge rules tools) | ✓ | simulator form | ok; verify arg parity between the two implementations |
+| `try_rules_edit` (replay) | ✗ → ✓ | ✓ | regression table | **gap** — rules iteration from an external agent is a core story |
+| `discover_paths` / `firestore_discover` | partial | ✓ | structure view | audit needed |
+| seed data / seed users | partial (data tools exist; bulk seed unclear) | ✓ | seed builder | audit needed |
+| `generate_fixture_from_session` | ✗ → ✓ | ✓ | derived action | **gap** — pairs with `pyric verify`, an external-agent workflow |
+| workspace file tools (read/write/edit) | ✗ | ✓ | editors | **deliberate** — external agents have their own filesystem; exposing a second one invites split-brain |
+| checkpoints / `workspace_git` / GitHub tools | ✗ | ✓ | Prototype | **deliberate** — session-workspace concerns; external agents use real git |
+| `bash` (VFS shell) | ✗ | ✓ | terminal | **deliberate** — same reason as file tools |
+
+First action: a **parity audit** that diffs the three registries
+(playground `src/lib/tools/`, bridge `tool-metadata.ts`,
+`pyric-tools/registry`) and emits this matrix mechanically, so drift is
+detected rather than remembered.
+
+## What this document governs
+
+- No feature ships without naming its tool(s), result type(s), and
+  surface kind.
+- New result type ⇒ new renderer spec (a `specs/` entry or an addition to a
+  workbench spec).
+- The registry convergence work (redesign doc, Phase 3) is what makes this
+  model physically true rather than aspirational.

--- a/docs/design/WORKFLOW.md
+++ b/docs/design/WORKFLOW.md
@@ -1,0 +1,83 @@
+# Studio Design Workflow
+
+How a view goes from idea to shipped UI without vibe-designing and without
+mock drift.
+
+## Why static mocks failed, and the replacement
+
+Static mocks are a parallel artifact: separate files, separate CSS, no
+tokens, no components. When implementation starts, the agent re-derives the
+UI from the prompt, not the mock, and the two diverge. The fix is to remove
+the parallel artifact entirely:
+
+1. **The spec (prose + grid sketches) is the design artifact.** It travels
+   in the repo, is reviewable as a diff, and is written in terms the
+   implementation must literally satisfy (content tiers, disclosure
+   mechanisms, grid contracts, URL states).
+2. **The canvas is the real app.** Studio's dev-seed build (`vite dev` with
+   `DevSeedProvider`) runs serverless with seeded data — that is where
+   layout exploration happens, using real tokens and real `@pyric/ui`
+   components, behind a dev flag when the work is exploratory. There is
+   never a "port from mock" step.
+3. **Conformance is checked mechanically**, not by trusting the agent's
+   self-report.
+
+## The loop, per view
+
+### 1. Spec (prose)
+
+Write or amend `docs/design/specs/<view>.md` from the template. The content
+inventory and the foundation grid sketch are the negotiation surface —
+agreement happens here, cheaply, before code.
+
+### 2. Build in the real app
+
+Implement against the dev-seed build. Exploratory variants live behind a dev
+flag route in the real app (P2). Agents doing this work load the
+design-principles skill (below) so L/C/N rules ride in their context.
+
+### 3. Verify (three mechanical passes)
+
+- **Design lint (static).** A script (`scripts/design-lint.mjs`, to be
+  built) over feature CSS and component source:
+  - flag `margin-*` used between siblings in layout CSS (L2) — allowlist for
+    genuine exceptions, each pointing at a spec justification;
+  - flag fixed pixel widths/heights outside the token sheet (L1);
+  - flag component root styles setting width/margin (L3);
+  - flag more than one element matching the header-bar contract (N1).
+- **Spec conformance review (agent).** A reviewer agent gets the spec + the
+  rendered DOM/screenshots and checks every inventory row: each
+  primary/secondary item visible in the default render; each tertiary item
+  absent from default render and reachable via its declared disclosure; the
+  primary action singular; each URL state loads. Output is a per-row
+  pass/fail table citing rule IDs — not an impression.
+- **Screenshot matrix (visual).** Playwright drives the dev-seed build at
+  three widths × the spec'd states (empty / dense / disclosed) and attaches
+  the grid of shots to the PR. Review compares shots against the spec's
+  states section — against intent, not pixels.
+
+### 4. Reconcile
+
+Where reality beat the spec, update the spec in the same PR (P3). A view
+change without a spec touch needs an explicit "no spec change because…"
+line in the PR description.
+
+## Making agents obey it
+
+- **A repo skill** (e.g. `.claude/skills/studio-design/`) that loads
+  `PRINCIPLES.md`, the spec template, and the lint/verify commands whenever
+  UI work starts. This is the direct fix for "the agent ignored the mocks":
+  the constraints are in-context at build time and machine-checked after.
+- **CLAUDE.md pointer** so any session touching `packages/studio` knows the
+  specs directory is normative.
+- The conformance review can run as a `/code-review`-style pass over UI PRs.
+
+## Order of first specs
+
+1. `shell.md` — the header and navigation (sacred space first; everything
+   else composes inside it).
+2. `home.md` — the hub.
+3. `rules.md` — the rules workbench (largest new mechanical surface).
+4. Data tabs (`firestore.md`, `auth.md`, …) — mostly codifying what exists,
+   then trimming to tier rules.
+5. `prototype.md` — the embedded prototyping surface and its seam.

--- a/docs/design/adoption-experience.md
+++ b/docs/design/adoption-experience.md
@@ -1,0 +1,95 @@
+# The Adoption Experience: Mirror and Disappear
+
+Status: draft, agreed direction (2026-07-08). Governs the server-side
+adoption story; companion to `remote-sandbox.md`.
+
+## The thesis
+
+Pyric mirrors Firebase and disappears in prod. Therefore **pyric
+identifiers in application code are a defect** — the `connectFirestoreEmulator()`
+trap. App code imports Firebase names; the *environment* decides what they
+resolve to. There is one substitution seam per runtime:
+
+| Runtime | Seam | Status |
+|---|---|---|
+| Browser, unbundled | `pyric serve` injected import map (`firebase/app` → `/__pyric/sdk/app.js`) | shipped |
+| Browser, bundled | Vite plugin aliasing | shipped |
+| Node (server) | module-customization hooks (`--import pyric-tools/register`) mapping `firebase-admin/*` → `pyric-admin/*`, `firebase/*` → `pyric/*` | to build |
+
+## Activator vs locator (decided)
+
+- **Activator**: an env signal (`PYRIC_SANDBOX=remote[:url]`) injected by
+  pyric tooling at invocation — never file presence, never app code.
+  The loader is inert without it; refuses under `NODE_ENV=production`
+  unless forced; logs one line on activation.
+- **Locator**: `.pyric/serve.json` discovery with health + instanceId
+  pinning (the existing mcp-proxy/connectRemoteSandbox protocol).
+
+Rationale: file-presence activation is ambient mode-by-side-effect
+(cwd-dependent, stale-file-prone, silent in both failure directions) —
+the Node twin of the outlawed M2 pattern. The invocation is the point of
+use; that's where the explicit parameter lives (the user's `dev` script).
+
+## One command, not two (decided)
+
+`serve` vs `dev` would split along frontend vs backend — incoherent for
+fullstack users, since `serve` already IS the dev command for frontends
+(it hosts the user's app with import-map substitution). One behavior,
+"stand up my dev world," with an optional child process = one command:
+
+- `pyric dev` — host + frontend + Studio/bridge; runs the package.json
+  `dev` script if present (env + loader injected, output prefixed), else
+  host-only; opens and monitors the sandbox tab.
+- `pyric dev -- <cmd>` — explicit child override.
+- `pyric dev --no-run --no-open` — exactly today's serve (composition
+  path for own-process-manager users).
+- `pyric dev --json` — machine mode for agents (today's `serve --json`).
+
+All current serve flags (`--persist`, `--seed`, `--fresh`, `--capture`)
+carry over — they belong to the host, which is unchanged. `serve` becomes
+a hidden alias through alpha, then retires; `.pyric/serve.json` keeps its
+name (it describes the host); pyric-plugin skill + agent docs migrate to
+`dev` immediately (they're ours). Getting-started only ever says
+`pyric dev`.
+
+## The layer model
+
+Defaults on top, composability all the way down; every layer is sugar over
+the one below, nothing reachable only through magic:
+
+1. `pyric dev` — the single front door (above).
+2. `pyric-tools/register` — the hooks alone, for users with their own
+   process manager.
+3. Ambient init — bare `initializeApp()` + env → lazy remote handle (for
+   manifest-alias users: `"firebase-admin": "npm:pyric-admin"`).
+4. `initializeApp({ sandbox })` + `connectRemoteSandbox()` — explicit
+   composition for tests/tools (legitimately pyric-aware code).
+5. Raw `RemoteSandboxChannel` — transport internals.
+
+## Target experience
+
+```bash
+npm i -D pyric-tools pyric-admin pyric
+pyric dev
+```
+
+Zero app-code changes. Prod = not running under pyric; nothing to revert.
+
+## Work items (post slice-1, alpha window)
+
+1. Default-app registry in pyric-admin (mirror conformance: bare
+   `initializeApp()`, no-arg `getDatabase()`/`getAuth()`, firebase-admin
+   duplicate-app error shapes) — S.
+2. Ambient init (env resolution in bare `initializeApp()`, lazy handle,
+   activation log, prod guard) — S, on checkpoint-2 machinery.
+3. `pyric-tools/register` module hooks — M. Edge: CJS `require()`
+   interception needs `module.registerHooks` (Node 22.15+) or
+   require-patching; ESM is clean via `module.register`. **Ask the first
+   user: ESM or CJS?** — decides whether this edge is first or later.
+4. `pyric dev` runner — M. Becomes the single front door and the single
+   activation concept for both env and loader.
+5. Adoption docs collapse to the two commands above.
+
+Sequence 1→2 first (completes the first user's ambient story with a
+manifest alias), then 3→4 (the full disappearing act). None of it gates
+the slice-1 publish.

--- a/docs/design/remote-sandbox.md
+++ b/docs/design/remote-sandbox.md
@@ -1,0 +1,411 @@
+# Remote Sandbox for `pyric-admin` (Gate B0 design spike)
+
+Status: spike complete — analysis + phased plan, no implementation.
+Scope: server-side `pyric-admin` (and, later, the Node client SDK)
+reaching the browser-hosted SharedWorker sandbox over the existing
+bridge transport. First slice: RTDB + Auth.
+
+## Feasibility verdict
+
+**Feasible, with one design correction.** The transport and worker
+protocol are largely already built: the worker protocol has every RTDB
+op the admin surface needs (`rtdb.get/set/update/remove/push`), an RTDB
+value subscription, and the full set of admin auth user-CRUD ops
+(`auth.listUsers` / `auth.adminCreateUser` / `auth.adminUpdateUser` /
+`auth.adminDeleteUser`), and the WS bridge already relays request/
+response frames server→browser→worker with correlation ids and
+last-connection-wins peer semantics. The missing piece is a generic
+op/subscription relay frame (today only `tool-call` crosses the WS) and
+the Node-side `connectRemoteSandbox()`.
+
+**The correction:** the assumed design — "`pyric-admin`'s entire seam
+is the `Sandbox` handle passed to `initializeApp({ sandbox })`, so a
+remote `Sandbox` plugs in with zero `pyric-admin` changes" — is **false
+for the RTDB and Auth sandbox backends as written**. Both keep their
+data in **process-local in-memory state keyed off the `Sandbox` object
+identity via a `WeakMap`**, consuming almost nothing from the `Sandbox`
+surface itself:
+
+- RTDB: `stateBySandbox = new WeakMap<Sandbox, SandboxState>()`
+  (`packages/pyric-admin/src/database/index.ts:171`); all ref ops read/
+  write a local JSON tree (`readPath`/`writePath`, lines 292–354). The
+  only `Sandbox` member consumed is `sandbox.onEvent` — to wipe the
+  tree on `session_boundary` (lines 183–187).
+- Auth: `sandboxStores = new WeakMap<Sandbox, AuthStore>()`
+  (`packages/pyric-admin/src/auth/index.ts:142`); user records live in a
+  local `Map<uid, UserRecord>` (line 112). Again only `sandbox.onEvent`
+  is consumed (lines 167–174). Tokens are stateless strings
+  (`SANDBOX_TOKEN_PREFIX`, line 194).
+
+A perfect remote `Sandbox` handle passed unchanged would therefore give
+the Node process a **private** RTDB tree and a **private** user table
+that never reach the browser worker — the first user's server-side
+writes would be invisible in Studio and in their app, which defeats the
+gate. (Note also: the spike brief said `pyric-admin/database` "delegates
+to pyric's own `adminGetDatabase`/`getDatabaseWithUrl` over the
+sandbox" — those imports are **firebase-admin's**, used only on the
+prod path; see `packages/pyric-admin/src/database/index.ts:63–67` and
+`126–129`.)
+
+So the design is: `connectRemoteSandbox()` (Node, pyric-tools) returns
+a **branded remote handle** that satisfies the subset of `Sandbox` that
+`pyric-admin` consumes and carries an internal **op channel** speaking
+the existing worker protocol over the bridge WS. `pyric-admin`'s
+`database` and `auth` sandbox backends gain a second dispatch arm: when
+the app's sandbox carries the remote brand, ref/auth methods route
+through the channel (worker ops) instead of the local WeakMap state.
+`initializeApp({ sandbox })` and all user-facing signatures stay
+unchanged — the change is internal to the two backend files, and we are
+pre-npm, so this is cheap now and expensive later.
+
+A pleasant side effect: routing admin ops through the worker makes
+server-side writes emit real `SandboxEvent`s into the unified stream
+(the worker's RTDB backend emits `operation`/`commit`/
+`service_mutation` events — `packages/pyric/src/database/sandbox/backend.ts`
+imports `emitSandboxEvent` and friends), so agent/Studio provenance
+sees server activity "for free". This is a deliberate behavior change
+from the current silent local tree, and the right one.
+
+## 1. The `Sandbox` surface, and what `pyric-admin` actually needs
+
+`Sandbox` is defined in `packages/pyric/src/sandbox/types.ts:954–1205`
+(exported via `pyric/sandbox`). Full member classification:
+
+| Member | Sync/async | Remotable as RPC? |
+|---|---|---|
+| `withAuth(auth): SandboxContext` | sync | yes — pure local pair construction (`SandboxContext` is `(sandbox, auth)`, types.ts:1218) |
+| `onEvent(cb): () => void` | sync subscribe, async delivery | yes — subscribe locally, feed from a WS event-stream sub |
+| `history(): SandboxEvent[]` | **sync return** | no — needs async variant or local event cache |
+| `admin` (`getDocument`/`listDocuments`/`setDocument`/`deleteDocument`) | **all sync** (types.ts:325–362) | no — Firestore admin plane is synchronous by contract |
+| `reset(): void` | **sync** (fire-and-forget possible) | degraded — can relay as fire-and-forget op; completion unobservable |
+| `dispose(): void` | sync | yes — local teardown |
+| `snapshot(): SandboxSnapshot` | **sync return** | no |
+| `loadSnapshot(data): void` | **sync** | degraded (fire-and-forget) |
+| `currentUser: AuthState` | **sync property** | no — needs a locally cached mirror fed by a subscription |
+| `onCurrentUserChanged(cb)` | sync subscribe | yes (mirror-fed) |
+| `enableTabSync(options)` | sync | n/a in Node — no-op |
+| `enablePersistence(opts)` | async | n/a — worker owns persistence; throw with guidance |
+| `flush()` / `clearPersistence()` | async | n/a — same |
+| `registerPersistableService(name, hooks)` | sync | n/a — worker owns persistence; throw with guidance |
+
+**What `pyric-admin` transitively consumes today:**
+
+- `pyric-admin/app` (`packages/pyric-admin/src/app/index.ts:64–76`):
+  stores the reference only. Needs nothing but a stable object.
+- RTDB path (`packages/pyric-admin/src/database/index.ts`): `onEvent`
+  (line 183) + object identity. Every `Reference` data method is
+  **already async** (`set`/`get`/`once('value')`/`update`/`remove`
+  return Promises, lines 491–534) — they map 1:1 onto worker ops. The
+  one sync-shaped API is `push()` (line 542): it returns a
+  `ThenableReference` whose `.key` must be available synchronously.
+  This is already solved by the worker protocol: the **client mints the
+  push id** and sends it (`rtdb.push` carries `key`,
+  `packages/pyric-tools/src/serve/worker/protocol.ts:367`; the push-id
+  generator is already inlined in pyric-admin, database/index.ts:409).
+  `ref()`/`child()`/`parent`/`DataSnapshot` accessors are pure local
+  path/value manipulation — no relay needed.
+- Auth path (`packages/pyric-admin/src/auth/index.ts`): `onEvent`
+  (line 169) + identity. Every implemented method is **already async**:
+  `createUser`, `getUser`, `getUserByEmail`, `deleteUser`,
+  `setCustomUserClaims` return Promises (lines 358–440).
+  `createCustomToken`/`verifyIdToken` (lines 276–350) are **stateless
+  string transforms** — they need no relay at all and work identically
+  against a remote sandbox (the token format round-trips through any
+  instance of the same backend).
+
+**Conclusion on the sync-member risk:** for slice 1 it is a non-issue —
+nothing `pyric-admin`'s RTDB/Auth paths need is sync-only. The `onEvent`
+consumption (reset detection) becomes unnecessary once the backends are
+remote-routed: they hold no local data to wipe. Proposed handling for
+the rest of the surface, pre-npm:
+
+1. `connectRemoteSandbox()` is **async** (`await connect…`) and its
+   handshake snapshots static config (project, databaseUrl, worker
+   `instanceId`/version via the existing `getVersion` op) so anything
+   config-shaped is available synchronously afterward.
+2. `currentUser` is a locally cached mirror fed by an `authState`
+   subscription established during the handshake.
+3. Genuinely sync members that cannot be mirrored (`admin.*`,
+   `snapshot()`, `history()`) **throw a branded, remediating error**
+   ("not available on a remote sandbox — use the async worker client
+   ops / Studio") on the remote handle. The handle is typed as
+   `RemoteSandbox` (structurally a `Sandbox`) with the limitation
+   documented; since we are pre-npm we can also split a
+   `MinimalSandbox` interface later if a second consumer appears.
+
+## 2. Worker protocol coverage
+
+From `packages/pyric-tools/src/serve/worker/protocol.ts` (ops) and
+`host.ts` / `host-auth.ts` (handlers):
+
+**RTDB — fully covered for the admin data plane:**
+
+| Need (admin `Reference`) | Existing op | Evidence |
+|---|---|---|
+| `get()` / `once('value')` | `rtdb.get` | protocol.ts:363; host.ts:900 |
+| `set(value)` | `rtdb.set` | protocol.ts:364; host.ts:908 |
+| `update(values)` | `rtdb.update` | protocol.ts:365; host.ts:918 |
+| `remove()` / `set(null)` | `rtdb.remove` | protocol.ts:366; host.ts:927 |
+| `push(value?)` (client-minted key) | `rtdb.push` | protocol.ts:367; host.ts:936 |
+| whole-tree admin read | `rtdb.adminSnapshot` | protocol.ts:368; host.ts:952 |
+| value subscription | `RtdbValueSubMessage` `{ t:'sub', target:{service:'rtdb', path} }` | protocol.ts:507–513; host.ts:1214 (`handleRtdbSub`, delivers `{t:'snap'}` per change) |
+
+Every op accepts an `actAs` auth lens (protocol.ts:436–444);
+`{ mode: 'admin' }` routes through the rule-bypass RTDB handle
+(`lensRtdb`, host.ts:479) — exactly firebase-admin's rules-bypass
+semantics. The remote admin backend should pin `actAs: { mode:'admin' }`
+on every relayed op.
+
+**Auth — covered for the pyric-admin subset:**
+
+| Need (admin `Auth`) | Existing op | Evidence |
+|---|---|---|
+| `createUser(props)` | `auth.adminCreateUser` | protocol.ts:399; host-auth.ts:282 → `authSandboxOps.createUser` |
+| `getUser(uid)` / `getUserByEmail` | `auth.listUsers` (filter client-side) | protocol.ts:398; host-auth.ts:274 |
+| `deleteUser(uid)` | `auth.adminDeleteUser` | protocol.ts:401; host-auth.ts:303 |
+| `setCustomUserClaims(uid, claims)` | `auth.adminUpdateUser` — `UpdateUserRequest.customClaims` exists (`packages/pyric/src/auth/sandbox-backend.ts:199–203`) | protocol.ts:400; host-auth.ts:292 |
+| `createCustomToken` / `verifyIdToken` | none needed — stateless local strings | pyric-admin/src/auth/index.ts:276–350 |
+| clear-all (tests) | `auth.adminClearUsers` | protocol.ts:402; host-auth.ts:311 |
+
+**Gaps (all small, none gating slice 1):**
+
+- No single-user lookup op (`auth.getUser`) — `listUsers` + filter is
+  O(n) over the wire; fine at sandbox scale, add a dedicated op if it
+  ever matters.
+- No RTDB `child_added`/`child_changed` granular listener relay — only
+  `value`. The admin sandbox backend throws on `on()` today anyway
+  (database/index.ts:578), so wiring admin `on('value')` via the value
+  sub is a strict **improvement** over the local backend, and other
+  event types stay not-implemented with the same error.
+- No RTDB transaction op — admin `transaction()` throws today
+  (line 587); parity preserved.
+- No RTDB query ops over the wire — query builders throw today
+  (lines 600–631); parity preserved.
+- Semantics note: the worker's `rtdb.update` goes through
+  `pyric/database/modular`'s full multi-path update, while the local
+  admin tree only does shallow merge (database/index.ts:44–47). Remote
+  routing *upgrades* this — document it.
+
+## 3. Bridge transport extension
+
+**Today's flow (tool calls only):**
+
+1. MCP call → `bridge.dispatch(name, args)` → `dispatchSandbox`
+   (`packages/pyric-tools/src/bridge/server/bridge.ts:261–302`): mints a
+   `randomUUID()` correlation id, stores a `PendingCall` with a **30s
+   timeout** (`callTimeoutMs`, line 156), sends
+   `{ type:'tool-call', id, name, args }` to the one peer.
+2. `attachPeer` (`bridge/server/peer.ts:18–63`) adapts the `ws` socket;
+   registration on `hello`, last-connection-wins
+   (`registerSandboxPeer`, bridge.ts:179–200 — a new peer fails all of
+   the old peer's pending calls).
+3. Browser peer (`bridge/client/bridge.ts`) receives `tool-call` and
+   dispatches; on the worker path the dispatcher is
+   `(_s, name, args) => workerCallTool(wdb, name, args)`
+   (`serve/entries/runtime.ts:510–515`), which posts a
+   `{ t:'tool', id, name, args }` worker message
+   (`serve/worker/client.ts:414–424`) → `handleTool` (host.ts:1317).
+   Result flows back as `{ type:'tool-result', id, … }`.
+
+**Extension — four new `BridgeMessage` frames** (in
+`bridge/protocol.ts`, protocol bump not needed if additive; peers that
+don't understand them simply never receive them because the bridge only
+sends worker frames after a capability flag in `hello`):
+
+```
+server→browser  { type:'worker-op',    id, op: OpMessage }        // any worker op, actAs pinned by server
+browser→server  { type:'worker-res',   id, ok, value? , error? }  // relayed ResMessage
+server→browser  { type:'worker-sub',   subId, sub: SubMessage }   // rtdb value sub (slice 1), events later
+server→browser  { type:'worker-unsub', subId }
+browser→server  { type:'worker-snap',  subId, value }             // relayed SnapMessage / EventStreamMessage
+```
+
+The browser relay is mechanical: forward `op`/`sub` to the worker port
+(namespacing `subId` as `bridge:<subId>` to avoid collisions with the
+page's own subs), forward `res`/`snap` back. Reuse the existing
+`hello.tools` mechanism plus a new `hello.capabilities: ['worker-relay']`
+so the bridge can fail fast against an old peer.
+
+Design points:
+
+- **Correlation ids.** Server-minted UUIDs, echoed back — same as
+  tool-calls. Late/unknown ids are already dropped silently
+  (bridge.ts:309). Tag each peer registration with a generation counter
+  so a frame from a replaced peer's socket can never resolve a new
+  peer's pending call (today `attachPeer`'s closure + `pending.delete`
+  make this near-impossible, but subscriptions make stale delivery
+  likelier — check generation on `worker-snap`).
+- **Subscription lifecycle over a reconnecting WS.** Ownership lives on
+  the **Node side**: `connectRemoteSandbox` keeps a registry of active
+  subs (subId → target + callback). The bridge keeps a mirror of
+  bridge-side subs. On peer replacement (tab refresh) or WS reconnect,
+  the bridge re-issues every registered `worker-sub` to the new peer on
+  `hello`. RTDB `value` semantics make this safe and cursor-free: every
+  (re)subscribe delivers a fresh initial snapshot, and value listeners
+  are last-value-wins — the Node consumer just sees an extra snapshot.
+  The worker's state survives tab refresh (IndexedDB persistence +
+  SharedWorker lifetime), so the re-subscribed value is continuous.
+  Surface a `stream-reset` notification on the Node handle for
+  consumers that care.
+- **The 30s timeout.** Keep it for `worker-op` (same `callTimeoutMs`
+  budget as tool-calls; `mcp-proxy` already sits above it at 35s,
+  `cli/mcp-proxy.ts:55`). Subscriptions get no per-frame timeout;
+  liveness comes from the existing ping/pong. Sub **establishment**
+  errors must relay: `handleRtdbSub` posts a
+  `{ value: { __error } }` snap on failure (host.ts:1231–1234) — the
+  relay forwards it and the Node side rejects the subscribe promise.
+- **Last-connection-wins with a Node client + agent tools sharing the
+  peer.** Both multiplex over the ONE bridge core and the ONE peer —
+  no change to peer semantics. Consequences: (a) a tab refresh fails
+  all in-flight ops for **both** consumers with "sandbox peer replaced"
+  (bridge.ts:186) — the Node client should classify that error as
+  retryable and retry once after the new peer's hello; (b) two browser
+  tabs still race for peerhood, but both tabs front the same
+  SharedWorker, so whichever tab wins relays to the same sandbox —
+  benign; (c) ops are async-multiplexed, so a slow agent tool call does
+  not block admin ops.
+- **Backpressure.** Slice 1 relays only RTDB value subs, which are
+  coalescible: if `ws.bufferedAmount` (browser) exceeds a threshold,
+  keep only the **latest** pending snap per subId (value subs are
+  last-value-wins, dropping intermediates is semantically safe). The
+  unified event stream (`target:'events'`, history batches) is NOT
+  coalescible — defer relaying it to slice 2 with an explicit bound
+  (cap + drop-oldest + `overflow: true` marker frame).
+
+## 4. Connection lifecycle
+
+- **Discovery.** Same pattern as `mcp-proxy`
+  (`packages/pyric-tools/src/cli/mcp-proxy.ts:132–193`): read
+  `.pyric/serve.json` in cwd — serve writes
+  `{ url, mcpUrl, port, pid, instanceId, project }`
+  (`packages/pyric-tools/src/cli/serve.ts:362–370`) — probe
+  `/__pyric/health` on both loopback families explicitly
+  (`basesForPort`, mcp-proxy.ts:84), and **pin `instanceId`** to avoid
+  the cross-family port-squatter split-brain. Factor `discoverServe`
+  out of `cli/` into a shared module rather than duplicating it.
+- **No browser tab open.** Health reports `sandboxConnected: false`
+  (`bridge.ts:349–359`). `connectRemoteSandbox()` fails fast, mirroring
+  `NO_SANDBOX_ERROR_MESSAGE` (`bridge/protocol.ts:146`):
+  `"no browser tab is connected to the sandbox — open <serve url> and retry"`
+  using the pointer's `url`. Optionally accept
+  `{ waitForPeer: ms }` to poll health briefly (a user who just ran
+  `pyric serve` has a tab opening). Do **not** silently fall back to an
+  in-process sandbox (the headless path `runHeadlessMcp` exists,
+  mcp-proxy.ts:236–240, but silently splitting the backend is exactly
+  the failure the gate is meant to avoid).
+- **Reconnect across tab refresh.** Three lifetimes to distinguish:
+  1. *Tab refresh, other tabs open* — SharedWorker lives; only the peer
+     WS churns. Bridge re-issues subs to the new peer (section 3);
+     Node-invisible apart from possible one failed in-flight op.
+  2. *All tabs closed, then reopened* — SharedWorker dies and restarts;
+     state restores from IndexedDB (worker persistence). Value subs
+     re-fire with restored state on re-subscribe. Nothing else to
+     re-establish: pyric-admin's plane is admin (no auth session), and
+     sandbox tokens are stateless.
+  3. *serve restarted* — new `instanceId`; the pinned identity check
+     fails; the Node handle surfaces a terminal
+     `"serve restarted — reconnecting"` and re-runs discovery.
+  What the Node side re-establishes, exhaustively: **subscriptions**
+  (registry replay) and its **`currentUser` mirror** (re-subscribe
+  `authState`). No admin auth session exists to restore.
+
+## 5. Phased implementation plan
+
+### Slice 1 — RTDB + Auth (the first user)
+
+| # | Work item | Files | Effort |
+|---|---|---|---|
+| 1 | Bridge frames: `worker-op`/`worker-res`/`worker-sub`/`worker-snap`/`worker-unsub` + `hello.capabilities` | `src/bridge/protocol.ts` | S |
+| 2 | Bridge core: generic op dispatch (reuse `PendingCall` machinery), bridge-side sub registry, resubscribe-on-new-peer, generation tagging | `src/bridge/server/bridge.ts`, `peer.ts` | M |
+| 3 | Browser relay: forward worker frames to the worker port; subId namespacing; buffered-amount coalescing for value snaps | `src/bridge/client/bridge.ts`, `src/serve/entries/runtime.ts`, small additions to `src/serve/worker/client.ts` | M |
+| 4 | `connectRemoteSandbox()` (Node): shared discovery (extract from `cli/mcp-proxy.ts`), WS client (`ws` pkg), handshake (getVersion + authState sub), branded `RemoteSandbox` handle with op channel + sub registry + fail-fast messaging | new `src/remote/` in pyric-tools | M |
+| 5 | `pyric-admin` remote dispatch: brand check in `getDatabase`/`getAuth` sandbox arms; route `Reference`/`Auth` methods through the channel (`actAs: admin` pinned); keep local backends for in-process sandboxes | `packages/pyric-admin/src/database/index.ts`, `src/auth/index.ts` (+ a tiny channel type in `pyric/sandbox` or a pyric-tools peer dependency seam — decide: the brand + channel should live in a leaf module so pyric-admin doesn't import pyric-tools) | M |
+| 6 | Optional worker op `auth.getUser` (else listUsers+filter) | `src/serve/worker/protocol.ts`, `host-auth.ts` | S |
+| 7 | Docs + error-message polish ("open <url>") | — | S |
+
+Overall slice-1 estimate: **M — roughly 3–5 focused days**, dominated
+by items 2–5. The single design decision to settle first is where the
+remote brand/channel interface lives so `pyric-admin` (which depends
+only on `pyric` and `firebase-admin`) can recognize a handle
+constructed by `pyric-tools` — a `Symbol.for('pyric.remote.sandbox')`
+brand plus a structurally-typed channel interface declared in
+`pyric/sandbox` types keeps the dependency direction clean.
+
+### Slice 2 — Firestore / Storage / fuller surface
+
+- Firestore admin + modular relay: worker ops already exist
+  (`getDoc`…`txnCommit`, `admin.*` — protocol.ts:344–362); Node client
+  SDK = re-target `serve/worker/client.ts`'s transport seam from
+  `MessagePort` to the WS frames (the client is already engine-free and
+  codec-complete). **L**
+- Storage: read ops exist (`storage.listAll/getMetadata/getBlob`,
+  protocol.ts:407–409); uploads need a new op + binary framing
+  (base64 or WS binary frames). **M**
+- Event-stream relay (`target:'events'`) with bounded backpressure, so
+  Node consumers get `onEvent`/`history` mirrors. **M**
+- `snapshot`/`loadSnapshot`/branch ops over the wire
+  (`exportState`/`importState`/`saveBranch`… already exist as ops). **S**
+- Auth session surface for the Node *client* SDK (per-connection
+  sessions mirror the worker's per-port sessions, #754). **M**
+
+### Test strategy
+
+The worker host already runs headless: `handleMessage` is the
+documented unit-test seam — existing tests build a real sandbox, fake
+`{ postMessage }` ports, and drive the full op/sub lifecycle with **no
+SharedWorker and no browser**
+(`packages/pyric-tools/test/serve/worker/host.test.ts:1–27`, plus
+`auth.test.ts`, `sub-lens.test.ts`, `per-port-sessions.test.ts`, …).
+
+Layered characterization tests:
+
+1. **In-process relay harness (no network):** a fake browser peer =
+   a function that receives `worker-op`/`worker-sub` frames and calls
+   `handleMessage(ctx, fakePort, …)` directly, piping the fake port's
+   posts back as `worker-res`/`worker-snap`. Drives `createBridge` +
+   `connectRemoteSandbox`'s core with an injected transport. Covers:
+   op round-trips, sub initial fire + updates, unsub, peer replacement
+   resubscribe, timeout, error relay (`__error` snap → rejected
+   subscribe).
+2. **Real-WS characterization:** stand up the actual bridge mount
+   (`ws` server via `serve/bridge-mount.ts` path) with the harness peer
+   on a real socket — locks the wire format.
+3. **pyric-admin conformance:** run the existing
+   `pyric-admin` database/auth test expectations (`database.test.ts`,
+   `auth.test.ts`) against a remote-branded sandbox backed by the
+   harness — the same assertions must pass locally and remotely (the
+   compat-model pattern: one oracle, two backends).
+4. **One manual end-to-end** against a real `pyric serve --bridge` +
+   browser tab before calling the slice done (tab-refresh resubscribe
+   is the scenario unit tests fake most heavily).
+
+## Risks
+
+1. **The zero-pyric-admin-change premise is false** (top risk, and a
+   contradiction of the assumed design). RTDB/Auth sandbox backends are
+   WeakMap-local; the remote design requires a dispatch change inside
+   `pyric-admin/{database,auth}`. Contained (two files, additive arm),
+   but it must be scoped into the gate, and the brand/channel interface
+   placement decides the dependency graph.
+2. **Behavioral upgrade is also behavioral change.** Today's local
+   admin tree emits no events, evaluates no listeners, and is invisible
+   to Studio; remote routing makes server writes emit events and fire
+   app listeners. Desired — but the local in-process backend then
+   *diverges* from the remote one (silent tree vs. live worker RTDB).
+   Consider follow-up: rewire the local admin backend onto
+   `pyric/database`'s sandbox backend too, so both arms share one tree
+   and one event story.
+3. **Tab-refresh + last-connection-wins.** In-flight ops fail on peer
+   replacement for both the Node client and agent tools; transparent
+   resubscribe needs generation tagging to avoid stale-snap delivery.
+   Mitigation is designed (section 3) but is the fiddliest code in the
+   slice.
+4. **Sync `Sandbox` members are unimplementable remotely**
+   (`admin.*`, `snapshot()`, `history()`, sync `currentUser` reads
+   before handshake). Slice 1 sidesteps them (pyric-admin doesn't use
+   them), but any consumer treating `RemoteSandbox` as a full `Sandbox`
+   hits branded throws. Pre-npm is the moment to either split the
+   interface or bless the throwing subset.
+5. **Backpressure on event streams.** Safe for slice 1 (value subs
+   coalesce); becomes real when the unified event stream is relayed in
+   slice 2 — needs an explicit bound before that ships.

--- a/docs/design/specs/TEMPLATE.md
+++ b/docs/design/specs/TEMPLATE.md
@@ -1,0 +1,65 @@
+# Spec: <view or component name>
+
+Route: `<clean URL under /__pyric/ui/>`
+Status: draft | agreed | built | drifted
+
+## Purpose
+
+One sentence: the user question this view answers.
+
+## Content inventory
+
+| Item | Tier | Rendering | Rationale |
+|---|---|---|---|
+| <content item> | primary | direct | why it earns default visibility |
+| <content item> | secondary | direct (subordinate) | |
+| <content item> | tertiary | drill-in → `<route>` / detail pane / popover | why disclosure, and which kind |
+
+Rules: tiers per C1–C4. Every tertiary row names its disclosure mechanism
+and, for drill-ins, the URL (N4). A modal requires a justification sentence
+here (C3).
+
+## Primary action
+
+The one visible primary action (C4), and where secondary actions live.
+
+## Foundation layout contract
+
+Prose description of the regions, plus the actual grid sketch — the sketch
+is the design artifact, not a mock:
+
+```css
+.view {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: var(--space-...);
+}
+.view__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));
+  gap: ...;
+}
+```
+
+State which region owns scroll (L5).
+
+## Local layouts
+
+Per component placed in the foundation: how it organizes its own content
+internally, and confirmation it assumes nothing about its container beyond
+available width (L3, L4).
+
+## States
+
+- Empty: what it shows, what it teaches (C5)
+- Loading:
+- Dense (lots of data):
+- Narrow (~1 column):
+
+## URL states
+
+Every addressable state of this view and its params (N4).
+
+## Open questions / justifications
+
+Any SHOULD-rule breaks, modal justifications, deferred decisions.

--- a/docs/design/specs/home.md
+++ b/docs/design/specs/home.md
@@ -1,0 +1,90 @@
+# Spec: Home (the hub)
+
+Route: `/__pyric/ui/` (default)
+Status: draft
+
+## Purpose
+
+Answer "what is happening in my sandbox, and what do I do next?" and route
+into the surface that does it.
+
+## Content inventory
+
+| Item | Tier | Rendering | Rationale |
+|---|---|---|---|
+| Command input (one box: deterministic actions + routes; NL when a key exists) | primary | direct, top of view | the agent-forward front door; degrades mechanically. Results contain actions and routes only — never settings (M4); NL results render through the shared result renderers (M5) |
+| Live activity feed (writes, denials, deploys, seeds; provenance-stamped) | primary | direct; each row links to its subject | the "it's real and working" signal, incl. external-agent work |
+| Sandbox status line (branch, persistence mode, rules drift repo↔sandbox) | secondary | direct, single compact row of chips | glanceable confidence; each chip links to its surface |
+| Surface tiles with live counts (docs, users, denials…) | secondary | direct, below feed | discovery + routing for console-first users |
+| Event detail (full payload, trace) | tertiary | drill-in → subject's tab (e.g. `/rules?denial=…`, `/firestore/<path>`) | detail belongs to the owning surface, not the feed |
+| Feed filters (by service, by identity/agent) | tertiary | popover on the feed header | tuning, not first-look content |
+| Maintenance (reset, export/import, branches) | tertiary | drill-in → Settings; drift chip links to Rules | destructive/rare |
+| MCP setup snippet, seed builder, rules import | tertiary normally; promoted into the empty state | direct within empty state only | onboarding is the empty state's job (C5) |
+
+No chat thread renders on Home in phase 1. Conversation history is a
+session-store concern shared with Prototype (see redesign doc §sessions);
+Home's command input stages single actions, it does not host a dialogue.
+
+## Primary action
+
+The command input. Secondary: tile navigation, status-chip links.
+
+## Foundation layout contract
+
+```css
+.home {
+  display: grid;
+  grid-template-rows: auto auto 1fr; /* command | status | body */
+  gap: var(--space-5);
+  /* readable measure without margin-centering: */
+  grid-template-columns: minmax(0, 72rem);
+  justify-content: center;
+}
+.home__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr));
+  gap: var(--space-5);
+  /* feed spans available columns first; tiles flow after */
+}
+.home__tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: var(--space-3);
+}
+```
+
+Scroll owner: the view content region (feed grows; page scrolls as one) —
+the feed is not an inner scroll trap on Home; full history lives in Traffic.
+Feed on Home is capped (latest N) with a drill-in link to Traffic.
+
+## Local layouts
+
+- Command input: single-row grid `1fr auto` (input | hint/key-state); result
+  list renders below in its own flow, gap-spaced.
+- Feed row: grid `auto 1fr auto` (provenance dot+identity | summary | time);
+  truncates middle; no internal margins.
+- Status chip / tile: intrinsic content boxes; tiles are a label + live
+  count + spark of recency; no fixed widths (L1, L3).
+
+## States
+
+- Empty (fresh sandbox): status row + three onboarding cards in the body
+  grid — connect your agent (MCP snippet), seed data (opens seed builder),
+  bring your rules (repo file detected → deploy). Command input present with
+  teaching placeholder.
+- Loading: status chips skeleton; feed rows skeleton.
+- Dense: feed capped at N with "view all in Traffic"; tiles unaffected.
+- Narrow: everything single-column via auto-fit; order = command, status,
+  feed, tiles.
+
+## URL states
+
+- `/` — hub.
+- Feed rows navigate away (`/traffic?...`, `/rules?denial=…`,
+  `/firestore/<path>`); Home itself keeps no deep state.
+
+## Open questions
+
+- Feed cap N and whether provenance filter state deserves a URL param.
+- Whether the drift chip deploys directly (one-click) or always routes to
+  Rules for review.

--- a/docs/design/specs/shell.md
+++ b/docs/design/specs/shell.md
@@ -1,0 +1,75 @@
+# Spec: Shell (header + navigation)
+
+Route: all (frame for every view)
+Status: draft
+
+## Purpose
+
+Get the user to the right surface and show, at a glance, whether the sandbox
+and its agents are alive — nothing else.
+
+## Content inventory
+
+| Item | Tier | Rendering | Rationale |
+|---|---|---|---|
+| Tab navigation (Home, Firestore, Auth, RTDB, Storage, Rules, Traffic, Prototype, Settings) | primary | direct | the bar's reason to exist |
+| Agent presence chip (MCP peer connected + client name) | secondary | direct, right cluster; details on popover | global status; true everywhere; one chip |
+| Sandbox health (worker connected / stale-worker warning) | secondary | direct only when degraded; otherwise absent | status by exception — a healthy sandbox earns no pixels |
+| Model/provider selection | tertiary | lives in the surface that uses it (Prototype), never the bar | contextual control; previous bar placement violated N2 |
+| Branch / persistence details | tertiary | Home status region + Settings | glanceable on Home; not global chrome |
+
+## Primary action
+
+None — the bar navigates and reports; it does not act (N2). Anything
+demanding an action (stale worker) links to the surface that resolves it.
+
+## Foundation layout contract
+
+One row, full width, fixed block-size row in the app grid; content region
+takes the rest and owns scroll (L5).
+
+```css
+.shell {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100dvh;
+}
+.shell__bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto; /* identity | nav | status */
+  align-items: center;
+  gap: var(--space-4);
+  padding-inline: var(--space-4);
+}
+.shell__nav {
+  display: flex;
+  gap: var(--space-1);
+  overflow-x: auto; /* nav scrolls before the bar wraps or stacks (N1) */
+}
+```
+
+## Local layouts
+
+- Nav tabs: flex row, gap-spaced, no per-tab margins (L2). Overflow scrolls
+  horizontally within the nav region; the bar never grows a second row.
+- Status cluster: flex row of chips, gap-spaced; each chip is
+  container-agnostic (L4).
+
+## States
+
+- Empty/first-run: identical bar; onboarding lives in Home, not the bar.
+- Degraded: single status chip appears (worker stale / bridge down).
+- Narrow: nav scrolls; identity collapses to mark; status cluster keeps at
+  most the presence chip.
+
+## URL states
+
+The bar itself holds no state; active tab derives from the path
+(`/__pyric/ui/<tab>/…`).
+
+## Open questions
+
+- Does Prototype appear for keyless users? (Redesign doc recommends yes.)
+- Exact right-cluster contents. Note: there is no lens or mode indicator
+  anywhere in the bar — modes don't exist (M2/M3); identity appears only as
+  a parameter on operations that take one.

--- a/docs/design/specs/traffic.md
+++ b/docs/design/specs/traffic.md
@@ -1,0 +1,95 @@
+# Spec: Traffic
+
+Route: `/traffic`, `/traffic/<eventId>`
+Status: draft (respecification — current tab is an assists artifact and is
+not a starting point)
+
+## Purpose
+
+Answer "what happened in my sandbox, in what order, and why" — Traffic is
+the addressable, user-facing projection of the sandbox event stream (see
+TOOL-SYSTEM.md "Traffic is a projection"), the ground truth every other
+surface links into. It is **multi-service**: Firestore and RTDB today,
+Auth and Storage to follow — one view, service as a first-class dimension,
+never per-service traffic surfaces.
+
+## Content inventory
+
+| Item | Tier | Rendering | Rationale |
+|---|---|---|---|
+| Event list (newest-first, **virtualized**, L6) | primary | direct | the view's reason to exist; unvirtualized lists have already failed firsthand |
+| Per-row derived action (denial → debug pipeline; write → open subject record) | primary | direct, one per row (M6) | events must connect to their consequence — the current tab's biggest miss |
+| Filter row (service, verdict, caller/provenance, session) | secondary | direct, single compact row | filtering is how a log is used; one row, no stacked toolbars |
+| Provenance (session name + caller) per row | secondary | direct, compact chip in row | the cross-tool session identity made visible |
+| Event detail (full payload, rule trace, timing) | tertiary | drill-in → `/traffic/<eventId>` (detail pane on wide, stacked on narrow) | detail is per-event, not default render |
+| Activity chart / rate summary | tertiary | disclosure (expandable summary strip) | useful sometimes; does not pull its weight as primary real estate |
+| Save-session-as-fixture | tertiary | overflow action on the filter row | valuable but rare; pairs with `pyric verify` |
+
+## Primary action
+
+Selecting an event (which reveals its derived action). The view itself has
+no global primary action — it is a record, not a workbench.
+
+## Foundation layout contract
+
+```css
+.traffic {
+  display: grid;
+  grid-template-rows: auto 1fr; /* filter row | body */
+  gap: var(--space-3);
+}
+.traffic__body {
+  display: grid;
+  /* list + detail pane when there is room; single column when not */
+  grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));
+  gap: var(--space-4);
+  min-height: 0; /* the list owns scroll (L5) */
+}
+```
+
+Scroll owner: the virtualized event list. The detail pane scrolls
+independently. The page never scrolls as a whole.
+
+## Local layouts
+
+- Event row: grid `auto auto 1fr auto auto` (service tag |
+  verdict/provenance chip | summary with subject path | time | derived
+  action); middle truncates; rows are container-agnostic and carry no
+  margins (L2, L4). With four services in one stream, the service tag must
+  make origin legible at a scan — a compact, color-consistent tag, not an
+  icon guessing game.
+- Detail pane: subject header (linked), result body (payload/trace),
+  derived actions — the standard result-renderer shape (`DenialDetail`,
+  write detail) from TOOL-SYSTEM.md.
+
+## Cross-links (the point of the respec)
+
+- Every row → `/traffic/<eventId>` (stable id; engineering prerequisite).
+- Subject link → the record it touched: `/firestore/<path>`,
+  `/rtdb/<path>`, `/storage/<path>`, `/auth/<uid>`.
+- Denied events → the denial pipeline in Rules, event pre-loaded:
+  `/rules?denial=<eventId>`.
+- Inbound: Home's feed rows and rules regression tables link back to
+  `/traffic/<eventId>`.
+
+## States
+
+- Empty: teaches — "traffic appears when your app, an agent, or a seed
+  touches the sandbox," with links to seed builder and MCP setup.
+- Loading: history batch skeleton rows.
+- Dense: virtualization handles volume; filters + session scoping keep it
+  navigable; no cap needed here (unlike Home's feed).
+- Narrow: single column; detail becomes a stacked drill-in.
+
+## URL states
+
+- `/traffic?service=&verdict=&caller=&session=` — filter state is
+  shareable.
+- `/traffic/<eventId>` — one event, detail disclosed.
+
+## Open questions
+
+- Retention/backpressure: history window size in the worker feed and
+  whether older events page in on demand.
+- Whether the disclosure chart is per-filter (rate of the filtered slice)
+  or global.

--- a/docs/design/studio-redesign.md
+++ b/docs/design/studio-redesign.md
@@ -1,0 +1,432 @@
+# Pyric Studio Redesign: From Found to Intentional
+
+Status: proposal draft, revision 1. Written 2026-07-08 against current `main`.
+
+Revision 1 changes: the previously-mounted AI surfaces were removed on
+purpose (bad form, good ideas) — nothing gets remounted as-is; routing is
+History-API, not hash; "Build" is renamed "Prototype" and sessions become a
+Studio-level primitive to avoid duplicate chat systems.
+
+Revision 2 changes: the design roots in the mechanical tool system, not in
+"assists" — see `TOOL-SYSTEM.md` (the root model document, including the
+assists failure ledger) and PRINCIPLES M1–M7. Consequences applied here:
+the global admin/app **lens is deleted as a concept** (data views are
+always admin; identity is a per-operation parameter; per-user visibility is
+a query/simulation), governance surfaces only where it fires, and staged
+changes live inline where the data lives with Review as an index.
+
+Revision 3 changes: **no tab is grandfathered** (M9) — "exists" describes
+code, not approval; every surface re-enters through a spec. Traffic is
+respecified (chart demoted, addressable + cross-linked events, virtualized,
+`specs/traffic.md`). Session naming (an assist idea that survives) becomes
+system-wide provenance. The tool exposure matrix (TOOL-SYSTEM.md, M8)
+captures the playground↔MCP registry gaps. The playground Firebase Tab gets
+a disposition plan, and deployment auth is simplified around a bundled
+OAuth client brokered by `pyric serve`.
+
+Revision 4 changes: traffic goes multi-service (a projection of the event
+stream — no raw events view); tool API design rules (T1–T4) and a candidate
+consolidated MCP façade added to TOOL-SYSTEM.md; and a **ship cut** section
+added below to serve the npm-today goal — publish is gated on API
+mechanics and naming decisions, not on UI.
+
+Companion documents: `TOOL-SYSTEM.md`, `PRINCIPLES.md`, `WORKFLOW.md`,
+`specs/`.
+
+## Ship cut for npm alpha (added rev 4)
+
+The publish constraint: npm today, alpha semantics (breaks are fine for
+~a month, then progressively less fine). The UI ships inside `pyric-tools`
+as an embedded asset and can change without any API break — so **the UI
+does not gate the publish; names and packaging do.**
+
+**Gate A — publish today (API mechanics + naming):**
+1. The pre-npm P0 mechanics (this doc's earlier assessment + CONTEXT.md):
+   packaging smoke-list sync, intentional versions, alpha-honest READMEs,
+   gates run from a clean tree, embedded UI asset checks.
+2. Tool-naming decision recorded, not implemented: adopt T1–T4 now, note in
+   the MCP/README docs that the tool surface will consolidate during
+   early alpha (so today's granular `firestore_*`/`rtdb_*` names carry an
+   explicit instability notice). Add **no new tools today** — especially no
+   new wrongly-scoped names (no `firestore_`-prefixed traffic tool).
+
+**Gate B0 — remote sandbox for `pyric-admin` (top post-publish priority):**
+A real first user (RTDB + Auth app, server-side architecture on the RTDB
+Admin SDK) needs server-side `pyric-admin` code to reach the browser-hosted
+sandbox. Design: a **remote `Sandbox` implementation** — since
+`pyric-admin`'s entire seam is the `Sandbox` handle passed to
+`initializeApp({ sandbox })`, a `connectRemoteSandbox()` (Node, in
+`pyric-tools`) that satisfies the sandbox surface over the existing bridge
+transport (WS `/__pyric/sandbox` → page relay → SharedWorker, the same
+server→browser direction MCP tool forwarding already uses) plugs in with
+zero `pyric-admin` changes and works for the client SDK in Node too.
+Discovery via `.pyric/serve.json`, like `mcp-proxy`. Scope first slice to
+RTDB + Auth ops. Accepted compromise: a browser tab must be open; failure
+mode must say so ("open <serve url>"). Spike questions: sync-vs-async
+surface of the `Sandbox` interface, listener (`on()`) relay over WS, and
+reconnect semantics across tab refresh. Additive — does not gate Gate A.
+
+**Gate B — core experience (first alpha days; UI-only, no breaks):**
+The structure, core workflow, and feel — not every feature:
+1. History-API routing + the route structure.
+2. Shell per `specs/shell.md`: one bar, Prototype rename, model controls
+   out of the bar.
+3. Home v1: status strip + capped provenance feed + tiles. (The command
+   input may land as navigation-only first.)
+4. Traffic v1 per `specs/traffic.md` minus full addressability:
+   virtualization (known failure), service dimension, subject links where
+   derivable today.
+
+**Gate C — early alpha window (breaks still free):**
+1. MCP façade consolidation per TOOL-SYSTEM.md (renames done while free).
+2. Stable event ids + session identity → full traffic addressability.
+3. Registry parity audit mechanized.
+
+Everything else (rules design track, seed builder, Review, Prototype
+session protocol, deploy-auth simplification, Firebase Tab dissolution)
+proceeds on the phased plan below, unhurried.
+
+## Purpose
+
+Redesign Pyric Studio as an agent-forward development console where the
+traditional data views remain first-class, the "playground" concept dissolves
+into an integrated assistant + opt-in prototyping surface, and every cognitive
+(AI) feature has a mechanical fallback. The same design becomes the Pyric
+website story: Studio running in the browser, showing instead of telling.
+
+## The grounding insight
+
+An audit of the current code shows the redesign is mostly *promotion and
+wiring*, not new architecture:
+
+1. **The data plane is already unified.** The app under test, Studio, the
+   Playground (in shared mode), and external MCP agents all operate on the ONE
+   `pyric-shared-worker` sandbox via `pyric-tools/serve/worker`. Agent writes
+   already flow through the unified `SandboxEvent` stream Studio consumes
+   (`host-events.ts` fan-out → `worker-live.ts` feed). "An agent just wrote 30
+   docs" is observable *today*; it just isn't surfaced.
+2. **Studio contains a de-mounted agent-forward layer whose ideas survive
+   and whose form does not.** The ⌘K palette, proposals/Review, permission
+   dial, Action Center, Rules surfaces, and Session digest exist in
+   `packages/studio/src/` but were deliberately removed from the shell: they
+   were confusing and hard to use. The concepts (staging, governance,
+   visibility, NL-to-action) are load-bearing in this redesign, but each
+   re-enters only through a fresh content-inventory spec (PRINCIPLES P4).
+   The code is salvage material — data layers and tool plumbing are reusable;
+   the UI forms are not a starting point.
+3. **Almost every cognitive feature in the Playground is a thin AI layer over
+   a deterministic tool.** The agent's power comes from its tool registry —
+   rules lint/validate/simulate, denial inspection, traffic replay
+   (`try_rules_edit`), index extraction, seeding, fixture generation, path
+   discovery. Those tools are ordinary functions. The AI decides *which* to
+   call and narrates; the machinery is mechanical.
+
+That third point is the design key:
+
+> **A mechanical fallback is not a degraded parallel feature. It is a
+> form-driven invocation of the same tool the agent calls.**
+
+Every capability becomes a triad: (a) a deterministic tool, (b) a mechanical
+UI form over that tool, (c) an agent that can compose the tools. AI adds
+composition and language, never exclusive access. This is also what makes the
+website story honest: visitors without keys use the real tools; keys unlock
+the narrator.
+
+## Design principles
+
+1. **One sandbox, one story.** Studio is a lens over the shared sandbox plus
+   the local repo. Nothing in Studio owns private state that another surface
+   can't see.
+2. **Progressive cognition.** Mechanical → AI-assisted → agent-driven, on the
+   same tools, in the same UI locations. No AI-key wall in front of any
+   workflow; a key upgrades the workflow in place.
+3. **The URL is the state.** Every view, selection, denial, session, and
+   review item is deep-linkable via clean History-API routes under the app
+   base (`/__pyric/ui/<tab>/<rest>?<query>`), replacing today's hash codec.
+   The codec module survives; only its transport changes from `location.hash`
+   to `pathname`. Serve's extension-less `index.html` SPA fallback already
+   supports this. The hub routes *into* the traditional tabs via these URLs.
+4. **External agents are the hero.** In local dev, the "agent" is usually
+   Claude Code / Cursor / Codex on the MCP bridge, not an in-Studio chat.
+   Studio's job is to make that activity visible, reviewable, and governable.
+5. **The repo is the source of truth.** Rules, fixtures, seed data, and index
+   files live in the user's repo; the sandbox is the running instance. Studio
+   shows sync state and offers write-back, never becoming a second silo.
+6. **App building is a cherry, not the frame.** Prototyping with preview,
+   GitHub import/export, and deploy stays — as an opt-in surface, framed as
+   "Build," not as the container everything else lives inside.
+
+## Information architecture
+
+### Navigation (top-level tabs)
+
+| Tab | Contents | Status today |
+|---|---|---|
+| **Home** (the hub) | Command bar, live activity feed, sandbox status, connected-agent presence, guided routes | Exists as static tile grid; becomes the hub |
+| **Firestore** | Data browser/editor | Exists |
+| **Auth** | Identity admin | Exists |
+| **RTDB** | Tree browser/editor | Exists |
+| **Storage** | Object browser | Exists |
+| **Rules** | Rules workbench: editor, lint, simulator, denial inspector, traffic replay, coverage | Machinery exists; UI form to be spec'd fresh (old surfaces removed) |
+| **Traffic** | The addressable event store: virtualized log, events cross-linked to subject and consequence, denial → pipeline | Assists artifact; respecified in `specs/traffic.md` (chart demoted to disclosure) |
+| **Review** | Index of `StagedChange` results; the changes themselves render inline where the data lives | Concept retained from removed proposals surface via TOOL-SYSTEM failure ledger; form to be spec'd fresh |
+| **Prototype** (side feature) | The former playground: prototyping, preview, GitHub, deploy | Exists as `playground` tab; seam redesigned (see below) |
+| **Settings** | Sandbox maintenance + AI providers/keys + governance | Maintenance exists; AI section to be spec'd fresh |
+
+Notes:
+
+- **"Status today" describes code, not approval (M9).** Every tab — data
+  views included — gets a content-inventory spec and must prove its worth;
+  "exists" surfaces are candidates for rework, not defaults.
+- "Playground" as a name disappears. The agent isn't a place; it's a layer.
+  The app-builder surface is "Prototype" — a side feature, not the frame.
+- A global command input (Home-anchored, ⌘K from anywhere) replaces the old
+  palette concept. Without AI it is a router over navigation + deterministic
+  actions; with AI, a sentence stages a change into Review. Its form is
+  spec'd fresh (`specs/home.md`), not inherited from the removed palette.
+- The `Session` surface's activity digest merges into Home's feed rather than
+  being its own tab.
+
+### Home: the hub
+
+Home stops being a tile grid and becomes the answer to "what is happening in
+my sandbox, and what should I do next?"
+
+1. **Status strip.** Sandbox instance, active branch, persistence mode
+   (ephemeral / IDB / `--persist`), deployed rules hash vs repo rules hash
+   (drift indicator). No mode indicators — there are no modes (M2).
+2. **Agent presence.** Bridge peer connected? MCP session active? Which
+   client (from the proxy handshake)? A quiet "● Claude Code connected" chip
+   is the single most confidence-building pixel for the target user.
+3. **Live activity feed.** The Action Center feed, promoted: writes, denials,
+   rule deploys, seeds — provenance-stamped (auth lens / agent vs app), each
+   row deep-linking to the doc, denial, or review item it references.
+4. **Command bar.** The ⌘K palette inline. Empty state teaches by example:
+   three mechanical suggestions ("Seed 20 users", "Simulate a write as
+   alice", "Replay traffic against edited rules") that are *buttons into
+   forms*, and — when a key is present — the same phrases work as NL.
+5. **Routes.** The tile grid survives below the fold as discovery, each tile
+   carrying live counts (docs, users, denials) instead of static copy.
+
+First-run (empty sandbox) Home is the onboarding: "connect your agent"
+(MCP setup snippet), "seed some data" (mechanical seed builder), "bring your
+rules" (repo file detected → deploy to sandbox).
+
+## Mechanical fallback inventory
+
+Each cognitive feature, its deterministic core, and the mechanical UI over it.
+
+| Cognitive feature (Playground/Studio) | Deterministic core | Mechanical UI design |
+|---|---|---|
+| NL data seeding | `seed_firestore_data_as_admin`, seed-proposal apply | **Seed builder**: pick collection, define fields (type + generator: name/email/int-range/enum/ref), count, write. Plus paste-JSON and import-from-repo-fixture. AI mode: NL box streams a proposal into the same builder for review. |
+| Data modeling / discovery | `sandbox_discover_paths`, `firestore_discover` | **Structure view** (in Firestore tab or Home): inferred collection/field tree from live data, exportable as markdown/typed model to repo. AI mode: narrative model critique. |
+| Security rules authoring | `pyric/rules` lint/validate/simulate, rules stdlib, `assembleGameRules` | **Rules workbench**: editor with lint-on-type, stdlib snippet picker, deploy-to-sandbox vs save-to-repo. Fully deterministic. AI mode: "draft rules for this structure." |
+| Rules simulation | `simulate_firestore_write` | **Simulator form**: operation, path, auth context (pick from real sandbox users), request data → allow/deny with evaluation trace. |
+| Denial debugging | `inspect_denial`, `debug_firestore_rules` | The **denial pipeline** (TOOL-SYSTEM.md): denial in Traffic → `DenialDetail` → re-simulate (`Verdict`, parameters editable) → edit rules → `RegressionTable` replay → deploy/save. Each stage renders a result and derives the next action; no standing control heaps (M6). The old `DenialInspector` form is explicitly not the starting point. AI mode: narration + suggested fix over the same pipeline. |
+| Rules regression check | `try_rules_edit` (replay captured writes + re-simulate denials) | **"Re-run traffic against edited rules"** button in the workbench: table of captured ops × old verdict × new verdict, regressions highlighted. This is the killer mechanical feature — deterministic, unique to Pyric, needs zero AI. |
+| Security/access audit | `firebase-audit` skill (composes read-only tools) | **Coverage matrix**: simulation sweep of discovered paths × operations × representative identities → allow/deny grid. Deterministic. AI mode: narrative findings and prioritization on top of the same matrix. |
+| Index derivation | `firestore_extract_indexes` | Button: "derive indexes from rules + observed queries" → diff against repo `firestore.indexes.json`, write back. |
+| Fixture generation | `generate_fixture_from_session`, `--capture` | **"Save session as fixture"** in Home/Traffic → writes to repo `fixtures/` via the disk workspace route, with the `pyric verify` command shown. |
+| Auth user seeding | `seed_auth_users` | Bulk-create form in Auth tab: count, provider mix, claim templates. |
+| Ideas / suggestions / prompt enhancer | none (pure LLM) | No mechanical twin; degrade to a template/example gallery in Build. These stay AI-only and Build-scoped. |
+| App building | esbuild-wasm preview compiles hand-written code without AI | Build surface works keyless as a manual editor + preview + deploy; the agent is the enhancement. |
+
+## The repo seam (single source of truth)
+
+`pyric serve --ui` already mounts disk routes: `/__pyric/workspace` and
+`/__pyric/projects`, and `init.json` carries `rulesHash`. Design:
+
+- **Rules**: workbench shows three states — repo file, deployed-to-sandbox,
+  editor buffer — with explicit actions "Deploy to sandbox" and "Save to
+  repo." Drift between repo hash and deployed hash surfaces on Home.
+- **Fixtures/seeds**: fixture save and seed-definition export write repo
+  files; the seed builder can load them back.
+- **Indexes**: extraction diffs against and writes `firestore.indexes.json`.
+- **Structure docs**: discovery export writes a markdown data-model doc.
+
+Result: the local coding agent (via MCP + repo files) and Studio (via UI +
+the same repo files) stop being two sources of truth.
+
+## The external-agent (MCP) story
+
+- **Presence + feed** (above) make agent work visible with zero new plumbing
+  — the event stream already carries it.
+- **Governance** (per M7, not the old dial): policy applies only to
+  agent-initiated mutations and surfaces where it fires — a blocked or
+  staged call appears as a `StagedChange` inline on the affected data, with
+  Review as the index. Mechanically, the worker is the right single
+  enforcement point: today sandbox-mode forwarded MCP calls are *not*
+  gated and the worker's `setPolicy` never reaches the bridge process (two
+  disconnected policy stores). The worker executes forwarded tool calls
+  (`{t:'tool'}` → `host.ts` dispatcher), so enforcement lands there; the
+  policy setting itself lives in Settings, not as ambient chrome.
+  *(Decision needed: default policy for MCP writes — allow-with-feed vs
+  stage.)*
+- **Audit**: the bridge already writes `~/.pyric/projects/<p>/events.ndjson`;
+  surface it later as a history view (P3).
+
+## One conversation system: sessions as a Studio primitive
+
+The trap to avoid: Home grows a prompt box with history, while Prototype
+keeps the playground's session system — two agent stacks (Studio's assist
+harness vs the playground session host), two BYOK stores, two histories,
+two tool registries, two model pickers, duplicating every feature and
+drifting. That is exactly how the experience falls apart.
+
+Resolution: **there is one session store, one key store, one tool registry,
+one history — owned at the Studio level.** A "prototype session" is not a
+different kind of conversation; it is a session that has a workspace
+(appSource/preview) attached. Sequencing:
+
+- **Near term, Home hosts no chat thread at all.** Its command input stages
+  single actions (mechanical always; NL-to-staged-change with a key).
+  Conversational agency lives where it genuinely is in local dev — the
+  user's external coding agent over MCP — and, for in-browser chat, inside
+  Prototype. No duplication because there is only one conversational
+  surface.
+- **When Studio needs native chat** (the website story), the session host +
+  tool registry extract from the playground into a shared package, and both
+  Home and Prototype become views over the same session store. History
+  management, keys, and model selection are implemented once.
+
+## Architecture: how Prototype integrates without a rewrite
+
+Studio (Vite) and Playground (Astro, static, own base path) stay **separate
+builds** through this redesign. Merging frameworks is expensive and blocks
+nothing above. What changes is the seam:
+
+1. **Studio owns all chrome.** Embedded (`?embed=studio`) playground hides
+   its TopBar already; extend so Studio also owns session switching, and the
+   Prototype surface defaults to the `firebase` profile with app-builder
+   chrome (ideas/suggestions/deploy sub-tabs, GitHub panels) behind an
+   opt-in.
+2. **Session lifecycle over postMessage, not page reloads.** Add
+   `pyric:playground:new-session`, `open-session {id}`, `list-sessions`,
+   and a `pyric:studio:session-changed` echo. The iframe navigates itself;
+   Studio never reloads. Sessions already live in IndexedDB, so this is
+   protocol work, not storage work.
+3. **URL sync.** `/prototype/<sessionId>` in Studio's route codec, kept in
+   sync with the echo messages. Deep-linking a session becomes real.
+4. **The Firebase Tab dissolves.** It was the only way to visualize sandbox
+   data; that is no longer true, so each sub-tab gets a disposition:
+   - *Redundant when shared* — Data/RTDB/Auth/Traffic/Sandbox-status
+     duplicate Studio's tabs over the same sandbox: hidden when embedded;
+     affordances (denial banner etc.) deep-link to Studio tabs via a
+     generalized `pyric:studio:navigate {path}` message.
+   - *Relocates to Studio* — the Seed sub-tab's concepts fold into Studio's
+     mechanical seed builder.
+   - *Prototype-specific stays* — Deploy (redesigned around the simplified
+     auth below), Ideas/Suggestions (AI-only, prototyping concerns).
+   - *Isolated-mode caveat* — an isolated session's sandbox is not the
+     shared worker, so Studio tabs can't show it. Near term: shared is the
+     default (already true when embedded); isolated becomes an advanced
+     option keeping only a minimal inspector. Visualizing isolated
+     sandboxes in Studio (multi-sandbox) is explicitly out of scope.
+
+## Deployment auth: one story
+
+GIS-in-the-browser for cloud-scope tokens was a moonshot and is now too
+complex; `pyric login` works but demands a user-supplied OAuth client and
+secret. Simplify to a single story:
+
+1. **Bundle an OAuth client with `pyric-tools`** so `pyric login` works out
+   of the box (PKCE/loopback installed-app flow — the `firebase-tools`
+   precedent: installed-app client secrets are not treated as confidential,
+   so bundling is normal practice). User-supplied clients remain a
+   power-user override.
+2. **`pyric serve` becomes the credential broker.** Browser surfaces
+   (Studio repo write-back, Prototype deploy) request short-lived tokens
+   from the local serve process (e.g. `/__pyric/auth/token`), which holds
+   the CLI credentials. The browser never runs its own OAuth dance in local
+   dev.
+3. **GIS survives only where there is no local serve** — the hosted website
+   — and only if the website keeps a deploy story at all (it may not need
+   one).
+
+One login (`pyric login`), everything brokers through serve, zero
+client/secret setup for the normal path.
+
+Longer term (post-npm, when the website needs a standalone assistant), the
+agent core — session host, tool registry, skills — extracts from the
+playground into a shared package so Studio can host chat natively. Not
+required for this redesign.
+
+### Tool registry convergence (P2)
+
+Three tool surfaces exist: the MCP bridge tools (`pyric-tools`
+`tool-metadata.ts`), the playground agent registry
+(`playground/src/lib/tools/`), and Studio's proposals-agent tools. They
+overlap and drift. Converge on `pyric-tools/registry` as the single
+composition consumed by all three, so the triad (tool / mechanical form /
+agent) is definitionally in sync, and every new tool automatically reaches
+MCP, the browser agent, and (with a small schema-to-form layer) a mechanical
+UI.
+
+## Website story
+
+Studio's `DevSeedProvider` already boots a seeded in-page sandbox with no
+server — the review build *is* the website build. The site is Studio Home on
+a seeded sandbox: visitors click through real denials, run the simulator,
+replay traffic, browse data; a BYOK key (or a hosted demo relay) lights up
+the command bar. Build (with Ollama as the zero-config local option) is the
+"and it can even build apps" epilogue. Blocker: the `@inbrowser/relay@0.4.0`
+migration left all Studio AI providers erroring "not wired yet" — the
+provider wiring must be restored for any AI-on story.
+
+## Phased plan
+
+**Phase 0 — Foundations (no new surfaces)**
+- Design system in force: PRINCIPLES.md, spec workflow, design lint.
+- History-API routing (port the hash codec's shape to pathname routes).
+- Fix the relay 0.4 provider wiring so Studio AI works at all.
+- Registry **parity audit**: mechanically diff playground tools, bridge
+  tool metadata, and `pyric-tools/registry` into the exposure matrix;
+  classify each gap as defect or deliberate (TOOL-SYSTEM.md, M8).
+- Stable event ids + session identity stamped through the event plane
+  (prerequisite for addressable traffic and provenance).
+- Ship the agent-presence chip + surface the activity feed data on Home
+  (form per `specs/home.md`).
+
+**Phase 1 — The hub and the mechanical core (spec-first)**
+- `specs/shell.md` + `specs/home.md` implemented: single sacred bar, hub
+  with command input, status, feed, live-count tiles, first-run onboarding.
+- Traffic rework per `specs/traffic.md`: virtualized, addressable events,
+  subject/consequence cross-links, chart demoted to disclosure.
+- **Rules design track** — the deepest surface gets its own dedicated
+  design effort, not one spec: rules editor, simulator/denial pipeline,
+  traffic-replay regression table, coverage sweep — each with its own
+  content inventory, designed as compositions of the same result renderers.
+- Mechanical seed builder (Firestore + Auth).
+
+**Phase 2 — The Prototype seam**
+- Rename playground → Prototype; opt-in app-builder chrome; embedded
+  profile defaults to firebase-focused.
+- Session lifecycle postMessage protocol + `/prototype/<id>` URL sync; kill
+  the reload-to-new-session flow.
+- Collapse redundant embedded sub-tabs; generalized `navigate {hash}`
+  deep-links into Studio tabs.
+
+**Phase 3 — Convergence and the repo seam**
+- Repo write-back for rules / fixtures / indexes / structure docs; drift
+  indicators on Home.
+- Unify policy enforcement in the worker; MCP proposals into Review.
+- Converge the three tool registries on `pyric-tools/registry`.
+
+**Phase 4 — Website / post-npm**
+- Publish the seeded-sandbox Studio build as the site.
+- Extract the agent core if/when Studio should host chat natively.
+- Coverage-matrix audit view; bridge audit-log history view.
+
+## Open decisions
+
+1. **Default MCP write policy** in sandbox mode: silent-with-feed,
+   notify, or propose-and-review? (Recommend: allow + feed by default,
+   dial available — friction on an already-local sandbox may hurt more
+   than it protects.)
+2. **Home vs Hub naming** — "Home" recommended; the hub is a behavior,
+   not a label.
+3. **Does Prototype appear in nav for keyless users?** Recommend yes,
+   since preview/editor/deploy work keyless, with copy framing it as
+   prototyping.
+4. **Dark-only through the redesign?** Recommended yes until post-npm; the
+   token system makes theming a later, contained task.

--- a/packages/pyric-tools/docs/reference/cli.md
+++ b/packages/pyric-tools/docs/reference/cli.md
@@ -47,7 +47,7 @@ is unavailable). `firestore.rules` is deployed and hot-reloaded over SSE.
 
 | Flag | Default | Description |
 |---|---|---|
-| `--port <n>` | `5000` | Port to serve on; scans forward when taken (macOS AirPlay commonly holds 5000). |
+| `--port <n>` | `3473` | Port to serve on ("FIRE" on a phone keypad); scans forward when taken. |
 | `--host <h>` | `localhost` | Host to bind. |
 | `--persist` | off | Persist sandbox state (docs + auth users) to a committable `.pyric/state/state.json`. Once a state file exists it wins; `--seed` then applies only on the first run. (On the SharedWorker path data is already durable in IndexedDB; this adds the on-disk, shareable copy.) |
 | `--fresh` | off | With `--persist`: discard the existing state file and re-seed from scratch. Does not clear the browser's IndexedDB. |

--- a/packages/pyric-tools/docs/tutorials/getting-started.md
+++ b/packages/pyric-tools/docs/tutorials/getting-started.md
@@ -38,7 +38,7 @@ npm install
 npx pyric dev
 ```
 
-Open <http://localhost:5000>. You'll see the scaffold app with two seeded
+Open <http://localhost:3473>. You'll see the scaffold app with two seeded
 posts ("Welcome to pyric"). Everything you're looking at is running
 against an **in-page Firestore sandbox**: `pyric dev` serves an import
 map that resolves the app's unmodified `firebase/*` imports to pyric's

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -171,8 +171,8 @@ COMMANDS
   whoami                     Print the signed-in account + the scopes Google granted.
 
 CORE FLAGS (dev)
-  --port             Port to serve on. Default 5000 (scans forward when taken —
-                     macOS AirPlay commonly holds 5000).
+  --port             Port to serve on. Default 3473 — "FIRE" on a phone keypad (scans forward when taken;
+                     macOS AirPlay squats 5000).
   --host             Host to bind. Default localhost.
   --no-cache         Rebuild the served pyric SDK bundles (skip ~/.pyric/serve-cache).
   --only hosting     Accepted for firebase-serve parity (hosting is all v1 serves).

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -1,6 +1,6 @@
 /**
  * `pyric dev` — local dev server with the pyric sandbox standing in for
- * Firebase. Feels like `firebase serve` (banner, labeled lines, port 5000,
+ * Firebase. Feels like `firebase serve` (banner, labeled lines, port 3473,
  * SIGINT shutdown) with the sandbox-flavored extras firebase can't do: the
  * served page runs an in-browser backend, your `firestore.rules` deploy into
  * it at page load, and unmodified `firebase/*` imports resolve to pyric via a
@@ -345,7 +345,7 @@ export async function startServe(opts: {
   });
   const handle = await startStaticServer({
     publicDir,
-    port: opts.port ?? 5000,
+    port: opts.port ?? 3473,
     host: opts.host ?? 'localhost',
     spaRewrite: wantsSpaRewrite(hosting),
     namespaceHandler: mount
@@ -477,7 +477,7 @@ export function bridgeEnabledFromFlags(flags: { get(key: string): unknown }): bo
 /** CLI entry. Resolves on SIGINT/SIGTERM after a clean stop. */
 export async function runServe(parsed: ParsedArgs): Promise<number> {
   const flagPort = parsed.flags.get('port');
-  const port = typeof flagPort === 'string' ? Number(flagPort) : 5000;
+  const port = typeof flagPort === 'string' ? Number(flagPort) : 3473;
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     process.stderr.write(`pyric: invalid --port '${flagPort}'.\n`);
     return 1;

--- a/packages/pyric-tools/src/cli/snapshot.ts
+++ b/packages/pyric-tools/src/cli/snapshot.ts
@@ -7,7 +7,7 @@
  *
  * Source preference:
  *   1. LIVE state from a running `pyric dev --persist`
- *      (`GET /__pyric/state` — `--port`, else the 5000+ scan window),
+ *      (`GET /__pyric/state` — `--port`, else the 3473+ scan window),
  *   2. else the on-disk `.pyric/state/state.json`,
  *   3. else exit 2 with a clear message.
  *
@@ -21,7 +21,7 @@ import type { ParsedArgs } from './parse-args.js';
 import { createStateStore, type PyricStateFile } from '../serve/state-store.js';
 
 /** Ports probed when --port is absent — serve's default + scan window. */
-const SCAN_PORTS = [5000, 5001, 5002, 5003, 5004];
+const SCAN_PORTS = [3473, 3474, 3475, 3476, 3477];
 
 /** Replacement for redacted passwords in a promoted fixture. Mirrors pyric's
  *  own `NO_PASSWORD_SENTINEL` so `seedUsers` accepts it on re-serve; defined
@@ -85,7 +85,7 @@ export async function runSnapshot(parsed: ParsedArgs, deps: SnapshotDeps = {}): 
     const found = await live(port);
     if (!found) continue;
     // Wrong-project guard (pre-mortem #4): the port scan can hit a NEIGHBOR
-    // project's serve (yours down, theirs on 5000). Refuse unless --port was
+    // project's serve (yours down, theirs on 3473). Refuse unless --port was
     // explicit AND warn either way.
     if (found.projectDir && found.projectDir !== cwd) {
       const explicit = typeof portFlag === 'string';

--- a/packages/pyric-tools/src/serve/bridge-mount.ts
+++ b/packages/pyric-tools/src/serve/bridge-mount.ts
@@ -2,7 +2,7 @@
  * `--bridge` for `pyric dev` — mounts the MCP bridge on the SAME origin
  * the app is served from, so one URL carries the app, the sandbox SDK, AND
  * the agent endpoint (the retrofit story end-to-end: `pyric dev --bridge`,
- * point an MCP client at `http://localhost:5000/__pyric/mcp`, and the agent
+ * point an MCP client at `http://localhost:3473/__pyric/mcp`, and the agent
  * drives the sandbox living in the served page).
  *
  * REUSES the bridge internals (`createBridge`, `buildMcpServer`,

--- a/packages/pyric-tools/src/serve/discovery.ts
+++ b/packages/pyric-tools/src/serve/discovery.ts
@@ -20,11 +20,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Ports probed when the pointer is absent — serve's default scan window PLUS
- *  the vite-plugin default (5174), which the old 5000-5004 window missed (so a
+ *  the vite-plugin default (5174), which the plain 3473+ window would miss (so a
  *  vite-only project was never found by scan). The standalone `pyric bridge`
  *  serves `/health` (not `/__pyric/health`) and writes no pointer, so it is
  *  registered directly via `claude mcp add`, not discovered here. */
-export const SCAN_PORTS = [5000, 5001, 5002, 5003, 5004, 5174];
+export const SCAN_PORTS = [3473, 3474, 3475, 3476, 3477, 5174];
 export const POINTER = join('.pyric', 'serve.json');
 
 export interface HealthLite {

--- a/packages/pyric-tools/src/serve/server.ts
+++ b/packages/pyric-tools/src/serve/server.ts
@@ -8,7 +8,7 @@
  * (`namespaceHandler`) and the import-map injection uses (`transformHtml`).
  *
  * UX parity targets: the `=== Serving from` banner, the labeled `Local server:`
- * line, port 5000 default with scan-forward on conflict, and SIGINT →
+ * line, port 3473 default ("FIRE" on a phone keypad) with scan-forward on conflict, and SIGINT →
  * `Shutting down...`.
  */
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
@@ -253,7 +253,7 @@ export interface ListenableLike {
   address(): { port: number } | string | null;
 }
 
-/** Listen, scanning forward from `port` on conflict (AirPlay squats 5000 on
+/** Listen, scanning forward from `port` on conflict (default 3473 avoids macOS AirPlay, which squats 5000 on
  *  macOS). Resolves with the bound port. */
 export function listenWithScan(
   server: ListenableLike,
@@ -325,7 +325,7 @@ export async function startStaticServer(opts: StaticServerOptions): Promise<Serv
 
   // Primary family: scan forward for a free port.
   const primary = newServer();
-  const port = await listenWithScan(primary, hosts[0]!, opts.port ?? 5000, opts.portScanLimit ?? 10, logger);
+  const port = await listenWithScan(primary, hosts[0]!, opts.port ?? 3473, opts.portScanLimit ?? 10, logger);
 
   // Remaining loopback families: bind the SAME port, best-effort. A loopback
   // port free on one family is virtually always free on the other; if not, warn


### PR DESCRIPTION
```
pyric dev
  ➜ http://localhost:3473
```

Port 5000 is a hostile default on macOS: AirPlay Receiver squats it, and sometimes *accepts* connections rather than failing cleanly — so even the existing scan-forward can't always save the experience. The new default is **3473 — "FIRE" on a phone keypad**: uncommon enough to collide with nothing well-known, memorable enough to document itself.

- Default and scan-forward start move to 3473; the AirPlay-specific warning remains for anyone passing `--port 5000` explicitly.
- The `mcp-proxy` and `snapshot` discovery windows move to `3473–3477` (+ the vite-plugin's `5174`).
- Explicit `--port` behavior unchanged; tests were already parameterized by explicit ports and needed no changes.
- Help text and docs updated.