### PR TITLE
Enforce storage rules in served worker mode

### DIFF
--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -23,7 +23,7 @@ import {
   materializeStudioUi,
   embeddedWorkerVersion,
 } from '../serve/standalone-assets.js';
-import { loadProjectDatabaseRules, loadProjectRules, watchProjectRules } from '../serve/rules.js';
+import { loadProjectDatabaseRules, loadProjectRules, loadProjectStorageRules, watchProjectRules } from '../serve/rules.js';
 import { hasSandboxBuildMarker } from '../serve/sandbox-marker.js';
 import { createEventHub, createPyricNamespace, injectServeTags, type InitPayload } from '../serve/namespace.js';
 import { createStateStore, STATE_FILE_VERSION, type PyricStateFile } from '../serve/state-store.js';
@@ -207,6 +207,11 @@ export async function startServe(opts: {
   // always serves the live version.
   const loaded = await loadProjectRules(opts.cwd, config);
   const loadedDatabase = await loadProjectDatabaseRules(opts.cwd, config);
+  // Storage rules deploy ONCE at boot — see the `storageRules` doc on
+  // `InitPayload`: `pyric/storage` only honors rules on the FIRST storage
+  // call per Sandbox, so unlike firestore/database rules there is no live
+  // "live" box to swap here; a storage.rules edit needs a restart.
+  const loadedStorage = await loadProjectStorageRules(opts.cwd, config);
   const live = {
     rules: loaded.rules,
     rulesHash: loaded.rulesHash,
@@ -336,6 +341,8 @@ export async function startServe(opts: {
     databaseRules: live.databaseRules,
     databaseRulesHash: live.databaseRulesHash,
     databaseUrl: live.databaseUrl,
+    storageRules: loadedStorage.rules,
+    storageRulesHash: loadedStorage.rulesHash,
     bridgeUrl: mount && origin.port > 0 ? mount.wsUrl(origin) : null,
     // Precedence: once a state file exists, the lived state is the truth —
     // --seed applies only on the first (state-less) run.
@@ -483,6 +490,12 @@ export async function startServe(opts: {
     loadedDatabase.rules
       ? `✔ rules    ${loadedDatabase.sourcePath} → deployed to the RTDB sandbox (hash ${loadedDatabase.rulesHash})`
       : `• rules    no database.rules — RTDB sandbox runs with default rules`,
+  );
+  logger.info(
+    loadedStorage.rules
+      ? `✔ rules    ${loadedStorage.sourcePath} → deployed to the storage sandbox (hash ${loadedStorage.rulesHash}; ` +
+        `edits require a restart — storage rules do not hot-reload)`
+      : `• rules    no storage.rules — storage sandbox runs open (no rules configured)`,
   );
   if (uiUrl) {
     logger.info(`✔ studio   Pyric Studio: ${uiUrl}`);

--- a/packages/pyric-tools/src/serve/entries/storage.ts
+++ b/packages/pyric-tools/src/serve/entries/storage.ts
@@ -64,12 +64,13 @@ function workerOrInPage<T extends (...args: any[]) => unknown>(name: string, fn:
 
 // Byte ops now have a worker protocol (base64 `storage.putBytes` /
 // `storage.getBytes` / `storage.deleteObject`), so worker mode routes them to
-// the shared object store instead of throwing. No lens is attached: storage
-// rules apply only when the HOST configured them on the sandbox's storage
-// service — the served worker currently configures none (setRules deploys
-// Firestore/RTDB only), so worker-mode storage is effectively open today.
-// The admin lens matters for embedding/test hosts that pre-open the service
-// with rules. Payloads are capped at 8 MiB per op.
+// the shared object store instead of throwing. No lens is attached (these
+// calls run as the shared anonymous page handle — `actAs` absent), but the
+// served worker's `applyServeInit` configures the sandbox's storage.rules at
+// boot (before any op can run), so that shared handle enforces them like
+// every other lens (see `lensStorage` in host.ts). The admin lens matters for
+// embedding/test hosts that pre-open the service with rules. Payloads are
+// capped at 8 MiB per op.
 export const uploadBytes = (useWorker ? workerUploadBytes : ip.uploadBytes) as typeof ip.uploadBytes;
 export const getBytes = (useWorker ? workerGetBytes : ip.getBytes) as typeof ip.getBytes;
 export const deleteObject = (useWorker ? workerDeleteObject : ip.deleteObject) as typeof ip.deleteObject;

--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -27,6 +27,16 @@ export interface InitPayload {
   databaseRules?: { rules: Record<string, unknown> } | null;
   databaseRulesHash?: string | null;
   databaseUrl?: string | null;
+  /** Storage rules source (plain storage-rules language), or null when the
+   *  project has no storage.rules configured/present. Deployed ONCE at
+   *  sandbox boot — `pyric/storage` only honors rules on the FIRST
+   *  storage call per `Sandbox` (a documented invariant, not an
+   *  oversight: a later, differing rules source would otherwise be a
+   *  silent rules wipe). Unlike firestore/database rules, storage rules
+   *  do NOT hot-reload — editing storage.rules while `pyric dev` is
+   *  running requires a restart to take effect. */
+  storageRules?: string | null;
+  storageRulesHash?: string | null;
   bridgeUrl: string | null;
   /** `--seed` documents (path → fields), applied admin-style at page init.
    *  Null in persist mode once a state file exists — the lived state wins. */

--- a/packages/pyric-tools/src/serve/rules.ts
+++ b/packages/pyric-tools/src/serve/rules.ts
@@ -14,6 +14,7 @@ import { watch, type FSWatcher } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { lintFirestoreRules, resolveModulesBrowser } from 'pyric/rules';
+import { parseStorageRules } from 'pyric/storage';
 import type { FirebaseJson } from '../cli/firebase-json.js';
 import { parseRtdbRulesJson } from '../rtdb/rules-json.js';
 
@@ -23,6 +24,14 @@ export interface LoadedRules {
   rules: string | null;
   rulesHash: string | null;
   /** Where it came from (diagnostics + the P3 watcher target). */
+  sourcePath: string | null;
+}
+
+export interface LoadedStorageRules {
+  /** Plain storage-rules source ready for the sandbox, or null when the
+   *  project has no storage rules file configured/present. */
+  rules: string | null;
+  rulesHash: string | null;
   sourcePath: string | null;
 }
 
@@ -99,6 +108,57 @@ export async function loadProjectRules(
   return { rules, rulesHash: rulesHashOf(rules), sourcePath: path };
 }
 
+/**
+ * Validate a raw storage-rules source. `pyric/storage`'s parser throws a
+ * plain `SyntaxError` (no line/col like the firestore lint path) — wrap it
+ * into the same actionable "fix before serving" message shape.
+ */
+export function prepareStorageRulesSource(raw: string, sourcePath: string): string {
+  try {
+    parseStorageRules(raw);
+  } catch (e) {
+    throw new Error(
+      `pyric dev: ${sourcePath} failed to parse: ${e instanceof Error ? e.message : String(e)} — fix the rules before serving.`,
+    );
+  }
+  return raw;
+}
+
+/**
+ * Load the project's storage rules per `firebase.json` (`storage.rules`
+ * path — the block may be a single object or an array of per-bucket
+ * entries; v1 has one implicit bucket, so the FIRST entry with a `rules`
+ * path wins, defaulting to `storage.rules` in cwd when the block is absent
+ * but the file exists). Missing file with no explicit config → `{ rules:
+ * null }` (serving without storage rules is fine — same posture as
+ * `loadProjectRules`). Missing file that IS explicitly configured → throw
+ * (the project says it should exist).
+ */
+export async function loadProjectStorageRules(
+  cwd: string,
+  config: FirebaseJson | null,
+): Promise<LoadedStorageRules> {
+  const block = config?.storage;
+  const entries = block ? (Array.isArray(block) ? block : [block]) : [];
+  const configured = entries.find((e) => e && typeof e === 'object' && e.rules)?.rules;
+  const rel = configured ?? 'storage.rules';
+  const path = isAbsolute(rel) ? rel : join(cwd, rel);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (configured) {
+        throw new Error(`pyric dev: firebase.json points storage.rules at ${path}, but it does not exist.`);
+      }
+      return { rules: null, rulesHash: null, sourcePath: null };
+    }
+    throw e;
+  }
+  const rules = prepareStorageRulesSource(raw, path);
+  return { rules, rulesHash: rulesHashOf(rules), sourcePath: path };
+}
+
 export async function loadProjectDatabaseRules(
   cwd: string,
   config: FirebaseJson | null,
@@ -156,6 +216,35 @@ export function watchProjectRules(
   onError: (message: string) => void,
   debounceMs = 150,
 ): FSWatcher {
+  return watchRulesFile(sourcePath, prepareRulesSource, onChange, onError, debounceMs);
+}
+
+/**
+ * Watch a project's storage.rules file, same contract as
+ * {@link watchProjectRules} but validating via `pyric/storage`'s parser.
+ */
+export function watchProjectStorageRules(
+  sourcePath: string,
+  onChange: (next: { rules: string; rulesHash: string }) => void,
+  onError: (message: string) => void,
+  debounceMs = 150,
+): FSWatcher {
+  return watchRulesFile(sourcePath, prepareStorageRulesSource, onChange, onError, debounceMs);
+}
+
+/**
+ * Shared watch implementation. Broken intermediate saves are LOGGED and
+ * skipped — the last-good ruleset stays live (the write_file lesson: never
+ * replace a working ruleset with un-evaluatable source). Debounced; returns
+ * the watcher for shutdown.
+ */
+function watchRulesFile(
+  sourcePath: string,
+  prepare: (raw: string, sourcePath: string) => string,
+  onChange: (next: { rules: string; rulesHash: string }) => void,
+  onError: (message: string) => void,
+  debounceMs: number,
+): FSWatcher {
   let timer: ReturnType<typeof setTimeout> | null = null;
   const watcher = watch(sourcePath, () => {
     if (timer) clearTimeout(timer);
@@ -163,7 +252,7 @@ export function watchProjectRules(
       void readFile(sourcePath, 'utf8').then(
         (raw) => {
           try {
-            const rules = prepareRulesSource(raw, sourcePath);
+            const rules = prepare(raw, sourcePath);
             onChange({ rules, rulesHash: rulesHashOf(rules) });
           } catch (e) {
             onError(e instanceof Error ? e.message : String(e));

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -2198,10 +2198,12 @@ export async function getBlob(reference: ClientStorageReference): Promise<Blob> 
 // Backed by the base64 `storage.putBytes` / `storage.getBytes` /
 // `storage.deleteObject` ops (remote sandbox, slice 2). No `actAs` lens is
 // attached: page callers run under the worker's page storage handle (same
-// model as `listAll`/`getMetadata` above). Storage rules apply only when the
-// HOST configured them on the sandbox's storage service — the served worker
-// currently configures none, so worker-mode storage is effectively open
-// today; the admin lens matters for embedding/test hosts that pre-open the
+// model as `listAll`/`getMetadata` above). Storage rules apply when the
+// HOST configured them on the sandbox's storage service — the served
+// worker's `applyServeInit` (serve-init.ts) does this at boot, before any op
+// can reach the host, so worker-mode storage enforces the project's
+// storage.rules the same as Firestore/RTDB (open only when the project has
+// none); the admin lens matters for embedding/test hosts that pre-open the
 // service with rules. Raw payloads are capped at 8 MiB
 // (`MAX_STORAGE_OP_BYTES`) — same cap the host enforces.
 

--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -621,12 +621,15 @@ function ensureStorage(ctx: HostCtx): FirebaseStorage {
  *   - absent / `app-session` → the shared anonymous page handle
  *     ({@link ensureStorage}). Storage rules apply only when the HOST
  *     configured them on this sandbox's storage service (first call per
- *     sandbox wins) — the SERVED worker currently configures none
- *     (`setRules`/`setDatabaseRules` cover Firestore/RTDB only), so
- *     worker-mode storage is effectively open today and all lenses behave
- *     alike there. The lens split matters for embedding/test hosts that
- *     pre-open the service with rules. (Storage also has no per-port
- *     session plumbing — reads always ran anonymous; writes keep that.)
+ *     sandbox wins) — the SERVED worker configures them via
+ *     `applyServeInit` (`serve-init.ts`), which opens the storage service
+ *     with `payload.storageRules` BEFORE any op can reach `ensureStorage`/
+ *     `lensStorage`, so every lens on a served worker enforces the
+ *     project's storage.rules (or runs open when the project has none,
+ *     matching Firestore/RTDB's no-rules posture). The lens split still
+ *     matters for embedding/test hosts that open the service directly.
+ *     (Storage also has no per-port session plumbing — reads always ran
+ *     anonymous; writes keep that.)
  *   - `{ mode: 'admin' }` → the rules-BYPASS handle from
  *     `pyric/storage/internal`'s admin plane — same per-sandbox store +
  *     ruleset, rule evaluation skipped (firebase-admin semantics for the

--- a/packages/pyric-tools/src/serve/worker/serve-init.ts
+++ b/packages/pyric-tools/src/serve/worker/serve-init.ts
@@ -30,6 +30,7 @@
 import { getFirestore, sandbox as sandboxOps } from 'pyric/firestore';
 import { getDatabase, sandbox as rtdbSandbox } from 'pyric/database/modular';
 import { getAuth, sandbox as authOps, type SeedUser } from 'pyric/auth';
+import { getStorageSandbox } from 'pyric/storage';
 import type { PersistenceBackend } from 'pyric/sandbox';
 import { initializeSandbox, serializeToBuckets, bundleRecords, parseBundle } from 'pyric/sandbox';
 import { primeEventHistory } from 'pyric/sandbox/internal';
@@ -85,6 +86,13 @@ export function setupWorkerHotReload(
  *  stops the capture event subscription (worker teardown / re-init). */
 export interface ServeInitResult {
   rulesDeployed: boolean;
+  /** Whether storage rules were deployed at boot. Storage rules are
+   *  honored only on the FIRST `pyric/storage` call per Sandbox
+   *  (see `getStorageSandbox`'s `StorageOptions.rules` doc) — so unlike
+   *  `rulesDeployed`/database rules this never flips true→false→true
+   *  across a session; it is decided once, here, before any storage op
+   *  runs. */
+  storageRulesDeployed: boolean;
   seededDocs: number;
   seededUsers: number;
   captureEnabled: boolean;
@@ -133,6 +141,7 @@ export function applyServeInit(
 ): ServeInitResult {
   const result: ServeInitResult = {
     rulesDeployed: false,
+    storageRulesDeployed: false,
     seededDocs: 0,
     seededUsers: 0,
     captureEnabled: false,
@@ -166,6 +175,21 @@ export function applyServeInit(
       status: 'active',
       messages: [],
     };
+  }
+
+  // 1b. Storage rules — deployed ONCE, here, before any storage op can run.
+  //     `pyric/storage`'s `getStorageSandbox` only honors a `rules` option on
+  //     the FIRST call per Sandbox (later differing rules throw — a
+  //     deliberate silent-rules-wipe guard, see StorageOptions.rules). This
+  //     call IS that first call: `ensureStorage`/`lensStorage` in host.ts
+  //     always open storage with no `rules` option, so whichever call opens
+  //     the service first wins — making this the sanctioned place to
+  //     configure it. `payload.storageRules` is null when the project has no
+  //     storage.rules, matching the same open-by-default posture as no
+  //     firestore.rules / no database.rules.
+  if (payload.storageRules) {
+    getStorageSandbox(ctx.sandbox, { rules: payload.storageRules });
+    result.storageRulesDeployed = true;
   }
 
   // A seed fixture applies only into an empty home — checked ONCE, before

--- a/packages/pyric-tools/test/serve/worker/serve-init.test.ts
+++ b/packages/pyric-tools/test/serve/worker/serve-init.test.ts
@@ -9,6 +9,7 @@
  * a network.
  */
 
+import 'fake-indexeddb/auto';
 import { describe, it, expect } from 'bun:test';
 import {
   handleMessage,
@@ -28,6 +29,7 @@ import {
 } from '../../../src/serve/worker/serve-init.js';
 import type { InitPayload } from '../../../src/serve/namespace.js';
 import type { OutboundMessage, ResMessage } from '../../../src/serve/worker/protocol.js';
+import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
 import { sandbox as authOps } from 'pyric/auth';
 import {
   initializeSandbox,
@@ -78,6 +80,23 @@ const RTDB_RULES = {
     '.write': true,
   },
 };
+
+// NOTE: like storage-ops.test.ts, storage rules are written WITHOUT the
+// /b/{bucket}/o wrapper — pyric/storage's evaluator matches against the
+// reference's raw fullPath.
+const DENY_ALL_STORAGE_RULES = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if false;
+  }
+}`;
+
+const OWNER_ONLY_STORAGE_RULES = `
+service firebase.storage {
+  match /users/{uid}/{file} {
+    allow read, write: if request.auth.uid == uid;
+  }
+}`;
 
 async function makeCtx(): Promise<HostCtx> {
   const sandbox = initializeSandbox();
@@ -175,6 +194,69 @@ describe('applyServeInit — rules', () => {
     const result = applyServeInit(ctx, { ...basePayload, rules: 'this is not valid rules {{' }, { fetch: recordingFetch() });
     expect(result.rulesDeployed).toBe(false);
     expect(result.rulesParseError).not.toBeNull();
+  });
+});
+
+describe('applyServeInit — storage rules', () => {
+  it('deploys storage.rules at boot: a deny-all ruleset denies an upload through the worker', async () => {
+    const ctx = await makeCtx();
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, storageRules: DENY_ALL_STORAGE_RULES },
+      { fetch: recordingFetch() },
+    );
+    expect(result.storageRulesDeployed).toBe(true);
+
+    const port = fakePort();
+    await handleMessage(ctx, port, {
+      t: 'op',
+      id: 's1',
+      method: 'storage.putBytes',
+      path: 'locked/x',
+      dataB64: bytesToBase64(new TextEncoder().encode('hello')),
+    });
+    const res = getRes(port, 's1');
+    expect(res.ok).toBe(false);
+    expect((res as ResMessage & { ok: false }).error.code).toBe('storage/unauthorized');
+  });
+
+  it('an allowed op passes through when rules permit it (owner-only, acting as the owner)', async () => {
+    const ctx = await makeCtx();
+    const result = applyServeInit(
+      ctx,
+      { ...basePayload, storageRules: OWNER_ONLY_STORAGE_RULES },
+      { fetch: recordingFetch() },
+    );
+    expect(result.storageRulesDeployed).toBe(true);
+
+    const port = fakePort();
+    await handleMessage(ctx, port, {
+      t: 'op',
+      id: 's2',
+      method: 'storage.putBytes',
+      path: 'users/ada/notes.txt',
+      dataB64: bytesToBase64(new TextEncoder().encode('mine')),
+      actAs: { mode: 'as', uid: 'ada' },
+    });
+    const res = getRes(port, 's2');
+    expect(res.ok).toBe(true);
+  });
+
+  it('no storage.rules configured: matches Firestore/RTDB\'s open-by-default posture', async () => {
+    const ctx = await makeCtx();
+    const result = applyServeInit(ctx, { ...basePayload, storageRules: null }, { fetch: recordingFetch() });
+    expect(result.storageRulesDeployed).toBe(false);
+
+    const port = fakePort();
+    await handleMessage(ctx, port, {
+      t: 'op',
+      id: 's3',
+      method: 'storage.putBytes',
+      path: 'anything/goes',
+      dataB64: bytesToBase64(new TextEncoder().encode('open')),
+    });
+    const res = getRes(port, 's3');
+    expect(res.ok).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What was open

`pyric dev` deployed `firestore.rules` and `database.rules` into the sandbox worker at init (`serve-init.ts`'s `applyServeInit`), but never `storage.rules`. `host.ts`'s `lensStorage`/`ensureStorage` opened the storage service with no rules configured, so every storage op in served (SharedWorker) mode ran against an effectively open bucket regardless of what `storage.rules` said — uploads/reads/deletes all bypassed the project's rules.

## What's enforced now

- `firebase.json`'s `storage` block (`{ rules: "storage.rules" }`, or an array of per-bucket entries — the first entry with a `rules` path wins, matching v1's single implicit bucket) is discovered the same way `firestore.rules`/`database.rules` are, falling back to `storage.rules` in cwd.
- The rules source is validated (`pyric/storage`'s parser) at CLI startup — a broken ruleset fails fast, same as firestore/database.
- `applyServeInit` opens the sandbox's storage service with those rules (`getStorageSandbox(ctx.sandbox, { rules })`) as its very first storage call, before any port op can reach `ensureStorage`/`lensStorage` in `host.ts` — so every lens (anonymous page handle, `{ as: uid }`, admin bypass) enforces the same ruleset consistently.
- Comments in `host.ts`, `client.ts`, and `entries/storage.ts` that claimed "worker-mode storage is effectively open today" are updated to describe the fix.

## No-rules-file behavior (precedent it matches)

No `storage.rules` configured → the sandbox opens with `rules: null`, and `pyric/storage`'s `enforce.ts` treats a null ruleset as allow-all. This is the same open-by-default posture as no `firestore.rules` (served with the permissive starter ruleset) and no `database.rules` (RTDB sandbox default rules) — not a new policy, just applying the existing convention to the third rules file.

## A real, called-out limitation: no hot-reload

Unlike Firestore/RTDB rules, storage rules do **not** hot-reload. `pyric/storage`'s `getStorageSandbox`/`getAdminStorageSandbox` only honor a `rules` option on the *first* call per `Sandbox` — a later, differing source throws (a deliberate silent-rules-wipe guard already in `pyric/storage`, not something this PR is changing). Firestore/RTDB rules are mutable in-process and support live re-deploy via SSE (`rules-changed`); storage's architecture doesn't currently support that. Editing `storage.rules` while `pyric dev` is running requires restarting the dev server. This is stated in the CLI's boot log (`✔ rules ... edits require a restart`) and in code comments, rather than silently doing nothing.

## Tests

`packages/pyric-tools/test/serve/worker/serve-init.test.ts` — new `applyServeInit — storage rules` block:
- deny-all `storage.rules` → an upload through the worker is denied (written FIRST, confirmed failing against current `main` before the fix — `storageRulesDeployed` was `undefined` and the deny-all upload succeeded)
- owner-only `storage.rules` → an allowed op (acting as the owner) passes
- no `storage.rules` → matches the open-by-default posture

Full `packages/pyric-tools` serve suite (394 tests) and `bun test`/typecheck are green. The only pre-existing failures in the wider `pyric-tools` suite are unrelated environment issues (SIGINT/process-exit timing tests, a `--help` snapshot test, and a missing `dist/register` build artifact) — none touch this change.