### PR TITLE
pyric dev: a child implies the bridge

### DIFF
--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -474,6 +474,20 @@ export function bridgeEnabledFromFlags(flags: { get(key: string): unknown }): bo
   return Boolean(flags.get('bridge')) || Boolean(flags.get('ui'));
 }
 
+/**
+ * A dev child also implies the bridge: the runner injects
+ * `PYRIC_SANDBOX=remote:<url>` into the child, whose remote client dials the
+ * `/__pyric/sandbox` WS — without the bridge mount that upgrade 404s and
+ * plain `pyric dev -- <cmd>` (or a detected dev script) breaks its own
+ * child. Pure + exported for unit coverage.
+ */
+export function bridgeEnabledFor(
+  flags: { get(key: string): unknown },
+  childPlan: unknown,
+): boolean {
+  return bridgeEnabledFromFlags(flags) || childPlan != null;
+}
+
 /** CLI entry. Resolves on SIGINT/SIGTERM after a clean stop. */
 export async function runServe(parsed: ParsedArgs): Promise<number> {
   const flagPort = parsed.flags.get('port');
@@ -496,7 +510,19 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   const json = Boolean(parsed.flags.get('json'));
 
   const uiOn = Boolean(parsed.flags.get('ui'));
-  const bridgeOn = bridgeEnabledFromFlags(parsed.flags);
+
+  // Resolve the child plan BEFORE the server starts: a planned child implies
+  // the bridge (see bridgeEnabledFor) — the child's injected PYRIC_SANDBOX
+  // is useless without the /__pyric/sandbox WS mount.
+  const cwd = process.cwd();
+  const plan = resolveDevChild({
+    passthrough: parsed.passthrough ?? [],
+    noRun: Boolean(parsed.flags.get('no-run')),
+    json,
+    devScript: readDevScript(cwd),
+    packageManager: detectPackageManager(cwd),
+  });
+  const bridgeOn = bridgeEnabledFor(parsed.flags, plan);
 
   let runtime: ServeRuntime;
   try {
@@ -558,15 +584,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   // command with the sandbox environment injected. Precedence: `-- <cmd>`
   // wins; else the package.json dev script; else host-only. --no-run forces
   // host-only; --json defaults to host-only (explicit `--` still wins).
-  const cwd = process.cwd();
-  const plan = resolveDevChild({
-    passthrough: parsed.passthrough ?? [],
-    noRun: Boolean(parsed.flags.get('no-run')),
-    json,
-    devScript: readDevScript(cwd),
-    packageManager: detectPackageManager(cwd),
-  });
-
+  // (`plan` was resolved above so it could imply the bridge mount.)
   let devChild: DevChildHandle | null = null;
   if (plan) {
     const info = json ? process.stderr : process.stdout;

--- a/packages/pyric-tools/test/serve/bridge-flag.test.ts
+++ b/packages/pyric-tools/test/serve/bridge-flag.test.ts
@@ -3,7 +3,7 @@
  * always wants MCP too, and the two independent flags were the setup footgun.
  */
 import { describe, it, expect } from 'bun:test';
-import { bridgeEnabledFromFlags } from '../../src/cli/serve.js';
+import { bridgeEnabledFor, bridgeEnabledFromFlags } from '../../src/cli/serve.js';
 
 const flags = (o: Record<string, unknown>) => new Map(Object.entries(o));
 
@@ -22,5 +22,18 @@ describe('bridgeEnabledFromFlags', () => {
 
   it('is false with neither', () => {
     expect(bridgeEnabledFromFlags(flags({ port: '5000' }))).toBe(false);
+  });
+});
+
+describe('bridgeEnabledFor (child implies bridge)', () => {
+  it('a planned dev child turns the bridge on without flags', () => {
+    expect(bridgeEnabledFor(flags({}), { label: 'node server.mjs' })).toBe(true);
+  });
+  it('no child and no flags leaves the bridge off', () => {
+    expect(bridgeEnabledFor(flags({}), null)).toBe(false);
+  });
+  it('flags still win independently of a child', () => {
+    expect(bridgeEnabledFor(flags({ bridge: true }), null)).toBe(true);
+    expect(bridgeEnabledFor(flags({ ui: true }), null)).toBe(true);
   });
 });


### PR DESCRIPTION
Found while writing the server-adoption guide with verified (executed, not imagined) transcripts: **plain `pyric dev -- node server.mjs` breaks its own child.** The runner injects `PYRIC_SANDBOX=remote:<url>` unconditionally, but the `/__pyric/sandbox` WS upgrade only mounts under `--bridge`/`--ui` — the child's remote client 404s. Every manual test so far used `--ui` (which implies bridge), masking it; the published two-command story would have hit it immediately.

Fix: the child plan resolves before the server starts, and a planned child implies the bridge exactly like `--ui` does (`bridgeEnabledFor`, pure + unit-tested). Verified end-to-end headlessly: plain `pyric dev -- node child.mjs` now prints the `✔ bridge` banner line and the child gets the correct "no browser tab is connected — open <url>" guidance instead of a WS 404.

CLI + serve suites green (81 tests in the touched dirs).

https://claude.ai/code/session_019Kbqv5Ta2DMdFT4VoeRnn7