### PR TITLE
Fix duplicate snapshots and peer-slot churn on the bridge

### DIFF
--- a/packages/pyric-admin/test/remote/remote-firestore.test.ts
+++ b/packages/pyric-admin/test/remote/remote-firestore.test.ts
@@ -803,6 +803,68 @@ describe('pyric-admin remote Firestore — onSnapshot', () => {
     unsub();
   });
 
+  it('spurious-emission matrix: unrelated activity and peer churn re-fire NOTHING', async () => {
+    // Live bug: with a browser tab + a Studio tab open, the two pages cycled
+    // through the bridge's last-wins peer registration (each reconnecting
+    // after ~500ms), and every registration re-issued the sub registry — the
+    // re-established worker listener's initial snapshot reached the consumer,
+    // so a remote doc listener fired ~1/sec with byte-identical data and no
+    // document change. Real Firestore listeners fire on change only; a
+    // callback that writes anything becomes an infinite write loop.
+    const { bridge, ctx, remote } = makeStack();
+    const db = getAdminFirestore(remote);
+    await db.doc('live/check').set({ n: 1, at: 'fixed' });
+
+    const docFires: string[] = [];
+    const queryFires: string[] = [];
+    onSnapshot(db.doc('live/check'), (snap) => {
+      docFires.push(JSON.stringify(snap.data()));
+    });
+    (
+      db.collection('live') as unknown as {
+        onSnapshot(cb: (snap: { docs: Array<{ id: string }> }) => void): () => void;
+      }
+    ).onSnapshot((snap) => {
+      queryFires.push(JSON.stringify(snap.docs.map((d) => d.id)));
+    });
+    await tick();
+    expect(docFires).toHaveLength(1); // initial snapshots only
+    expect(queryFires).toHaveLength(1);
+
+    // Unrelated activity on the shared worker sandbox — none of it touches
+    // live/*, so neither listener may fire.
+    await workerOp(ctx, {
+      method: 'setDoc', path: 'other/doc', data: { x: 1 }, actAs: { mode: 'admin' },
+    });
+    await workerOp(ctx, { method: 'rtdb.set', path: 'presence/x', value: { on: true } });
+    await workerOp(ctx, {
+      method: 'auth.createUser', email: 'ambient@example.com', password: 'pw-123456',
+    });
+    await workerOp(ctx, { method: 'exportState' }); // the persistence-flush read path
+    await workerOp(ctx, { method: 'admin.readState' });
+    await workerOp(ctx, { method: 'getDoc', path: 'live/check', actAs: { mode: 'admin' } }); // Studio-like reads
+    await workerOp(ctx, {
+      method: 'getDocs', source: { __ref: 'collection', path: 'other' }, actAs: { mode: 'admin' },
+    });
+    // Peer churn — the trigger the live cadence came from.
+    for (let i = 0; i < 3; i++) {
+      connectTab(bridge, ctx);
+      await tick();
+    }
+    await tick(50);
+    expect(docFires).toHaveLength(1); // zero spurious emissions
+    expect(queryFires).toHaveLength(1);
+
+    // Legitimate changes still deliver — rapid consecutive writes are two
+    // distinct emissions, and a change made right after churn delivers too.
+    await db.doc('live/check').set({ n: 2, at: 'fixed' });
+    await db.doc('live/check').set({ n: 3, at: 'fixed' });
+    await tick();
+    expect(docFires).toHaveLength(3);
+    expect(docFires[2]).toBe(JSON.stringify({ n: 3, at: 'fixed' }));
+    expect(queryFires).toHaveLength(3);
+  });
+
   it('a denied listener routes to onError with the local arm error shape', async () => {
     const { remote } = makeStack({ rules: MATRIX_RULES });
     const db = getFirestore(remote.withAuth({ uid: 'bob' }));

--- a/packages/pyric-tools/src/bridge/client/bridge.ts
+++ b/packages/pyric-tools/src/bridge/client/bridge.ts
@@ -13,6 +13,15 @@
  * Reconnect strategy: simple exponential backoff up to 30s. The
  * connection is best-effort — if the bridge is down the host app
  * keeps working; tool calls just won't reach an external agent.
+ *
+ * Standby: when the bridge closes this connection with the REPLACED code
+ * (another tab registered and won the last-connection-wins slot), the client
+ * does NOT re-hello — that would kick the winner right back out and the two
+ * tabs would fight forever. It health-polls the serve origin at a gentle
+ * jittered cadence and reconnects only once `sandboxConnected` is false
+ * (the winning tab closed or refreshed). Every other close keeps the
+ * immediate reconnect loop — that path is what makes tab-refresh takeover
+ * work.
  */
 
 import type { Sandbox } from 'pyric/sandbox';
@@ -31,6 +40,7 @@ import {
   assertJsonSafeRelayValue,
   DEFAULT_BRIDGE_PORT,
   DEFAULT_SANDBOX_PATH,
+  PEER_REPLACED_CLOSE_CODE,
   WORKER_RELAY_CAPABILITY,
 } from '../protocol.js';
 import { dispatchSandboxTool, SANDBOX_TOOL_NAMES } from './dispatch.js';
@@ -62,6 +72,16 @@ export interface ConnectBridgeOptions {
   initialReconnectDelayMs?: number;
   /** Max reconnect delay in ms (default 30_000). */
   maxReconnectDelayMs?: number;
+  /**
+   * Standby poll interval in ms (default 2_000). When the bridge closes this
+   * connection with the REPLACED code (another tab took the peer slot), the
+   * client polls the health endpoint at this cadence — plus per-poll jitter,
+   * so two standby tabs don't stampede a freshly vacant slot — and only
+   * reconnects when `sandboxConnected` is false.
+   */
+  standbyPollMs?: number;
+  /** Injectable fetch for the standby health poll (tests). Default: global. */
+  fetchImpl?: typeof fetch;
   /**
    * Disable the auto-reconnect loop (useful in tests where the test
    * harness explicitly controls connection lifecycle).
@@ -95,7 +115,14 @@ export type ConnectedBridgeState =
   | { kind: 'connecting' }
   | { kind: 'connected'; bridgeVersion: string }
   | { kind: 'disconnected'; reason: string }
-  | { kind: 'reconnecting'; attempt: number; delayMs: number };
+  | { kind: 'reconnecting'; attempt: number; delayMs: number }
+  /**
+   * Another tab holds the peer slot (this connection was closed with the
+   * REPLACED code). The client health-polls until the slot is vacant, then
+   * reconnects. Distinct from `reconnecting`: the bridge is healthy and
+   * deliberately serving a different tab.
+   */
+  | { kind: 'standby' };
 
 export interface SandboxToolDispatcher {
   /**
@@ -119,6 +146,14 @@ export interface ConnectedBridge {
 
 const DEFAULT_INITIAL_DELAY = 500;
 const DEFAULT_MAX_DELAY = 30_000;
+const DEFAULT_STANDBY_POLL_MS = 2_000;
+/** Per-poll jitter as a fraction of the poll interval (0..50% added), so two
+ *  standby tabs don't race a freshly vacant slot in lockstep. */
+const STANDBY_POLL_JITTER_RATIO = 0.5;
+/** Consecutive unreachable/unparseable health polls before standby gives up
+ *  and falls back to the plain reconnect loop (a restarted server has a
+ *  vacant slot but may briefly serve nothing). */
+const STANDBY_MAX_POLL_FAILURES = 3;
 
 export function connectBridge(
   sandbox: Sandbox,
@@ -132,6 +167,10 @@ export function connectBridge(
   const maxDelay = opts.maxReconnectDelayMs ?? DEFAULT_MAX_DELAY;
   const noReconnect = opts.noReconnect ?? false;
   const onStateChange = opts.onStateChange ?? (() => {});
+  const standbyPollMs = opts.standbyPollMs ?? DEFAULT_STANDBY_POLL_MS;
+  // Wrap rather than alias: an unbound `window.fetch` reference throws
+  // "Illegal invocation" in browsers.
+  const fetchImpl = opts.fetchImpl ?? ((input: Parameters<typeof fetch>[0]) => fetch(input));
 
   const workerRelay = opts.workerRelay ?? null;
 
@@ -139,6 +178,8 @@ export function connectBridge(
   let closed = false;
   let attempt = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let standbyTimer: ReturnType<typeof setTimeout> | null = null;
+  let standbyPollFailures = 0;
   let currentState: ConnectedBridgeState = { kind: 'connecting' };
   /** Live relay subscriptions (bridge subId → worker unsubscribe). Torn down
    *  on every socket close: the bridge re-issues its registry to the NEXT
@@ -247,6 +288,15 @@ export function connectBridge(
       // and re-issues it after the next hello, so live worker listeners from
       // THIS connection must go now (or the next connection double-delivers).
       teardownRelaySubs();
+      if (event.code === PEER_REPLACED_CLOSE_CODE) {
+        // Another tab won the peer slot. Re-helloing now would kick it right
+        // back out (last-connection-wins) and the two tabs would fight over
+        // the slot forever — re-firing every relayed subscription and
+        // failing all in-flight worker ops once per cycle. Go standby:
+        // health-poll until the slot is genuinely vacant.
+        enterStandby();
+        return;
+      }
       scheduleReconnect(reason);
     };
 
@@ -351,6 +401,86 @@ export function connectBridge(
     }
   }
 
+  // ── Standby: another tab holds the peer slot ─────────────────────────────
+
+  /**
+   * Health endpoints to poll while in standby, derived from the WS url —
+   * same host, http(s) for ws(s). `pyric dev` mounts `/__pyric/health`
+   * (bridge-mount.ts); the standalone bridge serves `/health` — try both.
+   */
+  function healthUrls(): string[] {
+    try {
+      const u = new URL(url);
+      u.protocol = u.protocol === 'wss:' ? 'https:' : 'http:';
+      const base = u.origin;
+      return [`${base}/__pyric/health`, `${base}/health`];
+    } catch {
+      return [];
+    }
+  }
+
+  function enterStandby() {
+    if (closed) return;
+    if (noReconnect) {
+      setState({ kind: 'disconnected', reason: 'replaced by a newer sandbox peer' });
+      return;
+    }
+    attempt = 0;
+    standbyPollFailures = 0;
+    setState({ kind: 'standby' });
+    scheduleStandbyPoll();
+  }
+
+  function scheduleStandbyPoll() {
+    if (closed) return;
+    const delay = standbyPollMs * (1 + Math.random() * STANDBY_POLL_JITTER_RATIO);
+    standbyTimer = setTimeout(() => {
+      standbyTimer = null;
+      void pollForVacantSlot();
+    }, delay);
+  }
+
+  async function pollForVacantSlot(): Promise<void> {
+    if (closed) return;
+    // null = health unreadable (unreachable / non-JSON / shape drift).
+    let vacant: boolean | null = null;
+    for (const target of healthUrls()) {
+      try {
+        const res = await fetchImpl(target);
+        if (!res.ok) continue;
+        const body = (await res.json()) as { sandboxConnected?: unknown };
+        if (typeof body.sandboxConnected === 'boolean') {
+          vacant = !body.sandboxConnected;
+          break;
+        }
+      } catch {
+        // try the next candidate
+      }
+    }
+    if (closed) return;
+    if (vacant === true) {
+      // The winning tab is gone (refresh / close) — claim the slot. The
+      // bridge replays its sub registry to us on hello; its re-issue dedup
+      // keeps unchanged listeners quiet.
+      connect();
+      return;
+    }
+    if (vacant === false) {
+      standbyPollFailures = 0;
+      scheduleStandbyPoll();
+      return;
+    }
+    // Health unreadable: a restarting server has a vacant slot but may
+    // briefly serve nothing. After a few consecutive failures fall back to
+    // the plain reconnect loop rather than idling in standby forever.
+    standbyPollFailures += 1;
+    if (standbyPollFailures >= STANDBY_MAX_POLL_FAILURES) {
+      scheduleReconnect('standby health poll unreachable');
+      return;
+    }
+    scheduleStandbyPoll();
+  }
+
   function scheduleReconnect(reason: string) {
     if (closed) return;
     if (noReconnect) {
@@ -376,6 +506,10 @@ export function connectBridge(
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
+      }
+      if (standbyTimer) {
+        clearTimeout(standbyTimer);
+        standbyTimer = null;
       }
       if (ws) {
         try {

--- a/packages/pyric-tools/src/bridge/protocol.ts
+++ b/packages/pyric-tools/src/bridge/protocol.ts
@@ -57,6 +57,22 @@ export const DEFAULT_MCP_PATH = '/mcp';
 /** Default health endpoint path. */
 export const DEFAULT_HEALTH_PATH = '/health';
 
+/**
+ * WS close code the transport sends a sandbox peer when a NEWER registration
+ * displaces it (last-connection-wins). Application-defined (4000–4999 per RFC
+ * 6455 §7.4.2) so it survives every WS stack verbatim. The browser client
+ * treats this close as "the slot is legitimately held by another tab" and
+ * enters STANDBY (poll the health endpoint, reconnect only when the slot is
+ * vacant) instead of re-helloing — two open tabs used to kick each other in a
+ * perpetual last-wins fight, re-firing every relayed subscription and failing
+ * all in-flight worker ops once per cycle. Any OTHER close (server restart,
+ * network drop, tab-refresh takeover) keeps the immediate-reconnect loop.
+ */
+export const PEER_REPLACED_CLOSE_CODE = 4001;
+
+/** Human-readable reason sent with {@link PEER_REPLACED_CLOSE_CODE}. */
+export const PEER_REPLACED_CLOSE_REASON = 'replaced by a newer sandbox peer';
+
 // ── Bridge ↔ browser WebSocket protocol ──────────────────────────────
 //
 // All messages are JSON. Each message has a `type` discriminator.

--- a/packages/pyric-tools/src/bridge/server/bridge.ts
+++ b/packages/pyric-tools/src/bridge/server/bridge.ts
@@ -216,6 +216,27 @@ interface PendingWorkerOp {
 interface WorkerSubEntry {
   sub: WorkerSubPayload;
   onSnap: (value: unknown) => void;
+  /**
+   * JSON of the last snap value delivered to `onSnap` — the re-issue dedup
+   * baseline. Lives on the bridge-side entry because this registry is the
+   * only state that SURVIVES peer churn (the browser tab and the worker
+   * listener are both rebuilt per peer).
+   */
+  lastDeliveredJson?: string;
+  /**
+   * Set when this sub was just (re-)issued to a newly registered peer and
+   * the next inbound snap is the fresh listener's INITIAL snapshot. When
+   * that snapshot is byte-identical to `lastDeliveredJson`, nothing changed
+   * while the peer churned and the frame is suppressed — real Firestore /
+   * RTDB listeners fire on CHANGE, not on transport reconnection. Live,
+   * two tabs fighting over last-wins registration (each reconnecting after
+   * ~500ms) re-issued every sub once per registration, so a consumer's
+   * doc listener fired ~1/sec with identical data forever. A snapshot that
+   * DIFFERS from the baseline (state changed while no peer was attached)
+   * still delivers. Scoped to the one-frame re-issue window so steady-state
+   * delivery is untouched.
+   */
+  awaitingReissueSnap?: boolean;
 }
 
 /** Build the typed Error worker-op rejections carry. `denialContext` (spike
@@ -307,12 +328,16 @@ export function createBridge(opts: BridgeOptions): Bridge {
       onReplaced,
     };
     peer = myPeer;
-    // Re-issue every registered worker subscription to the new peer. RTDB
-    // value / auth-state semantics make this safe and cursor-free: each
-    // (re)subscribe delivers a fresh initial snapshot and consumers are
-    // last-value-wins, so the Node side just sees one extra snapshot.
+    // Re-issue every registered worker subscription to the new peer — the
+    // replay is cursor-free because each (re)subscribe delivers a fresh
+    // initial snapshot. That snapshot is a DUPLICATE whenever nothing
+    // changed while the peer churned, so `awaitingReissueSnap` arms the
+    // per-sub dedup (see WorkerSubEntry) — without it, tabs cycling through
+    // last-wins registration re-fire every consumer listener with
+    // byte-identical data on every registration.
     if (myPeer.capabilities.has(WORKER_RELAY_CAPABILITY)) {
       for (const [subId, entry] of workerSubs) {
+        entry.awaitingReissueSnap = true;
         try {
           myPeer.send({ type: 'worker-sub', subId, sub: entry.sub });
         } catch {
@@ -527,6 +552,18 @@ export function createBridge(opts: BridgeOptions): Bridge {
         const snap = msg as WorkerSnapFrame;
         const entry = workerSubs.get(snap.subId);
         if (!entry) return; // unsubscribed or unknown — drop silently
+        // Re-issue dedup (see WorkerSubEntry.awaitingReissueSnap): the first
+        // snap after a peer (re)registration is the re-established listener's
+        // initial snapshot — suppress it when byte-identical to what the
+        // consumer already holds. Values are JSON-clean (they crossed the WS
+        // legs) and produced by the same serializer each time, so string
+        // equality is exact. One-frame window: the flag clears on the first
+        // snap either way, keeping steady-state delivery 1:1.
+        const json = JSON.stringify(snap.value);
+        const duplicate = entry.awaitingReissueSnap === true && json === entry.lastDeliveredJson;
+        entry.awaitingReissueSnap = false;
+        entry.lastDeliveredJson = json;
+        if (duplicate) return;
         try {
           entry.onSnap(snap.value);
         } catch {

--- a/packages/pyric-tools/src/bridge/server/peer.ts
+++ b/packages/pyric-tools/src/bridge/server/peer.ts
@@ -15,7 +15,12 @@
 import type { IncomingMessage } from 'node:http';
 import type { WebSocket } from 'ws';
 import { createBridge, type Bridge } from './bridge.js';
-import { isBridgeMessage, type BridgeMessage } from '../protocol.js';
+import {
+  isBridgeMessage,
+  PEER_REPLACED_CLOSE_CODE,
+  PEER_REPLACED_CLOSE_REASON,
+  type BridgeMessage,
+} from '../protocol.js';
 import { pyricToolsVersion } from '../../pkg-version.js';
 
 export function attachPeer(
@@ -74,9 +79,13 @@ export function attachPeer(
         // handler tears down its relayed worker subscriptions, so a
         // replaced tab's SharedWorker listeners don't keep streaming
         // snaps the bridge drops as stale-generation until the tab closes.
+        // The REPLACED close code tells that client to go STANDBY (health-
+        // poll for a vacant slot) instead of re-helloing — an immediate
+        // re-hello would kick the new peer right back, and two open tabs
+        // would fight over the slot forever.
         () => {
           try {
-            ws.close();
+            ws.close(PEER_REPLACED_CLOSE_CODE, PEER_REPLACED_CLOSE_REASON);
           } catch {}
         },
       );

--- a/packages/pyric-tools/test/bridge/peer-standby.test.ts
+++ b/packages/pyric-tools/test/bridge/peer-standby.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Peer standby — the fix for the two-tab peer-slot fight.
+ *
+ * Live failure mode: an app tab and a Studio tab both run `connectBridge`.
+ * Last-connection-wins registration closes the replaced peer's socket, whose
+ * reconnect loop re-helloed ~500ms later and kicked the other tab — forever.
+ * Beyond the duplicate-snapshot spam (deduped in the bridge core), every
+ * replacement fails ALL in-flight worker ops (`failAllPending`), so any op
+ * slower than the fight cycle (large storage putBytes, slow transactions)
+ * failed intermittently with 'unavailable'.
+ *
+ * The fix: the transport closes a replaced peer with
+ * PEER_REPLACED_CLOSE_CODE, and the client treats that close as "the slot is
+ * legitimately held" — it enters STANDBY (jittered health polling) and only
+ * reconnects when `sandboxConnected` is false. Network-drop closes keep the
+ * immediate reconnect loop (tab-refresh takeover depends on it).
+ *
+ * Harness: the REAL `connectBridge` client over a linked fake socket pair —
+ * the browser half satisfies the WebSocket global, the server half is fed to
+ * the REAL `attachPeer`, so hello/hello-ack, replacement close codes, and
+ * generation tagging all run production code in-process. Health polls hit a
+ * stub fetch that reports the REAL bridge's `health()`.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { createBridge, type Bridge } from '../../src/bridge/server/bridge.js';
+import { attachPeer } from '../../src/bridge/server/peer.js';
+import { PEER_REPLACED_CLOSE_CODE } from '../../src/bridge/protocol.js';
+import {
+  connectBridge,
+  type ConnectedBridge,
+  type ConnectBridgeOptions,
+} from '../../src/bridge/client/bridge.js';
+
+// ── Linked fake socket pair (browser WebSocket ⇄ ws-lib socket) ────────────
+
+type ServerHandler = (...args: unknown[]) => void;
+
+class LinkedWebSocket {
+  static OPEN = 1;
+  static instances: LinkedWebSocket[] = [];
+  /** Set by installLinkedWebSocket — every new socket attaches here. */
+  static bridge: Bridge | null = null;
+
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  private serverHandlers = new Map<string, ServerHandler>();
+
+  constructor(public url: string) {
+    LinkedWebSocket.instances.push(this);
+    // The server side accepts the connection and attaches the REAL peer
+    // transport. Open async — connectBridge assigns onopen after construction.
+    attachPeer(LinkedWebSocket.bridge!, this.serverSide());
+    queueMicrotask(() => {
+      if (this.readyState !== 0) return; // already closed
+      this.readyState = 1;
+      this.onopen?.();
+    });
+  }
+
+  /** The `ws`-shaped socket `attachPeer` consumes. */
+  private serverSide() {
+    const self = this;
+    return {
+      on(event: string, cb: ServerHandler) {
+        self.serverHandlers.set(event, cb);
+        return this;
+      },
+      send(data: string) {
+        self.onmessage?.({ data });
+      },
+      close(code?: number, reason?: string) {
+        self.closeFromServer(code ?? 1000, reason ?? '');
+      },
+    } as unknown as Parameters<typeof attachPeer>[1];
+  }
+
+  // browser → server
+  send(data: string): void {
+    this.serverHandlers.get('message')?.(data);
+  }
+
+  // client-initiated close (disconnect())
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.serverHandlers.get('close')?.();
+    this.onclose?.({ code: 1000, reason: 'closed by client' });
+  }
+
+  private closeFromServer(code: number, reason: string): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.serverHandlers.get('close')?.();
+    this.onclose?.({ code, reason });
+  }
+
+  /** Abrupt network drop: no server close frame semantics, code 1006. */
+  dropFromNetwork(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.serverHandlers.get('close')?.();
+    this.onclose?.({ code: 1006, reason: '' });
+  }
+}
+
+function installLinkedWebSocket(bridge: Bridge): () => void {
+  const prev = (globalThis as { WebSocket?: unknown }).WebSocket;
+  LinkedWebSocket.instances = [];
+  LinkedWebSocket.bridge = bridge;
+  (globalThis as { WebSocket?: unknown }).WebSocket = LinkedWebSocket;
+  return () => {
+    (globalThis as { WebSocket?: unknown }).WebSocket = prev;
+    LinkedWebSocket.bridge = null;
+  };
+}
+
+/** Stub fetch serving the REAL bridge health at /__pyric/health. */
+function healthFetch(bridge: Bridge): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const target = String(input);
+    if (!target.endsWith('/__pyric/health') && !target.endsWith('/health')) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(JSON.stringify(bridge.health()), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+function tick(ms = 5): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Harness state ───────────────────────────────────────────────────────────
+
+let restoreWs: (() => void) | null = null;
+const connections: ConnectedBridge[] = [];
+
+afterEach(() => {
+  for (const c of connections) c.disconnect();
+  connections.length = 0;
+  restoreWs?.();
+  restoreWs = null;
+});
+
+function makeStack() {
+  const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+  restoreWs = installLinkedWebSocket(bridge);
+  return bridge;
+}
+
+function connectClient(
+  bridge: Bridge,
+  overrides: Partial<ConnectBridgeOptions> & {
+    onWorkerOp?: (method: string) => Promise<unknown>;
+  } = {},
+) {
+  const { onWorkerOp, ...opts } = overrides;
+  const states: string[] = [];
+  let onSubscribe: (() => void) | null = null;
+  const conn = connectBridge(initializeSandbox(), {
+    url: 'ws://localhost:5000/__pyric/sandbox',
+    initialReconnectDelayMs: 10,
+    standbyPollMs: 20,
+    fetchImpl: healthFetch(bridge),
+    onStateChange: (s) => states.push(s.kind),
+    workerRelay: {
+      op: onWorkerOp
+        ? (op) => onWorkerOp(op.method)
+        : async () => ({ ok: true }),
+      subscribe: () => {
+        onSubscribe?.();
+        return () => {};
+      },
+    },
+    ...opts,
+  });
+  connections.push(conn);
+  return {
+    conn,
+    states,
+    socket: () => LinkedWebSocket.instances[LinkedWebSocket.instances.length - 1]!,
+    subscribeCalls: (cb: () => void) => {
+      onSubscribe = cb;
+    },
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('peer standby — replaced tabs stop fighting for the slot', () => {
+  it('the transport closes a replaced peer with the REPLACED code', async () => {
+    const bridge = makeStack();
+    const a = connectClient(bridge);
+    await tick(20);
+    const socketA = a.socket();
+    expect(bridge.isSandboxConnected()).toBe(true);
+
+    let closeSeen: { code: number; reason: string } | null = null;
+    const prevOnClose = socketA.onclose;
+    socketA.onclose = (ev) => {
+      closeSeen = ev;
+      prevOnClose?.(ev);
+    };
+
+    connectClient(bridge); // tab B wins the slot
+    await tick(20);
+    expect(closeSeen!.code).toBe(PEER_REPLACED_CLOSE_CODE);
+    expect(closeSeen!.reason).toContain('replaced');
+  });
+
+  it('a replaced client goes STANDBY and does not re-hello while a peer is healthy', async () => {
+    const bridge = makeStack();
+    const a = connectClient(bridge);
+    await tick(20);
+    connectClient(bridge); // tab B replaces tab A
+    await tick(20);
+
+    expect(a.conn.state().kind).toBe('standby');
+    const genAfterReplacement = bridge.peerGeneration();
+    const socketsAfterReplacement = LinkedWebSocket.instances.length;
+
+    // Pre-fix, tab A re-helloed after initialReconnectDelayMs (10ms here) and
+    // kicked tab B — generations churned continuously. Post-fix: many standby
+    // poll cycles pass (20ms cadence over 300ms) with zero new connections.
+    await tick(300);
+    expect(bridge.peerGeneration()).toBe(genAfterReplacement);
+    expect(LinkedWebSocket.instances.length).toBe(socketsAfterReplacement);
+    expect(a.conn.state().kind).toBe('standby');
+    expect(bridge.isSandboxConnected()).toBe(true); // tab B still holds the slot
+  });
+
+  it('a standby client claims the slot once the winner disconnects (tab refresh takeover)', async () => {
+    const bridge = makeStack();
+    const a = connectClient(bridge);
+    await tick(20);
+    const b = connectClient(bridge);
+    await tick(20);
+    expect(a.conn.state().kind).toBe('standby');
+
+    // The bridge holds a consumer sub — on takeover the registry must replay
+    // to the reclaiming tab (its relay `subscribe` is invoked; the re-issue
+    // DEDUP semantics themselves are covered in worker-relay.test.ts).
+    let subReplayedToA = false;
+    a.subscribeCalls(() => {
+      subReplayedToA = true;
+    });
+    bridge.subscribeWorker({ target: { __ref: 'doc', path: 'x/y' } } as never, () => {});
+
+    // "Winner refreshes": its socket drops; the slot is vacant.
+    b.conn.disconnect();
+    expect(bridge.isSandboxConnected()).toBe(false);
+
+    // Tab A's next health poll sees sandboxConnected:false and reconnects.
+    await tick(120);
+    expect(a.conn.state().kind).toBe('connected');
+    expect(bridge.isSandboxConnected()).toBe(true);
+    expect(subReplayedToA).toBe(true); // sub registry replayed on reclaim
+  });
+
+  it('a brand-new tab still wins the slot immediately (last-connection-wins unchanged)', async () => {
+    const bridge = makeStack();
+    connectClient(bridge);
+    await tick(20);
+    const genA = bridge.peerGeneration();
+
+    const b = connectClient(bridge);
+    await tick(20);
+    expect(bridge.peerGeneration()).toBe(genA + 1);
+    expect(b.conn.state().kind).toBe('connected');
+    expect(bridge.isSandboxConnected()).toBe(true);
+  });
+
+  it('network-drop closes keep the immediate reconnect loop (no health gate)', async () => {
+    const bridge = makeStack();
+    const a = connectClient(bridge);
+    await tick(20);
+    expect(a.conn.state().kind).toBe('connected');
+    const socketsBefore = LinkedWebSocket.instances.length;
+
+    a.socket().dropFromNetwork(); // code 1006 — not a replacement
+    await tick(60); // > initialReconnectDelayMs (10ms)
+
+    expect(LinkedWebSocket.instances.length).toBe(socketsBefore + 1);
+    expect(a.conn.state().kind).toBe('connected'); // re-helloed and re-acked
+    expect(a.states).toContain('reconnecting'); // took the reconnect path, not standby
+    expect(a.states).not.toContain('standby');
+    expect(bridge.isSandboxConnected()).toBe(true);
+  });
+
+  it('an in-flight worker op SURVIVES two-tab standby steady-state (the churn regression)', async () => {
+    const bridge = makeStack();
+    // Tab A: slow relay — its ops take 150ms, longer than many pre-fix fight
+    // cycles (10ms reconnect delay here). Pre-fix, tab B's re-hello landed
+    // mid-op and failAllPending rejected it with 'unavailable'.
+    connectClient(bridge, {
+      onWorkerOp: async () => {
+        await tick(150);
+        return { slow: true };
+      },
+    });
+    await tick(20);
+    // Tab B arrives, wins the slot with the same slow relay, and tab A goes
+    // standby instead of fighting back.
+    connectClient(bridge, {
+      onWorkerOp: async () => {
+        await tick(150);
+        return { slow: true };
+      },
+    });
+    await tick(20);
+
+    const result = await bridge.dispatchWorkerOp({ method: 'getVersion' } as never);
+    expect(result).toEqual({ slow: true });
+  });
+});

--- a/packages/pyric-tools/test/bridge/worker-relay.test.ts
+++ b/packages/pyric-tools/test/bridge/worker-relay.test.ts
@@ -455,17 +455,19 @@ describe('worker relay — peer replacement and reconnect', () => {
     expect(snaps).toHaveLength(1); // initial via tab A
 
     // Tab "refresh": a NEW tab registers (last-connection-wins). The bridge
-    // re-issues the sub registry to tab B; tab A's still-live deliveries are
+    // re-issues the sub registry to tab B; tab B's fresh initial snapshot is
+    // byte-identical to what the consumer already holds (nothing changed) so
+    // it is suppressed, and tab A's still-live deliveries are
     // stale-generation and must not reach the consumer.
     connectTab(bridge, ctx);
     await tick();
-    expect(snaps).toHaveLength(2); // exactly ONE extra initial snap (tab B); tab A delivers nothing
+    expect(snaps).toHaveLength(1); // NO delivery: listeners fire on change, not on peer churn
 
     await node.rtdb.set('game/state', { round: 2 });
     await tick();
     // Both tabs' worker ports fire; only tab B's (current generation) lands.
-    expect(snaps).toHaveLength(3);
-    expect(snaps[2]!.value).toEqual({ round: 2 });
+    expect(snaps).toHaveLength(2);
+    expect(snaps[1]!.value).toEqual({ round: 2 });
   });
 
   it('replacement tears the old peer down: onReplaced fires and its relayed worker subs unsubscribe', async () => {
@@ -524,15 +526,103 @@ describe('worker relay — peer replacement and reconnect', () => {
     // Ops while no peer is connected fail fast with the same guidance.
     await expect(node.rtdb.get('doc')).rejects.toThrow(/open http:\/\/localhost:5000/);
 
-    // A new tab connects: the bridge re-issues the sub; ops work again.
+    // A new tab connects: the bridge re-issues the sub (ops work again), but
+    // the re-established listener's initial snapshot matches what the
+    // consumer already holds — suppressed, not re-delivered.
     connectTab(bridge, ctx);
     await tick();
-    expect(snaps).toHaveLength(2); // fresh initial snapshot from the new peer
+    expect(snaps).toHaveLength(1); // unchanged across the gap ⇒ no re-fire
 
     await node.rtdb.set('doc', { alive: true });
     await tick();
+    expect(snaps).toHaveLength(2);
     expect(snaps[snaps.length - 1]!.value).toEqual({ alive: true });
     expect(await node.rtdb.get('doc')).toEqual({ alive: true });
+  });
+
+  it('repeated peer churn re-fires NOTHING while state is unchanged (doc + query listener)', async () => {
+    // The live "snapshot spam" bug: two tabs (app + Studio) cycling through
+    // last-wins registration re-issued every sub once per registration, and
+    // each re-issued listener's initial snapshot reached the consumer — a
+    // remote onSnapshot fired ~1/sec with byte-identical data, forever. A
+    // consumer whose callback writes anything becomes an infinite write loop.
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await node.channel.op({
+      method: 'setDoc', path: 'live/check', data: { n: 1, at: 'fixed' }, actAs: { mode: 'admin' },
+    });
+
+    const docSnaps: unknown[] = [];
+    const querySnaps: unknown[] = [];
+    node.channel.subscribe(
+      { target: { __ref: 'doc', path: 'live/check' }, actAs: { mode: 'admin' } },
+      (v) => docSnaps.push(v),
+    );
+    node.channel.subscribe(
+      { target: { __ref: 'collection', path: 'live' }, actAs: { mode: 'admin' } },
+      (v) => querySnaps.push(v),
+    );
+    await tick();
+    expect(docSnaps).toHaveLength(1); // initial snapshots only
+    expect(querySnaps).toHaveLength(1);
+
+    // Five churn cycles — pre-fix each one delivered a duplicate per sub.
+    for (let i = 0; i < 5; i++) {
+      connectTab(bridge, ctx);
+      await tick();
+    }
+    expect(docSnaps).toHaveLength(1); // zero extra emissions
+    expect(querySnaps).toHaveLength(1);
+
+    // Legitimate changes still deliver 1:1 — including rapid consecutive
+    // writes (two real changes = two emissions, never collapsed).
+    await node.channel.op({
+      method: 'setDoc', path: 'live/check', data: { n: 2, at: 'fixed' }, actAs: { mode: 'admin' },
+    });
+    await node.channel.op({
+      method: 'setDoc', path: 'live/check', data: { n: 3, at: 'fixed' }, actAs: { mode: 'admin' },
+    });
+    await tick();
+    expect(docSnaps).toHaveLength(3);
+    expect(querySnaps).toHaveLength(3);
+  });
+
+  it('re-issue DELIVERS when state changed while no peer was attached', async () => {
+    const bridge = makeRelayBridge();
+    const ctx = await makeWorkerCtx();
+    const tabA = connectTab(bridge, ctx);
+    const node = connectNode(bridge);
+    await node.core.ready;
+
+    await node.channel.op({
+      method: 'setDoc', path: 'gap/doc', data: { v: 1 }, actAs: { mode: 'admin' },
+    });
+    const snaps: Array<{ data?: { json?: string } }> = [];
+    node.channel.subscribe(
+      { target: { __ref: 'doc', path: 'gap/doc' }, actAs: { mode: 'admin' } },
+      (v) => snaps.push(v as { data?: { json?: string } }),
+    );
+    await tick();
+    expect(snaps).toHaveLength(1);
+
+    // Peer drops; the doc changes while nobody is attached (another client of
+    // the same worker — modelled as a direct port write to the shared ctx).
+    tabA.disconnect();
+    await handleMessage(ctx, { postMessage() {} }, {
+      t: 'op', id: 'gap-1', method: 'setDoc', path: 'gap/doc',
+      data: { v: 2 }, actAs: { mode: 'admin' },
+    } as InboundMessage);
+
+    // New peer: the re-issued listener's initial snapshot DIFFERS from the
+    // dedup baseline — it must deliver (suppression is duplicate-only).
+    connectTab(bridge, ctx);
+    await tick();
+    expect(snaps).toHaveLength(2);
+    expect(JSON.parse(snaps[1]!.data!.json!)).toEqual({ v: 2 });
   });
 
   it('attachPeer closes the replaced peer\'s socket (onReplaced → ws.close)', async () => {


### PR DESCRIPTION
Two defects found by a live listener left running during the pre-publish check, both in the bridge's connection-lifecycle layer (sandbox, worker host, and wire relay all proven clean by a headless emission matrix — and the in-page local arm was never affected).

## Duplicate snapshots on peer registration

The bridge re-issues every worker subscription to each newly registered peer, and the re-established listener's initial snapshot was delivered to consumers verbatim — a duplicate, byte-identical emission per registration. Two existing tests had enshrined the duplicate as acceptable. Fix: a per-subscription re-issue window in the bridge core suppresses the first post-re-issue snap iff it is byte-identical to the last delivered value. State changed while detached still delivers; steady-state delivery untouched; two rapid real changes remain two emissions. The spurious-emission matrix (unrelated firestore/rtdb/auth/storage/state activity, second-port reads, 5 churn cycles) now measures +0.

## Perpetual peer-slot fighting

Last-connection-wins + every replaced client immediately re-helloing = two open tabs (app page + Studio) kicking each other ~once per second, forever. That produced the visible snapshot spam cadence and a sharper hazard: the bridge fails all in-flight ops on replacement, so any op slower than the fight cycle would fail intermittently. Fix: replacement closes the old peer with WS close code 4001 ("replaced"); a client seeing 4001 enters standby — jittered health polling, reclaiming only when the slot is genuinely vacant — while non-4001 closes keep today's immediate reconnect (tab-refresh takeover preserved; fresh tab still wins instantly). Three unreadable polls fall back to the plain reconnect loop so a restarted server is never waited on forever.

## Verification

New tests fail pre-fix (verified by stashing the fix): 5-duplicates-per-5-churns → 0; standby holds with zero reconnects across poll cycles; a 150ms in-flight op survives two-tab steady state. Full suites green: pyric 4338, pyric-admin 566, pyric-tools 1205, root test exit 0; tsc clean.

Recommended live verification after merge: `live-check.mjs` under `pyric dev` with BOTH the app tab and Studio open for a couple of minutes — one `snap:` per Studio edit, silence otherwise, no reconnect flapping in the serve log.