### PR TITLE
pyric dev: wait for the browser tab before spawning the child

### DIFF
--- a/packages/pyric-tools/src/cli/dev-runner.ts
+++ b/packages/pyric-tools/src/cli/dev-runner.ts
@@ -19,6 +19,48 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+// ─── First-run race guard ───────────────────────────────────────────────────
+
+/**
+ * Wait (bounded) for a browser tab to register as the bridge's sandbox peer
+ * before the child spawns. `pyric dev` opens the tab and spawns the child in
+ * the same breath; a child whose first line is a sandbox op otherwise races
+ * the tab's boot and dies on the no-tab fail-fast — the exact first-run of
+ * the two-command story. Polls `/__pyric/health` (`sandboxConnected`).
+ *
+ * Returns true when a peer connected, false on timeout (caller warns and
+ * spawns anyway — the child may not touch the sandbox at all). Injectable
+ * clock/fetch for the unit suite.
+ */
+export async function waitForSandboxPeer(
+  serveUrl: string,
+  opts: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    fetchImpl?: typeof fetch;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<boolean> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const intervalMs = opts.intervalMs ?? 250;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetchImpl(`${serveUrl.replace(/\/$/, '')}/__pyric/health`);
+      if (res.ok) {
+        const health = (await res.json()) as { sandboxConnected?: boolean };
+        if (health.sandboxConnected === true) return true;
+      }
+    } catch {
+      // Health not up yet — keep polling until the deadline.
+    }
+    if (Date.now() >= deadline) return false;
+    await sleep(intervalMs);
+  }
+}
+
 // ─── Child-command resolution (pure) ───────────────────────────────────────
 
 export type PackageManager = 'bun' | 'pnpm' | 'yarn' | 'npm';

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -37,6 +37,7 @@ import {
   registerModuleUrl,
   resolveDevChild,
   spawnDevChild,
+  waitForSandboxPeer,
   type DevChildHandle,
 } from './dev-runner.js';
 
@@ -568,14 +569,13 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   // Auto-open the served page (best-effort) so the browser-resident sandbox is
   // actually running. Suppressed in non-interactive paths (--json, --no-open,
   // no TTY, CI) — see shouldAutoOpen. A failed open never fails serve.
-  if (
-    shouldAutoOpen({
-      json,
-      noOpen: Boolean(parsed.flags.get('no-open')),
-      isTTY: Boolean(process.stdout.isTTY),
-      env: process.env,
-    })
-  ) {
+  const opened = shouldAutoOpen({
+    json,
+    noOpen: Boolean(parsed.flags.get('no-open')),
+    isTTY: Boolean(process.stdout.isTTY),
+    env: process.env,
+  });
+  if (opened) {
     // With --ui, open Studio directly; the served page is still available.
     void openBrowser(runtime.uiUrl ?? runtime.handle.url);
   }
@@ -588,6 +588,20 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   let devChild: DevChildHandle | null = null;
   if (plan) {
     const info = json ? process.stderr : process.stdout;
+    // First-run race guard: we just opened the tab ourselves, so wait
+    // (bounded) for it to register as the sandbox peer before the child's
+    // first op can lose the race and die on the no-tab fail-fast. Skipped
+    // when nothing was opened (CI/--no-open/--json): no tab is coming, and
+    // stalling would only delay the honest failure.
+    if (opened) {
+      info.write('• run      waiting for the browser tab to connect the sandbox…\n');
+      const connected = await waitForSandboxPeer(runtime.handle.url);
+      if (!connected) {
+        info.write(
+          `  ⚠ no browser tab connected after 30s — starting your command anyway; sandbox ops will fail until ${runtime.handle.url} is open.\n`,
+        );
+      }
+    }
     info.write(
       `✔ run      \`${plan.label}\` — firebase-admin/firebase imports are routed to the sandbox at ${runtime.handle.url}\n`,
     );

--- a/packages/pyric-tools/test/cli/dev-runner.test.ts
+++ b/packages/pyric-tools/test/cli/dev-runner.test.ts
@@ -16,6 +16,7 @@ import {
   readDevScript,
   registerModuleUrl,
   resolveDevChild,
+  waitForSandboxPeer,
 } from '../../src/cli/dev-runner.js';
 
 describe('parseArgs `--` passthrough', () => {
@@ -146,5 +147,54 @@ describe('createLinePrefixer', () => {
     expect(out).toEqual(['[dev] hello\n', '[dev] world\n', '[dev] tail\n']);
     p.flush(); // idempotent
     expect(out).toHaveLength(3);
+  });
+});
+
+describe('waitForSandboxPeer (first-run race guard)', () => {
+  const health = (connected: boolean) =>
+    ({ ok: true, json: async () => ({ sandboxConnected: connected }) }) as Response;
+
+  it('resolves true as soon as the health endpoint reports a peer', async () => {
+    let calls = 0;
+    const ok = await waitForSandboxPeer('http://localhost:1', {
+      timeoutMs: 5000,
+      intervalMs: 1,
+      fetchImpl: async () => health(++calls >= 3),
+      sleep: async () => {},
+    });
+    expect(ok).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it('returns false at the deadline when no peer ever connects', async () => {
+    let now = 0;
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      const ok = await waitForSandboxPeer('http://localhost:1', {
+        timeoutMs: 1000,
+        intervalMs: 100,
+        fetchImpl: async () => health(false),
+        sleep: async () => { now += 100; },
+      });
+      expect(ok).toBe(false);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('tolerates fetch failures while the server boots', async () => {
+    let calls = 0;
+    const ok = await waitForSandboxPeer('http://localhost:1/', {
+      timeoutMs: 5000,
+      intervalMs: 1,
+      fetchImpl: async () => {
+        calls++;
+        if (calls < 2) throw new Error('ECONNREFUSED');
+        return health(true);
+      },
+      sleep: async () => {},
+    });
+    expect(ok).toBe(true);
   });
 });


### PR DESCRIPTION
Found live during the pre-publish check — the first-run race in the two-command story: `pyric dev` opens the browser tab and spawns the user's command simultaneously, so a server whose first line is a sandbox op (any real server) loses the race to the tab's boot and dies on the no-tab fail-fast. Every earlier manual run masked it because a tab was already open.

Fix: when the runner itself auto-opened a tab, it waits — `waitForSandboxPeer` polls `/__pyric/health` (`sandboxConnected`) with a 30s bound and one status line — before spawning the child. When nothing was opened (CI, `--no-open`, `--json`), it spawns immediately as before: no tab is coming, and stalling would only delay the honest failure. Timeout warns and spawns anyway (the child may not touch the sandbox).

Injectable clock/fetch; 3 new unit tests (immediate connect, deadline, boot-window fetch failures). CLI + serve suites green.