### PR TITLE
Traffic history survives worker death: hydrate from the capture file

### DIFF
--- a/packages/pyric-tools/src/serve/capture-store.ts
+++ b/packages/pyric-tools/src/serve/capture-store.ts
@@ -15,7 +15,7 @@
  * (.pyric/state/…) so it fits the same .gitignore pattern and feels like
  * one artifact family.
  */
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 /** Relative path (from project root) where the serve capture lives.
@@ -31,6 +31,13 @@ export interface CaptureStore {
    * as-is so `pyric verify` can hand it straight to the replay engine.
    */
   write(fixtureJson: string): void;
+  /**
+   * Read back the last-written fixture JSON verbatim, or `null` when the
+   * capture file does not exist yet (nothing captured this run). Powers
+   * GET /__pyric/capture, which the served SharedWorker fetches on boot to
+   * re-hydrate its in-memory event history after a worker death.
+   */
+  read(): string | null;
 }
 
 /**
@@ -45,6 +52,14 @@ export function createCaptureStore(projectDir: string): CaptureStore {
     write(fixtureJson: string): void {
       mkdirSync(dirname(path), { recursive: true });
       writeFileSync(path, fixtureJson);
+    },
+    read(): string | null {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        // ENOENT (nothing captured yet) or any read error → treat as absent.
+        return null;
+      }
     },
   };
 }

--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -97,10 +97,12 @@ export interface NamespaceOptions {
   events?: ServeEventHub;
   /** `--persist`: mounts GET/POST /__pyric/state (the state channel). */
   state?: StateStore;
-  /** `--capture`: mounts POST /__pyric/capture — the page pushes its session
-   *  fixture here; the handler writes it verbatim to `.pyric/last-session.json`
-   *  for `pyric verify` to replay. */
-  capture?: { write(json: string): void };
+  /** `--capture`: mounts GET/POST /__pyric/capture. POST — the page/worker
+   *  pushes its session fixture here; the handler writes it verbatim to
+   *  `.pyric/last-session.json` for `pyric verify` to replay. GET — returns the
+   *  current fixture JSON (200) or 404 when nothing is captured yet, so the
+   *  served worker can re-hydrate its event history on boot after a death. */
+  capture?: { write(json: string): void; read(): string | null };
   /** `--ui` (Pyric Studio): mounts `/__pyric/workspace` + `/__pyric/projects`
    *  (disk-backed `WorkspaceStore`/`ProjectStore`, plus the SSE watch stream)
    *  that `@pyric/studio`'s `local` mode talks to. */
@@ -193,10 +195,14 @@ async function handleState(
  * The server writes it verbatim to `.pyric/last-session.json` so
  * `pyric verify` can pick it up without any extra arguments.
  *
- * Only POST is valid (there's nothing to GET — the file is meant for
- * `pyric verify`, not for the page to read back). Fails fast rather than
- * silently swallowing write errors so the developer knows the capture
- * is broken.
+ * GET returns the current fixture JSON verbatim (200), or 404 when nothing
+ * has been captured yet. The served SharedWorker fetches this on boot to
+ * re-hydrate its in-memory event history after a worker death (Traffic /
+ * activity / metrics survive the refresh even though the worker restarted).
+ * Cheap + read-only.
+ *
+ * POST fails fast rather than silently swallowing write errors so the
+ * developer knows the capture is broken.
  *
  * We collect the RAW request body as a string rather than using
  * `collectBody` (which parses JSON). The capture must be stored verbatim
@@ -205,12 +211,25 @@ async function handleState(
  * what the page intended to write.
  */
 async function handleCapture(
-  capture: { write(json: string): void },
+  capture: { write(json: string): void; read(): string | null },
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<void> {
+  if (req.method === 'GET') {
+    const body = capture.read();
+    if (body === null) {
+      res.writeHead(404, { 'content-type': 'application/json' }).end('null');
+      return;
+    }
+    res.writeHead(200, {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    });
+    res.end(body);
+    return;
+  }
   if (req.method !== 'POST') {
-    res.writeHead(405, { allow: 'POST' }).end('method not allowed');
+    res.writeHead(405, { allow: 'GET, POST' }).end('method not allowed');
     return;
   }
   try {

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -32,9 +32,10 @@ import { getDatabase, sandbox as rtdbSandbox } from 'pyric/database/modular';
 import { getAuth, sandbox as authOps, type SeedUser } from 'pyric/auth';
 import type { PersistenceBackend } from 'pyric/sandbox';
 import { initializeSandbox, serializeToBuckets, bundleRecords, parseBundle } from 'pyric/sandbox';
+import { primeEventHistory } from 'pyric/sandbox/internal';
 import type { InitPayload } from '../namespace.js';
 import { ensureAuth, getOrCreateInstanceId, type HostCtx } from './host.js';
-import { buildVerifyFixture } from '../../verify/fixture.js';
+import { buildVerifyFixture, type PyricVerifyFixture } from '../../verify/fixture.js';
 
 /** Injected environment — `fetch` is the only ambient the worker init needs
  *  (capture POSTs through it). Injectable so tests drive it with a stub. */
@@ -181,6 +182,9 @@ export function applyServeInit(
           users: authOps.exportUsers(auth),
           currentUser: ctx.sandbox.currentUser,
         },
+        // Stamp WHO produced this capture so a booting worker only re-hydrates
+        // its OWN session (see hydrateEventHistory's identity guard).
+        capturedBy: ctx.instanceId,
       }));
       // Relative URL resolves against the worker script's origin (same origin
       // as the page). Fire-and-forget — capture failures never break ops.
@@ -206,6 +210,80 @@ export function applyServeInit(
   }
 
   return result;
+}
+
+// ─── Event-history hydration: survive worker death (served mode) ─────────────
+
+/**
+ * Cap on the number of events primed on boot. A long-lived session can
+ * accumulate a large capture; a fresh worker only needs enough recent history
+ * for Traffic / activity / metrics to feel continuous, so we prime the most
+ * recent N and drop older events rather than balloon worker memory with the
+ * whole log. The full log still lives on disk for `pyric verify`.
+ */
+export const MAX_PRIMED_EVENTS = 2000;
+
+/**
+ * Re-hydrate the worker's in-memory event history from the served capture
+ * file on boot — the fix for "worker death zeroes Traffic / activity / metrics
+ * even though the data restored from IDB".
+ *
+ * The SERVER already holds the complete event log (`.pyric/last-session.json`,
+ * written continuously by the capture flush). On a fresh worker we GET it back
+ * and REPLAY `events[]` into the sandbox's `history()` via the
+ * {@link primeEventHistory} seam — append-only, NO re-execution of ops and NO
+ * dispatch to live `onEvent` subscribers. Studio subscribes AFTER boot and
+ * reads history-first, so append-only-no-dispatch gives every consumer
+ * continuity for free with zero Studio changes.
+ *
+ * GUARD RAILS:
+ *  - Only primes when history is EMPTY (the {@link primeEventHistory} seam
+ *    enforces this) — a warm sandbox is never disturbed and primed events can
+ *    never interleave after live boot events. Call this BEFORE applyServeInit.
+ *  - Caps at {@link MAX_PRIMED_EVENTS} (most recent) so a huge capture can't
+ *    balloon worker memory.
+ *  - IDENTITY: skips when the capture was produced by a DIFFERENT instance
+ *    (`capturedBy !== ctx.instanceId`) — another browser profile sharing one
+ *    `pyric dev` shouldn't see someone else's session as its own. A capture
+ *    with no `capturedBy` (older / standalone) primes best-effort.
+ *  - Skips cleanly when the endpoint 404s (capture off / nothing captured) or
+ *    the fetch throws (standalone worker, no `pyric dev` behind it).
+ *
+ * FRESHNESS: the capture lags the last pre-death moments by up to the debounce
+ * window (~400ms), so the final events before a worker death may be missing.
+ * That is acceptable — the data itself is durable via IDB; this only restores
+ * the activity RECORD, and near-perfect is enough for Traffic/feed continuity.
+ *
+ * Returns the number of events primed (0 when skipped).
+ */
+export async function hydrateEventHistory(
+  ctx: HostCtx,
+  env: ServeInitEnv,
+): Promise<number> {
+  let res: Response;
+  try {
+    res = await env.fetch('/__pyric/capture');
+  } catch {
+    return 0; // standalone / no capture endpoint.
+  }
+  if (res.status !== 200) return 0; // 404 → capture off or nothing captured.
+
+  let fixture: PyricVerifyFixture;
+  try {
+    fixture = JSON.parse(await res.text()) as PyricVerifyFixture;
+  } catch {
+    return 0; // corrupt capture — never brick boot over the activity log.
+  }
+
+  const events = fixture.events;
+  if (!Array.isArray(events) || events.length === 0) return 0;
+
+  // Identity: don't show a neighbor profile's session as ours.
+  if (fixture.capturedBy && fixture.capturedBy !== ctx.instanceId) return 0;
+
+  const capped =
+    events.length > MAX_PRIMED_EVENTS ? events.slice(-MAX_PRIMED_EVENTS) : events;
+  return primeEventHistory(ctx.sandbox, capped);
 }
 
 // ─── Durable persistence: the --persist server-file tier + seedState (3c.D) ─
@@ -474,6 +552,20 @@ export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
     sessionBackend: env.idb,
     sessionMode: 'LOCAL',
   };
+
+  // Re-hydrate the event history from the served capture BEFORE applyServeInit
+  // runs — history is empty here (fresh sandbox, persistence restore emits no
+  // sandbox events), so primed events land first and any live boot events
+  // (seed, first ops) follow. This is what makes Traffic / activity / metrics
+  // survive a worker death: the DATA came back from IDB above, this restores
+  // the RECORD of it. Best-effort — a failure never blocks boot.
+  if (payload?.capture) {
+    try {
+      await hydrateEventHistory(ctx, env);
+    } catch {
+      /* activity-log hydration is non-essential; never brick boot over it. */
+    }
+  }
 
   // Apply rules / seed / authUsers / capture BEFORE any port op runs (so
   // seeded users exist and project rules govern the first write), then mirror

--- a/packages/pyric-tools/src/verify/fixture.ts
+++ b/packages/pyric-tools/src/verify/fixture.ts
@@ -17,6 +17,14 @@ export interface PyricVerifyFixture {
   schema: typeof VERIFY_FIXTURE_SCHEMA;
   description?: string;
   createdAt?: string;
+  /** Opaque id of the sandbox instance that produced this capture (the served
+   *  SharedWorker's `instanceId`). Purely additive: `pyric verify` ignores it.
+   *  Present only on captures written by the worker's capture flush; used by
+   *  boot-time event hydration to SKIP priming a capture that belongs to a
+   *  DIFFERENT instance (e.g. another browser profile sharing one `pyric dev`),
+   *  so someone else's session never shows up as yours. Absent on older /
+   *  standalone captures → hydration primes best-effort. */
+  capturedBy?: string;
   events: SandboxEvent[];
   services: {
     firestore?: {
@@ -54,6 +62,9 @@ export interface BuildVerifyFixtureInput {
     currentUser?: unknown;
   } | null;
   createdAt?: string;
+  /** Stamped into the fixture as `capturedBy` (identity for boot-time event
+   *  hydration). Omit for `pyric verify` builds — they have no instance. */
+  capturedBy?: string;
 }
 
 export function buildVerifyFixture(input: BuildVerifyFixtureInput): PyricVerifyFixture {
@@ -106,6 +117,7 @@ export function buildVerifyFixture(input: BuildVerifyFixtureInput): PyricVerifyF
     schema: VERIFY_FIXTURE_SCHEMA,
     ...(input.description ? { description: input.description } : {}),
     createdAt: input.createdAt ?? new Date().toISOString(),
+    ...(input.capturedBy ? { capturedBy: input.capturedBy } : {}),
     events,
     services,
   };

--- a/packages/pyric-tools/test/serve/capture-store.test.ts
+++ b/packages/pyric-tools/test/serve/capture-store.test.ts
@@ -61,6 +61,20 @@ describe('createCaptureStore', () => {
     }
   });
 
+  it('read returns null before any write, then the verbatim body after', () => {
+    const dir = tmp();
+    try {
+      const store = createCaptureStore(dir);
+      // Nothing captured yet → null (GET /__pyric/capture 404s → boot skips).
+      expect(store.read()).toBeNull();
+      const body = JSON.stringify({ schema: 'pyric.verify.fixture.v1', events: [{ id: 'e1' }], services: {} });
+      store.write(body);
+      expect(store.read()).toBe(body);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('overwrites on subsequent writes (last write wins)', () => {
     const dir = tmp();
     try {

--- a/packages/pyric-tools/test/serve/integration.test.ts
+++ b/packages/pyric-tools/test/serve/integration.test.ts
@@ -216,7 +216,7 @@ describe('hosting config helpers', () => {
 });
 
 describe('/__pyric/capture endpoint (serve-capture)', () => {
-  it('POST writes fixture to .pyric/last-session.json; GET returns 405', async () => {
+  it('POST writes fixture to .pyric/last-session.json; GET reads it back (worker boot hydration)', async () => {
     // The browser-push half of capture (the onEvent flush in runtime.ts) runs
     // only in a real browser — this test asserts the SERVER endpoint + file
     // write, which is the node-testable surface.
@@ -234,10 +234,16 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
     };
 
     // 1. POST → 204 and the file is written
+    // 0. Before any POST, GET → 404 (nothing captured; worker boot skips
+    //    hydration cleanly).
+    const empty = await fetch(`${base}/__pyric/capture`, { method: 'GET' });
+    expect(empty.status).toBe(404);
+
+    const body = JSON.stringify(fixture);
     const postRes = await fetch(`${base}/__pyric/capture`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(fixture),
+      body,
     });
     expect(postRes.status).toBe(204);
     expect(existsSync(capturePath)).toBe(true);
@@ -248,10 +254,17 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
     expect(written.state).toEqual(fixture.state);
     expect(written.events).toEqual(fixture.events);
 
-    // 3. Non-POST → 405
+    // 3. GET now returns the stored fixture verbatim (the worker's boot-time
+    //    event-history hydration reads it).
     const getRes = await fetch(`${base}/__pyric/capture`, { method: 'GET' });
-    expect(getRes.status).toBe(405);
-    expect(getRes.headers.get('allow')).toBe('POST');
+    expect(getRes.status).toBe(200);
+    expect(getRes.headers.get('content-type')).toContain('json');
+    expect(await getRes.text()).toBe(body);
+
+    // 4. An unsupported method → 405 advertising GET, POST.
+    const delRes = await fetch(`${base}/__pyric/capture`, { method: 'DELETE' });
+    expect(delRes.status).toBe(405);
+    expect(delRes.headers.get('allow')).toBe('GET, POST');
   }, 30_000);
 
   it('capture: false omits the route (static server falls through)', async () => {

--- a/packages/pyric-tools/test/serve/namespace.test.ts
+++ b/packages/pyric-tools/test/serve/namespace.test.ts
@@ -183,4 +183,46 @@ describe('namespace over the real server', () => {
     expect(await (await fetch(h.url + '/__pyric/playground/playground?embed=studio')).text()).toContain('playground');
     expect((await fetch(h.url + '/__pyric/playground/_astro/app.js')).status).toBe(200);
   });
+
+  it('GET /__pyric/capture returns the fixture (200) or 404 when absent; POST writes it', async () => {
+    const { site, sdk } = fixture();
+    let stored: string | null = null;
+    const ns = createPyricNamespace({
+      sdkDir: sdk,
+      initPayload: () => ({ rules: null, rulesHash: null, bridgeUrl: null }),
+      capture: { write: (json) => { stored = json; }, read: () => stored },
+    });
+    const h = await startStaticServer({
+      publicDir: site,
+      port: 0,
+      host: '127.0.0.1',
+      portScanLimit: 200,
+      logger: silentServeLogger(),
+      namespaceHandler: ns,
+    });
+    handles.push(h);
+
+    // Nothing captured yet → 404 (worker boot skips hydration cleanly).
+    const empty = await fetch(h.url + '/__pyric/capture');
+    expect(empty.status).toBe(404);
+
+    // POST writes verbatim; GET reads it back byte-for-byte.
+    const body = JSON.stringify({ schema: 'pyric.verify.fixture.v1', events: [{ id: 'e1' }], services: {} });
+    const post = await fetch(h.url + '/__pyric/capture', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+    expect(post.status).toBe(204);
+
+    const got = await fetch(h.url + '/__pyric/capture');
+    expect(got.status).toBe(200);
+    expect(got.headers.get('content-type')).toContain('json');
+    expect(await got.text()).toBe(body);
+
+    // Unsupported method → 405 advertising GET, POST.
+    const del = await fetch(h.url + '/__pyric/capture', { method: 'DELETE' });
+    expect(del.status).toBe(405);
+    expect(del.headers.get('allow')).toBe('GET, POST');
+  });
 });

--- a/packages/pyric-tools/test/serve/worker/serve-init.test.ts
+++ b/packages/pyric-tools/test/serve/worker/serve-init.test.ts
@@ -18,9 +18,12 @@ import {
 } from '../../../src/serve/worker/host.js';
 import {
   applyServeInit,
+  buildWorkerCtx,
   createWorkerDurableBackend,
+  hydrateEventHistory,
   setupServerAuthFlush,
   setupWorkerHotReload,
+  MAX_PRIMED_EVENTS,
   type EventSourceLike,
 } from '../../../src/serve/worker/serve-init.js';
 import type { InitPayload } from '../../../src/serve/namespace.js';
@@ -400,5 +403,184 @@ describe('setupWorkerHotReload — the worker owns the single SSE', () => {
 
     dispose();
     expect(es.closed).toBe(true);
+  });
+});
+
+// ─── Event-history hydration: survive worker death ──────────────────────────
+
+/** A capture fixture with `n` events, optionally stamped with `capturedBy`. */
+function captureFixture(n: number, capturedBy?: string): string {
+  const events = Array.from({ length: n }, (_, i) => ({
+    kind: 'service_mutation',
+    id: `cap-${i}`,
+    at: i,
+  }));
+  return JSON.stringify({
+    schema: 'pyric.verify.fixture.v1',
+    ...(capturedBy ? { capturedBy } : {}),
+    events,
+    services: {},
+  });
+}
+
+/** A fetch that answers GET /__pyric/capture with `captureBody` (or 404 when
+ *  null). Any other GET / POST resolves 204. */
+function captureFetch(captureBody: string | null): typeof fetch & { calls: string[] } {
+  const calls: string[] = [];
+  const fn = ((url: string, init?: { method?: string }) => {
+    calls.push(String(url));
+    if ((init?.method ?? 'GET') === 'GET' && String(url) === '/__pyric/capture') {
+      return captureBody === null
+        ? Promise.resolve({ status: 404, ok: false, text: () => Promise.resolve('null') } as Response)
+        : Promise.resolve({ status: 200, ok: true, text: () => Promise.resolve(captureBody) } as Response);
+    }
+    return Promise.resolve({ status: 204, ok: true, text: () => Promise.resolve('') } as Response);
+  }) as typeof fetch & { calls: string[] };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('hydrateEventHistory — Traffic/activity survives worker death', () => {
+  it('primes eventHistory from the served capture on a fresh worker', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const primed = await hydrateEventHistory(ctx, { fetch: captureFetch(captureFixture(3, 'inst-A')) });
+    expect(primed).toBe(3);
+    expect(ctx.sandbox.history().map((e) => e.id)).toEqual(['cap-0', 'cap-1', 'cap-2']);
+  });
+
+  it('does NOT dispatch primed events to live onEvent subscribers (append-only)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const seen: string[] = [];
+    ctx.sandbox.onEvent((e) => void seen.push(e.id));
+    await hydrateEventHistory(ctx, { fetch: captureFetch(captureFixture(3, 'inst-A')) });
+    // History has them (Studio reads history-first)…
+    expect(ctx.sandbox.history()).toHaveLength(3);
+    // …but no live re-emission to already-attached subscribers.
+    expect(seen).toEqual([]);
+  });
+
+  it('skips when history is already non-empty (empty-history guard)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    // A live write lands one real event first (client setDoc emits a request
+    // event; admin writes deliberately don't).
+    const port = fakePort();
+    await handleMessage(ctx, port, { t: 'op', id: 'w1', method: 'setDoc', path: 'a/b', data: { x: 1 } });
+    const before = ctx.sandbox.history().length;
+    expect(before).toBeGreaterThan(0);
+    const primed = await hydrateEventHistory(ctx, { fetch: captureFetch(captureFixture(3, 'inst-A')) });
+    expect(primed).toBe(0);
+    expect(ctx.sandbox.history().length).toBe(before);
+  });
+
+  it(`caps priming at the most recent ${MAX_PRIMED_EVENTS} events`, async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const primed = await hydrateEventHistory(ctx, {
+      fetch: captureFetch(captureFixture(MAX_PRIMED_EVENTS + 50, 'inst-A')),
+    });
+    expect(primed).toBe(MAX_PRIMED_EVENTS);
+    const hist = ctx.sandbox.history();
+    // Kept the tail (most recent), dropped the oldest 50.
+    expect(hist).toHaveLength(MAX_PRIMED_EVENTS);
+    expect(hist[0].id).toBe('cap-50');
+    expect(hist.at(-1)!.id).toBe(`cap-${MAX_PRIMED_EVENTS + 49}`);
+  });
+
+  it('skips a capture produced by a DIFFERENT instance (identity guard)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const primed = await hydrateEventHistory(ctx, { fetch: captureFetch(captureFixture(3, 'inst-OTHER')) });
+    expect(primed).toBe(0);
+    expect(ctx.sandbox.history()).toHaveLength(0);
+  });
+
+  it('primes best-effort when the capture carries no instance id (older/standalone)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const primed = await hydrateEventHistory(ctx, { fetch: captureFetch(captureFixture(2)) });
+    expect(primed).toBe(2);
+  });
+
+  it('skips cleanly on 404 (capture off / nothing captured yet)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const primed = await hydrateEventHistory(ctx, { fetch: captureFetch(null) });
+    expect(primed).toBe(0);
+  });
+
+  it('skips cleanly when fetch throws (standalone worker, no pyric dev)', async () => {
+    const ctx = { ...(await makeCtx()), instanceId: 'inst-A' } as HostCtx;
+    const throwing = (() => Promise.reject(new Error('offline'))) as unknown as typeof fetch;
+    const primed = await hydrateEventHistory(ctx, { fetch: throwing });
+    expect(primed).toBe(0);
+  });
+});
+
+describe('buildWorkerCtx — boot-time hydration + reset non-resurrection', () => {
+  const initJson = (capture: boolean): string =>
+    JSON.stringify({ rules: null, rulesHash: null, bridgeUrl: null, seed: null, capture });
+
+  /** A fetch that serves BOTH /__pyric/init.json and GET /__pyric/capture. */
+  function bootFetch(capture: string | null): typeof fetch {
+    return ((url: string, init?: { method?: string }) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u === '/__pyric/init.json') {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(JSON.parse(initJson(true))) } as Response);
+      }
+      if (u === '/__pyric/capture' && method === 'GET') {
+        return capture === null
+          ? Promise.resolve({ status: 404, ok: false, text: () => Promise.resolve('null') } as Response)
+          : Promise.resolve({ status: 200, ok: true, text: () => Promise.resolve(capture) } as Response);
+      }
+      return Promise.resolve({ status: 204, ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as Response);
+    }) as unknown as typeof fetch;
+  }
+
+  it('a booted worker re-hydrates its own session history from the capture', async () => {
+    const idb = createMemoryBackend();
+    const instanceId = await (await import('../../../src/serve/worker/host.js')).getOrCreateInstanceId(idb);
+    const ctx = await buildWorkerCtx({ fetch: bootFetch(captureFixture(4, instanceId)), idb });
+    expect(ctx.sandbox.history().filter((e) => e.id.startsWith('cap-'))).toHaveLength(4);
+  });
+
+  it('does NOT resurrect pre-reset events: a post-reset capture reflects the cleared log', async () => {
+    // 1. Boot, write, capture reflects the write.
+    const store = { body: null as string | null };
+    const captureCapturingFetch = ((url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u === '/__pyric/init.json') {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(JSON.parse(initJson(true))) } as Response);
+      }
+      if (u === '/__pyric/capture' && method === 'POST') {
+        store.body = String(init?.body ?? ''); // server writes verbatim.
+        return Promise.resolve({ status: 204, ok: true, text: () => Promise.resolve('') } as Response);
+      }
+      if (u === '/__pyric/capture' && method === 'GET') {
+        return store.body === null
+          ? Promise.resolve({ status: 404, ok: false, text: () => Promise.resolve('null') } as Response)
+          : Promise.resolve({ status: 200, ok: true, text: () => Promise.resolve(store.body) } as Response);
+      }
+      return Promise.resolve({ status: 204, ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as Response);
+    }) as unknown as typeof fetch;
+
+    const idb = createMemoryBackend();
+    const ctxA = await buildWorkerCtx({ fetch: captureCapturingFetch, idb, captureDebounceMs: 1 });
+    const port = fakePort();
+    await handleMessage(ctxA, port, { t: 'op', id: 'w1', method: 'setDoc', path: 'notes/x', data: { v: 1 } });
+    await tick(10);
+    // Sanity: the pre-reset capture DID hold the write event.
+    expect(store.body).not.toBeNull();
+    expect((JSON.parse(store.body!) as { events: { kind: string }[] }).events.some((e) => e.kind === 'write')).toBe(true);
+
+    // reset() clears history (after the boundary) → capture flush writes the
+    // cleared log. Wait out the debounce + flush.
+    ctxA.sandbox.reset();
+    await tick(30);
+    expect(store.body).not.toBeNull();
+    const afterReset = JSON.parse(store.body!) as { events: { id: string; kind: string }[] };
+    // No pre-reset write event survives in the persisted capture.
+    expect(afterReset.events.every((e) => e.kind !== 'write')).toBe(true);
+
+    // 2. A cold reboot hydrates from that cleared capture → no resurrection.
+    const ctxB = await buildWorkerCtx({ fetch: captureCapturingFetch, idb, captureDebounceMs: 1 });
+    expect(ctxB.sandbox.history().some((e) => e.kind === 'write')).toBe(false);
   });
 });

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -26,6 +26,7 @@ export { getInternalEnv } from './sandbox-impl.js';
 // envelope (id/at minted from the shared counter) auth/storage/rtdb emit.
 export {
   emitSandboxEvent,
+  primeEventHistory,
   stampProvenance,
   makeSandboxCommitEvent,
   makeSandboxListenerEvent,

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -353,6 +353,33 @@ export class SandboxImpl implements Sandbox {
   }
 
   /**
+   * Prime the event-history log with events from a PRIOR session of the
+   * SAME origin (the served `.pyric/last-session.json` capture), for display
+   * continuity after a SharedWorker death — Traffic / activity / metrics read
+   * `history()` (and history-first `onEvent` batches), so a fresh worker would
+   * otherwise show an empty feed even though the data restored from IDB.
+   *
+   * This is history-priming ONLY:
+   *  - events are APPENDED to `eventHistory` so `history()` and any consumer
+   *    that subscribes AFTER boot (Studio's history-first batch) sees them;
+   *  - they are NOT dispatched to live `onEvent` subscribers (no re-emission);
+   *  - no operation is re-executed — the underlying data is restored
+   *    separately from persistence, these events are the record of it;
+   *  - `dispatchedCount` is untouched (it counts THIS session's live
+   *    dispatches, which drive session_boundary's priorOpCount).
+   *
+   * No-op unless history is empty, so a warm sandbox (live events already
+   * accumulated during boot) is never disturbed and primed events can never
+   * interleave after live ones. Returns the number of events primed.
+   */
+  primeEventHistory(events: readonly SandboxEvent[]): number {
+    if (this.eventHistory.length > 0) return 0;
+    if (events.length === 0) return 0;
+    this.eventHistory.push(...events);
+    return events.length;
+  }
+
+  /**
    * Admin-plane access. Identity-agnostic: admin reads aren't gated on
    * auth, so they're a sandbox property — not something contexts carry.
    */
@@ -664,6 +691,30 @@ export function getInternalEnv(sandbox: Sandbox): LocalEnvironment {
     );
   }
   return sandbox.getEnv();
+}
+
+/**
+ * Prime a sandbox's `history()` log with events from a prior session of the
+ * same origin (the served capture file), WITHOUT dispatching them to live
+ * `onEvent` subscribers or re-executing any op. History-priming seam for the
+ * served worker's boot-time event hydration — see
+ * {@link SandboxImpl.primeEventHistory}. No-op unless history is empty.
+ * Returns the number of events primed.
+ *
+ * Throws if `sandbox` wasn't produced by `initializeSandbox()` (same guard
+ * as {@link getInternalEnv}).
+ */
+export function primeEventHistory(
+  sandbox: Sandbox,
+  events: readonly SandboxEvent[],
+): number {
+  if (!(sandbox instanceof SandboxImpl)) {
+    throw new SandboxError(
+      'invalid-argument',
+      'Sandbox handle was not produced by initializeSandbox(); custom Sandbox implementations are not supported.',
+    );
+  }
+  return sandbox.primeEventHistory(events);
 }
 
 /**


### PR DESCRIPTION
Worker death zeroed Traffic, the activity feed, and the metrics tabs even though the server holds the full event log in `.pyric/last-session.json`. The worker now hydrates its event history from the capture file at boot.

- New `GET /__pyric/capture` returns the current fixture (404 when capture is off)
- Worker boot primes `eventHistory` via an additive internal seam (`primeEventHistory`): append-only, no dispatch to live subscribers, no re-execution — Studio's history-first subscription gets continuity with zero UI changes
- Guard rails: primes only into an empty history, caps at the most recent 2000 events, skips cleanly when capture is absent, and skips when the capture belongs to a different worker instance (additive `capturedBy` stamp on the fixture; `pyric verify` ignores it)
- Reset doesn't resurrect: the boundary flush persists the cleared log, pinned by test
- Known lag: the capture debounce (~400ms) can drop the final pre-death moments from the record — the data itself is durable via IDB; this restores the activity trail

serve suite 367 green, pyric 4383 green, root build green. Two process-signal test flakes observed during the run reproduce without these changes (noted, not addressed here).