### PR TITLE
Remote Storage for pyric-admin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "fake-indexeddb": "^6.0.0",
         "typescript": "^5.7.0",
       },
     },

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -40,7 +40,8 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "fake-indexeddb": "^6.0.0"
   },
   "engines": {
     "node": ">=22"

--- a/packages/pyric-admin/src/firestore/index.ts
+++ b/packages/pyric-admin/src/firestore/index.ts
@@ -38,7 +38,7 @@ function adminAppToContext(app: PyricAdminApp): SandboxContext {
     if (isRemoteSandbox(app.sandbox)) {
       throw new Error(
         'pyric-admin/firestore: Firestore is not yet supported on a remote ' +
-          'sandbox — the bridge currently carries Realtime Database and Auth. ' +
+          'sandbox — the bridge currently carries Realtime Database, Auth, and Storage. ' +
           'Use pyric/firestore in the browser (or the MCP Firestore tools) ' +
           'until remote Firestore lands.',
       );

--- a/packages/pyric-admin/src/storage/index.ts
+++ b/packages/pyric-admin/src/storage/index.ts
@@ -12,6 +12,13 @@
  *     production `Storage`, so every method on `Storage` / `Bucket` /
  *     `File` (from `@google-cloud/storage`) is present unchanged.
  *
+ *   - **Remote sandbox path** — a handle branded by `pyric-tools`'
+ *     `connectRemoteSandbox()`/`remoteSandbox()` relays every data
+ *     operation over the bridge to the browser-hosted SharedWorker's
+ *     object store (admin lens pinned — rules bypass). Single bucket;
+ *     8 MiB per-op byte cap; `getSignedUrl` stays the local stub. See
+ *     the remote arm section below.
+ *
  *   - **Sandbox path** — returns an in-process {@link Storage} backed
  *     by an in-memory `Map<bucketName, Map<path, FileEntry>>`. State
  *     lives on the {@link Sandbox} via a `WeakMap`, so `sandbox.reset()`
@@ -40,7 +47,12 @@ import type { App as AdminApp } from 'firebase-admin/app';
 import type { Storage as ProdStorage } from 'firebase-admin/storage';
 import { getStorage as getProdStorage } from 'firebase-admin/storage';
 
-import { isRemoteSandbox, type Sandbox } from 'pyric/sandbox';
+import {
+  isRemoteSandbox,
+  type RemoteSandbox,
+  type RemoteSandboxChannel,
+  type Sandbox,
+} from 'pyric/sandbox';
 
 import {
   ADMIN_APP_TARGET,
@@ -195,12 +207,13 @@ export function getStorage(app?: StorageApp): Storage {
   // `app/no-app` FirebaseAppError (see pyric-admin/app getApp).
   const resolved: PyricAdminApp = app === undefined ? getApp() : (app as PyricAdminApp);
   if (resolved[ADMIN_APP_TARGET] === 'sandbox') {
+    // Remote brand checked BEFORE the local arm (same dispatch order as
+    // auth/database): the local arm's WeakMap state + `onEvent` reset hook
+    // must never touch a remote handle — local state keyed off a remote
+    // handle would be a private server-side store the browser never sees,
+    // and `onEvent` throws on remote handles by design.
     if (isRemoteSandbox(resolved.sandbox)) {
-      throw new Error(
-        'pyric-admin/storage: Storage is not yet supported on a remote ' +
-          'sandbox — the bridge currently carries Realtime Database and Auth. ' +
-          'Use pyric/storage in the browser (or Studio) until remote Storage lands.',
-      );
+      return getRemoteStorage(resolved.sandbox);
     }
     return getSandboxStorage(resolved);
   }
@@ -373,9 +386,7 @@ class SandboxFile implements File {
   }
 
   async getSignedUrl(options: GetSignedUrlOptions): Promise<[string]> {
-    const expiresMs = normalizeExpires(options.expires);
-    const url = `pyric-sandbox-storage://${this.bucket.name}/${this.name}?expires=${expiresMs}&action=${options.action}`;
-    return [url];
+    return [stubSignedUrl(this.bucket.name, this.name, options)];
   }
 
   // ─── Deferred surface (declared so TS callers see a clear error) ────
@@ -395,7 +406,224 @@ class SandboxFile implements File {
   }
 }
 
+// ─── Remote sandbox arm (remote sandbox, slice 2) ───────────────────────
+//
+// The app's `Sandbox` is a Node-side handle onto the browser-hosted
+// SharedWorker sandbox. Every data operation relays over the handle's
+// worker channel with `actAs: { mode: 'admin' }` pinned — firebase-admin's
+// rules-bypass semantics against the ONE object store the app + Studio +
+// agents share (the host resolves the lens to `pyric/storage/internal`'s
+// admin plane). There is deliberately NO local state here: a `WeakMap`
+// bucket map keyed off a remote handle would be private server-side data
+// the browser never sees, and the local arm's `onEvent` reset hook throws
+// on remote handles by design.
+//
+// Divergences from the local arm, all LOUD:
+//   - single bucket: the worker's `pyric/storage` store is single-bucket
+//     ("the data store is shared" — bucket names only round-trip in
+//     metadata), so `bucket('non-default')` throws instead of silently
+//     merging buckets. The default bucket name matches the local arm.
+//   - byte payloads are capped at 8 MiB per op (whole-object buffering
+//     over four relay hops; streaming stays unsupported on both arms).
+// `getSignedUrl` does NOT relay: it stays the byte-identical local stub.
+
+/** firebase-admin's rules-bypass lens, pinned on every relayed operation. */
+const STORAGE_REMOTE_ADMIN_LENS = { mode: 'admin' } as const;
+
+/**
+ * Raw per-op byte cap for relayed storage payloads. MUST mirror
+ * `pyric-tools`' `MAX_STORAGE_OP_BYTES` (serve/worker/protocol.ts) — the
+ * worker host enforces the same cap on its end. Inlined (like the RTDB
+ * push-id generator) because `pyric-admin` deliberately does not depend on
+ * `pyric-tools`.
+ */
+const MAX_REMOTE_STORAGE_OP_BYTES = 8 * 1024 * 1024;
+
+/** One remote `Storage` per remote handle (handles only — never data). */
+const remoteStorageBySandbox = new WeakMap<Sandbox, Storage>();
+
+function getRemoteStorage(sandbox: RemoteSandbox): Storage {
+  let storage = remoteStorageBySandbox.get(sandbox);
+  if (!storage) {
+    storage = new RemoteStorage(sandbox.channel);
+    remoteStorageBySandbox.set(sandbox, storage);
+  }
+  return storage;
+}
+
+/** Wire shape of the worker's `storage.getBytes` result. */
+interface RemoteGetBytesResult {
+  dataB64: string;
+  contentType?: string;
+  size: number;
+}
+
+class RemoteStorage implements Storage {
+  constructor(private readonly channel: RemoteSandboxChannel) {}
+
+  bucket(name?: string): Bucket {
+    // The worker's object store is single-bucket. A non-default name can't
+    // be faithfully relayed — throw loudly instead of silently merging
+    // buckets (the local arm has REAL multi-bucket isolation; this is the
+    // sharpest local/remote divergence, so it must be explicit).
+    if (name !== undefined && name !== DEFAULT_SANDBOX_BUCKET) {
+      throw new Error(
+        `pyric-admin/storage: the remote (browser) sandbox has a single bucket — ` +
+          `bucket('${name}') cannot be isolated. Use bucket() (the default ` +
+          `'${DEFAULT_SANDBOX_BUCKET}' bucket) instead.`,
+      );
+    }
+    return new RemoteBucket(DEFAULT_SANDBOX_BUCKET, this.channel);
+  }
+}
+
+class RemoteBucket implements Bucket {
+  constructor(
+    readonly name: string,
+    private readonly channel: RemoteSandboxChannel,
+  ) {}
+
+  file(path: string): File {
+    return new RemoteFile(path, this, this.channel);
+  }
+}
+
+class RemoteFile implements File {
+  constructor(
+    readonly name: string,
+    readonly bucket: Bucket,
+    private readonly channel: RemoteSandboxChannel,
+  ) {}
+
+  async save(
+    data: Buffer | string | Uint8Array,
+    options: SaveOptions = {},
+  ): Promise<void> {
+    if (options.resumable === true) {
+      throw new Error(
+        'not implemented in pyric-admin/storage remote sandbox backend: resumable uploads',
+      );
+    }
+    const bytes = toBytes(data);
+    if (bytes.byteLength > MAX_REMOTE_STORAGE_OP_BYTES) {
+      throw payloadTooLarge(bytes.byteLength, `save() payload for '${this.name}'`);
+    }
+    await this.channel.op({
+      method: 'storage.putBytes',
+      path: this.name,
+      dataB64: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64'),
+      ...(options.contentType !== undefined ? { contentType: options.contentType } : {}),
+      ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+      actAs: STORAGE_REMOTE_ADMIN_LENS,
+    });
+  }
+
+  async download(_options: DownloadOptions = {}): Promise<[Buffer]> {
+    let wire: RemoteGetBytesResult;
+    try {
+      wire = (await this.channel.op({
+        method: 'storage.getBytes',
+        path: this.name,
+        actAs: STORAGE_REMOTE_ADMIN_LENS,
+      })) as RemoteGetBytesResult;
+    } catch (err) {
+      if (isObjectNotFound(err)) {
+        // Mirror the gcs/firebase-admin (and local arm) message shape so
+        // consumer catch-blocks that string-match `No such object` work
+        // identically across arms.
+        throw new Error(`No such object: ${this.bucket.name}/${this.name}`);
+      }
+      throw err;
+    }
+    return [Buffer.from(wire.dataB64, 'base64')];
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await this.channel.op({
+        method: 'storage.deleteObject',
+        path: this.name,
+        actAs: STORAGE_REMOTE_ADMIN_LENS,
+      });
+    } catch (err) {
+      // The worker store's delete is already idempotent, but swallow a
+      // not-found defensively so the local arm's idempotent-delete contract
+      // holds even if `pyric/storage` adopts the strict prod throw later.
+      if (isObjectNotFound(err)) return;
+      throw err;
+    }
+  }
+
+  async exists(): Promise<[boolean]> {
+    try {
+      await this.channel.op({
+        method: 'storage.getMetadata',
+        path: this.name,
+        actAs: STORAGE_REMOTE_ADMIN_LENS,
+      });
+      return [true];
+    } catch (err) {
+      if (isObjectNotFound(err)) return [false];
+      throw err;
+    }
+  }
+
+  /** Local stub — byte-identical to the local arm's (no data needed, so it
+   *  never relays). The sandbox does NOT serve the URL. */
+  async getSignedUrl(options: GetSignedUrlOptions): Promise<[string]> {
+    return [stubSignedUrl(this.bucket.name, this.name, options)];
+  }
+
+  // ─── Deferred surface (remediating throws, remote-flavored) ─────────
+
+  createWriteStream(): never {
+    throw new Error(
+      'not implemented in pyric-admin/storage remote sandbox backend: createWriteStream — ' +
+        'streams cannot span the bridge relay; use file.save(buffer) (≤ 8 MiB) instead.',
+    );
+  }
+
+  createReadStream(): never {
+    throw new Error(
+      'not implemented in pyric-admin/storage remote sandbox backend: createReadStream — ' +
+        'streams cannot span the bridge relay; use file.download() (≤ 8 MiB) instead.',
+    );
+  }
+}
+
+/** Is this relayed error the worker's `storage/object-not-found`? */
+function isObjectNotFound(err: unknown): boolean {
+  return (err as { code?: unknown })?.code === 'storage/object-not-found';
+}
+
+/** Over-cap rejection (code `payload-too-large`) — mirrors the worker host's
+ *  message shape and names the streaming gap. */
+function payloadTooLarge(sizeBytes: number, what: string): Error & { code: string } {
+  const err = new Error(
+    `pyric-admin/storage: ${what} is ${sizeBytes} bytes — over the ` +
+      `${MAX_REMOTE_STORAGE_OP_BYTES / (1024 * 1024)} MiB remote storage op cap. ` +
+      'Streaming/resumable transfers are not supported on the sandbox backend; ' +
+      'split the object or keep it under the cap.',
+  ) as Error & { code: string };
+  err.code = 'payload-too-large';
+  return err;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * The deterministic sandbox signed-URL stub, shared by the local and remote
+ * arms so their output is byte-identical (the URL is never served — it's a
+ * stable placeholder for logs/fixtures/replay).
+ */
+function stubSignedUrl(
+  bucketName: string,
+  path: string,
+  options: GetSignedUrlOptions,
+): string {
+  const expiresMs = normalizeExpires(options.expires);
+  return `pyric-sandbox-storage://${bucketName}/${path}?expires=${expiresMs}&action=${options.action}`;
+}
 
 /**
  * Normalize `Buffer | string | Uint8Array` into a fresh `Uint8Array`.

--- a/packages/pyric-admin/test/remote/remote-storage.test.ts
+++ b/packages/pyric-admin/test/remote/remote-storage.test.ts
@@ -1,0 +1,495 @@
+/**
+ * `pyric-admin` remote-dispatch arm — Storage (remote sandbox, slice 2).
+ *
+ * Same headless harness as remote-dispatch.test.ts (REAL worker host behind
+ * the REAL bridge core + the EXACT production handle from
+ * `createRemoteSandboxHandle`) with ONE deliberate upgrade: every frame on
+ * BOTH relay legs (Node ⇄ bridge, bridge ⇄ tab) is round-tripped through
+ * `JSON.parse(JSON.stringify(frame))` — modelling the two WS legs that the
+ * slice-1 in-process pipe skipped. This is the binary-corruption regression
+ * seam: a Blob/TypedArray smuggled into a frame would be mangled here
+ * exactly as it would on the wire, so byte-equality assertions after the
+ * round-trip prove the base64 encoding is what keeps bytes faithful.
+ *
+ * Coverage (per the slice-2 spike test plan):
+ *   - save → download round-trip of non-UTF8 binary, byte-for-byte
+ *   - contentType/metadata via save options (read back via the worker)
+ *   - exists / delete / idempotent re-delete; `No such object` parity
+ *   - cross-visibility with an independent direct worker port (one store)
+ *   - 8 MiB cap: client-side rejection before send + host-side rejection
+ *   - non-default bucket / resumable / stream remediating throws
+ *   - getSignedUrl stub byte-identical to the local arm
+ *   - deny-all page rules bypassed by the pinned admin lens
+ *   - no-peer fail-fast through the storage API
+ *   - the local in-process arm still selected for plain sandboxes
+ *   - conformance: the same consumer assertions pass on BOTH arms
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { getStorageSandbox } from 'pyric/storage';
+
+import { createBridge, type Bridge } from '../../../pyric-tools/src/bridge/server/bridge.js';
+import { createConsumerSession } from '../../../pyric-tools/src/bridge/server/peer.js';
+import {
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../../pyric-tools/src/bridge/protocol.js';
+import {
+  createRemoteSandboxCore,
+  createRemoteSandboxHandle,
+  type RemoteSandbox,
+} from '../../../pyric-tools/src/remote/index.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../pyric-tools/src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../../pyric-tools/src/serve/worker/protocol.js';
+import {
+  bytesToBase64,
+  MAX_STORAGE_OP_BYTES,
+} from '../../../pyric-tools/src/serve/worker/protocol.js';
+
+import { initializeApp, deleteApp, getApps } from '../../src/app/index.js';
+import { getStorage, type Storage } from '../../src/storage/index.js';
+
+// ─── Harness (remote-dispatch.test.ts's, + JSON round-trips on both legs) ──
+
+const SERVE_URL = 'http://localhost:5000';
+
+const DENY_ALL_RULES = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if false;
+  }
+}`;
+
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+/** Model a WS leg: the frame must survive JSON serialization VERBATIM. */
+function overWire<T>(frame: T): T {
+  return JSON.parse(JSON.stringify(frame)) as T;
+}
+
+let dbSeq = 0;
+function makeWorkerCtx(opts: { rules?: string } = {}): HostCtx {
+  const sandbox = initializeSandbox();
+  // Isolate this ctx's storage store (fake-indexeddb's default DB name is
+  // process-global) and configure the PAGE's rules when the test needs them
+  // — first-call-per-sandbox, exactly how a served page configures rules.
+  getStorageSandbox(sandbox, {
+    dbName: `pyric-admin-remote-storage-${++dbSeq}-${Math.random().toString(36).slice(2, 8)}`,
+    ...(opts.rules ? { rules: opts.rules } : {}),
+  });
+  return {
+    db: getFirestore(sandbox),
+    sandbox,
+    instanceId: 'admin-remote-storage-test',
+    subs: new Map(),
+  };
+}
+
+/** Fake browser tab backed by the REAL worker host. Frames cross this leg
+ *  through a JSON round-trip in BOTH directions (the bridge⇄tab WS). */
+function connectTab(bridge: Bridge, ctx: HostCtx): void {
+  let gen = 0;
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      const m = raw as OutboundMessage;
+      if (m.t === 'res') {
+        bridge.handleSandboxMessage(
+          overWire(
+            m.ok
+              ? { type: 'worker-res', id: m.id, ok: true, value: m.value }
+              : { type: 'worker-res', id: m.id, ok: false, error: m.error },
+          ) as BridgeMessage,
+          gen,
+        );
+      } else if (m.t === 'snap') {
+        bridge.handleSandboxMessage(
+          overWire({ type: 'worker-snap', subId: m.subId, value: m.value }) as BridgeMessage,
+          gen,
+        );
+      }
+    },
+  };
+  const send = (msg: BridgeMessage): void => {
+    if (gen === 0) gen = bridge.peerGeneration();
+    const wire = overWire(msg);
+    if (wire.type === 'worker-op') {
+      void handleMessage(ctx, port, { ...wire.op, t: 'op', id: wire.id } as InboundMessage);
+    } else if (wire.type === 'worker-sub') {
+      void handleMessage(ctx, port, { ...wire.sub, t: 'sub', subId: wire.subId } as InboundMessage);
+    } else if (wire.type === 'worker-unsub') {
+      void handleMessage(ctx, port, { t: 'unsub', subId: wire.subId } as InboundMessage);
+    }
+  };
+  bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
+}
+
+/** The EXACT production remote handle, with the Node⇄bridge leg JSON
+ *  round-tripped in both directions. */
+function connectRemote(bridge: Bridge): RemoteSandbox {
+  let handleMsg: (msg: BridgeMessage) => void = () => {};
+  const session = createConsumerSession(bridge, (msg) => handleMsg(overWire(msg)));
+  const core = createRemoteSandboxCore(
+    { send: (msg) => session.handleMessage(overWire(msg)) },
+    { serveUrl: SERVE_URL },
+  );
+  handleMsg = core.handleMessage;
+  core.start();
+  return createRemoteSandboxHandle({
+    channel: core.channel,
+    serveUrl: SERVE_URL,
+    close: () => core.dispose('remote sandbox connection closed by the client'),
+  });
+}
+
+/** Independent direct worker port — the oracle proving admin operations
+ *  really landed in the worker's store (and letting "the browser app"
+ *  write from its side). */
+let directOpSeq = 0;
+function workerOp(ctx: HostCtx, op: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const port: PortLike = {
+      postMessage(raw: unknown) {
+        const m = raw as OutboundMessage;
+        if (m.t !== 'res') return;
+        if (m.ok) resolve(m.value);
+        else reject(Object.assign(new Error(m.error.message), { code: m.error.code }));
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...op,
+      t: 'op',
+      id: `direct-${++directOpSeq}`,
+    } as InboundMessage);
+  });
+}
+
+function makeStack(opts: { rules?: string } = {}) {
+  const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+  const ctx = makeWorkerCtx(opts);
+  connectTab(bridge, ctx);
+  const remote = connectRemote(bridge);
+  const app = initializeApp({ sandbox: remote });
+  return { bridge, ctx, remote, app };
+}
+
+/** Non-UTF8 binary (PNG magic + 0x00/0xFF runs) — the corruption payload. */
+function binaryFixture(): Buffer {
+  const bytes = Buffer.alloc(1024);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes);
+  bytes.fill(0x00, 8, 512);
+  bytes.fill(0xff, 512, 1024);
+  bytes[700] = 0x7f;
+  return bytes;
+}
+
+// ─── Data plane ─────────────────────────────────────────────────────────────
+
+describe('pyric-admin remote dispatch — Storage data plane', () => {
+  it('save → download round-trips non-UTF8 binary byte-for-byte through JSON-round-tripped frames', async () => {
+    const { app } = makeStack();
+    const bucket = getStorage(app).bucket();
+    const bytes = binaryFixture();
+
+    await bucket.file('uploads/avatar.png').save(bytes, { contentType: 'image/png' });
+    const [roundTripped] = await bucket.file('uploads/avatar.png').download();
+    expect(Buffer.isBuffer(roundTripped)).toBe(true);
+    expect(roundTripped.equals(bytes)).toBe(true);
+  });
+
+  it('save accepts string and Uint8Array inputs (local-arm input parity)', async () => {
+    const { app } = makeStack();
+    const bucket = getStorage(app).bucket();
+
+    await bucket.file('reports/run-1.json').save('{"ok":true}', {
+      contentType: 'application/json',
+    });
+    const [text] = await bucket.file('reports/run-1.json').download();
+    expect(text.toString('utf8')).toBe('{"ok":true}');
+
+    const raw = new Uint8Array([0, 255, 128, 1]);
+    await bucket.file('raw/bytes').save(raw);
+    const [back] = await bucket.file('raw/bytes').download();
+    expect(Array.from(back)).toEqual([0, 255, 128, 1]);
+  });
+
+  it('contentType + metadata round-trip via save options (read back through the worker)', async () => {
+    const { ctx, app } = makeStack();
+    const bucket = getStorage(app).bucket();
+
+    await bucket.file('docs/tagged.json').save(Buffer.from('{}'), {
+      contentType: 'application/json',
+      metadata: { cacheControl: 'no-store', metadata: { owner: 'ada' } },
+    });
+
+    const meta = (await workerOp(ctx, {
+      method: 'storage.getMetadata',
+      path: 'docs/tagged.json',
+      actAs: { mode: 'admin' },
+    })) as {
+      contentType: string;
+      cacheControl?: string;
+      customMetadata?: Record<string, string>;
+      size: number;
+    };
+    expect(meta.contentType).toBe('application/json');
+    expect(meta.cacheControl).toBe('no-store');
+    expect(meta.customMetadata).toEqual({ owner: 'ada' });
+    expect(meta.size).toBe(2);
+  });
+
+  it('exists / delete / idempotent re-delete; missing download throws "No such object" (local parity)', async () => {
+    const { app } = makeStack();
+    const bucket = getStorage(app).bucket();
+    const file = bucket.file('tmp/scratch');
+
+    expect(await file.exists()).toEqual([false]);
+    await file.save(Buffer.from('x'));
+    expect(await file.exists()).toEqual([true]);
+
+    await file.delete();
+    expect(await file.exists()).toEqual([false]);
+    await file.delete(); // idempotent — no throw
+
+    await expect(file.download()).rejects.toThrow('No such object: pyric-default/tmp/scratch');
+  });
+
+  it('cross-visibility: a browser-side write (direct worker port) is readable via admin download, and vice versa', async () => {
+    const { ctx, app } = makeStack();
+    const bucket = getStorage(app).bucket();
+
+    // "The browser app" uploads through its own port…
+    await workerOp(ctx, {
+      method: 'storage.putBytes',
+      path: 'shared/from-browser.txt',
+      dataB64: bytesToBase64(new TextEncoder().encode('hello from the page')),
+      contentType: 'text/plain',
+    });
+    // …and the admin arm reads the SAME store.
+    const [fromBrowser] = await bucket.file('shared/from-browser.txt').download();
+    expect(fromBrowser.toString('utf8')).toBe('hello from the page');
+
+    // Admin writes are visible to the browser side.
+    await bucket.file('shared/from-admin.txt').save('hello from the server');
+    const wire = (await workerOp(ctx, {
+      method: 'storage.getBytes',
+      path: 'shared/from-admin.txt',
+    })) as { dataB64: string };
+    expect(Buffer.from(wire.dataB64, 'base64').toString('utf8')).toBe('hello from the server');
+  });
+
+  it('getSignedUrl returns the deterministic local stub, byte-identical to the local arm', async () => {
+    const { app } = makeStack();
+    const remoteFile = getStorage(app).bucket().file('assets/logo.png');
+
+    const localApp = initializeApp({ sandbox: initializeSandbox() }, `local-${Date.now()}`);
+    const localFile = getStorage(localApp).bucket().file('assets/logo.png');
+
+    const options = { action: 'read' as const, expires: 1_800_000_000_000 };
+    const [remoteUrl] = await remoteFile.getSignedUrl(options);
+    const [localUrl] = await localFile.getSignedUrl(options);
+    expect(remoteUrl).toBe(localUrl);
+    expect(remoteUrl).toBe(
+      'pyric-sandbox-storage://pyric-default/assets/logo.png?expires=1800000000000&action=read',
+    );
+  });
+});
+
+// ─── Remediating throws + caps ──────────────────────────────────────────────
+
+describe('pyric-admin remote dispatch — Storage remediating throws', () => {
+  it('throws loudly on non-default bucket names (single-bucket worker store)', () => {
+    const { app } = makeStack();
+    const storage = getStorage(app);
+    expect(() => storage.bucket('my-other-bucket')).toThrow(/single bucket/);
+    expect(() => storage.bucket('my-other-bucket')).toThrow(/my-other-bucket/);
+    // The default bucket — named or unnamed — is fine.
+    expect(storage.bucket().name).toBe('pyric-default');
+    expect(storage.bucket('pyric-default').name).toBe('pyric-default');
+  });
+
+  it('rejects an over-cap save CLIENT-SIDE (before anything hits the wire)', async () => {
+    const { app } = makeStack();
+    const file = getStorage(app).bucket().file('big/blob');
+    const oversized = Buffer.alloc(MAX_STORAGE_OP_BYTES + 1);
+    try {
+      await file.save(oversized);
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('payload-too-large');
+      expect((err as Error).message).toContain('8 MiB');
+    }
+    expect(await file.exists()).toEqual([false]);
+  });
+
+  it('rejects an over-cap download HOST-SIDE (a big browser object cannot blow up the relay)', async () => {
+    const { ctx, app } = makeStack();
+    // Plant an over-cap object directly in the worker's store (the page's
+    // own in-worker surface has no cap).
+    const { uploadBytes, ref } = await import('pyric/storage');
+    const storage = getStorageSandbox(ctx.sandbox);
+    await uploadBytes(ref(storage, 'big/native'), new Uint8Array(MAX_STORAGE_OP_BYTES + 1));
+
+    const file = getStorage(app).bucket().file('big/native');
+    try {
+      await file.download();
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('payload-too-large');
+      expect((err as Error).message).toContain('8 MiB');
+    }
+  });
+
+  it('resumable saves and streams throw with remote-flavored remediation', async () => {
+    const { app } = makeStack();
+    const file = getStorage(app).bucket().file('x/y');
+    await expect(file.save(Buffer.from('x'), { resumable: true })).rejects.toThrow(
+      /resumable uploads/,
+    );
+    const asStreams = file as unknown as {
+      createWriteStream(): never;
+      createReadStream(): never;
+    };
+    expect(() => asStreams.createWriteStream()).toThrow(/createWriteStream.*save/s);
+    expect(() => asStreams.createReadStream()).toThrow(/createReadStream.*download/s);
+  });
+});
+
+// ─── Rules: the pinned admin lens bypasses page-configured rules ────────────
+
+describe('pyric-admin remote dispatch — Storage vs page-configured rules', () => {
+  it('deny-all page rules: every admin File op still succeeds (rules bypass), while page ops stay denied', async () => {
+    const { ctx, app } = makeStack({ rules: DENY_ALL_RULES });
+    const bucket = getStorage(app).bucket();
+    const file = bucket.file('locked/secret.bin');
+    const bytes = binaryFixture();
+
+    // The PAGE (no lens) is denied — the rules are genuinely live.
+    await expect(
+      workerOp(ctx, {
+        method: 'storage.putBytes',
+        path: 'locked/secret.bin',
+        dataB64: bytesToBase64(bytes),
+      }),
+    ).rejects.toThrow(/unauthorized/);
+
+    // The admin arm bypasses: full CRUD against the same denied tree.
+    await file.save(bytes, { contentType: 'application/octet-stream' });
+    expect(await file.exists()).toEqual([true]);
+    const [back] = await file.download();
+    expect(back.equals(bytes)).toBe(true);
+
+    // Page reads stay denied even though the object now exists.
+    await expect(
+      workerOp(ctx, { method: 'storage.getBytes', path: 'locked/secret.bin' }),
+    ).rejects.toThrow(/unauthorized/);
+
+    await file.delete();
+    expect(await file.exists()).toEqual([false]);
+  });
+});
+
+// ─── Arm selection + no-peer failure mode ───────────────────────────────────
+
+describe('pyric-admin remote dispatch — Storage arm selection', () => {
+  it('routes a remote-branded sandbox to the remote arm (no local state, no onEvent hook)', async () => {
+    const { ctx, app } = makeStack();
+    // The handle's `onEvent` throws — the local arm subscribes to it when
+    // creating its WeakMap state, so a working handle + a write landing in
+    // the WORKER's store proves the remote arm was selected.
+    const bucket = getStorage(app).bucket();
+    await bucket.file('dispatch/probe').save('via remote arm');
+    const wire = (await workerOp(ctx, {
+      method: 'storage.getBytes',
+      path: 'dispatch/probe',
+    })) as { dataB64: string };
+    expect(Buffer.from(wire.dataB64, 'base64').toString('utf8')).toBe('via remote arm');
+  });
+
+  it('getStorage(app) reuses one remote Storage per handle', () => {
+    const { app } = makeStack();
+    expect(getStorage(app)).toBe(getStorage(app));
+  });
+
+  it('still routes a plain in-process sandbox to the local arm', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+    const bucket = getStorage(app).bucket();
+    await bucket.file('local/probe').save('via local arm');
+    const [back] = await bucket.file('local/probe').download();
+    expect(back.toString('utf8')).toBe('via local arm');
+    // Local-arm signature: real multi-bucket isolation still works.
+    const other = getStorage(app).bucket('secondary');
+    expect(await other.file('local/probe').exists()).toEqual([false]);
+  });
+});
+
+describe('pyric-admin remote dispatch — Storage with no browser tab', () => {
+  it('fails fast with the "open <serve url>" guidance through the storage API', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    const remote = connectRemote(bridge); // NO tab registered
+    const app = initializeApp({ sandbox: remote });
+    const file = getStorage(app).bucket().file('x/y');
+
+    const started = Date.now();
+    await expect(file.save(Buffer.from('x'))).rejects.toThrow(/open http:\/\/localhost:5000/);
+    await expect(file.download()).rejects.toThrow(/open http:\/\/localhost:5000/);
+    await expect(file.exists()).rejects.toThrow(/open http:\/\/localhost:5000/);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});
+
+// ─── Conformance: one consumer flow, two arms ───────────────────────────────
+
+describe('pyric-admin storage conformance — same assertions, both arms', () => {
+  function runConsumerFlow(storage: Storage): Promise<void> {
+    return (async () => {
+      const bucket = storage.bucket();
+      const file = bucket.file('conformance/data.json');
+
+      expect(await file.exists()).toEqual([false]);
+      await expect(file.download()).rejects.toThrow(/No such object/);
+
+      await file.save(Buffer.from('{"n":1}'), { contentType: 'application/json' });
+      expect(await file.exists()).toEqual([true]);
+      const [buf] = await file.download();
+      expect(buf.toString('utf8')).toBe('{"n":1}');
+
+      // Overwrite replaces content (no append semantics).
+      await file.save('{"n":2}');
+      const [buf2] = await file.download();
+      expect(buf2.toString('utf8')).toBe('{"n":2}');
+
+      const [url] = await file.getSignedUrl({ action: 'read', expires: 1_800_000_000_000 });
+      expect(url).toBe(
+        'pyric-sandbox-storage://pyric-default/conformance/data.json?expires=1800000000000&action=read',
+      );
+
+      await expect(file.save(Buffer.from('x'), { resumable: true })).rejects.toThrow(/resumable/);
+
+      await file.delete();
+      await file.delete(); // idempotent
+      expect(await file.exists()).toEqual([false]);
+    })();
+  }
+
+  it('local arm passes the consumer flow', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+    await runConsumerFlow(getStorage(app));
+  });
+
+  it('remote arm passes the identical consumer flow', async () => {
+    const { app } = makeStack();
+    await runConsumerFlow(getStorage(app));
+  });
+});

--- a/packages/pyric-tools/src/bridge/client/bridge.ts
+++ b/packages/pyric-tools/src/bridge/client/bridge.ts
@@ -28,6 +28,7 @@ import type {
 } from '../protocol.js';
 import {
   isBridgeMessage,
+  assertJsonSafeRelayValue,
   DEFAULT_BRIDGE_PORT,
   DEFAULT_SANDBOX_PATH,
   WORKER_RELAY_CAPABILITY,
@@ -283,6 +284,10 @@ export function connectBridge(
     if (!workerRelay) return; // capability not advertised — drop (wire drift)
     try {
       const value = await workerRelay.op(req.op);
+      // Anti-corruption guard: a Blob/ArrayBuffer/TypedArray result would be
+      // SILENTLY mangled by the JSON WS legs ({} / index-keyed object) — turn
+      // it into a loud error naming the base64 storage ops instead.
+      assertJsonSafeRelayValue(req.op.method, value);
       send({ type: 'worker-res', id: req.id, ok: true, value });
     } catch (err) {
       send({

--- a/packages/pyric-tools/src/bridge/client/bridge.ts
+++ b/packages/pyric-tools/src/bridge/client/bridge.ts
@@ -287,7 +287,7 @@ export function connectBridge(
       // Anti-corruption guard: a Blob/ArrayBuffer/TypedArray result would be
       // SILENTLY mangled by the JSON WS legs ({} / index-keyed object) — turn
       // it into a loud error naming the base64 storage ops instead.
-      assertJsonSafeRelayValue(req.op.method, value);
+      assertJsonSafeRelayValue(`op '${req.op.method}'`, value);
       send({ type: 'worker-res', id: req.id, ok: true, value });
     } catch (err) {
       send({
@@ -307,6 +307,25 @@ export function connectBridge(
     if (relaySubs.has(req.subId)) return; // idempotent
     try {
       const unsubscribe = workerRelay.subscribe(req.sub, (value) => {
+        // Same anti-corruption guard as handleWorkerOp: a binary snap value
+        // would be silently mangled by the JSON WS legs — fail the sub with
+        // the snap-error convention (routes to onError on the Node side)
+        // instead of delivering garbage.
+        try {
+          assertJsonSafeRelayValue(`subscription '${req.subId}'`, value);
+        } catch (err) {
+          send({
+            type: 'worker-snap',
+            subId: req.subId,
+            value: {
+              __error: {
+                code: (err as { code?: string }).code ?? 'invalid-argument',
+                message: err instanceof Error ? err.message : String(err),
+              },
+            },
+          });
+          return;
+        }
         send({ type: 'worker-snap', subId: req.subId, value });
       });
       relaySubs.set(req.subId, unsubscribe);

--- a/packages/pyric-tools/src/bridge/protocol.ts
+++ b/packages/pyric-tools/src/bridge/protocol.ts
@@ -265,3 +265,58 @@ export const NO_SANDBOX_ERROR_MESSAGE =
 /** Error for worker ops against a peer that predates the worker relay. */
 export const NO_WORKER_RELAY_ERROR_MESSAGE =
   'the connected browser tab does not support the worker relay — reload the tab (and update pyric if reloading does not help).';
+
+// ─── Binary-payload guard (worker-op relay boundary) ────────────────────────
+//
+// Both WS legs of the worker relay are `JSON.stringify` — a `Blob` or
+// `ArrayBuffer` in a relayed value silently becomes `{}` and a TypedArray /
+// Buffer becomes an index-keyed object. Nothing errors; the far side just
+// receives garbage (the live failure mode: relaying `storage.getBlob` yields
+// `{}`). This guard turns that silent corruption into a loud, remediable
+// rejection at the relay boundary. It is a cheap explicit TYPE check
+// (Blob/ArrayBuffer/TypedArray/DataView), NOT a full JSON round-trip.
+
+/** Human label for a non-JSON-safe binary value, or null when `value` (and
+ *  every nested array/plain-object member) is free of binary containers. */
+export function findBinaryPayload(value: unknown): string | null {
+  if (value === null || typeof value !== 'object') return null;
+  if (typeof Blob !== 'undefined' && value instanceof Blob) return 'Blob';
+  if (value instanceof ArrayBuffer) return 'ArrayBuffer';
+  if (ArrayBuffer.isView(value)) {
+    return (value as { constructor?: { name?: string } }).constructor?.name ?? 'TypedArray';
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const hit = findBinaryPayload(item);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  for (const item of Object.values(value as Record<string, unknown>)) {
+    const hit = findBinaryPayload(item);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Assert a worker-op result is safe to serialize onto the JSON relay.
+ * Throws (code `invalid-argument`) naming the offending type and the
+ * base64 storage ops to use instead — so a future caller relaying
+ * `storage.getBlob` gets a clear error, not `{}`.
+ */
+export function assertJsonSafeRelayValue(
+  method: string,
+  value: unknown,
+): void {
+  const kind = findBinaryPayload(value);
+  if (!kind) return;
+  const err = new Error(
+    `worker op '${method}' produced a binary payload (${kind}) that cannot cross the ` +
+      'JSON bridge relay — it would be silently corrupted by JSON.stringify. Use the ' +
+      "base64 storage ops instead ('storage.getBytes' / 'storage.putBytes'), which carry " +
+      "bytes as JSON-safe 'dataB64' strings; 'storage.getBlob' is MessagePort-only.",
+  ) as Error & { code: string };
+  err.code = 'invalid-argument';
+  throw err;
+}

--- a/packages/pyric-tools/src/bridge/protocol.ts
+++ b/packages/pyric-tools/src/bridge/protocol.ts
@@ -300,19 +300,22 @@ export function findBinaryPayload(value: unknown): string | null {
 }
 
 /**
- * Assert a worker-op result is safe to serialize onto the JSON relay.
- * Throws (code `invalid-argument`) naming the offending type and the
- * base64 storage ops to use instead — so a future caller relaying
- * `storage.getBlob` gets a clear error, not `{}`.
+ * Assert a worker-op result (or subscription snap value) is safe to
+ * serialize onto the JSON relay. Throws (code `invalid-argument`) naming
+ * the offending type and the base64 storage ops to use instead — so a
+ * future caller relaying `storage.getBlob` gets a clear error, not `{}`.
+ *
+ * `context` is a human label for the message: `op '<method>'` for op
+ * results, `subscription '<subId>'` for snap values.
  */
 export function assertJsonSafeRelayValue(
-  method: string,
+  context: string,
   value: unknown,
 ): void {
   const kind = findBinaryPayload(value);
   if (!kind) return;
   const err = new Error(
-    `worker op '${method}' produced a binary payload (${kind}) that cannot cross the ` +
+    `worker ${context} produced a binary payload (${kind}) that cannot cross the ` +
       'JSON bridge relay — it would be silently corrupted by JSON.stringify. Use the ' +
       "base64 storage ops instead ('storage.getBytes' / 'storage.putBytes'), which carry " +
       "bytes as JSON-safe 'dataB64' strings; 'storage.getBlob' is MessagePort-only.",

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -31,6 +31,7 @@
  */
 import { WebSocket } from 'ws';
 import type { AuthUserRecord, CreateUserRequest, UpdateUserRequest } from 'pyric/auth';
+import type { FullMetadata } from 'pyric/storage';
 import {
   REMOTE_SANDBOX,
   SandboxContextImpl,
@@ -44,6 +45,7 @@ import type {
   WorkerSubPayload,
 } from '../bridge/protocol.js';
 import { isBridgeMessage, NO_SANDBOX_ERROR_MESSAGE } from '../bridge/protocol.js';
+import { MAX_STORAGE_OP_BYTES, storagePayloadTooLarge } from '../serve/worker/protocol.js';
 import { discoverServe } from '../serve/discovery.js';
 
 /** Sits just above the bridge's own 30s `callTimeoutMs` so a legitimately
@@ -131,6 +133,38 @@ export interface RemoteRtdb {
   ): () => void;
 }
 
+/**
+ * Thin Storage conveniences over the channel — the byte-carrying base64 ops
+ * plus browse/metadata. Every call pins `actAs: { mode: 'admin' }`
+ * (firebase-admin's rules-bypass semantics, matching {@link RemoteRtdb});
+ * use the raw `channel` for lensed (rules-evaluated) access. Bytes are
+ * capped at 8 MiB raw ({@link MAX_STORAGE_OP_BYTES}) on both ends —
+ * streaming transfers are not supported on the sandbox backend.
+ */
+export interface RemoteStorage {
+  /** Upload `data` at `path` (replaces any existing object). Resolves with
+   *  the stored object's `FullMetadata`. */
+  putBytes(
+    path: string,
+    data: Uint8Array,
+    options?: { contentType?: string; metadata?: Record<string, unknown> },
+  ): Promise<FullMetadata>;
+  /** Download the object's bytes. Rejects `storage/object-not-found` when
+   *  absent, `payload-too-large` when over the op cap. */
+  getBytes(path: string): Promise<Buffer>;
+  /** Delete the object at `path`. Idempotent (missing = no-op). */
+  deleteObject(path: string): Promise<void>;
+  /** Read the object's `FullMetadata`. */
+  getMetadata(path: string): Promise<FullMetadata>;
+  /** Does an object exist at `path`? (`getMetadata` with not-found → false.) */
+  exists(path: string): Promise<boolean>;
+  /** Enumerate immediate child items + prefixes under `path`. */
+  listAll(path: string): Promise<{
+    items: Array<{ fullPath: string; name: string }>;
+    prefixes: Array<{ fullPath: string; name: string }>;
+  }>;
+}
+
 /** Admin auth user-CRUD passthrough (never lensed — auth ops operate the
  *  worker's user pool directly, mirroring `pyric/auth`'s sandbox ops). */
 export interface RemoteAuthAdmin {
@@ -158,6 +192,8 @@ export interface RemoteSandbox extends RemoteSandboxBase {
   readonly channel: RemoteSandboxChannel;
   /** RTDB conveniences (admin lens pinned). */
   readonly rtdb: RemoteRtdb;
+  /** Storage conveniences (admin lens pinned; 8 MiB per-op byte cap). */
+  readonly storage: RemoteStorage;
   /** Admin auth user CRUD. */
   readonly auth: RemoteAuthAdmin;
   /** Close the connection. In-flight ops reject; subscriptions stop. */
@@ -395,6 +431,64 @@ export function buildRemoteRtdb(channel: RemoteSandboxChannel): RemoteRtdb {
   };
 }
 
+export function buildRemoteStorage(channel: RemoteSandboxChannel): RemoteStorage {
+  return {
+    async putBytes(path, data, options) {
+      // Client-side cap: reject BEFORE encoding/sending so an oversized
+      // payload never hits the wire (the host enforces the same cap on
+      // decode — belt and braces across the relay).
+      if (data.byteLength > MAX_STORAGE_OP_BYTES) {
+        throw storagePayloadTooLarge(data.byteLength, `storage payload for '${path}'`);
+      }
+      return (await channel.op({
+        method: 'storage.putBytes',
+        path,
+        dataB64: Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('base64'),
+        ...(options?.contentType !== undefined ? { contentType: options.contentType } : {}),
+        ...(options?.metadata !== undefined ? { metadata: options.metadata } : {}),
+        actAs: ADMIN_LENS,
+      })) as FullMetadata;
+    },
+    async getBytes(path) {
+      const res = (await channel.op({
+        method: 'storage.getBytes',
+        path,
+        actAs: ADMIN_LENS,
+      })) as { dataB64: string };
+      return Buffer.from(res.dataB64, 'base64');
+    },
+    async deleteObject(path) {
+      await channel.op({ method: 'storage.deleteObject', path, actAs: ADMIN_LENS });
+    },
+    async getMetadata(path) {
+      return (await channel.op({
+        method: 'storage.getMetadata',
+        path,
+        actAs: ADMIN_LENS,
+      })) as FullMetadata;
+    },
+    async exists(path) {
+      try {
+        await this.getMetadata(path);
+        return true;
+      } catch (err) {
+        if ((err as { code?: string }).code === 'storage/object-not-found') return false;
+        throw err;
+      }
+    },
+    async listAll(path) {
+      return (await channel.op({
+        method: 'storage.listAll',
+        path,
+        actAs: ADMIN_LENS,
+      })) as {
+        items: Array<{ fullPath: string; name: string }>;
+        prefixes: Array<{ fullPath: string; name: string }>;
+      };
+    },
+  };
+}
+
 export function buildRemoteAuthAdmin(channel: RemoteSandboxChannel): RemoteAuthAdmin {
   return {
     async listUsers() {
@@ -465,6 +559,7 @@ export function createRemoteSandboxHandle(opts: {
     serveUrl,
     channel,
     rtdb: buildRemoteRtdb(channel),
+    storage: buildRemoteStorage(channel),
     auth: buildRemoteAuthAdmin(channel),
     close,
 

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -206,6 +206,16 @@ export interface RemoteSandbox extends RemoteSandboxBase {
  *  `ws` socket; tests inject an in-process pipe to a `ConsumerSession`. */
 export interface RemoteTransport {
   send(msg: BridgeMessage): void;
+  /**
+   * OPTIONAL event-loop hold hooks (exit-hang fix). The WS adapter unrefs
+   * its socket once connected so an IDLE remote client never pins the Node
+   * event loop (a finished script exits); the core calls `ref()` when work
+   * becomes outstanding (first pending op / live subscription) and
+   * `unref()` when the last one settles, so in-flight delivery keeps the
+   * process alive. Pure in-process transports (tests) may omit both.
+   */
+  ref?(): void;
+  unref?(): void;
 }
 
 export interface RemoteSandboxCore {
@@ -259,6 +269,23 @@ export function createRemoteSandboxCore(
     transport.send(msg);
   }
 
+  /**
+   * Event-loop hold accounting (exit-hang fix): ref the transport while ANY
+   * op or subscription is outstanding, unref when the last one settles.
+   * Transition-edged so the hooks fire once per busy/idle flip.
+   */
+  let holdingLoop = false;
+  function updateLoopHold(): void {
+    const busy = pending.size + subs.size > 0;
+    if (busy && !holdingLoop) {
+      holdingLoop = true;
+      transport.ref?.();
+    } else if (!busy && holdingLoop) {
+      holdingLoop = false;
+      transport.unref?.();
+    }
+  }
+
   function op(payload: WorkerOpPayload): Promise<unknown> {
     if (disposed) {
       return Promise.reject(remoteError('unavailable', disposed));
@@ -268,6 +295,7 @@ export function createRemoteSandboxCore(
       const timer = setTimeout(() => {
         if (pending.has(id)) {
           pending.delete(id);
+          updateLoopHold();
           reject(
             remoteError(
               'deadline-exceeded',
@@ -277,11 +305,13 @@ export function createRemoteSandboxCore(
         }
       }, opTimeoutMs);
       pending.set(id, { resolve, reject, timer });
+      updateLoopHold();
       try {
         send({ type: 'worker-op', id, op: payload });
       } catch (err) {
         clearTimeout(timer);
         pending.delete(id);
+        updateLoopHold();
         reject(
           remoteError(
             'unavailable',
@@ -300,9 +330,11 @@ export function createRemoteSandboxCore(
     if (disposed) throw remoteError('unavailable', disposed);
     const subId = `rsub-${++subCounter}`;
     subs.set(subId, { onSnap, onError });
+    updateLoopHold();
     send({ type: 'worker-sub', subId, sub });
     return () => {
       if (!subs.delete(subId)) return;
+      updateLoopHold();
       if (!disposed) {
         try {
           send({ type: 'worker-unsub', subId });
@@ -324,6 +356,7 @@ export function createRemoteSandboxCore(
         if (!call) return; // late (already timed out) — drop
         clearTimeout(call.timer);
         pending.delete(msg.id);
+        updateLoopHold();
         if (msg.ok) {
           call.resolve(msg.value);
         } else {
@@ -332,6 +365,11 @@ export function createRemoteSandboxCore(
           // Enrich the bridge's generic no-peer error with actionable guidance.
           if (message === NO_SANDBOX_ERROR_MESSAGE) {
             message = noTabError(serveUrl).message;
+          } else if (/^Unknown method:/.test(message)) {
+            // Version skew: a live tab whose SharedWorker predates this op.
+            message +=
+              ' — the running sandbox may predate this feature; restart pyric dev ' +
+              'and reload the browser tab.';
           }
           call.reject(remoteError(code, message));
         }
@@ -374,6 +412,7 @@ export function createRemoteSandboxCore(
     }
     pending.clear();
     subs.clear();
+    updateLoopHold();
     readyReject(err); // no-op if already settled
   }
 
@@ -685,8 +724,20 @@ export async function connectRemoteSandbox(
   const wsUrl = `${wsBase.replace(/^http/, 'ws')}/__pyric/sandbox`;
   const ws = new WebSocket(wsUrl);
 
+  // Event-loop hold (exit-hang fix): `ws` exposes no ref/unref of its own —
+  // reach the underlying net.Socket (present once connected). Unref'ing only
+  // changes loop-exit accounting, never delivery: while ANY pending op or
+  // live subscription holds a ref (the core's updateLoopHold), frames flow
+  // normally; when idle, a finished script exits instead of hanging.
+  const wsSocket = (): { ref(): void; unref(): void } | undefined =>
+    (ws as unknown as { _socket?: { ref(): void; unref(): void } })._socket;
+
   const core = createRemoteSandboxCore(
-    { send: (msg) => ws.send(JSON.stringify(msg)) },
+    {
+      send: (msg) => ws.send(JSON.stringify(msg)),
+      ref: () => wsSocket()?.ref(),
+      unref: () => wsSocket()?.unref(),
+    },
     { serveUrl, opTimeoutMs: options.opTimeoutMs },
   );
 
@@ -709,6 +760,10 @@ export async function connectRemoteSandbox(
     );
     ws.once('open', () => {
       clearTimeout(timer);
+      // Idle default: an open-but-idle connection must not pin the event
+      // loop (both the eager and lazy `remoteSandbox` paths come through
+      // here). The core re-refs while ops/subs are outstanding.
+      wsSocket()?.unref();
       resolve();
     });
     ws.once('error', (err) => {

--- a/packages/pyric-tools/src/serve/entries/storage.ts
+++ b/packages/pyric-tools/src/serve/entries/storage.ts
@@ -15,9 +15,12 @@ import {
 import {
   getStorage as workerGetStorage,
   getBlob as workerGetBlob,
+  getBytes as workerGetBytes,
   getMetadata as workerGetMetadata,
   listAll as workerListAll,
   ref as workerRef,
+  uploadBytes as workerUploadBytes,
+  deleteObject as workerDeleteObject,
 } from '../worker/client.js';
 import { sandbox, useWorker, workerDb } from './runtime.js';
 
@@ -59,8 +62,13 @@ function workerOrInPage<T extends (...args: any[]) => unknown>(name: string, fn:
   return (useWorker ? (() => unsupportedWorkerApi(name)) : fn) as T;
 }
 
-export const uploadBytes = workerOrInPage('uploadBytes', ip.uploadBytes);
+// Byte ops now have a worker protocol (base64 `storage.putBytes` /
+// `storage.getBytes` / `storage.deleteObject`), so worker mode routes them to
+// the shared object store instead of throwing. Page-configured rules apply
+// (no lens attached); payloads are capped at 8 MiB per op.
+export const uploadBytes = (useWorker ? workerUploadBytes : ip.uploadBytes) as typeof ip.uploadBytes;
+export const getBytes = (useWorker ? workerGetBytes : ip.getBytes) as typeof ip.getBytes;
+export const deleteObject = (useWorker ? workerDeleteObject : ip.deleteObject) as typeof ip.deleteObject;
+
 export const uploadString = workerOrInPage('uploadString', ip.uploadString);
-export const getBytes = workerOrInPage('getBytes', ip.getBytes);
-export const deleteObject = workerOrInPage('deleteObject', ip.deleteObject);
 export const updateMetadata = workerOrInPage('updateMetadata', ip.updateMetadata);

--- a/packages/pyric-tools/src/serve/entries/storage.ts
+++ b/packages/pyric-tools/src/serve/entries/storage.ts
@@ -64,8 +64,12 @@ function workerOrInPage<T extends (...args: any[]) => unknown>(name: string, fn:
 
 // Byte ops now have a worker protocol (base64 `storage.putBytes` /
 // `storage.getBytes` / `storage.deleteObject`), so worker mode routes them to
-// the shared object store instead of throwing. Page-configured rules apply
-// (no lens attached); payloads are capped at 8 MiB per op.
+// the shared object store instead of throwing. No lens is attached: storage
+// rules apply only when the HOST configured them on the sandbox's storage
+// service — the served worker currently configures none (setRules deploys
+// Firestore/RTDB only), so worker-mode storage is effectively open today.
+// The admin lens matters for embedding/test hosts that pre-open the service
+// with rules. Payloads are capped at 8 MiB per op.
 export const uploadBytes = (useWorker ? workerUploadBytes : ip.uploadBytes) as typeof ip.uploadBytes;
 export const getBytes = (useWorker ? workerGetBytes : ip.getBytes) as typeof ip.getBytes;
 export const deleteObject = (useWorker ? workerDeleteObject : ip.deleteObject) as typeof ip.deleteObject;

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -1998,10 +1998,13 @@ export async function getBlob(reference: ClientStorageReference): Promise<Blob> 
 // ─── Storage mutations + JSON-safe reads (worker-mode byte ops) ───────────
 // Backed by the base64 `storage.putBytes` / `storage.getBytes` /
 // `storage.deleteObject` ops (remote sandbox, slice 2). No `actAs` lens is
-// attached: page callers run under the worker's page storage handle, so
-// page-configured rules apply (same model as `listAll`/`getMetadata` above).
-// Raw payloads are capped at 8 MiB (`MAX_STORAGE_OP_BYTES`) — same cap the
-// host enforces.
+// attached: page callers run under the worker's page storage handle (same
+// model as `listAll`/`getMetadata` above). Storage rules apply only when the
+// HOST configured them on the sandbox's storage service — the served worker
+// currently configures none, so worker-mode storage is effectively open
+// today; the admin lens matters for embedding/test hosts that pre-open the
+// service with rules. Raw payloads are capped at 8 MiB
+// (`MAX_STORAGE_OP_BYTES`) — same cap the host enforces.
 
 /** Mirror of `pyric/storage`'s `SettableMetadata` (plain JSON on the wire). */
 export interface ClientSettableMetadata {

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -83,7 +83,14 @@ import type {
   ResolvedIdentity,
 } from './protocol.js';
 import type { PolicyRequest } from './protocol.js';
-import { deserializeDocData, isSentinelMarker } from './protocol.js';
+import {
+  deserializeDocData,
+  isSentinelMarker,
+  bytesToBase64,
+  base64ToBytes,
+  storagePayloadTooLarge,
+  MAX_STORAGE_OP_BYTES,
+} from './protocol.js';
 // TYPE-ONLY — the generic worker-relay wire payloads (op/sub messages minus
 // the port-level ids this module re-mints). Erased at build; `bridge/
 // protocol.ts` itself has no runtime imports, so no engine code is pulled in.
@@ -1980,9 +1987,88 @@ export async function getMetadata(reference: ClientStorageReference): Promise<Fu
   })) as FullMetadata;
 }
 
-/** Read an object's bytes as a Blob (Pyric Studio inspector preview). */
+/** Read an object's bytes as a Blob (Pyric Studio inspector preview).
+ *  MessagePort-only — a Blob cannot cross the JSON bridge relay. */
 export async function getBlob(reference: ClientStorageReference): Promise<Blob> {
   return (await rpc(reference.port, {
     t: 'op', id: nextId(), method: 'storage.getBlob', path: reference.fullPath,
   })) as Blob;
+}
+
+// ─── Storage mutations + JSON-safe reads (worker-mode byte ops) ───────────
+// Backed by the base64 `storage.putBytes` / `storage.getBytes` /
+// `storage.deleteObject` ops (remote sandbox, slice 2). No `actAs` lens is
+// attached: page callers run under the worker's page storage handle, so
+// page-configured rules apply (same model as `listAll`/`getMetadata` above).
+// Raw payloads are capped at 8 MiB (`MAX_STORAGE_OP_BYTES`) — same cap the
+// host enforces.
+
+/** Mirror of `pyric/storage`'s `SettableMetadata` (plain JSON on the wire). */
+export interface ClientSettableMetadata {
+  contentType?: string;
+  cacheControl?: string;
+  contentDisposition?: string;
+  contentEncoding?: string;
+  contentLanguage?: string;
+  customMetadata?: { [key: string]: string };
+}
+
+/** Upload bytes at the reference's path (replaces existing content).
+ *  Mirrors `pyric/storage`'s `uploadBytes` result shape. */
+export async function uploadBytes(
+  reference: ClientStorageReference,
+  data: Blob | Uint8Array | ArrayBuffer,
+  metadata?: ClientSettableMetadata,
+): Promise<{ ref: ClientStorageReference; metadata: FullMetadata }> {
+  const bytes =
+    data instanceof Blob
+      ? new Uint8Array(await data.arrayBuffer())
+      : data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : data;
+  if (bytes.byteLength > MAX_STORAGE_OP_BYTES) {
+    throw storagePayloadTooLarge(bytes.byteLength, `uploadBytes payload for '${reference.fullPath}'`);
+  }
+  // contentType precedence mirrors pyric/storage: caller metadata → Blob.type.
+  const contentType =
+    metadata?.contentType ?? (data instanceof Blob && data.type ? data.type : undefined);
+  const stored = (await rpc(reference.port, {
+    t: 'op',
+    id: nextId(),
+    method: 'storage.putBytes',
+    path: reference.fullPath,
+    dataB64: bytesToBase64(bytes),
+    ...(contentType !== undefined ? { contentType } : {}),
+    ...(metadata !== undefined ? { metadata: metadata as Record<string, unknown> } : {}),
+  })) as FullMetadata;
+  return { ref: reference, metadata: stored };
+}
+
+/** Read an object's bytes (JSON-safe base64 op → `ArrayBuffer`). Mirrors
+ *  `pyric/storage`'s `getBytes`, including the optional client-side cap. */
+export async function getBytes(
+  reference: ClientStorageReference,
+  maxDownloadSizeBytes?: number,
+): Promise<ArrayBuffer> {
+  const res = (await rpc(reference.port, {
+    t: 'op', id: nextId(), method: 'storage.getBytes', path: reference.fullPath,
+  })) as { dataB64: string; size: number };
+  if (typeof maxDownloadSizeBytes === 'number' && res.size > maxDownloadSizeBytes) {
+    const err = new Error(
+      `storage/quota-exceeded: object at '${reference.fullPath}' is ${res.size} bytes — ` +
+        `over the requested maxDownloadSizeBytes (${maxDownloadSizeBytes}).`,
+    ) as Error & { code: string };
+    err.code = 'storage/quota-exceeded';
+    throw err;
+  }
+  const bytes = base64ToBytes(res.dataB64);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/** Delete the object at the reference's path (idempotent — missing = no-op,
+ *  matching the sandbox backend's delete semantics). */
+export async function deleteObject(reference: ClientStorageReference): Promise<void> {
+  await rpc(reference.port, {
+    t: 'op', id: nextId(), method: 'storage.deleteObject', path: reference.fullPath,
+  });
 }

--- a/packages/pyric-tools/src/serve/worker/host-context.ts
+++ b/packages/pyric-tools/src/serve/worker/host-context.ts
@@ -44,6 +44,13 @@ export interface HostCtx {
   rtdb?: Database;
   /** Cached admin (rules-bypass) RTDB handle for Studio/Playground data inspection. */
   adminRtdb?: Database;
+  /** Cached admin (rules-bypass) Storage handle for the `{ mode: 'admin' }`
+   *  lens — `pyric/storage/internal`'s `getAdminStorageSandbox`, the handle
+   *  the pyric-admin remote arm's storage ops resolve to. */
+  adminStorage?: FirebaseStorage;
+  /** Per-uid/token Storage handles for the impersonation lens (rules evaluate
+   *  as that user). Mirrors {@link HostCtx.lensRtdbs}. */
+  lensStorages?: Map<string, FirebaseStorage>;
   /** Per-uid RTDB handles carrying a port session's real identity. */
   sessionRtdbs?: Map<string, Database>;
   /** Per-uid/token RTDB handles for the Studio impersonation lens. */

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -521,9 +521,14 @@ function ensureStorage(ctx: HostCtx): FirebaseStorage {
  * lens — the storage mirror of {@link lensRtdb}:
  *
  *   - absent / `app-session` → the shared anonymous page handle
- *     ({@link ensureStorage}); page-configured rules apply. (Storage has no
- *     per-port session plumbing today — reads always ran anonymous; writes
- *     keep the same model.)
+ *     ({@link ensureStorage}). Storage rules apply only when the HOST
+ *     configured them on this sandbox's storage service (first call per
+ *     sandbox wins) — the SERVED worker currently configures none
+ *     (`setRules`/`setDatabaseRules` cover Firestore/RTDB only), so
+ *     worker-mode storage is effectively open today and all lenses behave
+ *     alike there. The lens split matters for embedding/test hosts that
+ *     pre-open the service with rules. (Storage also has no per-port
+ *     session plumbing — reads always ran anonymous; writes keep that.)
  *   - `{ mode: 'admin' }` → the rules-BYPASS handle from
  *     `pyric/storage/internal`'s admin plane — same per-sandbox store +
  *     ruleset, rule evaluation skipped (firebase-admin semantics for the

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -91,12 +91,20 @@ import { getInternalEnv } from 'pyric/sandbox/internal';
 import { initializeApp } from 'pyric/app';
 import {
   getStorage,
+  getStorageSandbox,
   ref as storageRef,
   listAll as storageListAll,
   getMetadata as storageGetMetadata,
   getBlob as storageGetBlob,
+  getBytes as storageGetBytes,
+  uploadBytes as storageUploadBytes,
+  deleteObject as storageDeleteObject,
   type FirebaseStorage,
+  type SettableMetadata,
 } from 'pyric/storage';
+// Host-only rules-bypass admin plane — the storage mirror of
+// `getAdminFirestore`/`getAdminDatabase`, resolved for `actAs: { mode: 'admin' }`.
+import { getAdminStorageSandbox } from 'pyric/storage/internal';
 import {
   getDatabase as pyricGetDatabase,
   getAdminDatabase as pyricGetAdminDatabase,
@@ -133,6 +141,11 @@ import {
   isAuthSub,
   isEventSub,
   isRtdbSub,
+  bytesToBase64,
+  base64ToBytes,
+  storagePayloadTooLarge,
+  MAX_STORAGE_OP_BYTES,
+  MAX_STORAGE_OP_B64_LENGTH,
 } from './protocol.js';
 // The canonical agent tool dispatcher — reused on the worker so a bridged agent
 // executes against THIS sandbox (one backend for app + Studio + agent), instead
@@ -501,6 +514,77 @@ function lensRtdb(ctx: HostCtx, actAs: AuthLens | undefined, port: PortLike): Da
  *  `pyric/storage` ops enforce rules, so the host reads through them. */
 function ensureStorage(ctx: HostCtx): FirebaseStorage {
   return (ctx.storage ??= getStorage(initializeApp({ sandbox: ctx.sandbox })));
+}
+
+/**
+ * Resolve the Storage handle a storage op runs against, given its `actAs`
+ * lens — the storage mirror of {@link lensRtdb}:
+ *
+ *   - absent / `app-session` → the shared anonymous page handle
+ *     ({@link ensureStorage}); page-configured rules apply. (Storage has no
+ *     per-port session plumbing today — reads always ran anonymous; writes
+ *     keep the same model.)
+ *   - `{ mode: 'admin' }` → the rules-BYPASS handle from
+ *     `pyric/storage/internal`'s admin plane — same per-sandbox store +
+ *     ruleset, rule evaluation skipped (firebase-admin semantics for the
+ *     `pyric-admin` remote arm / Studio admin lens).
+ *   - `{ mode: 'as', uid }` → a frozen-identity `getStorageSandbox(
+ *     sandbox.withAuth({ uid, token? }))` handle; rules evaluate AS that
+ *     user. Cached per uid/token key on `ctx.lensStorages`.
+ */
+function lensStorage(ctx: HostCtx, actAs?: AuthLens): FirebaseStorage {
+  if (!actAs || actAs.mode === 'app-session') {
+    return ensureStorage(ctx);
+  }
+  if (actAs.mode === 'admin') {
+    return (ctx.adminStorage ??= getAdminStorageSandbox(ctx.sandbox));
+  }
+  const handles = (ctx.lensStorages ??= new Map());
+  const key = lensCacheKey(actAs);
+  let handle = handles.get(key);
+  if (!handle) {
+    handle = getStorageSandbox(ctx.sandbox.withAuth(authStateForLens(actAs)));
+    handles.set(key, handle);
+  }
+  return handle;
+}
+
+/**
+ * Map a wire `storage.putBytes` payload to `pyric/storage`'s
+ * `SettableMetadata`. The explicit `contentType` field wins; recognized
+ * settable fields are lifted from `metadata`; a GCS-style nested custom map
+ * (`metadata.metadata`, as `@google-cloud/storage`'s `save` spells it) or a
+ * pyric-style `metadata.customMetadata` becomes `customMetadata` with
+ * values coerced to strings (the storage-rules `metadata` model).
+ */
+function toSettableMetadata(msg: {
+  contentType?: string;
+  metadata?: Record<string, unknown>;
+}): SettableMetadata {
+  const md = msg.metadata ?? {};
+  const str = (key: string): string | undefined =>
+    typeof md[key] === 'string' ? (md[key] as string) : undefined;
+  const customSource = md['customMetadata'] ?? md['metadata'];
+  let customMetadata: Record<string, string> | undefined;
+  if (customSource !== null && typeof customSource === 'object' && !Array.isArray(customSource)) {
+    customMetadata = {};
+    for (const [k, v] of Object.entries(customSource as Record<string, unknown>)) {
+      customMetadata[k] = String(v);
+    }
+  }
+  const settable: SettableMetadata = {};
+  const contentType = msg.contentType ?? str('contentType');
+  if (contentType !== undefined) settable.contentType = contentType;
+  const cacheControl = str('cacheControl');
+  if (cacheControl !== undefined) settable.cacheControl = cacheControl;
+  const contentDisposition = str('contentDisposition');
+  if (contentDisposition !== undefined) settable.contentDisposition = contentDisposition;
+  const contentEncoding = str('contentEncoding');
+  if (contentEncoding !== undefined) settable.contentEncoding = contentEncoding;
+  const contentLanguage = str('contentLanguage');
+  if (contentLanguage !== undefined) settable.contentLanguage = contentLanguage;
+  if (customMetadata !== undefined) settable.customMetadata = customMetadata;
+  return settable;
 }
 
 function ensureRtdb(ctx: HostCtx): Database {
@@ -1059,9 +1143,10 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
     }
 
     case 'storage.listAll': {
-      // Object browse. `listAll` enforces `read` rules on the scanned prefix.
+      // Object browse. `listAll` enforces `read` rules on the scanned prefix
+      // under the op's lens (admin lens bypasses — see lensStorage).
       try {
-        const storage = ensureStorage(ctx);
+        const storage = lensStorage(ctx, msg.actAs);
         const result = await storageListAll(storageRef(storage, msg.path));
         ok(port, msg.id, {
           items: result.items.map((r) => ({ fullPath: r.fullPath, name: r.name })),
@@ -1073,7 +1158,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
 
     case 'storage.getMetadata': {
       try {
-        const storage = ensureStorage(ctx);
+        const storage = lensStorage(ctx, msg.actAs);
         // FullMetadata is plain JSON (bucket/fullPath/name/size/contentType/...).
         ok(port, msg.id, await storageGetMetadata(storageRef(storage, msg.path)));
       } catch (e) { fail(port, msg.id, e); }
@@ -1081,9 +1166,80 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
     }
 
     case 'storage.getBlob': {
+      // MessagePort-ONLY: the Blob structured-clones to in-page callers
+      // (Studio previews) but silently corrupts under the JSON WS relay — the
+      // bridge client rejects relaying it (binary-payload guard). Remote
+      // callers use `storage.getBytes` (base64) instead.
       try {
-        const storage = ensureStorage(ctx);
+        const storage = lensStorage(ctx, msg.actAs);
         ok(port, msg.id, await storageGetBlob(storageRef(storage, msg.path)));
+      } catch (e) { fail(port, msg.id, e); }
+      break;
+    }
+
+    case 'storage.putBytes': {
+      // Byte upload (remote sandbox, slice 2). Decode-end size cap: reject an
+      // oversized base64 string BEFORE materializing its bytes, then re-check
+      // the exact decoded length. Rules enforce under the op's lens; the
+      // upload emits `service_mutation` events, so server writes get Studio
+      // provenance for free.
+      try {
+        if (msg.dataB64.length > MAX_STORAGE_OP_B64_LENGTH) {
+          throw storagePayloadTooLarge(
+            Math.floor(msg.dataB64.length * 0.75),
+            `storage.putBytes payload for '${msg.path}'`,
+          );
+        }
+        const bytes = base64ToBytes(msg.dataB64);
+        if (bytes.byteLength > MAX_STORAGE_OP_BYTES) {
+          throw storagePayloadTooLarge(bytes.byteLength, `storage.putBytes payload for '${msg.path}'`);
+        }
+        const storage = lensStorage(ctx, msg.actAs);
+        const result = await storageUploadBytes(
+          storageRef(storage, msg.path),
+          bytes,
+          toSettableMetadata(msg),
+        );
+        // FullMetadata — plain JSON, relay-safe.
+        ok(port, msg.id, result.metadata);
+      } catch (e) { fail(port, msg.id, e); }
+      break;
+    }
+
+    case 'storage.getBytes': {
+      // JSON-safe byte download (remote sandbox, slice 2): base64 in the
+      // result. Encode-end size cap so a big browser-side object can't blow
+      // up the relay. Metadata is read alongside for contentType (both reads
+      // run under the same lens; rule-eval order keeps `unauthorized`
+      // superseding `not-found`, matching pyric/storage).
+      try {
+        const storage = lensStorage(ctx, msg.actAs);
+        const r = storageRef(storage, msg.path);
+        const meta = await storageGetMetadata(r);
+        if (meta.size > MAX_STORAGE_OP_BYTES) {
+          throw storagePayloadTooLarge(meta.size, `object '${msg.path}'`);
+        }
+        const buf = await storageGetBytes(r);
+        if (buf.byteLength > MAX_STORAGE_OP_BYTES) {
+          throw storagePayloadTooLarge(buf.byteLength, `object '${msg.path}'`);
+        }
+        ok(port, msg.id, {
+          dataB64: bytesToBase64(new Uint8Array(buf)),
+          contentType: meta.contentType,
+          size: buf.byteLength,
+        });
+      } catch (e) { fail(port, msg.id, e); }
+      break;
+    }
+
+    case 'storage.deleteObject': {
+      // `pyric/storage`'s sandbox delete is idempotent (no-op on missing) —
+      // matching the pyric-admin local arm's delete semantics. Rules enforce
+      // `write` under the op's lens; deletes emit `service_mutation` events.
+      try {
+        const storage = lensStorage(ctx, msg.actAs);
+        await storageDeleteObject(storageRef(storage, msg.path));
+        ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
     }

--- a/packages/pyric-tools/src/serve/worker/index.ts
+++ b/packages/pyric-tools/src/serve/worker/index.ts
@@ -123,8 +123,13 @@ export {
   listAll,
   getMetadata,
   getBlob,
+  // Storage byte ops (worker-mode uploads/reads via the base64 protocol)
+  uploadBytes,
+  getBytes,
+  deleteObject,
   type ClientFirebaseStorage,
   type ClientStorageReference,
+  type ClientSettableMetadata,
   // Event stream (Pyric Studio keystone — onEvent/history over the port)
   subscribeEvents,
   eventHistory,

--- a/packages/pyric-tools/src/serve/worker/protocol.ts
+++ b/packages/pyric-tools/src/serve/worker/protocol.ts
@@ -400,13 +400,29 @@ export type OpMessage = (
   | { t: 'op'; id: string; method: 'auth.adminUpdateUser'; uid: string; request: Record<string, unknown> }
   | { t: 'op'; id: string; method: 'auth.adminDeleteUser'; uid: string }
   | { t: 'op'; id: string; method: 'auth.adminClearUsers' }
-  // Storage ops (Pyric Studio data browse): mirror `pyric/storage` over the port.
-  // The ref is a path; `listAll` replies with plain `{ fullPath, name }` entries,
-  // `getMetadata` with the plain `FullMetadata`, and `getBlob` with a structured
-  // cloneable browser Blob.
+  // Storage ops (Pyric Studio data browse + pyric-admin remote arm): mirror
+  // `pyric/storage` over the port. The ref is a path; `listAll` replies with
+  // plain `{ fullPath, name }` entries, `getMetadata` with the plain
+  // `FullMetadata`, and `getBlob` with a structured-cloneable browser Blob.
+  // All storage ops honor the shared `actAs` lens (admin ⇒ rules bypass via
+  // `pyric/storage/internal`'s admin plane; `{ as: uid }` ⇒ rules evaluate as
+  // that uid; absent ⇒ the worker's anonymous page handle).
   | { t: 'op'; id: string; method: 'storage.listAll'; path: string }
   | { t: 'op'; id: string; method: 'storage.getMetadata'; path: string }
   | { t: 'op'; id: string; method: 'storage.getBlob'; path: string }
+  // Byte-carrying storage ops (remote sandbox, slice 2). Bytes travel as
+  // BASE64 STRINGS (`dataB64`) inside the op payload/result so ONE encoding
+  // survives both the MessagePort (structured clone) and the two JSON WS
+  // relay legs verbatim — Blob/ArrayBuffer/TypedArray silently corrupt under
+  // `JSON.stringify` ({} / index-keyed objects), which is why `getBlob` must
+  // NEVER be relayed (see the bridge client's binary-payload guard). Raw
+  // payloads are capped at {@link MAX_STORAGE_OP_BYTES} on BOTH the encode
+  // and decode ends. `metadata` carries `pyric/storage` `SettableMetadata`
+  // fields (contentType/cacheControl/…/customMetadata); GCS-style nested
+  // custom maps (`metadata.metadata`) are folded into `customMetadata`.
+  | { t: 'op'; id: string; method: 'storage.putBytes'; path: string; dataB64: string; contentType?: string; metadata?: Record<string, unknown> }
+  | { t: 'op'; id: string; method: 'storage.getBytes'; path: string }
+  | { t: 'op'; id: string; method: 'storage.deleteObject'; path: string }
   // Staleness guard: report the worker's baked build version so the page can
   // warn when a still-running OLD worker serves code older than what's served.
   | { t: 'op'; id: string; method: 'getVersion' }
@@ -665,6 +681,62 @@ export function serializeDocData(data: Record<string, unknown>): SerializedDocDa
  */
 export function deserializeDocData(serialized: SerializedDocData): unknown {
   return rehydrateDocValue(JSON.parse(serialized.json));
+}
+
+// ─── Storage byte payloads (base64 + size cap) ────────────────────────────
+
+/**
+ * Maximum RAW byte size a single storage op may carry (`storage.putBytes`
+ * payloads and `storage.getBytes` results). 8 MiB raw ≈ 11 MiB base64 —
+ * comfortably under `ws`'s 100 MiB default `maxPayload` while keeping the
+ * four-hop whole-object buffering (Node → bridge → page → worker and back)
+ * sane. Enforced on BOTH ends: the Node conveniences / pyric-admin remote
+ * arm reject before sending, and the worker host rejects oversized inputs
+ * and results so a big browser-side object can't blow up the relay. Bigger
+ * objects need the (unshipped) streaming story — do not raise the cap.
+ */
+export const MAX_STORAGE_OP_BYTES = 8 * 1024 * 1024;
+
+/** Base64 length ceiling for a payload within {@link MAX_STORAGE_OP_BYTES} —
+ *  a cheap pre-decode gate so an oversized `dataB64` is rejected without
+ *  materializing its bytes first. */
+export const MAX_STORAGE_OP_B64_LENGTH = Math.ceil(MAX_STORAGE_OP_BYTES / 3) * 4;
+
+/** Build the canonical over-cap error (`code: 'payload-too-large'`). */
+export function storagePayloadTooLarge(
+  sizeBytes: number,
+  what: string,
+): Error & { code: string } {
+  const err = new Error(
+    `${what} is ${sizeBytes} bytes — over the ${MAX_STORAGE_OP_BYTES / (1024 * 1024)} MiB ` +
+      'storage op cap (MAX_STORAGE_OP_BYTES). Streaming/resumable transfers are not ' +
+      'supported on the sandbox backend; split the object or keep it under the cap.',
+  ) as Error & { code: string };
+  err.code = 'payload-too-large';
+  return err;
+}
+
+/**
+ * Encode bytes to standard base64. Chunked `String.fromCharCode` so a
+ * multi-MiB payload doesn't overflow the argument-spread limit. `btoa` is
+ * available in browsers, workers, Node ≥ 16, and Bun.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode.apply(null, slice as unknown as number[]);
+  }
+  return btoa(binary);
+}
+
+/** Decode standard base64 to bytes (inverse of {@link bytesToBase64}). */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
 }
 
 // ─── Error serialization ──────────────────────────────────────────────────

--- a/packages/pyric-tools/test/bridge/connect-bridge-relay-guard.test.ts
+++ b/packages/pyric-tools/test/bridge/connect-bridge-relay-guard.test.ts
@@ -1,0 +1,174 @@
+/**
+ * connectBridge's worker relay — the anti-corruption guard AT ITS CALL SITE.
+ *
+ * relay-binary-guard.test.ts unit-tests `assertJsonSafeRelayValue`; this
+ * file proves `connectBridge` actually invokes it on BOTH relay legs:
+ * deleting the guard call in `handleWorkerOp` (or the snap path in
+ * `handleWorkerSub`) fails these tests.
+ *
+ * No real WS: the WebSocket global is faked (the same pattern as
+ * `packages/studio/src/clients/bridge-peer.test.ts`) and worker frames are
+ * injected through `onmessage`, so the REAL `connectBridge` wiring runs
+ * end-to-end in-process with a recording `workerRelay`.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { connectBridge, type ConnectedBridge } from '../../src/bridge/client/bridge.js';
+
+// ── Fake browser WebSocket (studio's bridge-peer.test.ts pattern) ──────────
+
+type WsEvent = { data?: string; code?: number; reason?: string };
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = 0;
+  sent: Array<Record<string, unknown>> = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: WsEvent) => void) | null = null;
+  onclose: ((ev: WsEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as Record<string, unknown>);
+  }
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: 'closed by client' });
+  }
+  // test drivers
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+  emit(msg: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+}
+
+function installFakeWebSocket(): () => void {
+  const prev = (globalThis as { WebSocket?: unknown }).WebSocket;
+  FakeWebSocket.instances = [];
+  (globalThis as { WebSocket?: unknown }).WebSocket = FakeWebSocket;
+  return () => {
+    (globalThis as { WebSocket?: unknown }).WebSocket = prev;
+  };
+}
+
+function tick(ms = 5): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+let restoreWs: (() => void) | null = null;
+let connection: ConnectedBridge | null = null;
+
+afterEach(() => {
+  connection?.disconnect();
+  connection = null;
+  restoreWs?.();
+  restoreWs = null;
+});
+
+/** Bring up the REAL connectBridge over the fake socket with a recording
+ *  relay whose op results / snap deliveries the test controls. */
+function connectWithRelay(opResult: (method: string) => unknown) {
+  restoreWs = installFakeWebSocket();
+  let deliverSnap: ((value: unknown) => void) | null = null;
+  connection = connectBridge(initializeSandbox(), {
+    url: 'ws://localhost:5174/sandbox',
+    noReconnect: true,
+    workerRelay: {
+      op: async (op) => opResult(op.method),
+      subscribe: (_sub, onValue) => {
+        deliverSnap = onValue;
+        return () => {
+          deliverSnap = null;
+        };
+      },
+    },
+  });
+  const ws = FakeWebSocket.instances[0]!;
+  ws.open();
+  ws.emit({ type: 'hello-ack', bridgeVersion: 'test' });
+  return { ws, snap: (value: unknown) => deliverSnap!(value) };
+}
+
+// ── worker-op leg ───────────────────────────────────────────────────────────
+
+describe('connectBridge handleWorkerOp — binary guard at the call site', () => {
+  it('a Blob-bearing op result fails the op with the guard error (never a corrupted ok)', async () => {
+    const { ws } = connectWithRelay((method) =>
+      method === 'storage.getBlob' ? new Blob(['png-bytes']) : { fine: true },
+    );
+    expect((ws.sent[0] as { capabilities?: string[] }).capabilities).toEqual(['worker-relay']);
+
+    ws.emit({ type: 'worker-op', id: 'op-1', op: { method: 'storage.getBlob', path: 'x' } });
+    await tick();
+
+    const res = ws.sent.find((m) => m.type === 'worker-res' && m.id === 'op-1') as {
+      ok: boolean;
+      error?: { code: string; message: string };
+    };
+    expect(res).toBeDefined();
+    expect(res.ok).toBe(false);
+    expect(res.error!.code).toBe('invalid-argument');
+    expect(res.error!.message).toContain("op 'storage.getBlob'");
+    expect(res.error!.message).toContain('Blob');
+    expect(res.error!.message).toContain('storage.getBytes');
+  });
+
+  it('a JSON-safe op result still relays ok', async () => {
+    const { ws } = connectWithRelay(() => ({ dataB64: 'aGVsbG8=', size: 5 }));
+    ws.emit({ type: 'worker-op', id: 'op-2', op: { method: 'storage.getBytes', path: 'x' } });
+    await tick();
+
+    const res = ws.sent.find((m) => m.type === 'worker-res' && m.id === 'op-2') as {
+      ok: boolean;
+      value: unknown;
+    };
+    expect(res.ok).toBe(true);
+    expect(res.value).toEqual({ dataB64: 'aGVsbG8=', size: 5 });
+  });
+});
+
+// ── worker-snap leg ─────────────────────────────────────────────────────────
+
+describe('connectBridge handleWorkerSub — binary guard on snap values', () => {
+  it('a binary snap value fails the sub via the __error convention (never corrupted delivery)', async () => {
+    const { ws, snap } = connectWithRelay(() => null);
+    ws.emit({ type: 'worker-sub', subId: 'sub-1', sub: { target: { service: 'rtdb', path: 'x' } } });
+    await tick();
+
+    snap(new Uint8Array([137, 80, 78, 71]));
+    await tick();
+
+    const frame = ws.sent.find((m) => m.type === 'worker-snap' && m.subId === 'sub-1') as {
+      value: { __error?: { code: string; message: string } };
+    };
+    expect(frame).toBeDefined();
+    expect(frame.value.__error).toBeDefined();
+    expect(frame.value.__error!.code).toBe('invalid-argument');
+    expect(frame.value.__error!.message).toContain("subscription 'sub-1'");
+    expect(frame.value.__error!.message).toContain('Uint8Array');
+    expect(frame.value.__error!.message).toContain('storage.getBytes');
+  });
+
+  it('a JSON-safe snap value still relays normally', async () => {
+    const { ws, snap } = connectWithRelay(() => null);
+    ws.emit({ type: 'worker-sub', subId: 'sub-2', sub: { target: { service: 'rtdb', path: 'x' } } });
+    await tick();
+
+    snap({ key: 'x', exists: true, value: 42, size: 1 });
+    await tick();
+
+    const frame = ws.sent.find((m) => m.type === 'worker-snap' && m.subId === 'sub-2') as {
+      value: Record<string, unknown>;
+    };
+    expect(frame.value).toEqual({ key: 'x', exists: true, value: 42, size: 1 });
+  });
+});

--- a/packages/pyric-tools/test/bridge/relay-binary-guard.test.ts
+++ b/packages/pyric-tools/test/bridge/relay-binary-guard.test.ts
@@ -49,7 +49,7 @@ describe('assertJsonSafeRelayValue — the loud rejection', () => {
   it('throws invalid-argument naming the offender and the base64 ops for a relayed getBlob', () => {
     let caught: (Error & { code?: string }) | null = null;
     try {
-      assertJsonSafeRelayValue('storage.getBlob', new Blob(['png-bytes']));
+      assertJsonSafeRelayValue("op 'storage.getBlob'", new Blob(['png-bytes']));
     } catch (err) {
       caught = err as Error & { code?: string };
     }
@@ -63,12 +63,12 @@ describe('assertJsonSafeRelayValue — the loud rejection', () => {
 
   it('accepts the base64 storage op results untouched', () => {
     expect(() =>
-      assertJsonSafeRelayValue('storage.getBytes', {
+      assertJsonSafeRelayValue("op 'storage.getBytes'", {
         dataB64: 'iVBORw0KGgo=',
         contentType: 'image/png',
         size: 8,
       }),
     ).not.toThrow();
-    expect(() => assertJsonSafeRelayValue('storage.deleteObject', null)).not.toThrow();
+    expect(() => assertJsonSafeRelayValue("op 'storage.deleteObject'", null)).not.toThrow();
   });
 });

--- a/packages/pyric-tools/test/bridge/relay-binary-guard.test.ts
+++ b/packages/pyric-tools/test/bridge/relay-binary-guard.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Anti-corruption guard at the worker-op relay boundary (remote sandbox,
+ * slice 2 hygiene).
+ *
+ * Both WS legs of the relay are `JSON.stringify`: a `Blob` result becomes
+ * `{}`, a TypedArray becomes an index-keyed object — SILENTLY. The guard
+ * (`assertJsonSafeRelayValue`, called by `connectBridge`'s `handleWorkerOp`
+ * before the `worker-res` is serialized) turns that into a loud error
+ * naming the base64 storage ops. This is a cheap explicit TYPE check, not
+ * a JSON round-trip per op.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  findBinaryPayload,
+  assertJsonSafeRelayValue,
+} from '../../src/bridge/protocol.js';
+
+describe('findBinaryPayload — detection', () => {
+  it('detects the top-level binary containers JSON silently mangles', () => {
+    expect(findBinaryPayload(new Blob(['x']))).toBe('Blob');
+    expect(findBinaryPayload(new ArrayBuffer(4))).toBe('ArrayBuffer');
+    expect(findBinaryPayload(new Uint8Array([1, 2]))).toBe('Uint8Array');
+    expect(findBinaryPayload(new Float64Array(2))).toBe('Float64Array');
+    expect(findBinaryPayload(new DataView(new ArrayBuffer(4)))).toBe('DataView');
+    // Node/Bun Buffer is a Uint8Array subclass — also non-JSON-safe (its
+    // JSON form `{type:'Buffer',data:[…]}` is an accidental wire format).
+    expect(findBinaryPayload(Buffer.from('x'))).toBe('Buffer');
+  });
+
+  it('detects binary nested in arrays and plain objects', () => {
+    expect(findBinaryPayload({ meta: { blob: new Blob(['x']) } })).toBe('Blob');
+    expect(findBinaryPayload([1, 'a', [new Uint8Array(1)]])).toBe('Uint8Array');
+  });
+
+  it('passes ordinary JSON-safe values (incl. base64 strings)', () => {
+    expect(findBinaryPayload(null)).toBeNull();
+    expect(findBinaryPayload(undefined)).toBeNull();
+    expect(findBinaryPayload('aGVsbG8=')).toBeNull();
+    expect(findBinaryPayload(42)).toBeNull();
+    expect(
+      findBinaryPayload({ dataB64: 'aGVsbG8=', contentType: 'text/plain', size: 5 }),
+    ).toBeNull();
+    expect(findBinaryPayload({ items: [{ fullPath: 'a/b', name: 'b' }] })).toBeNull();
+  });
+});
+
+describe('assertJsonSafeRelayValue — the loud rejection', () => {
+  it('throws invalid-argument naming the offender and the base64 ops for a relayed getBlob', () => {
+    let caught: (Error & { code?: string }) | null = null;
+    try {
+      assertJsonSafeRelayValue('storage.getBlob', new Blob(['png-bytes']));
+    } catch (err) {
+      caught = err as Error & { code?: string };
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.code).toBe('invalid-argument');
+    expect(caught!.message).toContain("worker op 'storage.getBlob'");
+    expect(caught!.message).toContain('Blob');
+    expect(caught!.message).toContain('storage.getBytes');
+    expect(caught!.message).toContain('storage.putBytes');
+  });
+
+  it('accepts the base64 storage op results untouched', () => {
+    expect(() =>
+      assertJsonSafeRelayValue('storage.getBytes', {
+        dataB64: 'iVBORw0KGgo=',
+        contentType: 'image/png',
+        size: 8,
+      }),
+    ).not.toThrow();
+    expect(() => assertJsonSafeRelayValue('storage.deleteObject', null)).not.toThrow();
+  });
+});

--- a/packages/pyric-tools/test/remote/loop-hold.test.ts
+++ b/packages/pyric-tools/test/remote/loop-hold.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Remote client — event-loop hold + version-skew guidance (integration-smoke
+ * fixes for the remote sandbox client).
+ *
+ * 1. Exit-hang fix: an IDLE remote connection must not pin the Node event
+ *    loop. The core calls the transport's optional `ref()`/`unref()` hooks
+ *    on busy/idle TRANSITIONS (first outstanding op or subscription → ref;
+ *    last one settles → unref), and the WS adapter unrefs the socket once
+ *    connected — so a finished script exits, while in-flight ops/subs still
+ *    hold the process.
+ *
+ * 2. Version skew: a live tab whose SharedWorker predates a new op returns
+ *    a raw "Unknown method: …" — the client appends restart/reload guidance.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { createBridge, type Bridge } from '../../src/bridge/server/bridge.js';
+import { createConsumerSession } from '../../src/bridge/server/peer.js';
+import {
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../src/bridge/protocol.js';
+import {
+  createRemoteSandboxCore,
+  type RemoteSandboxCore,
+} from '../../src/remote/index.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../src/serve/worker/protocol.js';
+
+// ─── Harness (worker-relay.test.ts's, + ref/unref recording) ───────────────
+
+function makeWorkerCtx(): HostCtx {
+  const sandbox = initializeSandbox();
+  return { db: getFirestore(sandbox), sandbox, instanceId: 'loop-hold-test', subs: new Map() };
+}
+
+function connectTab(bridge: Bridge, ctx: HostCtx, opts: { dropOps?: boolean } = {}): void {
+  let gen = 0;
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      const m = raw as OutboundMessage;
+      if (m.t === 'res') {
+        bridge.handleSandboxMessage(
+          m.ok
+            ? { type: 'worker-res', id: m.id, ok: true, value: m.value }
+            : { type: 'worker-res', id: m.id, ok: false, error: m.error },
+          gen,
+        );
+      } else if (m.t === 'snap') {
+        bridge.handleSandboxMessage({ type: 'worker-snap', subId: m.subId, value: m.value }, gen);
+      }
+    },
+  };
+  const send = (msg: BridgeMessage): void => {
+    if (gen === 0) gen = bridge.peerGeneration();
+    if (msg.type === 'worker-op') {
+      if (opts.dropOps) return;
+      void handleMessage(ctx, port, { ...msg.op, t: 'op', id: msg.id } as InboundMessage);
+    } else if (msg.type === 'worker-sub') {
+      void handleMessage(ctx, port, { ...msg.sub, t: 'sub', subId: msg.subId } as InboundMessage);
+    } else if (msg.type === 'worker-unsub') {
+      void handleMessage(ctx, port, { t: 'unsub', subId: msg.subId } as InboundMessage);
+    }
+  };
+  bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
+}
+
+/** Node core over a recording transport: every ref()/unref() lands in
+ *  `holds` — the fake-ws assertion seam for the exit-hang fix. */
+function connectNode(bridge: Bridge, opts: { opTimeoutMs?: number } = {}) {
+  const holds: Array<'ref' | 'unref'> = [];
+  let core: RemoteSandboxCore;
+  const session = createConsumerSession(bridge, (msg) => core.handleMessage(msg));
+  core = createRemoteSandboxCore(
+    {
+      send: (msg) => session.handleMessage(msg),
+      ref: () => holds.push('ref'),
+      unref: () => holds.push('unref'),
+    },
+    { serveUrl: 'http://localhost:5000', opTimeoutMs: opts.opTimeoutMs },
+  );
+  core.start();
+  return { core, session, channel: core.channel, holds };
+}
+
+function tick(ms = 10): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─── Event-loop hold ────────────────────────────────────────────────────────
+
+describe('remote core — event-loop hold (ref/unref transitions)', () => {
+  it('attach + idle never refs; an op refs once and unrefs when it settles', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, makeWorkerCtx());
+    const node = connectNode(bridge);
+    await node.core.ready;
+    expect(node.holds).toEqual([]); // attach handshake is not "work"
+
+    await node.channel.op({ method: 'getVersion' });
+    expect(node.holds).toEqual(['ref', 'unref']);
+  });
+
+  it('overlapping ops hold ONE ref until the last settles (transition-edged)', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, makeWorkerCtx());
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await Promise.all([
+      node.channel.op({ method: 'getVersion' }),
+      node.channel.op({ method: 'getVersion' }),
+      node.channel.op({ method: 'getVersion' }),
+    ]);
+    expect(node.holds).toEqual(['ref', 'unref']);
+  });
+
+  it('a live subscription holds the ref; unsubscribe releases it', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, makeWorkerCtx());
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    const unsubscribe = node.channel.subscribe(
+      { target: { service: 'rtdb', path: 'held' } },
+      () => {},
+    );
+    await tick();
+    expect(node.holds).toEqual(['ref']); // still held while the sub lives
+
+    // An op during the sub does NOT double-ref (already busy) …
+    await node.channel.op({ method: 'getVersion' });
+    expect(node.holds).toEqual(['ref']);
+
+    unsubscribe();
+    expect(node.holds).toEqual(['ref', 'unref']);
+  });
+
+  it('an op that times out releases the hold; dispose releases everything', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test', callTimeoutMs: 5000 });
+    connectTab(bridge, makeWorkerCtx(), { dropOps: true }); // hung tab
+    const node = connectNode(bridge, { opTimeoutMs: 30 });
+    await node.core.ready;
+
+    await expect(node.channel.op({ method: 'getVersion' })).rejects.toThrow(/timed out/);
+    expect(node.holds).toEqual(['ref', 'unref']);
+
+    node.channel.subscribe({ target: { service: 'rtdb', path: 'x' } }, () => {});
+    expect(node.holds).toEqual(['ref', 'unref', 'ref']);
+    node.core.dispose('closed');
+    expect(node.holds).toEqual(['ref', 'unref', 'ref', 'unref']);
+  });
+});
+
+// ─── Version-skew guidance ──────────────────────────────────────────────────
+
+describe('remote core — version-skew guidance on Unknown method', () => {
+  it('appends restart/reload guidance when the worker predates an op', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, makeWorkerCtx());
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    // The REAL worker host replies "Unknown method: …" for ops it does not
+    // know — exactly what an old tab does when the Node side is newer.
+    try {
+      await node.channel.op({ method: 'storage.notShippedYet' });
+      throw new Error('expected rejection');
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain('Unknown method: storage.notShippedYet');
+      expect(message).toContain('the running sandbox may predate this feature');
+      expect(message).toContain('restart pyric dev');
+      expect(message).toContain('reload the browser tab');
+    }
+  });
+
+  it('leaves other worker errors untouched', async () => {
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, makeWorkerCtx());
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    try {
+      await node.channel.op({ method: 'storage.getBytes', path: 'missing/x' });
+      throw new Error('expected rejection');
+    } catch (err) {
+      expect((err as { code?: string }).code).toBe('storage/object-not-found');
+      expect((err as Error).message).not.toContain('predate');
+    }
+  });
+});

--- a/packages/pyric-tools/test/serve/worker/storage-ops.test.ts
+++ b/packages/pyric-tools/test/serve/worker/storage-ops.test.ts
@@ -1,0 +1,307 @@
+/**
+ * SharedWorker host — storage byte ops + auth lens (remote sandbox, slice 2).
+ *
+ * Covers the new base64 ops (`storage.putBytes` / `storage.getBytes` /
+ * `storage.deleteObject`) and the `actAs` lens on ALL storage ops:
+ *   - binary-faithful put → get round-trip (non-UTF8 bytes)
+ *   - contentType + customMetadata round-trip
+ *   - the 8 MiB raw cap, enforced on BOTH the decode end (oversized
+ *     putBytes payload) and the encode end (oversized getBytes result)
+ *   - idempotent delete; object-not-found on missing reads
+ *   - deny-all page-configured rules: the admin lens genuinely BYPASSES
+ *     them (spike risk 5), the anonymous page lens still enforces, and
+ *     the `{ as: uid }` lens evaluates as that user.
+ *
+ * Same harness style as host.test.ts: REAL sandbox + fake ports, no
+ * browser. `fake-indexeddb` backs the storage persistence; each ctx gets a
+ * unique dbName so state never leaks across tests (the default
+ * `pyric-storage` DB is process-global under fake-indexeddb).
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { getStorageSandbox, ref as storageRef, uploadBytes } from 'pyric/storage';
+
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  ResMessage,
+} from '../../../src/serve/worker/protocol.js';
+import {
+  bytesToBase64,
+  base64ToBytes,
+  MAX_STORAGE_OP_BYTES,
+  MAX_STORAGE_OP_B64_LENGTH,
+} from '../../../src/serve/worker/protocol.js';
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+// NOTE: rules are written WITHOUT the /b/{bucket}/o wrapper — pyric/storage's
+// evaluator matches rules against the reference's raw fullPath (the existing
+// pyric rules tests embed the wrapper INTO their object paths instead).
+const DENY_ALL_RULES = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if false;
+  }
+}`;
+
+const OWNER_ONLY_RULES = `
+service firebase.storage {
+  match /users/{uid}/{file} {
+    allow read, write: if request.auth.uid == uid;
+  }
+}`;
+
+let dbSeq = 0;
+function uniqueDbName(): string {
+  return `pyric-storage-worker-ops-${++dbSeq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Fresh worker ctx; `rules` configures the sandbox's ONE storage service
+ *  (first-call-per-sandbox wins — exactly how a served page configures it). */
+function makeCtx(rules?: string): HostCtx {
+  const sandbox = initializeSandbox();
+  // Pre-open the per-sandbox storage service with an isolated IDB name (and
+  // the page's rules, when given) BEFORE any host op lazily opens it.
+  getStorageSandbox(sandbox, { dbName: uniqueDbName(), ...(rules ? { rules } : {}) });
+  return { db: getFirestore(sandbox), sandbox, instanceId: 'storage-ops-test', subs: new Map() };
+}
+
+let opSeq = 0;
+function op(ctx: HostCtx, payload: Record<string, unknown>): Promise<ResMessage> {
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'res') resolve(msg);
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...payload,
+      t: 'op',
+      id: `sop-${++opSeq}`,
+    } as InboundMessage);
+  });
+}
+
+async function opOk(ctx: HostCtx, payload: Record<string, unknown>): Promise<unknown> {
+  const res = await op(ctx, payload);
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.code} — ${res.error.message}`);
+  return res.value;
+}
+
+async function opFail(
+  ctx: HostCtx,
+  payload: Record<string, unknown>,
+): Promise<{ code: string; message: string }> {
+  const res = await op(ctx, payload);
+  if (res.ok) throw new Error(`expected failure, got ok: ${JSON.stringify(res.value)}`);
+  return res.error;
+}
+
+/** Non-UTF8 binary: PNG magic + 0x00/0xFF runs — the corruption regression
+ *  payload from the design spike. */
+function binaryFixture(): Uint8Array {
+  const bytes = new Uint8Array(512);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG magic
+  for (let i = 8; i < 256; i++) bytes[i] = 0x00;
+  for (let i = 256; i < 512; i++) bytes[i] = 0xff;
+  bytes[300] = 0x7f;
+  return bytes;
+}
+
+const ADMIN = { actAs: { mode: 'admin' } } as const;
+
+// ─── Byte ops ───────────────────────────────────────────────────────────────
+
+describe('storage worker ops — putBytes / getBytes / deleteObject', () => {
+  it('round-trips non-UTF8 binary byte-for-byte (base64 payloads)', async () => {
+    const ctx = makeCtx();
+    const bytes = binaryFixture();
+
+    const meta = (await opOk(ctx, {
+      method: 'storage.putBytes',
+      path: 'blobs/probe.png',
+      dataB64: bytesToBase64(bytes),
+      contentType: 'image/png',
+    })) as { fullPath: string; size: number; contentType: string };
+    expect(meta.fullPath).toBe('blobs/probe.png');
+    expect(meta.size).toBe(bytes.byteLength);
+    expect(meta.contentType).toBe('image/png');
+
+    const wire = (await opOk(ctx, {
+      method: 'storage.getBytes',
+      path: 'blobs/probe.png',
+    })) as { dataB64: string; contentType: string; size: number };
+    expect(wire.size).toBe(bytes.byteLength);
+    expect(wire.contentType).toBe('image/png');
+    expect(Array.from(base64ToBytes(wire.dataB64))).toEqual(Array.from(bytes));
+  });
+
+  it('round-trips contentType + customMetadata via metadata options', async () => {
+    const ctx = makeCtx();
+    await opOk(ctx, {
+      method: 'storage.putBytes',
+      path: 'docs/report.json',
+      dataB64: bytesToBase64(new TextEncoder().encode('{"ok":true}')),
+      metadata: {
+        contentType: 'application/json',
+        cacheControl: 'no-store',
+        customMetadata: { owner: 'ada', run: '42' },
+      },
+    });
+    const meta = (await opOk(ctx, {
+      method: 'storage.getMetadata',
+      path: 'docs/report.json',
+    })) as {
+      contentType: string;
+      cacheControl?: string;
+      customMetadata?: Record<string, string>;
+    };
+    expect(meta.contentType).toBe('application/json');
+    expect(meta.cacheControl).toBe('no-store');
+    expect(meta.customMetadata).toEqual({ owner: 'ada', run: '42' });
+  });
+
+  it('folds a GCS-style nested custom map (metadata.metadata) into customMetadata', async () => {
+    const ctx = makeCtx();
+    await opOk(ctx, {
+      method: 'storage.putBytes',
+      path: 'docs/gcs-style.txt',
+      dataB64: bytesToBase64(new TextEncoder().encode('x')),
+      contentType: 'text/plain',
+      metadata: { metadata: { source: 'admin-arm' } },
+    });
+    const meta = (await opOk(ctx, {
+      method: 'storage.getMetadata',
+      path: 'docs/gcs-style.txt',
+    })) as { customMetadata?: Record<string, string> };
+    expect(meta.customMetadata).toEqual({ source: 'admin-arm' });
+  });
+
+  it('getBytes on a missing path fails storage/object-not-found', async () => {
+    const ctx = makeCtx();
+    const err = await opFail(ctx, { method: 'storage.getBytes', path: 'missing/nothing' });
+    expect(err.code).toBe('storage/object-not-found');
+  });
+
+  it('deleteObject removes the object and is idempotent on re-delete', async () => {
+    const ctx = makeCtx();
+    await opOk(ctx, {
+      method: 'storage.putBytes',
+      path: 'tmp/scratch',
+      dataB64: bytesToBase64(new Uint8Array([1, 2, 3])),
+    });
+    await opOk(ctx, { method: 'storage.deleteObject', path: 'tmp/scratch' });
+    const err = await opFail(ctx, { method: 'storage.getBytes', path: 'tmp/scratch' });
+    expect(err.code).toBe('storage/object-not-found');
+    // Idempotent: deleting the now-missing path still succeeds.
+    await opOk(ctx, { method: 'storage.deleteObject', path: 'tmp/scratch' });
+  });
+});
+
+// ─── Size cap (both ends) ───────────────────────────────────────────────────
+
+describe('storage worker ops — 8 MiB raw cap', () => {
+  it('rejects an oversized putBytes payload BEFORE decoding it (decode end)', async () => {
+    const ctx = makeCtx();
+    // A base64 string longer than any within-cap payload could produce —
+    // the pre-decode gate must reject without materializing bytes.
+    const oversizedB64 = 'A'.repeat(MAX_STORAGE_OP_B64_LENGTH + 4);
+    const err = await opFail(ctx, {
+      method: 'storage.putBytes',
+      path: 'big/blob',
+      dataB64: oversizedB64,
+    });
+    expect(err.code).toBe('payload-too-large');
+    expect(err.message).toContain('8 MiB');
+    // Nothing was written.
+    const miss = await opFail(ctx, { method: 'storage.getBytes', path: 'big/blob' });
+    expect(miss.code).toBe('storage/object-not-found');
+  });
+
+  it('rejects an oversized getBytes result (encode end) — a big browser-side object cannot blow up the relay', async () => {
+    const ctx = makeCtx();
+    // Plant an over-cap object DIRECTLY through pyric/storage (the page's own
+    // in-worker surface has no cap) …
+    const storage = getStorageSandbox(ctx.sandbox);
+    const big = new Uint8Array(MAX_STORAGE_OP_BYTES + 1);
+    await uploadBytes(storageRef(storage, 'big/native'), big, { contentType: 'application/octet-stream' });
+    // … then the relay-facing op must refuse to encode it.
+    const err = await opFail(ctx, { method: 'storage.getBytes', path: 'big/native' });
+    expect(err.code).toBe('payload-too-large');
+    expect(err.message).toContain('8 MiB');
+  });
+});
+
+// ─── Auth lens + rules (spike risk 5: page-configured rules vs admin) ──────
+
+describe('storage worker ops — actAs lens against page-configured rules', () => {
+  it('deny-all rules: anonymous page ops are denied; the admin lens genuinely bypasses', async () => {
+    const ctx = makeCtx(DENY_ALL_RULES);
+    const dataB64 = bytesToBase64(binaryFixture());
+
+    // Page (no lens): every op denied.
+    const putErr = await opFail(ctx, { method: 'storage.putBytes', path: 'locked/x', dataB64 });
+    expect(putErr.code).toBe('storage/unauthorized');
+
+    // Admin lens: write, read, browse, metadata, delete — all bypass.
+    await opOk(ctx, { method: 'storage.putBytes', path: 'locked/x', dataB64, ...ADMIN });
+    const wire = (await opOk(ctx, { method: 'storage.getBytes', path: 'locked/x', ...ADMIN })) as {
+      dataB64: string;
+    };
+    expect(wire.dataB64).toBe(dataB64);
+    const listing = (await opOk(ctx, { method: 'storage.listAll', path: 'locked', ...ADMIN })) as {
+      items: Array<{ fullPath: string }>;
+    };
+    expect(listing.items.map((i) => i.fullPath)).toEqual(['locked/x']);
+    await opOk(ctx, { method: 'storage.getMetadata', path: 'locked/x', ...ADMIN });
+
+    // Page reads stay denied even though the object exists (rules first).
+    const readErr = await opFail(ctx, { method: 'storage.getBytes', path: 'locked/x' });
+    expect(readErr.code).toBe('storage/unauthorized');
+    const blobErr = await opFail(ctx, { method: 'storage.getBlob', path: 'locked/x' });
+    expect(blobErr.code).toBe('storage/unauthorized');
+    const listErr = await opFail(ctx, { method: 'storage.listAll', path: 'locked' });
+    expect(listErr.code).toBe('storage/unauthorized');
+
+    await opOk(ctx, { method: 'storage.deleteObject', path: 'locked/x', ...ADMIN });
+    const gone = await opFail(ctx, { method: 'storage.getBytes', path: 'locked/x', ...ADMIN });
+    expect(gone.code).toBe('storage/object-not-found');
+  });
+
+  it('the { as: uid } lens evaluates rules AS that user (owner-only ruleset)', async () => {
+    const ctx = makeCtx(OWNER_ONLY_RULES);
+    const dataB64 = bytesToBase64(new TextEncoder().encode('mine'));
+    const asAda = { actAs: { mode: 'as', uid: 'ada' } } as const;
+    const asBob = { actAs: { mode: 'as', uid: 'bob' } } as const;
+
+    await opOk(ctx, { method: 'storage.putBytes', path: 'users/ada/notes.txt', dataB64, ...asAda });
+    const wire = (await opOk(ctx, {
+      method: 'storage.getBytes',
+      path: 'users/ada/notes.txt',
+      ...asAda,
+    })) as { dataB64: string };
+    expect(wire.dataB64).toBe(dataB64);
+
+    // Bob is not ada: denied on both write and read.
+    const writeErr = await opFail(ctx, {
+      method: 'storage.putBytes', path: 'users/ada/notes.txt', dataB64, ...asBob,
+    });
+    expect(writeErr.code).toBe('storage/unauthorized');
+    const readErr = await opFail(ctx, {
+      method: 'storage.getBytes', path: 'users/ada/notes.txt', ...asBob,
+    });
+    expect(readErr.code).toBe('storage/unauthorized');
+
+    // Admin still bypasses the owner scoping entirely.
+    await opOk(ctx, { method: 'storage.getMetadata', path: 'users/ada/notes.txt', ...ADMIN });
+  });
+});

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js"
     },
+    "./storage/internal": {
+      "types": "./dist/storage/internal.d.ts",
+      "import": "./dist/storage/internal.js"
+    },
     "./rules": {
       "types": "./dist/rules/index.d.ts",
       "import": "./dist/rules/index.js"

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -87,7 +87,7 @@ export async function deleteObject(ref: StorageReference): Promise<void> {
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
-  });
+  }, target);
   await service.backend.delete(ref.fullPath);
   try {
     emitSandboxEvent(
@@ -134,7 +134,7 @@ async function fetchBlob(
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
-  });
+  }, target);
   const blob = await service.backend.getBlob(ref.fullPath);
   if (!blob) {
     throw objectNotFound(ref.fullPath);

--- a/packages/pyric/src/storage/enforce.ts
+++ b/packages/pyric/src/storage/enforce.ts
@@ -20,14 +20,18 @@
  * configured the check is a no-op (open-by-default), so the
  * session-archive demo is unaffected.
  */
-import type { StorageService } from './service.js';
+import type { StorageService, Target } from './service.js';
 import { evaluateStorageRules, type EvaluationInput } from './rules.js';
 import { unauthorized } from './errors.js';
 
 export function enforceRules(
   service: StorageService,
   input: EvaluationInput,
+  target?: Target,
 ): void {
+  // Admin plane (internal `getAdminStorageSandbox` handles): rules are
+  // bypassed entirely — firebase-admin semantics. See `SandboxTarget.admin`.
+  if (target?.kind === 'sandbox' && target.admin === true) return;
   if (!service.rules) return;
   const result = evaluateStorageRules(service.rules, input);
   if (result.allowed) return;

--- a/packages/pyric/src/storage/internal.ts
+++ b/packages/pyric/src/storage/internal.ts
@@ -1,0 +1,18 @@
+/**
+ * `pyric/storage/internal` — host-only admin plane for the sandbox
+ * storage backend.
+ *
+ * The public `pyric/storage` surface is deliberately rules-honest:
+ * every operation on a handle from `getStorageSandbox` evaluates the
+ * configured storage rules against the handle's context identity.
+ * Hosts that must serve firebase-admin semantics (the SharedWorker
+ * host resolving `actAs: { mode: 'admin' }` storage ops for
+ * `pyric-admin`'s remote dispatch arm, Pyric Studio's admin lens)
+ * need a rules-BYPASS handle onto the SAME per-sandbox store.
+ *
+ * This subpath exists so that bypass never leaks onto the public
+ * modular surface — mirroring how `pyric/sandbox/internal` carries
+ * the sandbox's host-only seams.
+ */
+
+export { getAdminStorageSandbox } from './service.js';

--- a/packages/pyric/src/storage/list.ts
+++ b/packages/pyric/src/storage/list.ts
@@ -67,7 +67,7 @@ export async function listAll(refIn: StorageReference): Promise<ListResult> {
       path: refIn.fullPath,
     },
     resource: null,
-  });
+  }, target);
   const scanPrefix = refIn.fullPath === '' ? '' : `${refIn.fullPath}/`;
   const records = await service.backend.listByPrefix(scanPrefix);
 

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -140,7 +140,7 @@ export async function getMetadata(ref: StorageReference): Promise<FullMetadata> 
       path: ref.fullPath,
     },
     resource: resourceFromStored(stored),
-  });
+  }, target);
   if (!stored) {
     throw objectNotFound(ref.fullPath);
   }
@@ -189,7 +189,7 @@ export async function updateMetadata(
         : undefined,
     },
     resource: resourceFromStored(existing),
-  });
+  }, target);
   if (!existing) {
     throw objectNotFound(ref.fullPath);
   }

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -59,6 +59,17 @@ export interface SandboxTarget {
   readonly context: SandboxContext;
   readonly bucket: string;
   readonly servicePromise: Promise<StorageService>;
+  /**
+   * Rules-bypass admin plane. `true` only on handles minted by the
+   * INTERNAL {@link getAdminStorageSandbox} factory (exported via
+   * `pyric/storage/internal`, never the public surface): operations
+   * on an admin handle skip rule evaluation entirely — the storage
+   * mirror of `getAdminFirestore` / `getAdminDatabase`. The public
+   * modular surface stays rules-honest; this exists so hosts (the
+   * SharedWorker's `actAs: { mode: 'admin' }` lens) can serve
+   * firebase-admin semantics against the same shared store.
+   */
+  readonly admin?: boolean;
 }
 
 /**
@@ -206,6 +217,56 @@ export function getStorageSandbox(
   const handle: FirebaseStorage = Object.freeze({ [TARGET_SYMBOL]: sandboxTarget });
   SANDBOX_HANDLES.set(ctx, handle);
   if (fromBareSandbox) BARE_SANDBOX_HANDLES.set(sandbox, handle);
+  return handle;
+}
+
+/** One rules-bypass admin handle per `Sandbox` (internal admin plane). */
+const ADMIN_SANDBOX_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
+
+/**
+ * INTERNAL (exported via `pyric/storage/internal` only) — construct
+ * (or return cached) the rules-BYPASS admin `FirebaseStorage` handle
+ * for a sandbox. Shares the SAME `StorageService` (one IDB store, one
+ * ruleset) as every rules-honest handle on that sandbox; only rule
+ * evaluation is skipped (see {@link SandboxTarget.admin}). Bucket /
+ * dbName / rules options follow the same first-call-per-`Sandbox`
+ * semantics as {@link getStorageSandbox}.
+ *
+ * This is the storage mirror of `getAdminFirestore` /
+ * `getAdminDatabase` — the handle the SharedWorker host resolves for
+ * `actAs: { mode: 'admin' }` storage ops (firebase-admin semantics
+ * over the bridge). Deliberately NOT on the public `pyric/storage`
+ * surface so the modular API stays rules-honest.
+ */
+export function getAdminStorageSandbox(
+  sandbox: Sandbox,
+  options: StorageOptions = {},
+): FirebaseStorage {
+  const cached = ADMIN_SANDBOX_HANDLES.get(sandbox);
+  if (cached) return cached;
+
+  let servicePromise = SERVICES.get(sandbox);
+  if (!servicePromise) {
+    const rules = options.rules ? parseStorageRules(options.rules) : null;
+    servicePromise = openStorageBackend(options.dbName).then(
+      (backend) => new StorageService(backend, rules),
+    );
+    SERVICES.set(sandbox, servicePromise);
+  }
+
+  const sandboxTarget: SandboxTarget = {
+    kind: 'sandbox',
+    sandbox,
+    // Anonymous context: the admin plane has no acting user. Rules are
+    // bypassed, so the context identity only feeds event provenance
+    // (`auth: null` — same as an anonymous caller).
+    context: sandbox.withAuth(null),
+    bucket: options.bucket ?? DEFAULT_BUCKET,
+    servicePromise,
+    admin: true,
+  };
+  const handle: FirebaseStorage = Object.freeze({ [TARGET_SYMBOL]: sandboxTarget });
+  ADMIN_SANDBOX_HANDLES.set(sandbox, handle);
   return handle;
 }
 

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -161,6 +161,50 @@ const SANDBOX_HANDLES = new WeakMap<SandboxContext, FirebaseStorage>();
 const BARE_SANDBOX_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
 
 /**
+ * The rules SOURCE each sandbox's service was opened with (`null` when
+ * opened without rules). Late-config detection: rules are honored only on
+ * the FIRST storage call per `Sandbox`, so silently discarding a LATER,
+ * DIFFERENT `rules` option would be a silent rules wipe — {@link
+ * ensureService} throws instead. Re-supplying the IDENTICAL source stays
+ * fine (idempotent multi-handle construction, e.g. per-user contexts).
+ */
+const SERVICE_RULES_SOURCE = new WeakMap<Sandbox, string | null>();
+
+/**
+ * Get (or open) the ONE per-sandbox `StorageService`. Loud on the
+ * silent-rules-wipe hazard: when the service is already open and the
+ * caller supplies a `rules` source differing from the one it was opened
+ * with (including "opened without rules"), this throws — configure rules
+ * on the first storage call for the sandbox instead.
+ */
+function ensureService(
+  sandbox: Sandbox,
+  options: StorageOptions,
+  caller: string,
+): Promise<StorageService> {
+  const existing = SERVICES.get(sandbox);
+  if (existing) {
+    const openedWith = SERVICE_RULES_SOURCE.get(sandbox) ?? null;
+    if (options.rules !== undefined && options.rules !== openedWith) {
+      throw new Error(
+        `pyric/storage: ${caller} received a rules source, but this sandbox's storage ` +
+          `service is already open ${openedWith === null ? 'without rules' : 'with a different rules source'} ` +
+          '— rules are honored only on the FIRST storage call per Sandbox, so these rules ' +
+          'would be silently discarded. Configure rules on the first storage call for this sandbox.',
+      );
+    }
+    return existing;
+  }
+  const rules = options.rules ? parseStorageRules(options.rules) : null;
+  const servicePromise = openStorageBackend(options.dbName).then(
+    (backend) => new StorageService(backend, rules),
+  );
+  SERVICES.set(sandbox, servicePromise);
+  SERVICE_RULES_SOURCE.set(sandbox, options.rules ?? null);
+  return servicePromise;
+}
+
+/**
  * Type predicate distinguishing `SandboxContext` from `Sandbox`. We
  * use the class-identity test (every real `SandboxContext` is a
  * `SandboxContextImpl`) so the TS narrowing works downstream.
@@ -182,11 +226,16 @@ export function getStorageSandbox(
   const fromBareSandbox = !isContext(target);
   const sandbox: Sandbox = isContext(target) ? target.sandbox : target;
 
+  // Open (or fetch) the ONE per-sandbox service FIRST — before any handle
+  // cache fast-path — so a late, differing `rules` option throws instead of
+  // being silently discarded (see ensureService).
+  const servicePromise = ensureService(sandbox, options, 'getStorageSandbox');
+
   // Fast path: a repeat bare-`Sandbox` call returns the cached
   // anonymous handle (the per-context cache below can't catch it
   // because `withAuth(null)` mints a fresh context each time). Like
-  // the per-context path, bucket/dbName/rules options are honored
-  // only on the FIRST call per Sandbox.
+  // the per-context path, bucket/dbName options are honored only on
+  // the FIRST call per Sandbox.
   if (fromBareSandbox) {
     const cachedBare = BARE_SANDBOX_HANDLES.get(sandbox);
     if (cachedBare) return cachedBare;
@@ -194,15 +243,6 @@ export function getStorageSandbox(
 
   const ctx = isContext(target) ? target : target.withAuth(null);
   const bucket = options.bucket ?? DEFAULT_BUCKET;
-
-  let servicePromise = SERVICES.get(sandbox);
-  if (!servicePromise) {
-    const rules = options.rules ? parseStorageRules(options.rules) : null;
-    servicePromise = openStorageBackend(options.dbName).then(
-      (backend) => new StorageService(backend, rules),
-    );
-    SERVICES.set(sandbox, servicePromise);
-  }
 
   const cached = SANDBOX_HANDLES.get(ctx);
   if (cached) return cached;
@@ -242,17 +282,11 @@ export function getAdminStorageSandbox(
   sandbox: Sandbox,
   options: StorageOptions = {},
 ): FirebaseStorage {
+  // Service first (late differing `rules` must throw, even on a cache hit).
+  const servicePromise = ensureService(sandbox, options, 'getAdminStorageSandbox');
+
   const cached = ADMIN_SANDBOX_HANDLES.get(sandbox);
   if (cached) return cached;
-
-  let servicePromise = SERVICES.get(sandbox);
-  if (!servicePromise) {
-    const rules = options.rules ? parseStorageRules(options.rules) : null;
-    servicePromise = openStorageBackend(options.dbName).then(
-      (backend) => new StorageService(backend, rules),
-    );
-    SERVICES.set(sandbox, servicePromise);
-  }
 
   const sandboxTarget: SandboxTarget = {
     kind: 'sandbox',

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -78,7 +78,7 @@ export async function uploadBytes(
       }),
     },
     resource: resourceFromStored(existing),
-  });
+  }, target);
   await service.backend.put(ref.fullPath, blob, stored);
   // Land the put on the unified Studio stream. Best-effort: a throw from
   // the emit path must not fail the upload the caller just completed.

--- a/packages/pyric/test/storage/rules.test.ts
+++ b/packages/pyric/test/storage/rules.test.ts
@@ -445,3 +445,48 @@ describe('no-rules mode is open', () => {
     expect(await (await getBlob(r)).text()).toBe('ok');
   });
 });
+
+// ─── Late rules config is loud (silent-rules-wipe guard) ──────────
+
+describe('late rules configuration throws instead of silently discarding', () => {
+  const DENY_ALL = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if false;
+  }
+}`;
+
+  it('optionless first call, rules later → throws (service opened without rules)', () => {
+    const sandbox = initializeSandbox({});
+    getStorageSandbox(sandbox, { dbName: uniqueDbName('late-rules-open') });
+    expect(() =>
+      getStorageSandbox(sandbox, { rules: DENY_ALL }),
+    ).toThrow(/first storage call/);
+  });
+
+  it('admin plane first, rules later → throws (getAdminStorageSandbox opened the service)', async () => {
+    const { getAdminStorageSandbox } = await import('../../src/storage/internal.js');
+    const sandbox = initializeSandbox({});
+    getAdminStorageSandbox(sandbox, { dbName: uniqueDbName('late-rules-admin') });
+    expect(() =>
+      getStorageSandbox(sandbox, { rules: DENY_ALL }),
+    ).toThrow(/already open without rules/);
+  });
+
+  it('a DIFFERENT rules source after a rules-configured open → throws', () => {
+    const sandbox = initializeSandbox({});
+    getStorageSandbox(sandbox, { dbName: uniqueDbName('late-rules-diff'), rules: DENY_ALL });
+    expect(() =>
+      getStorageSandbox(sandbox, { rules: SESSION_ARCHIVE_RULES }),
+    ).toThrow(/different rules source/);
+  });
+
+  it('re-supplying the IDENTICAL rules source stays allowed (idempotent per-user handles)', () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('late-rules-same');
+    getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { dbName, rules: DENY_ALL });
+    expect(() =>
+      getStorageSandbox(sandbox.withAuth({ uid: 'bob' }), { dbName, rules: DENY_ALL }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Stacked on #32. Server-side `firebase-admin/storage` code now drives the browser-hosted sandbox — the second service your first user needs, completing RTDB + Auth + Storage over the bridge.

```js
// unchanged firebase-admin code, under `pyric dev`
const bucket = getStorage().bucket();
await bucket.file('avatar.png').save(bytes, { contentType: 'image/png' });
const [data] = await bucket.file('avatar.png').download();
```

## How bytes cross the wire

Three new worker ops — `storage.putBytes` / `storage.getBytes` / `storage.deleteObject` — carry **base64** (`dataB64`), one JSON-safe encoding that survives the MessagePort and both WS legs identically. **No bridge-protocol changes.** 8 MiB raw cap enforced on both encode and decode ends (exact math, no padding tricks — adversarially reviewed); chunked conversion so 8 MiB can't blow the stack. Tests JSON-round-trip every frame on both relay legs with non-UTF8 fixtures and assert byte equality.

## The admin lens, honestly scoped

All storage ops (new and existing) now resolve through `lensStorage` (admin / `{as: uid}` / page default), backed by `getAdminStorageSandbox` in a new `pyric/storage/internal` export. The bypass gate is default-closed at all six `enforceRules` sites and unreachable without holding the `Sandbox` object. Honesty caveat, documented in-code: **the served worker doesn't configure storage rules today** (`setRules` covers Firestore/RTDB only), so worker-mode storage is effectively open and the lens matters for embedding/test hosts — wiring storage rules into serve is filed as alpha-window work. A latent silent rules-wipe (first-call-wins config discarding later `{rules}`) now throws with guidance; identical re-supply stays allowed.

## The dispatch arm and guardrails

`pyric-admin/storage` remote arm: `bucket().file().save/download/delete/exists/getSignedUrl`, admin-pinned, zero local state; loud throws for non-default buckets (single-bucket worker store), >8 MiB saves, `resumable`, and streams; `getSignedUrl` shares a byte-identical stub with the local arm; "No such object" parity. The pre-existing silent binary corruption on the relay (Blob → `{}`) is now an explicit teachable error on **both** legs (op results and subscription snaps), with the guard's call sites driven by real `connectBridge` tests over a faked WebSocket — deleting the guard fails tests.

## Also fixed (integration-smoke findings)

- **Idle remote clients no longer pin the Node event loop** — short scripts exit immediately (verified: infinite hang → 0.16 s) via socket unref + a ref/unref lifecycle edged on pending ops/subs; delivery unaffected.
- **Version-skew guidance**: "Unknown method: …" errors now append "the running sandbox may predate this feature; restart pyric dev and reload the browser tab."
- Side-quest: worker-mode browser `uploadBytes`/`getBytes`/`deleteObject` now work (previously threw).

Suites: pyric 4359/0, pyric-tools 1172/0 (6 pre-existing skips), pyric-admin 528/0, root test green, `lint:manifest` clean incl. the new export. Adversarially reviewed pre-PR (rules-bypass surface, caps, fidelity verified clean; all findings fixed in the final two commits). Remote Firestore is spiked (docs pending) and follows separately.