### PR TITLE
Studio: surface missing parent documents in the Firestore browser

### DIFF
--- a/packages/studio/src/clients/worker-live.test.ts
+++ b/packages/studio/src/clients/worker-live.test.ts
@@ -189,6 +189,44 @@ describe('workerEventFeed (F1 live-feed adapter)', () => {
   });
 });
 
+describe('listDocuments (F2 phantom-inclusive browse)', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("rides the 'admin.listDocuments' op and keeps the phantom flag", async () => {
+    const sw = controllableSharedWorker();
+    restore = sw.restore;
+    const plane = connectWorkerLive('worker://test')!;
+
+    const listed = plane.listDocuments('zones');
+    const opMsg = sw.port.sent.find(
+      (m): m is { t: 'op'; id: string; method: string; path: string } =>
+        (m as { method?: string }).method === 'admin.listDocuments',
+    );
+    expect(opMsg).toBeDefined();
+    expect(opMsg!.path).toBe('zones');
+
+    // The host answers with full `{ path, data, phantom? }` records; the
+    // plane drops `data` (browse needs ids, content reads via getDoc).
+    sw.deliver({
+      t: 'res',
+      id: opMsg!.id,
+      ok: true,
+      value: [
+        { path: 'zones/spawn', data: { open: true } },
+        { path: 'zones/village', data: {}, phantom: true },
+      ],
+    });
+    expect(await listed).toEqual([
+      { path: 'zones/spawn', phantom: undefined },
+      { path: 'zones/village', phantom: true },
+    ]);
+  });
+});
+
 describe("createStudioEnvironment('local') live-plane gating", () => {
   let restore: (() => void) | null = null;
   afterEach(() => {

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -57,6 +57,7 @@ import {
   getPolicy as workerGetPolicy,
   listRootCollections as workerListRootCollections,
   listSubcollections as workerListSubcollections,
+  adminListDocuments as workerAdminListDocuments,
   listUsers as workerListUsers,
   adminCreateUser as workerAdminCreateUser,
   adminUpdateUser as workerAdminUpdateUser,
@@ -124,6 +125,9 @@ export interface WorkerLivePlane {
   listRootCollections(): Promise<string[]>;
   /** F2 data browse: enumerate subcollection ids under a document path. */
   listSubcollections(docPath: string): Promise<string[]>;
+  /** F2 data browse: phantom-inclusive document listing for a collection path
+   *  (`phantom: true` = a "missing" parent — descendants but no stored doc). */
+  listDocuments(collectionPath: string): Promise<{ path: string; phantom?: boolean }[]>;
   /** RTDB browse: read the full worker-backed RTDB tree with the admin lens. */
   readRtdbState(): Promise<unknown>;
   /** RTDB browse: replace a node with the admin lens. */
@@ -310,6 +314,13 @@ export function connectWorkerLive(
     getPolicy: () => workerGetPolicy(db),
     listRootCollections: () => workerListRootCollections(db),
     listSubcollections: (docPath) => workerListSubcollections(db, docPath),
+    // Browse-only listing: drop `data` at this seam (the pane only needs the
+    // id + the phantom flag; document CONTENT always reads via getDoc).
+    listDocuments: async (collectionPath) =>
+      (await workerAdminListDocuments(db, collectionPath)).map(({ path, phantom }) => ({
+        path,
+        phantom,
+      })),
     readRtdbState: () => workerAdminReadRtdbState(db),
     setRtdbValue: (path, value) => workerAdminSetRtdbValue(db, path, value),
     updateRtdbValue: (path, values) => workerAdminUpdateRtdbValue(db, path, values),

--- a/packages/studio/src/features/data/FirestoreDocumentTree.tsx
+++ b/packages/studio/src/features/data/FirestoreDocumentTree.tsx
@@ -637,8 +637,10 @@ interface SubcollectionsSectionProps {
 
 /** Same section `<DocumentPreview>` renders, reimplemented against this
  *  component's own tree/row CSS so it sits in the same rhythm as the
- *  fields above it. */
-function SubcollectionsSection({
+ *  fields above it. Exported: `DocumentDetailColumn` also renders it for a
+ *  MISSING document (no stored fields, real subcollections), where the tree
+ *  itself doesn't mount but the subtree must stay reachable. */
+export function SubcollectionsSection({
   firestore,
   documentRef,
   listSubcollections,

--- a/packages/studio/src/features/data/FirestorePane.tsx
+++ b/packages/studio/src/features/data/FirestorePane.tsx
@@ -33,7 +33,7 @@ import { PANEL_BREAKPOINTS, panelWindow } from './panelLayout.js';
 import type { StudioDataHandles } from './sandbox.js';
 import { ImportJsonPanel } from './FirestoreImportPanel.js';
 import { FirestoreCreateModal, type FirestoreCreateSubmit } from './FirestoreCreateModal.js';
-import { FirestoreDocumentTree } from './FirestoreDocumentTree.js';
+import { FirestoreDocumentTree, SubcollectionsSection } from './FirestoreDocumentTree.js';
 import { OverflowMenu } from './OverflowMenu.js';
 import { makeRecursiveDeleteImpl } from './recursiveDelete.js';
 import './firestore.css';
@@ -68,6 +68,20 @@ async function createDocWithProbe(
     throw new Error(`Document "${docId}" already exists here — choose a different ID.`);
   }
   await api.setDoc(ref, data);
+}
+
+/**
+ * A "missing" parent doc (no stored fields, real descendants) rendered as a
+ * navigable row. Queries correctly exclude these (Firebase parity), so the
+ * DocumentColumn synthesizes just enough of a snapshot for `<DocumentList>`'s
+ * surface (`.id` + `.ref`) and marks it so the renderers can style it.
+ */
+function makePhantomRow(ref: DocumentReference): QueryDocumentSnapshot {
+  return { id: ref.id, ref, __pyricPhantom: true } as unknown as QueryDocumentSnapshot;
+}
+
+function isPhantomRow(snap: QueryDocumentSnapshot): boolean {
+  return (snap as unknown as { __pyricPhantom?: boolean }).__pyricPhantom === true;
 }
 
 /**
@@ -362,6 +376,37 @@ function DocumentColumn({
   );
   const { documents, isLoading, error, hasMore, loadMore, createDocument, deleteDocument } =
     useDocumentList({ collection });
+  // "Missing" parents come from the phantom-inclusive listDocuments seam —
+  // the paged getDocs above can't see them (queries match stored docs only).
+  // Re-fetched whenever the real page changes so create/delete stays in sync.
+  const [phantomIds, setPhantomIds] = useState<readonly string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve(handles.listDocuments(collectionPath))
+      .then((entries) => {
+        if (cancelled) return;
+        setPhantomIds(
+          entries.filter((e) => e.phantom).map((e) => e.path.split('/').pop() ?? ''),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setPhantomIds([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [handles, collectionPath, documents]);
+  // Real docs first (the paged order), phantoms after — the same order
+  // `LocalState.list` guarantees — deduped by id so a real doc always wins.
+  const rows = useMemo(() => {
+    const realIds = new Set(documents.map((d) => d.id));
+    return [
+      ...documents,
+      ...phantomIds
+        .filter((id) => id.length > 0 && !realIds.has(id))
+        .map((id) => makePhantomRow(api.doc(firestore, `${collectionPath}/${id}`))),
+    ];
+  }, [documents, phantomIds, api, firestore, collectionPath]);
   const collId = collectionPath.split('/').pop() ?? collectionPath;
   // Per-row delete: plain click arms an inline confirm; shift-click deletes
   // immediately (rapid bulk delete). Only one row arms at a time.
@@ -446,7 +491,7 @@ function DocumentColumn({
 
       {!importing ? (
         <DocumentList
-        documents={documents}
+        documents={rows}
         isLoading={isLoading}
         error={error}
         hasMore={hasMore}
@@ -456,11 +501,21 @@ function DocumentColumn({
           const ref = (snap as unknown as { ref: DocumentReference }).ref;
           return (
             <span data-pyric-selected={selectedId === ref.id ? '' : undefined} style={{ display: 'contents' }}>
-              {snap.id}
+              {isPhantomRow(snap) ? (
+                <>
+                  <span className="fs-doc-phantom">{snap.id}</span>
+                  <span className="fs-sub fs-doc-phantom-hint">missing</span>
+                </>
+              ) : (
+                snap.id
+              )}
             </span>
           );
         }}
         renderRowAction={(snap: QueryDocumentSnapshot) => {
+          // No per-row delete on a phantom: there is no stored doc to delete.
+          // Its subtree deletes through the detail column / delete-collection.
+          if (isPhantomRow(snap)) return null;
           const r = (snap as unknown as { ref: DocumentReference }).ref;
           if (confirmingId === r.id) {
             return (
@@ -621,7 +676,17 @@ function DocumentDetailColumn({
           }}
         />
       ) : (
-        <p className="fs-empty">Empty document.</p>
+        <>
+          {/* Console parity: a missing doc still lists its subcollections —
+              that's the only way deep data under a phantom stays reachable. */}
+          <p className="fs-empty">This document does not exist.</p>
+          <SubcollectionsSection
+            firestore={firestore}
+            documentRef={ref}
+            listSubcollections={listSubcollections}
+            onSubcollectionClick={onOpenSubcollection}
+          />
+        </>
       )}
     </section>
   );

--- a/packages/studio/src/features/data/firestore.css
+++ b/packages/studio/src/features/data/firestore.css
@@ -478,6 +478,19 @@
   padding: 6px 16px;
 }
 
+/* a "missing" parent doc row (Console parity): no stored fields, real
+   descendants — italic + muted, but still a navigable row so the subtree
+   stays reachable */
+[data-pyric-ui='fs-browser'] .fs-doc-phantom {
+  font-style: italic;
+  color: var(--color-slate-gray);
+}
+
+[data-pyric-ui='fs-browser'] .fs-doc-phantom-hint {
+  font-style: italic;
+  margin-right: 6px;
+}
+
 /* the secondary text on a row (doc title / collection count) */
 [data-pyric-ui='fs-browser'] .fs-sub {
   font-size: 11.5px;

--- a/packages/studio/src/features/data/missingDocs.test.ts
+++ b/packages/studio/src/features/data/missingDocs.test.ts
@@ -8,7 +8,9 @@
  *     in-process handle builders share) is phantom-INCLUSIVE,
  *   - queries (`getDocs`) and `getDoc` stay phantom-FREE (Firebase parity),
  *   - the recursive delete walks THROUGH phantoms, so deep leaves are found
- *     and removed when an ancestor collection is deleted.
+ *     and removed when an ancestor collection is deleted,
+ *   - the clear-sandbox sweep (`collectAllDocPaths`) reaches stored docs
+ *     under phantoms and collects nothing for the phantoms themselves.
  *
  * Handles are built off the internal env directly (not `makeHandles`, whose
  * storage handle needs IndexedDB) — the same `getInternalEnv` wiring both
@@ -32,7 +34,11 @@ import {
   startAfter,
 } from 'pyric/firestore';
 import type { FirestoreApi } from '@pyric/ui/firestore';
-import { listDocumentsForBrowse, type StudioDataHandles } from './sandbox.js';
+import {
+  collectAllDocPaths,
+  listDocumentsForBrowse,
+  type StudioDataHandles,
+} from './sandbox.js';
 import { makeRecursiveDeleteImpl } from './recursiveDelete.js';
 
 /** `exists` is a method on modular snapshots, a boolean on compat shapes. */
@@ -114,5 +120,22 @@ describe('recursive delete through missing parents', () => {
     expect(handles.listRootCollections()).toEqual([]);
     // Only the real leaf counts as a deletion; the phantom parent is a no-op.
     expect(progress.at(-1)).toEqual({ deletedCount: 1, done: true });
+  });
+});
+
+describe('clear sandbox through missing parents (collectAllDocPaths)', () => {
+  it('collects only stored docs, reaching leaves under phantoms', async () => {
+    const { handles, db } = await seedDeepOnly();
+
+    const { docPaths, errors } = await collectAllDocPaths(handles);
+    expect(errors).toEqual([]);
+    // The leaf is found through the missing parent; the phantom itself is
+    // traversed but never collected (nothing stored to delete).
+    expect(docPaths).toEqual(['zones/village/players/anonymous-2']);
+
+    // The clear's delete loop over the collected paths empties the keyspace.
+    for (const path of docPaths) await deleteDoc(doc(db, path));
+    expect(exists(await getDoc(doc(db, 'zones/village/players/anonymous-2')))).toBe(false);
+    expect(handles.listRootCollections()).toEqual([]);
   });
 });

--- a/packages/studio/src/features/data/missingDocs.test.ts
+++ b/packages/studio/src/features/data/missingDocs.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Missing/phantom parent documents (the Console-parity browse seam).
+ *
+ * Seeding ONLY a deep path (`zones/village/players/anonymous-2`) stores no
+ * doc at `zones/village` — a "missing" parent with real descendants. These
+ * pin the contract the Firestore pane composes over:
+ *   - `handles.listDocuments` (via `listDocumentsForBrowse`, the mapping both
+ *     in-process handle builders share) is phantom-INCLUSIVE,
+ *   - queries (`getDocs`) and `getDoc` stay phantom-FREE (Firebase parity),
+ *   - the recursive delete walks THROUGH phantoms, so deep leaves are found
+ *     and removed when an ancestor collection is deleted.
+ *
+ * Handles are built off the internal env directly (not `makeHandles`, whose
+ * storage handle needs IndexedDB) — the same `getInternalEnv` wiring both
+ * handle builders use.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getInternalEnv } from 'pyric/sandbox/internal';
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getAdminFirestore,
+  getDoc,
+  getDocs,
+  limit,
+  query,
+  setDoc,
+  startAfter,
+} from 'pyric/firestore';
+import type { FirestoreApi } from '@pyric/ui/firestore';
+import { listDocumentsForBrowse, type StudioDataHandles } from './sandbox.js';
+import { makeRecursiveDeleteImpl } from './recursiveDelete.js';
+
+/** `exists` is a method on modular snapshots, a boolean on compat shapes. */
+function exists(snap: unknown): boolean {
+  const e = (snap as { exists: boolean | (() => boolean) }).exists;
+  return typeof e === 'function' ? e.call(snap) : e;
+}
+
+/** A sandbox whose ONLY data is one deep leaf under a missing parent. */
+async function seedDeepOnly() {
+  const sandbox = initializeSandbox();
+  const env = getInternalEnv(sandbox);
+  const db = getAdminFirestore(sandbox);
+  const handles: Pick<
+    StudioDataHandles,
+    'listRootCollections' | 'listSubcollections' | 'listDocuments'
+  > = {
+    listRootCollections: () => env.listRootCollections(),
+    listSubcollections: (docPath: string) => env.listSubcollections(docPath),
+    listDocuments: (collectionPath: string) => listDocumentsForBrowse(env, collectionPath),
+  };
+  await setDoc(doc(db, 'zones/village/players/anonymous-2'), { hp: 10 });
+  return { handles, db };
+}
+
+describe('StudioDataHandles.listDocuments (phantom-inclusive browse)', () => {
+  it('lists a missing parent as phantom; queries + getDoc stay phantom-free', async () => {
+    const { handles, db } = await seedDeepOnly();
+
+    expect(handles.listRootCollections()).toEqual(['zones']);
+    expect(await handles.listDocuments('zones')).toEqual([
+      { path: 'zones/village', phantom: true },
+    ]);
+
+    // Firebase parity: a query over `zones` matches stored docs only…
+    const snap = await getDocs(query(collection(db, 'zones')));
+    expect(snap.docs.length).toBe(0);
+    // …and a direct read of the phantom stays exists-false.
+    expect(exists(await getDoc(doc(db, 'zones/village')))).toBe(false);
+  });
+
+  it('a real doc wins over its phantom synthesis', async () => {
+    const { handles, db } = await seedDeepOnly();
+    await setDoc(doc(db, 'zones/village'), { name: 'Village' });
+    expect(await handles.listDocuments('zones')).toEqual([{ path: 'zones/village' }]);
+  });
+
+  it('lists phantoms in nested collections too', async () => {
+    const { handles, db } = await seedDeepOnly();
+    await setDoc(doc(db, 'zones/village/players/p1/inventory/sword'), { dmg: 3 });
+    expect(await handles.listDocuments('zones/village/players')).toEqual([
+      { path: 'zones/village/players/anonymous-2' },
+      { path: 'zones/village/players/p1', phantom: true },
+    ]);
+  });
+});
+
+describe('recursive delete through missing parents', () => {
+  it('deleting the root collection removes leaves under phantoms', async () => {
+    const { handles, db } = await seedDeepOnly();
+    const api: FirestoreApi = {
+      addDoc,
+      collection,
+      deleteDoc,
+      doc,
+      getDoc,
+      getDocs,
+      limit,
+      query,
+      setDoc,
+      startAfter,
+    };
+    const impl = makeRecursiveDeleteImpl(api, handles);
+
+    const progress = [];
+    for await (const p of impl.start(collection(db, 'zones'))) progress.push(p);
+
+    expect(exists(await getDoc(doc(db, 'zones/village/players/anonymous-2')))).toBe(false);
+    expect(handles.listRootCollections()).toEqual([]);
+    // Only the real leaf counts as a deletion; the phantom parent is a no-op.
+    expect(progress.at(-1)).toEqual({ deletedCount: 1, done: true });
+  });
+});

--- a/packages/studio/src/features/data/recursiveDelete.ts
+++ b/packages/studio/src/features/data/recursiveDelete.ts
@@ -9,7 +9,9 @@
  * new worker message type for this, the walk is done CLIENT-SIDE against
  * the existing primitives: `listSubcollections` (already on
  * `StudioDataHandles`, sync in-process / async over the worker) to find a
- * document's children, `getDocs` to list a collection's documents, and
+ * document's children, `listDocuments` to enumerate a collection — NOT
+ * `getDocs`: a query excludes "missing" parent docs (no stored fields,
+ * real descendants), which would orphan everything beneath them — and
  * `deleteDoc` to remove leaves. This keeps the sandbox/worker protocol
  * untouched while still giving the panel a real recursive delete.
  *
@@ -38,16 +40,20 @@ function isDocumentPath(path: string): boolean {
 
 export function makeRecursiveDeleteImpl(
   api: FirestoreApi,
-  handles: Pick<StudioDataHandles, 'listSubcollections'>,
+  handles: Pick<StudioDataHandles, 'listSubcollections' | 'listDocuments'>,
 ): RecursiveDeleteImpl {
   async function* walkDoc(
     ref: DocumentReference,
     countRef: { n: number },
+    phantom = false,
   ): AsyncIterableIterator<RecursiveDeleteProgress> {
     const subIds = await handles.listSubcollections(ref.path);
     for (const collId of subIds) {
       yield* walkCollection(api.collection(ref, collId), countRef);
     }
+    // A phantom has no stored doc: the subtree walk above is the whole job,
+    // and a delete would be a no-op we'd miscount as a deletion.
+    if (phantom) return;
     await api.deleteDoc(ref);
     countRef.n++;
     yield { deletedCount: countRef.n, done: false };
@@ -57,12 +63,13 @@ export function makeRecursiveDeleteImpl(
     coll: CollectionReference,
     countRef: { n: number },
   ): AsyncIterableIterator<RecursiveDeleteProgress> {
-    // `getDocs` wants a `Query`, not a bare `CollectionReference` — wrap it
-    // with zero constraints (same shape `useDocumentList`'s paged fetch uses).
-    const snap = await api.getDocs(api.query(coll));
-    for (const d of snap.docs) {
-      const ref = (d as unknown as { ref: DocumentReference }).ref;
-      yield* walkDoc(ref, countRef);
+    // The phantom-INCLUSIVE listing, not a `getDocs` query: queries exclude
+    // "missing" parent docs, so their descendants would survive the delete.
+    const entries = await handles.listDocuments(coll.path);
+    for (const entry of entries) {
+      const id = entry.path.split('/').pop();
+      if (!id) continue;
+      yield* walkDoc(api.doc(coll, id), countRef, entry.phantom === true);
     }
   }
 

--- a/packages/studio/src/features/data/sandbox.ts
+++ b/packages/studio/src/features/data/sandbox.ts
@@ -86,6 +86,42 @@ export function listDocumentsForBrowse(
   return env.listDocuments(collectionPath).map(({ path, phantom }) => ({ path, phantom }));
 }
 
+/**
+ * Collect every STORED document path in the keyspace: root collections walked
+ * recursively through the phantom-inclusive `listDocuments` seam, so docs
+ * under "missing" parents are reached (a `getDocs` walk would skip the
+ * phantom and orphan everything beneath it). Phantoms are traversed but not
+ * collected — there is nothing stored to delete. Per-collection failures are
+ * reported, not thrown, so one bad branch doesn't abort the sweep ("clear
+ * sandbox" semantics — see `useStudioClear`).
+ */
+export async function collectAllDocPaths(
+  handles: Pick<
+    StudioDataHandles,
+    'listRootCollections' | 'listSubcollections' | 'listDocuments'
+  >,
+): Promise<{ docPaths: string[]; errors: string[] }> {
+  const docPaths: string[] = [];
+  const errors: string[] = [];
+  const walk = async (collPath: string): Promise<void> => {
+    try {
+      const entries = await handles.listDocuments(collPath);
+      for (const entry of entries) {
+        if (entry.phantom !== true) docPaths.push(entry.path);
+        for (const sub of await handles.listSubcollections(entry.path)) {
+          await walk(`${entry.path}/${sub}`);
+        }
+      }
+    } catch (e) {
+      errors.push(`list ${collPath}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+  for (const collId of handles.listRootCollections()) {
+    await walk(collId);
+  }
+  return { docPaths, errors };
+}
+
 /** Build the handle bundle for a freshly-created sandbox. */
 function makeHandles(sandbox: Sandbox): StudioDataHandles {
   const app = initializeApp({ sandbox });

--- a/packages/studio/src/features/data/sandbox.ts
+++ b/packages/studio/src/features/data/sandbox.ts
@@ -44,6 +44,14 @@ import type { StorageApi } from '@pyric/ui/storage';
 /** Stable durable-state bucket key for Studio's mirror of the sandbox. */
 const PERSIST_KEY = 'pyric-studio';
 
+/** One entry from a phantom-inclusive collection listing (browse traversal).
+ *  `phantom: true` marks a "missing" parent doc — no stored fields, real
+ *  descendants — which queries correctly exclude but the browser must show. */
+export interface ListedDocument {
+  path: string;
+  phantom?: boolean;
+}
+
 /** The resolved data handles for one Studio sandbox, plus collection listing. */
 export interface StudioDataHandles {
   sandbox: Sandbox;
@@ -59,6 +67,23 @@ export interface StudioDataHandles {
   /** Subcollection IDs under a document path. Sync in-process (dev-seed),
    *  async over the worker (served mode); callers await either. */
   listSubcollections(docPath: string): string[] | Promise<string[]>;
+  /** Phantom-inclusive document listing for a collection path (mirrors live
+   *  Firestore's `listDocuments`). Browse-only: queries stay phantom-free.
+   *  Sync in-process, async over the worker; callers await either. */
+  listDocuments(collectionPath: string): ListedDocument[] | Promise<ListedDocument[]>;
+}
+
+/**
+ * Phantom-inclusive browse listing off a sandbox's internal env, mapped to
+ * the handle shape (drops `data`: browse needs ids + the phantom flag;
+ * document content always reads via `getDoc`). Shared by both in-process
+ * handle builders (here and `handlesFromSeed` in `shell/studio-data.ts`).
+ */
+export function listDocumentsForBrowse(
+  env: Pick<ReturnType<typeof getInternalEnv>, 'listDocuments'>,
+  collectionPath: string,
+): ListedDocument[] {
+  return env.listDocuments(collectionPath).map(({ path, phantom }) => ({ path, phantom }));
 }
 
 /** Build the handle bundle for a freshly-created sandbox. */
@@ -74,6 +99,7 @@ function makeHandles(sandbox: Sandbox): StudioDataHandles {
     storage: getStorage(app),
     listRootCollections: () => env.listRootCollections(),
     listSubcollections: (docPath: string) => env.listSubcollections(docPath),
+    listDocuments: (collectionPath: string) => listDocumentsForBrowse(env, collectionPath),
   };
 }
 

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -43,6 +43,7 @@ import { useDevSeed } from '../dev/DevSeedProvider.js';
 import { useEnvironment } from './environment.js';
 import type { WorkerLivePlane } from '../env.js';
 import {
+  listDocumentsForBrowse,
   useStudioData,
   type StudioDataHandles,
   type StudioDataState,
@@ -59,7 +60,7 @@ import {
 } from '../features/rules-debug/model.js';
 
 /** Lift the dev-seed's `SeededHandles` to the richer `StudioDataHandles` the F2
- *  panes expect (the only delta is the two keyspace-listing helpers, which come
+ *  panes expect (the only delta is the keyspace-listing helpers, which come
  *  straight off the sandbox's internal env). */
 function handlesFromSeed(seed: {
   sandbox: StudioDataHandles['sandbox'];
@@ -79,6 +80,7 @@ function handlesFromSeed(seed: {
     storage: seed.storage,
     listRootCollections: () => env.listRootCollections(),
     listSubcollections: (docPath: string) => env.listSubcollections(docPath),
+    listDocuments: (collectionPath: string) => listDocumentsForBrowse(env, collectionPath),
   };
 }
 
@@ -132,6 +134,7 @@ export function useStudioDataSource(): StudioDataState {
               storage: live.storage,
               listRootCollections: () => workerRoots,
               listSubcollections: (docPath: string) => live.listSubcollections(docPath),
+              listDocuments: (collectionPath: string) => live.listDocuments(collectionPath),
             },
           };
         }

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -24,9 +24,6 @@ import {
   sandbox as firestoreSandbox,
   doc as inProcessDoc,
   setDoc as inProcessSetDoc,
-  collection as inProcessCollection,
-  query as inProcessQuery,
-  getDocs as inProcessGetDocs,
   deleteDoc as inProcessDeleteDoc,
 } from 'pyric/firestore';
 import { sandbox as authSandbox, type CreateUserRequest } from 'pyric/auth';
@@ -43,6 +40,7 @@ import { useDevSeed } from '../dev/DevSeedProvider.js';
 import { useEnvironment } from './environment.js';
 import type { WorkerLivePlane } from '../env.js';
 import {
+  collectAllDocPaths,
   listDocumentsForBrowse,
   useStudioData,
   type StudioDataHandles,
@@ -433,8 +431,9 @@ export function useStudioSeedAuth(): (
 /**
  * Clear the sandbox: delete every Firestore document (root collections +
  * recursive subcollections, via the admin handle) and clear all auth users.
- * Subcollection refs are built from the parent doc ref (not multi-segment
- * collection paths), so it works in both in-process and served modes.
+ * The walk rides the handles' path-based listing seams — phantom-inclusive
+ * (see {@link collectAllDocPaths}), so data under "missing" parents is
+ * reached — and works unchanged in both in-process and served modes.
  */
 export function useStudioClear(): () => Promise<{ cleared: number; errors: string[] }> {
   const data = useStudioDataSource();
@@ -442,32 +441,8 @@ export function useStudioClear(): () => Promise<{ cleared: number; errors: strin
     if (data.status !== 'ready') throw new Error('No sandbox to clear.');
     const adminDb = data.handles.adminFirestore as unknown as Parameters<typeof inProcessDoc>[0];
     const docFn = (data.firestoreApi?.doc ?? inProcessDoc) as typeof inProcessDoc;
-    const collectionFn = (data.firestoreApi?.collection ?? inProcessCollection) as typeof inProcessCollection;
-    const queryFn = (data.firestoreApi?.query ?? inProcessQuery) as typeof inProcessQuery;
-    const getDocsFn = (data.firestoreApi?.getDocs ?? inProcessGetDocs) as typeof inProcessGetDocs;
     const deleteDocFn = (data.firestoreApi?.deleteDoc ?? inProcessDeleteDoc) as typeof inProcessDeleteDoc;
-    const errors: string[] = [];
-    const docPaths: string[] = [];
-
-    // Collect every doc path, recursing subcollections (parent-ref form).
-    const collectFrom = async (collRef: unknown, collPath: string): Promise<void> => {
-      try {
-        const snap = await getDocsFn(queryFn(collRef as never));
-        for (const d of snap.docs) {
-          const docPath = `${collPath}/${d.id}`;
-          docPaths.push(docPath);
-          const subIds = await data.handles.listSubcollections(docPath);
-          for (const sub of subIds) {
-            await collectFrom(collectionFn(docFn(adminDb, docPath) as never, sub), `${docPath}/${sub}`);
-          }
-        }
-      } catch (e) {
-        errors.push(`list ${collPath}: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    };
-    for (const collId of data.handles.listRootCollections()) {
-      await collectFrom(collectionFn(adminDb as never, collId), collId);
-    }
+    const { docPaths, errors } = await collectAllDocPaths(data.handles);
 
     let cleared = 0;
     for (const path of docPaths) {


### PR DESCRIPTION
## The bug

Write only `zones/village/players/anonymous-2` and Studio's Firestore tab lists `zones` as a root collection but shows "No documents" — the whole subtree is unreachable from the UI, undeletable by "Delete collection", and missed by "Clear sandbox". `zones/village` is a Firestore *missing document*: no fields, real subcollections. The real Firebase console renders these as italicized, navigable phantom entries.

## The composition bug, not a primitive bug

The sandbox already models phantoms correctly: `LocalState.list()` synthesizes `{ path, data: {}, phantom: true }` for parents of deeper descendants, `sandbox.admin.listDocuments` exposes them, and the worker op `admin.listDocuments` carries them end to end. Studio just never consumed it. The collections column derives from the keyspace (any descendant counts) while the documents column reads through `getDocs`, which correctly excludes phantoms — real Firestore queries never return missing docs either. Each primitive is parity-correct; composing them made subtrees invisible.

## The fix: browse uses the listDocuments seam, queries stay pure

- `StudioDataHandles.listDocuments(collectionPath)` — phantom-inclusive listing on the handles, wired in-process (dev-seed and local) and served (over the existing `admin.listDocuments` worker op).
- `DocumentColumn` merges phantom rows after the paged `getDocs` docs (real doc wins on id collision), rendered muted/italic with a "missing" hint, fully navigable.
- `DocumentDetailColumn` drops its `exists` gate on subcollections: a missing doc says so plainly and still lists its subcollections, matching the console.
- `recursiveDelete` walks the phantom-inclusive listing so "Delete collection" reaches descendants under missing parents (phantoms recurse, are never deleted or counted).
- `useStudioClear` sweeps the keyspace through the same seam (`collectAllDocPaths`), so "Clear sandbox" reaches deep data too.

Deliberately unchanged, with tests pinning it: `getDocs` still returns zero rows for a phantom-only collection and `getDoc` on a missing doc stays exists-false. That exclusion is Firebase parity.

## Tests

- Seed-only-deep-path: `listDocuments('zones')` returns the `village` phantom; queries and gets unchanged.
- Real doc wins over its phantom; nested-collection phantoms.
- Recursive delete of a phantom-rooted collection removes the deep leaf (`deletedCount` excludes phantoms).
- Clear-sandbox sweep collects exactly the stored leaves and empties the keyspace.
- Worker plane preserves the phantom flag over `admin.listDocuments`.

`bun test packages/studio` (source): 292 pass / 0 fail. `bun test packages/pyric-tools/test/serve/worker`: 186 pass / 0 fail. Studio tsc + vite build clean.