### PR TITLE
Collapse playground settings sections behind disclosures

### DIFF
--- a/packages/playground/src/components/SettingsModal.render.test.tsx
+++ b/packages/playground/src/components/SettingsModal.render.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Render states for the settings modal's disclosure affordance on
+ * "Enable pyric diagnostics" — the acceptance case for making
+ * parent-with-children settings collapsible (see
+ * `settings-disclosure.ts`). No DOM runner; `renderToString` checks
+ * the initial-render contract: collapsed by default, a derived
+ * on-count summary in place of the child list, and the master
+ * checkbox / disclosure caret kept as separate, independently
+ * toggleable controls.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToString } from 'react-dom/server';
+import { SettingsModal } from './SettingsModal';
+import { DIAGNOSTIC_TOOL_MANIFEST } from '~/lib/tools/diagnostics';
+
+describe('SettingsModal diagnostics disclosure', () => {
+  test('renders collapsed by default: no per-tool checkboxes in the DOM', () => {
+    const html = renderToString(<SettingsModal open onClose={() => {}} />);
+
+    expect(html).toContain('Enable pyric diagnostics');
+    // The child group's section heading and every per-tool row are
+    // absent until expanded.
+    expect(html).not.toContain('diagnostic tools');
+    for (const entry of DIAGNOSTIC_TOOL_MANIFEST) {
+      expect(html).not.toContain(entry.label);
+    }
+  });
+
+  test('shows a derived on-count summary instead of the description while collapsed', () => {
+    const html = renderToString(<SettingsModal open onClose={() => {}} />);
+
+    // All manifest entries default to enabled (isDiagnosticToolEnabled
+    // treats an absent key as on), so the summary is "N of N tools on"
+    // where N == the manifest length — derived, not hardcoded.
+    const total = DIAGNOSTIC_TOOL_MANIFEST.length;
+    expect(html).toContain(`${total} of ${total} tools on`);
+    // The full body copy (only shown expanded) is not present.
+    expect(html).not.toContain('inline rules lint');
+  });
+
+  test('disclosure caret is keyboard accessible and reports aria-expanded=false', () => {
+    const html = renderToString(<SettingsModal open onClose={() => {}} />);
+
+    expect(html).toContain('aria-controls="settings-diagnostic-tools"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-label="Expand Enable pyric diagnostics"');
+  });
+
+  test('master checkbox keeps its own switch semantics, independent of the caret', () => {
+    const html = renderToString(<SettingsModal open onClose={() => {}} />);
+
+    // pyricDiagnosticsEnabled defaults to true.
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('aria-checked="true"');
+  });
+
+  test('the auto-fold row (no children) is unaffected — no disclosure caret', () => {
+    const html = renderToString(<SettingsModal open onClose={() => {}} />);
+
+    expect(html).toContain('Auto-fold all but the most recent turn');
+    expect(html).toContain('collapse older now');
+  });
+});

--- a/packages/playground/src/components/SettingsModal.tsx
+++ b/packages/playground/src/components/SettingsModal.tsx
@@ -46,6 +46,13 @@ import {
 } from '~/lib/llm/inference/diagnostics';
 import { useLlmStore } from '~/lib/store/llm';
 import { Modal } from './Modal';
+import {
+  countEnabled,
+  isDisclosureExpanded,
+  summarizeOnCount,
+  toggleDisclosure,
+  type DisclosureState,
+} from './settings-disclosure';
 
 interface Props {
   open: boolean;
@@ -94,6 +101,15 @@ export function SettingsModal({ open, onClose }: Props) {
   // copy it, paste it back when reporting an issue.
   const [diagOutput, setDiagOutput] = useState('');
   const [diagStatus, setDiagStatus] = useState('');
+
+  // Disclosure state for parent settings with a child group (e.g. the
+  // diagnostic-tools list below). UI-only, ephemeral, keyed by section
+  // id — default collapsed, same "dense by default" convention as
+  // `Fold.tsx`. Generic across any parent-with-children setting; wired
+  // to diagnostics today because it's the only settings entry with a
+  // real multi-item child group.
+  const [disclosure, setDisclosure] = useState<DisclosureState>({});
+  const toggleSection = (id: string) => setDisclosure((s) => toggleDisclosure(s, id));
 
   const handleTogglePyricDiagnostics = () => {
     const next = !pyricDiagnosticsEnabled;
@@ -194,32 +210,45 @@ export function SettingsModal({ open, onClose }: Props) {
         </div>
 
         <div className="space-y-1.5 pt-2">
-          <ToggleRow
+          <DisclosureToggleRow
             checked={pyricDiagnosticsEnabled}
             onChange={handleTogglePyricDiagnostics}
             title="Enable pyric diagnostics"
             body="Inline rules lint, recent denials, and rules-pitfalls primer in the agent's system prompt, plus diagnostic tools under tools/diagnostics/. Core write/run tools stay registered either way. Turn off to A/B-compare agent behavior without playground-supplied diagnostics. Toggling is logged as a session event in the exported JSON."
+            expanded={isDisclosureExpanded(disclosure, 'diagnostics')}
+            onToggleExpand={() => toggleSection('diagnostics')}
+            collapsedSummary={summarizeOnCount(
+              DIAGNOSTIC_TOOL_MANIFEST.length,
+              countEnabled(DIAGNOSTIC_TOOL_MANIFEST, (entry) =>
+                isDiagnosticToolEnabled({ diagnosticToolsEnabled }, entry.key),
+              ),
+              'tools',
+            )}
+            controlsId="settings-diagnostic-tools"
           />
-          <div
-            className={[
-              'pl-7 pt-1.5 space-y-1.5 transition-opacity',
-              pyricDiagnosticsEnabled ? 'opacity-100' : 'opacity-40 pointer-events-none',
-            ].join(' ')}
-            aria-disabled={!pyricDiagnosticsEnabled}
-          >
-            <p className="text-[10px] uppercase tracking-wider text-slate-gray font-bold">
-              diagnostic tools
-            </p>
-            {DIAGNOSTIC_TOOL_MANIFEST.map((entry) => (
-              <SubToggleRow
-                key={entry.key}
-                checked={isDiagnosticToolEnabled({ diagnosticToolsEnabled }, entry.key)}
-                onChange={() => handleToggleDiagnosticTool(entry.key, entry.label)}
-                title={entry.label}
-                body={entry.description}
-              />
-            ))}
-          </div>
+          {isDisclosureExpanded(disclosure, 'diagnostics') ? (
+            <div
+              id="settings-diagnostic-tools"
+              className={[
+                'pl-7 pt-1.5 space-y-1.5 transition-opacity',
+                pyricDiagnosticsEnabled ? 'opacity-100' : 'opacity-40 pointer-events-none',
+              ].join(' ')}
+              aria-disabled={!pyricDiagnosticsEnabled}
+            >
+              <p className="text-[10px] uppercase tracking-wider text-slate-gray font-bold">
+                diagnostic tools
+              </p>
+              {DIAGNOSTIC_TOOL_MANIFEST.map((entry) => (
+                <SubToggleRow
+                  key={entry.key}
+                  checked={isDiagnosticToolEnabled({ diagnosticToolsEnabled }, entry.key)}
+                  onChange={() => handleToggleDiagnosticTool(entry.key, entry.label)}
+                  title={entry.label}
+                  body={entry.description}
+                />
+              ))}
+            </div>
+          ) : null}
         </div>
 
         <div className="space-y-1.5 pt-2">
@@ -598,6 +627,102 @@ function ToggleRow({
         <span className="block text-[11px] text-slate-gray leading-snug">{body}</span>
       </span>
     </button>
+  );
+}
+
+/**
+ * ToggleRow variant for a parent setting with a collapsible child
+ * group (e.g. "Enable pyric diagnostics" → its per-tool checkboxes).
+ * Same master-gate checkbox as `ToggleRow`, plus a sibling disclosure
+ * caret — deliberately NOT nested inside the checkbox button, since a
+ * `<button>` inside a `<button>` is invalid and would make the caret
+ * click also fire the checkbox toggle. Caret visual matches `Fold.tsx`
+ * (`chevron_right`, rotates 90° open, `material-symbols-outlined`) so
+ * the modal doesn't invent a second disclosure idiom.
+ *
+ * Collapsed, the body line is replaced by `collapsedSummary` (e.g.
+ * "5 of 6 tools on") so the row stays informative without the full
+ * child list eating vertical space. Toggling the checkbox never
+ * changes `expanded` — presentation and the enable/disable cascade
+ * are fully independent.
+ */
+function DisclosureToggleRow({
+  checked,
+  onChange,
+  title,
+  body,
+  expanded,
+  onToggleExpand,
+  collapsedSummary,
+  controlsId,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  title: string;
+  body: string;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  collapsedSummary: string;
+  controlsId: string;
+}) {
+  return (
+    <div className="w-full flex items-start gap-2">
+      <button
+        type="button"
+        onClick={onChange}
+        role="switch"
+        aria-checked={checked}
+        className="flex-1 min-w-0 flex items-start gap-3 text-left group py-1 -my-1"
+      >
+        <span
+          className={[
+            'mt-0.5 inline-flex shrink-0 w-[18px] h-[18px] items-center justify-center rounded-sm border transition-colors',
+            checked
+              ? 'bg-primary border-primary'
+              : 'bg-transparent border-slate-gray group-hover:border-soft-white',
+          ].join(' ')}
+          aria-hidden="true"
+        >
+          {checked ? (
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-[14px] h-[14px] text-content-bg"
+            >
+              <polyline points="3 8.5 6.5 12 13 4.5" />
+            </svg>
+          ) : null}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] text-soft-white font-medium">{title}</span>
+          <span className="block text-[11px] text-slate-gray leading-snug">
+            {expanded ? body : collapsedSummary}
+          </span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        aria-expanded={expanded}
+        aria-controls={controlsId}
+        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${title}`}
+        className="shrink-0 mt-0.5 p-1 -m-1 rounded text-slate-gray hover:text-soft-white transition-colors"
+      >
+        <span
+          className={[
+            'material-symbols-outlined text-[18px] transition-transform',
+            expanded ? 'rotate-90' : '',
+          ].join(' ')}
+          aria-hidden="true"
+        >
+          chevron_right
+        </span>
+      </button>
+    </div>
   );
 }
 

--- a/packages/playground/src/components/settings-disclosure.test.ts
+++ b/packages/playground/src/components/settings-disclosure.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  countEnabled,
+  isDisclosureExpanded,
+  summarizeOnCount,
+  toggleDisclosure,
+  type DisclosureState,
+} from './settings-disclosure';
+
+describe('isDisclosureExpanded', () => {
+  test('an id absent from the map reads as collapsed', () => {
+    expect(isDisclosureExpanded({}, 'diagnostics')).toBe(false);
+  });
+
+  test('an id explicitly set to false reads as collapsed', () => {
+    expect(isDisclosureExpanded({ diagnostics: false }, 'diagnostics')).toBe(false);
+  });
+
+  test('an id explicitly set to true reads as expanded', () => {
+    expect(isDisclosureExpanded({ diagnostics: true }, 'diagnostics')).toBe(true);
+  });
+
+  test('unrelated ids in the map do not affect the queried id', () => {
+    expect(isDisclosureExpanded({ other: true }, 'diagnostics')).toBe(false);
+  });
+});
+
+describe('toggleDisclosure', () => {
+  test('flips a collapsed (absent) id to expanded', () => {
+    const next = toggleDisclosure({}, 'diagnostics');
+    expect(next).toEqual({ diagnostics: true });
+  });
+
+  test('flips an expanded id back to collapsed', () => {
+    const next = toggleDisclosure({ diagnostics: true }, 'diagnostics');
+    expect(next).toEqual({ diagnostics: false });
+  });
+
+  test('does not mutate the input state', () => {
+    const state: DisclosureState = { diagnostics: false };
+    const next = toggleDisclosure(state, 'diagnostics');
+    expect(state).toEqual({ diagnostics: false });
+    expect(next).not.toBe(state);
+  });
+
+  test('preserves other sections when toggling one', () => {
+    const state: DisclosureState = { diagnostics: true, autoFold: false };
+    const next = toggleDisclosure(state, 'autoFold');
+    expect(next).toEqual({ diagnostics: true, autoFold: true });
+  });
+});
+
+describe('countEnabled', () => {
+  test('counts items matching the predicate', () => {
+    const items = [{ on: true }, { on: false }, { on: true }, { on: true }];
+    expect(countEnabled(items, (i) => i.on)).toBe(3);
+  });
+
+  test('returns 0 for an empty list', () => {
+    expect(countEnabled([], () => true)).toBe(0);
+  });
+
+  test('returns 0 when nothing matches', () => {
+    const items = [{ on: false }, { on: false }];
+    expect(countEnabled(items, (i) => i.on)).toBe(0);
+  });
+
+  test('returns the full length when everything matches', () => {
+    const items = [{ on: true }, { on: true }];
+    expect(countEnabled(items, (i) => i.on)).toBe(2);
+  });
+});
+
+describe('summarizeOnCount', () => {
+  test('derives the collapsed-row summary from counts, not a hardcoded string', () => {
+    expect(summarizeOnCount(6, 5, 'tools')).toBe('5 of 6 tools on');
+  });
+
+  test('handles all-on', () => {
+    expect(summarizeOnCount(6, 6, 'tools')).toBe('6 of 6 tools on');
+  });
+
+  test('handles all-off', () => {
+    expect(summarizeOnCount(6, 0, 'tools')).toBe('0 of 6 tools on');
+  });
+
+  test('respects a different noun for a non-tools parent setting', () => {
+    expect(summarizeOnCount(3, 1, 'options')).toBe('1 of 3 options on');
+  });
+});

--- a/packages/playground/src/components/settings-disclosure.ts
+++ b/packages/playground/src/components/settings-disclosure.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure helpers for the settings modal's disclosure affordance — any
+ * parent setting with a child group (e.g. "Enable pyric diagnostics"
+ * → its per-tool checkboxes) gets a caret that reveals/hides the
+ * children. Kept separate from `SettingsModal.tsx` so the state
+ * machine and the collapsed-row summary text are unit-testable
+ * without rendering React.
+ *
+ * Expansion state is UI-only and keyed by an arbitrary section id
+ * (e.g. `'diagnostics'`) so one `DisclosureState` map can back every
+ * collapsible section in the modal. Default is collapsed — an id
+ * absent from the map reads as collapsed, matching the modal's
+ * "dense by default, open what you want to inspect" convention (see
+ * `Fold.tsx`).
+ */
+
+/** `{ [sectionId]: expanded }`. Absent key = collapsed. */
+export type DisclosureState = Record<string, boolean>;
+
+/** Absent key defaults to collapsed. */
+export function isDisclosureExpanded(state: DisclosureState, id: string): boolean {
+  return state[id] === true;
+}
+
+/** Returns a new state with `id` flipped; does not mutate `state`. */
+export function toggleDisclosure(state: DisclosureState, id: string): DisclosureState {
+  return { ...state, [id]: !isDisclosureExpanded(state, id) };
+}
+
+/**
+ * Count how many items satisfy `isEnabled`. Generic over the item
+ * shape so it works for the diagnostic-tool manifest today and any
+ * future parent-with-children setting without a new counting
+ * function.
+ */
+export function countEnabled<T>(
+  items: readonly T[],
+  isEnabled: (item: T) => boolean,
+): number {
+  let count = 0;
+  for (const item of items) {
+    if (isEnabled(item)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Collapsed-row summary text, derived rather than hardcoded — e.g.
+ * `summarizeOnCount(6, 5, 'tools')` → "5 of 6 tools on".
+ */
+export function summarizeOnCount(total: number, onCount: number, noun: string): string {
+  return `${onCount} of ${total} ${noun} on`;
+}


### PR DESCRIPTION
Settings sections with children collapse behind a disclosure so the modal opens to a scannable list instead of a wall. Disclosure state logic in `settings-disclosure.ts` with tests.