### PR TITLE
Ship the root README on npm for the core packages (alpha.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
   <img src="https://raw.githubusercontent.com/davideast/pyric/main/docs/pyric-logo.png" alt="Pyric" width="180" />
 </p>
 
-<h1 align="center">Firebase that runs in your browser</h1>
+<h1 align="center">Firebase that runs in the browser</h1>
 
 <p align="center">Agentic coding without production consequences</p>
+
+<p align="center"><a href="https://pyric.dev">pyric.dev</a></p>
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/pyric-logo.png" alt="Pyric" width="180" />
+  <img src="https://raw.githubusercontent.com/davideast/pyric/main/docs/pyric-logo.png" alt="Pyric" width="180" />
 </p>
 
 <h1 align="center">Firebase that runs in your browser</h1>

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Pyric admin-shape adapters (firestore, auth, database, storage) with swappable sandbox/prod backends. Mirrors firebase-admin.",
   "type": "module",
   "exports": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pyric-admin",
   "version": "0.1.0-alpha.8",
+  "homepage": "https://pyric.dev",
   "description": "Pyric admin-shape adapters (firestore, auth, database, storage) with swappable sandbox/prod backends. Mirrors firebase-admin.",
   "type": "module",
   "exports": {

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pyric-tools",
   "version": "0.1.0-alpha.8",
+  "homepage": "https://pyric.dev",
   "description": "Pyric CLI binary (`pyric`) + programmatic deploy / bridge / discover / auth-config helpers. Mirrors firebase-tools.",
   "type": "module",
   "exports": {

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-tools",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Pyric CLI binary (`pyric`) + programmatic deploy / bridge / discover / auth-config helpers. Mirrors firebase-tools.",
   "type": "module",
   "exports": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Firebase for agents — modular Web SDK adapters (firestore, auth, database, storage) with swappable sandbox/prod backends, plus rules tooling and in-process sandbox. Mirrors firebase.",
   "type": "module",
   "exports": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,7 +1,8 @@
 {
   "name": "pyric",
   "version": "0.1.0-alpha.8",
-  "description": "Firebase for agents — modular Web SDK adapters (firestore, auth, database, storage) with swappable sandbox/prod backends, plus rules tooling and in-process sandbox. Mirrors firebase.",
+  "homepage": "https://pyric.dev",
+  "description": "Firebase for agents \u2014 modular Web SDK adapters (firestore, auth, database, storage) with swappable sandbox/prod backends, plus rules tooling and in-process sandbox. Mirrors firebase.",
   "type": "module",
   "exports": {
     "./app": {

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-serve-persistence-and-multi-tab.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-serve-persistence-and-multi-tab.md
@@ -51,14 +51,12 @@ worker stays alive and everything in this table trivially survives a refresh.
 | Firestore documents | ✓ | ✓ IndexedDB | ✓ | ✓ |
 | Auth users + session | ✓ | ✓ IndexedDB | ✓ | ✓ |
 | Storage objects | ✓ | ✓ IndexedDB (its own store) | ✗ | ✗ |
-| RTDB data | ✓ | ✗ session-only | ✗ | ✗ |
-| Traffic / event history | ✓ | ✗ session-only | ✗ | ✗ |
+| RTDB data | ✓ | ✓ IndexedDB | ✓ | ✓ (rides the state blob) |
+| Traffic / event history | ✓ | ✓ re-hydrated from the session capture (served mode; the last ~400ms can lag) | ✗ | ✗ |
 | Sandbox branches | ✓ | ✓ IndexedDB | ✗ deliberately local | ✗ |
 
 Notes, honestly stated:
 
-- **RTDB is session-scoped in this release.** It has no persistence hooks yet;
-  worker death loses the tree. Treat RTDB data as a fixture you can re-seed.
 - **Storage persists in this browser but does not ride `--persist`** — objects
   live in their own IndexedDB store, so they survive restarts on your machine
   but are not part of the committable state file or `pyric snapshot`.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@pyric/ui",
   "version": "0.1.0-alpha.8",
-  "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (pyric/firestore against pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling — consumers bring their own design system via className + data-* attributes.",
+  "homepage": "https://pyric.dev",
+  "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (pyric/firestore against pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling \u2014 consumers bring their own design system via className + data-* attributes.",
   "type": "module",
   "exports": {
     "./auth": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Headless React data-admin components and hooks for Firebase apps built on pyric. Same components work in sandbox (pyric/firestore against pyric/sandbox) and production (firebase/firestore against real Firebase) via a single Firestore handle prop. Ships zero visual styling — consumers bring their own design system via className + data-* attributes.",
   "type": "module",
   "exports": {

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -62,6 +62,21 @@ mkdir -p "$OUT_DIR"
 echo ""
 echo "━━━ Phase 2: pack ━━━"
 
+# The npm-facing README for the core packages is the ROOT readme (the
+# branded one npmjs renders for `latest`); each package keeps its own
+# README.md in the source tree as the in-repo doc. COPY, never symlink —
+# `npm pack` does not follow symlinks. The original is restored even on
+# failure (RETURN trap), so the working tree stays clean.
+ROOT_README_PACKAGES=("pyric" "pyric-admin" "pyric-tools")
+
+uses_root_readme() {
+  local name="$1"
+  for n in "${ROOT_README_PACKAGES[@]}"; do
+    [ "$n" = "$name" ] && return 0
+  done
+  return 1
+}
+
 pack_one() {
   local pkg_dir="$1"
   local name
@@ -69,6 +84,21 @@ pack_one() {
   local version
   version=$(jq -r '.version' "$ROOT/$pkg_dir/package.json")
   echo "▸ packing $name@$version"
+
+  local swapped=0
+  restore_readme() {
+    if [ "$swapped" -eq 1 ]; then
+      mv "$ROOT/$pkg_dir/README.md.orig" "$ROOT/$pkg_dir/README.md"
+      swapped=0
+    fi
+  }
+  trap restore_readme RETURN
+  if uses_root_readme "$name"; then
+    mv "$ROOT/$pkg_dir/README.md" "$ROOT/$pkg_dir/README.md.orig"
+    cp "$ROOT/README.md" "$ROOT/$pkg_dir/README.md"
+    swapped=1
+    echo "    (README: root readme swapped in for npm)"
+  fi
 
   # npm pack writes <flattened-name>-<version>.tgz (scope removed,
   # `/` replaced by `-`). Capture the produced filename via npm's


### PR DESCRIPTION
npmjs renders the tarball's README, and alpha.7 shipped the per-package ones. Now `pack-packages.sh` swaps the root readme into pyric / pyric-admin / pyric-tools at pack time (copy with a restore trap — never a symlink, which `npm pack` drops), the hero logo becomes an absolute raw.githubusercontent URL (npm doesn't resolve repo-relative images), and all four packages bump lockstep to `0.1.0-alpha.8` since published versions are immutable. `@pyric/ui` keeps its own readme. Verified in the packed tarballs; source tree stays clean after packing.