### PR TITLE
Persist storage rules through the verify fixture

### DIFF
--- a/packages/pyric-tools/src/verify/fixture.ts
+++ b/packages/pyric-tools/src/verify/fixture.ts
@@ -1,4 +1,5 @@
 import type { EventService, Sandbox, SandboxEvent } from 'pyric/sandbox';
+import { getStorageSandbox } from 'pyric/storage';
 import { isRtdbRulesJson } from '../rtdb/rules-json.js';
 
 export const VERIFY_FIXTURE_SCHEMA = 'pyric.verify.fixture.v1' as const;
@@ -11,6 +12,11 @@ export interface VerifyFirestoreRulesBlock {
 export interface VerifyRtdbRulesBlock {
   format: 'rtdb.rules.json';
   json: { rules: Record<string, unknown> };
+}
+
+export interface VerifyStorageRulesBlock {
+  format: 'storage.rules';
+  source: string;
 }
 
 export interface PyricVerifyFixture {
@@ -43,7 +49,10 @@ export interface PyricVerifyFixture {
       };
     };
     storage?: {
-      rules?: { format: 'storage.rules'; source: string };
+      /** RULES TEXT ONLY — captured object state is a separate, larger
+       *  redesign (persistence.ts's IDB blob store) and is deliberately
+       *  left untouched here. `state` stays `null` until that lands. */
+      rules: VerifyStorageRulesBlock;
       state: unknown;
     };
     [service: string]: unknown;
@@ -57,6 +66,10 @@ export interface BuildVerifyFixtureInput {
   rtdbRules?: { rules: Record<string, unknown> } | null;
   rtdbState?: unknown;
   rtdbDatabaseUrl?: string | null;
+  /** Currently-deployed storage rules text. RULES ONLY — there is no
+   *  `storageState` input; captured storage OBJECTS are a separate,
+   *  larger redesign left untouched by this fixture. */
+  storageRules?: string | null;
   authState?: {
     users?: unknown[];
     currentUser?: unknown;
@@ -102,6 +115,20 @@ export function buildVerifyFixture(input: BuildVerifyFixtureInput): PyricVerifyF
     };
   }
 
+  if (
+    input.storageRules != null ||
+    events.some((event) => eventService(event) === 'storage')
+  ) {
+    services.storage = {
+      rules: {
+        format: 'storage.rules',
+        source: input.storageRules ?? '',
+      },
+      // RULES TEXT ONLY (scope note above) — objects are never captured.
+      state: null,
+    };
+  }
+
   const authUsers = input.authState?.users;
   const currentUser = input.authState?.currentUser ?? input.sandbox.currentUser;
   if ((authUsers && authUsers.length > 0) || currentUser != null) {
@@ -144,6 +171,9 @@ export function parseVerifyFixture(value: unknown): PyricVerifyFixture {
   if (services.rtdb !== undefined) {
     assertRtdbService(services.rtdb);
   }
+  if (services.storage !== undefined) {
+    assertStorageService(services.storage);
+  }
   if (services.auth !== undefined && !isVerifyFixtureObject(services.auth)) {
     throw new Error('fixture.services.auth must be an object.');
   }
@@ -182,6 +212,38 @@ function assertRtdbService(value: unknown): void {
   if (!isVerifyFixtureObject(value.state) || !('tree' in value.state)) {
     throw new Error('fixture.services.rtdb.state.tree is required.');
   }
+}
+
+function assertStorageService(value: unknown): void {
+  if (!isVerifyFixtureObject(value)) throw new Error('fixture.services.storage must be an object.');
+  if (
+    !isVerifyFixtureObject(value.rules) ||
+    value.rules.format !== 'storage.rules' ||
+    typeof value.rules.source !== 'string'
+  ) {
+    throw new Error('fixture.services.storage.rules must contain storage.rules source.');
+  }
+}
+
+/**
+ * Re-deploy a fixture's captured storage rules into a sandbox's storage
+ * evaluator. RULES TEXT ONLY, mirroring the capture-side scope note: this
+ * never touches storage OBJECTS (persistence.ts's IDB blob store) — only
+ * `fixture.services.storage.rules.source` is applied.
+ *
+ * Storage rules are honored only on the FIRST `getStorageSandbox` call per
+ * `Sandbox` (see `storage/service.ts`), so this must run before any other
+ * code opens the storage service on `sandbox` — exactly the same ordering
+ * constraint firestore/rtdb rules already have at restore time. A no-op
+ * when the fixture carries no storage block.
+ */
+export function restoreStorageRulesFromFixture(
+  fixture: PyricVerifyFixture,
+  sandbox: Sandbox,
+): void {
+  const source = fixture.services.storage?.rules?.source;
+  if (source === undefined) return;
+  getStorageSandbox(sandbox, { rules: source });
 }
 
 function eventService(event: SandboxEvent): EventService {

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -38,11 +38,13 @@ export {
   buildVerifyFixture,
   fixtureVerifiableServices,
   parseVerifyFixture,
+  restoreStorageRulesFromFixture,
   VERIFY_FIXTURE_SCHEMA,
   type BuildVerifyFixtureInput,
   type PyricVerifyFixture,
   type VerifyFirestoreRulesBlock,
   type VerifyRtdbRulesBlock,
+  type VerifyStorageRulesBlock,
 } from './fixture.js';
 export {
   deriveRulesTestCases,

--- a/packages/pyric-tools/test/verify/verify.test.ts
+++ b/packages/pyric-tools/test/verify/verify.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
   getDatabase,
@@ -11,15 +12,21 @@ import {
 import { defineRtdbRules, allow, deny } from 'pyric/rules/rtdb';
 import { initializeSandbox } from 'pyric/sandbox';
 import { getAdminFirestore, getFirestore } from 'pyric/sandbox/admin-firestore';
+import { getStorageSandbox, ref as storageRef, uploadBytes } from 'pyric/storage';
 import {
   buildVerifyFixture,
   deriveRulesTestCases,
   parseVerifyFixture,
+  restoreStorageRulesFromFixture,
   verifyFixture,
   VerifyInputError,
   type PyricVerifyFixture,
 } from '../../src/verify/index.js';
 import type { ProjectScope } from '../../src/deploy/index.js';
+
+function uniqueDbName(label: string): string {
+  return `pyric-storage-verify-${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 const ALLOW_ALL_RTDB = { rules: { '.read': true, '.write': true } };
 const DENY_ALL_RTDB = { rules: { '.read': false, '.write': false } };
@@ -321,5 +328,89 @@ describe('verifyFixture', () => {
         rulesTestApi: { scope: MOCK_SCOPE },
       }),
     ).rejects.toThrow(VerifyInputError);
+  });
+});
+
+// ─── Storage rules — capture / restore round-trip ───────────────────────
+//
+// `services.storage.rules` used to be a typed-but-never-written slot:
+// firestore and rtdb rules ride the fixture (captured above), but no
+// caller ever passed `storageRules` into `buildVerifyFixture`, and
+// `parseVerifyFixture` didn't validate the block. This covers the full
+// loop: deployed rules -> captured fixture -> fresh sandbox restore ->
+// the restored rules actually enforcing (one denied op).
+describe('storage rules — fixture capture and restore', () => {
+  const OWNER_ONLY_RULES = `
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /users/{uid}/{fileName} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}`;
+
+  it('captures the deployed storage rules source into the fixture', async () => {
+    const sandbox = initializeSandbox();
+    getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
+      dbName: uniqueDbName('capture'),
+      rules: OWNER_ONLY_RULES,
+    });
+
+    const fixture = buildVerifyFixture({ sandbox, storageRules: OWNER_ONLY_RULES });
+
+    expect(fixture.services.storage?.rules).toEqual({
+      format: 'storage.rules',
+      source: OWNER_ONLY_RULES,
+    });
+    // Round-trips through parse/validate too.
+    expect(parseVerifyFixture(fixture).services.storage?.rules.source).toBe(OWNER_ONLY_RULES);
+  });
+
+  it('omits the storage block when no storage rules were deployed', () => {
+    const fixture = buildVerifyFixture({ sandbox: initializeSandbox() });
+    expect(fixture.services.storage).toBeUndefined();
+  });
+
+  it('restores captured rules into a fresh sandbox and they enforce (denied op)', async () => {
+    // Session 1: deploy rules, capture a fixture.
+    const dbName1 = uniqueDbName('restore-src');
+    const sandbox1 = initializeSandbox();
+    getStorageSandbox(sandbox1.withAuth({ uid: 'alice' }), {
+      dbName: dbName1,
+      rules: OWNER_ONLY_RULES,
+    });
+    const fixture = buildVerifyFixture({ sandbox: sandbox1, storageRules: OWNER_ONLY_RULES });
+
+    // Session 2: a FRESH sandbox that never saw the rules directly —
+    // restore them from the fixture before anything else opens storage.
+    const dbName2 = uniqueDbName('restore-dst');
+    const sandbox2 = initializeSandbox();
+    restoreStorageRulesFromFixture(fixture, sandbox2);
+
+    // Allowed: alice writing under her own uid.
+    const aliceStorage = getStorageSandbox(sandbox2.withAuth({ uid: 'alice' }), { dbName: dbName2 });
+    const allowedResult = await uploadBytes(
+      storageRef(aliceStorage, 'b/pyric-default/o/users/alice/notes.txt'),
+      new Blob(['hi']),
+      { contentType: 'text/plain' },
+    );
+    expect(allowedResult.metadata.fullPath).toBe('b/pyric-default/o/users/alice/notes.txt');
+
+    // Denied: bob writing under alice's uid — the restored rules are
+    // actually enforcing, not just present as inert text.
+    const bobStorage = getStorageSandbox(sandbox2.withAuth({ uid: 'bob' }), { dbName: dbName2 });
+    await expect(
+      uploadBytes(
+        storageRef(bobStorage, 'b/pyric-default/o/users/alice/hijack.txt'),
+        new Blob(['nope']),
+        { contentType: 'text/plain' },
+      ),
+    ).rejects.toThrow(/unauthorized/);
+  });
+
+  it('is a no-op when the fixture carries no storage block', () => {
+    const fixture = buildVerifyFixture({ sandbox: initializeSandbox() });
+    const sandbox = initializeSandbox();
+    expect(() => restoreStorageRulesFromFixture(fixture, sandbox)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Firestore and RTDB rules text ride `buildVerifyFixture`'s captured
snapshot (`services.firestore.rules`, `services.rtdb.rules`), but the
matching `services.storage.rules` slot was typed and never written —
no caller passed storage rules in, and `parseVerifyFixture` didn't
validate the block. This populates that dead slot end to end.

- `BuildVerifyFixtureInput.storageRules` captures the currently-deployed
  storage rules text into `services.storage.rules` on `buildVerifyFixture`.
- `parseVerifyFixture` now validates the storage block the same way it
  validates firestore/rtdb.
- `restoreStorageRulesFromFixture(fixture, sandbox)` re-deploys the
  captured rules into a fresh sandbox's storage evaluator via
  `getStorageSandbox({ rules })`.

**Scope note:** rules text only. Storage OBJECTS (the IDB blob store in
`packages/pyric/src/storage/persistence.ts`) are a separate, larger
redesign and are untouched here — `fixture.services.storage.state` stays
`null`.

**Not done / left for the concurrent branch:** wiring
`restoreStorageRulesFromFixture` into the live `pyric dev` worker boot
path (`packages/pyric-tools/src/serve/worker/serve-init.ts`). That file
is owned by `serve-storage-rules-enforcement`, which is concurrently
wiring storage rules deployment into serve's worker init, so it's left
for that branch to call this function rather than duplicating the work
here. The round-trip test in this PR exercises capture → restore →
enforcement directly against the exported function, without touching
serve-init.

## Test plan

- [x] `packages/pyric-tools/test/verify/verify.test.ts` — new
      `describe('storage rules — fixture capture and restore')` block:
      captures deployed rules into a fixture, confirms the block is
      omitted when no storage rules were deployed, restores captured
      rules into a fresh sandbox and confirms enforcement (an allowed
      write for the owner, a denied write for a different uid), and a
      no-op case when the fixture carries no storage block.
- [x] `bun test` in `packages/pyric-tools` — full suite green except 4
      pre-existing failures in `test/register/register-child.test.ts`
      that reproduce on a clean `origin/main` checkout in this
      environment (missing an unrelated build/register step) and are
      unrelated to this change.
- [x] `bun x tsc --noEmit` clean in `packages/pyric-tools`.