### PR TITLE
RTDB joins sandbox persistence: same durability contract as Firestore/auth

### DIFF
--- a/packages/pyric-tools/src/serve/entries/runtime.ts
+++ b/packages/pyric-tools/src/serve/entries/runtime.ts
@@ -209,6 +209,12 @@ if (!useWorker) try {
   if (!res.ok) throw new Error(`/__pyric/init.json → ${res.status}`);
   const payload = (await res.json()) as InitPayload;
   bridgeUrlFromPayload = payload.bridgeUrl;
+  // Register RTDB with the persistence registry BEFORE enablePersistence
+  // (below) so the restored tree rides the controller blob and is applied
+  // during restore-on-attach — same eager-registration reasoning as the
+  // worker path (serve-init.ts). `getDatabase(sandbox)` is idempotent
+  // (one backend per sandbox) so a later rules/op call reuses it.
+  getDatabase(sandbox);
   if (payload.rules) {
     const db = getFirestore(sandbox);
     const lint = sandboxOps.setRules(db, payload.rules);

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -1190,6 +1190,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
         const db = lensRtdb(ctx, msg.actAs, port);
         const value = resolveRtdbSentinels(msg.value);
         await rtdbSet(rtdbRef(db, msg.path), value as never);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1199,6 +1200,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       try {
         const db = lensRtdb(ctx, msg.actAs, port);
         await rtdbUpdate(rtdbRef(db, msg.path), resolveRtdbSentinels(msg.values) as Record<string, unknown>);
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1208,6 +1210,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       try {
         const db = lensRtdb(ctx, msg.actAs, port);
         await rtdbRemove(rtdbRef(db, msg.path));
+        await bestEffortFlush(ctx);
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1222,6 +1225,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
             rtdbRef(db, childPath),
             resolveRtdbSentinels(msg.value) as never,
           );
+          await bestEffortFlush(ctx);
         }
         const normalizedPath = `/${childPath.split('/').filter(Boolean).join('/')}`;
         ok(port, msg.id, { key: msg.key, path: normalizedPath });

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -459,6 +459,16 @@ export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
   // all tabs (sessions are per-port; see host-auth.ts).
   getAuth(sandbox);
 
+  // Register RTDB with the persistence registry EAGERLY, same reasoning as
+  // auth above: `getDatabase(sandbox)` calls `registerPersistableService`,
+  // which makes the persisted tree ride the controller blob AND (via the
+  // controller's late-registration hook) applies the restored tree NOW. The
+  // worker otherwise creates RTDB handles lazily (`ctx.rtdb ??= ...`), so a
+  // Studio RTDB-tab read that arrives before any RTDB op would see an empty
+  // tree even though a prior session's data was persisted. Eager registration
+  // makes the restored tree queryable immediately.
+  getDatabase(sandbox);
+
   // Sandbox-live Firestore: `getFirestore(sandbox)` reads
   // `sandbox.currentUser` per operation, so auth changes propagate
   // to subsequent Firestore ops without rebuilding the handle.

--- a/packages/pyric-tools/test/serve/worker/persistence-durability.test.ts
+++ b/packages/pyric-tools/test/serve/worker/persistence-durability.test.ts
@@ -134,6 +134,76 @@ describe('worker persistence: acked writes survive abrupt teardown', () => {
     expect((b.value as { n?: number } | null)?.n).toBe(2);
   });
 
+  it('an acked rtdb.set restores after a cold reboot over the same IDB', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const write = await op(ctxA, {
+      id: 'w1',
+      method: 'rtdb.set',
+      path: '/rooms/general',
+      value: { name: 'General' },
+    });
+    expect(write.ok).toBe(true);
+    // Abrupt teardown: nothing runs after the ack.
+
+    const ctxB = await bootWorker(key);
+    // FIRST op on the rebooted worker is a read — proves the restored tree is
+    // queryable immediately (eager RTDB registration at boot), not only after
+    // some prior RTDB op lazily creates the backend.
+    const read = await op(ctxB, { id: 'r1', method: 'rtdb.get', path: '/rooms/general' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { value?: { name?: string } }).value).toEqual({ name: 'General' });
+  });
+
+  it('an acked rtdb.remove stays removed after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    await op(ctxA, { id: 'w1', method: 'rtdb.set', path: '/rooms/doomed', value: { x: 1 } });
+    const del = await op(ctxA, { id: 'd1', method: 'rtdb.remove', path: '/rooms/doomed' });
+    expect(del.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'rtdb.get', path: '/rooms/doomed' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { exists?: boolean }).exists).toBe(false);
+  });
+
+  it('an acked rtdb.push value restores after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    const pushed = await op(ctxA, {
+      id: 'p1',
+      method: 'rtdb.push',
+      path: '/messages',
+      key: 'm-abc',
+      value: { text: 'hello' },
+    });
+    expect(pushed.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'rtdb.get', path: '/messages/m-abc' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { value?: { text?: string } }).value).toEqual({ text: 'hello' });
+  });
+
+  it('an acked rtdb.update restores after a cold reboot', async () => {
+    const key = freshKey();
+    const ctxA = await bootWorker(key);
+    await op(ctxA, { id: 'w1', method: 'rtdb.set', path: '/rooms/general', value: { name: 'General' } });
+    const upd = await op(ctxA, {
+      id: 'u1',
+      method: 'rtdb.update',
+      path: '/rooms/general',
+      values: { members: 5 },
+    });
+    expect(upd.ok).toBe(true);
+
+    const ctxB = await bootWorker(key);
+    const read = await op(ctxB, { id: 'r1', method: 'rtdb.get', path: '/rooms/general' });
+    expect(read.ok).toBe(true);
+    expect((read.value as { value?: unknown }).value).toEqual({ name: 'General', members: 5 });
+  });
+
   it('an acked auth.adminCreateUser restores after a cold reboot', async () => {
     const key = freshKey();
     const ctxA = await bootWorker(key);

--- a/packages/pyric/src/database/modular.ts
+++ b/packages/pyric/src/database/modular.ts
@@ -108,6 +108,33 @@ function getOrCreateBackend(sandbox: Sandbox): RtdbBackend {
     // on the unified Studio `onEvent`/`history()` stream (keystone T1).
     backend = new RtdbBackend(sandbox);
     backendBySandbox.set(sandbox, backend);
+    // Register the RTDB tree as a persistable service on the sandbox — the
+    // same durability mechanism auth uses (see auth/index.ts:backendFor).
+    // This makes `enablePersistence` include the tree in the serialized blob
+    // and restore it on reload (worker death / browser restart), instead of
+    // the old memory-only behavior where RTDB data was lost while Firestore
+    // docs + auth users came back.
+    //
+    // Guarded by the WeakMap memoization above: we only reach this branch
+    // ONCE per sandbox, so double-registration is impossible in practice
+    // (registerPersistableService throws on duplicates anyway).
+    //
+    //   - snapshot: serialize the tree as a plain JSON value.
+    //   - restore : REPLACE the tree AND fire listeners so a live RTDB view
+    //               (Studio's RTDB tab) converges on the restored data.
+    //   - subscribe: notify the controller on ANY write so a mutation
+    //               schedules a debounced flush. RTDB writes emit
+    //               `service_mutation` events, which the controller's
+    //               `isPersistableEvent` does NOT cover — so this hook is the
+    //               sole flush trigger, exactly as auth does it.
+    const capturedBackend = backend;
+    sandbox.registerPersistableService('rtdb', {
+      snapshot: () => capturedBackend.exportTree(),
+      restore: (data: unknown) => {
+        capturedBackend.restoreTree(data as JsonValue);
+      },
+      subscribe: (onChange: () => void) => capturedBackend.subscribeWrites(onChange),
+    });
   }
   return backend;
 }

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -152,6 +152,17 @@ export class RtdbBackend {
   private nextId = 0;
 
   /**
+   * Persistence change-subscribers. The sandbox persistence controller
+   * registers one of these (via {@link RtdbBackend.subscribeWrites}) so any
+   * tree mutation schedules a debounced flush. RTDB writes emit
+   * `kind: 'service_mutation'` events, which are NOT in the controller's
+   * `isPersistableEvent` set (`write`/`session_boundary`) — so the sandbox
+   * event stream never triggers an RTDB flush. This subscriber channel is
+   * the sole flush trigger, mirroring how auth drives its own flushes.
+   */
+  private readonly writeSubscribers = new Set<() => void>();
+
+  /**
    * The owning `Sandbox`, when this backend was created through the
    * modular surface's `getDatabase(sandbox)` / `getDatabase(ctx)` path.
    * Held only to emit RTDB write activity onto the unified Studio
@@ -367,6 +378,7 @@ export class RtdbBackend {
       );
       this.tree.write(path, resolved);
     }
+    this.notifyWrite();
   }
 
   setRules(rulesJson: { rules: Record<string, unknown> } | null): void {
@@ -422,6 +434,7 @@ export class RtdbBackend {
       replay: { requestTime: now },
       detail: { admin: true },
     });
+    this.notifyWrite();
   }
 
   adminUpdate(path: string, patch: Record<string, JsonValue>): void {
@@ -455,6 +468,7 @@ export class RtdbBackend {
         replay: { requestTime: now },
         detail: { admin: true, multiPath: true, paths: Object.keys(expanded) },
       });
+      this.notifyWrite();
       return;
     }
 
@@ -485,6 +499,7 @@ export class RtdbBackend {
       replay: { requestTime: now },
       detail: { admin: true, multiPath: false, keys: Object.keys(resolvedPatch) },
     });
+    this.notifyWrite();
   }
 
   adminRemove(path: string): void {
@@ -589,6 +604,7 @@ export class RtdbBackend {
       replay: { requestTime: now },
     });
     this.emitRtdbEvent(auth, effectiveOp, canonicalPath(path), { before, after });
+    this.notifyWrite();
   }
 
   remove(auth: AuthState, path: string): void {
@@ -668,6 +684,7 @@ export class RtdbBackend {
         after: expanded,
         detail: { multiPath: true, paths: Object.keys(expanded) },
       });
+      this.notifyWrite();
       return;
     }
     // Shallow merge mode. Each top-level key of `patch` replaces the
@@ -729,6 +746,7 @@ export class RtdbBackend {
       after: resolvedPatch,
       detail: { multiPath: false, keys: Object.keys(resolvedPatch) },
     });
+    this.notifyWrite();
   }
 
   // Note: `push()` is implemented entirely on the modular surface
@@ -1136,6 +1154,7 @@ export class RtdbBackend {
         after: resolved,
         detail: { committed: true },
       });
+      this.notifyWrite();
       return { committed: true, val: resolved, key };
     }
     // applyLocally: false — rule-check FIRST, write only if allowed,
@@ -1547,6 +1566,68 @@ export class RtdbBackend {
           detail: { query: true },
         });
         // Swallow — see fanOut.
+      }
+    }
+  }
+
+  // ─── Persistence (PersistableService) ──────────────────────────────
+  //
+  // The RTDB tree rides the sandbox persistence controller's `services`
+  // blob exactly like the auth user DB. `getDatabase(sandbox)` registers
+  // these hooks once per sandbox (see modular.ts). Together they give RTDB
+  // the same durability contract as Firestore/auth: worker death / browser
+  // restart restores the whole tree instead of losing it.
+
+  /** Serialize the whole tree as a plain JSON value for the persistence
+   *  snapshot. Defensive deep-copy (via `DataTree.snapshot`). */
+  exportTree(): JsonValue {
+    return this.tree.snapshot();
+  }
+
+  /**
+   * Replace the whole tree with a persisted snapshot, then fire listeners
+   * so any live UI (Studio's RTDB tab) converges on the restored data
+   * rather than showing a stale/empty view.
+   *
+   * REPLACE, not merge — the tree becomes EXACTLY the snapshot. On boot /
+   * late-registration the tree is empty so this is a pure load; for a
+   * runtime `loadSnapshot()` it clobbers divergent state, matching auth's
+   * restore policy.
+   *
+   * Notification: we capture each child-listener parent's prior children
+   * BEFORE the swap, then fan out value listeners from the root (every
+   * listener re-reads its path) and child listeners against the diff. The
+   * value-listener no-op suppression (DB-B8) means a listener whose subtree
+   * is byte-identical to the snapshot won't spuriously re-fire.
+   */
+  restoreTree(root: JsonValue): void {
+    const priors = this.snapshotChildListenerParents();
+    this.tree.restore(root ?? {});
+    this.fanOut(['/']);
+    this.fanOutChildren(priors);
+  }
+
+  /**
+   * Register a persistence change-subscriber. Returns an unsubscribe.
+   * Fired (best-effort, isolated) after every committed tree mutation so
+   * the controller schedules a debounced flush.
+   */
+  subscribeWrites(onChange: () => void): () => void {
+    this.writeSubscribers.add(onChange);
+    return () => {
+      this.writeSubscribers.delete(onChange);
+    };
+  }
+
+  /** Notify persistence subscribers that the tree changed. Best-effort +
+   *  isolated — a subscriber throw must never break the write. */
+  private notifyWrite(): void {
+    if (this.writeSubscribers.size === 0) return;
+    for (const sub of this.writeSubscribers) {
+      try {
+        sub();
+      } catch {
+        // Observational — never let a flush-scheduler throw break a write.
       }
     }
   }

--- a/packages/pyric/test/sandbox/rtdb-persistence.test.ts
+++ b/packages/pyric/test/sandbox/rtdb-persistence.test.ts
@@ -1,0 +1,253 @@
+/**
+ * RTDB persistence round-trip tests.
+ *
+ * Verifies that the RTDB tree registers with the persistable-service
+ * registry and rides the serialized blob exactly like the auth user DB —
+ * giving RTDB the same durability contract as Firestore/auth (worker death
+ * / browser restart restores the whole tree instead of losing it).
+ *
+ * Covers (modeled on `auth-persistence.test.ts`):
+ *   - Basic round-trip: write, flush, fresh sandbox restore → tree present.
+ *   - Late registration: `enablePersistence` BEFORE `getDatabase`.
+ *   - Early registration: `getDatabase` BEFORE `enablePersistence`.
+ *   - Snapshot shape: `sandbox.snapshot().services.rtdb` holds the tree.
+ *   - RTDB writes trigger a debounced flush without a Firestore write
+ *     (RTDB writes emit `service_mutation` events, which the controller's
+ *     `isPersistableEvent` does NOT cover — the service `subscribe` hook is
+ *     the sole flush trigger).
+ *   - Restore fires listeners so a live view converges (notification
+ *     design), exercised directly against `RtdbBackend`.
+ *
+ * Pattern: injected in-memory backend for determinism; explicit
+ * `sandbox.flush()` except where the debounce is under test.
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+  createMemoryBackend,
+  deserializeFromBuckets,
+  initializeSandbox,
+  type PersistenceBackend,
+} from '../../src/sandbox/index.js';
+import {
+  getDatabase,
+  ref,
+  set,
+  get,
+  remove,
+  sandbox as rtdbSandbox,
+} from '../../src/database/modular.js';
+import { RtdbBackend } from '../../src/database/sandbox/backend.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── Snapshot shape ────────────────────────────────────────────────────
+
+describe('SandboxSnapshot.services — rtdb', () => {
+  it('includes the rtdb tree after getDatabase + a write', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox);
+    await set(ref(db, '/rooms/general'), { name: 'General' });
+
+    const snap = sandbox.snapshot();
+    expect(snap.services).toHaveProperty('rtdb');
+    expect(snap.services.rtdb).toEqual({ rooms: { general: { name: 'General' } } });
+  });
+
+  it('registers rtdb even before any write (empty tree snapshot)', () => {
+    const sandbox = initializeSandbox();
+    getDatabase(sandbox);
+    const snap = sandbox.snapshot();
+    expect(snap.services).toHaveProperty('rtdb');
+    expect(snap.services.rtdb).toEqual({});
+  });
+});
+
+// ─── Basic round-trip ─────────────────────────────────────────────────
+
+describe('rtdb persistence — basic round-trip', () => {
+  it('restores the tree after flush → fresh sandbox restore', async () => {
+    const backend = createMemoryBackend();
+
+    const sandbox1 = initializeSandbox();
+    await sandbox1.enablePersistence({ key: 'rtdb:rt', injectedBackend: backend });
+    const db1 = getDatabase(sandbox1);
+    await set(ref(db1, '/rooms/general'), { name: 'General', members: 3 });
+    await set(ref(db1, '/rooms/random'), { name: 'Random' });
+    await sandbox1.flush();
+
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:rt', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2);
+
+    const snap = await get(ref(db2, '/rooms'));
+    expect(snap.val()).toEqual({
+      general: { name: 'General', members: 3 },
+      random: { name: 'Random' },
+    });
+  });
+
+  it('a removed subtree stays removed after restore', async () => {
+    const backend = createMemoryBackend();
+
+    const sandbox1 = initializeSandbox();
+    await sandbox1.enablePersistence({ key: 'rtdb:rm', injectedBackend: backend });
+    const db1 = getDatabase(sandbox1);
+    await set(ref(db1, '/rooms/doomed'), { x: 1 });
+    await remove(ref(db1, '/rooms/doomed'));
+    await sandbox1.flush();
+
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:rm', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2);
+
+    const snap = await get(ref(db2, '/rooms/doomed'));
+    expect(snap.exists()).toBe(false);
+  });
+});
+
+// ─── Late registration ─────────────────────────────────────────────────
+
+describe('rtdb persistence — late registration (enablePersistence before getDatabase)', () => {
+  it('writes made after enablePersistence are flushed and restored', async () => {
+    const backend = createMemoryBackend();
+
+    const sandbox1 = initializeSandbox();
+    await sandbox1.enablePersistence({ key: 'rtdb:late', injectedBackend: backend });
+    // getDatabase registers 'rtdb' AFTER the controller has already attached.
+    const db1 = getDatabase(sandbox1);
+    await set(ref(db1, '/counters/global'), { clicks: 7 });
+    await sandbox1.flush();
+
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:late', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2);
+
+    const snap = await get(ref(db2, '/counters/global'));
+    expect(snap.val()).toEqual({ clicks: 7 });
+  });
+
+  it('restored tree is queryable on the FIRST read after restore (eager-registration path)', async () => {
+    const backend = createMemoryBackend();
+
+    const sandbox1 = initializeSandbox();
+    await sandbox1.enablePersistence({ key: 'rtdb:first', injectedBackend: backend });
+    await set(ref(getDatabase(sandbox1), '/rooms/general'), { name: 'General' });
+    await sandbox1.flush();
+
+    // Session 2: register rtdb eagerly (as the worker boot does), then the
+    // controller's late-registration hook applies the restore synchronously.
+    // The very first read sees the restored tree — no prior op needed.
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:first', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2); // eager registration → restore applied
+    const snap = await get(ref(db2, '/rooms/general'));
+    expect(snap.val()).toEqual({ name: 'General' });
+  });
+});
+
+// ─── Early registration ─────────────────────────────────────────────────
+
+describe('rtdb persistence — early registration (getDatabase before enablePersistence)', () => {
+  it('writes made before enablePersistence are flushed on the next flush', async () => {
+    const backend = createMemoryBackend();
+    const sandbox = initializeSandbox();
+
+    const db = getDatabase(sandbox);
+    await set(ref(db, '/rooms/general'), { name: 'General' });
+
+    await sandbox.enablePersistence({ key: 'rtdb:early', injectedBackend: backend });
+    await sandbox.flush();
+
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:early', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2);
+
+    const snap = await get(ref(db2, '/rooms/general'));
+    expect(snap.val()).toEqual({ name: 'General' });
+  });
+});
+
+// ─── Auto-flush on RTDB write without a Firestore write ────────────────
+
+describe('rtdb persistence — auto-flush on write', () => {
+  it('an RTDB write triggers a debounced flush even with no Firestore write', async () => {
+    const backend = createMemoryBackend();
+    let writeCount = 0;
+    const counting: PersistenceBackend = {
+      getRecord: backend.getRecord.bind(backend),
+      listRecords: backend.listRecords.bind(backend),
+      putRecords: async (k, r) => { writeCount++; await backend.putRecords(k, r); },
+      deleteRecords: backend.deleteRecords.bind(backend),
+      clear: backend.clear.bind(backend),
+    };
+
+    const sandbox = initializeSandbox();
+    await sandbox.enablePersistence({
+      key: 'rtdb:autof',
+      injectedBackend: counting,
+      flushIntervalMs: 20,
+    });
+    const db = getDatabase(sandbox);
+
+    // A write schedules the debounced flush via the service `subscribe`
+    // hook. No Firestore write happens; RTDB's `service_mutation` event is
+    // NOT a persistable sandbox event, so this is the sole trigger.
+    await set(ref(db, '/rooms/general'), { name: 'General' });
+
+    // Before debounce window: flush hasn't fired yet.
+    expect(writeCount).toBe(0);
+
+    await sleep(60);
+    expect(writeCount).toBeGreaterThan(0);
+
+    const records: [string, unknown][] = [];
+    for (const id of await backend.listRecords('rtdb:autof')) {
+      records.push([id, await backend.getRecord('rtdb:autof', id)]);
+    }
+    const { services } = deserializeFromBuckets(records);
+    expect((services as { rtdb?: unknown }).rtdb).toEqual({ rooms: { general: { name: 'General' } } });
+  });
+});
+
+// ─── Restore fires listeners (notification design) ─────────────────────
+
+describe('rtdb persistence — restore notifies live listeners', () => {
+  it('restoreTree fires an attached onValue listener with the restored value', () => {
+    const backend = new RtdbBackend();
+    const fires: Array<{ val: unknown; exists: boolean }> = [];
+    // Attach a plain-ref value listener (admin auth) at /rooms/general.
+    backend.onValue({ mode: 'admin' } as never, '/rooms/general', (snap) => {
+      fires.push({ val: snap.val, exists: snap.exists });
+    });
+    // Initial fire is the empty/absent path.
+    expect(fires).toHaveLength(1);
+    expect(fires[0]).toEqual({ val: null, exists: false });
+
+    // Restore a snapshot that populates the listener's path.
+    backend.restoreTree({ rooms: { general: { name: 'General' } } });
+
+    // The listener must have re-fired with the restored value so a live UI
+    // converges rather than showing stale/empty data.
+    expect(fires).toHaveLength(2);
+    expect(fires[1]).toEqual({ val: { name: 'General' }, exists: true });
+  });
+});
+
+// ─── snapshotState helper agrees with restored tree ────────────────────
+
+describe('rtdb persistence — snapshotState after restore', () => {
+  it('rtdbSandbox.snapshotState reflects the restored tree', async () => {
+    const backend = createMemoryBackend();
+    const sandbox1 = initializeSandbox();
+    await sandbox1.enablePersistence({ key: 'rtdb:snapstate', injectedBackend: backend });
+    await set(ref(getDatabase(sandbox1), '/a/b'), 1);
+    await sandbox1.flush();
+
+    const sandbox2 = initializeSandbox();
+    await sandbox2.enablePersistence({ key: 'rtdb:snapstate', injectedBackend: backend });
+    const db2 = getDatabase(sandbox2);
+    expect(rtdbSandbox.snapshotState(db2)).toEqual({ a: { b: 1 } });
+  });
+});


### PR DESCRIPTION
RTDB data was memory-only — worker death or a browser restart lost the whole tree while Firestore docs and auth users came back. RTDB now registers with the persistence controller exactly the way auth does.

- `getDatabase(sandbox)` registers a 'rtdb' persistable service (snapshot/restore/subscribe on the backend); every commit point notifies, so writes flush on the controller's debounce
- Restore REPLACES the tree (matching auth) and fans out to live listeners so open views converge on restored data instead of going stale
- The worker awaits the IDB commit before acking rtdb.set/update/remove/push — acked-means-committed now holds for RTDB (#62's contract)
- Eager registration at worker boot (and in the in-page runtime before `enablePersistence`) so restored data is visible to the first read, not just after the first write
- `--persist` comes along for free: services ride the controller blob that mirrors to `.pyric/state/state.json` (round-trip verified)

Tests: 10 new pyric cases + 4 new worker reload-durability cases (boot-twice over one fake IndexedDB, including first-read-after-reboot visibility); pyric 4393 green; root build green. Two flaky child-process suites in pyric-tools reproduce without this change (noted).

Follow-ups flagged, not included: the sandbox-mode example bundle forces the in-page path (`__PYRIC_FORCE_INPAGE__`), so a manual Studio-RTDB-tab round-trip through the SharedWorker is the last human confirmation; and `database/modular.ts` carries two pre-existing NUL bytes that make grep treat it as binary — separate cleanup.

This flips the RTDB row in the persistence coverage matrix (#79) — whichever merges second should reconcile the table.