### PR TITLE
README: narrative rewrite; vendor the readme-bookstore-test skill

### DIFF
--- a/.agents/skills/readme-bookstore-test/SKILL.md
+++ b/.agents/skills/readme-bookstore-test/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: readme-bookstore-test
+description: Generates and iterates a README that earns the reader's attention progressively (cover → inner flap → reading the book), then verifies every claim and example against the real artifact. Use when writing or reviewing a README or landing page for a library or tool. Includes an iteration ratchet - corrections made during review are captured as general principles, not one-off edits.
+---
+
+# README — The Bookstore Test
+
+Write a README the way a person decides to buy a book: they glance at the
+**cover**, read the **inner flap**, then commit to **reading the book**. The
+README must earn the reader's attention at each stage before asking for more
+of it.
+
+This skill runs in four phases: **Draft → Verify → Iterate → Ratchet.**
+The draft is cheap; the verification is the product. A README is a set of
+claims, and unverified claims rot.
+
+---
+
+## Phase 1 — Draft
+
+### The Cover
+
+Open with a single sentence that states what problem this library solves —
+not what the library *is*, and not the product it belongs to. The reader
+should recognize their own situation. No taglines, no badges, no logos.
+
+**Good:** "Coordinate multiple coding agent sessions across a repository and
+merge their pull requests sequentially."
+**Bad:** "Jules Fleet is a powerful orchestration framework built on the
+Jules platform for enterprise-grade AI agent management."
+
+### The Inner Flap
+
+Immediately show the library in use. Code speaks louder than descriptions.
+Show the **primary workflow** in a single, copy-pasteable example, then one
+or two **secondary workflows** that reveal depth.
+
+- **No setup first.** Don't open with installation, auth, or configuration.
+  The reader hasn't decided to use the library yet.
+- **Anchor in the reader's existing habit.** If the library mirrors,
+  replaces, or extends something the reader already knows, the first example
+  should read like the thing they already write — with the delta made
+  explicit ("the one line that differs is…"). The fastest route to "I get
+  it" is recognition plus one visible change, not novelty.
+- **Straightforward language.** Describe what the code does, not how
+  impressive it is. Never "powerful", "seamless", "robust",
+  "enterprise-grade", "cutting-edge".
+- **Working examples.** Valid, runnable code — no pseudocode, no `// ...`
+  elisions.
+- **Progressive complexity.** Simplest useful invocation first, then one
+  advanced case that reveals a second capability.
+
+### Reading the Book
+
+Now the reader is committed. Document the full top-level API — every
+command, function, or option a user would reach for. Comprehensive in
+scope, concise in explanation. Structure as **reference**, not tutorial:
+what it does (one line), minimal usage, options as a table or list. Setup,
+auth, and configuration go here — after the reader has decided.
+
+### Tone
+
+Write like a colleague explaining their work to another engineer. Direct
+and specific. Don't sell — inform. If a feature has limitations, state
+them as facts with pointers to where they're tracked, not as hedges. Trust
+earns more adoption than marketing.
+
+### Vocabulary
+
+- One name per concept, used consistently from the first mention. If the
+  project has internal codenames or a domain glossary, either define a term
+  on first use or don't use it.
+- Freeze the vocabulary before you publish it. If a rename is already
+  planned, write the new name or delay the section — never document a name
+  scheduled to die.
+- Give the reader the parent term before the precise ones. Readers need one
+  broad word for the whole apparatus before they can absorb the taxonomy
+  beneath it.
+
+---
+
+## Phase 2 — Verify (the phase that isn't optional)
+
+Every README is a set of claims. Before publishing, verify each class:
+
+1. **Execute every command.** Run each shell command in the README exactly
+   as written, in a fresh directory. A command transcribed from a source
+   file's comment or your memory is a guess, not a fact — tooling entries
+   go missing, flags drift, scripts get renamed.
+2. **Run every example against the installed artifact.** Examples must be
+   validated against what the reader will actually have — the packed
+   tarball or published package installed into a clean consumer project —
+   not against the source tree. Source trees resolve imports and carry
+   state that installed packages don't.
+3. **Match every claim to its evidence tier.** State only what the
+   project's tests or documentation system actually back. "Compatible
+   with X" is a different claim from "mirrors X's behavior, verified
+   against captures of X" — write the one that's true, and link to the
+   proof rather than substituting adjectives for it. Receipts beat
+   superlatives.
+4. **Treat hand-maintained lists as drift debt.** Any README table that
+   mirrors machine truth — exported subpaths, commands, option lists —
+   WILL drift from the source of truth. Either generate it from that
+   source, add a mechanical check that diffs it, or replace it with a link
+   to generated reference docs. If none of those, consciously accept the
+   debt and note where the truth lives.
+5. **State the stability contract explicitly.** Version, maturity (alpha /
+   beta / stable), what is promised and what may change — in plain words,
+   near the top of Reading the Book. An experimental product loses nothing
+   by saying so and loses everything by being discovered to be.
+
+---
+
+## Phase 3 — Iterate
+
+Generate the draft, then hand it to the human owner for nuance. Expect
+corrections — the owner holds context the generator doesn't (positioning,
+audience, history). Apply corrections faithfully. Do not defend the draft.
+
+---
+
+## Phase 4 — Ratchet (how this skill improves)
+
+After each iteration session, for every correction the human made, ask:
+**"What is the general principle behind this correction — stated so it
+applies to any library, not this one?"** Append the answer to the Learned
+Principles section below, dated. Corrections that are genuinely one-off
+(taste, positioning specific to this product) are applied but not recorded.
+
+This is the ratchet: the skill accumulates judgment; the next first draft
+starts where the last iteration ended.
+
+### Learned Principles
+
+- **2026-07-08 — Commands rot silently.** A documented command referenced a
+  tool whose runner entry was never wired up; nothing failed until the
+  command was executed during fact-checking. Principle: executing every
+  documented command is the cheapest bug-finder a docs pass has — Phase 2.1
+  exists because transcription is not verification.
+- **2026-07-08 — Surface tables drift.** Hand-maintained API/subpath tables
+  in shipped READMEs were missing a meaningful fraction of real exports,
+  unnoticed for months, because nothing checked them. Principle: Phase 2.4 —
+  generate, check, link, or consciously accept.
+- **2026-07-08 — Recognition beats explanation.** The strongest first
+  example for a mirror-style product was the upstream product's own
+  canonical snippet with exactly one changed line, and the gap that broke
+  that snippet was the product's highest-priority bug. Principle: the inner
+  flap's first example should be the reader's existing muscle memory plus a
+  visible delta (Phase 1, "anchor in the reader's existing habit").
+- **2026-07-08 — Claims need a tier, not an adjective.** "Verified against
+  production behavior" and "believed correct from documentation" are
+  different claims that both hide behind "compatible". Principle: Phase 2.3
+  — write the claim at the strength the evidence supports and link the
+  evidence.
+- **2026-07-08 — Narrative before inventory.** A structurally correct,
+  fully verified draft was rejected because it read like a manual: it
+  documented the codebase instead of telling the reader what their life
+  looks like with the product. The reader's test is "oh, I could use this
+  for…" — every section must serve self-interest woven into a story
+  (the problem's real cost, the one-command relief, what the reader keeps).
+  A README is not a repo autobiography; put the story ahead of the API and
+  let the reference material live in linked docs.
+- **2026-07-08 — For invisible-by-design products, the product's API is
+  the wrong hero.** When a product's ideal usage hides it (a dev-time
+  layer, a wrapper, a runner), most users never import it — so the primary
+  example must show the user's UNCHANGED world plus the one command that
+  adds the product, and the product's own API belongs in a "when you want
+  explicit control" section near the end. Recognition-plus-delta (an
+  earlier principle) was necessary but insufficient: the delta for these
+  products is a command, not a changed import.
+- **2026-07-08 — Position as AND, not VS.** If the product complements an
+  incumbent rather than replacing it, say so explicitly and early ("X
+  during development, incumbent in production") — otherwise the reader
+  manufactures a migration decision the product never asks them to make,
+  and declines it.
+- **2026-07-08 — Show uniqueness, never declare it.** "Nothing else does
+  this" is pretentious and unfalsifiable; a concrete list of capabilities
+  the reader has never had (with what each one is FOR) makes the same
+  point and survives skepticism. Related: capabilities are supporting
+  cast — name the protagonist (the core primitive that makes them
+  possible) and attach every capability to it, rather than presenting a
+  flat feature list.
+- **2026-07-08 — Name the tax.** The strongest problem statement
+  enumerates the incumbent's real setup/friction cost concretely (logins,
+  installs, config wiring), then contrasts it with the product's single
+  step. Specific friction is recognizable; abstract friction ("it's hard
+  to get started") is not.
+- **2026-07-08 — Enthusiasm spends trust; facts earn it.** A draft was
+  rejected for tone: celebratory interjections ("That's it"), speed/power
+  adverbs ("at full speed"), and grammatical flourishes trip the reader's
+  bullshit meter, and each one undermines the technical merit it decorates.
+  Plain declarative sentences and plain punctuation (no em dashes, no
+  exclamations). If the product pioneered a category, the reader must reach
+  that conclusion themselves; stating it, or writing like it, prevents them.
+- **2026-07-08 — A list of things the product is NOT is a pitch, not
+  information.** "No account, no project, no config" reads as selling and
+  adds confusion. State what the one step does; let the absent steps be
+  conspicuous by their absence in the enumerated incumbent tax.
+- **2026-07-08 — Don't write the reader as an owner.** "Your app boots"
+  assumes adoption the reader hasn't granted. Describe the app, the
+  session, the workflow in neutral terms until the reader has actually
+  made something theirs.
+- **2026-07-08 — Headings carry the story.** Label headings ("Features",
+  "What the agent can do now") stall the narrative; each heading should be
+  a step in the reader's journey ("Starting a project", "Work that carries
+  to production"). Read the headings alone: they should summarize the
+  story.
+- **2026-07-08 — Foreground what only this product does; commodity
+  integrations get one flat sentence.** A draft undersold the genuinely
+  novel capabilities (in this case rules-as-a-library, denial inspection,
+  index extraction, session replay) while presenting a now-commonplace
+  integration (an editor/agent plugin) as a selling point. Inventory the
+  capabilities that exist nowhere else and give them the narrative space;
+  mention table-stakes integrations without ceremony.
+- **2026-07-08 — Don't showcase code that isn't the product's.** A
+  mirror/wrapper product's README spent its examples on the upstream SDK's
+  API, which demonstrates the incumbent, not the product. Code examples
+  should exercise the product's own novel surfaces; the "your code is
+  unchanged" exhibit needs only a sentence or a short fragment, not the
+  spotlight.
+- **2026-07-08 — Build a capability census before drafting, and diff the
+  draft against it.** Across three rounds the same omission recurred: the
+  product's unique tools were repeatedly left out or reduced to a link,
+  because the draft was written from the narrative downward instead of
+  from the product's own inventory upward. Before Phase 1: enumerate the
+  capabilities from the repo's own inventories (tool lists, exports,
+  docs), and for each one decide include-by-name or consciously exclude.
+  A capability the owner considers core that appears zero times is a
+  failed draft regardless of prose quality.
+- **2026-07-08 — Name the architectural spine.** Features presented as a
+  flat list undersell; the primitive that unifies them (here, a typed
+  event stream every diagnostic consumes) gives the reader the model that
+  makes each feature legible and the whole feel designed. Find the one
+  sentence of architecture that explains the most features and spend it.
+- **2026-07-08 — Describe tools from their source descriptions, not their
+  names.** A tool's name suggests less (or different) than what it does;
+  the source's own description field is the verified claim. Paraphrase
+  it, don't infer from the identifier.
+- **2026-07-08 — No manual line wrapping in markdown prose.** One line
+  per paragraph; hard-wrapped prose is a diff and editing nuisance and an
+  owner correction that should never recur.
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails |
+| :--- | :--- |
+| Leading with badges, logos, or status shields | Visual noise before the reader knows what the library does |
+| "Getting Started" as the first section | Forces setup before demonstrating value |
+| Feature bullet lists without code | Tells instead of shows — the reader can't evaluate the API |
+| "Easy to use", "simple", "just works" | Self-congratulatory claims that invite skepticism |
+| Long install/config blocks before any usage | Asks for investment before demonstrating return |
+| Collapsible sections hiding core API docs | Buries the content committed readers came for |
+| Unexecuted commands and untested examples | The README becomes the first place the product breaks |
+| Adjectives where evidence should be | "Robust" is a claim with no falsifier; a linked test count is one |
+| Documenting names scheduled for renaming | Ships vocabulary that contradicts the next release |
+
+## Checklist
+
+Before publishing, verify:
+
+- [ ] Can a reader understand what the library does in under 10 seconds?
+- [ ] Is there a runnable code example within the first scroll?
+- [ ] Does the first example anchor in something the reader already knows,
+      with the delta explicit?
+- [ ] Does setup/config appear *after* the first code example?
+- [ ] Has every shell command been executed as written, in a fresh
+      directory?
+- [ ] Has every code example been run against the installed package (not
+      the source tree)?
+- [ ] Is every factual claim written at the strength its evidence supports,
+      with a link to the evidence?
+- [ ] Are all hand-maintained lists generated, mechanically checked, or
+      consciously accepted as drift debt?
+- [ ] Is the stability contract (version, maturity, what may change) stated
+      plainly?
+- [ ] Is the language descriptive rather than promotional?
+- [ ] Does the reference section cover every top-level API entry?
+- [ ] Were this iteration's corrections generalized into Learned Principles?

--- a/README.md
+++ b/README.md
@@ -1,86 +1,101 @@
-# Pyric — Firebase for agents
+# Pyric
 
-**The Firebase backend, running inside your page, so you and your agent can
-build against real rules, real auth, and real data semantics without deploying
-anything.**
+Pyric is a development-time layer for Firebase. It runs Firestore, Auth, Realtime Database, Storage, and security rules inside the application process, so Firebase apps and the agents that work on them can be developed without a live project, the emulator, or a network connection. Production builds do not include it: application code keeps its `firebase/*` imports, the sandbox backs them during development, and real Firebase backs them in production.
 
-Pyric mirrors Firebase's package shape while swapping the backend for an
-in-process sandbox during local development. Your app can keep canonical
-`firebase/*` imports under `pyric dev`, or import `pyric/*` directly when you
-want explicit sandbox-vs-production control.
+## Starting a project
+
+Firebase development begins with an account, a project, enabled services, the emulator suite and its Java dependency, and hand-wired switching between emulator and production in the SDK. An agent working in that environment touches real infrastructure, so writes, deploys, and rules changes need supervision.
+
+Pyric starts from one command, in an existing Firebase app or a scaffolded one:
 
 ```bash
-npx pyric init --template web
-npm install
+npx pyric init --template web   # scaffold, or run pyric dev in an existing app
 npx pyric dev
 ```
 
-Live demo: [pyric-playground.web.app](https://pyric-playground.web.app)
+`pyric dev` serves the app against the in-process sandbox. During web development the sandbox runs in the page itself; in Node it runs in the process. It holds data, identities, and rules that can be seeded, snapshotted, and reset. Live demo: [pyric-playground.web.app](https://pyric-playground.web.app).
 
-## Why this exists
+## Security rules as a library
 
-Firebase development has a feedback-loop problem: security rules usually need a
-deploy or a separate emulator before you can feel the result. Pyric closes that
-loop by putting a Firebase-shaped sandbox in the running app, exposing rules as
-a library, and giving agents safe tools for reading, writing, simulating, and
-debugging local state.
+Pyric includes a rules engine for Firestore and Realtime Database rules: parser, linter, validator, and simulator, usable in-process and from the CLI.
 
-The main pieces:
+```bash
+pyric rules:lint firestore.rules
+pyric rules:simulate --stdin
+pyric database:rules:validate database.rules.json
+```
 
-- **`pyric/sandbox`** — in-process Firestore, Auth, Realtime Database, Storage,
-  and rules evaluation for browser and Node.
-- **`pyric/rules`** — parser, linter, simulator, module resolver, and stdlib
-  tooling for Firestore rules.
-- **`pyric-tools`** — the `pyric` CLI, `pyric dev`, MCP bridge, deploy helpers,
-  schema discovery, and Vite plugin.
-- **`pyric-admin`** — `firebase-admin`-shaped adapters with sandbox and
-  production backends.
-- **`@pyric/ui`** — headless React components for Firebase/Pyric admin surfaces.
-- **`@pyric/studio`** — the local data-management and debugging console served
-  by `pyric dev --ui`.
+Rules edits take effect in the running app without a deploy. Realtime Database `.validate` rules are evaluated on writes, matching production behavior.
 
-## Workflow
+## Everything the sandbox does is an event
 
-1. **Start** with `pyric init`, or run `pyric dev` in an existing Firebase app.
-2. **Iterate** against the sandbox: rules hot-reload, data is inspectable, auth
-   can be seeded, and state can be reset or snapshotted.
-3. **Ask an agent for help** through `pyric dev --bridge` or the included
-   [Claude Code plugin](pyric-plugin/README.md).
-4. **Ship deliberately** by building normally against real Firebase and using
-   `pyric deploy <rules|indexes|database|hosting|functions>` when you want Pyric's
-   deploy helpers.
+The sandbox emits a typed event for every operation it performs: reads, writes, auth transitions, and rules verdicts, including denials with the rule, path, and data that produced them. The diagnostics are consumers of that stream:
 
-## Packages
+- Traffic inspection: what the app actually did, live, in the `pyric dev --ui` console or through the `@pyric/ui` traffic and events components.
+- Denial inspection: a rejected operation carries its verdict instead of a bare `permission-denied` error.
+- Capture and replay: `pyric snapshot` records state, and captured sessions replay through the same event stream, which is what `pyric verify` is built on.
+
+## Tools an agent can hold
+
+The sandbox and its services are exposed as 51 agent-callable tools, reachable over MCP through `pyric dev --bridge` (the included [Claude Code plugin](pyric-plugin/README.md) auto-wires this) or composed programmatically into any agent framework. The inventory is in [docs/agent-tools.md](docs/agent-tools.md); the ones with no equivalent elsewhere:
+
+- `firestore_simulate_rules` and `rtdb_simulate_access` evaluate a rules verdict for a hypothetical operation without performing it.
+- `firestore_simulator_*` runs a stateful Firestore session with seed, execute, batch, transaction, undo, redo, and an inspectable event log.
+- `sandbox_inspect`, `firestore_discover_paths`, and `rtdb_crawl_structure` map what exists in the data and how it is shaped.
+- `rtdb_validated_write` runs pre-flight checks before writing: it infers the schema at the target path, validates the payload against it, and simulates the rules verdict, returning schema warnings and simulation results alongside the write outcome.
+- `firestore_extract_indexes` derives composite-index definitions from the query shapes in source.
+- The deploy factories (`firestore_deploy_rules`, `firestore_deploy_indexes`, `rtdb_deploy_rules`, `hosting_deploy`, `functions_deploy`) drive the Firebase control plane over REST, without the `firebase-tools` CLI.
+
+## Work that carries to production
+
+A sandbox session produces the artifacts a production deploy needs. Rules leave the sandbox already exercised against the app's actual behavior; `pyric deploy rules` ships them. Composite indexes come from `firestore_extract_indexes` instead of a hand-maintained `firestore.indexes.json`; `pyric deploy indexes` ships those. And `pyric verify` replays a captured session against a candidate ruleset and reports which operations change verdict before production finds out.
+
+## Holding the sandbox to Firebase's behavior
+
+A sandbox is only useful if it behaves like the real service, so that claim is tested rather than assumed. Probes run against production Firebase and their recorded behavior is committed to the repository as observations, currently 138 of them. CI replays every observation against the sandbox on every change. The public contract is a compatibility matrix of 610 rows, 539 conforming today, and known divergences are documented rather than hidden: [Firestore](packages/pyric/docs/firestore/COMPAT.md), [Auth](packages/pyric/docs/auth/COMPAT.md), [Realtime Database](packages/pyric/docs/database/COMPAT.md), [Storage](packages/pyric/docs/storage/COMPAT.md), and [how the conformance system runs](docs/conformance/how-to-run-the-conformance-system.md). An undocumented divergence is treated as a bug.
+
+## Using the packages directly
+
+Most apps never import Pyric. For tests, Node scripts, and programmatic control of sandboxes, the `pyric/*` and `pyric-admin/*` packages mirror the Firebase SDKs' shape:
+
+```js
+import { initializeSandbox } from 'pyric/sandbox';
+import { initializeApp } from 'pyric-admin/app';
+import { getDatabase } from 'pyric-admin/database';
+
+initializeApp({ sandbox: initializeSandbox() }); // the only non-firebase-admin line
+const db = getDatabase();
+await db.ref('rooms/lobby').set({ topic: 'launch day' });
+```
 
 | Package | Purpose | Docs |
 |---|---|---|
-| `pyric` | Modular SDK adapters, rules tooling, and sandbox runtime | [docs](packages/pyric/docs/) |
-| `pyric-admin` | Admin-shaped adapters over sandbox or production Firebase | [docs](packages/pyric-admin/docs/firestore/) |
-| `pyric-tools` | CLI, bridge, deploy, discovery, credentials, Vite plugin | [docs](packages/pyric-tools/docs/) |
+| `pyric` | Web SDK mirror, rules tooling, sandbox runtime | [docs](packages/pyric/docs/) |
+| `pyric-admin` | `firebase-admin` mirror over sandbox or production | [docs](packages/pyric-admin/docs/firestore/) |
+| `pyric-tools` | The `pyric` CLI: `dev`, `init`, MCP bridge, deploy, verify | [docs](packages/pyric-tools/docs/) |
 | `@pyric/ui` | Headless React admin components and hooks | [docs](packages/ui/docs/) |
-| `@pyric/studio` | Local sandbox console for `pyric dev --ui` | [README](packages/studio/README.md) |
+| `@pyric/studio` | The local console behind `pyric dev --ui` | [README](packages/studio/README.md) |
 
-Agent tool inventory: [docs/agent-tools.md](docs/agent-tools.md).
+```bash
+npm install -D pyric-tools    # the CLI; sufficient for most apps
+npm install pyric pyric-admin # for direct sandbox control
+```
+
+Node 22 or later. All packages are ESM-only with subpath exports (`pyric/firestore`, not `pyric`).
 
 ## Development
 
-Requires Bun and Node 22+.
+Requires Bun and Node 22 or later.
 
 ```bash
 bun install
 bun run build
-bun run test
+bun test packages/pyric packages/pyric-admin packages/pyric-tools packages/ui
 npm run test:packaging
 ```
 
-Useful examples:
+Examples: [examples/vite-sandbox-app](examples/vite-sandbox-app/), the shape `pyric init --template web` generates, and [examples/admin-playground](examples/admin-playground/), a `@pyric/ui` showcase.
 
-- [examples/vite-sandbox-app](examples/vite-sandbox-app/) — the reference app
-  shape generated by `pyric init --template web`.
-- [examples/admin-playground](examples/admin-playground/) — `@pyric/ui`
-  component showcase.
+## Stability
 
-## Status
-
-Pre-1.0. Public APIs are intended to be Firebase-shaped, but Pyric-specific
-surfaces can still change while the package set hardens.
+Alpha, `0.1.0-alpha.7`, published as an experimental product. The one stability goal is the Firebase mirror: code written against mirrored surfaces is intended to keep working, tracked in the compatibility matrices. Pyric-specific APIs (sandbox lifecycle, replay, serve and bridge internals) are public-alpha and may change between releases.


### PR DESCRIPTION
Rewrites the root README as a narrative rather than a repo manual. The structure follows the development loop: the setup tax and the one-command start, security rules as a library, the sandbox's typed event stream as the spine that traffic inspection, denial inspection, and capture/replay all consume, the 51 agent tools with the differentiators named individually, the artifacts a session produces for production, and the conformance receipts. The `pyric/*` packages move to one explicit-control section near the end, since most apps never import them.

Verification (per the vendored skill's process): every command executed as written, the code example extracted from the final file and run against packed tarballs installed in a clean consumer, all relative links checked, conformance numbers taken from a fresh `compat:report`, and tool capabilities paraphrased from the tools' own source `description` fields rather than inferred from names.

Also vendors `.agents/skills/readme-bookstore-test`: the Bookstore Test prompt extended into a four-phase process (draft, verify, iterate, ratchet). The ratchet turns review corrections into general principles recorded in the skill itself; sixteen were captured across this README's three iteration rounds.