### PR TITLE
Fix RTDB atomic multi-path update rule projection

### DIFF
--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -638,7 +638,18 @@ export class RtdbBackend {
       }
       // Check every path under the rules engine. ANY denial fails the
       // entire update — the multi-path atomicity contract.
+      //
+      // A multi-path update is atomic: every path's `.write`/`.validate`
+      // rules must see `newData` reflecting the ENTIRE projected post-update
+      // tree (all paths applied together), not just its own leaf. Pass the
+      // full update set so the simulator builds one shared projection — a
+      // rule on `/a` that reads a sibling `/b` written in the same update
+      // must see `/b`'s new value.
       const mock = this.tree.snapshot() as Record<string, unknown>;
+      const updates = Object.entries(expanded).map(([absPath, value]) => ({
+        path: absPath,
+        value,
+      }));
       for (const [absPath, value] of Object.entries(expanded)) {
         const at = Date.now();
         const before = this.tree.read(absPath);
@@ -646,6 +657,7 @@ export class RtdbBackend {
           auth,
           mockData: mock,
           newData: value,
+          updates,
         });
         const common = {
           at,

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -75,6 +75,13 @@ export interface EvalContext {
   mockData: Record<string, unknown>;
   /** Proposed value at `path` for write/validate ops. Ignored for read. */
   newData?: unknown;
+  /**
+   * All paths written together in one atomic multi-path `update()`. When
+   * set, the simulator projects every listed path onto a single post-write
+   * tree so `path`'s rules see `newData` reflecting its sibling paths in the
+   * same update. Omit for single-path writes.
+   */
+  updates?: { path: string; value: unknown }[];
 }
 
 export class RulesEvaluator {
@@ -143,6 +150,7 @@ export class RulesEvaluator {
       auth: normalisedAuth,
       mockData: ctx.mockData,
       newData: ctx.newData,
+      updates: ctx.updates,
     });
     if (!result.success) {
       if (result.error.code === 'NO_MATCHING_RULE') {

--- a/packages/pyric/src/database/simulation/handler.ts
+++ b/packages/pyric/src/database/simulation/handler.ts
@@ -196,6 +196,41 @@ function withValueAt(root: unknown, segments: string[], value: unknown): unknown
   return currentObj;
 }
 
+/**
+ * Build the single post-write tree that a write/validate evaluation sees as
+ * `newData`.
+ *
+ * For a single-path write this is just `withValueAt(base, targetSegments,
+ * targetNewData)`. For an atomic multi-path `update()` — where `updates`
+ * lists every path written together — this folds `withValueAt` over EVERY
+ * listed path so the projection reflects the ENTIRE update applied at once.
+ * Each written path's rules are then evaluated against this shared tree,
+ * matching production RTDB: a multi-path update is atomic, so a rule on one
+ * written path sees `newData` for its sibling paths in the same update.
+ *
+ * Evaluating each path leaf-by-leaf against only its own new value (the old
+ * behavior) is a wrong-verdict bug: a rule that depends on a sibling path
+ * written in the same update sees that sibling as absent, flipping legal
+ * writes to a false DENY (and the reverse for `!exists()`-style escape
+ * hatches, a false ALLOW).
+ */
+function projectPostWriteTree(
+  base: unknown,
+  targetSegments: string[],
+  targetNewData: unknown,
+  updates: readonly { path: string; value?: unknown }[] | undefined,
+): unknown {
+  if (!updates || updates.length === 0) {
+    return withValueAt(base, targetSegments, targetNewData ?? null);
+  }
+  let root = base;
+  for (const update of updates) {
+    const segments = update.path.split('/').filter(Boolean);
+    root = withValueAt(root, segments, update.value ?? null);
+  }
+  return root;
+}
+
 export class SimulateHandler {
   execute(ir: RtdbIR | null, rawInput: unknown): SimulateResult {
     if (!ir) {
@@ -221,7 +256,7 @@ export class SimulateHandler {
       };
     }
 
-    const { operation, path, auth, mockData, newData } = parsed.data;
+    const { operation, path, auth, mockData, newData, updates } = parsed.data;
 
     try {
       const pathSegments = path.split('/').filter(Boolean);
@@ -240,10 +275,15 @@ export class SimulateHandler {
       // deepest path usually doesn't exist yet), which silently satisfies
       // `!data.exists()`-style escape hatches and produces a false ALLOW.
       const rootData = new DataSnapshot(mockData, '/');
-      // Post-write tree: mockData with `newData` merged in at the write
-      // path. Reads don't have a "post-write" state, so leave it as-is.
+      // Post-write tree: mockData with the proposed write merged in. Reads
+      // don't have a "post-write" state, so leave it as-is. For an atomic
+      // multi-path `update()` (`updates` present) the projection reflects
+      // EVERY path written together, so this path's rules see `newData` for
+      // its sibling paths in the same update.
       const mergedRoot =
-        operation === 'read' ? mockData : withValueAt(mockData, pathSegments, newData ?? null);
+        operation === 'read'
+          ? mockData
+          : projectPostWriteTree(mockData, pathSegments, newData, updates);
       const mergedRootData = new DataSnapshot(mergedRoot, '/');
 
       const dataAtPath = rootData.child(pathSegments.join('/'));

--- a/packages/pyric/src/database/simulation/spec.ts
+++ b/packages/pyric/src/database/simulation/spec.ts
@@ -9,6 +9,18 @@ export const SimulationInputSchema = z.object({
   ]),
   mockData: z.record(z.unknown()),
   newData: z.unknown().optional(),
+  /**
+   * The full set of paths written together in one atomic multi-path
+   * `update()` (the `{ "/a/b": 1, "/c/d": 2 }` shape). When present, the
+   * simulator projects EVERY listed path onto a single post-write tree and
+   * evaluates `path`'s rules against that shared projection — so a rule on
+   * one written path sees `newData` reflecting its sibling paths in the
+   * same update. Omit for single-path writes (the simulator then projects
+   * only `path`/`newData`). Each path is absolute (root-relative).
+   */
+  updates: z
+    .array(z.object({ path: z.string().min(1).startsWith('/'), value: z.unknown() }))
+    .optional(),
 });
 export type SimulationInput = z.infer<typeof SimulationInputSchema>;
 

--- a/packages/pyric/test/database/modular/sandbox-target.test.ts
+++ b/packages/pyric/test/database/modular/sandbox-target.test.ts
@@ -236,6 +236,61 @@ describe('update — multi-path atomic (matrix row #23)', () => {
     // deny reads for the other-user path.)
     expect(rtdbSandbox.snapshotState(aliceDb)).toEqual({});
   });
+
+  it('a path whose rule depends on a sibling written in the SAME update is allowed (atomic projection)', async () => {
+    // A multi-path update is atomic: every path's rules see `newData`
+    // reflecting the ENTIRE projected post-update tree. Here `/rooms/r1/
+    // messages` may only be written when the room's `meta/count` is present;
+    // the same update supplies it. Leaf-by-leaf evaluation would project the
+    // messages path alone, see `meta/count` absent, and falsely deny.
+    const { db } = setup();
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          $roomId: {
+            messages: {
+              '.write': "newData.parent().child('meta/count').exists()",
+            },
+            meta: { '.write': 'true' },
+          },
+        },
+      },
+    });
+    await update(ref(db, '/'), {
+      '/rooms/r1/messages/m1': 'hi',
+      '/rooms/r1/meta/count': 1,
+    });
+    expect(rtdbSandbox.snapshotState(db)).toEqual({
+      rooms: { r1: { messages: { m1: 'hi' }, meta: { count: 1 } } },
+    });
+  });
+
+  it('denies the whole update when a path depends on a sibling that is NOT in the update', async () => {
+    const { db } = setup();
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          $roomId: {
+            messages: {
+              '.write': "newData.parent().child('meta/count').exists()",
+            },
+            meta: { '.write': 'true' },
+          },
+        },
+      },
+    });
+    let threw = false;
+    try {
+      // Only the messages path is written; `meta/count` is absent, so the
+      // messages rule denies and the whole atomic update rejects.
+      await update(ref(db, '/'), { '/rooms/r1/messages/m1': 'hi' });
+    } catch (e) {
+      threw = true;
+      expect((e as Error & { code: string }).code).toBe('PERMISSION_DENIED');
+    }
+    expect(threw).toBe(true);
+    expect(rtdbSandbox.snapshotState(db)).toEqual({});
+  });
 });
 
 describe('push (oracle: rtdb-push-autoid-format)', () => {

--- a/packages/pyric/test/database/simulation/handler.test.ts
+++ b/packages/pyric/test/database/simulation/handler.test.ts
@@ -644,3 +644,270 @@ describe('SimulateHandler — data/newData rooted at rule location', () => {
     if (denied.success) expect(denied.data.allowed).toBe(false);
   });
 });
+
+// ── atomic multi-path update projection ─────────────────────────────────
+//
+// An atomic multi-path `update()` (the `{ "/a/b": 1, "/c/d": 2 }` shape)
+// applies every listed path together. Production RTDB evaluates each
+// written path's rules against a `newData` reflecting the ENTIRE projected
+// post-update tree — all paths merged — while still checking each path's
+// rules individually. Evaluating leaf-by-leaf (each path against only its
+// own new value) is a wrong-verdict bug: a rule on path A that depends on a
+// sibling path B written in the SAME update sees B as absent, flipping a
+// legal write to a false DENY. The `updates` field carries the full update
+// set so the simulator builds one shared projection.
+describe('SimulateHandler — atomic multi-path update projection', () => {
+  const handler = new SimulateHandler();
+
+  const expr = (raw: string): RtdbNode['write'] => ({
+    raw,
+    parsed: { raw, valid: true, errors: [], warnings: [], referencedIdentifiers: [] },
+  });
+
+  const node = (partial: Partial<RtdbNode> & { path: string }): RtdbNode => ({
+    pathVariables: [],
+    exists: true,
+    children: [],
+    ...partial,
+  });
+
+  const ir = (rules: RtdbNode): RtdbIR => ({
+    service: 'realtime-database',
+    databaseUrl: 'https://test.firebaseio.com',
+    rules,
+  });
+
+  const authed = { uid: 'alice', token: {} };
+
+  // `.write` on the messages path depends on a sibling `meta/count` under
+  // the SAME room; the room's `/meta` subtree is write-open so the second
+  // leaf lands on its own merit.
+  const siblingDepIR = ir(
+    node({
+      path: '/',
+      children: [
+        node({
+          path: '/rooms',
+          children: [
+            node({
+              path: '/rooms/$roomId',
+              pathVariables: ['$roomId'],
+              children: [
+                node({
+                  path: '/rooms/$roomId/messages',
+                  pathVariables: ['$roomId'],
+                  write: expr("newData.parent().child('meta/count').exists()"),
+                }),
+                node({
+                  path: '/rooms/$roomId/meta',
+                  pathVariables: ['$roomId'],
+                  write: expr('true'),
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    }),
+  );
+
+  test('(a) ALLOWS a path whose rule depends on a sibling path written in the SAME update', () => {
+    // Old leaf-by-leaf behavior: `/rooms/room1/messages` was projected with
+    // ONLY its own value, so `meta/count` looked absent → false DENY.
+    const updates = [
+      { path: '/rooms/room1/messages', value: { m1: 'hi' } },
+      { path: '/rooms/room1/meta/count', value: 1 },
+    ];
+    const result = handler.execute(siblingDepIR, {
+      operation: 'write',
+      path: '/rooms/room1/messages',
+      auth: authed,
+      mockData: {},
+      newData: { m1: 'hi' },
+      updates,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.allowed).toBe(true);
+  });
+
+  test('(b) DENIES the same path when the depended-on sibling is NOT part of the update', () => {
+    // No `updates` (or a single-path update): the projection contains only
+    // the messages write, `meta/count` is genuinely absent → correct DENY.
+    const result = handler.execute(siblingDepIR, {
+      operation: 'write',
+      path: '/rooms/room1/messages',
+      auth: authed,
+      mockData: {},
+      newData: { m1: 'hi' },
+      updates: [{ path: '/rooms/room1/messages', value: { m1: 'hi' } }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.allowed).toBe(false);
+  });
+
+  test('(b2) characterizes the OLD leaf-by-leaf behavior — a single-path projection of the depended-on path denies', () => {
+    // With no `updates` the handler projects only `path`/`newData`. This is
+    // exactly what the pre-fix fan-out did for EVERY path, which is why the
+    // legal cross-path write in (a) used to falsely deny.
+    const result = handler.execute(siblingDepIR, {
+      operation: 'write',
+      path: '/rooms/room1/messages',
+      auth: authed,
+      mockData: {},
+      newData: { m1: 'hi' },
+    });
+    expect(result.success && result.data.allowed).toBe(false);
+  });
+
+  test('(c) evaluates .validate against the shared projected tree', () => {
+    const validateExpr = (raw: string): RtdbNode['validate'] => ({
+      raw,
+      parsed: { raw, valid: true, errors: [], warnings: [], referencedIdentifiers: [] },
+    });
+    const validateIR = ir(
+      node({
+        path: '/',
+        write: expr('true'),
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                children: [
+                  node({
+                    path: '/rooms/$roomId/messages',
+                    pathVariables: ['$roomId'],
+                    // A message may only be written when the room's total is
+                    // present in the same atomic update.
+                    validate: validateExpr("newData.parent().child('meta/count').exists()"),
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const allowed = handler.execute(validateIR, {
+      operation: 'write',
+      path: '/rooms/room1/messages',
+      auth: authed,
+      mockData: {},
+      newData: { m1: 'hi' },
+      updates: [
+        { path: '/rooms/room1/messages', value: { m1: 'hi' } },
+        { path: '/rooms/room1/meta/count', value: 1 },
+      ],
+    });
+    expect(allowed.success && allowed.data.allowed).toBe(true);
+
+    const denied = handler.execute(validateIR, {
+      operation: 'write',
+      path: '/rooms/room1/messages',
+      auth: authed,
+      mockData: {},
+      newData: { m1: 'hi' },
+      updates: [{ path: '/rooms/room1/messages', value: { m1: 'hi' } }],
+    });
+    expect(denied.success && denied.data.allowed).toBe(false);
+  });
+
+  test('(d) a denied path in the update returns allowed=false (caller rejects the whole atomic batch)', () => {
+    // The fan-out throws on the first denied path so nothing applies; at the
+    // handler level the denied path surfaces as allowed=false.
+    const ownedIR = ir(
+      node({
+        path: '/',
+        children: [
+          node({
+            path: '/users',
+            children: [
+              node({
+                path: '/users/$uid',
+                pathVariables: ['$uid'],
+                write: expr('auth.uid === $uid'),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const updates = [
+      { path: '/users/alice/name', value: 'Alice' },
+      { path: '/users/bob/name', value: 'Bob' },
+    ];
+    const ownPath = handler.execute(ownedIR, {
+      operation: 'write',
+      path: '/users/alice/name',
+      auth: authed,
+      mockData: {},
+      newData: 'Alice',
+      updates,
+    });
+    expect(ownPath.success && ownPath.data.allowed).toBe(true);
+
+    const otherPath = handler.execute(ownedIR, {
+      operation: 'write',
+      path: '/users/bob/name',
+      auth: authed,
+      mockData: {},
+      newData: 'Bob',
+      updates,
+    });
+    expect(otherPath.success && otherPath.data.allowed).toBe(false);
+  });
+
+  test('(e) an ANCESTOR rule over deep paths sees the full merged projection of all update paths', () => {
+    // `.write` at `/rooms/$roomId` requires both `a` and `b` present in the
+    // post-write room. Two deep paths under the common ancestor supply them
+    // in one update; evaluating either deep path, the ancestor rule (rooted
+    // at the room) must see both.
+    const ancestorIR = ir(
+      node({
+        path: '/',
+        children: [
+          node({
+            path: '/rooms',
+            children: [
+              node({
+                path: '/rooms/$roomId',
+                pathVariables: ['$roomId'],
+                write: expr("newData.hasChildren(['a', 'b'])"),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const updates = [
+      { path: '/rooms/room1/a', value: 1 },
+      { path: '/rooms/room1/b', value: 2 },
+    ];
+    for (const target of ['/rooms/room1/a', '/rooms/room1/b']) {
+      const result = handler.execute(ancestorIR, {
+        operation: 'write',
+        path: target,
+        auth: authed,
+        mockData: {},
+        newData: target.endsWith('/a') ? 1 : 2,
+        updates,
+      });
+      expect(result.success && result.data.allowed).toBe(true);
+    }
+
+    // Without the sibling in the update, the ancestor rule denies — only one
+    // of the two required children is present.
+    const partial = handler.execute(ancestorIR, {
+      operation: 'write',
+      path: '/rooms/room1/a',
+      auth: authed,
+      mockData: {},
+      newData: 1,
+      updates: [{ path: '/rooms/room1/a', value: 1 }],
+    });
+    expect(partial.success && partial.data.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug: leaf-by-leaf multi-path validation

A multi-path `update()` — the `{ "/a/b": 1, "/c/d": 2 }` shape — is **atomic** in production RTDB. Every written path's `.write`/`.validate` rules must see `newData` reflecting the **entire projected post-update tree** (all paths applied together), while each written path's rules are still evaluated individually.

The simulator validated each path in isolation. The multi-path fan-out in `backend.ts` called the rules engine once per path with `newData: <only this path's new value>`, and the handler projected only that single path onto the current tree (via #103's `withValueAt`). So when evaluating path A, any sibling path B written in the **same** update looked **absent**.

### Root-cause characterization (what the old behavior actually did)

For a rule on path A that depends on a sibling B in the same update, the projected `newData` never contained B. Concretely it was a **false DENY** for existence-style dependencies, and the mirror **false ALLOW** for `!exists()`-style escape hatches — a wrong-verdict class, a security-relevant divergence from prod.

### Concrete two-path example

Rules:
```
/rooms/$roomId/messages  .write: newData.parent().child('meta/count').exists()
/rooms/$roomId/meta      .write: true
```
Update:
```js
update(ref(db, '/'), {
  '/rooms/r1/messages/m1': 'hi',
  '/rooms/r1/meta/count': 1,   // sibling the messages rule depends on
})
```
Production **allows** this (the atomic tree has both). The old simulator projected `/rooms/r1/messages/m1` alone, saw `meta/count` absent, and **falsely denied** the whole batch.

## The fix

Build **one** projected post-write tree by folding `withValueAt` over **every** path in the update, then evaluate each written path's rules against that shared projection. Atomicity of application was already correct — the fan-out threw on the first denied path and applied nothing until all paths passed; only the per-path `newData` projection was wrong.

- `spec.ts`: optional `updates` field carries the full atomic update set (`{ path, value }[]`).
- `handler.ts`: `projectPostWriteTree` folds all update paths onto one tree (single-path writes unchanged).
- `rules-eval.ts`: threads `updates` through `EvalContext`.
- `backend.ts`: the multi-path fan-out builds the update set once and passes it to every per-path evaluation.

## Tests

Handler unit suite `SimulateHandler — atomic multi-path update projection`:
- `(a) ALLOWS a path whose rule depends on a sibling path written in the SAME update`
- `(b) DENIES the same path when the depended-on sibling is NOT part of the update`
- `(b2) characterizes the OLD leaf-by-leaf behavior — a single-path projection of the depended-on path denies`
- `(c) evaluates .validate against the shared projected tree`
- `(d) a denied path in the update returns allowed=false (caller rejects the whole atomic batch)`
- `(e) an ANCESTOR rule over deep paths sees the full merged projection of all update paths`

End-to-end `update — multi-path atomic (matrix row #23)` (real fan-out):
- `a path whose rule depends on a sibling written in the SAME update is allowed (atomic projection)`
- `denies the whole update when a path depends on a sibling that is NOT in the update`

`bun test` (4419 pass, 0 fail) and `bunx tsc --noEmit` (no new errors) green.

## Overlap with #103

Built on `main`, which already has #103 (`Fix RTDB rules data/newData rooting false-allow`). This change **reuses #103's `withValueAt` helper and depends on its data/newData rooting**: the shared projection is fed to ancestor rules through the same rooting path #103 established. No merge conflict is expected against current `main`, but both PRs live in the same `handler.ts` neighborhood (the `mergedRoot` construction) — review should sequence #103 first, then this. If #103's `mergedRoot` line changes further before merge, expect a small overlap right at `projectPostWriteTree`'s call site.

Draft — do not merge.
