### PR TITLE
Persistence guardrails: seed never stomps existing data, --fresh never lies

### DIFF
--- a/packages/pyric-tools/docs/how-to/serve-persistence-and-multi-tab.md
+++ b/packages/pyric-tools/docs/how-to/serve-persistence-and-multi-tab.md
@@ -70,9 +70,18 @@ Two stores can hold data — clear the one(s) you need:
 | **IndexedDB** (the SharedWorker's default durable store) | the browser, per origin | DevTools → **Application → Storage → Clear site data**, then reload — or just use a private window |
 | **`.pyric/state/state.json`** (the `--persist` file) | your project directory | `pyric dev --persist --fresh` (discards it and re-seeds) |
 
+`--fresh` **requires `--persist`** — it discards `.pyric/state/state.json`, and
+without `--persist` there is no such file, so `pyric dev` now errors instead of
+silently doing nothing.
+
 `--fresh` clears only the on-disk file — it does **not** touch the browser's
-IndexedDB. For a fully clean slate on the SharedWorker path, **clear site data**
-(or use a private window) and add `--fresh` if you use `--persist`.
+IndexedDB. ⚠ **This makes `--fresh` a half-reset**: prime-once only fills an
+EMPTY IndexedDB, so a browser tab that already has sandbox data KEEPS it, and
+that tab's next flush writes it straight back into the file `--fresh` just
+cleared — the "fresh" file quietly refills with the old data. For a fully clean
+slate on the SharedWorker path, you must **also clear site data** (or use a
+private window) whenever you pass `--fresh`. (A real reset handshake that makes
+`--fresh` clear the browser store too is future work.)
 
 ## Seed data on boot — `--seed`
 
@@ -81,9 +90,18 @@ pyric dev --seed seed.json
 ```
 
 Loads a fixture document set admin-style before your app runs. Accepts either a
-`"collection/doc" → fields` map or a `pyric snapshot` state file. With
-`--persist`, the seed applies only on the **first** (state-less) run — after
-that the lived state wins; use `--fresh` to re-seed.
+`"collection/doc" → fields` map or a `pyric snapshot` state file.
+
+**A seed applies only into an empty home.** If the sandbox already holds
+restored data — a `--persist` state file, or data IndexedDB restored from an
+earlier session (which happens even without `--persist`, since IndexedDB is the
+SharedWorker's default durable store) — the fixture is skipped, not applied on
+top of it, and a console line explains why. This is what stops `--seed` from
+silently reverting your edits on every reload: without it, default (ephemeral)
+mode had no state file to gate on, so the fixture re-applied on every boot no
+matter what you'd changed in the browser. Use `--persist --fresh` (plus
+clearing browser storage — see above) to discard existing state and re-seed
+from scratch.
 
 ## SharedWorker troubleshooting
 
@@ -123,8 +141,8 @@ the in-page fallback.
 | Flag | Effect |
 |---|---|
 | `--persist` | durable, git-trackable state at `.pyric/state/state.json` (worker mirrors to it; the in-page fallback uses it as its durable store) |
-| `--fresh` | discard the `.pyric/state` file and re-seed — does **not** clear browser IndexedDB |
-| `--seed <file>` | load fixture docs on boot (a `"collection/doc" → fields` map, or a `pyric snapshot` file) |
+| `--fresh` | requires `--persist` (errors otherwise); discards the `.pyric/state` file and re-seeds — does **not** clear browser IndexedDB, so a browser with existing data writes it right back (also clear site data / use a private window for a full reset) |
+| `--seed <file>` | load fixture docs on boot (a `"collection/doc" → fields` map, or a `pyric snapshot` file) — applies only into an empty sandbox; skipped (with a console note) if restored/lived data is already present |
 | `--no-capture` | disable the default-on session capture (`.pyric/last-session.json`, replayed by `pyric verify`) |
 
 The complete `pyric dev` flag set (`--port`, `--host`, `--bridge`,

--- a/packages/pyric-tools/docs/reference/cli.md
+++ b/packages/pyric-tools/docs/reference/cli.md
@@ -49,9 +49,9 @@ is unavailable). `firestore.rules` is deployed and hot-reloaded over SSE.
 |---|---|---|
 | `--port <n>` | `3473` | Port to serve on ("FIRE" on a phone keypad); scans forward when taken. |
 | `--host <h>` | `localhost` | Host to bind. |
-| `--persist` | off | Persist sandbox state (docs + auth users) to a committable `.pyric/state/state.json`. Once a state file exists it wins; `--seed` then applies only on the first run. (On the SharedWorker path data is already durable in IndexedDB; this adds the on-disk, shareable copy.) |
-| `--fresh` | off | With `--persist`: discard the existing state file and re-seed from scratch. Does not clear the browser's IndexedDB. |
-| `--seed <file>` | — | Load a `"collection/doc" → fields` JSON map admin-style before app code runs. Also accepts a `pyric snapshot` state file (detected by its `version` key) — seeds docs + auth users. |
+| `--persist` | off | Persist sandbox state (docs + auth users) to a committable `.pyric/state/state.json`. Once a state file exists it wins; `--seed` then applies only into an empty sandbox. (On the SharedWorker path data is already durable in IndexedDB; this adds the on-disk, shareable copy.) |
+| `--fresh` | off | Requires `--persist` — errors otherwise (there's no state file to discard). Discards the existing state file and re-seeds from scratch. Does **not** clear the browser's IndexedDB, so a browser tab with existing sandbox data keeps it and writes it right back into the new file; also clear site data (or use a private window) for a full reset. |
+| `--seed <file>` | — | Load a `"collection/doc" → fields` JSON map admin-style before app code runs. Also accepts a `pyric snapshot` state file (detected by its `version` key) — seeds docs + auth users. Applies only into an empty sandbox: if it already holds restored/lived data (a state file, or IndexedDB from an earlier session even without `--persist`), the seed is skipped and a console line explains why. |
 | `--no-capture` | capture on | Disable the session capture. By default pyric dev writes `.pyric/last-session.json` for `pyric verify` to replay. Captures use `pyric.verify.fixture.v1`, with one event timeline and per-service Firestore/RTDB rules + state blocks. |
 | `--no-watch` | watch on | Disable `firestore.rules` hot-reload. |
 | `--no-open` | auto-open on | Don't auto-open the browser. (Auto-open is already suppressed under `--json`, no TTY, and CI.) |

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -201,9 +201,14 @@ CORE FLAGS (dev)
                      restarts. Once a state file exists it wins; --seed
                      applies only on the first (state-less) run. Ephemeral
                      is the default.
-  --fresh            With --persist: discard the existing state file and
+  --fresh            Requires --persist: discard the existing state file and
                      re-seed from scratch (escape hatch when you've edited
-                     seed.json).
+                     seed.json). Without --persist, --fresh errors — there is
+                     no state file to discard. Half-reset warning: a browser
+                     tab that already has sandbox data in IndexedDB keeps it
+                     and writes it back to the new file; also clear the
+                     browser store (Studio → Settings → Reset, or an
+                     incognito window) for a full reset.
   -- <cmd>           Run <cmd> once the host is up, with PYRIC_SANDBOX set and
                      NODE_OPTIONS extended with --import pyric-tools/register
                      so firebase-admin/firebase resolve to the sandbox. When

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -138,6 +138,17 @@ export async function startServe(opts: {
 }): Promise<ServeRuntime> {
   const logger = opts.logger ?? consoleServeLogger();
 
+  // --fresh only means anything against the state.json file `--persist`
+  // maintains — without `--persist` there is no file to discard, so
+  // `--fresh` alone was a silent no-op (nothing happened, nothing said so).
+  // Fail fast instead of pretending to reset something.
+  if (opts.fresh && !opts.persist) {
+    throw new Error(
+      'pyric dev: --fresh requires --persist (it discards .pyric/state/state.json). ' +
+        'Browser-stored data is cleared from Studio → Settings → Reset, or DevTools → Clear site data.',
+    );
+  }
+
   // firebase.json is optional for serving (firebase-serve parity: warn, then
   // serve the directory anyway).
   let config: FirebaseJson | null = null;
@@ -218,6 +229,19 @@ export async function startServe(opts: {
   if (state && opts.fresh) {
     for (const p of [state.path, state.backupPath]) if (existsSync(p)) rmSync(p);
     logger.note('  ⓘ --fresh: discarded the existing state file; re-seeding');
+    // Half-reset warning: --fresh only deletes the SERVER file. The worker's
+    // durable store is browser IndexedDB, and prime-once only fills an EMPTY
+    // IDB (createWorkerDurableBackend) — a browser that already holds sandbox
+    // data KEEPS it and its next flush repopulates the supposedly-fresh file.
+    // The reset handshake (making --fresh actually clear the browser store) is
+    // future work; until then, say so loudly rather than let the file quietly
+    // refill.
+    logger.note(
+      '  ⚠ --fresh only resets the server-side state file — a browser tab that already has ' +
+        'sandbox data in IndexedDB keeps it and will write it straight back on its next flush. ' +
+        'For a full reset, also clear the browser store: Studio → Settings → Reset, or open an ' +
+        'incognito/private window.',
+    );
   }
   let persistedEnvelope = state?.load() ?? null;
 

--- a/packages/pyric-tools/src/serve/entries/runtime.ts
+++ b/packages/pyric-tools/src/serve/entries/runtime.ts
@@ -176,6 +176,9 @@ interface ServeDiagnostics {
   lastFlushAt: number | null;
   /** True when another tab holds the writer lock — this tab won't persist. */
   persistReadOnly: boolean;
+  /** True when a `--seed` fixture was withheld because the sandbox already
+   *  held restored/lived data (see the seed-docs block below). */
+  seedSkipped: boolean;
 }
 
 declare global {
@@ -195,6 +198,7 @@ const diagnostics: ServeDiagnostics = {
   persistEnabled: false,
   lastFlushAt: null,
   persistReadOnly: false,
+  seedSkipped: false,
 };
 globalThis.__pyricServe = diagnostics;
 
@@ -415,10 +419,23 @@ if (!useWorker) try {
     }
   }
   if (payload.seed && Object.keys(payload.seed).length > 0) {
-    // Admin-style fixture load (bypasses rules) — runs before app code
-    // (top-level await), so the app's first render sees the seeded state.
-    sandboxOps.seedDocuments(getFirestore(sandbox), payload.seed);
-    diagnostics.seededDocs = Object.keys(payload.seed).length;
+    // A seed fixture applies only into an empty home — mirrors the worker's
+    // guard (serve/worker/serve-init.ts): by this point any --persist restore
+    // above has already run, so an existing document means lived/restored
+    // data, not a blank slate. Never stomp it with a fixture.
+    const existing = Object.keys(sandboxOps.snapshotState(getFirestore(sandbox))).length > 0;
+    if (existing) {
+      diagnostics.seedSkipped = true;
+      console.info(
+        '[pyric dev] --seed skipped: the sandbox already has restored data — the fixture would ' +
+          'have overwritten it. Use `--persist --fresh` to discard existing state and re-seed.',
+      );
+    } else {
+      // Admin-style fixture load (bypasses rules) — runs before app code
+      // (top-level await), so the app's first render sees the seeded state.
+      sandboxOps.seedDocuments(getFirestore(sandbox), payload.seed);
+      diagnostics.seededDocs = Object.keys(payload.seed).length;
+    }
   }
 } catch (e) {
   diagnostics.initError = e instanceof Error ? e.message : String(e);

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -90,7 +90,31 @@ export interface ServeInitResult {
   /** Parse error from a malformed ruleset (defensive — the server lints first);
    *  the sandbox keeps its default rules rather than bricking. */
   rulesParseError: string | null;
+  /** Set when a `--seed` fixture (docs and/or authUsers) was withheld because
+   *  the sandbox already held restored/lived data — see the "seed applies
+   *  only into an empty home" guard below. */
+  seedSkipped: 'existing-data' | null;
   dispose(): void;
+}
+
+/**
+ * A seed fixture applies ONLY into an empty home. `buildWorkerCtx` calls
+ * `sandbox.enablePersistence` (restoring from IDB — and, with `--persist`,
+ * priming from the committable server file — see `createWorkerDurableBackend`)
+ * BEFORE `applyServeInit` runs, so by the time this check runs any restored
+ * data is already visible on `ctx`. If the sandbox holds ANY Firestore
+ * document or auth user at this point, that's lived/restored state, not a
+ * blank slate — a `--seed` fixture must never stomp it. This is the fix for
+ * the worst persistence bug: without it, `--seed` (map form) re-applies on
+ * EVERY boot because default (no `--persist`) mode never has a state.json
+ * file to gate on, silently reverting whatever IndexedDB persistence just
+ * restored.
+ */
+function sandboxHasExistingData(ctx: HostCtx): boolean {
+  const docs = sandboxOps.snapshotState(ctx.db);
+  if (Object.keys(docs).length > 0) return true;
+  const auth = ensureAuth(ctx);
+  return authOps.exportUsers(auth).length > 0;
 }
 
 /**
@@ -112,6 +136,7 @@ export function applyServeInit(
     seededUsers: 0,
     captureEnabled: false,
     rulesParseError: null,
+    seedSkipped: null,
     dispose: () => {},
   };
 
@@ -142,16 +167,32 @@ export function applyServeInit(
     };
   }
 
+  // A seed fixture applies only into an empty home — checked ONCE, before
+  // either seed step, so step 2's own writes can't make step 3's check look
+  // non-empty (see sandboxHasExistingData).
+  const hasExistingData =
+    ((payload.seed && Object.keys(payload.seed).length > 0) ||
+      (payload.authUsers && payload.authUsers.length > 0)) &&
+    sandboxHasExistingData(ctx);
+  if (hasExistingData) {
+    result.seedSkipped = 'existing-data';
+    console.info(
+      '[pyric worker] --seed skipped: the sandbox already has restored data (persisted state or ' +
+        'an earlier session in this browser) — the fixture would have overwritten it. Use ' +
+        '`--persist --fresh` to discard existing state and re-seed from scratch.',
+    );
+  }
+
   // 2. Auth users — seed BEFORE docs so any owner-uid the rules reference
   //    resolves, and before session restore so there is a DB to restore into.
-  if (payload.authUsers && payload.authUsers.length > 0) {
+  if (!hasExistingData && payload.authUsers && payload.authUsers.length > 0) {
     const auth = ensureAuth(ctx);
     authOps.seedUsers(auth, payload.authUsers as unknown as ReadonlyArray<SeedUser>);
     result.seededUsers = payload.authUsers.length;
   }
 
   // 3. Seed docs — admin-style fixture load (bypasses rules).
-  if (payload.seed && Object.keys(payload.seed).length > 0) {
+  if (!hasExistingData && payload.seed && Object.keys(payload.seed).length > 0) {
     sandboxOps.seedDocuments(ctx.db, payload.seed);
     result.seededDocs = Object.keys(payload.seed).length;
   }

--- a/packages/pyric-tools/test/serve/persist.test.ts
+++ b/packages/pyric-tools/test/serve/persist.test.ts
@@ -174,3 +174,21 @@ describe('pyric dev --persist', () => {
     expect((await post('tab-B')).status).toBe(204);
   }, 30_000);
 });
+
+describe('pyric dev --fresh guardrails', () => {
+  it('--fresh without --persist errors instead of silently no-opping', async () => {
+    const cwd = project();
+    await expect(
+      startServe({ cwd, port: 0, cacheRoot: join(cwd, '.cache'), fresh: true, logger: silentServeLogger() }),
+    ).rejects.toThrow(/--fresh requires --persist/);
+  });
+
+  it('--persist --fresh is fine (the escape hatch works)', async () => {
+    const cwd = project();
+    const r = await startServe({
+      cwd, port: 0, cacheRoot: join(cwd, '.cache'), persist: true, fresh: true, logger: silentServeLogger(),
+    });
+    stops.push(r);
+    expect(r.persist).toEqual({ restoredDocs: 0, restoredUsers: 0 });
+  }, 30_000);
+});

--- a/packages/pyric-tools/test/serve/worker/serve-init.test.ts
+++ b/packages/pyric-tools/test/serve/worker/serve-init.test.ts
@@ -213,6 +213,92 @@ describe('applyServeInit — seed + authUsers', () => {
   });
 });
 
+describe('applyServeInit — seed applies only into an empty home (guardrail)', () => {
+  it('skips seed docs when the sandbox already has a document (restored/lived data)', async () => {
+    const ctx = await makeCtx();
+    // Simulate a restore that ran before applyServeInit (buildWorkerCtx calls
+    // enablePersistence before applyServeInit): a doc already lives in the db.
+    await handleMessage(ctx, fakePort(), { t: 'op', id: 'pre', method: 'setDoc', path: 'todos/existing', data: { title: 'lived' } });
+
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, seed: { 'todos/t1': { title: 'seeded', done: false } } },
+      { fetch: recordingFetch() },
+    );
+    expect(result.seededDocs).toBe(0);
+    expect(result.seedSkipped).toBe('existing-data');
+
+    const port = fakePort();
+    await handleMessage(ctx, port, { t: 'op', id: 'g1', method: 'getDoc', path: 'todos/t1' });
+    const res = getRes(port, 'g1') as ResMessage & { ok: true };
+    expect((res.value as { exists: boolean }).exists).toBe(false); // fixture never applied
+  });
+
+  it('skips seeding authUsers when the sandbox already has a document', async () => {
+    const ctx = await makeCtx();
+    await handleMessage(ctx, fakePort(), { t: 'op', id: 'pre', method: 'setDoc', path: 'todos/existing', data: { title: 'lived' } });
+
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, authUsers: [{ uid: 'u1', email: 'a@b.com', password: 'pw123456' }] },
+      { fetch: recordingFetch() },
+    );
+    expect(result.seededUsers).toBe(0);
+    expect(result.seedSkipped).toBe('existing-data');
+    expect(authOps.exportUsers(ensureAuth(ctx)).map((u) => u.email)).not.toContain('a@b.com');
+  });
+
+  it('skips seed docs when the sandbox already has an auth user (no docs, users only)', async () => {
+    const ctx = await makeCtx();
+    authOps.seedUsers(ensureAuth(ctx), [{ uid: 'existing', email: 'x@y.com', password: 'pw123456' }]);
+
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, seed: { 'todos/t1': { title: 'seeded' } } },
+      { fetch: recordingFetch() },
+    );
+    expect(result.seededDocs).toBe(0);
+    expect(result.seedSkipped).toBe('existing-data');
+  });
+
+  it('applies the seed (docs + authUsers) when the sandbox is genuinely empty', async () => {
+    const ctx = await makeCtx();
+    const result = applyServeInit(
+      ctx,
+      {
+        ...basePayload,
+        seed: { 'todos/t1': { title: 'seeded' } },
+        authUsers: [{ uid: 'u1', email: 'a@b.com', password: 'pw123456' }],
+      },
+      { fetch: recordingFetch() },
+    );
+    expect(result.seededDocs).toBe(1);
+    expect(result.seededUsers).toBe(1);
+    expect(result.seedSkipped).toBeNull();
+  });
+
+  it('--persist first run: IDB already holding data (prior non-persist session) is treated as non-empty', async () => {
+    // Regression for the interaction the task flagged: a --persist FIRST run
+    // (no server file yet) where IDB already has data from an earlier
+    // non-persist session must NOT be treated as empty.
+    const sandbox = initializeSandbox();
+    const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
+    getAdminFirestore(sandbox.withAuth(null)).setRules(PERMISSIVE_RULES);
+    const idb = createMemoryBackend();
+    await idb.putRecords('pyric-shared-worker', serializeToBuckets({ 'todos/carried-over': { v: 1 } }, {}, 0));
+    await sandbox.enablePersistence({ key: 'pyric-shared-worker', injectedBackend: idb });
+    const ctx: HostCtx = { db: getFirestore(sandbox), sandbox, subs: new Map() };
+
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, seed: { 'todos/t1': { title: 'seeded' } } },
+      { fetch: recordingFetch() },
+    );
+    expect(result.seededDocs).toBe(0);
+    expect(result.seedSkipped).toBe('existing-data');
+  });
+});
+
 describe('applyServeInit — capture (the verify loop)', () => {
   it('POSTs the service-shaped session fixture to /__pyric/capture, then dispose stops it', async () => {
     const ctx = await makeCtx();


### PR DESCRIPTION
**Publish-gating.** Closes the three data-loss-shaped cells in the current persistence flags, ahead of the full three-homes API redesign.

1. **A seed applies only into an empty home.** The map-form `--seed` was staged on every boot in default mode and applied unconditionally — silently reverting user edits to seeded paths every session. `applyServeInit` now checks the restored sandbox (docs OR users present, computed once before both seed steps) and skips docs + users seeding with an honest log line and a `seedSkipped: 'existing-data'` result. Covers the `--persist`-first-run-with-prior-IDB-data case (regression-tested). In-page fallback mirrored defensively. The envelope-fixture path already primed empty-only — both seed formats now behave identically.
2. **`--fresh` without `--persist` hard-errors** (was a silent no-op): names what it requires and where browser-stored data actually gets cleared. Exit 2 via the existing error path; help text updated.
3. **`--fresh` half-reset warns loudly**: the file is discarded, but a browser already holding sandbox data keeps it and writes it straight back on its next flush — the warning names Studio → Settings → Reset / incognito for the full reset, until the real reset handshake ships with the redesigned API.

Docs: persistence guide's start-fresh section + flag tables updated to match.

Tests: 5 new seed-guard cases + 2 new --fresh cases; pyric-tools full suite 1246 pass / 0 fail; root build green.

Note for merge order: this touches the same guide as #79 (different sections — expected to auto-merge; I'll reconcile if not). The full persistence-API redesign (modes / seed-once markers / reset handshake / storage-in-the-home) is the designed follow-up, not this PR.