### PR TITLE
Session breadcrumb rail in the playground

### DIFF
--- a/packages/playground/src/components/PlaygroundPage.tsx
+++ b/packages/playground/src/components/PlaygroundPage.tsx
@@ -32,6 +32,7 @@ import { AutosaveStatus } from './AutosaveStatus';
 import { SessionReadOnlyBanner } from './SessionReadOnlyBanner';
 import { SettingsModal } from './SettingsModal';
 import { WorkspacePanel, type WorkspaceTabId } from './WorkspacePanel';
+import { SessionBreadcrumbs } from './SessionBreadcrumbs';
 import { StatusBar } from './StatusBar';
 import { TopBar } from './TopBar';
 import { ToastProvider } from '@pyric/ui/primitives';
@@ -951,6 +952,14 @@ export function PlaygroundPage() {
               before the input. On desktop it stays below as a
               footer. Visual order matches importance per breakpoint. */}
           <StatusBar
+            leading={
+              <SessionBreadcrumbs
+                base={playgroundBase}
+                embedded={embeddedInStudio}
+                sessionTitle={sessionRouting.title}
+                sessionId={sessionRouting.sessionId ?? ''}
+              />
+            }
             modelLabel={`${activeProvider.label}: ${activeModelLabel}`}
             sessionState={sessionState}
             error={error}

--- a/packages/playground/src/components/SessionBreadcrumbs.render.test.tsx
+++ b/packages/playground/src/components/SessionBreadcrumbs.render.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Same idiom as `AutosaveStatus.render.test.tsx`: no DOM runner,
+ * `renderToString` checks the markup contract for each state
+ * directly off props (no store to fake).
+ */
+import { describe, test, expect } from 'bun:test';
+import { renderToString } from 'react-dom/server';
+import { SessionBreadcrumbs } from './SessionBreadcrumbs';
+
+describe('SessionBreadcrumbs render states', () => {
+  test('non-embed: root crumb is a real link to the app base, labeled Playground', () => {
+    const html = renderToString(
+      <SessionBreadcrumbs
+        base="/"
+        embedded={false}
+        sessionTitle="Firestore rules for chat app"
+        sessionId="sess-1"
+      />,
+    );
+    expect(html).toContain('Playground');
+    expect(html).toContain('<a href="/"');
+    expect(html).toContain('Firestore rules for chat app');
+  });
+
+  test('embed=studio: root crumb still a real link, labeled Prototype and carrying the embed param', () => {
+    const html = renderToString(
+      <SessionBreadcrumbs
+        base="/__pyric/playground/"
+        embedded
+        sessionTitle="My session"
+        sessionId="sess-2"
+      />,
+    );
+    expect(html).toContain('Prototype');
+    expect(html).toContain('<a href="/__pyric/playground/?embed=studio"');
+  });
+
+  test('session crumb is non-navigating and marked as the current page', () => {
+    const html = renderToString(
+      <SessionBreadcrumbs base="/" embedded={false} sessionTitle="A session" sessionId="sess-3" />,
+    );
+    expect(html).toContain('aria-current="page"');
+    // The current crumb renders as a <span>, not a second <a>.
+    expect(html.match(/<a /g)?.length ?? 0).toBe(1);
+  });
+
+  test('falls back to a short id form before the session title has hydrated', () => {
+    const html = renderToString(
+      <SessionBreadcrumbs base="/" embedded={false} sessionTitle={null} sessionId="sess-abcdefgh" />,
+    );
+    expect(html).toContain('sess-abc…');
+  });
+});

--- a/packages/playground/src/components/SessionBreadcrumbs.tsx
+++ b/packages/playground/src/components/SessionBreadcrumbs.tsx
@@ -1,0 +1,60 @@
+/**
+ * Root → session breadcrumb, rendered as `StatusBar`'s `leading`
+ * slot (the status rail is the one workbench-chrome element that is
+ * NOT hidden in studio-embed mode — see `lib/breadcrumbs.ts` for why
+ * this needed a home other than the embed-hidden `TopBar`).
+ *
+ * Real `<a>` for the root crumb (full-page nav back to the composer,
+ * keyboard-focusable, works with cmd/ctrl-click same as any link) and
+ * a plain `aria-current="page"` span for the session crumb — it names
+ * the current location, it doesn't navigate anywhere.
+ */
+import { buildPlaygroundBreadcrumbs } from '~/lib/breadcrumbs';
+
+export interface SessionBreadcrumbsProps {
+  base: string;
+  embedded: boolean;
+  sessionTitle: string | null | undefined;
+  sessionId: string;
+}
+
+export function SessionBreadcrumbs({
+  base,
+  embedded,
+  sessionTitle,
+  sessionId,
+}: SessionBreadcrumbsProps) {
+  const crumbs = buildPlaygroundBreadcrumbs({ base, embedded, sessionTitle, sessionId });
+
+  return (
+    <nav
+      aria-label="Playground breadcrumb"
+      className="flex items-center gap-1 min-w-0 shrink-0 sm:shrink"
+    >
+      {crumbs.map((crumb, i) => (
+        <span key={i} className="flex items-center gap-1 min-w-0">
+          {i > 0 ? (
+            <span aria-hidden className="text-slate-gray/60 text-[11px] shrink-0">
+              /
+            </span>
+          ) : null}
+          {crumb.href ? (
+            <a
+              href={crumb.href}
+              className="text-[11px] font-mono text-slate-gray hover:text-soft-white transition-colors shrink-0"
+            >
+              {crumb.label}
+            </a>
+          ) : (
+            <span
+              aria-current="page"
+              className="text-[11px] font-mono text-soft-white truncate max-w-[140px] sm:max-w-[220px]"
+            >
+              {crumb.label}
+            </span>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/packages/playground/src/components/StatusBar.tsx
+++ b/packages/playground/src/components/StatusBar.tsx
@@ -6,6 +6,10 @@
 import { formatCostUsd } from '~/lib/llm/pricing';
 
 export interface StatusBarProps {
+  /** Rendered at the very left edge of the rail, before the model
+   *  label / error text. Used for the session breadcrumb — see
+   *  `SessionBreadcrumbs` and `lib/breadcrumbs.ts`. */
+  leading?: React.ReactNode;
   modelLabel?: string | null;
   sessionState: 'idle' | 'streaming' | 'failed';
   error?: string | null;
@@ -21,6 +25,7 @@ export interface StatusBarProps {
 }
 
 export function StatusBar({
+  leading,
   modelLabel,
   sessionState,
   error,
@@ -31,33 +36,39 @@ export function StatusBar({
   costEstimated = false,
 }: StatusBarProps) {
   return (
-    <footer className="h-[28px] bg-sidebar-bg border-t border-[#2a2a32] shrink-0 flex items-center justify-between px-3 relative">
-      {error ? (
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="material-symbols-outlined text-[14px] text-red-500 shrink-0">
-            error
-          </span>
-          <span className="text-[11px] text-red-400 truncate">{error}</span>
-        </div>
-      ) : (
-        <div className="flex items-center gap-2 min-w-0">
-          {modelLabel ? (
-            <span className="text-[11px] font-mono text-slate-gray truncate">
-              {modelLabel}
+    <footer className="h-[28px] bg-sidebar-bg border-t border-[#2a2a32] shrink-0 flex items-center justify-between gap-2 px-3 relative">
+      <div className="flex items-center gap-2 min-w-0">
+        {leading}
+        {leading ? (
+          <span className="w-px h-3 bg-[#2a2a32] shrink-0" aria-hidden />
+        ) : null}
+        {error ? (
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="material-symbols-outlined text-[14px] text-red-500 shrink-0">
+              error
             </span>
-          ) : null}
-          {/* Streaming has its own per-message indicator on the
-              timeline row — surfacing it here too duplicates the
-              signal. Only show a state pill on failed; idle is
-              implied by the absence of any pill. */}
-          {sessionState === 'failed' ? (
-            <>
-              <span className="hidden sm:inline text-[11px] text-slate-gray shrink-0">·</span>
-              <span className="text-[11px] text-red-400 shrink-0">failed</span>
-            </>
-          ) : null}
-        </div>
-      )}
+            <span className="text-[11px] text-red-400 truncate">{error}</span>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 min-w-0">
+            {modelLabel ? (
+              <span className="text-[11px] font-mono text-slate-gray truncate">
+                {modelLabel}
+              </span>
+            ) : null}
+            {/* Streaming has its own per-message indicator on the
+                timeline row — surfacing it here too duplicates the
+                signal. Only show a state pill on failed; idle is
+                implied by the absence of any pill. */}
+            {sessionState === 'failed' ? (
+              <>
+                <span className="hidden sm:inline text-[11px] text-slate-gray shrink-0">·</span>
+                <span className="text-[11px] text-red-400 shrink-0">failed</span>
+              </>
+            ) : null}
+          </div>
+        )}
+      </div>
 
       <div className="flex items-center gap-2 sm:gap-3 shrink-0">
         {/* Session cost leads the stat cluster — the primary metric of a

--- a/packages/playground/src/hooks/useSessionRouting.ts
+++ b/packages/playground/src/hooks/useSessionRouting.ts
@@ -83,6 +83,10 @@ export interface SessionRoutingState {
   takeOver: () => Promise<void>;
   /** GitHub repo linked at session creation (home page). */
   githubRepo: SessionMeta['githubRepo'] | null;
+  /** `SessionMeta.title` — short label derived from the opening
+   *  prompt (or 'Untitled session'). Null until hydration completes;
+   *  the breadcrumb rail falls back to a short id form until then. */
+  title: string | null;
   sandboxMode: PlaygroundSandboxMode;
   setSandboxMode: (mode: PlaygroundSandboxMode) => Promise<void>;
 }
@@ -93,6 +97,7 @@ export function useSessionRouting(): SessionRoutingState {
   const [error, setError] = useState<string | null>(null);
   const [isWriter, setIsWriter] = useState(true);
   const [githubRepo, setGithubRepo] = useState<SessionMeta['githubRepo'] | null>(null);
+  const [title, setTitle] = useState<string | null>(null);
   const [sandboxMode, setSandboxModeState] = useState<PlaygroundSandboxMode>(() =>
     typeof window === 'undefined' ? 'isolated' : readPlaygroundSandboxMode(window.location.search),
   );
@@ -159,6 +164,7 @@ export function useSessionRouting(): SessionRoutingState {
     setSessionId(id);
     if (hydratedSessionRef.current && hydratedSessionRef.current !== id) {
       applyGithubRepo(null);
+      setTitle(null);
     }
 
     let cancelled = false;
@@ -201,6 +207,7 @@ export function useSessionRouting(): SessionRoutingState {
         if (cancelled) return;
         applyGithubRepo(meta.githubRepo ?? null);
         applySandboxMode(meta.sandboxMode ?? fallbackMode);
+        setTitle(meta.title ?? null);
         hydratedSessionRef.current = id;
         applyPayload(payload);
         hydratingRef.current = false;
@@ -259,6 +266,7 @@ export function useSessionRouting(): SessionRoutingState {
       hydratingRef.current = true;
       applyGithubRepo(meta.githubRepo ?? null);
       applySandboxMode(meta.sandboxMode ?? sandboxModeRef.current);
+      setTitle(meta.title ?? null);
       applyPayload(payload);
     } catch (e) {
       console.warn('[playground] take-over re-sync failed:', e);
@@ -397,6 +405,7 @@ export function useSessionRouting(): SessionRoutingState {
     isWriter,
     takeOver,
     githubRepo,
+    title,
     sandboxMode,
     setSandboxMode,
   };

--- a/packages/playground/src/lib/breadcrumbs.test.ts
+++ b/packages/playground/src/lib/breadcrumbs.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { buildPlaygroundBreadcrumbs, deriveSessionCrumbLabel } from './breadcrumbs';
+import { playgroundRootCrumbLabel } from './studio-embed';
+
+describe('deriveSessionCrumbLabel', () => {
+  test('uses the trimmed session title when present', () => {
+    expect(deriveSessionCrumbLabel('  Firestore rules for chat app  ', 'abc123')).toBe(
+      'Firestore rules for chat app',
+    );
+  });
+
+  test('falls back to a short id form when the title is missing', () => {
+    expect(deriveSessionCrumbLabel(null, 'session-abcdefgh-1234')).toBe('session-…');
+  });
+
+  test('falls back to a short id form when the title is undefined', () => {
+    expect(deriveSessionCrumbLabel(undefined, 'session-abcdefgh-1234')).toBe('session-…');
+  });
+
+  test('falls back to a short id form when the title is blank/whitespace', () => {
+    expect(deriveSessionCrumbLabel('   ', 'session-abcdefgh-1234')).toBe('session-…');
+  });
+
+  test('returns a short id verbatim (no ellipsis) when already <= the short-id length', () => {
+    expect(deriveSessionCrumbLabel('', 's1')).toBe('s1');
+  });
+});
+
+describe('playgroundRootCrumbLabel', () => {
+  test('reads "Playground" outside embed', () => {
+    expect(playgroundRootCrumbLabel(false)).toBe('Playground');
+  });
+
+  test('reads "Prototype" inside the Studio embed', () => {
+    expect(playgroundRootCrumbLabel(true)).toBe('Prototype');
+  });
+});
+
+describe('buildPlaygroundBreadcrumbs', () => {
+  test('root crumb navigates to the app base, session crumb is non-navigating', () => {
+    const crumbs = buildPlaygroundBreadcrumbs({
+      base: '/',
+      embedded: false,
+      sessionTitle: 'My rules session',
+      sessionId: 'sess-1',
+    });
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: 'Playground', href: '/' });
+    expect(crumbs[1]).toEqual({ label: 'My rules session', href: null });
+  });
+
+  test('root href carries the studio embed param and label when embedded', () => {
+    const crumbs = buildPlaygroundBreadcrumbs({
+      base: '/__pyric/playground/',
+      embedded: true,
+      sessionTitle: null,
+      sessionId: 'sess-2-longer-id',
+    });
+    expect(crumbs[0]).toEqual({
+      label: 'Prototype',
+      href: '/__pyric/playground/?embed=studio',
+    });
+    // Session crumb falls back to short id form pre-hydration.
+    expect(crumbs[1]).toEqual({ label: 'sess-2-l…', href: null });
+  });
+
+  test('root href respects a non-root base mount', () => {
+    const crumbs = buildPlaygroundBreadcrumbs({
+      base: '/app',
+      embedded: false,
+      sessionTitle: 'x',
+      sessionId: 's',
+    });
+    expect(crumbs[0].href).toBe('/app/');
+  });
+});

--- a/packages/playground/src/lib/breadcrumbs.ts
+++ b/packages/playground/src/lib/breadcrumbs.ts
@@ -1,0 +1,87 @@
+/**
+ * Playground breadcrumb rail — pure derivation logic.
+ *
+ * The IA is exactly two levels: root (composer/home) → current
+ * session. There is no third level — no focused-file or sub-tab
+ * crumb — because none of those states are addressable outside the
+ * session itself (a file path doesn't survive a fresh `?session=`
+ * load the way the session id does), so a deeper crumb would just be
+ * decoration, not navigation.
+ *
+ * This exists because `TopBar` (the old home-link's only home) is
+ * hidden entirely in studio-embed mode (see `studio-embed.ts`), and
+ * even outside embed the link was a small brand mark easy to miss —
+ * once inside a session there was no reliable UI path back to the
+ * composer. The rail below renders unconditionally in `StatusBar`,
+ * which is not gated on embed mode, so the escape hatch survives
+ * both layouts.
+ */
+import { playgroundHomeHref, playgroundRootCrumbLabel } from './studio-embed';
+
+/** Characters of a session id kept when a session has no usable
+ *  title yet (pre-hydration, or a title that somehow came back
+ *  blank). Long enough to disambiguate at a glance, short enough to
+ *  fit the 28px status rail. */
+const SHORT_ID_LENGTH = 8;
+
+export interface PlaygroundCrumb {
+  label: string;
+  /** `null` means "this is the current location" — render as
+   *  non-navigating text with `aria-current="page"`, not a link. */
+  href: string | null;
+}
+
+/**
+ * Session crumb label: the session's stored title when it has one,
+ * else a short form of its id. Mirrors the title HomePage's recent-
+ * sessions list already renders (`SessionMeta.title`, derived from
+ * the opening prompt at save time in `lib/sessions/index.ts`) rather
+ * than re-deriving a label from prompt text here.
+ */
+export function deriveSessionCrumbLabel(
+  title: string | null | undefined,
+  sessionId: string,
+): string {
+  const trimmed = title?.trim();
+  if (trimmed) return trimmed;
+  return sessionId.length > SHORT_ID_LENGTH
+    ? `${sessionId.slice(0, SHORT_ID_LENGTH)}…`
+    : sessionId;
+}
+
+export interface BuildPlaygroundBreadcrumbsInput {
+  /** Astro's `BASE_URL` — where the app is mounted. */
+  base: string;
+  /** `?embed=studio` — see `isStudioEmbedSearch`. */
+  embedded: boolean;
+  /** `SessionMeta.title`, or `null` before the session has hydrated. */
+  sessionTitle: string | null | undefined;
+  sessionId: string;
+}
+
+/**
+ * Root → current-session crumb list. The root crumb's href is a
+ * full-page navigation to the app base (matches the architecture
+ * `TopBar`'s Brand link already used) — including inside the Studio
+ * iframe, where navigating the iframe's own location is correct;
+ * Studio's outer chrome is a separate document. The session crumb
+ * has `href: null` — it names "you are here", it doesn't re-navigate
+ * to the same page.
+ */
+export function buildPlaygroundBreadcrumbs({
+  base,
+  embedded,
+  sessionTitle,
+  sessionId,
+}: BuildPlaygroundBreadcrumbsInput): PlaygroundCrumb[] {
+  return [
+    {
+      label: playgroundRootCrumbLabel(embedded),
+      href: playgroundHomeHref({ base, embedded }),
+    },
+    {
+      label: deriveSessionCrumbLabel(sessionTitle, sessionId),
+      href: null,
+    },
+  ];
+}

--- a/packages/playground/src/lib/studio-embed.ts
+++ b/packages/playground/src/lib/studio-embed.ts
@@ -81,6 +81,17 @@ export function normalizePlaygroundBase(base: string): string {
   return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
 }
 
+/**
+ * Root-crumb label for the playground breadcrumb rail. Mirrors the
+ * embed flag so the crumb reads like the surface it actually is:
+ * "Prototype" is Studio's name for the embedded playground iframe
+ * (see plans/studio-embed), "Playground" is the standalone app's own
+ * name. Both point at the same href — `playgroundHomeHref`.
+ */
+export function playgroundRootCrumbLabel(embedded: boolean): string {
+  return embedded ? 'Prototype' : 'Playground';
+}
+
 export function playgroundHomeHref({
   base = '/',
   embedded = false,


### PR DESCRIPTION
Adds a breadcrumb rail to the playground status bar so a trapped session (deep in a prototype) always has a one-click path back out. Pure UI; breadcrumb derivation lives in `lib/breadcrumbs.ts` with tests.