### PR TITLE
Real-browser soak harness for the bridge lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/pyric-tools && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun test scripts/tool-parity.test.mjs",
     "tool:parity": "bun run scripts/tool-parity.mjs",
     "tool:parity:check": "bun run scripts/tool-parity.mjs --check",
+    "test:soak": "bun run --cwd packages/pyric-tools test:soak",
     "test:packaging": "bash scripts/packaging-test.sh",
     "test:install-matrix": "bash scripts/install-matrix.sh",
     "lint:manifest": "bash scripts/manifest-lint.sh",

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -84,6 +84,7 @@
   "scripts": {
     "build": "tsc && bun run scripts/postbuild.ts",
     "test": "bun test",
+    "test:soak": "playwright test --config test/e2e/soak/playwright.config.ts",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",
     "compile": "bun scripts/compile.ts",
     "release": "bun scripts/release.ts",

--- a/packages/pyric-tools/test/e2e/README.md
+++ b/packages/pyric-tools/test/e2e/README.md
@@ -15,6 +15,17 @@ The CI guard for the fix is the unit test `test/serve/worker/random-uuid.test.ts
 - `fixture/` — a minimal firebase/* app (`signInWithPopup` + `onAuthStateChanged`).
 - `auth-popup.pw.ts` — the test.
 - `playwright.config.ts` — `testMatch: **/*.pw.ts`; auto-starts `pyric dev` for localhost.
+- `soak/` — the bridge lifecycle soak suite (its own config; files are
+  `*.soak.ts`, so neither `bun test` nor this config picks them up). Each
+  scenario spawns a real `pyric dev --ui --bridge --no-open --port 0 --json`
+  serve and drives real tabs (app + Studio), a real Node remote client
+  (`pyric-tools/remote`), and the MCP streamable-HTTP endpoint — the
+  connection-lifecycle layer (peer slot, standby, sub re-issue dedup) that
+  headless tests can't see. On its first run it found the admin-lens
+  listener denial (pinned as an expected-fail test) and the stale
+  serve-bundle-cache masking of pyric-tools client fixes (the suite runs
+  `--no-cache`). Run from the repo root with `bun run test:soak` (same
+  prerequisites as below; ~1.5 minutes, the headline scenario soaks ~60s).
 
 ## Run (localhost — passes)
 ```sh

--- a/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
+++ b/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
@@ -1,0 +1,563 @@
+/**
+ * Real-browser soak suite for the bridge lifecycle layer.
+ *
+ * Every scenario runs the REAL stack end to end: a spawned
+ * `pyric dev --ui --bridge --no-open --port 0 --json` serve, real Chromium
+ * pages (app fixture + Pyric Studio) whose SharedWorker hosts the one
+ * sandbox, and a real Node-side remote client (`pyric-tools/remote`) over
+ * the bridge WS — the exact topology where five live-only bugs hid from
+ * ~7k green headless tests (Studio-tab peer, origin split, first-run child
+ * race, duplicate snapshots on re-registration, perpetual peer-slot
+ * fighting).
+ *
+ * Observation points (no product code added):
+ *  - `window.__wsLog` (test init script) counts each tab's bridge `hello`
+ *    registrations + close codes (4001 = replaced → standby).
+ *  - `/__pyric/health` (`sandboxConnected`) — the same signal the standby
+ *    poller and the dev-runner's first-run gate consume.
+ *  - the Node client's own listener callbacks (emission counts/payloads).
+ */
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+import { pathToFileURL } from 'node:url';
+import { connectRemoteSandbox, type RemoteSandbox } from 'pyric-tools/remote';
+import {
+  CLI_PATH,
+  McpHttpClient,
+  WS_INSTRUMENTATION,
+  health,
+  sleep,
+  startSoakServe,
+  waitFor,
+  waitForPeer,
+  type PageWsLog,
+  type SoakServe,
+} from './harness.js';
+
+// ─── shared helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Lens for the suite's Firestore SUBSCRIPTIONS. Deliberately NOT
+ * `{ mode: 'admin' }`: this suite found that a Firestore snapshot listener
+ * registered through the admin (rules-bypass) handle still rule-evaluates
+ * its reads as UNAUTHENTICATED and errors `permission-denied` under any
+ * auth-gated ruleset — ops bypass rules, listeners don't (see the dedicated
+ * scenario 7 below, which pins that finding). The impersonation lens gives
+ * the lifecycle scenarios a working listener so their invariants (dedup,
+ * handoff, fidelity) stay observable.
+ */
+const OBSERVER_LENS = { mode: 'as', uid: 'soak-observer' } as const;
+
+const wsLog = (page: Page): Promise<PageWsLog> =>
+  page.evaluate(() => (window as unknown as { __wsLog: PageWsLog }).__wsLog);
+
+/** Parse the worker's serialized Firestore doc snapshot. */
+function parseDocSnap(value: unknown): { exists: boolean; data: Record<string, unknown> | null } {
+  const snap = value as { exists: boolean; data?: { json: string } };
+  return { exists: snap.exists, data: snap.data ? (JSON.parse(snap.data.json) as Record<string, unknown>) : null };
+}
+
+/** Collects listener emissions + errors for exact-count assertions. */
+function makeCollector() {
+  const values: unknown[] = [];
+  const errors: Error[] = [];
+  return {
+    values,
+    errors,
+    onSnap: (v: unknown) => values.push(v),
+    onError: (e: Error) => errors.push(e),
+  };
+}
+
+/**
+ * Open two real tabs against the serve in a settled state: `first` connects
+ * and registers, `second` registers after it and wins the last-wins slot,
+ * `first` observes close 4001 and goes standby. Deterministic ordering —
+ * each step waits on an observable.
+ */
+async function openTwoTabs(
+  context: BrowserContext,
+  serve: SoakServe,
+  order: { first: string; second: string },
+): Promise<{ standbyTab: Page; winnerTab: Page }> {
+  const first = await context.newPage();
+  await first.goto(order.first);
+  await waitForPeer(serve.info.url);
+  await waitFor('first tab registered (hello sent)', async () => (await wsLog(first)).hellos >= 1);
+
+  const second = await context.newPage();
+  await second.goto(order.second);
+  await waitFor('second tab registered (hello sent)', async () => (await wsLog(second)).hellos >= 1, {
+    timeoutMs: 20_000,
+  });
+  // The replacement is the observable settlement signal: the first tab's
+  // socket must close with the REPLACED code (4001) and enter standby.
+  await waitFor('first tab replaced (close 4001)', async () =>
+    (await wsLog(first)).closes.includes(4001),
+  );
+  await waitForPeer(serve.info.url);
+  return { standbyTab: first, winnerTab: second };
+}
+
+async function newInstrumentedContext(browser: import('@playwright/test').Browser): Promise<BrowserContext> {
+  const context = await browser.newContext();
+  await context.addInitScript(WS_INSTRUMENTATION);
+  return context;
+}
+
+// ─── scenarios ───────────────────────────────────────────────────────────────
+
+test.describe('bridge lifecycle soak', () => {
+  test('1. two-tab steady-state soak: zero spurious emissions, stable peer slot, slow op mid-soak', async ({ browser }) => {
+    test.setTimeout(145_000);
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      expect(serve.info.uiUrl, 'serve must expose Studio (--ui)').toBeTruthy();
+      const { standbyTab, winnerTab } = await openTwoTabs(context, serve, {
+        first: serve.info.url,
+        second: serve.info.uiUrl!,
+      });
+
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      await sb.channel.op({ method: 'setDoc', path: 'soak/doc', data: { n: 0 }, actAs: { mode: 'admin' } });
+      await sb.rtdb.set('soak/presence', { on: true });
+
+      const doc = makeCollector();
+      const rtdb = makeCollector();
+      const unsubDoc = sb.channel.subscribe(
+        { target: { __ref: 'doc', path: 'soak/doc' }, actAs: OBSERVER_LENS },
+        doc.onSnap,
+        doc.onError,
+      );
+      const unsubRtdb = sb.rtdb.onValue('soak/presence', rtdb.onSnap, rtdb.onError);
+      await waitFor('initial snapshots', () => doc.values.length >= 1 && rtdb.values.length >= 1);
+      expect(doc.values).toHaveLength(1);
+      expect(rtdb.values).toHaveLength(1);
+      expect(parseDocSnap(doc.values[0]).data).toEqual({ n: 0 });
+
+      // Baseline AFTER settle: any further hello is a peer-slot fight.
+      const helloBaseline = {
+        standby: (await wsLog(standbyTab)).hellos,
+        winner: (await wsLog(winnerTab)).hellos,
+      };
+      expect(helloBaseline).toEqual({ standby: 1, winner: 1 });
+
+      // ── the soak: ~60s of real time, health sampled every 2s ──
+      const SOAK_MS = 60_000;
+      const started = Date.now();
+      const healthSamples: boolean[] = [];
+      let slowOpMeta: unknown = null;
+      let slowOpError: Error | null = null;
+      while (Date.now() - started < SOAK_MS) {
+        await sleep(2_000);
+        healthSamples.push((await health(serve.info.url))?.sandboxConnected === true);
+        // Mid-soak (once, ~30s in): a deliberately slow-ish op — 8 MiB
+        // (the relay cap) through putBytes must complete, not 'unavailable'.
+        if (slowOpMeta === null && slowOpError === null && Date.now() - started >= SOAK_MS / 2) {
+          const bytes = new Uint8Array(8 * 1024 * 1024).fill(0xab);
+          try {
+            slowOpMeta = await sb.storage.putBytes('soak/blob.bin', bytes, {
+              contentType: 'application/octet-stream',
+            });
+          } catch (e) {
+            slowOpError = e as Error;
+          }
+        }
+      }
+
+      // Invariants.
+      expect(slowOpError, `mid-soak 8 MiB putBytes failed: ${slowOpError?.message}`).toBeNull();
+      expect(slowOpMeta).toBeTruthy();
+      expect(await sb.storage.exists('soak/blob.bin')).toBe(true);
+      expect(healthSamples.length).toBeGreaterThanOrEqual(25);
+      expect(
+        healthSamples.every((s) => s === true),
+        `health flapped during soak: ${JSON.stringify(healthSamples)}`,
+      ).toBe(true);
+      // ZERO emissions beyond the initials.
+      expect(doc.values, `spurious doc emissions: ${JSON.stringify(doc.values.slice(1))}`).toHaveLength(1);
+      expect(rtdb.values, `spurious rtdb emissions: ${JSON.stringify(rtdb.values.slice(1))}`).toHaveLength(1);
+      expect(doc.errors).toHaveLength(0);
+      expect(rtdb.errors).toHaveLength(0);
+      // Peer-slot stability: not one additional hello registration on either tab.
+      expect(await wsLog(standbyTab).then((l) => l.hellos)).toBe(helloBaseline.standby);
+      expect(await wsLog(winnerTab).then((l) => l.hellos)).toBe(helloBaseline.winner);
+
+      unsubDoc();
+      unsubRtdb();
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+
+  test('2. change fidelity under two tabs: exactly N emissions, correct payloads, in order', async ({ browser }) => {
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      const { standbyTab } = await openTwoTabs(context, serve, {
+        first: serve.info.url, // app tab first (ends standby)
+        second: serve.info.uiUrl!, // Studio wins the slot
+      });
+
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      await sb.channel.op({ method: 'setDoc', path: 'soak/fidelity', data: { seq: 0 }, actAs: { mode: 'admin' } });
+
+      const doc = makeCollector();
+      const unsub = sb.channel.subscribe(
+        { target: { __ref: 'doc', path: 'soak/fidelity' }, actAs: OBSERVER_LENS },
+        doc.onSnap,
+        doc.onError,
+      );
+      await waitFor('initial snapshot', () => doc.values.length >= 1);
+
+      // N spaced edits driven from the BROWSER (the app tab's page client →
+      // SharedWorker), exercising browser→server delivery while a different
+      // tab (Studio) holds the peer slot.
+      const N = 5;
+      for (let i = 1; i <= N; i++) {
+        await standbyTab.evaluate(
+          ([path, seq]) =>
+            (window as unknown as { __soak: { setDoc(p: string, d: unknown): Promise<void> } }).__soak.setDoc(
+              path as string,
+              { seq },
+            ),
+          ['soak/fidelity', i] as const,
+        );
+        await sleep(400);
+      }
+
+      await waitFor(`exactly ${N} change emissions`, () => doc.values.length >= 1 + N, { timeoutMs: 10_000 });
+      await sleep(1_500); // quiet window: nothing further may arrive
+      expect(doc.values, `emissions: ${JSON.stringify(doc.values.map(parseDocSnap))}`).toHaveLength(1 + N);
+      expect(doc.errors).toHaveLength(0);
+      const seqs = doc.values.map((v) => parseDocSnap(v).data?.seq);
+      expect(seqs).toEqual([0, 1, 2, 3, 4, 5]); // correct payloads, order preserved
+      unsub();
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+
+  test('3. tab refresh mid-listen: dedup holds, exactly one emission for the post-refresh change', async ({ browser }) => {
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      // Studio first (ends standby, keeps the SharedWorker alive across the
+      // refresh), app tab second — the app tab HOLDS the peer slot.
+      const { winnerTab } = await openTwoTabs(context, serve, {
+        first: serve.info.uiUrl!,
+        second: serve.info.url,
+      });
+
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      await sb.channel.op({ method: 'setDoc', path: 'soak/refresh', data: { n: 1 }, actAs: { mode: 'admin' } });
+      const doc = makeCollector();
+      const unsub = sb.channel.subscribe(
+        { target: { __ref: 'doc', path: 'soak/refresh' }, actAs: OBSERVER_LENS },
+        doc.onSnap,
+        doc.onError,
+      );
+      await waitFor('initial snapshot', () => doc.values.length >= 1);
+
+      // Refresh the peer-holding tab. The slot churns (standby tab may claim
+      // and be re-replaced by the reloaded page) — every re-issued initial
+      // snapshot is byte-identical, so NOTHING may reach the listener.
+      await winnerTab.reload();
+      await waitForPeer(serve.info.url);
+      await sleep(3_000); // full churn + re-issue window
+      expect(
+        doc.values,
+        `refresh re-fired the listener: ${JSON.stringify(doc.values.map(parseDocSnap))}`,
+      ).toHaveLength(1);
+      expect(doc.errors).toHaveLength(0);
+
+      // A write AFTER the refresh delivers exactly once.
+      await sb.channel.op({ method: 'setDoc', path: 'soak/refresh', data: { n: 2 }, actAs: { mode: 'admin' } });
+      await waitFor('post-refresh emission', () => doc.values.length >= 2, { timeoutMs: 10_000 });
+      await sleep(1_500);
+      expect(doc.values).toHaveLength(2);
+      expect(parseDocSnap(doc.values[1]).data).toEqual({ n: 2 });
+      expect(doc.errors).toHaveLength(0); // listener never errored
+      unsub();
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+
+  test('4. peer handoff: standby claims a vacated slot, ops resume, fresh-tab-wins is quiet', async ({ browser }) => {
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      // Studio first (standby), app second (winner).
+      const { standbyTab, winnerTab } = await openTwoTabs(context, serve, {
+        first: serve.info.uiUrl!,
+        second: serve.info.url,
+      });
+
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      await sb.channel.op({ method: 'setDoc', path: 'soak/handoff', data: { stage: 'before' }, actAs: { mode: 'admin' } });
+      const doc = makeCollector();
+      const unsub = sb.channel.subscribe(
+        { target: { __ref: 'doc', path: 'soak/handoff' }, actAs: OBSERVER_LENS },
+        doc.onSnap,
+        doc.onError,
+      );
+      await waitFor('initial snapshot', () => doc.values.length >= 1);
+
+      // Close the winning tab ENTIRELY. The standby tab's health poll
+      // (2s + ≤50% jitter) must claim the vacant slot.
+      const claimStarted = Date.now();
+      await winnerTab.close();
+      await waitFor(
+        'standby tab claimed the slot (second hello)',
+        async () => (await wsLog(standbyTab)).hellos >= 2,
+        { timeoutMs: 10_000 },
+      );
+      await waitForPeer(serve.info.url, 10_000);
+      const claimMs = Date.now() - claimStarted;
+
+      // Ops resume against the new peer.
+      await sb.rtdb.set('soak/afterHandoff', { ok: true });
+      expect(await sb.rtdb.get('soak/afterHandoff')).toEqual({ ok: true });
+
+      // Reopen a fresh tab: fresh-tab-wins must displace the current holder
+      // once (no fight) and must not disturb the Node client.
+      const fresh = await context.newPage();
+      await fresh.goto(serve.info.url);
+      await waitFor('fresh tab won the slot', async () => (await wsLog(fresh)).hellos >= 1, { timeoutMs: 20_000 });
+      await waitFor('ex-standby replaced again (close 4001)', async () => {
+        const log = await wsLog(standbyTab);
+        return log.closes.filter((c) => c === 4001).length >= 2;
+      });
+      await waitForPeer(serve.info.url);
+      await sleep(2_500); // quiet window after the churn
+
+      // The Node client is undisturbed: ops work, the listener saw NOTHING
+      // from two handoffs (the doc never changed), and no errors surfaced.
+      expect(await sb.channel.op({ method: 'getDoc', path: 'soak/handoff', actAs: { mode: 'admin' } })).toBeTruthy();
+      expect(
+        doc.values,
+        `handoffs re-fired the listener: ${JSON.stringify(doc.values.map(parseDocSnap))}`,
+      ).toHaveLength(1);
+      expect(doc.errors).toHaveLength(0);
+      // Fresh tab helloed exactly once; no slot fighting after settle.
+      expect((await wsLog(fresh)).hellos).toBe(1);
+      expect((await wsLog(standbyTab)).hellos).toBe(2);
+
+      test.info().annotations.push({ type: 'timing', description: `standby claimed slot in ${claimMs}ms` });
+      unsub();
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+
+  test('5. first-run race: --no-open skips the wait by design; child fails fast then recovers; the gate holds when polled', async ({ browser }) => {
+    // The opened-gating in src/cli/serve.ts: waitForSandboxPeer runs ONLY
+    // when serve itself opened a tab (`opened`), and --json/--no-open force
+    // opened=false — so a `-- <cmd>` child under --json is DOCUMENTED to
+    // race: its first sandbox op fails fast with the "no browser tab is
+    // connected … and retry" guidance, and a retry after a tab opens works.
+    const remoteDistUrl = pathToFileURL(
+      CLI_PATH.replace(/cli[\\/]index\.js$/, 'remote/index.js'),
+    ).href;
+    const childScript = `// first line of work is a sandbox op — the race under test
+import { connectRemoteSandbox } from '${remoteDistUrl}';
+const url = (process.env.PYRIC_SANDBOX ?? '').replace(/^remote:/, '');
+try {
+  const sb = await connectRemoteSandbox({ url });
+  console.log('FIRST_OP_OK');
+  sb.close();
+} catch (err) {
+  console.log('FIRST_OP_ERR:' + err.message);
+}
+const deadline = Date.now() + 25_000;
+for (;;) {
+  try {
+    const sb = await connectRemoteSandbox({ url });
+    await sb.rtdb.set('soak/firstRun', { ok: true });
+    const v = await sb.rtdb.get('soak/firstRun');
+    console.log('RETRY_OK:' + JSON.stringify(v));
+    sb.close();
+    break;
+  } catch (err) {
+    if (Date.now() > deadline) {
+      console.log('RETRY_TIMEOUT:' + err.message);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+`;
+    const serve = await startSoakServe({
+      extraFiles: { 'child.mjs': childScript },
+      passthrough: ['node', 'child.mjs'],
+    });
+    const context = await newInstrumentedContext(browser);
+    try {
+      // The design promise, part 1: with --json/--no-open nothing was opened,
+      // so the runner must NOT hold the child for a tab.
+      expect(serve.stderr()).not.toContain('waiting for the browser tab');
+
+      // The child raced and lost — fail-fast with the documented remediation.
+      await waitFor(
+        'child first-op fail-fast marker',
+        () => serve.stderr().includes('FIRST_OP_ERR:'),
+        { timeoutMs: 20_000 },
+      );
+      expect(serve.stderr()).toContain('no browser tab is connected');
+      expect(serve.stderr()).not.toContain('FIRST_OP_OK');
+
+      // Deliberate 2s delay, then Playwright opens the tab the guidance asks for.
+      await sleep(2_000);
+      const page = await context.newPage();
+      await page.goto(serve.info.url);
+      await waitFor('child recovered after the tab opened', () => serve.stderr().includes('RETRY_OK:'), {
+        timeoutMs: 30_000,
+      });
+      expect(serve.stderr()).toContain('RETRY_OK:{"ok":true}');
+      await page.close();
+    } finally {
+      await context.close();
+      await serve.stop();
+    }
+
+    // Part 2 — the auto-open case, simulated: the SAME gate the opened path
+    // runs (waitForSandboxPeer from dist) polled against a fresh serve while
+    // Playwright plays the auto-opened tab arriving 2s later. The gate must
+    // hold until the peer registers — a child spawned behind it would never
+    // see the no-tab error.
+    const { waitForSandboxPeer } = (await import(
+      pathToFileURL(CLI_PATH.replace(/index\.js$/, 'dev-runner.js')).href
+    )) as { waitForSandboxPeer: (url: string) => Promise<boolean> };
+    const serve2 = await startSoakServe();
+    const context2 = await newInstrumentedContext(browser);
+    try {
+      expect((await health(serve2.info.url))?.sandboxConnected).toBe(false);
+      const gateStarted = Date.now();
+      const gate = waitForSandboxPeer(serve2.info.url);
+      await sleep(2_000);
+      const page = await context2.newPage();
+      await page.goto(serve2.info.url);
+      expect(await gate).toBe(true);
+      const heldMs = Date.now() - gateStarted;
+      expect(heldMs).toBeGreaterThanOrEqual(1_900); // held until the tab actually arrived
+      expect((await health(serve2.info.url))?.sandboxConnected).toBe(true);
+    } finally {
+      await context2.close();
+      await serve2.stop();
+    }
+  });
+
+  test('6. MCP over streamable HTTP works concurrently with the Node client, same sandbox state', async ({ browser }) => {
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      expect(serve.info.mcpUrl, 'serve must expose the MCP endpoint (--bridge)').toBeTruthy();
+      const page = await context.newPage();
+      await page.goto(serve.info.url);
+      await waitForPeer(serve.info.url);
+
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      await sb.channel.op({ method: 'setDoc', path: 'soak/mcp', data: { answer: 42 }, actAs: { mode: 'admin' } });
+
+      const mcp = new McpHttpClient(serve.info.mcpUrl!);
+      await mcp.initialize();
+      const tools = await mcp.toolsList();
+      expect(tools).toContain('firestore_get_document');
+      expect(tools).toContain('firestore_list_documents');
+
+      // Both callers concurrently against the one sandbox: the MCP tool call
+      // must round-trip the doc the Node client wrote, WHILE a Node-side op
+      // is in flight on the same bridge.
+      const [mcpResult, nodeResult] = await Promise.all([
+        mcp.toolCall('firestore_get_document', { path: 'soak/mcp' }),
+        sb.channel.op({ method: 'getDoc', path: 'soak/mcp', actAs: { mode: 'admin' } }),
+      ]);
+      expect(mcpResult.ok, `MCP tool call failed: ${mcpResult.summary}`).toBe(true);
+      const mcpData = mcpResult.data as { exists: boolean; data: Record<string, unknown> | null };
+      expect(mcpData.exists).toBe(true);
+      expect(mcpData.data).toEqual({ answer: 42 });
+      expect(parseDocSnap(nodeResult).data).toEqual({ answer: 42 });
+
+      // And the reverse direction: an MCP write is visible to the Node client.
+      const write = await mcp.toolCall('firestore_update_document', {
+        path: 'soak/mcp',
+        data: { answer: 42, via: 'mcp' },
+      });
+      expect(write.ok, `MCP update failed: ${write.summary}`).toBe(true);
+      const after = parseDocSnap(
+        await sb.channel.op({ method: 'getDoc', path: 'soak/mcp', actAs: { mode: 'admin' } }),
+      );
+      expect(after.data).toEqual({ answer: 42, via: 'mcp' });
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+
+  test('7. FINDING (expected fail): admin-lens Firestore listener is rules-evaluated as unauthenticated', async ({ browser }) => {
+    // Found by this suite on its first live run. The `actAs: { mode: 'admin' }`
+    // lens is documented (worker protocol, FirestoreSubMessage.actAs) to
+    // register a snapshot listener "through the rule-bypass handle", and the
+    // worker host resolves it via the same lensDb path ops use. Ops DO bypass
+    // rules (the admin setDoc below succeeds against `allow write: if
+    // request.auth != null`). But the LISTENER's rule evaluation
+    // (LocalEnvironment.silentReadDoc → addSnapshotListener's ListenerAuth)
+    // has no bypass: the admin handle registers with a null auth, the
+    // listener-init read simulates `get` as UNAUTHENTICATED, and the
+    // subscription dies with `permission-denied: get <path> denied by rules`.
+    //
+    // Reproduces headlessly in-process too (getAdminFirestore + onSnapshot
+    // under any auth-gated ruleset), so the fix's regression test can live in
+    // the unit suite. Until fixed, `pyric-admin`'s remote onSnapshot (admin
+    // plane) errors on every project whose rules require auth.
+    //
+    // test.fail(): this test PASSES only while the bug exists; when the
+    // listener bypass is fixed it will flip to "expected to fail but passed",
+    // flagging that this pin (and OBSERVER_LENS above) should be retired.
+    test.fail();
+    const serve = await startSoakServe();
+    const context = await newInstrumentedContext(browser);
+    let sb: RemoteSandbox | null = null;
+    try {
+      const page = await context.newPage();
+      await page.goto(serve.info.url);
+      await waitForPeer(serve.info.url);
+      sb = await connectRemoteSandbox({ url: serve.info.url });
+      // Admin OP bypasses the auth-gated rules — this succeeds.
+      await sb.channel.op({ method: 'setDoc', path: 'soak/adminListen', data: { n: 0 }, actAs: { mode: 'admin' } });
+
+      const doc = makeCollector();
+      sb.channel.subscribe(
+        { target: { __ref: 'doc', path: 'soak/adminListen' }, actAs: { mode: 'admin' } },
+        doc.onSnap,
+        doc.onError,
+      );
+      await waitFor('admin-lens listener settles', () => doc.values.length >= 1 || doc.errors.length >= 1, {
+        timeoutMs: 10_000,
+      });
+      // What the docs promise (and what currently FAILS): an initial snapshot,
+      // no permission-denied.
+      expect(doc.errors.map((e) => e.message)).toEqual([]);
+      expect(doc.values).toHaveLength(1);
+    } finally {
+      sb?.close();
+      await context.close();
+      await serve.stop();
+    }
+  });
+});

--- a/packages/pyric-tools/test/e2e/soak/fixture/firestore.rules
+++ b/packages/pyric-tools/test/e2e/soak/fixture/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/packages/pyric-tools/test/e2e/soak/fixture/index.html
+++ b/packages/pyric-tools/test/e2e/soak/fixture/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>pyric bridge soak</title>
+  </head>
+  <body>
+    <p id="status">loading</p>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/pyric-tools/test/e2e/soak/fixture/main.js
+++ b/packages/pyric-tools/test/e2e/soak/fixture/main.js
@@ -1,0 +1,23 @@
+// Minimal firebase/* app for the bridge soak suite. Under `pyric dev` these
+// imports resolve to the pyric sandbox (SharedWorker-backed), so a write made
+// here exercises the full browser→worker→bridge→Node delivery path.
+import { initializeApp } from 'firebase/app';
+import { getAuth, signInAnonymously } from 'firebase/auth';
+import { getFirestore, doc, setDoc } from 'firebase/firestore';
+
+const app = initializeApp({ apiKey: 'demo', projectId: 'demo' });
+const db = getFirestore(app);
+
+// The rules require request.auth != null (the linter rejects allow-all), so
+// the page session signs in anonymously before it drives any write.
+const session = signInAnonymously(getAuth(app));
+
+window.__soak = {
+  // Studio-side / app-side edit driver for the change-fidelity scenario.
+  setDoc: async (path, data) => {
+    await session;
+    return setDoc(doc(db, path), data);
+  },
+};
+
+document.getElementById('status').textContent = 'ready';

--- a/packages/pyric-tools/test/e2e/soak/harness.ts
+++ b/packages/pyric-tools/test/e2e/soak/harness.ts
@@ -1,0 +1,351 @@
+/**
+ * Soak-suite harness: spawn a REAL `pyric dev --ui --bridge --no-open
+ * --port 0 --json` serve in a throwaway copy of the fixture, parse the
+ * one-line `--json` contract for URLs, and provide the observation
+ * helpers the scenarios share:
+ *
+ *  - `waitFor` — bounded condition polling (never a bare sleep where a
+ *    condition exists).
+ *  - `health` — the bridge's `/__pyric/health` (`sandboxConnected`).
+ *  - `WS_INSTRUMENTATION` — a page init script that wraps
+ *    `window.WebSocket` so each tab's bridge `hello` registrations and
+ *    close codes are countable from the test (no product code needed:
+ *    the bridge client runs in the page, so the page's own socket IS the
+ *    observation point for peer-slot churn).
+ *  - `McpHttpClient` — a minimal MCP streamable-HTTP client (initialize /
+ *    tools-list / tools-call) speaking directly to `/__pyric/mcp`.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const CLI_PATH = join(HERE, '..', '..', '..', 'dist', 'cli', 'index.js');
+const FIXTURE_DIR = join(HERE, 'fixture');
+
+// ─── waitFor ────────────────────────────────────────────────────────────────
+
+export async function waitFor<T>(
+  label: string,
+  condition: () => Promise<T | null | undefined | false> | T | null | undefined | false,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const intervalMs = opts.intervalMs ?? 150;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await condition();
+    if (value !== null && value !== undefined && value !== false) return value as T;
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms: ${label}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─── serve orchestration ────────────────────────────────────────────────────
+
+export interface ServeJson {
+  url: string;
+  port: number;
+  uiUrl: string | null;
+  mcpUrl: string | null;
+  rulesHash: string | null;
+}
+
+export interface SoakServe {
+  info: ServeJson;
+  /** Temp project dir the serve runs in. */
+  dir: string;
+  child: ChildProcess;
+  /** Everything the serve (and any `--` child) wrote to stderr so far. */
+  stderr: () => string;
+  /** Full stdout (line 1 is the --json contract; a `--` child's output is
+   *  prefixed `[dev] ` on stderr, never here). */
+  stdout: () => string;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Copy the fixture into a fresh temp dir (plus any extra files) and start
+ * `pyric dev --ui --bridge --no-open --port 0 --json [-- <cmd>]` there.
+ * Resolves once the one-line JSON contract arrives on stdout.
+ */
+export async function startSoakServe(
+  opts: { extraFiles?: Record<string, string>; passthrough?: string[]; flags?: string[] } = {},
+): Promise<SoakServe> {
+  const dir = mkdtempSync(join(tmpdir(), 'pyric-bridge-soak-'));
+  cpSync(FIXTURE_DIR, dir, { recursive: true });
+  for (const [name, content] of Object.entries(opts.extraFiles ?? {})) {
+    writeFileSync(join(dir, name), content);
+  }
+
+  const args = [
+    CLI_PATH,
+    'dev',
+    '--ui',
+    '--bridge',
+    '--no-open',
+    '--port',
+    '0',
+    '--json',
+    // ALWAYS bundle fresh. Finding from this suite's first run: the serve
+    // bundle cache key (serve/bundler.ts cacheKey) hashes the pyric version +
+    // the serve/entries sources only — NOT the bridge client / worker client
+    // sources the bundle also includes — so a warm ~/.pyric/serve-cache keeps
+    // serving a PRE-FIX in-page bridge client after pyric-tools-only changes
+    // (observed live: a stale client ignored the standby protocol and bounced
+    // the peer slot once per replacement). The suite must test the code as
+    // built, so it opts out of the cache.
+    '--no-cache',
+    ...(opts.flags ?? []),
+    ...(opts.passthrough && opts.passthrough.length > 0 ? ['--', ...opts.passthrough] : []),
+  ];
+  const child = spawn(process.execPath, args, {
+    cwd: dir,
+    env: { ...process.env, CI: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let out = '';
+  let err = '';
+  child.stdout!.setEncoding('utf8');
+  child.stderr!.setEncoding('utf8');
+  child.stdout!.on('data', (c: string) => (out += c));
+  child.stderr!.on('data', (c: string) => (err += c));
+
+  const exited = new Promise<number | null>((resolve) => {
+    child.once('exit', (code) => resolve(code));
+  });
+
+  let info: ServeJson;
+  try {
+    info = await waitFor<ServeJson>(
+      `pyric dev --json line`,
+      () => {
+        if (child.exitCode !== null) {
+          throw new Error(
+            `pyric dev exited early (code ${child.exitCode}). stderr:\n${err.slice(-2000)}`,
+          );
+        }
+        const line = out.split('\n').find((l) => l.trim().startsWith('{'));
+        if (!line) return null;
+        try {
+          return JSON.parse(line) as ServeJson;
+        } catch {
+          return null;
+        }
+      },
+      // First run may build the SDK bundles; later runs hit the cache.
+      { timeoutMs: 90_000, intervalMs: 100 },
+    );
+  } catch (e) {
+    child.kill('SIGKILL');
+    throw e;
+  }
+
+  const stop = async (): Promise<void> => {
+    if (child.exitCode === null) {
+      child.kill('SIGTERM');
+      const killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+      await exited;
+      clearTimeout(killTimer);
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort temp cleanup
+    }
+  };
+
+  return { info, dir, child, stderr: () => err, stdout: () => out, stop };
+}
+
+// ─── bridge health ──────────────────────────────────────────────────────────
+
+export async function health(serveUrl: string): Promise<{ sandboxConnected: boolean } | null> {
+  try {
+    const res = await fetch(`${serveUrl.replace(/\/$/, '')}/__pyric/health`);
+    if (!res.ok) return null;
+    return (await res.json()) as { sandboxConnected: boolean };
+  } catch {
+    return null;
+  }
+}
+
+export async function waitForPeer(serveUrl: string, timeoutMs = 20_000): Promise<void> {
+  await waitFor(
+    `a sandbox peer at ${serveUrl}`,
+    async () => (await health(serveUrl))?.sandboxConnected === true,
+    { timeoutMs, intervalMs: 200 },
+  );
+}
+
+// ─── page-side WS observation ───────────────────────────────────────────────
+
+/** Shape of `window.__wsLog` installed by {@link WS_INSTRUMENTATION}. */
+export interface PageWsLog {
+  /** Total bridge `hello` frames this page has sent (peer registrations). */
+  hellos: number;
+  /** One record per WebSocket to the bridge sandbox path. */
+  sockets: Array<{
+    url: string;
+    openedAt: number;
+    hellos: number;
+    hellosAt: number[];
+    closeCode: number | null;
+    closeAt: number | null;
+  }>;
+  /** Close codes observed, in order (4001 = replaced → standby). */
+  closes: number[];
+}
+
+/**
+ * Init script wrapping `window.WebSocket`: counts `hello` frames (bridge
+ * peer registrations) and records close codes for sockets to
+ * `/__pyric/sandbox`. Pure test-side observation — the page's bridge client
+ * is untouched, this only watches the frames it already sends.
+ */
+export const WS_INSTRUMENTATION = `(() => {
+  const log = { hellos: 0, sockets: [], closes: [] };
+  Object.defineProperty(window, '__wsLog', { value: log });
+  const Native = window.WebSocket;
+  window.WebSocket = class extends Native {
+    constructor(url, protocols) {
+      super(url, protocols);
+      const isBridge = String(url).includes('/__pyric/sandbox');
+      const rec = { url: String(url), openedAt: Date.now(), hellos: 0, hellosAt: [], closeCode: null, closeAt: null };
+      if (isBridge) log.sockets.push(rec);
+      this.addEventListener('close', (e) => {
+        if (isBridge) { rec.closeCode = e.code; rec.closeAt = Date.now(); log.closes.push(e.code); }
+      });
+      const nativeSend = this.send.bind(this);
+      this.send = (data) => {
+        if (isBridge && typeof data === 'string' && data.includes('"type":"hello"')) {
+          rec.hellos += 1;
+          rec.hellosAt.push(Date.now());
+          log.hellos += 1;
+        }
+        return nativeSend(data);
+      };
+    }
+  };
+})();`;
+
+// ─── minimal MCP streamable-HTTP client ─────────────────────────────────────
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Speaks MCP over the streamable HTTP endpoint directly (initialize →
+ * notifications/initialized → tools/list → tools/call), carrying the
+ * `Mcp-Session-Id` the stateful transport mints on initialize.
+ */
+export class McpHttpClient {
+  private sessionId: string | null = null;
+  private nextId = 1;
+
+  constructor(private readonly mcpUrl: string) {}
+
+  private async post(body: Record<string, unknown>): Promise<{ msg: JsonRpcResponse | null; status: number }> {
+    const res = await fetch(this.mcpUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    const sid = res.headers.get('mcp-session-id');
+    if (sid) this.sessionId = sid;
+    const contentType = res.headers.get('content-type') ?? '';
+    let msg: JsonRpcResponse | null = null;
+    if (contentType.includes('text/event-stream')) {
+      // A POST-scoped SSE stream: the transport writes the one response and
+      // closes, so reading to end is bounded.
+      const text = await res.text();
+      for (const line of text.split('\n')) {
+        if (!line.startsWith('data:')) continue;
+        try {
+          const parsed = JSON.parse(line.slice(5).trim()) as JsonRpcResponse;
+          if (parsed.id === body.id) msg = parsed;
+        } catch {
+          // non-JSON SSE line — skip
+        }
+      }
+    } else if (contentType.includes('application/json')) {
+      msg = (await res.json()) as JsonRpcResponse;
+    }
+    return { msg, status: res.status };
+  }
+
+  async initialize(): Promise<JsonRpcResponse> {
+    const { msg, status } = await this.post({
+      jsonrpc: '2.0',
+      id: this.nextId++,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'bridge-soak', version: '0.0.0' },
+      },
+    });
+    if (!msg || msg.error) {
+      throw new Error(`MCP initialize failed (status ${status}): ${JSON.stringify(msg?.error)}`);
+    }
+    // Per spec, follow with the initialized notification (202, no body).
+    await fetch(this.mcpUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    });
+    return msg;
+  }
+
+  async toolsList(): Promise<string[]> {
+    const { msg, status } = await this.post({
+      jsonrpc: '2.0',
+      id: this.nextId++,
+      method: 'tools/list',
+      params: {},
+    });
+    if (!msg || msg.error) {
+      throw new Error(`MCP tools/list failed (status ${status}): ${JSON.stringify(msg?.error)}`);
+    }
+    const tools = (msg.result as { tools: Array<{ name: string }> }).tools;
+    return tools.map((t) => t.name);
+  }
+
+  /** Call a tool; returns the parsed bridge result from the text content. */
+  async toolCall(name: string, args: Record<string, unknown>): Promise<{ ok: boolean; summary: string; data?: unknown }> {
+    const { msg, status } = await this.post({
+      jsonrpc: '2.0',
+      id: this.nextId++,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    });
+    if (!msg || msg.error) {
+      throw new Error(`MCP tools/call ${name} failed (status ${status}): ${JSON.stringify(msg?.error)}`);
+    }
+    const content = (msg.result as { content: Array<{ type: string; text: string }> }).content;
+    const text = content.find((c) => c.type === 'text')?.text;
+    if (!text) throw new Error(`MCP tools/call ${name}: no text content in result`);
+    return JSON.parse(text) as { ok: boolean; summary: string; data?: unknown };
+  }
+}

--- a/packages/pyric-tools/test/e2e/soak/playwright.config.ts
+++ b/packages/pyric-tools/test/e2e/soak/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+// Real-browser soak suite for the bridge lifecycle layer (peer slot,
+// standby, sub re-issue dedup, MCP route). Each test spawns its own
+// `pyric dev --ui --bridge --no-open --port 0 --json` serve in a temp copy
+// of the fixture — there is deliberately NO shared webServer here.
+//
+// Files are named `*.soak.ts` so neither `bun test` (`*.test.ts` /
+// `*.spec.ts`) nor the sibling auth e2e config (`**/*.pw.ts`) ever picks
+// them up. Run via the root `bun run test:soak` (requires the built
+// pyric-tools dist + `bunx playwright install chromium`).
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.soak.ts',
+  // The headline scenario soaks ~60s of real time on top of serve boot.
+  timeout: 150_000,
+  reporter: 'list',
+  workers: 1,
+  fullyParallel: false,
+  use: {
+    headless: true,
+  },
+});


### PR DESCRIPTION
Converts the hand-probing that found five live-only bugs into a permanent test class: real `pyric dev`, real Chromium tabs, a real Node remote client, and real time. Runs in ~1.5 minutes via `bun run test:soak`; excluded from the default unit sweep; no product code changes (observation via a page-level WebSocket wrapper and the health endpoint).

Scenarios, all green against main (validating #57 under live conditions):

1. Two-tab 60s steady-state soak: one hello per tab then silence, zero spurious listener emissions, an 8 MiB storage op mid-soak completes.
2. Change fidelity: five browser-driven edits while Studio holds the peer slot produce exactly six emissions, in order.
3. Tab refresh mid-listen: nothing re-fires; the next change delivers exactly once.
4. Peer handoff: standby claims a vacated slot within its poll window; a fresh tab later wins quietly.
5. First-run race: documents and tests the actual design (the wait is skipped under --no-open/--json; the auto-open path holds the child until the tab registers).
6. MCP over streamable HTTP concurrently with the Node client, round-tripping shared sandbox state — the first live coverage this path has ever had.

Two findings, characterized rather than papered over:

7. **New bug, pinned as an expected-fail test**: a Firestore snapshot listener registered through the admin (rules-bypass) lens is rules-evaluated as unauthenticated and dies with permission-denied under any auth-gated ruleset — ops bypass rules, listeners do not (`local-environment.ts` ListenerAuth has no bypass). Reproduces headlessly, so the fix can carry a unit regression test. The `test.fail()` pin flips loudly the day it is fixed.
8. **Serve-bundle cache gap** (noted in the suite, not fixed): the serve cache key hashes the package version and `serve/entries` sources but not the `bridge/client`/worker-client sources bundled in, so same-version development builds can serve stale client code. The harness runs `--no-cache`; published version bumps bust the cache naturally.

Suggested CI shape: label-gated or nightly job (`playwright install chromium`, build, `test:soak`), plus on changes under `packages/pyric-tools/src/{bridge,serve,remote}/**`.