### PR TITLE
One canonical URL, and Studio carries the bridge

### DIFF
--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -39,6 +39,10 @@
         "import": "./dist/bridge/server.js"
       }
     },
+    "./bridge/client": {
+      "types": "./dist/bridge/client.d.ts",
+      "import": "./dist/bridge/client.js"
+    },
     "./discover": {
       "types": "./dist/discover/index.d.ts",
       "import": "./dist/discover/index.js"

--- a/packages/pyric-tools/src/bridge/client.ts
+++ b/packages/pyric-tools/src/bridge/client.ts
@@ -9,6 +9,12 @@
  *
  * The Node-side server entry lives in `./server.ts`. Wire format
  * shared by both lives in `./protocol.ts`.
+ *
+ * ALSO reachable as `pyric-tools/bridge/client` — an explicit, condition-free
+ * subpath for browser apps whose TYPE resolution doesn't apply the `browser`
+ * condition (Pyric Studio's `moduleResolution: bundler` tsconfig resolves the
+ * `./bridge` subpath's top-level `types` to the SERVER entry). Same file,
+ * same surface.
  */
 
 export type {
@@ -28,5 +34,13 @@ export { connectBridge } from './client/bridge.js';
 export type {
   ConnectBridgeOptions,
   ConnectedBridge,
+  ConnectedBridgeState,
   SandboxToolDispatcher,
+  WorkerRelay,
 } from './client/bridge.js';
+
+// Re-anchor a served bridge URL to the page's own origin. The served app page
+// and Pyric Studio both do this before connecting as the bridge peer (see
+// `serve/entries/bridge-url.ts` for why the baked host can be the wrong
+// machine). Pure + browser-safe; exported here so Studio reuses it verbatim.
+export { toPageOriginWsUrl } from '../serve/entries/bridge-url.js';

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -563,9 +563,17 @@ export async function connectRemoteSandbox(
 ): Promise<RemoteSandbox> {
   const cwd = options.cwd ?? process.cwd();
 
+  // Two URLs on purpose: `serveUrl` is the CANONICAL display URL that lands in
+  // "open <url>" guidance — it MUST match the origin serve's banner/auto-open
+  // use (`http://localhost:<port>` for the default host), or a user following
+  // the guidance opens a DIFFERENT browser origin (127.0.0.1 vs localhost →
+  // separate SharedWorkers → split sandboxes). `wsBase` is connectivity: the
+  // literal loopback family the health probe actually reached.
   let serveUrl: string;
+  let wsBase: string;
   if (options.url) {
     serveUrl = options.url.replace(/\/$/, '');
+    wsBase = serveUrl;
   } else {
     const found = await discoverServe(cwd);
     if (!found) {
@@ -575,10 +583,11 @@ export async function connectRemoteSandbox(
           `${cwd} and the default ports) — start your dev server with the bridge enabled and retry.`,
       );
     }
-    serveUrl = found.base;
+    serveUrl = found.url;
+    wsBase = found.base;
   }
 
-  const wsUrl = `${serveUrl.replace(/^http/, 'ws')}/__pyric/sandbox`;
+  const wsUrl = `${wsBase.replace(/^http/, 'ws')}/__pyric/sandbox`;
   const ws = new WebSocket(wsUrl);
 
   const core = createRemoteSandboxCore(

--- a/packages/pyric-tools/src/serve/discovery.ts
+++ b/packages/pyric-tools/src/serve/discovery.ts
@@ -36,6 +36,16 @@ export interface HealthLite {
 
 export interface Discovered {
   mcpUrl: string;
+  /**
+   * The CANONICAL display URL — what a human/browser should OPEN. Comes from
+   * the serve-written pointer when present (`http://localhost:<port>` for the
+   * default host, the explicit `--host` otherwise); falls back to
+   * `http://localhost:<port>`. NEVER a literal loopback address: to a browser
+   * `localhost` and `127.0.0.1` are DIFFERENT ORIGINS (different
+   * SharedWorkers, so different sandboxes), and serve's banner/auto-open use
+   * `localhost` — guidance built from this field must land on the SAME origin.
+   * Node-side connectivity uses `base`/`mcpUrl` instead.
+   */
   url: string;
   /** `http://<family>:<port>` the server actually answered on. */
   base: string;
@@ -99,6 +109,27 @@ function portOf(u: string | undefined): number | null {
   return m ? Number(m[1]) : null;
 }
 
+/**
+ * Canonical display URL for a serve on `port`. Prefers the pointer's own
+ * `url` (serve writes `http://<requested host>:<port>` — `localhost` for the
+ * default, the explicit `--host` otherwise) so guidance shares the origin the
+ * banner/auto-open used; falls back to `http://localhost:<port>` (browsers
+ * resolve `localhost` dual-stack, so it reaches either loopback family).
+ */
+export function canonicalServeUrl(port: number, pointerUrl?: string): string {
+  if (pointerUrl) {
+    try {
+      const u = new URL(pointerUrl);
+      if (u.protocol === 'http:' || u.protocol === 'https:') {
+        return `${u.protocol}//${u.host}`;
+      }
+    } catch {
+      /* malformed pointer url — fall through to the localhost default */
+    }
+  }
+  return `http://localhost:${port}`;
+}
+
 /** Find the running serve: pointer first (in `cwd`), then a port scan. The
  *  pointer gives the PORT and (when present) the identity; the family is
  *  resolved by probing, so the returned base always uses the address the
@@ -126,7 +157,7 @@ export async function discoverServe(
         if (hit) {
           return {
             mcpUrl: `${hit.base}/__pyric/mcp`,
-            url: hit.base,
+            url: canonicalServeUrl(port, p.url),
             base: hit.base,
             instanceId: hit.instanceId,
             source: `pointer ${POINTER}`,
@@ -142,7 +173,8 @@ export async function discoverServe(
               `that isn't answering on port ${port} — another sandbox may be squatting the ` +
               `port on the other loopback family, or the server stopped. Not falling back to ` +
               `a blind port scan (it could hit the wrong sandbox). Restart your dev server, ` +
-              `and open http://127.0.0.1:${port} (NOT localhost) so a single family is used.`,
+              `and open the exact URL it prints (http://localhost:<port> by default) — every ` +
+              `page must share that ONE origin, or the browser splits into separate sandboxes.`,
           );
           return null;
         }
@@ -156,7 +188,7 @@ export async function discoverServe(
     if (hit) {
       return {
         mcpUrl: `${hit.base}/__pyric/mcp`,
-        url: hit.base,
+        url: canonicalServeUrl(port),
         base: hit.base,
         instanceId: hit.instanceId,
         source: `port scan (:${port})`,

--- a/packages/pyric-tools/src/serve/worker/index.ts
+++ b/packages/pyric-tools/src/serve/worker/index.ts
@@ -19,6 +19,14 @@
  */
 
 export {
+  // Bridge-peer relay seams (leaf-safe: ids are re-minted in-page, frames go
+  // over the worker port). The served page wires these into `connectBridge`'s
+  // `dispatcher`/`workerRelay` (entries/runtime.ts); Pyric Studio reuses the
+  // SAME wiring (studio's clients/bridge-peer.ts) so a Studio-only session
+  // still serves agent tool-calls + remote worker-ops.
+  callTool,
+  relayWorkerOp,
+  relayWorkerSub,
   // Connect + handles
   getFirestore,
   getAuth,

--- a/packages/pyric-tools/src/vite.ts
+++ b/packages/pyric-tools/src/vite.ts
@@ -8,3 +8,10 @@
  */
 export { pyricSandbox } from './serve/vite-plugin.js';
 export type { PyricSandboxOptions } from './serve/vite-plugin.js';
+
+// The benign node-builtin shims serve's bundler and this plugin apply when
+// bundling pyric's browser graph (`fs`/`path`/`url` reached via the rules
+// module resolver — see `serve/bundler.ts`). Exported so a browser app that
+// bundles pyric-tools' browser-side bridge client (Pyric Studio registers as
+// the bridge peer) applies the SAME shims instead of re-deriving them.
+export { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from './serve/bundler.js';

--- a/packages/pyric-tools/test/cli/mcp-proxy.test.ts
+++ b/packages/pyric-tools/test/cli/mcp-proxy.test.ts
@@ -44,6 +44,11 @@ describe('discoverServe', () => {
     expect(found).not.toBeNull();
     expect(found!.source).toContain('pointer');
     expect(found!.mcpUrl).toMatch(new RegExp(`^http://(127\\.0\\.0\\.1|\\[::1\\]):${r.handle.port}/__pyric/mcp$`));
+    // `base` is connectivity (the literal family that answered); `url` is the
+    // CANONICAL display URL — the pointer's `localhost` origin, never a literal
+    // loopback address (guidance built from it must match the banner's origin).
+    expect(found!.base).toMatch(new RegExp(`^http://(127\\.0\\.0\\.1|\\[::1\\]):${r.handle.port}$`));
+    expect(found!.url).toBe(`http://localhost:${r.handle.port}`);
     // the pointer carries the server's identity, and discovery pins it
     expect(found!.instanceId).toBeTruthy();
   }, 30_000);

--- a/packages/pyric-tools/test/serve/canonical-url.test.ts
+++ b/packages/pyric-tools/test/serve/canonical-url.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Canonical URL pinning — ONE origin everywhere for the default host.
+ *
+ * `pyric dev` binds BOTH loopback families for the default `localhost` host,
+ * but to a browser `http://localhost:<port>` and `http://127.0.0.1:<port>` are
+ * DIFFERENT ORIGINS — different SharedWorkers, so different sandboxes. Every
+ * user-facing and machine-facing URL must therefore agree on the ONE canonical
+ * origin the banner/auto-open use:
+ *
+ *   banner + auto-open      → handle.url
+ *   `--json` machine line   → serveJsonLine(runtime).url
+ *   .pyric/serve.json       → pointer url / mcpUrl
+ *   runner env              → PYRIC_SANDBOX=remote:<handle.url>
+ *   discovery guidance      → discoverServe(cwd).url ("open <url>" strings)
+ *
+ * A user following any of them must land on the SAME origin. Literal loopback
+ * addresses stay where they belong: connectivity (`Discovered.base`, the
+ * health probes) — never identity.
+ */
+import { afterAll, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startServe, serveJsonLine, type ServeRuntime } from '../../src/cli/serve.js';
+import { buildChildEnv } from '../../src/cli/dev-runner.js';
+import { silentServeLogger } from '../../src/serve/server.js';
+import { discoverServe, canonicalServeUrl } from '../../src/serve/discovery.js';
+
+function project(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pyric-canon-'));
+  writeFileSync(join(dir, 'firebase.json'), JSON.stringify({ hosting: { public: 'public' } }));
+  mkdirSync(join(dir, 'public'));
+  writeFileSync(join(dir, 'public', 'index.html'), '<!doctype html><html><head></head><body>c</body></html>');
+  return dir;
+}
+
+const stops: ServeRuntime[] = [];
+afterAll(async () => {
+  for (const r of stops) await r.handle.stop();
+});
+
+describe('canonical serve URL (default host)', () => {
+  it('banner/auto-open, --json, serve.json, runner env, and discovery guidance all share the localhost origin', async () => {
+    const cwd = project();
+    const r = await startServe({
+      cwd, port: 0, cacheRoot: join(cwd, '.cache'),
+      bridge: true, disableAuditLog: true, logger: silentServeLogger(),
+    });
+    stops.push(r);
+
+    // The banner (`Local server:`) and auto-open both print handle.url.
+    const bannerHost = new URL(r.handle.url).hostname;
+    expect(bannerHost).toBe('localhost');
+
+    // The --json machine line agents parse.
+    const json = JSON.parse(serveJsonLine(r)) as { url: string; mcpUrl: string | null };
+    expect(new URL(json.url).hostname).toBe(bannerHost);
+    expect(new URL(json.mcpUrl!).hostname).toBe(bannerHost);
+
+    // The .pyric/serve.json discovery pointer.
+    const pointer = JSON.parse(readFileSync(join(cwd, '.pyric', 'serve.json'), 'utf8')) as {
+      url: string;
+      mcpUrl: string;
+    };
+    expect(new URL(pointer.url).hostname).toBe(bannerHost);
+    expect(new URL(pointer.mcpUrl).hostname).toBe(bannerHost);
+
+    // The runner env (`PYRIC_SANDBOX=remote:<serve url>`) — the activator the
+    // child's `pyric-tools/register` reads.
+    const env = buildChildEnv({}, { serveUrl: r.handle.url, registerUrl: 'file:///register.js' });
+    const activated = env.PYRIC_SANDBOX!.replace(/^remote:/, '');
+    expect(new URL(activated).hostname).toBe(bannerHost);
+
+    // Discovery: `url` (the "open <url>" guidance origin) is canonical and
+    // EQUALS the banner origin; `base` stays a literal family (connectivity).
+    const found = await discoverServe(cwd);
+    expect(found).not.toBeNull();
+    expect(found!.url).toBe(r.handle.url);
+    expect(found!.base).toMatch(/^http:\/\/(127\.0\.0\.1|\[::1\]):\d+$/);
+  }, 30_000);
+
+  it('an explicit --host is the canon for every consumer', async () => {
+    const cwd = project();
+    const r = await startServe({
+      cwd, port: 0, host: '127.0.0.1', cacheRoot: join(cwd, '.cache'),
+      bridge: true, disableAuditLog: true, logger: silentServeLogger(),
+    });
+    stops.push(r);
+
+    expect(new URL(r.handle.url).hostname).toBe('127.0.0.1');
+    const pointer = JSON.parse(readFileSync(join(cwd, '.pyric', 'serve.json'), 'utf8')) as { url: string };
+    expect(new URL(pointer.url).hostname).toBe('127.0.0.1');
+
+    // Discovery honors the pointer's explicit host as the display URL.
+    const found = await discoverServe(cwd);
+    expect(found).not.toBeNull();
+    expect(found!.url).toBe(r.handle.url);
+  }, 30_000);
+});
+
+describe('canonicalServeUrl', () => {
+  it('prefers the pointer url origin, falls back to localhost', () => {
+    expect(canonicalServeUrl(3473, 'http://localhost:3473')).toBe('http://localhost:3473');
+    expect(canonicalServeUrl(3473, 'http://127.0.0.1:3473')).toBe('http://127.0.0.1:3473');
+    expect(canonicalServeUrl(3473, 'not a url')).toBe('http://localhost:3473');
+    expect(canonicalServeUrl(3473)).toBe('http://localhost:3473');
+  });
+});

--- a/packages/studio/src/clients/bridge-peer.test.ts
+++ b/packages/studio/src/clients/bridge-peer.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Studio bridge peer (`bridge-peer.ts`) — the wiring that registers SERVED
+ * Studio as the bridge's sandbox peer, so a Studio-only session (what
+ * `pyric dev --ui` auto-opens) serves agent tool-calls and remote worker-ops
+ * instead of failing with "no browser tab is connected".
+ *
+ * No browser, no real WS, no real worker: the WebSocket global is faked (the
+ * transport `connectBridge` drives), the SharedWorker is the same recording
+ * shim `worker-live.test.ts` uses, and worker replies are injected through the
+ * port's `onmessage` — so the tests exercise the REAL `connectBridge` +
+ * `callTool`/`relayWorkerOp`/`relayWorkerSub` wiring end-to-end in-process.
+ *
+ * Covers:
+ *   - no-op when no serve answers /__pyric/init.json (dev-seed / review), when
+ *     the response isn't JSON (a Vite SPA fallback), and when the bridge is off
+ *   - connects as a relay-capable peer: hello advertises `worker-relay`, the
+ *     WS URL is re-anchored to the page origin
+ *   - serves a worker-op / worker-sub / tool-call through the worker port —
+ *     the same frames the worker-relay suite drives from the Node side
+ *   - reconnects after a WS drop (the app page's resilience, inherited)
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { connectStudioBridgePeer } from './bridge-peer.js';
+import { createStudioEnvironment } from '../env.js';
+import { getFirestore, type ClientDb } from 'pyric-tools/serve/worker';
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+type WsEvent = { data?: string; code?: number; reason?: string };
+
+/** Minimal browser-WebSocket fake capturing every instance + sent frame. */
+class FakeWebSocket {
+  static OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = 0;
+  sent: unknown[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: WsEvent) => void) | null = null;
+  onclose: ((ev: WsEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(JSON.parse(data));
+  }
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: 'closed by client' });
+  }
+  // test drivers
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+  emit(msg: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+  drop(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1006, reason: 'dropped' });
+  }
+}
+
+/** Recorded worker port: captures page→worker posts; tests reply by invoking
+ *  `onmessage` (the handler `wirePort` installed) — same style as
+ *  `worker-live.test.ts`, plus the reply channel. */
+interface RecordedPort {
+  posts: Array<Record<string, unknown>>;
+  reply(msg: unknown): void;
+}
+
+function shimSharedWorker(): { restore: () => void; lastPort: () => RecordedPort } {
+  const prevWorker = (globalThis as { SharedWorker?: unknown }).SharedWorker;
+  let current: RecordedPort | null = null;
+  (globalThis as { SharedWorker?: unknown }).SharedWorker = class {
+    port: {
+      postMessage(m: unknown): void;
+      start(): void;
+      onmessage: ((ev: { data: unknown }) => void) | null;
+    };
+    constructor(_url: unknown, _opts: unknown) {
+      const posts: Array<Record<string, unknown>> = [];
+      const port = {
+        posts,
+        postMessage: (m: unknown) => posts.push(m as Record<string, unknown>),
+        start() {},
+        onmessage: null as ((ev: { data: unknown }) => void) | null,
+      };
+      this.port = port;
+      current = {
+        posts,
+        reply: (msg) => port.onmessage?.({ data: msg }),
+      };
+    }
+  };
+  return {
+    restore: () => {
+      (globalThis as { SharedWorker?: unknown }).SharedWorker = prevWorker;
+    },
+    lastPort: () => {
+      if (!current) throw new Error('no SharedWorker constructed');
+      return current;
+    },
+  };
+}
+
+function installFakeWebSocket(): () => void {
+  const prev = (globalThis as { WebSocket?: unknown }).WebSocket;
+  FakeWebSocket.instances = [];
+  (globalThis as { WebSocket?: unknown }).WebSocket = FakeWebSocket;
+  return () => {
+    (globalThis as { WebSocket?: unknown }).WebSocket = prev;
+  };
+}
+
+const LOC = { href: 'http://localhost:3473/__pyric/ui/', protocol: 'http:', host: 'localhost:3473' };
+
+function servedFetch(bridgeUrl: string | null): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify({ bridgeUrl }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+}
+
+function tick(ms = 5): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('connectStudioBridgePeer', () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) restores.pop()!();
+  });
+
+  function makeDb(): { db: ClientDb; port: () => RecordedPort } {
+    const shim = shimSharedWorker();
+    restores.push(shim.restore);
+    const db = getFirestore('/__pyric/sdk/worker.js');
+    return { db, port: shim.lastPort };
+  }
+
+  it('no-ops when no serve answers init.json (dev-seed / review mode)', async () => {
+    restores.push(installFakeWebSocket());
+    const { db } = makeDb();
+    const failing = (async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch;
+    expect(await connectStudioBridgePeer(db, { fetchImpl: failing, locationLike: LOC })).toBeNull();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('no-ops on a non-JSON answer (a plain Vite host SPA-falls-back to HTML)', async () => {
+    restores.push(installFakeWebSocket());
+    const { db } = makeDb();
+    const html = (async () =>
+      new Response('<!doctype html><html></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })) as unknown as typeof fetch;
+    expect(await connectStudioBridgePeer(db, { fetchImpl: html, locationLike: LOC })).toBeNull();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('no-ops when the serve runs without --bridge (bridgeUrl null)', async () => {
+    restores.push(installFakeWebSocket());
+    const { db } = makeDb();
+    expect(
+      await connectStudioBridgePeer(db, { fetchImpl: servedFetch(null), locationLike: LOC }),
+    ).toBeNull();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('connects as a relay-capable peer on the page origin and serves worker frames', async () => {
+    restores.push(installFakeWebSocket());
+    const { db, port } = makeDb();
+
+    const bridge = await connectStudioBridgePeer(db, {
+      // A baked host that differs from the page origin: the peer must
+      // re-anchor to the page's own host (Tailscale / LAN / https safety).
+      fetchImpl: servedFetch('ws://127.0.0.1:3473/__pyric/sandbox'),
+      locationLike: LOC,
+    });
+    expect(bridge).not.toBeNull();
+    restores.push(() => bridge!.disconnect());
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const ws = FakeWebSocket.instances[0]!;
+    expect(ws.url).toBe('ws://localhost:3473/__pyric/sandbox');
+
+    // hello advertises the worker-relay capability + the sandbox tool names —
+    // the same hello the served app page sends.
+    ws.open();
+    const hello = ws.sent[0] as { type: string; capabilities?: string[]; tools: string[] };
+    expect(hello.type).toBe('hello');
+    expect(hello.capabilities).toContain('worker-relay');
+    expect(hello.tools.length).toBeGreaterThan(0);
+    ws.emit({ type: 'hello-ack', protocol: 1, bridgeVersion: 'test' });
+    expect(bridge!.state()).toEqual({ kind: 'connected', bridgeVersion: 'test' });
+
+    // worker-op → forwarded over the worker port; the reply comes back as
+    // worker-res correlated by the BRIDGE id.
+    ws.emit({ type: 'worker-op', id: 'w1', op: { method: 'getVersion' } });
+    await tick();
+    const opPost = port().posts.find((p) => p.t === 'op' && p.method === 'getVersion')!;
+    expect(opPost).toBeDefined();
+    port().reply({ t: 'res', id: opPost.id, ok: true, value: { version: 'dev' } });
+    await tick();
+    expect(ws.sent).toContainEqual({ type: 'worker-res', id: 'w1', ok: true, value: { version: 'dev' } });
+
+    // worker-sub → relayed subscription; snaps stream back tagged with the
+    // bridge's subId; unsub tears the worker listener down.
+    ws.emit({ type: 'worker-sub', subId: 's1', sub: { target: { __ref: 'doc', path: 'rooms/lobby' } } });
+    const subPost = port().posts.find((p) => p.t === 'sub')!;
+    expect(subPost).toBeDefined();
+    port().reply({ t: 'snap', subId: subPost.subId, value: { open: true } });
+    expect(ws.sent).toContainEqual({ type: 'worker-snap', subId: 's1', value: { open: true } });
+    ws.emit({ type: 'worker-unsub', subId: 's1' });
+    expect(port().posts.some((p) => p.t === 'unsub' && p.subId === subPost.subId)).toBe(true);
+
+    // tool-call → dispatched through the worker (`callTool`), not in-page.
+    ws.emit({ type: 'tool-call', id: 't1', name: 'sandbox_inspect', args: {} });
+    await tick();
+    const toolPost = port().posts.find((p) => p.t === 'tool')!;
+    expect(toolPost.name).toBe('sandbox_inspect');
+    port().reply({ t: 'res', id: toolPost.id, ok: true, value: { ok: true, summary: 'inspected' } });
+    await tick();
+    expect(ws.sent).toContainEqual({
+      type: 'tool-result',
+      id: 't1',
+      ok: true,
+      result: { ok: true, summary: 'inspected' },
+    });
+  });
+
+  it('createStudioEnvironment(local) wires the peer when a serve answers (and stays sync)', async () => {
+    restores.push(installFakeWebSocket());
+    const shim = shimSharedWorker();
+    restores.push(shim.restore);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = servedFetch('ws://localhost:3473/__pyric/sandbox');
+    restores.push(() => {
+      globalThis.fetch = prevFetch;
+    });
+
+    const env = createStudioEnvironment('local');
+    expect(env.live).toBeDefined(); // the factory itself stays synchronous
+    await tick();
+    // The fire-and-forget peer connect opened the bridge WS.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]!.url).toBe('ws://localhost:3473/__pyric/sandbox');
+  });
+
+  it('reconnects after a WS drop (the app page resilience, inherited)', async () => {
+    restores.push(installFakeWebSocket());
+    const { db } = makeDb();
+    const bridge = await connectStudioBridgePeer(db, {
+      fetchImpl: servedFetch('ws://localhost:3473/__pyric/sandbox'),
+      locationLike: LOC,
+      initialReconnectDelayMs: 10,
+      maxReconnectDelayMs: 20,
+    });
+    restores.push(() => bridge!.disconnect());
+    const first = FakeWebSocket.instances[0]!;
+    first.open();
+    first.emit({ type: 'hello-ack', protocol: 1, bridgeVersion: 'test' });
+
+    first.drop();
+    expect(bridge!.state().kind).toBe('reconnecting');
+    await tick(30);
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    const second = FakeWebSocket.instances[1]!;
+    second.open();
+    second.emit({ type: 'hello-ack', protocol: 1, bridgeVersion: 'test' });
+    expect(bridge!.state()).toEqual({ kind: 'connected', bridgeVersion: 'test' });
+  });
+});

--- a/packages/studio/src/clients/bridge-peer.ts
+++ b/packages/studio/src/clients/bridge-peer.ts
@@ -1,0 +1,128 @@
+/**
+ * Studio bridge peer — register the SERVED Studio page as the bridge's
+ * sandbox peer, exactly like the served app page does.
+ *
+ * WHY: the bridge relays agent tool-calls and remote worker-ops (the MCP
+ * endpoint, `connectRemoteSandbox`) through ONE registered browser peer into
+ * the SharedWorker. That peer was wired only in the served APP page
+ * (`connectBridgePeer` in pyric-tools' `serve/entries/runtime.ts`) — so a user
+ * with ONLY Studio open (exactly what `pyric dev --ui` auto-opens) got
+ * "no browser tab is connected" even though Studio talks to the very same
+ * SharedWorker. Studio must register too.
+ *
+ * WIRING (reused, not duplicated): `connectBridge` (the reconnecting WS client
+ * from `pyric-tools/bridge/client`) with the SAME `dispatcher`/`workerRelay`
+ * closures the app page uses — `callTool` / `relayWorkerOp` / `relayWorkerSub`
+ * from `pyric-tools/serve/worker`, forwarding every frame over the worker
+ * `MessagePort` the live plane already holds. Last-connection-wins peer
+ * semantics make app page + Studio both being open safe: whichever page holds
+ * the peer slot fronts the one shared SharedWorker sandbox identically.
+ *
+ * LIFECYCLE: discovery is the serve init payload (`/__pyric/init.json`) —
+ * present only when Studio is SERVED (`pyric dev --ui` / the Vite plugin). In
+ * dev-seed / review mode there is no serve, the fetch fails (or returns
+ * non-JSON), and this module no-ops cleanly. Once connected, resilience is
+ * `connectBridge`'s own reconnect loop (exponential backoff — the same
+ * behavior the app page gets).
+ */
+
+import {
+  connectBridge,
+  toPageOriginWsUrl,
+  type ConnectBridgeOptions,
+  type ConnectedBridge,
+} from 'pyric-tools/bridge/client';
+import {
+  callTool,
+  relayWorkerOp,
+  relayWorkerSub,
+  type ClientDb,
+} from 'pyric-tools/serve/worker';
+
+/** The slice of the serve init payload this module reads. */
+interface InitPayloadLite {
+  /** Bridge WS URL when `--bridge` is on; null otherwise. */
+  bridgeUrl?: string | null;
+}
+
+export interface StudioBridgePeerOptions {
+  /** Base URL of the serve (`''` = same origin, the served default). */
+  baseUrl?: string;
+  /** Injectable fetch (tests). Defaults to the global. */
+  fetchImpl?: typeof fetch;
+  /** Injectable location (tests / non-window hosts). Defaults to `window.location`. */
+  locationLike?: { href: string; protocol: string; host: string };
+  /** Reconnect tuning passed through to `connectBridge` (tests). */
+  initialReconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+}
+
+/**
+ * Build the `ConnectBridgeOptions` wiring for a Studio peer over `db` — the
+ * SAME shape the served app page passes on its worker path (see
+ * `connectBridgePeer` in pyric-tools' `entries/runtime.ts`): tool-calls
+ * dispatch through the worker (`callTool`), and the generic worker relay
+ * forwards ops/subscriptions over the worker port. Exported for tests.
+ */
+export function studioBridgePeerOptions(db: ClientDb, url: string): ConnectBridgeOptions {
+  return {
+    url,
+    dispatcher: (_sandbox, name, args) => callTool(db, name, args),
+    workerRelay: {
+      op: (op) => relayWorkerOp(db, op),
+      subscribe: (sub, onValue) => relayWorkerSub(db, sub, onValue),
+    },
+  };
+}
+
+/**
+ * Register served Studio as the bridge's sandbox peer over the live plane's
+ * worker port. Resolves with the connected bridge handle, or `null` when there
+ * is no serve/bridge to register with (dev-seed / review mode, serve without
+ * `--bridge`) — never throws.
+ */
+export async function connectStudioBridgePeer(
+  db: ClientDb,
+  options: StudioBridgePeerOptions = {},
+): Promise<ConnectedBridge | null> {
+  const baseUrl = options.baseUrl ?? '';
+  const doFetch = options.fetchImpl ?? (typeof fetch !== 'undefined' ? fetch : null);
+  if (!doFetch) return null;
+
+  // Serve discovery: only a pyric serve answers /__pyric/init.json with JSON.
+  // Anything else (no server, a dev-seed Vite host SPA-falling-back to HTML,
+  // a non-200) means "not served" → no-op.
+  let bridgeUrl: string | null;
+  try {
+    const res = await doFetch(`${baseUrl}/__pyric/init.json`);
+    if (!res.ok) return null;
+    bridgeUrl = ((await res.json()) as InitPayloadLite).bridgeUrl ?? null;
+  } catch {
+    return null;
+  }
+  if (!bridgeUrl) return null; // served, but the bridge is off
+
+  // Re-anchor the WS to THIS page's origin (Tailscale / LAN / https) — the
+  // same re-anchoring the app page does before connecting.
+  const loc =
+    options.locationLike ?? (typeof window !== 'undefined' ? window.location : null);
+  const url = loc ? toPageOriginWsUrl(bridgeUrl, loc) : bridgeUrl;
+
+  const bridge = connectBridge(
+    // The sandbox parameter is only ever handed to the dispatcher, and ours
+    // routes through the worker instead — the in-page sandbox does not exist
+    // on this path (same contract as the app page's worker-path wiring).
+    null as never,
+    {
+      ...studioBridgePeerOptions(db, url),
+      ...(options.initialReconnectDelayMs !== undefined
+        ? { initialReconnectDelayMs: options.initialReconnectDelayMs }
+        : {}),
+      ...(options.maxReconnectDelayMs !== undefined
+        ? { maxReconnectDelayMs: options.maxReconnectDelayMs }
+        : {}),
+    },
+  );
+  console.info('[pyric studio] registered as the sandbox bridge peer at', url);
+  return bridge;
+}

--- a/packages/studio/src/env.ts
+++ b/packages/studio/src/env.ts
@@ -29,6 +29,7 @@ import {
   connectWorkerLive,
   type WorkerLivePlane,
 } from './clients/worker-live.js';
+import { connectStudioBridgePeer } from './clients/bridge-peer.js';
 
 /** Where Studio's storage lives. Only `local` is wired in v1. */
 export type StudioMode = 'local' | 'browser' | 'hosted';
@@ -109,6 +110,14 @@ export function createStudioEnvironment(
       ? null
       : connectWorkerLive(options.workerUrl);
 
+    // Served Studio must ALSO register as the bridge's sandbox peer — the
+    // relay the agent (MCP) and `connectRemoteSandbox` reach the SharedWorker
+    // through. Otherwise a Studio-only session (exactly what `pyric dev --ui`
+    // auto-opens) gets "no browser tab is connected". Fire-and-forget: the
+    // factory stays synchronous, and the peer connect no-ops cleanly when no
+    // serve is present (dev-seed / review) or the bridge is off.
+    if (live) void connectStudioBridgePeer(live.db, { baseUrl });
+
     return {
       mode,
       projects: httpProjectStore(baseUrl),
@@ -145,3 +154,11 @@ export {
   type LiveEventFeed,
   type StudioLens,
 } from './clients/worker-live.js';
+
+// Re-export the bridge-peer seam (served Studio registers as the bridge's
+// sandbox peer) for the same reason.
+export {
+  connectStudioBridgePeer,
+  studioBridgePeerOptions,
+  type StudioBridgePeerOptions,
+} from './clients/bridge-peer.js';

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from 'pyric-tools/vite';
 
 /**
  * Studio app build. Outputs static assets to `dist/app`, served by
@@ -11,9 +12,33 @@ import tailwindcss from '@tailwindcss/vite';
  * served under `/__pyric/ui/`) can set `STUDIO_BASE=/__pyric/ui/`. The default
  * `/` keeps the dev server and the in-repo review build rooted at `/`.
  */
+
+/**
+ * Benign node-builtin shims (`fs`/`path`/`url`) — the SAME shims serve's
+ * bundler and the `pyricSandbox` Vite plugin apply to pyric's browser graph.
+ * Needed because Studio's bridge peer (clients/bridge-peer.ts) bundles
+ * pyric-tools' browser-side bridge client, whose default dispatcher statically
+ * reaches the pyric rules module resolver (a Node module the browser path
+ * never actually calls into — see pyric-tools' serve/bundler.ts).
+ */
+function nodeBuiltinShims(): Plugin {
+  const PREFIX = '\0pyric-node-shim:';
+  return {
+    name: 'studio-node-builtin-shims',
+    enforce: 'pre',
+    resolveId(source) {
+      const m = NODE_BUILTIN_RE.exec(source);
+      return m ? PREFIX + m[2]! : null;
+    },
+    load(id) {
+      return id.startsWith(PREFIX) ? NODE_BUILTIN_SHIMS[id.slice(PREFIX.length)] : null;
+    },
+  };
+}
+
 export default defineConfig({
   base: process.env.STUDIO_BASE ?? '/',
-  plugins: [react(), tailwindcss()],
+  plugins: [nodeBuiltinShims(), react(), tailwindcss()],
   build: {
     outDir: 'dist/app',
     emptyOutDir: true,


### PR DESCRIPTION
Fixes the two first-user failures found in manual e2e: guidance messages pointing at a *different origin* than the one open (silently splitting the sandbox in two), and `pyric dev --ui`'s auto-opened Studio tab not being sufficient to serve the bridge.

## Every URL is the same URL

`localhost` and `127.0.0.1` are different browser origins — different SharedWorkers, different sandboxes. The banner and serve.json already said `localhost`; the literal leaked from `discoverServe()`, which returned its connectivity probe base as the URL, so `connectRemoteSandbox`'s "no browser tab is connected — open <url>" told users to open `127.0.0.1` while their tab sat on `localhost`. Discovery now distinguishes identity from connectivity: `Discovered.url` is canonical (the serve-written origin, so explicit `--host` remains the canon; `localhost` fallback for port-scan hits) and feeds all human guidance; `Discovered.base` keeps the literal family for Node dialing and health probes. A squatter diagnostic that literally instructed "open http://127.0.0.1 (NOT localhost)" is rewritten. New `test/serve/canonical-url.test.ts` pins banner === `--json` === serve.json === `PYRIC_SANDBOX` env === discovery url, against a real serve.

## The tab pyric dev opens is now enough

The bridge peer (the page-side WS relay that carries external ops into the SharedWorker) was wired only into the served app page — so a user with only Studio open (exactly what `--ui` auto-opens, and the *only* page a server-only app has) got "no browser tab is connected" despite an open tab. Served Studio now registers as a peer with the identical machinery the app page uses — real `connectBridge` + `relayWorkerOp`/`relayWorkerSub` over its existing worker MessagePort, reconnect via `connectBridge`'s own backoff — wired fire-and-forget in `createStudioEnvironment('local')`, and a clean no-op in dev-seed/review builds (no serve → no `init.json` → nothing happens). Both pages open is already handled by last-connection-wins: either page fronts the same worker identically. No relay logic duplicated: helpers newly exported from the leaf-safe `pyric-tools/serve/worker` barrel plus a new condition-free `./bridge/client` export (the `./bridge` browser condition mis-resolves types under `moduleResolution: bundler`).

Verification: full build green with the studio-ui embed rebuilt and confirmed to contain the peer wiring; root test script all green (pyric-tools 1142/0, studio 269/0); `lint:manifest` green including the new export; headless smoke from a temp project confirms serve.json/mcpUrl/init.json bridgeUrl all say `localhost` and `/__pyric/ui/` serves.