### PR TITLE
README logo served from pyric.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/davideast/pyric/main/docs/pyric-logo.png" alt="Pyric" width="180" />
+  <img src="https://pyric.dev/pyric-logo.svg" alt="Pyric" width="180" />
 </p>
 
 <h1 align="center">Firebase that runs in the browser</h1>


### PR DESCRIPTION
The repo is private, so raw.githubusercontent 404s for anonymous viewers — broken hero image on GitHub and it would break identically on npm. The logo now loads from https://pyric.dev/pyric-logo.svg (200, verified), which is independent of repo visibility permanently. One line; catch it before the alpha.8 publish so the npm page renders whole.