### PR TITLE
Serve fallback favicon: neutral placeholder square

### DIFF
--- a/packages/pyric-tools/src/serve/server.ts
+++ b/packages/pyric-tools/src/serve/server.ts
@@ -256,13 +256,14 @@ async function handleRequest(
   if (!file && url.pathname === '/favicon.ico') {
     // The browser requests /favicon.ico on every load; without this an app
     // that ships no favicon logs a 404 in every console. Serve a tiny inline
-    // SVG (the pyric flame) so consoles stay clean. An on-disk favicon.ico
-    // was already resolved above and wins.
+    // SVG (a neutral placeholder square — the real mark comes with the logo
+    // work) so consoles stay clean. An on-disk favicon.ico was already
+    // resolved above and wins.
     res.writeHead(200, { 'content-type': 'image/svg+xml', 'cache-control': 'max-age=3600' });
     res.end(
       req.method === 'HEAD'
         ? undefined
-        : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><text y="13" font-size="13">🔥</text></svg>',
+        : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect x="2" y="2" width="12" height="12" rx="2" fill="#e8e8ee"/></svg>',
     );
     return;
   }


### PR DESCRIPTION
The serve fallback favicon becomes a neutral placeholder square (the flame emoji predated the logo decision; the real mark lands with the logo work). Missed the #71 merge window by minutes.