### PR TITLE
Traffic rows: service labels, aligned chips, uppercase filter pills

### DIFF
--- a/packages/studio/src/features/traffic/traffic.css
+++ b/packages/studio/src/features/traffic/traffic.css
@@ -360,6 +360,10 @@
   color: var(--muted);
   font: inherit;
   font-size: var(--fs-caption);
+  /* Pills are uppercase everywhere (ALLOW / DENY / ADMIN verdicts, the
+     service labels) — the filter pills match the standard. */
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
   padding: 2px 10px;
   cursor: pointer;
 }
@@ -506,13 +510,39 @@
   font-weight: 600;
 }
 
-/* The method badge (the only chip the library row still draws). */
+/* The service label — which backend the op hit (FIRESTORE / RTDB / STORAGE /
+   AUTH). Styled apart from the op chip (solid tint, no border) so the eye
+   catches the service split; FIXED width (fits "FIRESTORE") so every row's
+   op chip and path start at the same x regardless of label length. */
+.traffic__log [data-pyric-traffic-service] {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  width: 74px;
+  padding: 1px 0;
+  border-radius: 4px;
+  background: var(--elevated);
+  color: var(--faint);
+  text-align: center;
+  flex-shrink: 0;
+}
+/* Unknown service (pre-provenance events): keep the slot, drop the chrome —
+   the column stays aligned without a mystery empty pill. */
+.traffic__log [data-pyric-traffic-service=''] {
+  background: none;
+}
+
+/* The method badge — FIXED width (fits "LISTEN") for the same alignment
+   reason: a variable-width chip shifted every path after it. */
 .traffic__log [data-pyric-badge-kind] {
   font-family: var(--font-ui);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  padding: 1px 6px;
+  width: 58px;
+  padding: 1px 0;
+  text-align: center;
   border-radius: 4px;
   border: 1px solid var(--line-2);
   color: var(--muted);

--- a/packages/ui/src/traffic/components/TrafficRow.tsx
+++ b/packages/ui/src/traffic/components/TrafficRow.tsx
@@ -35,6 +35,9 @@ export interface TrafficRowProps {
  *   `data-pyric-result`, `data-pyric-origin`, `data-pyric-method`
  * - `[data-pyric-traffic-row][data-pyric-selected]` — active row
  * - `[data-pyric-traffic-time]` / `[data-pyric-traffic-path]`
+ * - `[data-pyric-traffic-service]` — the service label (firestore / rtdb /
+ *   storage / auth), rendered even when unknown (empty) so fixed-width
+ *   styling keeps the columns aligned
  * - method renders as `<Badge>` (`data-pyric-badge-kind`)
  */
 export function TrafficRow({
@@ -57,6 +60,7 @@ export function TrafficRow({
       data-pyric-selected={selected ? '' : undefined}
     >
       <span data-pyric-traffic-time="">{formatTime(event.at)}</span>
+      <span data-pyric-traffic-service={event.service ?? ''}>{event.service ?? ''}</span>
       <Badge kind={event.method}>{event.method}</Badge>
       <span data-pyric-traffic-path="">{event.path}</span>
       {renderClassification ? renderClassification(event) : null}


### PR DESCRIPTION
Rows now show which backend an op hit — a fixed-width FIRESTORE / RTDB / STORAGE / AUTH label between the timestamp and the op chip, styled apart from the op chip (solid tint, no border). The op chip is fixed-width too, so LISTEN no longer misaligns its row's path. Pre-provenance events without a service keep the empty slot (alignment holds) without a mystery empty pill. Verdict filter pills are uppercase per the pill standard.

Headless change: `TrafficRow` renders a `data-pyric-traffic-service` slot; styling stays in Studio.