### PR TITLE
OpenRouter OAuth (PKCE) sign-in for playground BYOK

### DIFF
--- a/packages/playground/src/components/ApiKeyForm.tsx
+++ b/packages/playground/src/components/ApiKeyForm.tsx
@@ -31,6 +31,13 @@ export interface ApiKeyField {
    * string when not. Surfaced under the input and blocks submit.
    */
   validate?: (value: string) => string | null;
+  /**
+   * Optional provider-specific UI rendered below the input — e.g.
+   * OpenRouter's "Sign in with OpenRouter" button and "remember on
+   * this device" checkbox. Free-form so the form stays agnostic to
+   * what any one provider needs.
+   */
+  extra?: React.ReactNode;
 }
 
 export interface ApiKeyFormProps {
@@ -139,6 +146,7 @@ export function ApiKeyForm({
               ) : f.hint ? (
                 <span className="text-[12px] text-slate-gray opacity-60">{f.hint}</span>
               ) : null}
+              {f.extra ?? null}
             </div>
           );
         })}

--- a/packages/playground/src/components/OpenRouterSignIn.tsx
+++ b/packages/playground/src/components/OpenRouterSignIn.tsx
@@ -1,0 +1,94 @@
+/**
+ * "Sign in with OpenRouter" — rendered as the OpenRouter row's `extra`
+ * slot in the BYOK modal (see `byok-field.tsx`), alongside the manual
+ * paste input. Two states:
+ *
+ *   - No session-backed key: a button that starts the OAuth (PKCE)
+ *     redirect (`beginSignIn` in `lib/llm/openrouter-oauth.ts`). The
+ *     button click is the only thing this component does before the
+ *     full-page navigation away — completion happens on the NEXT page
+ *     load, handled by `PlaygroundPage`'s mount effect.
+ *   - A session-backed key exists (`openrouterByok.hasSessionKey()`):
+ *     a "Remember on this device" checkbox that promotes it to
+ *     `localStorage` via `promoteToLocal()`. One-way — unchecking does
+ *     not demote a promoted key back to session-only.
+ *
+ * `signInError` is passed down from `PlaygroundPage` because the
+ * exchange that can fail (`completeSignInIfPending`) runs in a mount
+ * effect, not from this button — the button only fires the redirect
+ * half of the flow, which effectively never "fails" client-side (it's
+ * a network call for the authorize URL, then a navigation).
+ */
+import { useState } from 'react';
+import { beginSignIn } from '~/lib/llm/openrouter-oauth';
+import { openrouterByok } from '~/lib/llm/byok';
+
+export interface OpenRouterSignInProps {
+  /** Bumps the modal's re-read of `byok.hasKey()` after a promote. */
+  onKeyChanged: () => void;
+  /** Surfaced from the OAuth callback exchange (see PlaygroundPage's
+   *  mount effect), not from this component's own button click. */
+  signInError?: string | null;
+  /** Called when the user starts a fresh attempt — lets the parent
+   *  clear a stale `signInError` from a previous denied/expired code
+   *  before the new redirect happens. */
+  onRetry?: () => void;
+}
+
+export function OpenRouterSignIn({ onKeyChanged, signInError, onRetry }: OpenRouterSignInProps) {
+  const [starting, setStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+  const hasSessionKey = openrouterByok.hasSessionKey();
+
+  const handleSignIn = async () => {
+    setStarting(true);
+    setStartError(null);
+    onRetry?.();
+    try {
+      // Redirects the page away on success — this call does not
+      // resolve in the normal case. It only returns (and rethrows)
+      // when minting the authorize URL itself fails, e.g. offline.
+      await beginSignIn();
+    } catch (e) {
+      setStarting(false);
+      setStartError(
+        e instanceof Error ? e.message : 'Could not start OpenRouter sign-in.',
+      );
+    }
+  };
+
+  const handleRemember = (checked: boolean) => {
+    if (!checked) return; // one-way promote; unchecking is a no-op
+    openrouterByok.promoteToLocal();
+    onKeyChanged();
+  };
+
+  const error = startError ?? signInError ?? null;
+
+  return (
+    <div className="flex flex-col gap-2 pt-1">
+      <button
+        type="button"
+        onClick={() => void handleSignIn()}
+        disabled={starting}
+        className={`rounded-md border border-[#2a2a35] px-3 py-2 text-[13px] font-medium text-soft-white transition-colors ${
+          starting ? 'opacity-50 cursor-not-allowed' : 'hover:border-slate-gray cursor-pointer'
+        }`}
+      >
+        {starting ? 'Redirecting to OpenRouter…' : 'Sign in with OpenRouter'}
+      </button>
+      {error ? <span className="text-[12px] text-red-400">{error}</span> : null}
+      {hasSessionKey ? (
+        <label className="flex items-center gap-2 text-[12px] text-slate-gray">
+          <input
+            type="checkbox"
+            className="accent-soft-white"
+            onChange={(e) => handleRemember(e.target.checked)}
+          />
+          Remember on this device (stores the key in localStorage instead of
+          just this session)
+        </label>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/playground/src/components/PlaygroundPage.tsx
+++ b/packages/playground/src/components/PlaygroundPage.tsx
@@ -73,6 +73,7 @@ import {
 } from '~/lib/studio-embed';
 import { listToolHandlersForProfile } from '~/lib/tools';
 import { completeRedirectSignIn } from '~/lib/firebase/auth';
+import { completeSignInIfPending } from '~/lib/llm/openrouter-oauth';
 import { installDiagnosticsGlobals, logPage } from '~/lib/llm/inference/diagnostics';
 import { installOpenRouterInspector } from '~/lib/llm/inference/openrouter-inspect';
 import { ModelPicker } from './ModelPicker';
@@ -248,6 +249,34 @@ export function PlaygroundPage() {
   const [externalCompose, setExternalCompose] = useState<{ text: string; nonce: number } | null>(null);
   // Tick so the modal re-reads `hasKey()` after a save.
   const [keysTick, setKeysTick] = useState(0);
+  // Surfaced from the OpenRouter OAuth callback exchange below —
+  // shown as the key modal's form-level error so a denied/expired
+  // `code` is visible rather than silently dropped.
+  const [openrouterSignInError, setOpenrouterSignInError] = useState<string | null>(null);
+
+  // Complete a pending OpenRouter OAuth (PKCE) round trip on load. A
+  // no-op unless the URL carries `?code=` (i.e. we were just
+  // redirected back from OpenRouter's authorize page — see
+  // `beginSignIn` in `lib/llm/openrouter-oauth.ts`). Static build, no
+  // server routes: the whole exchange runs here, client-side. Success
+  // or failure, the `code` param gets stripped from the URL inside
+  // `completeSignInIfPending` so a reload can't resubmit it (codes are
+  // single-use — retrying would just fail and could loop the user back
+  // into a broken redirect).
+  useEffect(() => {
+    void completeSignInIfPending().then((result) => {
+      if (result.status === 'not-pending') return;
+      setKeysTick((t) => t + 1);
+      if (result.status === 'error') {
+        setOpenrouterSignInError(result.message);
+        openKeys();
+      } else {
+        setOpenrouterSignInError(null);
+        openKeys();
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // `[` hotkey — fold all turns except the most recent. Same
   // primitive as the auto-fold-on-new-turn setting; this is the
@@ -664,6 +693,7 @@ export function PlaygroundPage() {
     if (ollamaUrlChanged) {
       void useOllamaModelsStore.getState().refresh();
     }
+    setOpenrouterSignInError(null);
     setKeysTick((t) => t + 1);
     setKeysOpen(false);
   }, []);
@@ -1021,10 +1051,17 @@ export function PlaygroundPage() {
           <ApiKeyForm
             title="API keys"
             subtitle="Bring your own keys. Stored in this browser only — never sent to a server we control."
-            fields={PROVIDER_LIST.map((def) => buildApiKeyField(def)).filter((f) => f !== null)}
+            fields={PROVIDER_LIST.map((def) =>
+              buildApiKeyField(def, {
+                onKeyChanged: () => setKeysTick((t) => t + 1),
+                openrouterSignInError,
+                onOpenrouterSignInRetry: () => setOpenrouterSignInError(null),
+              }),
+            ).filter((f) => f !== null)}
           onSubmit={handleSaveKeys}
           submitLabel="Save"
-          footerText="Update or remove anytime."
+          error={openrouterSignInError}
+          footerText="Update or remove anytime. Until preview isolation lands, code running in the preview can read stored keys."
         />
       </Modal>
     </ToastProvider>

--- a/packages/playground/src/components/byok-field.tsx
+++ b/packages/playground/src/components/byok-field.tsx
@@ -12,13 +12,26 @@
  * inline CORS warning for Ollama specifically.
  */
 import type { ApiKeyField } from './ApiKeyForm';
+import { OpenRouterSignIn } from './OpenRouterSignIn';
 import { validateBaseUrl } from '~/lib/llm/byok';
 import type { ProviderDef } from '~/lib/llm/registry';
 
 const OLLAMA_FAQ_URL =
   'https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-configure-ollama-server';
 
-export function buildApiKeyField(def: ProviderDef): ApiKeyField | null {
+export interface BuildApiKeyFieldOpts {
+  /** Only used by the `openrouter` row — see `OpenRouterSignIn`. */
+  onKeyChanged?: () => void;
+  /** Only used by the `openrouter` row — see `OpenRouterSignIn`. */
+  openrouterSignInError?: string | null;
+  /** Only used by the `openrouter` row — see `OpenRouterSignIn`. */
+  onOpenrouterSignInRetry?: () => void;
+}
+
+export function buildApiKeyField(
+  def: ProviderDef,
+  opts: BuildApiKeyFieldOpts = {},
+): ApiKeyField | null {
   // `none` slots (Claude local CLI) have no credential to collect —
   // auth is the CLI's own subscription login on the dev server. The
   // modal simply omits the row.
@@ -66,6 +79,7 @@ export function buildApiKeyField(def: ProviderDef): ApiKeyField | null {
     };
   }
   const has = def.byok.hasKey();
+  const isOpenRouter = def.id === 'openrouter';
   return {
     id: def.id,
     label: def.byok.label,
@@ -73,5 +87,16 @@ export function buildApiKeyField(def: ProviderDef): ApiKeyField | null {
     hint: has
       ? 'Key is set. Type to replace.'
       : `Get one at ${def.byok.helpUrl.replace(/^https?:\/\//, '')}`,
+    ...(isOpenRouter && opts.onKeyChanged
+      ? {
+          extra: (
+            <OpenRouterSignIn
+              onKeyChanged={opts.onKeyChanged}
+              signInError={opts.openrouterSignInError}
+              onRetry={opts.onOpenrouterSignInRetry}
+            />
+          ),
+        }
+      : {}),
   };
 }

--- a/packages/playground/src/lib/llm/byok.test.ts
+++ b/packages/playground/src/lib/llm/byok.test.ts
@@ -1,0 +1,141 @@
+/**
+ * BYOK slot storage — specifically the session-backed variant added for
+ * OpenRouter's OAuth flow: `setKey({ backend })`, `getKey()` precedence
+ * between the two backends, `hasSessionKey()`, and `promoteToLocal()`
+ * ("remember on this device"). Manual-paste (`localStorage`-only)
+ * behavior is covered implicitly — `backend` defaults to `'local'`, so
+ * every existing call site (`slot.setKey(value)`) is unaffected.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+// bun test has no DOM. Shim `window.localStorage` + `window.sessionStorage`
+// as independent in-memory maps, mirroring the convention in
+// `sandbox-headless.test.ts`.
+interface MemStorage {
+  getItem(k: string): string | null;
+  setItem(k: string, v: string): void;
+  removeItem(k: string): void;
+  clear(): void;
+  key(): null;
+  readonly length: number;
+}
+
+function memStorage(): MemStorage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+interface WindowShim {
+  localStorage: MemStorage;
+  sessionStorage: MemStorage;
+}
+
+if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+  (globalThis as unknown as { window?: WindowShim }).window = {
+    localStorage: memStorage(),
+    sessionStorage: memStorage(),
+  };
+}
+const win = (globalThis as unknown as { window: WindowShim }).window;
+if (!win.localStorage) win.localStorage = memStorage();
+if (!win.sessionStorage) win.sessionStorage = memStorage();
+
+import { openrouterByok } from './byok';
+
+function reset() {
+  win.localStorage.clear();
+  win.sessionStorage.clear();
+}
+
+describe('apiKey slot — backend selection', () => {
+  beforeEach(reset);
+
+  test('setKey defaults to localStorage (manual paste, unchanged behavior)', () => {
+    openrouterByok.setKey('sk-or-v1-manual');
+    expect(win.localStorage.getItem('pyric.playground.byok.openrouter')).toBe(
+      'sk-or-v1-manual',
+    );
+    expect(win.sessionStorage.getItem('pyric.playground.byok.openrouter')).toBeNull();
+  });
+
+  test('setKey({ backend: "session" }) writes to sessionStorage only', () => {
+    openrouterByok.setKey('sk-or-v1-oauth', { backend: 'session' });
+    expect(win.sessionStorage.getItem('pyric.playground.byok.openrouter')).toBe(
+      'sk-or-v1-oauth',
+    );
+    expect(win.localStorage.getItem('pyric.playground.byok.openrouter')).toBeNull();
+  });
+});
+
+describe('apiKey slot — read precedence + hasKey/hasSessionKey', () => {
+  beforeEach(reset);
+
+  test('absent everywhere: hasKey/hasSessionKey false, getKey null', () => {
+    expect(openrouterByok.hasKey()).toBe(false);
+    expect(openrouterByok.hasSessionKey()).toBe(false);
+    expect(openrouterByok.getKey()).toBeNull();
+  });
+
+  test('local only: getKey returns it, hasSessionKey stays false', () => {
+    openrouterByok.setKey('sk-local');
+    expect(openrouterByok.hasKey()).toBe(true);
+    expect(openrouterByok.hasSessionKey()).toBe(false);
+    expect(openrouterByok.getKey()).toBe('sk-local');
+  });
+
+  test('session only: getKey returns it, hasSessionKey true', () => {
+    openrouterByok.setKey('sk-session', { backend: 'session' });
+    expect(openrouterByok.hasKey()).toBe(true);
+    expect(openrouterByok.hasSessionKey()).toBe(true);
+    expect(openrouterByok.getKey()).toBe('sk-session');
+  });
+
+  test('both set: session wins (fresher OAuth key over a stale pasted one)', () => {
+    openrouterByok.setKey('sk-local-stale');
+    openrouterByok.setKey('sk-session-fresh', { backend: 'session' });
+    expect(openrouterByok.getKey()).toBe('sk-session-fresh');
+    expect(openrouterByok.hasSessionKey()).toBe(true);
+  });
+});
+
+describe('apiKey slot — promoteToLocal ("remember on this device")', () => {
+  beforeEach(reset);
+
+  test('moves the session key to localStorage and clears the session copy', () => {
+    openrouterByok.setKey('sk-session', { backend: 'session' });
+    openrouterByok.promoteToLocal();
+    expect(win.localStorage.getItem('pyric.playground.byok.openrouter')).toBe('sk-session');
+    expect(win.sessionStorage.getItem('pyric.playground.byok.openrouter')).toBeNull();
+    expect(openrouterByok.hasSessionKey()).toBe(false);
+    expect(openrouterByok.getKey()).toBe('sk-session');
+  });
+
+  test('is a no-op when there is no session key', () => {
+    openrouterByok.setKey('sk-local-only');
+    openrouterByok.promoteToLocal();
+    expect(win.localStorage.getItem('pyric.playground.byok.openrouter')).toBe(
+      'sk-local-only',
+    );
+  });
+});
+
+describe('apiKey slot — clearKey removes both backends', () => {
+  beforeEach(reset);
+
+  test('clearKey wipes local and session copies', () => {
+    openrouterByok.setKey('sk-local');
+    openrouterByok.setKey('sk-session', { backend: 'session' });
+    openrouterByok.clearKey();
+    expect(openrouterByok.hasKey()).toBe(false);
+    expect(openrouterByok.getKey()).toBeNull();
+  });
+});

--- a/packages/playground/src/lib/llm/byok.ts
+++ b/packages/playground/src/lib/llm/byok.ts
@@ -1,5 +1,6 @@
 /**
- * BYOK — bring-your-own-key. localStorage-backed per-provider.
+ * BYOK — bring-your-own-key. localStorage-backed per-provider, with an
+ * optional session-scoped backend for `apiKey` slots.
  *
  * Why client-side: this is a static Astro site. No backend means no
  * shared key store; the only honest answer is "your browser, your
@@ -18,8 +19,25 @@
  * a `baseUrl` slot resets to the `defaultBaseUrl`, not to absent —
  * Ollama is useless without one and `http://localhost:11434` is the
  * upstream default.
+ *
+ * Session-backed keys (`apiKey` slots only). A key can live in
+ * `sessionStorage` instead of `localStorage` — used for OpenRouter's
+ * OAuth-provisioned keys, which default to the tab's lifetime rather
+ * than surviving indefinitely on disk. One storage key, one mechanism:
+ * `getKey()`/`hasKey()` check `sessionStorage` first, then fall back to
+ * `localStorage`, so callers that only care about "is there a usable
+ * key" never need to know which backend holds it. `setKey(key, {
+ * backend })` picks where a *new* value lands (default `'local'`,
+ * preserving the historical manually-pasted-key behavior).
+ * `promoteToLocal()` moves a session-backed key to `localStorage`
+ * ("remember on this device") without ever holding the secret in two
+ * places at once.
  */
 const PREFIX = 'pyric.playground.byok.';
+
+/** Where a key value is persisted. `'session'` clears when the tab
+ *  closes; `'local'` survives indefinitely (the historical default). */
+export type ByokBackend = 'local' | 'session';
 
 interface ByokSlotBase {
   /** Display label (e.g. "Gemini API key"). */
@@ -38,6 +56,20 @@ interface ByokSlotBase {
 
 export interface ApiKeyByokSlot extends ByokSlotBase {
   kind: 'apiKey';
+  /** True when a key is currently held in the session-scoped backend
+   *  specifically (as opposed to `localStorage`). Drives the "remember
+   *  on this device" affordance in the key UI — offering to promote a
+   *  key that's already local would be a no-op. */
+  hasSessionKey(): boolean;
+  /** Persist a key. `opts.backend` picks the storage backend for THIS
+   *  write (default `'local'`) — it does not touch a value already
+   *  sitting in the other backend, so callers that want a clean switch
+   *  should `clearKey()` first (see `promoteToLocal` for the one case
+   *  that needs it). */
+  setKey(key: string, opts?: { backend?: ByokBackend }): void;
+  /** Move a session-backed key to `localStorage` ("remember on this
+   *  device"). No-op when there is no session-backed key. */
+  promoteToLocal(): void;
 }
 
 export interface BaseUrlByokSlot extends ByokSlotBase {
@@ -61,6 +93,18 @@ function safeLocalStorage(): Storage | null {
   }
 }
 
+function safeSessionStorage(): Storage | null {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeStorage(backend: ByokBackend): Storage | null {
+  return backend === 'session' ? safeSessionStorage() : safeLocalStorage();
+}
+
 function createApiKeySlot(id: string, label: string, helpUrl: string): ApiKeyByokSlot {
   const storageKey = `${PREFIX}${id}`;
   return {
@@ -68,22 +112,44 @@ function createApiKeySlot(id: string, label: string, helpUrl: string): ApiKeyByo
     label,
     helpUrl,
     hasKey() {
-      const ls = safeLocalStorage();
-      return ls ? !!ls.getItem(storageKey) : false;
+      return (
+        !!safeStorage('session')?.getItem(storageKey) ||
+        !!safeStorage('local')?.getItem(storageKey)
+      );
+    },
+    hasSessionKey() {
+      return !!safeStorage('session')?.getItem(storageKey);
     },
     getKey() {
-      const ls = safeLocalStorage();
-      return ls ? ls.getItem(storageKey) : null;
+      // Session-backed keys win over a stale localStorage value — a
+      // freshly-completed OAuth sign-in should take effect immediately
+      // even if an older manually-pasted key is still on disk.
+      return (
+        safeStorage('session')?.getItem(storageKey) ??
+        safeStorage('local')?.getItem(storageKey) ??
+        null
+      );
     },
-    setKey(key) {
-      const ls = safeLocalStorage();
-      if (!ls) return;
-      if (key.trim().length === 0) ls.removeItem(storageKey);
-      else ls.setItem(storageKey, key.trim());
+    setKey(key, opts) {
+      const backend = opts?.backend ?? 'local';
+      const store = safeStorage(backend);
+      if (!store) return;
+      const trimmed = key.trim();
+      if (trimmed.length === 0) store.removeItem(storageKey);
+      else store.setItem(storageKey, trimmed);
     },
     clearKey() {
-      const ls = safeLocalStorage();
-      ls?.removeItem(storageKey);
+      safeStorage('session')?.removeItem(storageKey);
+      safeStorage('local')?.removeItem(storageKey);
+    },
+    promoteToLocal() {
+      const session = safeStorage('session');
+      const value = session?.getItem(storageKey);
+      if (!value) return;
+      const local = safeStorage('local');
+      if (!local) return;
+      local.setItem(storageKey, value);
+      session?.removeItem(storageKey);
     },
   };
 }

--- a/packages/playground/src/lib/llm/openrouter-oauth.test.ts
+++ b/packages/playground/src/lib/llm/openrouter-oauth.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure parts of the OpenRouter OAuth (PKCE) flow: callback detection,
+ * URL cleaning, and the verifier stash lifecycle. The redirect round
+ * trip through OpenRouter's authorize page (`beginSignIn` /
+ * `completeSignInIfPending`) is NOT covered here — it needs a real
+ * browser + network and a human to click through it.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+// bun test has no DOM. Shim just enough `window.sessionStorage` for the
+// verifier-stash helpers, mirroring the convention in
+// `sandbox-headless.test.ts`.
+if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+  (globalThis as { window?: unknown }).window = {};
+}
+const win = (globalThis as unknown as { window: Record<string, unknown> }).window;
+if (!win.sessionStorage) {
+  const store = new Map<string, string>();
+  win.sessionStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+import {
+  cleanOAuthUrl,
+  clearCodeVerifier,
+  detectOAuthCode,
+  readCodeVerifier,
+  stashCodeVerifier,
+} from './openrouter-oauth';
+
+describe('detectOAuthCode', () => {
+  test('extracts ?code= from a callback URL', () => {
+    expect(detectOAuthCode('https://pyric.dev/playground?code=abc123')).toBe('abc123');
+  });
+
+  test('extracts code alongside other query params', () => {
+    expect(
+      detectOAuthCode('https://pyric.dev/playground?session=xyz&code=abc123&foo=bar'),
+    ).toBe('abc123');
+  });
+
+  test('returns null when no code param is present', () => {
+    expect(detectOAuthCode('https://pyric.dev/playground?session=xyz')).toBeNull();
+  });
+
+  test('returns null for an empty code value', () => {
+    expect(detectOAuthCode('https://pyric.dev/playground?code=')).toBeNull();
+  });
+
+  test('returns null for an unparseable URL rather than throwing', () => {
+    expect(detectOAuthCode('not a url')).toBeNull();
+  });
+});
+
+describe('cleanOAuthUrl', () => {
+  test('strips code but keeps other query params and the path', () => {
+    expect(cleanOAuthUrl('https://pyric.dev/playground?session=xyz&code=abc123')).toBe(
+      '/playground?session=xyz',
+    );
+  });
+
+  test('drops an empty query string entirely when code was the only param', () => {
+    expect(cleanOAuthUrl('https://pyric.dev/playground?code=abc123')).toBe('/playground');
+  });
+
+  test('preserves the hash', () => {
+    expect(cleanOAuthUrl('https://pyric.dev/playground?code=abc123#agent')).toBe(
+      '/playground#agent',
+    );
+  });
+
+  test('is a no-op when there is no code param', () => {
+    expect(cleanOAuthUrl('https://pyric.dev/playground?session=xyz')).toBe(
+      '/playground?session=xyz',
+    );
+  });
+});
+
+describe('verifier stash lifecycle', () => {
+  beforeEach(() => {
+    clearCodeVerifier();
+  });
+
+  test('starts absent', () => {
+    expect(readCodeVerifier()).toBeNull();
+  });
+
+  test('stash then read round-trips the verifier', () => {
+    stashCodeVerifier('verifier-123');
+    expect(readCodeVerifier()).toBe('verifier-123');
+  });
+
+  test('clear removes it', () => {
+    stashCodeVerifier('verifier-123');
+    clearCodeVerifier();
+    expect(readCodeVerifier()).toBeNull();
+  });
+
+  test('a second stash overwrites the first (one flow in flight at a time)', () => {
+    stashCodeVerifier('first');
+    stashCodeVerifier('second');
+    expect(readCodeVerifier()).toBe('second');
+  });
+});

--- a/packages/playground/src/lib/llm/openrouter-oauth.ts
+++ b/packages/playground/src/lib/llm/openrouter-oauth.ts
@@ -1,0 +1,161 @@
+/**
+ * OpenRouter "Sign in with OpenRouter" — client-side OAuth (PKCE) via
+ * `@inbrowser/model`'s `beginOpenRouterOAuth` / `completeOpenRouterOAuth`.
+ * Lets the user provision an OpenRouter key without pasting one, on a
+ * STATIC build (no server routes) — the whole exchange runs page-side.
+ *
+ * Flow (full-page redirect; there is no popup here — a popup would need
+ * a same-origin postMessage relay this static site doesn't have):
+ *
+ *   1. `beginSignIn()` — mint a PKCE verifier + challenge, stash the
+ *      verifier in `sessionStorage` (must survive the redirect; a
+ *      full-page navigation clears in-memory state), then
+ *      `window.location.assign(authUrl)`.
+ *   2. OpenRouter redirects back to THIS page with `?code=...`.
+ *      `completeSignInIfPending()` runs once on load: detects the
+ *      `code` param, reads the stashed verifier, exchanges them for a
+ *      key, stores the key through the existing BYOK slot (session
+ *      backend — see `byok.ts`), clears the verifier, and cleans the
+ *      `code` param off the URL via `history.replaceState` so a reload
+ *      doesn't re-run the exchange (OpenRouter codes are single-use;
+ *      retrying would fail and could loop).
+ *
+ * The pure pieces (callback detection, URL cleaning, verifier stash
+ * lifecycle) are unit tested in `openrouter-oauth.test.ts`. The actual
+ * redirect round trip through OpenRouter's authorize page is NOT
+ * exercised by any test here — it needs a human to click through it in
+ * a real browser. See AGENTS.md / the PR description for the manual
+ * check.
+ */
+import {
+  beginOpenRouterOAuth,
+  completeOpenRouterOAuth,
+} from '@inbrowser/model';
+import { openrouterByok } from './byok';
+
+const VERIFIER_KEY = 'pyric.playground.oauth.openrouter.verifier';
+const CODE_PARAM = 'code';
+
+// ── Pure helpers ────────────────────────────────────────────────────
+
+/**
+ * Does `url` carry an OpenRouter OAuth callback (`?code=...`)? Returns
+ * the code, or null when this isn't a callback load. Pulled out of
+ * `completeSignInIfPending` so it's testable without touching
+ * `sessionStorage` or the network.
+ */
+export function detectOAuthCode(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const code = parsed.searchParams.get(CODE_PARAM);
+  return code && code.length > 0 ? code : null;
+}
+
+/**
+ * Strip the OAuth `code` query param from `url`, returning the cleaned
+ * URL string. Used with `history.replaceState` so the code — single-use
+ * and otherwise re-submitted on every reload — doesn't linger in the
+ * address bar. Leaves every other query param and the hash untouched.
+ */
+export function cleanOAuthUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.delete(CODE_PARAM);
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+function safeSessionStorage(): Storage | null {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the PKCE verifier across the redirect. */
+export function stashCodeVerifier(verifier: string): void {
+  safeSessionStorage()?.setItem(VERIFIER_KEY, verifier);
+}
+
+/** Read the stashed verifier, or null if none is pending. */
+export function readCodeVerifier(): string | null {
+  return safeSessionStorage()?.getItem(VERIFIER_KEY) ?? null;
+}
+
+/** Drop the stashed verifier — called once the exchange has been
+ *  attempted (success or failure), so a stale verifier can't be reused
+ *  or mistaken for a still-pending flow. */
+export function clearCodeVerifier(): void {
+  safeSessionStorage()?.removeItem(VERIFIER_KEY);
+}
+
+// ── Orchestration (needs a browser + network; not unit tested) ──────
+
+/** Where OpenRouter should send the user back. The current page,
+ *  stripped of any prior `code` — OpenRouter constrains this to https
+ *  on port 443/3000, or localhost on any port, which every supported
+ *  deploy target (prod, preview, local dev) satisfies. */
+function callbackUrl(): string {
+  return `${window.location.origin}${cleanOAuthUrl(window.location.href)}`;
+}
+
+/**
+ * Kick off the OAuth flow: mint a verifier, stash it, and redirect the
+ * whole page to OpenRouter's authorize screen. Never returns (the
+ * navigation replaces the page) — callers should not expect code after
+ * this to run in the same page lifecycle.
+ */
+export async function beginSignIn(): Promise<void> {
+  const { authUrl, codeVerifier } = await beginOpenRouterOAuth({
+    callbackUrl: callbackUrl(),
+  });
+  stashCodeVerifier(codeVerifier);
+  window.location.assign(authUrl);
+}
+
+export type CompleteSignInResult =
+  | { status: 'not-pending' }
+  | { status: 'success' }
+  | { status: 'error'; message: string };
+
+/**
+ * Call once on page load. If the URL carries a pending OAuth callback,
+ * completes the exchange and stores the key via `openrouterByok`
+ * (session backend — see `byok.ts`'s storage policy). Always cleans the
+ * `code` param off the URL when one was present, success or failure, so
+ * a refresh can't re-submit an already-used code and loop.
+ */
+export async function completeSignInIfPending(): Promise<CompleteSignInResult> {
+  const code = detectOAuthCode(window.location.href);
+  if (!code) return { status: 'not-pending' };
+
+  const cleaned = cleanOAuthUrl(window.location.href);
+  // Clean the URL first — whatever happens below, we never want a
+  // reload to resubmit this code.
+  window.history.replaceState(null, '', cleaned);
+
+  const codeVerifier = readCodeVerifier();
+  clearCodeVerifier();
+  if (!codeVerifier) {
+    return {
+      status: 'error',
+      message:
+        'Sign-in could not be completed — the verification token was lost (e.g. the tab was closed mid-flow). Try signing in again.',
+    };
+  }
+
+  try {
+    const { key } = await completeOpenRouterOAuth({ code, codeVerifier });
+    // OAuth-provisioned keys default to sessionStorage — the owner's
+    // storage policy for keys the user didn't type themselves. The key
+    // UI offers "remember on this device" to promote to localStorage.
+    openrouterByok.setKey(key, { backend: 'session' });
+    return { status: 'success' };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'OpenRouter sign-in failed.';
+    return { status: 'error', message };
+  }
+}


### PR DESCRIPTION
Adds an OpenRouter OAuth PKCE flow to the playground's BYOK modal so a key can be provisioned without pasting one. Keys default to sessionStorage with an opt-in "remember on this device". No server component; the callback completes in-page.