### PR TITLE
Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ clones/
 
 # Design/process working documents — never repo content (see #29/#32 accident)
 docs/design/
+
+# Claude Code worktrees — never repo content
+.claude/worktrees/


### PR DESCRIPTION
`git add .` at the repo root sweeps agent worktrees in as embedded repositories — same accident class as #40's design-docs sweep. Ignored so staging can never pick them up.

https://claude.ai/code/session_019Kbqv5Ta2DMdFT4VoeRnn7