### PR TITLE
Support granular Storage rule verbs (get/list/create/update/delete)

### DIFF
--- a/packages/pyric/docs/storage/reference/rules-subset.md
+++ b/packages/pyric/docs/storage/reference/rules-subset.md
@@ -36,12 +36,17 @@ Path variables bind to the surrounding scope — `uid` from the parent match is 
 
 ## Allow conditions
 
-Two verbs:
+Coarse umbrellas and granular verbs, matching production Storage semantics.
 
-- `allow read: if <expr>` — matches `getBytes`, `getBlob`, `getMetadata`.
-- `allow write: if <expr>` — matches `uploadBytes`, `uploadString`, `updateMetadata`, `deleteObject`.
+- `allow read: if <expr>` — the umbrella for `get` + `list`.
+- `allow write: if <expr>` — the umbrella for `create` + `update` + `delete`.
+- `allow get` — `getBlob` / `getBytes` / `getMetadata`.
+- `allow list` — `listAll`.
+- `allow create` — `uploadBytes` / `uploadString` to a path with no existing object.
+- `allow update` — `uploadBytes` / `uploadString` over an existing object, and `updateMetadata`.
+- `allow delete` — `deleteObject`.
 
-The granular forms (`get`, `list`, `create`, `update`, `delete`) are deferred. The parser rejects them.
+A granular grant covers only its own verb: `allow get` does not grant `list`, and `allow create` does not grant `update` or `delete`. Verbs may be comma-separated in one clause (`allow get, list: if <expr>`). A verb with no applicable grant is denied.
 
 ## Request bindings
 
@@ -84,7 +89,6 @@ These produce parse errors:
 - `matches()` / regex predicates.
 - Rule function definitions (`function isOwner() { return ... }`).
 - Deep dotted access into `customMetadata.<field>` — use the bracket form.
-- Granular verbs (`get`, `list`, `create`, `update`, `delete`).
 
 See [Implementation scope and deferred features](../explanation/implementation-scope.md) for the reasoning.
 

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -83,7 +83,7 @@ export async function deleteObject(ref: StorageReference): Promise<void> {
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'write',
+      method: 'delete',
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
@@ -130,7 +130,7 @@ async function fetchBlob(
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'read',
+      method: 'get',
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),

--- a/packages/pyric/src/storage/index.ts
+++ b/packages/pyric/src/storage/index.ts
@@ -71,6 +71,9 @@ export { parseStorageRules, evaluateStorageRules } from './rules.js';
 export type {
   StorageRules,
   StorageMethod,
+  StorageVerb,
+  StorageRequestMethod,
+  StorageGrantVerb,
   StorageAuth,
   StorageRequest,
   StorageResource,

--- a/packages/pyric/src/storage/list.ts
+++ b/packages/pyric/src/storage/list.ts
@@ -63,7 +63,7 @@ export async function listAll(refIn: StorageReference): Promise<ListResult> {
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'read',
+      method: 'list',
       path: refIn.fullPath,
     },
     resource: null,

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -136,7 +136,7 @@ export async function getMetadata(ref: StorageReference): Promise<FullMetadata> 
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'read',
+      method: 'get',
       path: ref.fullPath,
     },
     resource: resourceFromStored(stored),
@@ -173,7 +173,9 @@ export async function updateMetadata(
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'write',
+      // updateMetadata always targets an existing object (it throws
+      // object-not-found below when absent), so the verb is `update`.
+      method: 'update',
       path: ref.fullPath,
       // The patched view drives `request.resource` for size /
       // contentType / metadata rule checks. Custom metadata is

--- a/packages/pyric/src/storage/rules.ts
+++ b/packages/pyric/src/storage/rules.ts
@@ -18,8 +18,11 @@
  *   - Nested `match` blocks with path segments:
  *       literal (`sessions`), parameter (`{sessionId}`), and
  *       multi-segment wildcard (`{allPaths=**}`)
- *   - `allow read | write : if <expr>;` (other granular verbs
- *     defer)
+ *   - `allow <verb>[, <verb>]* : if <expr>;` where verb is one of
+ *     the coarse umbrellas (`read`, `write`) or the granular verbs
+ *     (`get`, `list`, `create`, `update`, `delete`). `read` grants
+ *     get + list; `write` grants create + update + delete; a granular
+ *     grant covers only its own verb.
  *   - Expressions:
  *       literals: number, string, boolean, null
  *       identifiers: `request`, `resource`, plus path parameters
@@ -31,8 +34,7 @@
  * Out of scope (mirrors the survey + plan): `request.time`,
  * `matches()`/regex, function definitions, `customMetadata.<field>`
  * deep access (use bracket form against `resource.metadata` when
- * really needed), the granular verbs `get | list | create | update
- * | delete`. Hooks for adding them later live at the obvious
+ * really needed). Hooks for adding more live at the obvious
  * extension seams in the parser + evaluator.
  */
 
@@ -40,8 +42,42 @@
 // Public types
 // ═══════════════════════════════════════════════════════════════
 
-/** Method abstraction the operation layer hands to the evaluator. */
+/** Coarse permission umbrellas. `read` covers get + list; `write`
+ *  covers create + update + delete. */
 export type StorageMethod = 'read' | 'write';
+
+/** Granular operation verbs. Production Storage maps each operation to
+ *  exactly one of these:
+ *    download / getMetadata      → get
+ *    list                        → list
+ *    upload to NONEXISTENT path  → create
+ *    upload / updateMetadata over
+ *      an EXISTING object        → update
+ *    delete                      → delete
+ */
+export type StorageVerb = 'get' | 'list' | 'create' | 'update' | 'delete';
+
+/** What a caller records as the request's operation. Callers pass the
+ *  precise granular verb; the coarse forms remain accepted so the
+ *  umbrella semantics are symmetric. */
+export type StorageRequestMethod = StorageMethod | StorageVerb;
+
+/** A verb token that may appear in an `allow` clause. */
+export type StorageGrantVerb = StorageMethod | StorageVerb;
+
+/**
+ * Expand a coarse umbrella verb into its granular sub-verbs; a granular
+ * verb expands to itself. This is the single definition of the
+ * read→{get,list} / write→{create,update,delete} semantics, used by both
+ * the request side and the grant side of matching.
+ */
+function expandVerb(verb: StorageGrantVerb | StorageRequestMethod): StorageVerb[] {
+  switch (verb) {
+    case 'read': return ['get', 'list'];
+    case 'write': return ['create', 'update', 'delete'];
+    default: return [verb];
+  }
+}
 
 /** Identity passed in with the request. `null` is anonymous. */
 export interface StorageAuth {
@@ -52,7 +88,7 @@ export interface StorageAuth {
 /** Inbound request bindings the rules see. */
 export interface StorageRequest {
   auth: StorageAuth | null;
-  method: StorageMethod;
+  method: StorageRequestMethod;
   /** Path of the object the request targets. */
   path: string;
   /** Per-Firebase: on writes, `request.resource` describes the
@@ -103,7 +139,7 @@ type PathSegment =
   | { kind: 'wildcard'; name: string };
 
 interface AllowRule {
-  verbs: StorageMethod[];
+  verbs: StorageGrantVerb[];
   condition: Expr | null;
 }
 
@@ -130,7 +166,12 @@ type Token =
 
 const KEYWORDS = new Set([
   'service', 'match', 'allow', 'if', 'true', 'false', 'null',
-  'read', 'write',
+  'read', 'write', 'get', 'list', 'create', 'update', 'delete',
+]);
+
+/** Verb tokens accepted in an `allow` clause. */
+const GRANT_VERBS = new Set<StorageGrantVerb>([
+  'read', 'write', 'get', 'list', 'create', 'update', 'delete',
 ]);
 const MULTI_CHAR_OPS = ['==', '!=', '<=', '>=', '&&', '||'];
 
@@ -301,7 +342,7 @@ class Parser {
   /** Parse `allow <verb>[, <verb>]*: if <expr>;` */
   private parseAllow(): AllowRule {
     this.expectIdent('allow');
-    const verbs: StorageMethod[] = [];
+    const verbs: StorageGrantVerb[] = [];
     verbs.push(this.parseVerb());
     while (this.atPunct(',')) {
       this.expectPunct(',');
@@ -317,11 +358,13 @@ class Parser {
     return { verbs, condition };
   }
 
-  private parseVerb(): StorageMethod {
+  private parseVerb(): StorageGrantVerb {
     const t = this.expect('ident');
-    if (t.value === 'read' || t.value === 'write') return t.value;
+    if (GRANT_VERBS.has(t.value as StorageGrantVerb)) {
+      return t.value as StorageGrantVerb;
+    }
     throw new SyntaxError(
-      `Unsupported verb "${t.value}" at offset ${t.pos}. V1 scope supports only 'read' and 'write'; the granular forms (get/list/create/update/delete) defer to follow-up work.`,
+      `Unsupported verb "${t.value}" at offset ${t.pos}. Storage rules support read, write, get, list, create, update, and delete.`,
     );
   }
 
@@ -557,6 +600,11 @@ export function evaluateStorageRules(
   const pathSegments = splitPath(input.request.path);
   const reasons: string[] = [];
 
+  // The operation's verb, reduced to its granular set. A coarse
+  // request method expands to its sub-verbs so umbrella semantics are
+  // symmetric; a precise granular verb expands to itself.
+  const requestVerbs = new Set(expandVerb(input.request.method));
+
   /**
    * Walk a match block. `remaining` is the still-unmatched part of
    * the request path; `params` are the bindings accumulated so far.
@@ -578,13 +626,18 @@ export function evaluateStorageRules(
     // rules. (Or if a wildcard absorbed the remainder.)
     if (left.length === 0) {
       for (const rule of block.allows) {
-        if (!rule.verbs.includes(input.request.method)) continue;
+        // A grant applies when the operation's verb falls within the
+        // grant's verbs after coarse→granular expansion. `allow read`
+        // covers get + list; `allow get` covers only get.
+        const grantVerbs = new Set(rule.verbs.flatMap(expandVerb));
+        const applies = [...requestVerbs].some((v) => grantVerbs.has(v));
+        if (!applies) continue;
         const result = rule.condition
           ? truthy(evalExpr(rule.condition, input, newParams))
           : true;
         if (result) return true;
         reasons.push(
-          `match ${formatPath(block.segments)} ${rule.verbs.join(', ')}: condition false`,
+          `match ${formatPath(block.segments)} ${input.request.method}: condition false`,
         );
       }
     }

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -69,7 +69,10 @@ export async function uploadBytes(
   enforceRules(service, {
     request: {
       auth: target.context.auth,
-      method: 'write',
+      // A write to a nonexistent object is a `create`; a write over an
+      // existing one is an `update`. The resource-exists fact (`existing`)
+      // makes the distinction the granular verbs need.
+      method: existing ? 'update' : 'create',
       path: ref.fullPath,
       resource: requestResourceFor({
         size: stored.size,

--- a/packages/pyric/test/storage/rules.test.ts
+++ b/packages/pyric/test/storage/rules.test.ts
@@ -67,14 +67,24 @@ describe('parseStorageRules', () => {
     ).toThrow();
   });
 
-  it('rejects unsupported verbs in the v1 scope subset', () => {
+  it('parses the granular verbs (get/list/create/update/delete)', () => {
     expect(() =>
       parseStorageRules(`service firebase.storage {
         match /b/{bucket}/o {
-          match /x/{id} { allow get: if true; }
+          match /x/{id} { allow get, list, create, update, delete: if true; }
         }
       }`),
-    ).toThrow(/Unsupported verb "get"/);
+    ).not.toThrow();
+  });
+
+  it('rejects verbs outside the storage grammar', () => {
+    expect(() =>
+      parseStorageRules(`service firebase.storage {
+        match /b/{bucket}/o {
+          match /x/{id} { allow query: if true; }
+        }
+      }`),
+    ).toThrow(/Unsupported verb "query"/);
   });
 
   it('rejects unterminated strings', () => {
@@ -263,6 +273,128 @@ describe('evaluateStorageRules — metadata bindings (#764)', () => {
   });
 });
 
+// ─── Granular verbs (get/list/create/update/delete) ──────────────
+//
+// Production Storage semantics:
+//   - `read`  is the umbrella for `get` + `list`.
+//   - `write` is the umbrella for `create` + `update` + `delete`.
+//   - A granular grant covers ONLY its own verb.
+//   - Deny-by-default: a verb with no applicable grant is denied.
+
+describe('evaluateStorageRules — granular verbs', () => {
+  const path = 'b/pyric-default/o/files/f1.bin';
+
+  function evalVerb(source: string, method: string) {
+    const rules = parseStorageRules(source);
+    return evaluateStorageRules(rules, {
+      request: { auth: { uid: 'alice' }, method: method as never, path },
+      resource: null,
+    }).allowed;
+  }
+
+  function ruleset(allow: string): string {
+    return `service firebase.storage {
+      match /b/{bucket}/o {
+        match /files/{fileId} { ${allow} }
+      }
+    }`;
+  }
+
+  it('read is an umbrella granting both get and list', () => {
+    const src = ruleset('allow read: if true;');
+    expect(evalVerb(src, 'get')).toBe(true);
+    expect(evalVerb(src, 'list')).toBe(true);
+  });
+
+  it('write is an umbrella granting create, update, and delete', () => {
+    const src = ruleset('allow write: if true;');
+    expect(evalVerb(src, 'create')).toBe(true);
+    expect(evalVerb(src, 'update')).toBe(true);
+    expect(evalVerb(src, 'delete')).toBe(true);
+  });
+
+  it('allow get grants get but NOT list', () => {
+    const src = ruleset('allow get: if true;');
+    expect(evalVerb(src, 'get')).toBe(true);
+    expect(evalVerb(src, 'list')).toBe(false);
+  });
+
+  it('allow list grants list but NOT get', () => {
+    const src = ruleset('allow list: if true;');
+    expect(evalVerb(src, 'list')).toBe(true);
+    expect(evalVerb(src, 'get')).toBe(false);
+  });
+
+  it('allow create grants create but NOT update or delete', () => {
+    const src = ruleset('allow create: if true;');
+    expect(evalVerb(src, 'create')).toBe(true);
+    expect(evalVerb(src, 'update')).toBe(false);
+    expect(evalVerb(src, 'delete')).toBe(false);
+  });
+
+  it('allow update grants update but NOT create or delete', () => {
+    const src = ruleset('allow update: if true;');
+    expect(evalVerb(src, 'update')).toBe(true);
+    expect(evalVerb(src, 'create')).toBe(false);
+    expect(evalVerb(src, 'delete')).toBe(false);
+  });
+
+  it('allow delete grants delete but NOT create or update', () => {
+    const src = ruleset('allow delete: if true;');
+    expect(evalVerb(src, 'delete')).toBe(true);
+    expect(evalVerb(src, 'create')).toBe(false);
+    expect(evalVerb(src, 'update')).toBe(false);
+  });
+
+  it('parses and honors a comma-separated verb list (allow get, list)', () => {
+    const src = ruleset('allow get, list: if true;');
+    expect(evalVerb(src, 'get')).toBe(true);
+    expect(evalVerb(src, 'list')).toBe(true);
+    expect(evalVerb(src, 'create')).toBe(false);
+  });
+
+  it('mixes granular grants: create allowed, update/delete denied', () => {
+    const src = ruleset('allow create: if request.auth != null; allow get: if true;');
+    expect(evalVerb(src, 'create')).toBe(true);
+    expect(evalVerb(src, 'get')).toBe(true);
+    expect(evalVerb(src, 'update')).toBe(false);
+    expect(evalVerb(src, 'delete')).toBe(false);
+    expect(evalVerb(src, 'list')).toBe(false);
+  });
+
+  it('deny-by-default: a verb with no applicable grant is denied', () => {
+    const src = ruleset('allow get: if true;');
+    const rules = parseStorageRules(src);
+    const r = evaluateStorageRules(rules, {
+      request: { auth: { uid: 'alice' }, method: 'delete' as never, path },
+      resource: null,
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reasons.length).toBeGreaterThan(0);
+    // The reason names the verb that was actually evaluated.
+    expect(r.reasons.join(' ')).toContain('delete');
+  });
+
+  it('create-vs-update discriminates on object existence (nonexistent → create)', () => {
+    // Grant only create; the create verb (nonexistent object) is allowed,
+    // the update verb (existing object) is denied — the caller supplies
+    // the verb based on the resource-exists fact.
+    const src = ruleset('allow create: if true;');
+    // create: request.resource present, resource (existing) null
+    const rules = parseStorageRules(src);
+    const asCreate = evaluateStorageRules(rules, {
+      request: { auth: { uid: 'alice' }, method: 'create' as never, path, resource: { size: 1 } },
+      resource: null,
+    });
+    const asUpdate = evaluateStorageRules(rules, {
+      request: { auth: { uid: 'alice' }, method: 'update' as never, path, resource: { size: 1 } },
+      resource: { size: 1 },
+    });
+    expect(asCreate.allowed).toBe(true);
+    expect(asUpdate.allowed).toBe(false);
+  });
+});
+
 // ─── Operation integration tests ──────────────────────────────────
 
 function authedStorage(label: string, auth: { uid: string } | null) {
@@ -431,6 +563,43 @@ describe('metadata-based authorization threads through real ops (#764)', () => {
     });
     const anon = metadataStorage(sandbox, dbName, null);
     await expect(getBlob(ref(anon, path))).rejects.toThrow(/unauthorized/);
+  });
+});
+
+describe('granular verbs thread through real ops (create vs update)', () => {
+  // Only `create` is granted: the first upload to a fresh path (a
+  // create) succeeds; a second upload over the now-existing object (an
+  // update) is denied. The caller classifies the op by object existence.
+  const CREATE_ONLY = `
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /files/{fileId} {
+      allow create: if request.auth != null;
+      allow read: if request.auth != null;
+    }
+  }
+}`;
+
+  const path = 'b/pyric-default/o/files/f1.json';
+
+  it('allows the initial create but denies an overwrite update', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('granular-create-only');
+    const alice = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { dbName, rules: CREATE_ONLY });
+    // First upload = create → allowed.
+    await uploadBytes(ref(alice, path), new Blob(['{}']), { contentType: 'application/json' });
+    // Second upload over the existing object = update → denied.
+    await expect(
+      uploadBytes(ref(alice, path), new Blob(['{"v":2}']), { contentType: 'application/json' }),
+    ).rejects.toThrow(/unauthorized/);
+  });
+
+  it('denies a delete when only create/read are granted', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('granular-no-delete');
+    const alice = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { dbName, rules: CREATE_ONLY });
+    await uploadBytes(ref(alice, path), new Blob(['{}']), { contentType: 'application/json' });
+    await expect(deleteObject(ref(alice, path))).rejects.toThrow(/unauthorized/);
   });
 });
 


### PR DESCRIPTION
## What

The hand-rolled Storage rules evaluator (`packages/pyric/src/storage/rules.ts`) supported only the coarse `allow read` / `allow write` verbs and **threw** on the granular forms. This implements production Firebase Storage semantics for `get`, `list`, `create`, `update`, and `delete`.

## Verb semantics

| Grant | Covers | Does NOT cover |
|-------|--------|----------------|
| `allow read` | `get`, `list` | — (umbrella) |
| `allow write` | `create`, `update`, `delete` | — (umbrella) |
| `allow get` | `get` | `list` |
| `allow list` | `list` | `get` |
| `allow create` | `create` | `update`, `delete` |
| `allow update` | `update` | `create`, `delete` |
| `allow delete` | `delete` | `create`, `update` |

- Comma-separated verb lists parse: `allow get, list: if ...`.
- **Deny-by-default**: a verb with no applicable grant is denied.

## Operation to verb mapping (callers pass the precise verb)

| Operation | Verb |
|-----------|------|
| `getBlob` / `getBytes` / `getMetadata` | `get` |
| `listAll` | `list` |
| upload to a **nonexistent** object | `create` |
| upload over an **existing** object / `updateMetadata` | `update` |
| `deleteObject` | `delete` |

The create-vs-update split reuses the resource-exists fact the evaluator already receives (`existing` in `upload.ts`).

## Scope

The `{ allowed, reasons[] }` result shape is unchanged; `reasons` now name the precise verb evaluated. No other rule-language surface is added — `request.time`, regex/`matches()`, function definitions, and firestore lookups remain out of scope and keep failing as before.

## Tests

Added to `packages/pyric/test/storage/rules.test.ts`:
- `evaluateStorageRules — granular verbs`: per-verb grant/deny matrix, read/write umbrella cases, comma-separated lists, mixed granular grants, deny-by-default (reason names the verb), create-vs-update discrimination on object existence.
- `granular verbs thread through real ops (create vs update)`: initial create allowed but overwrite update denied; delete denied when only create/read granted.
- Updated the parser test that previously asserted granular verbs throw.

Storage rules suite green (52 pass); package typecheck clean.