### PR TITLE
Unblock the release gate: marker export on register, CI node pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.15'
 
       # The gate's consumer install resolves firebase/firebase-admin (large)
       # from the registry every run on a cold runner — measured 47s of the
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.15'
 
       - name: Enable pnpm (corepack)
         if: matrix.pm == 'pnpm'

--- a/docs/design/remote-firestore.md
+++ b/docs/design/remote-firestore.md
@@ -1,0 +1,385 @@
+# Remote Firestore for `pyric-admin` (remote sandbox, slice 2 — design spike)
+
+Status: spike complete — analysis + plan, no implementation.
+Scope: `pyric-admin/firestore` gaining a REMOTE dispatch arm — server-side
+Node code driving the browser-hosted SharedWorker sandbox's Firestore over
+the slice-1 bridge machinery (`worker-op`/`worker-sub` frames,
+`connectRemoteSandbox()`'s `RemoteSandboxChannel`). Companion to
+`docs/design/remote-sandbox.md` (slice 1: RTDB + Auth) and the parallel
+Storage spike (`docs/design/remote-storage.md`).
+
+## Verdict on the architectural fork
+
+**Parallel channel-backed arm — the admin-firestore layer cannot run
+unchanged over a remote context.** Same conclusion as slice 1's RTDB/Auth
+correction, but for a deeper reason: RTDB/Auth kept WeakMap-local *state*;
+admin-firestore's problem is a **synchronous engine seam**. The chainable
+admin-compat layer is built directly on `LocalEnvironment`, whose contract
+is synchronous end to end, and synchrony cannot span a WebSocket. There is
+no narrow async interface to swap an implementation behind — the seam that
+exists (`getInternalEnv`) hands back the whole sync engine and explicitly
+rejects any sandbox that isn't the in-process `SandboxImpl`.
+
+Evidence chain:
+
+1. **The layering.** `pyric-admin/firestore` is a thin re-export +
+   default-app resolver over `pyric/sandbox/admin-firestore`
+   (`packages/pyric-admin/src/firestore/index.ts:18`, `:63–73`). The real
+   layer is `packages/pyric/src/sandbox/admin-firestore/index.ts`, which
+   wraps `pyric/sandbox/admin-compat` =
+   `packages/pyric/src/sandbox/firestore/admin-compat/*` (~2.3k lines).
+
+2. **The seam is `LocalEnvironment`, obtained per-op.**
+   `buildFirestoreHandle` constructs a fresh compat delegate per call via
+   `createCompatFirestore(getInternalEnv(ctx.sandbox), { auth, bypassRules })`
+   (`admin-firestore/index.ts:200–201`). `getInternalEnv` **throws
+   `invalid-argument` unless `sandbox instanceof SandboxImpl`**
+   (`packages/pyric/src/sandbox/internal/sandbox-impl.ts:632–640`) — a
+   branded remote handle can never pass it. The sandbox-only methods call
+   it directly too (`setRules`/`seed`/`snapshot`,
+   `admin-firestore/index.ts:225–240`). `onSnapshot` also reaches for it:
+   `getInternalEnv(ctx.sandbox)` then `env.addSnapshotListener(...)`
+   (`admin-firestore/index.ts:570–608`).
+
+3. **The consumed `LocalEnvironment` surface is synchronous.** What
+   admin-compat actually calls:
+   - `env.execute({ method, path, data, auth, merge?, bypassRules })` —
+     **sync return** of `OperationResult`
+     (`admin-compat/doc-ref.ts:90–104`, `:128`, `:141`, `:152`, `:160`,
+     `:171`).
+   - `env.getDocument(path)` — **sync existence peek** inside `set()` merge
+     dispatch (`doc-ref.ts:126`, `:139`) and, load-bearingly, inside the
+     **sync** `WriteBatch.set()` queueing ("the batch path has no async
+     wrapping", `admin-compat/batch.ts:45–53`).
+   - `env.batch(ops, auth, bypassRules)` — sync (`batch.ts:69–73`).
+   - `env.transaction(cb, opts)` where the callback receives a **sync
+     `SimTransaction`** — `simTx.get(path)` returns a snapshot
+     synchronously and `simTx.getAll(...paths)` registers the read-set
+     synchronously (`admin-compat/transaction.ts:65`, `:69`;
+     `admin-compat/firestore.ts:115–124`).
+   - queries: `env.scanDocuments(collectionPath, { directOnly })`
+     (`admin-compat/query.ts:480`), `env.readQueryCandidates(...)`
+     (`query.ts:514`), and collection-group scans over `env.snapshot()`
+     (`query.ts:847`) — all sync.
+   - `env.addSnapshotListener(target, cb, options, auth, onError,
+     followsCurrentUser)` (`admin-firestore/index.ts:606–608`).
+
+   The *public* admin surface is mostly async (`get/set/update/delete`,
+   `Query.get`, `aggregate`, `commit`, `runTransaction` — all
+   Promise-returning, `admin-compat/types.ts:88–96`, `:161–179`, `:218–223`,
+   `:226–234`), but three members are irreducibly sync at the API contract:
+   `WriteBatch.set/update/delete` chain-queueing (fine — pure local
+   buffering, except the `set()` existence peek), `Transaction.set/update/
+   delete` (fine — local queueing), and the sandbox-only
+   `SandboxFirestore.setRules/seed/snapshot` (`admin-firestore/index.ts:
+   161–174` — `LintResult`/map returned synchronously).
+
+4. **Why not async-ify the seam?** Making admin-compat consume an
+   `AsyncEnvironment` interface would mean rewriting `execute`-call plumbing
+   across doc-ref/query/batch/firestore (~2.3k lines), changing
+   `WriteBatch.set`'s sync-peek design, replacing the sync `SimTransaction`
+   inside `env.transaction` with a wire transaction (the worker doesn't even
+   expose an interactive transaction — see §3), and re-plumbing
+   `addSnapshotListener`. The result would still need per-method wire
+   translation (sentinels, codec, error shapes). That is strictly more work
+   and more risk than a parallel arm, and it perturbs the heavily-tested
+   local compat layer (the conformance exemplar) for zero local benefit.
+
+5. **The parallel arm is cheap because it already half-exists.** The worker
+   client (`packages/pyric-tools/src/serve/worker/client.ts`) demonstrates
+   every needed pattern engine-free: descriptor building (`QueryDescriptor`,
+   protocol.ts:91–106), write ops, batch descriptors, the optimistic
+   transaction protocol (client.ts:938–1040), snapshot rehydration
+   (`deserializeDocData`, client.ts:115–116). And the RTDB remote arm shows
+   the pyric-admin-side shape: channel ops with a pinned lens, no local
+   state, shared shell between arms
+   (`packages/pyric-admin/src/database/index.ts:800–1000`).
+
+So: **implement the admin Firestore SHAPE (`admin-compat/types.ts`
+interfaces, re-used verbatim) directly over channel ops**, dispatched on
+`isRemoteSandbox(ctx.sandbox)` — the same fork `database/index.ts` took.
+The remote arm and the local arm share the type surface and the conformance
+suite, not the implementation.
+
+### Where the dispatch lives
+
+Not in `pyric-admin/firestore/index.ts` alone. The current guard there
+(`packages/pyric-admin/src/firestore/index.ts:38–45`) only covers
+**app-based** resolution (`getFirestore(app)` / `getFirestore()`); the
+ctx-form `getFirestore(sandbox.withAuth(...))` with a remote sandbox slips
+through to `baseGetFirestore` and dies later with `getInternalEnv`'s
+misleading `invalid-argument` ("custom Sandbox implementations are not
+supported") on the *first operation* (per-op delegate,
+`admin-firestore/index.ts:200`), or immediately on `setRules`.
+
+The brand lives in `pyric` (`packages/pyric/src/sandbox/remote.ts:36`,
+guard `:126`) with a structurally-typed loose channel
+(`RemoteSandboxChannel`, remote.ts:48–69) *specifically so pyric-side code
+can consume it without importing pyric-tools*. Therefore:
+
+- **Dispatch point:** `getFirestore` / `getAdminFirestore` in
+  `packages/pyric/src/sandbox/admin-firestore/index.ts` (`:266`, `:324`)
+  branch on `isRemoteSandbox(ctx.sandbox)` and return a channel-backed
+  `SandboxFirestore`.
+- **The remote impl:** a new sibling module, e.g.
+  `packages/pyric/src/sandbox/firestore/admin-compat-remote/` implementing
+  `admin-compat/types.ts`'s `Firestore`/`DocumentReference`/`Query`/
+  `WriteBatch`/`Transaction` over `RemoteSandboxChannel.op/subscribe`,
+  spelling ops loosely (`{ method: 'getDoc', path, actAs }`) exactly as
+  `pyric-admin/database`'s remote arm does.
+- The `pyric-admin/firestore` guard (`index.ts:38–45`) is then deleted —
+  app resolution flows into the now-remote-aware base `getFirestore`.
+
+## 2. Worker protocol coverage vs the admin surface
+
+Ops (`packages/pyric-tools/src/serve/worker/protocol.ts:343–435`) all
+accept `actAs?: AuthLens` (`:436–444`); handlers in
+`packages/pyric-tools/src/serve/worker/host.ts` (`handleOp`, `:558`) resolve
+the data handle via `lensDb` (`:385–405`).
+
+| Admin surface (admin-compat/types.ts) | Worker op / sub | Evidence | Status |
+|---|---|---|---|
+| `doc(path).get()` | `getDoc` | protocol.ts:344; host.ts:572 | covered |
+| `doc().set(data, {merge?, mergeFields?})` | `setDoc` (options carried) | protocol.ts:346; host.ts:597 | covered (create-vs-update dispatch happens worker-side via the modular set path — no client peek needed) |
+| `doc().update()` / `.delete()` | `updateDoc` / `deleteDoc` | protocol.ts:347–348; host.ts:607/617 | covered |
+| `collection().add()` | `addDoc` (worker mints id) | protocol.ts:349; host.ts:626 | covered |
+| `Query.get()` incl. where/orderBy/limit/limitToLast/cursors | `getDocs` + `QueryDescriptor` constraints | protocol.ts:345, 98–106; host.ts:581 | covered for simple constraints |
+| `Query.applyFilter({kind:'and'/'or'})` (composite filters, types.ts:113–130) | — no composite kind in `QueryConstraintDescriptor` (protocol.ts:98–106 is where/orderBy/limit/cursors only) | | **GAP 1** |
+| `startCursorFromSnapshot` / `endCursorFromSnapshot` (types.ts:150–163) | client-side value extraction → plain `startAt`/`endAt` values | protocol.ts:103–106 | covered (resolve snapshot→values locally) |
+| `Query.aggregate({count})` | `count` | protocol.ts:350; host.ts:636 | covered |
+| `Query.aggregate({sum/average})` (types.ts:188–192) | — only `count` exists | | **GAP 2** |
+| `collectionGroup(id)` | `GroupRef` source in `getDocs`/`count` | protocol.ts:80–83 | covered |
+| `batch().commit()` | `batchCommit` + `WriteDescriptor[]` | protocol.ts:351, 140–143; host.ts:661 | covered (`set` descriptor carries merge options; no queue-time peek needed) |
+| `runTransaction(fn)` | `getDoc` reads + single-shot `txnCommit` (optimistic read-set validation, client retry) | protocol.ts:352, 146–164; host.ts:680–798; client model client.ts:938–1040 | covered — see §3 |
+| `onSnapshot(doc/query)` (admin-firestore/index.ts:442–609) | `FirestoreSubMessage` (`t:'sub'`, target + `actAs`) | protocol.ts:451–469; snap value = getDoc/getDocs shape (protocol.ts:576–586) | covered; constraints ride `QueryDescriptor` (same GAP 1 for composite filters) |
+| `setRules` (admin-firestore/index.ts:161) | `setFirestoreRules` / `setRules` | protocol.ts:353–354; host.ts:800 | covered (returns lint) — but must become **async** remotely |
+| `seed({documents})` (index.ts:168) | — no seed/clear op; composable from `admin.listDocuments` + `admin.deleteDocument` + `admin.setDocument` (protocol.ts:359–361) but non-atomic and chatty | | **GAP 3** (optional op) |
+| `snapshot()` (index.ts:174, sync) | `admin.readState` / `getSnapshot` exist but async by nature | protocol.ts:362, 435 | irreducibly sync → **remediating throw**, plus async alternative |
+| `FieldValue` sentinels (types.ts:274–290: `{__type:'serverTimestamp'/…}`) | wire `SentinelMarker` `{__sentinel:…}` (protocol.ts:122–127), resolved host-side via `resolveSentinels` → modular factories (host.ts:286–322) | shape mismatch: `__type`+`value` vs `__sentinel`+`n`; sandbox's own capture keys on `__type` (packages/pyric/src/sandbox/firestore/sentinel-capture.ts:55–63) | covered with a **small client-side translation** (§3) |
+| Admin `Timestamp` (types.ts:300–358) | JSON leg emits `toJSON()` → `{type:'firestore/timestamp/1.0',…}`; `rehydrateDocValue` recognizes both marker families (packages/pyric/src/firestore-values/index.ts:104–145) | read path fine; write path see **GAP 4** | partial |
+| `getFirestore(ctx)` rules-applied identity | `actAs: {mode:'as', uid, token?}` (types.ts:909–911; lensDb host.ts:397–405 honors token claims) | | covered for signed identities |
+| `getFirestore(sandbox.withAuth(null))` — explicitly unauthenticated | — absent lens ⇒ **the relay port's session** (`sessionDb`, host.ts:448–466), i.e. the *browser tab's* signed-in user, not "anonymous" | | **GAP 5** |
+| `getAdminFirestore` rules bypass | `actAs: {mode:'admin'}` → `pyricGetAdminFirestore` (host.ts:392–394) | | covered |
+| `listCollections` (firebase-admin has it; admin-compat does **not** expose it — types.ts:236–256 has no such member) | `listRootCollections`/`listSubcollections` exist anyway (protocol.ts:372–373; host.ts:645/654) | | parity preserved; ops available if the surface ever grows |
+| Structured denial context (`SandboxError.denialContext` via `wrapWithErrorTranslation`, admin-firestore/index.ts:274) | `serializeError` flattens to `{code,message}` only (protocol.ts:684–695) | | **GAP 6** (fidelity) |
+
+### Gap list (consolidated)
+
+1. **Composite filters** — `QueryConstraintDescriptor` has no
+   `{kind:'filter', filter: Filter}` variant; `or()`/`and()` queries can't
+   cross the wire. Additive protocol change.
+2. **sum/average aggregates** — only `count` (protocol.ts:350). Add
+   `{method:'aggregate', source, spec}` (or extend `count`). Additive.
+3. **`seed`** — no atomic seed/clear-documents op. Either add
+   `{method:'firestore.seed', documents}` or ship v1 with a composed
+   (non-atomic) implementation over `admin.*` ops.
+4. **Write-data rehydration host-side** — host write handlers only run
+   `resolveSentinels` (host.ts:600, 610, 629, 777–781); they never
+   `rehydrateDocValue` the data. Over the WS leg `JSON.stringify` turns a
+   Node-side `Timestamp` into its marker (`{type:'firestore/timestamp/1.0'}`
+   admin shape, or `{__type:'timestamp'}` rules shape), which the worker
+   then **stores as a plain map**: readers rehydrate it back (reads look
+   right), but in-worker rules comparisons and `orderBy` over that field
+   see a map, not a timestamp. Fix host-side (`rehydrateDocValue` on
+   `msg.data` / batch / txn writes) — behavior change only, no wire change.
+5. **No "anonymous" lens** — `AuthLens` is `admin | as(uid) | app-session`
+   (packages/pyric/src/sandbox/types.ts:909–912). A relayed op with no lens
+   resolves to the **browser tab's port session** (host.ts:448–466), so the
+   remote arm cannot express `withAuth(null)`. Add `{mode:'anon'}`
+   (additive) — without it, remote `getFirestore(sandbox.withAuth(null))`
+   silently runs as whoever is signed in in the tab. This is the one gap
+   that is a **correctness/security hazard**, not a feature hole.
+6. **Denial-context fidelity** — extend `serializeError` to carry an
+   optional structured `denialContext` field (additive on `ResMessage.
+   error`), so remote `SandboxError`s match local ones.
+
+## 3. Codec fidelity and transactions over the relay
+
+**Doc-data codec survives the WS leg.** Both bridge legs are JSON
+(`connectRemoteSandbox` does `ws.send(JSON.stringify(msg))`,
+`packages/pyric-tools/src/remote/index.ts:594`; the browser peer relays the
+frames into `relayWorkerOp/relayWorkerSub`
+(`packages/pyric-tools/src/bridge/client/bridge.ts:216–221`,
+`serve/entries/runtime.ts:522–523`). Read-path doc data is already a JSON
+string envelope — `SerializedDocData = { json: string }`
+(protocol.ts:636–650) — so double JSON encoding is loss-free; the Node side
+runs `deserializeDocData` → `rehydrateDocValue`
+(protocol.ts:666–668), which is a **leaf module (`pyric/firestore-values`)
+that runs fine in Node** (protocol.ts:46–51). Both admin (`type:
+'firestore/timestamp/1.0'`) and rules (`__type:'timestamp'`) marker
+families rehydrate (firestore-values/index.ts:104–145). One type mismatch
+to translate at the arm boundary: `rehydrateDocValue` yields
+`pyric/firestore-values`' `Timestamp` (`seconds`/`nanos`), while the admin
+surface re-exports admin-compat's `Timestamp` (`seconds`/`nanoseconds`,
+types.ts:300) — the remote arm should map rehydrated values into the
+admin-compat classes so `instanceof Timestamp` against the `pyric-admin/
+firestore` export holds (S — a small value-walk, same shape the client.ts
+read-translation does).
+
+**Sentinels resolve host-side for Node-originated writes.** The remote arm
+translates admin `FieldValueSentinel` (`{__type:'increment', value}`,
+types.ts:274–290) → wire `SentinelMarker` (`{__sentinel:'increment', n}`,
+protocol.ts:122–127) while walking write data; `resolveSentinels` on the
+host rebuilds real modular sentinels before the write (host.ts:286–322), so
+`serverTimestamp()` resolves against the **worker's** clock and
+`increment`/`arrayUnion` apply against worker state — correct semantics.
+(Sending the `__type` shapes raw would *probably* also work, since the
+sandbox detects sentinels by `__type` shape — sentinel-capture.ts:55–63 —
+but the `__sentinel` marker is the documented wire contract; translate.)
+
+**Transactions: single-shot commit, multi-roundtrip reads — the correlated
+op model is sufficient.** The worker has **no interactive transaction
+session**: the protocol is (a) each `txn.get` is an ordinary `getDoc` op
+recording `{path, data}` into a client-held read-set (client.ts:40–55,
+987–1021), (b) one `txnCommit` op ships `reads + writes`
+(protocol.ts:352, 146–164), (c) the host re-reads each path inside a real
+sandbox transaction, compares serialized JSON forms, applies writes or
+returns `{code:'aborted'}` (host.ts:680–798), (d) the client retries
+`updateFn` up to a max-attempt bound (client.ts:949, 1036). Every message
+is an independent correlated request/response — exactly what
+`RemoteSandboxChannel.op` provides (remote/index.ts:226–257). No worker
+state spans ops, so peer replacement mid-transaction just fails one op and
+the retry loop re-runs `updateFn` — safe. The 35s Node-side / 30s bridge
+timeouts apply per op, not per transaction, so long `updateFn`s are fine.
+One semantic note to document: read-set comparison is
+serialized-JSON equality computed **worker-side** (host.ts:700–719 relies
+on same-process `JSON.stringify` determinism); since the Node arm submits
+reads exactly as the worker serialized them (the `SerializedDocData.json`
+string, unmodified), determinism holds — the arm must keep the *original*
+json strings in its read-set, never re-serialize rehydrated data.
+
+`TransactionImpl`-shape queueing (`tx.set/update/delete` return `this`
+synchronously) maps to local descriptor buffering — no wire interaction
+until commit. `tx.get(query)` mirrors client behavior: run `getDocs`, then
+record each returned doc path + serialized data into the read-set
+(the worker-side commit re-reads them; matches admin-compat's
+`simTx.getAll` registration, transaction.ts:53–67).
+
+## 4. Plan
+
+### Architecture (from §1)
+
+- New `packages/pyric/src/sandbox/firestore/admin-compat-remote/`:
+  channel-backed implementations of `Firestore`, `DocumentReference`,
+  `CollectionReference`/`Query` (descriptor-building, mirrors
+  client.ts:251–265), `WriteBatch`, `Transaction` (optimistic model above),
+  plus `onSnapshot` routing to `channel.subscribe` with a
+  `FirestoreSubMessage` payload. All ops pin the lens derived from the
+  handle: `getAdminFirestore` → `{mode:'admin'}`; `getFirestore(ctx)` with
+  `ctx.auth = {uid, token?}` → `{mode:'as', uid, token}`;
+  `ctx.auth === null` → `{mode:'anon'}` (new lens, GAP 5) — never omit
+  `actAs` (an absent lens silently adopts the browser tab's session).
+- Dispatch in `pyric/sandbox/admin-firestore`'s `getFirestore` /
+  `getAdminFirestore` (index.ts:266, :324) on `isRemoteSandbox(ctx.sandbox)`;
+  `onSnapshot` (index.ts:501) branches before `getInternalEnv`.
+  Error translation: reuse `wrapWithErrorTranslation` where possible;
+  wire errors (`{code,message}` + optional denialContext per GAP 6) map to
+  `SandboxError`.
+- Delete the guard at `packages/pyric-admin/src/firestore/index.ts:38–45`.
+
+### Remediating throws (can't work remotely)
+
+- `SandboxFirestore.snapshot()` — sync map return; throw
+  `unimplemented` with "use `channel.op({method:'admin.readState'})` or
+  Studio" (matches the slice-1 handle's `admin`/`snapshot` throws,
+  remote/index.ts:494–510).
+- `setRules` / `seed` — sync `LintResult` returns. Options: (a) throw with
+  guidance toward async channel ops (`setFirestoreRules` exists), or
+  (b) pre-npm, loosen the `SandboxFirestore` signature to
+  `LintResult | Promise<LintResult>` so the remote arm can be async.
+  Recommend (b) for `setRules` (test ergonomics depend on it) and (a)+GAP-3
+  op for `seed`.
+- The `FOLLOWS_CURRENT_USER` live-listener mode (index.ts:120) — remote
+  handles have no `currentUser` mirror in slice 2; frozen-identity only
+  (the marker is stamped by the modular browser layer, which never runs in
+  Node — non-issue in practice, throw defensively if seen).
+
+### Protocol changes to land BEFORE npm publish freezes the wire (public-alpha — additive, but cheap now, migration-noise later)
+
+1. `{mode:'anon'}` `AuthLens` variant + `lensDb`/`lensRtdb`/sub handling
+   (types.ts:909; host.ts:385, :479, :558–562). **The must-do.**
+2. Composite-filter constraint descriptor (GAP 1).
+3. `aggregate` op for sum/average (GAP 2).
+4. `serializeError` structured `denialContext` passthrough (GAP 6).
+5. Host-side `rehydrateDocValue` on write data (GAP 4 — host behavior, not
+   wire shape, but it defines observable stored-data semantics; fix before
+   external SDKs depend on the buggy form).
+6. Optional: `firestore.seed` op (GAP 3).
+
+### Work items
+
+| # | Item | Files | Effort |
+|---|---|---|---|
+| 1 | `{mode:'anon'}` lens end-to-end (type, lensDb/lensRtdb/sub paths, provenance) | `pyric/src/sandbox/types.ts`, `pyric-tools/src/serve/worker/host.ts` | S |
+| 2 | Protocol additions: composite filter descriptor, `aggregate` op, error denialContext | `pyric-tools/src/serve/worker/protocol.ts`, `host.ts` | M |
+| 3 | Host write-data rehydration (`setDoc`/`updateDoc`/`addDoc`/batch/txn) + tests | `pyric-tools/src/serve/worker/host.ts` | S |
+| 4 | Remote refs + one-shot ops: `FirestoreImpl`/`DocumentRefImpl`/query descriptor builder, sentinel `__type`→`__sentinel` walk, read-value admin-class mapping | new `pyric/src/sandbox/firestore/admin-compat-remote/` | M |
+| 5 | Remote `WriteBatch` + `Transaction` (optimistic read-set, retry loop, original-json read-set invariant) | same | M |
+| 6 | Remote `onSnapshot` (doc + query targets, actAs pinned, `__error` snap → onError, options normalization shared with local impl) | same + `pyric/src/sandbox/admin-firestore/index.ts` | M |
+| 7 | Dispatch + error translation + remediating throws (`getFirestore`/`getAdminFirestore`/`onSnapshot` brand branch; async `setRules`; delete the pyric-admin guard) | `pyric/src/sandbox/admin-firestore/index.ts`, `pyric-admin/src/firestore/index.ts` | S |
+| 8 | Conformance: run the existing pyric-admin firestore suites against a remote-branded handle on the headless harness | `packages/pyric-admin/test/remote/` (extend `remote-dispatch.test.ts`'s harness), reuse `packages/pyric-admin/test/firestore/*` expectations | M |
+| 9 | Docs + `seed` decision (op vs composed vs throw) | protocol.ts, design docs | S |
+
+**Total: L — roughly 6–9 focused days**, dominated by items 4–6 and 8.
+(Slice 1 was M/3–5 days; Firestore's surface is ~3× RTDB's.)
+
+### Test plan (headless harness — no browser, no WS)
+
+The pattern is already proven twice: `packages/pyric-tools/test/bridge/
+worker-relay.test.ts` (checkpoint 1) and `packages/pyric-admin/test/remote/
+remote-dispatch.test.ts` (checkpoint 2) run the REAL worker host
+(`handleMessage` + fake ports) behind the REAL bridge core + consumer
+session, fronted by the EXACT handle `createRemoteSandboxHandle` builds
+(remote-dispatch.test.ts:1–56). Extend it:
+
+1. **Op-level round-trips:** get/set/update/delete/add, merge/mergeFields,
+   sentinel resolution (assert worker-side stored value via an independent
+   direct port — serverTimestamp resolves, increment applies), Timestamp/
+   Bytes/LatLng write→read fidelity across the JSON leg (this is the test
+   that catches GAP 4).
+2. **Queries:** constraints incl. cursors, collectionGroup, composite
+   filters (post GAP-1), aggregates (post GAP-2), rules-applied vs admin
+   lens vs `anon` lens (a signed-in port session must NOT leak into a
+   `withAuth(null)` handle — the GAP-5 regression test).
+3. **Batch + transaction:** atomicity, `already-exists`, read-set conflict
+   (interleave a direct-port write between remote `txn.get` and commit →
+   assert one retry), retry exhaustion.
+4. **onSnapshot:** initial + update + unsub; establishment `__error` →
+   onError; peer-replacement resubscribe (bridge re-issues subs — note:
+   Firestore snap subs are last-value-wins like RTDB value subs, so replay
+   is cursor-free and safe).
+5. **Conformance:** the compat-model pattern — run
+   `packages/pyric-admin/test/firestore/` suites (admin.test.ts,
+   on-denial.test.ts, scenarios/) parameterized over {local sandbox,
+   remote-branded handle}; same assertions must pass on both arms.
+6. **One manual end-to-end** against real `pyric dev --bridge` + tab before
+   calling it done (Node write visible live in Studio; Studio write visible
+   to a Node `onSnapshot`).
+
+## Risks
+
+1. **Silent identity leak without the `anon` lens (GAP 5).** An unlensed
+   relayed op runs as the browser tab's signed-in session. Any remote arm
+   shipped before the lens exists would make `withAuth(null)` mean
+   "whoever the developer happens to be signed in as". Land item 1 first.
+2. **Write-data fidelity (GAP 4)** — pre-existing host behavior, but the
+   remote arm makes it reachable from Node in one line. Reads mask it
+   (rehydration on read), so it would ship unnoticed and surface as
+   "orderBy on my timestamp field is wrong". Characterization-test it.
+3. **Two implementations of one surface.** The parallel arm can drift from
+   admin-compat semantics (set-as-create-vs-update, denial codes, aggregate
+   NaN handling, query value-ordering). Mitigation is the parameterized
+   conformance suite (item 8) — the same oracle, two backends, per the
+   compat model.
+4. **Read-set determinism invariant** (§3): if the remote transaction ever
+   re-serializes rehydrated data instead of echoing the worker's original
+   `json` strings, cross-process key-order differences would cause phantom
+   aborts (livelock under retry). Encode the invariant in a test.
+5. **Behavioral upgrade = behavioral change** (same as slice 1): remote
+   Firestore ops emit real sandbox events and wake app listeners; the local
+   in-process arm's ops already do too (Firestore rides the env fan-out) —
+   so unlike RTDB, the two arms *agree* here. Lower risk than slice 1.
+6. **Sub backpressure:** Firestore query snaps can be large (full doc list
+   per fire, protocol.ts:576–586) but are last-value-wins per subId —
+   the slice-1 coalescing design applies unchanged. The unified event
+   stream remains deferred.

--- a/docs/design/remote-storage.md
+++ b/docs/design/remote-storage.md
@@ -1,0 +1,299 @@
+# Remote Storage for `pyric-admin` (slice 2 design spike)
+
+Status: spike complete — analysis + plan, no implementation.
+Scope: a REMOTE dispatch arm for `pyric-admin/storage` — server-side Node
+code driving the browser-hosted SharedWorker sandbox's Storage over the
+slice-1 bridge machinery (`connectRemoteSandbox` → `RemoteSandboxChannel` →
+`worker-op` frames → SharedWorker host). This replaces the guard at
+`packages/pyric-admin/src/storage/index.ts:198–204`
+("Storage is not yet supported on a remote sandbox").
+
+## Feasibility verdict
+
+**Feasible, smaller than slice 1.** All the slice-1 transport machinery
+(bridge frames, browser relay, `RemoteSandboxChannel`, brand dispatch in
+pyric-admin) is reusable unchanged — the `worker-op` relay is
+payload-agnostic JSON, so **no bridge-protocol changes are needed**. Two
+real gaps:
+
+1. **The worker protocol is read-only for storage.** Only
+   `storage.listAll` / `storage.getMetadata` / `storage.getBlob` exist
+   (`serve/worker/protocol.ts:407–409`). The admin surface needs write
+   ops (`putBytes`, `deleteObject`) and a JSON-safe read op.
+2. **Binary does NOT survive the WS legs today** — the key unknown,
+   answered: bytes cross the MessagePort by structured clone (fine), but
+   both WS legs are `JSON.stringify` (`bridge/client/bridge.ts:168`,
+   `remote/index.ts:594`), which **silently corrupts** binary
+   (`Blob` → `{}`, `ArrayBuffer` → `{}`, `Uint8Array` → `{"0":…}` index
+   object). Nothing rejects; the far side just receives garbage. The fix
+   is **base64 fields inside the new storage op payloads themselves**
+   (worker-protocol level), so one encoding works verbatim over
+   MessagePort and WS with zero relay special-casing.
+
+A third, smaller gap: storage ops carry no `actAs` lens and `pyric/storage`
+has no rules-bypass admin plane — the admin arm needs one (small, pre-npm).
+
+Total estimate: **M — roughly 2–3 focused days.**
+
+## 1. The admin storage surface today
+
+`packages/pyric-admin/src/storage/index.ts`:
+
+- **Dispatch**: `getStorage(app)` (line 193) reads the `ADMIN_APP_TARGET`
+  brand; the sandbox arm currently guards remote handles with a throw
+  (lines 198–204 — the thing this slice replaces) and otherwise calls
+  `getSandboxStorage(app)` (line 292). Prod arm delegates to
+  `firebase-admin/storage` unchanged (line 231).
+- **State**: process-local `WeakMap<Sandbox, BucketMap>` (`SANDBOX_STATE`,
+  line 261) — `Map<bucketName, Map<path, FileEntry>>` — plus a
+  `sandbox.onEvent` reset hook (lines 270–290). Same pattern (and same
+  remote hazard) as the pre-slice-1 RTDB/Auth backends: keying local state
+  off a remote handle would create a private server-side store the browser
+  never sees, and the `onEvent` hook would throw on a remote handle
+  immediately. The remote arm must keep **no local state**.
+- **Shapes**: `Storage.bucket(name?)` → `Bucket` (line 65/80),
+  `Bucket.file(path)` → `File` (line 97). `File` methods on the LOCAL
+  sandbox arm (`SandboxFile`, line 329):
+
+  | Member | Behavior | Evidence |
+  |---|---|---|
+  | `save(data, opts?)` | `Buffer \| string \| Uint8Array`, replaces content; `resumable: true` throws | 336–353 (throw 340–344) |
+  | `download()` | `[Buffer]`; missing → throws `No such object: <bucket>/<path>` | 355–365 |
+  | `delete()` | idempotent (missing = no-op) | 367–369 |
+  | `exists()` | `[boolean]` | 371–373 |
+  | `getSignedUrl(opts)` | deterministic local stub `pyric-sandbox-storage://<bucket>/<path>?expires=…&action=…` — never served | 375–379 |
+  | `createWriteStream` / `createReadStream` | throw "not implemented in … sandbox backend" | 384–396 |
+
+  No `list`/`getFiles`, no `getMetadata`/`setMetadata` on `File`, no signed
+  cookies/IAM/ACL/copy/move (module header, lines 30–36).
+
+- **First user's typical server code** (unchanged by this slice):
+
+  ```ts
+  const app = initializeApp({ sandbox: remoteSandbox() });   // or connectRemoteSandbox()
+  const bucket = getStorage(app).bucket();
+  await bucket.file('reports/run-1.json').save(buf, { contentType: 'application/json' });
+  const [bytes] = await bucket.file('uploads/avatar.png').download();
+  const [ok] = await bucket.file('uploads/avatar.png').exists();
+  await bucket.file('tmp/scratch').delete();
+  ```
+
+## 2. Worker protocol coverage vs. the admin surface
+
+What exists (Studio's "data browse" is read-only):
+
+| Op | Handler | Notes |
+|---|---|---|
+| `storage.listAll` | `host.ts:1061–1072` | returns `{ items, prefixes }` of `{ fullPath, name }` — plain JSON |
+| `storage.getMetadata` | `host.ts:1074–1081` | `FullMetadata`, plain JSON |
+| `storage.getBlob` | `host.ts:1083–1089` | **returns a `Blob`** — MessagePort-only; corrupts over WS |
+
+Declared at `serve/worker/protocol.ts:407–409`. None carry `actAs` (unlike
+every RTDB op). The host reads through `pyric/storage` with a bare-sandbox
+(anonymous) context: `ensureStorage` at `host.ts:499–503` does
+`getStorage(initializeApp({ sandbox: ctx.sandbox }))`, and `pyric/storage`
+evaluates rules (when configured) against `target.context.auth`
+(`upload.ts:71`, `download.ts:85`, `enforce.ts:27–36`; open-by-default when
+no rules — `getStorageSandbox` options honored first-call-per-sandbox,
+`service.ts:137` `SERVICES` WeakMap). Note the worker's store is the SAME
+store the page uses in worker mode — one IndexedDB-backed
+`StorageService` per `Sandbox` — and uploads emit `service_mutation`
+sandbox events (`upload.ts:86`), so server writes get Studio provenance
+for free, same as RTDB in slice 1.
+
+**Missing vs. the admin surface from §1:**
+
+| Admin need | Worker op today | Gap |
+|---|---|---|
+| `file.save` | — (browser entry throws too: `serve/entries/storage.ts:62`, `uploadBytes` unsupported in worker mode) | new `storage.putBytes` |
+| `file.download` | `storage.getBlob` — Blob corrupts over WS | new JSON-safe `storage.getBytes` (base64) |
+| `file.delete` | — (`entries/storage.ts:65` throws in worker mode) | new `storage.deleteObject` |
+| `file.exists` | `storage.getMetadata` (map not-found → false) | none — reuse |
+| `file.getSignedUrl` | n/a | none — stays a **local** stub (deterministic string, no data needed) |
+| admin/rules-bypass identity | RTDB ops have `actAs` (`protocol.ts:443`); storage ops have none | add `actAs` to storage ops + a bypass path in `pyric/storage` |
+
+Pleasant side effect: adding write ops also unblocks the browser entry's
+worker-mode `uploadBytes`/`getBytes`/`deleteObject`
+(`entries/storage.ts:51–66` currently throw "not supported over the pyric
+SharedWorker yet").
+
+## 3. Binary payloads over the relay — the key unknown, answered
+
+**Today's paths:**
+
+- Worker host → page: `ok(port, msg.id, blob)` posts a `Blob`
+  (`host.ts:1086`) — structured clone over the `MessagePort`, lossless.
+  The Studio client consumes it directly (`worker/client.ts:1984–1990`).
+- Node ↔ bridge ↔ browser: both WS legs are JSON.
+  Browser peer: `ws.send(JSON.stringify(msg))`
+  (`bridge/client/bridge.ts:168`); server peer adapter:
+  `ws.send(JSON.stringify(out))` (`bridge/server/peer.ts:46,62`); Node
+  client: `ws.send(JSON.stringify(msg))` (`remote/index.ts:594`).
+
+**Would the slice-1 relay corrupt or reject an ArrayBuffer today?**
+Corrupt, silently. `handleWorkerOp` forwards `req.op` verbatim into the
+worker and `send`s the result (`bridge/client/bridge.ts:282–298`) — no
+type check anywhere. `JSON.stringify` turns `ArrayBuffer`/`Blob` into `{}`
+and `Uint8Array`/`Buffer` into an index-keyed plain object
+(`{"0":137,"1":80,…}` — Buffer becomes `{type:'Buffer',data:[…]}`, which
+"works" but is ~4–5x the bytes and an accidental wire format). Nothing
+errors; a relayed `storage.getBlob` from Node would resolve to `{}`.
+
+**The fix — encoding lands in the WORKER protocol, not the bridge:**
+
+- New storage ops carry bytes as **base64 strings inside the op
+  payload/result** (`dataB64` fields). One representation, valid JSON,
+  travels identically over MessagePort and both WS legs; the bridge
+  protocol, browser relay, and `RemoteSandboxChannel` need **zero
+  changes** (they are already payload-agnostic). Base64 over MessagePort
+  is a minor efficiency loss for the (future) in-browser callers of these
+  ops — acceptable; Studio keeps using `storage.getBlob` for its own
+  reads.
+- **Size cap**: enforce `MAX_STORAGE_OP_BYTES` (proposed **8 MiB raw**,
+  ~11 MiB base64 — comfortably under `ws`'s 100 MiB default `maxPayload`;
+  the bridge sets none, `serve/bridge-mount.ts:170`) at BOTH ends: the
+  Node conveniences reject before sending (`payload-too-large`, message
+  naming the cap and pointing at streams-unsupported), and the worker host
+  rejects oversized `putBytes`/`getBytes` results so a big browser-side
+  object can't blow up the relay. Whole-payload buffering is inherent —
+  streams/resumable stay unsupported (they throw on the local arm too).
+- Non-goal: WS binary frames / structured-clone-over-WS. The uniform-JSON
+  wire ("auditable with a single parser", `bridge/protocol.ts:62–64`) is a
+  deliberate property; base64-in-payload preserves it. Revisit only if
+  large-object throughput becomes a real requirement.
+- Hygiene follow-up (S): the relay could refuse to serialize a `worker-res`
+  whose value fails a JSON round-trip sanity check, turning future silent
+  corruption (e.g. someone relaying `storage.getBlob`) into a loud error.
+  Optional; the remote conveniences simply never call `getBlob`.
+
+## 4. The dispatch arm plan (mirroring `database/index.ts`'s remote arm)
+
+**New/changed worker ops** (`serve/worker/protocol.ts`, handlers in
+`host.ts` next to `storage.*` at 1061; all gain `actAs?: AuthLens` like the
+RTDB ops at `protocol.ts:443`):
+
+| Admin member | Worker op | Payload → result |
+|---|---|---|
+| `file.save(data, opts)` | `storage.putBytes` (new) | `{ path, dataB64, contentType?, metadata?, actAs }` → `FullMetadata` |
+| `file.download()` | `storage.getBytes` (new) | `{ path, actAs }` → `{ dataB64, contentType, size }` |
+| `file.delete()` | `storage.deleteObject` (new) | `{ path, actAs }` → `void`; remote arm swallows `storage/object-not-found` to preserve the local arm's idempotent delete (`storage/index.ts:367`; `pyric/storage`'s `deleteObject` throws on missing, `download.ts:69–74`) |
+| `file.exists()` | `storage.getMetadata` (existing, + actAs) | not-found → `[false]` |
+| `file.getSignedUrl()` | none — local stub | same string as `storage/index.ts:375–379`, byte-for-byte |
+
+**Identity/actAs pinning**: every relayed op pins
+`actAs: { mode: 'admin' }`, exactly like the RTDB remote arm's
+`REMOTE_ADMIN_LENS` (`database/index.ts:814–815`). The host maps the admin
+lens to a rules-bypass path. Since `pyric/storage` has no bypass today
+(rules always evaluate against `target.context.auth` when configured), add
+one in `pyric/storage` — smallest shape: internal admin variants (or an
+`admin: true` service flag on a host-only context) exported via an
+internal subpath, mirroring how `lensRtdb` gives RTDB its bypass handle
+(`host.ts:479`). Non-admin lenses (`{ mode: 'as', uid }`) can be supported
+in the same change by constructing `getStorageSandbox(ctx.sandbox.withAuth(lensAuth))`
+contexts, but only the admin lens is required for this slice.
+
+**pyric-admin remote arm** (`packages/pyric-admin/src/storage/index.ts`,
+replacing the guard at 198–204): dispatch order matches auth
+(`auth/index.ts:892–897` — remote brand checked BEFORE the local arm, since
+the local arm's `WeakMap` + `onEvent` hook must never touch a remote
+handle). `getRemoteStorage(sandbox)` keeps a
+`WeakMap<Sandbox, Storage>` of handles only (no data — same as
+`remoteDbBySandbox`, `database/index.ts:838`) and builds
+`Storage`/`Bucket`/`File` objects whose data methods relay
+`sandbox.channel.op(...)` (the structurally-typed channel from
+`pyric/sandbox/remote.ts:48–69`; brand check via `isRemoteSandbox`,
+`remote.ts:126`, already imported at `storage/index.ts:43`).
+
+**Remediating throws on the remote arm:**
+
+- `createWriteStream` / `createReadStream` — keep throwing; upgrade the
+  message to name the remote context and the buffer-based alternative
+  (`save`/`download`).
+- `save(..., { resumable: true })` — throw, parity with local (line 340).
+- payloads over the size cap — `payload-too-large` with the cap in the
+  message.
+- **Non-default bucket names — throw** (new divergence, must be explicit):
+  the local arm has real multi-bucket isolation (`BucketMap`), but
+  `pyric/storage`'s worker store is single-bucket ("the data store is
+  shared", `service.ts:100–106` bucket option doc). Faithful relaying is
+  impossible; a remediating throw on `storage.bucket('non-default')`
+  ("the browser sandbox has a single bucket — use the default bucket")
+  beats silently merging buckets. The first user's flow uses the default
+  bucket.
+- `getSignedUrl` does NOT throw — local stub, identical output to the
+  local arm.
+
+**Test plan** (pattern: `packages/pyric-admin/test/remote/remote-dispatch.test.ts`
+— real worker host `handleMessage` + fake ports behind the real bridge core
+and the EXACT production handle from `createRemoteSandboxHandle`, no
+browser/WS):
+
+1. New `packages/pyric-admin/test/remote/remote-storage.test.ts` reusing
+   that harness verbatim, plus `import 'fake-indexeddb/auto'` (the storage
+   backend is IndexedDB, `storage/persistence.ts:154–158`; pyric's own
+   storage tests already run headless this way,
+   `packages/pyric/test/storage/persistence.test.ts:13`). Coverage:
+   - save → download round-trip of **non-UTF8 binary** (e.g. PNG-magic
+     bytes + 0x00/0xFF runs) — the corruption regression test; assert
+     byte equality through a full JSON.stringify/parse of every frame
+     (the harness should round-trip frames through JSON to model the WS
+     legs, which the slice-1 harness's in-process pipe does not).
+   - exists()/delete()/idempotent re-delete; `No such object` on missing
+     download (message parity with local arm, line 361).
+   - contentType/metadata round-trip via save options.
+   - cross-visibility: write via an independent direct worker port
+     (`storage.getBytes`), read via admin `download()` — one shared store.
+   - size-cap rejection; resumable/stream/non-default-bucket throws;
+     no-peer "open <serve url>" error surfacing through `file.save`.
+   - the local in-process arm still selected for plain sandboxes.
+2. Worker-host op tests beside `pyric-tools/test/serve/worker/host.test.ts`:
+   `putBytes`/`getBytes`/`deleteObject` handlers incl. admin-lens bypass
+   with deny-all rules configured, and the anonymous lens still enforcing.
+3. Conformance: run the local-arm storage assertions against the remote
+   arm (one oracle, two backends — same pattern as slice 1's step 3).
+4. One manual end-to-end against real `pyric dev --bridge` + tab (uploads
+   visible in Studio's storage browser).
+
+## 5. Work items
+
+| # | Work item | Files | Effort |
+|---|---|---|---|
+| **Worker/bridge** | | | |
+| 1 | Ops `storage.putBytes`/`storage.getBytes`/`storage.deleteObject` + `actAs` on all storage ops; `MAX_STORAGE_OP_BYTES` const | `pyric-tools/src/serve/worker/protocol.ts` | S |
+| 2 | Host handlers + admin-lens storage path (rules bypass) | `pyric-tools/src/serve/worker/host.ts`; small internal export in `pyric/src/storage/` (upload/download/enforce or a service flag) | M |
+| 3 | Bridge protocol / relay changes | **none** (payload-agnostic JSON; base64 rides inside op payloads) | — |
+| 4 | (Optional) unblock worker-mode browser entry: `uploadBytes`/`getBytes`/`deleteObject` via the new ops | `pyric-tools/src/serve/worker/client.ts`, `src/serve/entries/storage.ts` | S (optional) |
+| **Remote client conveniences** | | | |
+| 5 | `RemoteStorage` conveniences (putBytes/getBytes/delete/getMetadata/listAll; base64 helpers; admin lens pinned; client-side size cap) on the handle, beside `buildRemoteRtdb` (`remote/index.ts:358`) | `pyric-tools/src/remote/index.ts` | S |
+| **pyric-admin dispatch arm** | | | |
+| 6 | Replace the guard (198–204) with `getRemoteStorage`: remote `Storage`/`Bucket`/`File` over `sandbox.channel`; remediating throws (streams/resumable/non-default bucket/size cap); local `getSignedUrl` stub; idempotent delete mapping | `pyric-admin/src/storage/index.ts` | M |
+| **Tests** | | | |
+| 7 | `remote-storage.test.ts` (harness + fake-indexeddb + JSON-round-trip frames) + conformance vs local arm | `pyric-admin/test/remote/remote-storage.test.ts` | M |
+| 8 | Worker-host storage-op + lens tests | `pyric-tools/test/serve/worker/` | S |
+
+**Total: M — ~2–3 focused days**, dominated by items 2, 6, 7.
+
+## Risks
+
+1. **Silent binary corruption is the failure mode, not rejection** —
+   already live: relaying `storage.getBlob` through the slice-1 channel
+   today yields `{}` with no error. The base64 ops fix the admin path, but
+   nothing stops a future caller relaying `getBlob`; consider the item-3
+   hygiene guard (JSON-round-trip check in the relay) as cheap insurance.
+2. **`pyric/storage` grows an admin plane** — the rules-bypass touches a
+   package outside pyric-tools/pyric-admin; keep it internal-subpath-only
+   so the public modular surface stays rules-honest. Pre-npm, cheap now.
+3. **Local vs. remote arm divergence** (slice-1 risk 2, again): local =
+   in-memory multi-bucket Map, no rules, no events; remote = worker's
+   IndexedDB store, rules-evaluated (bypassed via admin lens), emits
+   events, single bucket. The non-default-bucket throw makes the sharpest
+   divergence loud; consider the same follow-up as RTDB — rewire the local
+   admin arm onto `pyric/storage`'s sandbox backend so both arms share one
+   store and one event story.
+4. **Memory/size semantics**: whole-object buffering + base64 (+33%) on
+   four hops. The 8 MiB cap keeps it sane; document that big-file flows
+   need the (unshipped) streaming story rather than raising the cap.
+5. **Rules interaction with page-configured rules**: the worker's storage
+   service is first-call-wins per sandbox (`service.ts:137`); if the page
+   configured deny-y rules, the admin lens must genuinely bypass them —
+   test 2's deny-all case pins this.

--- a/packages/pyric-admin/src/firestore/index.ts
+++ b/packages/pyric-admin/src/firestore/index.ts
@@ -21,7 +21,7 @@ import {
   getFirestore as baseGetFirestore,
   type SandboxFirestore,
 } from 'pyric/sandbox/admin-firestore';
-import type { SandboxContext } from 'pyric/sandbox';
+import { isRemoteSandbox, type SandboxContext } from 'pyric/sandbox';
 import {
   ADMIN_APP_TARGET,
   getApp,
@@ -35,6 +35,14 @@ import {
  *  in-process backend does not model. */
 function adminAppToContext(app: PyricAdminApp): SandboxContext {
   if (isSandboxAdminApp(app)) {
+    if (isRemoteSandbox(app.sandbox)) {
+      throw new Error(
+        'pyric-admin/firestore: Firestore is not yet supported on a remote ' +
+          'sandbox — the bridge currently carries Realtime Database and Auth. ' +
+          'Use pyric/firestore in the browser (or the MCP Firestore tools) ' +
+          'until remote Firestore lands.',
+      );
+    }
     return app.sandbox.withAuth(null);
   }
   throw new Error(

--- a/packages/pyric-admin/src/storage/index.ts
+++ b/packages/pyric-admin/src/storage/index.ts
@@ -40,7 +40,7 @@ import type { App as AdminApp } from 'firebase-admin/app';
 import type { Storage as ProdStorage } from 'firebase-admin/storage';
 import { getStorage as getProdStorage } from 'firebase-admin/storage';
 
-import type { Sandbox } from 'pyric/sandbox';
+import { isRemoteSandbox, type Sandbox } from 'pyric/sandbox';
 
 import {
   ADMIN_APP_TARGET,
@@ -195,6 +195,13 @@ export function getStorage(app?: StorageApp): Storage {
   // `app/no-app` FirebaseAppError (see pyric-admin/app getApp).
   const resolved: PyricAdminApp = app === undefined ? getApp() : (app as PyricAdminApp);
   if (resolved[ADMIN_APP_TARGET] === 'sandbox') {
+    if (isRemoteSandbox(resolved.sandbox)) {
+      throw new Error(
+        'pyric-admin/storage: Storage is not yet supported on a remote ' +
+          'sandbox — the bridge currently carries Realtime Database and Auth. ' +
+          'Use pyric/storage in the browser (or Studio) until remote Storage lands.',
+      );
+    }
     return getSandboxStorage(resolved);
   }
   if (resolved[ADMIN_APP_TARGET] === 'prod') {

--- a/packages/pyric-tools/src/register/index.ts
+++ b/packages/pyric-tools/src/register/index.ts
@@ -132,6 +132,11 @@ function activate(): void {
   );
 }
 
+/** Whether this process's firebase-admin/firebase imports are being rewritten
+ *  to the pyric sandbox — true only when `PYRIC_SANDBOX` was set (and not
+ *  refused by the production guard) at the moment this module loaded. */
+export let active = false;
+
 if (process.env.PYRIC_SANDBOX) {
   if (process.env.NODE_ENV === 'production' && process.env.PYRIC_SANDBOX_FORCE !== '1') {
     process.stderr.write(
@@ -141,6 +146,7 @@ if (process.env.PYRIC_SANDBOX) {
     );
   } else {
     activate();
+    active = true;
   }
 }
-// No PYRIC_SANDBOX → inert by design: importing this module does nothing.
+// No PYRIC_SANDBOX → inert by design: importing this module rewrites nothing.

--- a/packages/pyric/src/sandbox/admin-firestore/index.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/index.ts
@@ -33,6 +33,7 @@ import type {
 import type { LintResult } from 'pyric/rules';
 
 import type { Sandbox, SandboxContext } from 'pyric/sandbox';
+import { isRemoteSandbox } from '../remote.js';
 import { getInternalEnv } from 'pyric/sandbox/internal';
 import { CONTEXT_SYMBOL, registerOnSnapshotImpl, wrapWithErrorTranslation } from './error-translation.js';
 
@@ -197,6 +198,17 @@ function buildFirestoreHandle(
   ctx: SandboxContext,
   bypassRules = false,
 ): SandboxFirestore {
+  // Remote-branded sandboxes have no local engine; without this check the
+  // ctx-form dies later with a misleading `invalid-argument` from
+  // getInternalEnv. Throw the honest not-yet-supported error up front.
+  if (isRemoteSandbox(ctx.sandbox)) {
+    throw new Error(
+      'pyric/sandbox/admin-firestore: Firestore is not yet supported on a ' +
+        'remote sandbox — the bridge currently carries Realtime Database and ' +
+        'Auth. Use pyric/firestore in the browser (or the MCP Firestore ' +
+        'tools) until remote Firestore lands.',
+    );
+  }
   const delegate = (): Firestore =>
     createCompatFirestore(getInternalEnv(ctx.sandbox), { auth: ctx.auth, bypassRules });
 

--- a/packages/pyric/src/sandbox/remote.ts
+++ b/packages/pyric/src/sandbox/remote.ts
@@ -124,7 +124,12 @@ export type RemoteSandboxFactory = (
  * than into process-local state.
  */
 export function isRemoteSandbox(sandbox: Sandbox): sandbox is RemoteSandbox {
+  // Null-safe by contract: guard call sites probe values that may not be a
+  // Sandbox at all (e.g. legacy callers passing a raw Sandbox where a
+  // SandboxContext is expected leave `.sandbox` undefined). A brand check
+  // must classify, never throw.
   return (
+    sandbox != null &&
     (sandbox as Partial<Record<typeof REMOTE_SANDBOX, unknown>>)[
       REMOTE_SANDBOX
     ] === true


### PR DESCRIPTION
The final release-gate run (pinned to `80f9c33`) passed everything except the install matrix, which failed identically under npm/pnpm/bun on `pyric-tools/register` — a side-effect-only `node --import` entrypoint with zero exports, tripping the matrix's >0-exports subpath heuristic.

Two possible fixes; this takes the marker export, not a script exemption list — exemption lists are the manual-drift pattern these gates were just cured of, and the export is genuinely useful: `active` tells any consumer whether the hooks actually engaged in this process (env set, production guard not tripped).

Also pins CI `node-version` from `'22'` to `'22.15'`, making pyric-tools' `engines >=22.15` floor (required by `module.registerHooks`) an explicit guarantee instead of a latest-22.x coincidence.

Verified: register suite 20/0, `test:install-matrix npm` now fully green (47/47 subpaths).