### PR TITLE
Fix Firestore simulator to OR-combine overlapping match blocks

### DIFF
--- a/packages/pyric/src/rules/simulator/handler.ts
+++ b/packages/pyric/src/rules/simulator/handler.ts
@@ -67,20 +67,32 @@ function renderBlockPath(block: MatchBlock): string {
 }
 
 /**
- * Given a document path like "chess/game1", find the matching match block
- * in the AST. Resolves wildcards and binds path variables.
+ * Given a document path like "chess/game1", find EVERY match block in the
+ * AST whose path pattern fully resolves the request path. Resolves
+ * wildcards and binds path variables per block.
+ *
+ * Why every block, not the first: production Firestore OR-combines `allow`
+ * statements across ALL overlapping `match` blocks. When two sibling
+ * blocks both match a path (e.g. `match /docs/{doc}` and a sibling
+ * `match /{document=**}`), the request is granted if EITHER block's
+ * applicable allow evaluates true — there is no first-match-wins and no
+ * way for one block to revoke another's grant. Returning only the first
+ * match (the previous behavior) produced a false DENY whenever the first
+ * block in source order denied but a later overlapping block would have
+ * allowed. Each returned block carries its OWN wildcard bindings, so a
+ * block's variable names bind independently of its siblings.
  *
  * When `recorder` is supplied, every block the function considers
  * (matched or not) is logged as a `PathResolutionEntry`. Tests +
  * `debug_firestore_rules` rely on this trace; production callers can
  * omit it and pay zero cost.
  */
-function resolveMatch(
+function collectMatches(
   block: MatchBlock,
   pathSegments: string[],
   parentFunctions: FunctionDef[],
   recorder?: PathResolutionRecorder,
-): MatchResult | null {
+): MatchResult[] {
   const allFunctions = [...parentFunctions, ...block.functions];
 
   // Check if this block's path pattern matches the remaining segments
@@ -133,12 +145,14 @@ function resolveMatch(
       matched: false,
       reason: failureReason,
     });
-    return null;
+    return [];
   }
 
   const remaining = pathSegments.slice(consumed);
 
-  // If all segments consumed, this block matches directly
+  // If all segments consumed, this block matches directly. Its own allow
+  // rules apply to the document at this path; nested children can't match
+  // (there are no remaining segments for them to consume), so we stop here.
   if (remaining.length === 0) {
     recorder?.push({
       ...(block.loc ? { line: block.loc.line } : {}),
@@ -148,42 +162,35 @@ function resolveMatch(
       bindings,
       matched: true,
     });
-    return { block, pathVariables: bindings, parentFunctions: allFunctions };
+    return [{ block, pathVariables: bindings, parentFunctions: allFunctions }];
   }
 
-  // Otherwise, try children
+  // Otherwise descend into EVERY child and collect all matches — this block
+  // is a container for the deeper document, so its own allow rules do NOT
+  // apply, but multiple children (and their descendants) may each match and
+  // must all be OR-combined.
+  const results: MatchResult[] = [];
   for (const child of block.children) {
-    const childResult = resolveMatch(child, remaining, allFunctions, recorder);
-    if (childResult) {
-      // Parent recorded as a successful "partial" match — the child
-      // completed the resolution. Record THIS block as matched too;
-      // bindings merge happens below.
-      recorder?.push({
-        ...(block.loc ? { line: block.loc.line } : {}),
-        blockPath: renderBlockPath(block),
-        matchedSegments: consumed,
-        totalSegments: pattern.length,
-        bindings,
-        matched: true,
-      });
-      // Merge parent bindings
+    for (const childResult of collectMatches(child, remaining, allFunctions, recorder)) {
+      // Merge this block's bindings into each descendant match.
       childResult.pathVariables = { ...bindings, ...childResult.pathVariables };
-      return childResult;
+      results.push(childResult);
     }
   }
 
-  // Block consumed its own segments but no child block covered the
-  // remaining request segments. Record + bail.
+  // Record THIS block's own attempt: matched (as a container) when at least
+  // one descendant completed the resolution, else the near-miss reason.
   recorder?.push({
     ...(block.loc ? { line: block.loc.line } : {}),
     blockPath: renderBlockPath(block),
     matchedSegments: consumed,
     totalSegments: pattern.length,
     bindings,
-    matched: false,
-    reason: 'no-matching-child',
+    ...(results.length > 0
+      ? { matched: true }
+      : { matched: false, reason: 'no-matching-child' as const }),
   });
-  return null;
+  return results;
 }
 
 // ═══ Operation mapping ═══
@@ -560,13 +567,16 @@ export class SimulateFirestoreRulesHandler {
       // start matching from its children directly.
       const pathSegments = tc.path.split('/').filter(Boolean);
       const rootFunctions = ast.service.match.functions;
-      let match: MatchResult | null = null;
+      // Collect EVERY match block that resolves this path (not just the
+      // first). Production OR-combines allows across all overlapping
+      // blocks, so we must evaluate them all. Order is preserved in source
+      // order for deterministic, readable traces.
+      let matches: MatchResult[] = [];
       // Fresh recorder per test case so each `TestResult.pathResolution`
       // captures only its own resolution attempts.
       const pathRecorder = new PathResolutionRecorder();
       for (const child of ast.service.match.children) {
-        match = resolveMatch(child, pathSegments, rootFunctions, pathRecorder);
-        if (match) break;
+        matches.push(...collectMatches(child, pathSegments, rootFunctions, pathRecorder));
       }
       // `list` targets a COLLECTION, but rules match blocks are document-
       // level: real Firestore evaluates a query against the doc block with
@@ -577,20 +587,19 @@ export class SimulateFirestoreRulesHandler {
       // list paths (`menuItems/any`) keep resolving on the first attempt,
       // so existing call sites are unaffected. (RULES-LIST parity pack.)
       let syntheticListDoc = false;
-      if (!match && tc.method === 'list') {
+      if (matches.length === 0 && tc.method === 'list') {
         const widened = [...pathSegments, '__hypothetical_doc__'];
         for (const child of ast.service.match.children) {
-          match = resolveMatch(child, widened, rootFunctions, pathRecorder);
-          if (match) break;
+          matches.push(...collectMatches(child, widened, rootFunctions, pathRecorder));
         }
-        if (match) syntheticListDoc = true;
+        if (matches.length > 0) syntheticListDoc = true;
       }
       const pathResolution: PathResolutionTrace = {
         requestPath: tc.path,
         attempts: pathRecorder.attempts,
       };
 
-      if (!match) {
+      if (matches.length === 0) {
         // No match block at all → production default-DENY. Expectation
         // 'DENY' agrees → PASSED; expectation 'ALLOW' disagrees → FAILED.
         const state = tc.expectation === 'DENY' ? 'PASSED' : 'FAILED';
@@ -607,17 +616,50 @@ export class SimulateFirestoreRulesHandler {
         continue;
       }
 
-      // Build context — `rootBindings` carries the root-match wildcards
-      // (e.g. `db` or `database`) so `$(name)` interpolation inside
-      // get()/exists() paths resolves regardless of which name the
-      // ruleset chose. Child match bindings override on collision (a
-      // child rule that shadows the name wins inside that scope).
-      const allFunctions = [...match.parentFunctions, ...match.block.functions];
-      const pathVars = { ...rootBindings, ...match.pathVariables };
-      const ctx = buildContext(tc, allFunctions, pathVars, opts?.getDoc);
+      // OR-combine every matching block. Production grants the request if
+      // ANY matching block's applicable allow evaluates true; there is no
+      // first-match-wins and no way for one block to revoke another's
+      // grant. So we evaluate each block independently and short-circuit on
+      // the first ALLOW. Each block builds its OWN context with its OWN
+      // wildcard bindings (`rootBindings` carries the root-match wildcards
+      // like `db`/`database` so `$(name)` interpolation inside
+      // get()/exists() paths resolves; the block's own bindings override on
+      // collision). Every rule-evaluation entry is tagged with its block's
+      // path so a multi-block DENY trace stays unambiguous.
+      //
+      // Decision combine: ALLOW (any block) > UNSUPPORTED (any block
+      // abstained on a sim gap, and nothing granted) > DENY (default —
+      // nothing matched or nothing granted). ALLOW wins even over an
+      // UNSUPPORTED sibling: a definite grant is not weakened by a sim gap
+      // elsewhere. Only when NO block grants do we escalate to UNSUPPORTED,
+      // so the agent sees "sim couldn't decide" rather than a false DENY.
+      let decision: Decision = 'DENY';
+      const trace: RuleEvaluation[] = [];
+      const notes: string[] = [];
+      let sawUnsupported = false;
+      let grantingBlockPath: string | undefined;
+      for (const match of matches) {
+        const allFunctions = [...match.parentFunctions, ...match.block.functions];
+        const pathVars = { ...rootBindings, ...match.pathVariables };
+        const ctx = buildContext(tc, allFunctions, pathVars, opts?.getDoc);
 
-      // Evaluate rules
-      const { decision, trace, notes } = evaluateRules(match.block, tc.method, ctx);
+        const blockPath = renderBlockPath(match.block);
+        const res = evaluateRules(match.block, tc.method, ctx);
+        for (const entry of res.trace) entry.matchPath = blockPath;
+        trace.push(...res.trace);
+        notes.push(...res.notes);
+
+        if (res.decision === 'ALLOW') {
+          decision = 'ALLOW';
+          grantingBlockPath = blockPath;
+          break;
+        }
+        if (res.decision === 'UNSUPPORTED') sawUnsupported = true;
+      }
+      if (decision !== 'ALLOW' && sawUnsupported) decision = 'UNSUPPORTED';
+      if (decision === 'ALLOW' && grantingBlockPath) {
+        notes.push(`Allowed by match block '${grantingBlockPath}'`);
+      }
       if (syntheticListDoc) {
         notes.push(
           `list on collection path '${tc.path}' evaluated against the document-level match block (document wildcard hypothetical, resource undefined) — emulator-faithful`,

--- a/packages/pyric/src/rules/test/spec.ts
+++ b/packages/pyric/src/rules/test/spec.ts
@@ -168,6 +168,16 @@ export interface RuleEvaluation {
   /** 1-indexed source line of the `allow` keyword. Populated when the
    *  rule's `loc` was set by the parser. */
   line?: number;
+  /**
+   * Source-rendered path of the `match` block this rule belongs to, e.g.
+   * `'/docs/{docId}'` or `'/{document=**}'`. Populated when the request
+   * path matches MORE THAN ONE overlapping `match` block: allows OR-combine
+   * across every matching block (production semantics — there is no
+   * first-match-wins), so a DENY trace can carry entries from several
+   * blocks. This field keeps them unambiguous — which block did this rule
+   * live in. Absent for the common single-block case.
+   */
+  matchPath?: string;
   /** Human-readable diagnostic — populated for `UNSUPPORTED` (which sim
    *  surface is missing) and `ERROR` (which runtime error caused the
    *  rule to abort). */
@@ -212,9 +222,13 @@ export interface PathResolutionEntry {
    *  the overall match failed — the partial bindings are still
    *  diagnostic). */
   bindings: Record<string, string>;
-  /** True only for the block that fully resolved (no remaining
-   *  request segments AND every nested match either completed or
-   *  wasn't needed). */
+  /** True for a block that fully resolved (no remaining request
+   *  segments AND every nested match either completed or wasn't
+   *  needed). MULTIPLE entries may be `matched: true` in one trace:
+   *  a request path can match several overlapping `match` blocks
+   *  (e.g. `/docs/{doc}` and a sibling `/{document=**}`), and every
+   *  matching block's allows OR-combine. Container blocks whose
+   *  children completed the resolution are also flagged matched. */
   matched: boolean;
   /** Why the resolver moved on. Absent when `matched: true`.
    *   - `'literal-mismatch'` — a literal segment in the block
@@ -230,8 +244,9 @@ export interface PathResolutionTrace {
   /** The request path that was resolved, verbatim from `TestCase.path`. */
   requestPath: string;
   /** One entry per match block the resolver considered, in the
-   *  order it tried them. `attempts[i].matched: true` marks the
-   *  winning block — at most one per trace. */
+   *  order it tried them. `attempts[i].matched: true` marks a
+   *  block that fully resolved; one or more per trace, since
+   *  overlapping blocks all match and OR-combine. */
   attempts: PathResolutionEntry[];
 }
 

--- a/packages/pyric/test/rules/simulator/handler.test.ts
+++ b/packages/pyric/test/rules/simulator/handler.test.ts
@@ -600,10 +600,12 @@ service cloud.firestore {
       expect(attempts.every(a => !a.matched && a.reason === 'literal-mismatch')).toBe(true);
     });
 
-    test('multiple siblings: first match short-circuits, later siblings are NOT recorded', () => {
-      // The resolver stops at the first match. Later siblings don't
-      // get attempted (or recorded) — the agent's near-miss list
-      // should not include blocks the resolver never considered.
+    test('multiple siblings: ALL are considered (no first-match short-circuit in resolution)', () => {
+      // Overlapping-match semantics: the resolver evaluates EVERY sibling
+      // block, not just the first that matches, because allows OR-combine
+      // across all matching blocks. Here `/alpha/{x}` matches and
+      // `/beta/{y}` is a literal-mismatch — but both appear in the trace
+      // so the agent's near-miss list is complete.
       const TWO_SIBLINGS = `rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
@@ -624,11 +626,12 @@ service cloud.firestore {
       expect(r.success).toBe(true);
       if (!r.success) return;
       const attempts = r.data.results[0].pathResolution!.attempts;
-      expect(attempts.length).toBe(1);
-      expect(attempts[0].blockPath).toBe('/alpha/{x}');
-      expect(attempts[0].matched).toBe(true);
-      // `/beta/{y}` was never tried — confirm it's not in the trace.
-      expect(attempts.find(a => a.blockPath === '/beta/{y}')).toBeUndefined();
+      const alpha = attempts.find(a => a.blockPath === '/alpha/{x}');
+      const beta = attempts.find(a => a.blockPath === '/beta/{y}');
+      expect(alpha?.matched).toBe(true);
+      // `/beta/{y}` IS recorded now — it was considered, and reasoned out.
+      expect(beta?.matched).toBe(false);
+      expect(beta?.reason).toBe('literal-mismatch');
     });
 
     test('request-shorter fires at a literal segment too (not just wildcards)', () => {
@@ -1082,5 +1085,170 @@ service cloud.firestore {
     }]);
     expect(r.success).toBe(true);
     if (r.success) expect(r.data.results[0].state).toBe('PASSED'); // DENY (limitation) matches
+  });
+
+  describe('overlapping match blocks — allows OR-combine (firestore.overlapping-match-or)', () => {
+    // Production Firestore semantics: when MULTIPLE match blocks match the
+    // same document path, the request is allowed if ANY matching block's
+    // applicable allow evaluates true. Allows OR-combine across all matching
+    // blocks — there is NO first-match-wins, and no block can revoke a grant
+    // made by another block. The simulator previously stopped at the first
+    // matching block in source order, producing a FALSE DENY whenever an
+    // earlier block denied but a later overlapping block would have allowed
+    // (a security-relevant divergence: agents would harden a rule that
+    // production already permits, or miss that a `{document=**}` catch-all
+    // silently opens a path). These cases pin the OR-combine contract.
+
+    test('second block allows what the first denies — production ALLOWS', () => {
+      // `/docs/{doc}` (source-first) denies for this request; the sibling
+      // catch-all `/{document=**}` allows. OR-combine → ALLOW. Under the old
+      // first-match-wins resolver this was a false DENY.
+      const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /docs/{doc} {
+      allow read: if false;
+    }
+    match /{document=**} {
+      allow read: if true;
+    }
+  }
+}`;
+      const r = handler.simulate(RULES, [{
+        description: 'first denies, second (catch-all) allows',
+        expectation: 'ALLOW',
+        method: 'get',
+        path: 'docs/d1',
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      const result = r.data.results[0];
+      expect(result.decision).toBe('ALLOW');
+      expect(result.state).toBe('PASSED');
+    });
+
+    test('reverse source order — first block allows, later denies — still ALLOWS', () => {
+      // Same two blocks, order flipped: the catch-all comes first and
+      // allows. The verdict must not depend on source order — either
+      // ordering grants, because a deny cannot revoke an allow.
+      const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read: if true;
+    }
+    match /docs/{doc} {
+      allow read: if false;
+    }
+  }
+}`;
+      const r = handler.simulate(RULES, [{
+        description: 'catch-all first allows, specific denies',
+        expectation: 'ALLOW',
+        method: 'get',
+        path: 'docs/d1',
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('nested {document=**} catch-all overlaps a specific match', () => {
+      // A recursive wildcard block matches paths of any depth. Here it
+      // overlaps the specific `/rooms/{room}/msgs/{msg}` block. The specific
+      // block denies (wrong owner); the catch-all grants admins. Deep path
+      // must resolve BOTH blocks and OR-combine to ALLOW.
+      const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /rooms/{room}/msgs/{msg} {
+      allow read: if request.auth.uid == resource.data.owner;
+    }
+    match /{path=**} {
+      allow read: if request.auth.token.admin == true;
+    }
+  }
+}`;
+      const r = handler.simulate(RULES, [{
+        description: 'admin reads via catch-all despite specific-block deny',
+        expectation: 'ALLOW',
+        method: 'get',
+        path: 'rooms/r1/msgs/m1',
+        auth: { uid: 'someoneElse', token: { admin: true } },
+        resource: { owner: 'owner1' },
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('DENY requires NO matching block to allow — both blocks deny → DENY', () => {
+      // Deny-by-default is preserved: when every matching block's applicable
+      // allow evaluates false, the request is denied. Both the specific
+      // block and the catch-all deny this request.
+      const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /docs/{doc} {
+      allow read: if false;
+    }
+    match /{document=**} {
+      allow read: if request.auth != null;
+    }
+  }
+}`;
+      const r = handler.simulate(RULES, [{
+        description: 'neither block grants — deny',
+        expectation: 'DENY',
+        method: 'get',
+        path: 'docs/d1',
+        auth: null,
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      const result = r.data.results[0];
+      expect(result.decision).toBe('DENY');
+      expect(result.state).toBe('PASSED');
+      // The DENY trace carries entries from BOTH evaluated blocks, each
+      // tagged with the block it came from so the report is unambiguous.
+      const blockPaths = result.trace.map(e => e.matchPath).sort();
+      expect(blockPaths).toEqual(['/docs/{doc}', '/{document=**}']);
+      expect(result.trace.every(e => e.verdict === 'DENY')).toBe(true);
+    });
+
+    test('each block binds its OWN wildcard names independently', () => {
+      // The two overlapping blocks name the SAME path segment differently
+      // (`{doc}` vs `{id}`). Each block's condition reads its own wildcard;
+      // resolution must bind per-block, not leak one block's names into the
+      // other. The first block denies (compares to a non-matching literal);
+      // the second allows because `id` binds to the actual segment.
+      const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /items/{doc} {
+      allow read: if doc == 'nope';
+    }
+    match /items/{id} {
+      allow read: if id == 'real1';
+    }
+  }
+}`;
+      const r = handler.simulate(RULES, [{
+        description: 'per-block wildcard binding',
+        expectation: 'ALLOW',
+        method: 'get',
+        path: 'items/real1',
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      const result = r.data.results[0];
+      expect(result.decision).toBe('ALLOW');
+      expect(result.state).toBe('PASSED');
+      // The granting entry is the `{id}` block; its `id` bound to 'real1'.
+      const granting = result.trace.find(e => e.verdict === 'ALLOW');
+      expect(granting?.matchPath).toBe('/items/{id}');
+    });
   });
 });


### PR DESCRIPTION
## The semantic bug

The Firestore rules simulator resolved each request against only the **first** `match` block in source order (`resolveMatch` returned on first hit; the handler `break`-ed out of the sibling loop), then evaluated that one block's `allow` statements in isolation.

Production Firestore is different: when **multiple** `match` blocks match the same document path, `allow` statements **OR-combine across every matching block**. The request is granted if ANY matching block's applicable `allow` evaluates true. There is no first-match-wins, and no block can revoke a grant made by another block.

The old behavior produced a **false DENY** whenever an earlier block in source order denied but a later overlapping block would have allowed. This is security-relevant in the opposite direction too: a `{document=**}` catch-all that opens a path could be masked by a specific block that happened to come first and deny, so an agent would not see that production actually allows the request.

## Concrete two-block before / after

```
match /docs/{doc}      { allow read: if false; }   // source-first, denies
match /{document=**}   { allow read: if true;  }   // sibling catch-all, allows
```

Request: `get docs/d1`

- **Before:** resolver stops at `/docs/{doc}`, evaluates `if false` → **DENY** (wrong).
- **After:** both blocks resolve; allows OR-combine → **ALLOW** (matches production). Verdict is independent of source order (the reverse-order case is covered by a test).

## The fix

- `resolveMatch` (first-match) becomes `collectMatches`, returning **every** block whose pattern fully resolves the path. Each returned block carries its **own** wildcard bindings, so a block's variable names bind independently of its siblings.
- The handler evaluates each matching block with its own context and OR-combines the decisions: **ALLOW** if any block grants (short-circuits on the first grant, matching production laziness) → else **UNSUPPORTED** if any block abstained on a simulator gap and nothing granted → else **DENY**.
- `RuleEvaluation.matchPath` (new optional field) tags each trace entry with the block it came from, so a multi-block DENY trace is unambiguous; an ALLOW reports the granting block in `notes` and via the `matched` entry's `matchPath`.

## How deny-by-default is preserved

Nothing about the default-deny path changed: when `collectMatches` returns no blocks, the request still defaults to DENY. When blocks match but **none** grants, the combine falls through to DENY. A test pins that both a specific block and a catch-all denying the same request yields DENY, with both blocks present in the trace.

## Tests

New `describe('overlapping match blocks — allows OR-combine ...')` in `handler.test.ts`, written to fail against the old first-match resolver:

- second block allows what the first denies → ALLOW
- reverse source order → still ALLOW (order-independent)
- nested `{document=**}` catch-all overlapping a specific deep match → ALLOW
- both blocks deny → DENY, deny-by-default preserved (trace carries both blocks)
- each block binds its own wildcard names independently

The stale `first match short-circuits, later siblings NOT recorded` test was updated: under correct semantics all siblings are considered and recorded.

Full `packages/pyric` `bun test` (rules + firestore sandbox scenarios) green; `bunx tsc --noEmit` clean.

Scope note: `src/sandbox/firestore/list-query-proof.ts` has its own first-match `resolveMatchBlock` mirror for list-query safety proofs; it is out of scope here and a candidate for the same treatment as a follow-up.
