### PR TITLE
Fix worker persistence: acked writes durable before reply

### DIFF
--- a/packages/pyric-tools/src/serve/worker/entry.ts
+++ b/packages/pyric-tools/src/serve/worker/entry.ts
@@ -46,30 +46,16 @@ interface SharedWorkerGlobalScope {
   onconnect: ((e: MessageEvent) => void) | null;
 }
 
-import {
-  initializeSandbox,
-  attachPersistence,
-  createIndexedDBBackend,
-} from 'pyric/sandbox';
-import { getFirestore } from 'pyric/firestore';
-import { getAuth } from 'pyric/auth';
+import { createIndexedDBBackend } from 'pyric/sandbox';
 
 import {
   handleMessage,
   cleanupPort,
-  getOrCreateInstanceId,
   type HostCtx,
   type PortLike,
 } from './host.js';
-import {
-  applyServeInit,
-  createWorkerDurableBackend,
-  setupServerAuthFlush,
-  setupWorkerHotReload,
-  type EventSourceLike,
-} from './serve-init.js';
+import { buildWorkerCtx, type EventSourceLike } from './serve-init.js';
 import type { InboundMessage } from './protocol.js';
-import type { InitPayload } from '../namespace.js';
 
 // ─── Singleton context ────────────────────────────────────────────────────
 
@@ -84,17 +70,6 @@ import type { InitPayload } from '../namespace.js';
 let _ctx: HostCtx | null = null;
 let _ctxPromise: Promise<HostCtx> | null = null;
 
-const PERMISSIVE_RULES = `
-  rules_version = '2';
-  service cloud.firestore {
-    match /databases/{database}/documents {
-      match /{document=**} {
-        allow read, write: if true;
-      }
-    }
-  }
-`;
-
 /**
  * Return the shared context, memoizing the in-flight init promise so
  * concurrent first messages await ONE build (see `_ctxPromise` above).
@@ -105,100 +80,32 @@ function getCtx(): Promise<HostCtx> {
 
 /**
  * Build the ONE shared sandbox + Firestore handle. Invoked exactly once per
- * worker lifetime via the `getCtx` memo — never concurrently.
+ * worker lifetime via the `getCtx` memo — never concurrently. The real boot
+ * logic lives in `buildWorkerCtx` (serve-init.ts) so it is testable without
+ * a SharedWorker runtime; this shell only supplies the real ambients.
+ *
+ * NOTE (#754): no worker-side session restore. Sessions are per-port; each
+ * PAGE re-establishes its own session from web storage via
+ * `auth.restorePortSession` (runtime.ts). The user DB itself is restored
+ * from the persisted snapshot inside buildWorkerCtx (#629).
  */
 async function buildCtx(): Promise<HostCtx> {
-  const sandbox = initializeSandbox();
-
-  // Deploy permissive starter rules via admin-firestore.
-  // Callers override at runtime via the setRules op.
-  const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
-  const adminDb = getAdminFirestore(sandbox.withAuth(null));
-  adminDb.setRules(PERMISSIVE_RULES);
-
   // ONE IDB backend for the whole worker. createIndexedDBBackend's guard
   // checks `typeof indexedDB === 'undefined'` — SharedWorkers have full
   // IndexedDB access, so this succeeds. The persistence controller's
   // window.addEventListener('beforeunload', ...) is guarded by
-  // `typeof window !== 'undefined'`, so attachPersistence is worker-safe.
-  const idb = createIndexedDBBackend();
-
-  // Fetch serve's init payload FIRST — it decides the DURABLE strategy before
-  // we attach: `--persist` mirrors the controller blob to the committable
-  // server file (and primes from it on a fresh worker); a `seedState` fixture
-  // primes IDB once. Null when standalone (no `pyric dev` behind us).
-  const payload = await fetchInitPayload();
-
-  // The persistence-controller backend. `--persist`/`seedState` wrap IDB (see
-  // createWorkerDurableBackend); plain IDB otherwise. The session record stays
-  // on the RAW idb (local-only — it must NEVER reach the committable server
-  // file), so that is what we hand the host as `sessionBackend`.
-  const durable = payload ? createWorkerDurableBackend(idb, payload, { fetch }) : idb;
-  await attachPersistence(sandbox, {
-    key: 'pyric-shared-worker',
-    injectedBackend: durable,
+  // `typeof window !== 'undefined'`, so enablePersistence is worker-safe.
+  const ctx = await buildWorkerCtx({
+    fetch,
+    idb: createIndexedDBBackend(),
+    // EventSource is available in workers; guard anyway for exotic hosts.
+    makeEventSource:
+      typeof EventSource !== 'undefined'
+        ? (url) => new EventSource(url) as unknown as EventSourceLike
+        : null,
   });
-
-  // Register the auth service with the persistence registry BEFORE we read
-  // back any session: `getAuth(sandbox)` makes the user DB ride the snapshot
-  // (the #629 mechanism). One auth per worker — one shared session across all
-  // tabs (the v1 decision; see host.ts for the SESSION/LOCAL collapse note).
-  getAuth(sandbox);
-
-  // Sandbox-live Firestore: `getFirestore(sandbox)` reads
-  // `sandbox.currentUser` per operation, so auth changes propagate
-  // to subsequent Firestore ops without rebuilding the handle.
-  const db = getFirestore(sandbox);
-
-  const ctx: HostCtx = {
-    db,
-    sandbox,
-    // Stable per-SharedWorker identity (raw idb, local-only). Two browser
-    // profiles on the same port get two ids — how the UI tells them apart.
-    instanceId: await getOrCreateInstanceId(idb),
-    subs: new Map(),
-    sessionBackend: idb,
-    sessionMode: 'LOCAL',
-  };
   _ctx = ctx; // publish the resolved ctx for the synchronous close handler
-
-  // Apply rules / seed / authUsers / capture BEFORE session restore (so seeded
-  // users exist for the restore and project rules govern the first write),
-  // then mirror auth to the committable server file (`--persist` only).
-  if (payload) {
-    applyServeInit(ctx, payload, { fetch });
-    setupServerAuthFlush(ctx, payload, { fetch });
-  }
-
-  // The worker owns the SINGLE hot-reload stream for the origin (tabs open
-  // none) — so a rules change deploys once and multi-tab pages never exhaust
-  // the per-origin connection cap. EventSource is available in workers.
-  if (typeof EventSource !== 'undefined') {
-    setupWorkerHotReload(ctx, (url) => new EventSource(url) as unknown as EventSourceLike);
-  }
-
-  // NOTE (#754): no worker-side session restore anymore. Sessions are
-  // per-port; each PAGE re-establishes its own session from web storage via
-  // `auth.restorePortSession` (runtime.ts). The user DB itself was already
-  // restored from the snapshot above (#629).
-
   return ctx;
-}
-
-/**
- * Fetch + parse `/__pyric/init.json`. The URL is relative to the worker
- * script's origin (same origin as the page). Returns null on any failure: a
- * worker opened outside `pyric dev` has no init endpoint and simply keeps
- * the permissive starter rules + a plain-IDB durable store.
- */
-async function fetchInitPayload(): Promise<InitPayload | null> {
-  try {
-    const res = await fetch('/__pyric/init.json');
-    if (!res.ok) return null;
-    return (await res.json()) as InitPayload;
-  } catch {
-    return null;
-  }
 }
 
 // ─── SharedWorker connect handler ─────────────────────────────────────────

--- a/packages/pyric-tools/src/serve/worker/host-auth.ts
+++ b/packages/pyric-tools/src/serve/worker/host-auth.ts
@@ -18,7 +18,7 @@
  * imports).
  */
 
-import { type HostCtx, type PortLike, post, ok, fail } from './host-context.js';
+import { type HostCtx, type PortLike, post, ok, fail, bestEffortFlush } from './host-context.js';
 import {
   getAuth,
   sandbox as authSandboxOps,
@@ -133,6 +133,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
           kind: 'createPassword', email: msg.email, password: msg.password,
         });
         setPortSession(ctx, port, session);
+        await bestEffortFlush(ctx); // new user record must be durable at ack
         ok(port, msg.id, credReply(session, null));
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -162,6 +163,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
         }
         const session = authSandboxOps.mintSession(auth, { kind: 'anonymous' });
         setPortSession(ctx, port, session);
+        await bestEffortFlush(ctx); // anonymous sign-in creates a user record
         ok(port, msg.id, credReply(session, null));
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -243,6 +245,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
         const profile = { displayName: msg.displayName, photoURL: msg.photoURL };
         authSandboxOps.updateProfile(auth, session.user.uid, profile);
         applyProfileToUser(session.user, profile);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, serializeUser(session.user));
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -266,6 +269,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
         }]);
         const session = authSandboxOps.mintSession(auth, { kind: 'uid', uid });
         setPortSession(ctx, port, session);
+        await bestEffortFlush(ctx); // seeded provider identity must be durable
         ok(port, msg.id, credReply(session, providerId));
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -281,21 +285,25 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
 
     case 'auth.adminCreateUser': {
       try {
-        ok(port, msg.id, authSandboxOps.createUser(
+        const created = authSandboxOps.createUser(
           auth,
           msg.request as Parameters<typeof authSandboxOps.createUser>[1],
-        ));
+        );
+        await bestEffortFlush(ctx);
+        ok(port, msg.id, created);
       } catch (e) { fail(port, msg.id, e); }
       break;
     }
 
     case 'auth.adminUpdateUser': {
       try {
-        ok(port, msg.id, authSandboxOps.updateUser(
+        const updated = authSandboxOps.updateUser(
           auth,
           msg.uid,
           msg.request as Parameters<typeof authSandboxOps.updateUser>[2],
-        ));
+        );
+        await bestEffortFlush(ctx);
+        ok(port, msg.id, updated);
       } catch (e) { fail(port, msg.id, e); }
       break;
     }
@@ -303,6 +311,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
     case 'auth.adminDeleteUser': {
       try {
         authSandboxOps.deleteUser(auth, msg.uid);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -311,6 +320,7 @@ export async function handleAuthOp(ctx: HostCtx, port: PortLike, msg: OpMessage)
     case 'auth.adminClearUsers': {
       try {
         authSandboxOps.clearUsers(auth);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;

--- a/packages/pyric-tools/src/serve/worker/host-context.ts
+++ b/packages/pyric-tools/src/serve/worker/host-context.ts
@@ -183,3 +183,25 @@ export function fail(port: PortLike, id: string, err: unknown): void {
   // post it whole so the structured denial frame reaches remote consumers.
   post(port, { t: 'res', id, ok: false, error: serializeError(err) });
 }
+
+/**
+ * Await a persistence flush BEFORE acking a mutating op, so an acknowledged
+ * write is durable in IndexedDB when the reply reaches the client. This is
+ * the worker's ONLY durability mechanism: there is no beforeterminate-style
+ * event for a SharedWorker, so a teardown on last-tab close/reload can kill
+ * the worker inside the controller's debounce window — an un-flushed write
+ * would be silently lost (the reload-durability bug).
+ *
+ * "Best-effort" refers to the REPLY, not the flush: a flush failure (e.g.
+ * storage quota) must not turn a successful in-memory mutation into a wire
+ * error, but it IS logged — a silently swallowed flush failure is exactly
+ * how a broken flush contract stays invisible.
+ */
+export async function bestEffortFlush(ctx: HostCtx): Promise<void> {
+  try {
+    await ctx.sandbox.flush?.();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[pyric worker] persistence flush after acked write failed:', e);
+  }
+}

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -160,7 +160,7 @@ import {
 // of a separate in-page sandbox.
 import { buildSandboxDispatcher } from '../../bridge/client/dispatch.js';
 
-import { type HostCtx, type PortLike, post, ok, fail } from './host-context.js';
+import { type HostCtx, type PortLike, post, ok, fail, bestEffortFlush } from './host-context.js';
 import {
   authSubsFor,
   isAuthOp,
@@ -700,15 +700,6 @@ function ensureRtdb(ctx: HostCtx): Database {
   return (ctx.rtdb ??= pyricGetDatabase(ctx.sandbox));
 }
 
-async function bestEffortFlush(ctx: HostCtx): Promise<void> {
-  try {
-    await ctx.sandbox.flush?.();
-  } catch {
-    // Admin playground writes should report the mutation result. Persistence
-    // flush failures are lifecycle/diagnostic events, not write denials.
-  }
-}
-
 function rtdbSnapToWire(snap: DataSnapshot): unknown {
   return {
     key: snap.key,
@@ -792,6 +783,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
         const ref = pyricDoc(db, msg.path);
         const data = prepareWriteData(msg.data) as Record<string, unknown>;
         await setDoc(ref, data, msg.options as SetOptions | undefined);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -802,6 +794,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
         const ref = pyricDoc(db, msg.path);
         const data = prepareWriteData(msg.data) as Record<string, unknown>;
         await updateDoc(ref, data);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -811,6 +804,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       try {
         const ref = pyricDoc(db, msg.path);
         await deleteDoc(ref);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -821,6 +815,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
         const coll = pyricCollection(db, msg.collectionPath);
         const data = prepareWriteData(msg.data) as Record<string, unknown>;
         const ref = await addDoc(coll, data);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, { id: ref.id, path: ref.path });
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -877,6 +872,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
           applyWriteToBatch(db, batch, w);
         }
         await (batch as { commit(): Promise<void> }).commit();
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1067,6 +1063,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
             }
           }
         });
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) {
         if (e === TXN_ABORT) {

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -27,13 +27,13 @@
  * loop than the per-tab in-page capture it replaces.
  */
 
-import { sandbox as sandboxOps } from 'pyric/firestore';
+import { getFirestore, sandbox as sandboxOps } from 'pyric/firestore';
 import { getDatabase, sandbox as rtdbSandbox } from 'pyric/database/modular';
-import { sandbox as authOps, type SeedUser } from 'pyric/auth';
+import { getAuth, sandbox as authOps, type SeedUser } from 'pyric/auth';
 import type { PersistenceBackend } from 'pyric/sandbox';
-import { serializeToBuckets, bundleRecords, parseBundle } from 'pyric/sandbox';
+import { initializeSandbox, serializeToBuckets, bundleRecords, parseBundle } from 'pyric/sandbox';
 import type { InitPayload } from '../namespace.js';
-import { ensureAuth, type HostCtx } from './host.js';
+import { ensureAuth, getOrCreateInstanceId, type HostCtx } from './host.js';
 import { buildVerifyFixture } from '../../verify/fixture.js';
 
 /** Injected environment — `fetch` is the only ambient the worker init needs
@@ -381,4 +381,130 @@ export function setupServerAuthFlush(
     if (timer) clearTimeout(timer);
     unsub();
   };
+}
+
+// ─── Worker boot: build the ONE shared HostCtx ──────────────────────────────
+
+/** Default persistence key — also the IndexedDB database name. Package-level
+ *  default; stable across reloads (never derived from the page path, so every
+ *  boot on an origin opens the SAME database). */
+export const WORKER_PERSISTENCE_KEY = 'pyric-shared-worker';
+
+const PERMISSIVE_RULES = `
+  rules_version = '2';
+  service cloud.firestore {
+    match /databases/{database}/documents {
+      match /{document=**} {
+        allow read, write: if true;
+      }
+    }
+  }
+`;
+
+/** Environment for {@link buildWorkerCtx}. Everything ambient is injected so
+ *  the REAL boot path is testable headlessly (fake-indexeddb + stub fetch). */
+export interface WorkerBootEnv extends ServeInitEnv {
+  /** The raw local backend (IndexedDB in the real worker). Also used for the
+   *  instance id + branches + (via the durable wrapper) the controller blob. */
+  idb: PersistenceBackend;
+  /** Persistence key / IDB database name. Default {@link WORKER_PERSISTENCE_KEY}. */
+  persistenceKey?: string;
+  /** Hot-reload EventSource factory. Omit/null when unavailable (tests, hosts
+   *  without EventSource). */
+  makeEventSource?: ((url: string) => EventSourceLike) | null;
+}
+
+/**
+ * Build the ONE shared sandbox + Firestore handle — the SharedWorker's boot
+ * path, extracted from `entry.ts` so it is testable without a SharedWorker
+ * runtime (the reload-durability regression tests boot it twice over one
+ * fake-IDB factory).
+ *
+ * DURABILITY CONTRACT: persistence is wired via `sandbox.enablePersistence`
+ * (NOT the raw `attachPersistence` helper) so the controller registers on the
+ * sandbox and `sandbox.flush()` works. The worker host awaits that flush —
+ * which awaits the IndexedDB transaction's `oncomplete` — before acking every
+ * mutating op. That is the worker's ONLY durability mechanism: a SharedWorker
+ * gets no beforeunload/beforeterminate, so anything not committed to IDB when
+ * the last tab closes is lost.
+ */
+export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
+  const sandbox = initializeSandbox();
+
+  // Deploy permissive starter rules via admin-firestore.
+  // Callers override at runtime via the setRules op.
+  const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
+  const adminDb = getAdminFirestore(sandbox.withAuth(null));
+  adminDb.setRules(PERMISSIVE_RULES);
+
+  // Fetch serve's init payload FIRST — it decides the DURABLE strategy before
+  // we attach: `--persist` mirrors the controller blob to the committable
+  // server file (and primes from it on a fresh worker); a `seedState` fixture
+  // primes IDB once. Null when standalone (no `pyric dev` behind us).
+  const payload = await fetchInitPayload(env.fetch);
+
+  // The persistence-controller backend. `--persist`/`seedState` wrap IDB (see
+  // createWorkerDurableBackend); plain IDB otherwise. The session record stays
+  // on the RAW idb (local-only — it must NEVER reach the committable server
+  // file), so that is what we hand the host as `sessionBackend`.
+  const durable = payload ? createWorkerDurableBackend(env.idb, payload, env) : env.idb;
+  await sandbox.enablePersistence({
+    key: env.persistenceKey ?? WORKER_PERSISTENCE_KEY,
+    injectedBackend: durable,
+  });
+
+  // Register the auth service with the persistence registry BEFORE we read
+  // back any session: `getAuth(sandbox)` makes the user DB ride the snapshot
+  // (the #629 mechanism). One auth per worker — one shared user pool across
+  // all tabs (sessions are per-port; see host-auth.ts).
+  getAuth(sandbox);
+
+  // Sandbox-live Firestore: `getFirestore(sandbox)` reads
+  // `sandbox.currentUser` per operation, so auth changes propagate
+  // to subsequent Firestore ops without rebuilding the handle.
+  const db = getFirestore(sandbox);
+
+  const ctx: HostCtx = {
+    db,
+    sandbox,
+    // Stable per-SharedWorker identity (raw idb, local-only). Two browser
+    // profiles on the same port get two ids — how the UI tells them apart.
+    instanceId: await getOrCreateInstanceId(env.idb),
+    subs: new Map(),
+    sessionBackend: env.idb,
+    sessionMode: 'LOCAL',
+  };
+
+  // Apply rules / seed / authUsers / capture BEFORE any port op runs (so
+  // seeded users exist and project rules govern the first write), then mirror
+  // auth to the committable server file (`--persist` only).
+  if (payload) {
+    applyServeInit(ctx, payload, env);
+    setupServerAuthFlush(ctx, payload, env);
+  }
+
+  // The worker owns the SINGLE hot-reload stream for the origin (tabs open
+  // none) — so a rules change deploys once and multi-tab pages never exhaust
+  // the per-origin connection cap.
+  if (env.makeEventSource) {
+    setupWorkerHotReload(ctx, env.makeEventSource);
+  }
+
+  return ctx;
+}
+
+/**
+ * Fetch + parse `/__pyric/init.json`. The URL is relative to the worker
+ * script's origin (same origin as the page). Returns null on any failure: a
+ * worker opened outside `pyric dev` has no init endpoint and simply keeps
+ * the permissive starter rules + a plain-IDB durable store.
+ */
+async function fetchInitPayload(fetchFn: typeof fetch): Promise<InitPayload | null> {
+  try {
+    const res = await fetchFn('/__pyric/init.json');
+    if (!res.ok) return null;
+    return (await res.json()) as InitPayload;
+  } catch {
+    return null;
+  }
 }

--- a/packages/pyric-tools/test/bridge/worker-relay.test.ts
+++ b/packages/pyric-tools/test/bridge/worker-relay.test.ts
@@ -46,7 +46,7 @@ import type {
   InboundMessage,
   OutboundMessage,
 } from '../../src/serve/worker/protocol.js';
-import { initializeSandbox, attachPersistence, createMemoryBackend } from 'pyric/sandbox';
+import { initializeSandbox, createMemoryBackend } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
 import type { AuthUserRecord } from 'pyric/auth';
 
@@ -68,7 +68,7 @@ async function makeWorkerCtx(): Promise<HostCtx> {
   const sandbox = initializeSandbox();
   const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
   getAdminFirestore(sandbox.withAuth(null)).setRules(PERMISSIVE_RULES);
-  await attachPersistence(sandbox, {
+  await sandbox.enablePersistence({
     key: `relay-test-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });

--- a/packages/pyric-tools/test/serve/worker/event-stream.test.ts
+++ b/packages/pyric-tools/test/serve/worker/event-stream.test.ts
@@ -30,7 +30,6 @@ import type {
 } from '../../../src/serve/worker/protocol.js';
 import {
   initializeSandbox,
-  attachPersistence,
   createMemoryBackend,
 } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
@@ -68,7 +67,7 @@ async function makeCtx(): Promise<HostCtx> {
   const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
   const adminDb = getAdminFirestore(sandbox.withAuth(null));
   adminDb.setRules(PERMISSIVE_RULES);
-  await attachPersistence(sandbox, {
+  await sandbox.enablePersistence({
     key: `test-worker-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });

--- a/packages/pyric-tools/test/serve/worker/host.test.ts
+++ b/packages/pyric-tools/test/serve/worker/host.test.ts
@@ -32,7 +32,6 @@ import type {
 } from '../../../src/serve/worker/protocol.js';
 import {
   initializeSandbox,
-  attachPersistence,
   createMemoryBackend,
 } from 'pyric/sandbox';
 import {
@@ -98,7 +97,7 @@ async function makeCtx(rules: string = PERMISSIVE_RULES): Promise<HostCtx> {
   const adminDb = getAdminFirestore(sandbox.withAuth(null));
   adminDb.setRules(rules);
 
-  await attachPersistence(sandbox, {
+  await sandbox.enablePersistence({
     key: `test-worker-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });

--- a/packages/pyric-tools/test/serve/worker/integration.test.ts
+++ b/packages/pyric-tools/test/serve/worker/integration.test.ts
@@ -17,7 +17,6 @@ import {
 import type { InboundMessage, OutboundMessage } from '../../../src/serve/worker/protocol.js';
 import {
   initializeSandbox,
-  attachPersistence,
   createMemoryBackend,
 } from 'pyric/sandbox';
 import { getFirestore as ipGetFirestore } from 'pyric/firestore';
@@ -55,7 +54,7 @@ async function makeHostCtx(): Promise<HostCtx> {
   const sandbox = initializeSandbox();
   const { getFirestore: adm } = await import('pyric/sandbox/admin-firestore');
   adm(sandbox.withAuth(null)).setRules(GATE_RULES);
-  await attachPersistence(sandbox, { key: `int-${Math.random()}`, injectedBackend: createMemoryBackend() });
+  await sandbox.enablePersistence({ key: `int-${Math.random()}`, injectedBackend: createMemoryBackend() });
   ipGetAuth(sandbox);
   return { db: ipGetFirestore(sandbox), sandbox, subs: new Map(), sessionMode: 'LOCAL', sessionBackend: createMemoryBackend() };
 }

--- a/packages/pyric-tools/test/serve/worker/persistence-durability.test.ts
+++ b/packages/pyric-tools/test/serve/worker/persistence-durability.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Reload-durability regression tests — an ACKNOWLEDGED write must survive an
+ * abrupt SharedWorker teardown (last tab closed / page reloaded).
+ *
+ * THE BUG THIS PINS DOWN: `entry.ts` wired persistence via the raw
+ * `attachPersistence()` helper instead of `sandbox.enablePersistence()`, so
+ * the controller was never registered on the sandbox and `sandbox.flush()`
+ * threw `failed-precondition` — silently swallowed by the host's best-effort
+ * flush. The "awaited flush before ack" was a no-op, and (because
+ * `admin.setDocument` emits no persistable sandbox event) not even the
+ * debounced auto-flush ever ran for admin writes. Result: a write acked over
+ * the worker port never reached IndexedDB, and a page reload (which lets the
+ * browser kill the SharedWorker) lost it.
+ *
+ * Strategy: boot the REAL worker boot path (`buildWorkerCtx`, the exact code
+ * `entry.ts` runs) over fake-indexeddb, perform an acked op via
+ * `handleMessage`, then ABANDON the ctx — no dispose, no timers awaited, no
+ * event-loop settling — exactly like a browser terminating the worker. Boot
+ * a second ctx over the SAME IndexedDB and assert the data restored.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { handleMessage, type HostCtx, type PortLike } from '../../../src/serve/worker/host.js';
+import { buildWorkerCtx } from '../../../src/serve/worker/serve-init.js';
+import type { OutboundMessage, ResMessage } from '../../../src/serve/worker/protocol.js';
+import { createIndexedDBBackend } from 'pyric/sandbox';
+
+/** Stub fetch: standalone worker (no `pyric dev` behind it) — init.json 404s. */
+const offlineFetch = (async () => {
+  throw new Error('offline');
+}) as unknown as typeof fetch;
+
+function fakePort(): PortLike & { messages: OutboundMessage[] } {
+  const messages: OutboundMessage[] = [];
+  return { messages, postMessage: (m: OutboundMessage) => { messages.push(m); } };
+}
+
+/** Boot the worker exactly as entry.ts does, against the shared fake IDB. */
+function bootWorker(key: string): Promise<HostCtx> {
+  return buildWorkerCtx({
+    fetch: offlineFetch,
+    idb: createIndexedDBBackend(),
+    persistenceKey: key,
+  });
+}
+
+async function op(ctx: HostCtx, msg: Record<string, unknown>): Promise<ResMessage> {
+  const port = fakePort();
+  await handleMessage(ctx, port, { t: 'op', ...msg } as never);
+  const res = port.messages.find(
+    (m): m is ResMessage => m.t === 'res' && m.id === msg.id,
+  );
+  if (!res) throw new Error(`no res for ${String(msg.id)}`);
+  return res;
+}
+
+let seq = 0;
+const freshKey = (): string => `durability-test-${Date.now()}-${seq++}`;
+
+describe('worker persistence: acked writes survive abrupt teardown', () => {
+  it('sandbox.flush() is actually wired (enablePersistence, not raw attach)', async () => {
+    const ctx = await bootWorker(freshKey());
+    // Pre-fix this threw failed-precondition ('flush() called before
+    // enablePersistence()') and the host swallowed it.
+    await ctx.sandbox.flush();
+  });
+
+  it('an acked admin.setDocument restores after a cold reboot over the same IDB', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const write = await op(ctxA, {
+      id: 'w1',
+      method: 'admin.setDocument',
+      path: 'notes/reload-check',
+      data: { marker: 'alpha' },
+    });
+    expect(write.ok).toBe(true);
+    // Abrupt teardown: nothing runs after the ack (no dispose, no settling).
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'admin.getDocument', path: 'notes/reload-check' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { marker?: string } | null)?.marker).toBe('alpha');
+  });
+
+  it('an acked client setDoc restores after a cold reboot over the same IDB', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const write = await op(ctxA, {
+      id: 'w1',
+      method: 'setDoc',
+      path: 'notes/client-write',
+      data: { marker: 'beta' },
+    });
+    expect(write.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'admin.getDocument', path: 'notes/client-write' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { marker?: string } | null)?.marker).toBe('beta');
+  });
+
+  it('an acked admin.deleteDocument stays deleted after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    await op(ctxA, { id: 'w1', method: 'admin.setDocument', path: 'notes/doomed', data: { x: 1 } });
+    const del = await op(ctxA, { id: 'd1', method: 'admin.deleteDocument', path: 'notes/doomed' });
+    expect(del.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'admin.getDocument', path: 'notes/doomed' });
+    expect(read.ok).toBe(true);
+    expect(read.value).toBeNull();
+  });
+
+  it('an acked batchCommit restores after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const commit = await op(ctxA, {
+      id: 'b1',
+      method: 'batchCommit',
+      writes: [
+        { method: 'set', path: 'notes/batch-a', data: { n: 1 } },
+        { method: 'set', path: 'notes/batch-b', data: { n: 2 } },
+      ],
+    });
+    expect(commit.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const a = await op(ctxB, { id: 'r1', method: 'admin.getDocument', path: 'notes/batch-a' });
+    const b = await op(ctxB, { id: 'r2', method: 'admin.getDocument', path: 'notes/batch-b' });
+    expect((a.value as { n?: number } | null)?.n).toBe(1);
+    expect((b.value as { n?: number } | null)?.n).toBe(2);
+  });
+
+  it('an acked auth.adminCreateUser restores after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const created = await op(ctxA, {
+      id: 'u1',
+      method: 'auth.adminCreateUser',
+      request: { email: 'durable@example.com', password: 'hunter22' },
+    });
+    expect(created.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const list = await op(ctxB, { id: 'l1', method: 'auth.listUsers' });
+    expect(list.ok).toBe(true);
+    const emails = (list.value as Array<{ email?: string }>).map((u) => u.email);
+    expect(emails).toContain('durable@example.com');
+  });
+});

--- a/packages/pyric-tools/test/serve/worker/serve-init.test.ts
+++ b/packages/pyric-tools/test/serve/worker/serve-init.test.ts
@@ -28,7 +28,6 @@ import type { OutboundMessage, ResMessage } from '../../../src/serve/worker/prot
 import { sandbox as authOps } from 'pyric/auth';
 import {
   initializeSandbox,
-  attachPersistence,
   createMemoryBackend,
   serializeToBuckets,
   deserializeFromBuckets,
@@ -81,7 +80,7 @@ async function makeCtx(): Promise<HostCtx> {
   const sandbox = initializeSandbox();
   const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
   getAdminFirestore(sandbox.withAuth(null)).setRules(PERMISSIVE_RULES);
-  await attachPersistence(sandbox, {
+  await sandbox.enablePersistence({
     key: `serve-init-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });


### PR DESCRIPTION
IDB persistence in the served worker was never actually wired: `attachPersistence()`'s result was discarded, flush errors landed in a swallowed catch, and admin writes never armed the debounce. Acked writes could vanish on reload.

Now the worker awaits the IndexedDB transaction's `oncomplete` before acking, so acked means committed. Six durability tests cover the contract (reload survival, admin writes, flush-on-close).

Publish-gating: without this, the persistence story in the README is false.