### PR TITLE
Fix RTDB rules data/newData rooting false-allow

### DIFF
--- a/packages/pyric/src/database/simulation/handler.ts
+++ b/packages/pyric/src/database/simulation/handler.ts
@@ -8,6 +8,10 @@ import type { SimulateResult } from './spec.js';
 interface AncestorMatch {
   node: RtdbNode;
   pathVariableBindings: Record<string, string>;
+  /** Number of `path` segments consumed to reach this node from the root —
+   *  i.e. this ancestor's own location, used to root `data`/`newData` at
+   *  the rule's location rather than at the operation's target path. */
+  depth: number;
 }
 
 /** Builds the evaluation context for a rule at a given node — supplied by
@@ -137,8 +141,9 @@ function collectAncestors(
   node: RtdbNode,
   pathSegments: string[],
   bindings: Record<string, string>,
+  depth = 0,
 ): AncestorMatch[] {
-  const ancestors: AncestorMatch[] = [{ node, pathVariableBindings: { ...bindings } }];
+  const ancestors: AncestorMatch[] = [{ node, pathVariableBindings: { ...bindings }, depth }];
 
   if (pathSegments.length === 0) return ancestors;
 
@@ -153,13 +158,42 @@ function collectAncestors(
       const newBindings = isPathVar
         ? { ...bindings, [lastSegment]: pathSegments[0] }
         : { ...bindings };
-      const deeper = collectAncestors(child, pathSegments.slice(1), newBindings);
+      const deeper = collectAncestors(child, pathSegments.slice(1), newBindings, depth + 1);
       ancestors.push(...deeper);
       return ancestors;
     }
   }
 
   return ancestors;
+}
+
+/**
+ * Return a new tree equal to `root` but with the value at `segments`
+ * replaced by `value` (a `null`/`undefined` value deletes the node, same
+ * as an RTDB write of `null`). Used to build the post-write tree so that
+ * `newData` at an ANCESTOR of the write location reflects the merged
+ * result at that ancestor's own path, not just the raw payload at the
+ * deepest write path.
+ */
+function withValueAt(root: unknown, segments: string[], value: unknown): unknown {
+  if (segments.length === 0) return value ?? null;
+
+  const [head, ...rest] = segments;
+  const currentObj: Record<string, unknown> =
+    root !== null && typeof root === 'object' && !Array.isArray(root)
+      ? { ...(root as Record<string, unknown>) }
+      : {};
+
+  const existingChild = Object.hasOwn(currentObj, head) ? currentObj[head] : null;
+  const childValue = withValueAt(existingChild, rest, value);
+
+  if (childValue === null || childValue === undefined) {
+    delete currentObj[head];
+  } else {
+    currentObj[head] = childValue;
+  }
+
+  return currentObj;
 }
 
 export class SimulateHandler {
@@ -196,9 +230,24 @@ export class SimulateHandler {
       const ancestors = collectAncestors(rootNode, pathSegments, {});
 
       // Walk from root down. First ancestor whose rule evaluates to true wins.
+      //
+      // `data`/`newData` must be rooted at EACH ancestor's own location —
+      // not at the operation's target path — matching live RTDB semantics:
+      // a rule declared at `/rooms/$roomId` sees `data`/`newData` as the
+      // snapshot AT `/rooms/$roomId`, even when the write is deeper (e.g.
+      // `/rooms/$roomId/title`). Rooting everything at the deepest write
+      // path instead makes ancestor rules see "no data" (since the
+      // deepest path usually doesn't exist yet), which silently satisfies
+      // `!data.exists()`-style escape hatches and produces a false ALLOW.
       const rootData = new DataSnapshot(mockData, '/');
-      const dataAtPath = rootData.child(path.slice(1));
-      const newDataSnap = new DataSnapshot(newData ?? null, path);
+      // Post-write tree: mockData with `newData` merged in at the write
+      // path. Reads don't have a "post-write" state, so leave it as-is.
+      const mergedRoot =
+        operation === 'read' ? mockData : withValueAt(mockData, pathSegments, newData ?? null);
+      const mergedRootData = new DataSnapshot(mergedRoot, '/');
+
+      const dataAtPath = rootData.child(pathSegments.join('/'));
+      const newDataSnap = mergedRootData.child(pathSegments.join('/'));
 
       const buildContext: ContextBuilder = (data, newDataArg, bindings) => {
         const pvBindings: Record<string, string> = {};
@@ -221,10 +270,14 @@ export class SimulateHandler {
         if (!ruleExpr) continue;
         if (!ruleExpr.parsed.valid) continue;
 
+        const ancestorSegments = pathSegments.slice(0, ancestor.depth).join('/');
+        const dataAtAncestor = rootData.child(ancestorSegments);
+        const newDataAtAncestor = mergedRootData.child(ancestorSegments);
+
         const match = grammar.match(ruleExpr.raw.trim());
         const result = evaluateExpression(
           match,
-          buildContext(dataAtPath, newDataSnap, ancestor.pathVariableBindings),
+          buildContext(dataAtAncestor, newDataAtAncestor, ancestor.pathVariableBindings),
         );
 
         if (Boolean(result)) {

--- a/packages/pyric/test/database/simulation/handler.test.ts
+++ b/packages/pyric/test/database/simulation/handler.test.ts
@@ -415,3 +415,232 @@ describe('SimulateHandler — .validate (write path)', () => {
     expect(result.success && result.data.allowed).toBe(true);
   });
 });
+
+// ── `data`/`newData` rooting at the RULE's own location ─────────────────
+//
+// Live RTDB roots `data`/`newData` at the location of the RULE being
+// evaluated, not at the operation's target path. A rule declared on an
+// ANCESTOR of a deeper write/read must see `data`/`newData` as the
+// snapshot at the ancestor's own location — not at the deeper path, and
+// not "no data" just because the deeper path itself is empty. Getting
+// this wrong is a false-ALLOW bug class: an ancestor rule like
+// `data.child('owner').val() === auth.uid || !data.exists()` is meant as
+// "owner check, but allow creating a brand-new room" — rooting `data` at
+// the deep write path instead of the room's own path makes `data.exists()`
+// false for every write below an existing room, so the `!data.exists()`
+// escape hatch fires even though the room (and its `owner`) already exist.
+describe('SimulateHandler — data/newData rooted at rule location', () => {
+  const handler = new SimulateHandler();
+
+  const expr = (raw: string): RtdbNode['read'] => ({
+    raw,
+    parsed: { raw, valid: true, errors: [], warnings: [], referencedIdentifiers: [] },
+  });
+
+  const node = (partial: Partial<RtdbNode> & { path: string }): RtdbNode => ({
+    pathVariables: [],
+    exists: true,
+    children: [],
+    ...partial,
+  });
+
+  const ir = (rules: RtdbNode): RtdbIR => ({
+    service: 'realtime-database',
+    databaseUrl: 'https://test.firebaseio.com',
+    rules,
+  });
+
+  test('an ancestor .write rooted with an owner-or-new-doc escape hatch denies writes under an EXISTING doc owned by someone else', () => {
+    // `.write` at `/rooms/$roomId` — `data` must be the snapshot at
+    // `/rooms/$roomId` (with `owner: 'bob'`), not at the deep write path
+    // `/rooms/room1/title` (which has no value and so looks "not exists").
+    const ownerOrNewIR = ir(
+      node({
+        path: '/',
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                write: expr("data.child('owner').val() === auth.uid || !data.exists()"),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const mockData = { rooms: { room1: { owner: 'bob', title: 'old' } } };
+
+    // mallory is not the owner of the EXISTING room1 — must be denied.
+    const denied = handler.execute(ownerOrNewIR, {
+      operation: 'write',
+      path: '/rooms/room1/title',
+      auth: { uid: 'mallory', token: {} },
+      mockData,
+      newData: 'hijacked',
+    });
+    expect(denied.success).toBe(true);
+    if (denied.success) expect(denied.data.allowed).toBe(false);
+
+    // bob IS the owner — allowed.
+    const allowed = handler.execute(ownerOrNewIR, {
+      operation: 'write',
+      path: '/rooms/room1/title',
+      auth: { uid: 'bob', token: {} },
+      mockData,
+      newData: 'new title',
+    });
+    expect(allowed.success).toBe(true);
+    if (allowed.success) expect(allowed.data.allowed).toBe(true);
+
+    // Nobody owns a room that doesn't exist yet — the `!data.exists()`
+    // escape hatch still legitimately allows creating a brand-new room.
+    const created = handler.execute(ownerOrNewIR, {
+      operation: 'write',
+      path: '/rooms/room2/title',
+      auth: { uid: 'mallory', token: {} },
+      mockData,
+      newData: 'brand new room',
+    });
+    expect(created.success).toBe(true);
+    if (created.success) expect(created.data.allowed).toBe(true);
+  });
+
+  test('a rule reading data.child(...) at the rule location sees the correct nested value regardless of write depth', () => {
+    const readIR = ir(
+      node({
+        path: '/',
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                read: expr("data.child('visibility').val() === 'public'"),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const mockData = { rooms: { room1: { visibility: 'private', messages: { m1: 'hi' } } } };
+
+    const denied = handler.execute(readIR, {
+      operation: 'read',
+      path: '/rooms/room1/messages/m1',
+      auth: null,
+      mockData,
+    });
+    expect(denied.success).toBe(true);
+    if (denied.success) expect(denied.data.allowed).toBe(false);
+
+    const publicMockData = { rooms: { room1: { visibility: 'public', messages: { m1: 'hi' } } } };
+    const allowed = handler.execute(readIR, {
+      operation: 'read',
+      path: '/rooms/room1/messages/m1',
+      auth: null,
+      mockData: publicMockData,
+    });
+    expect(allowed.success).toBe(true);
+    if (allowed.success) expect(allowed.data.allowed).toBe(true);
+  });
+
+  test('newData at an ancestor rule reflects the merged post-write value at that ancestor location, not the raw payload at the deep write path', () => {
+    // `.write` at `/rooms/$roomId` checks `newData.child('locked').val()`
+    // — the post-write value of the ROOM, which must still show
+    // `locked: true` (untouched by a write to a sibling field) rather than
+    // being computed from the raw write payload at the deep path.
+    const lockedIR = ir(
+      node({
+        path: '/',
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                write: expr("newData.child('locked').val() !== true"),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const mockData = { rooms: { room1: { locked: true, title: 'old' } } };
+
+    // Writing just `/title` on a locked room: the merged post-write room
+    // still has `locked: true`, so the rule must deny.
+    const denied = handler.execute(lockedIR, {
+      operation: 'write',
+      path: '/rooms/room1/title',
+      auth: { uid: 'anyone', token: {} },
+      mockData,
+      newData: 'new title',
+    });
+    expect(denied.success).toBe(true);
+    if (denied.success) expect(denied.data.allowed).toBe(false);
+
+    // An unlocked room allows the same write.
+    const unlockedMockData = { rooms: { room1: { locked: false, title: 'old' } } };
+    const allowed = handler.execute(lockedIR, {
+      operation: 'write',
+      path: '/rooms/room1/title',
+      auth: { uid: 'anyone', token: {} },
+      mockData: unlockedMockData,
+      newData: 'new title',
+    });
+    expect(allowed.success).toBe(true);
+    if (allowed.success) expect(allowed.data.allowed).toBe(true);
+  });
+
+  test('newData.parent() from a nested write resolves through the merged tree, not just the written subtree', () => {
+    // A `.validate` at a deep node using `newData.parent()` must be able
+    // to see sibling fields merged from the pre-write tree.
+    const expr2 = (raw: string): RtdbNode['validate'] => ({
+      raw,
+      parsed: { raw, valid: true, errors: [], warnings: [], referencedIdentifiers: [] },
+    });
+    const parentIR = ir(
+      node({
+        path: '/',
+        write: expr('auth !== null'),
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                children: [
+                  node({
+                    path: '/rooms/$roomId/title',
+                    pathVariables: ['$roomId'],
+                    validate: expr2("newData.parent().child('locked').val() !== true"),
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const mockData = { rooms: { room1: { locked: true, title: 'old' } } };
+    const denied = handler.execute(parentIR, {
+      operation: 'write',
+      path: '/rooms/room1/title',
+      auth: { uid: 'anyone', token: {} },
+      mockData,
+      newData: 'new title',
+    });
+    expect(denied.success).toBe(true);
+    if (denied.success) expect(denied.data.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Bug

The RTDB rules simulator (`packages/pyric/src/database/simulation/handler.ts`) rooted `data` and `newData` at the operation's target path for every rule it evaluated, including ancestor rules declared above that path. Live RTDB roots `data`/`newData` at each rule's *own* location, not at the deep operation path.

This produces false ALLOWs whenever an ancestor rule inspects `data`/`newData` with an "existing doc" style guard.

### Before/after example

Rules:

```json
{
  "rules": {
    "rooms": {
      "$roomId": {
        ".write": "data.child('owner').val() === auth.uid || !data.exists()"
      }
    }
  }
}
```

Data: `{ rooms: { room1: { owner: 'bob', title: 'old' } } }`

Operation: write `'hijacked'` to `/rooms/room1/title` as `mallory`.

- Real Firebase: `data` at the rule's location (`/rooms/room1`) exists and its `owner` is `bob`, not `mallory`. Neither clause is true &rarr; **DENY**.
- Old simulator: rooted `data` at the write's exact path (`/rooms/room1/title`), which has no value, so `data.exists()` was `false`, and `!data.exists()` fired &rarr; **false ALLOW**.
- Fixed simulator: `data` is rooted at `/rooms/room1` (the rule's own location) &rarr; **DENY**, matching Firebase.

`newData` had the mirror-image bug: it held only the raw write payload placed at the deep path, so an ancestor rule inspecting other fields of the post-write value (e.g. `newData.child('locked').val()`) saw nothing instead of the merged post-write value.

## Fix

- `collectAncestors` now tracks how many `path` segments each ancestor consumed, i.e. that ancestor's own depth/location.
- For each ancestor rule, `data` is rooted at that ancestor's location (via `rootData.child(ancestorSegments)`) instead of the operation's full path.
- `newData` is now derived from a merged post-write tree (`mockData` with the proposed value applied at the write path via a new `withValueAt` helper), then rooted per-ancestor the same way `data` is — so `.parent()` traversal and sibling-field checks resolve correctly across the whole tree, not just the written subtree.
- The `.validate` enforcement path (which already rooted correctly at the write location) is unaffected; it now reuses the merged tree for consistency.

## Tests

Added `describe('SimulateHandler — data/newData rooted at rule location', ...)` in `packages/pyric/test/database/simulation/handler.test.ts`:

- `an ancestor .write rooted with an owner-or-new-doc escape hatch denies writes under an EXISTING doc owned by someone else`
- `a rule reading data.child(...) at the rule location sees the correct nested value regardless of write depth`
- `newData at an ancestor rule reflects the merged post-write value at that ancestor location, not the raw payload at the deep write path`
- `newData.parent() from a nested write resolves through the merged tree, not just the written subtree`

All four fail against the pre-fix code (verified by stashing the handler.ts change and re-running) and pass with the fix. Full `bun test` run across `packages/pyric` (4397 pass) and the RTDB/Firestore rules conformance suites is green.

## Test plan

- [x] `bun test packages/pyric/test/database/simulation/handler.test.ts` — new regression tests pass
- [x] Confirmed new tests fail against pre-fix `handler.ts` (false ALLOW reproduced)
- [x] `bun test` in `packages/pyric` — 4397 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean