### PR TITLE
Thread storage-op provenance through async dispatch

### DIFF
--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -88,7 +88,7 @@ import {
   type Query,
   type SetOptions,
 } from 'pyric/firestore';
-import type { Sandbox, PersistenceBackend, AuthLens } from 'pyric/sandbox';
+import type { Sandbox, PersistenceBackend, AuthLens, EventProvenance } from 'pyric/sandbox';
 // The canonical value codec (same module the protocol's read path uses) —
 // write payloads rehydrate host-side so marker-shaped scalars from the JSON
 // relay legs are STORED as real wrapper instances (see prepareWriteData).
@@ -1381,8 +1381,10 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       // Byte upload (remote sandbox, slice 2). Decode-end size cap: reject an
       // oversized base64 string BEFORE materializing its bytes, then re-check
       // the exact decoded length. Rules enforce under the op's lens; the
-      // upload emits `service_mutation` events, so server writes get Studio
-      // provenance for free.
+      // upload emits `service_mutation` events. Storage dispatch is async, so
+      // the event escapes the ambient-provenance window `handleMessage` opened;
+      // thread the op's provenance EXPLICITLY so a Studio-issued write is
+      // attributable end to end (issue #84 item 3).
       try {
         if (msg.dataB64.length > MAX_STORAGE_OP_B64_LENGTH) {
           throw storagePayloadTooLarge(
@@ -1399,6 +1401,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
           storageRef(storage, msg.path),
           bytes,
           toSettableMetadata(msg),
+          opProvenance(msg),
         );
         // FullMetadata — plain JSON, relay-safe.
         ok(port, msg.id, result.metadata);
@@ -1436,9 +1439,11 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       // `pyric/storage`'s sandbox delete is idempotent (no-op on missing) —
       // matching the pyric-admin local arm's delete semantics. Rules enforce
       // `write` under the op's lens; deletes emit `service_mutation` events.
+      // Async dispatch escapes the ambient window — thread provenance
+      // explicitly (issue #84 item 3).
       try {
         const storage = lensStorage(ctx, msg.actAs);
-        await storageDeleteObject(storageRef(storage, msg.path));
+        await storageDeleteObject(storageRef(storage, msg.path), opProvenance(msg));
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1691,33 +1696,50 @@ export async function handleMessage(
   port: PortLike,
   msg: InboundMessage,
 ): Promise<void> {
-  // Op provenance, stamped MECHANICALLY at dispatch:
-  //   - `actor`: a client that DECLARED itself the issuer (`issuer: 'studio'`,
-  //     stamped by Studio's worker client — see `setOpIssuer` in client.ts)
-  //     gets `actor: { kind: 'studio' }`. Bridge-relayed frames are forwarded
-  //     verbatim without the stamp (client.ts `relayWorkerOp`), so remote
-  //     admin/agent traffic is never mislabeled as Studio's.
-  //   - `authLens`: the op's EFFECTIVE lens (`msg.actAs`) is stamped whenever
-  //     present — independent of issuer declaration, because admin is admin
-  //     regardless of who asked (an agent tool relay's admin op must classify
-  //     as a rules BYPASS in Traffic, not as a rules allow). Without this,
-  //     Firestore admin-lens ops carried no lens on their events and
-  //     `verdictFor` mislabeled the bypass as ALLOW (the RTDB/Firestore
-  //     asymmetry the traffic-metrics work flagged).
-  // Events an emitter already stamped win over the window (stampProvenance
-  // semantics: the event's own field always beats the ambient default).
-  const issuer = (msg as { issuer?: 'studio' }).issuer;
-  const actAs = (msg as { actAs?: AuthLens }).actAs;
-  if ((issuer === 'studio' || actAs) && ctx.sandbox.runWithProvenance) {
-    return ctx.sandbox.runWithProvenance(
-      {
-        ...(issuer === 'studio' ? { actor: { kind: 'studio' } } : {}),
-        ...(actAs ? { authLens: actAs } : {}),
-      },
-      () => dispatchMessage(ctx, port, msg),
-    );
+  // Op provenance, bound at dispatch by `opProvenance` (see its docs). Opened
+  // as the sandbox's SYNCHRONOUS ambient window so firestore/rtdb/auth emits —
+  // which run inside `dispatchMessage` before any await — pick it up. Storage
+  // ops emit AFTER async awaits, outside this window, so they thread the same
+  // provenance EXPLICITLY instead (see `handleOp`'s storage cases). Without the
+  // lens on admin ops, `verdictFor` mislabeled a rules BYPASS as ALLOW (the
+  // RTDB/Firestore asymmetry the traffic-metrics work flagged).
+  const prov = opProvenance(msg);
+  if (prov && ctx.sandbox.runWithProvenance) {
+    return ctx.sandbox.runWithProvenance(prov, () => dispatchMessage(ctx, port, msg));
   }
   return dispatchMessage(ctx, port, msg);
+}
+
+/**
+ * Op provenance from an inbound message, bound at ISSUE time. The single
+ * source of truth for both the SYNCHRONOUS ambient-provenance window
+ * (firestore/rtdb/auth emit inside it) and the EXPLICIT thread that storage
+ * ops need (their emits run after async awaits, outside any window — see
+ * `handleOp`'s storage cases and `uploadBytes`'s provenance note).
+ *
+ *   - `actor`: a client that DECLARED itself the issuer (`issuer: 'studio'`,
+ *     stamped by Studio's worker client — `setOpIssuer` in client.ts) gets
+ *     `actor: { kind: 'studio' }`. Bridge-relayed frames are forwarded
+ *     verbatim without the stamp (client.ts `relayWorkerOp`), so remote
+ *     admin/agent traffic is never mislabeled as Studio's.
+ *   - `authLens`: the op's EFFECTIVE lens (`msg.actAs`) whenever present —
+ *     independent of issuer, because admin is admin regardless of who asked
+ *     (an agent tool relay's admin op must classify as a rules BYPASS in
+ *     Traffic, not a rules allow).
+ *
+ * Returns `undefined` for a plain served-app op (no issuer, no lens) so the
+ * event keeps the app-session default — a served-app op stays untagged.
+ * Events an emitter already stamped win over these defaults (stampProvenance
+ * semantics: the event's own field beats the ambient/threaded default).
+ */
+function opProvenance(msg: InboundMessage): EventProvenance | undefined {
+  const issuer = (msg as { issuer?: 'studio' }).issuer;
+  const actAs = (msg as { actAs?: AuthLens }).actAs;
+  if (issuer !== 'studio' && !actAs) return undefined;
+  return {
+    ...(issuer === 'studio' ? { actor: { kind: 'studio' } } : {}),
+    ...(actAs ? { authLens: actAs } : {}),
+  };
 }
 
 async function dispatchMessage(

--- a/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
+++ b/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Storage-op PROVENANCE across the async dispatch boundary (worker host).
+ *
+ * THE BUG THIS PINS (issue #84 item 3 — async provenance for service ops):
+ * op provenance (`actor`, `authLens`) is stamped via the sandbox's SYNCHRONOUS
+ * ambient-provenance window (`runWithProvenance`), opened by `handleMessage`
+ * around `dispatchMessage`. Firestore/RTDB/auth emit their events
+ * synchronously inside that window, so the stamp lands. STORAGE ops dispatch
+ * ASYNCHRONOUSLY — `uploadBytes`/`deleteObject` await the backend
+ * (getMetadata → put/delete) before emitting the `service_mutation` event. By
+ * the time the emit runs, `runWithProvenance`'s synchronous `finally` has
+ * already restored the ambient window, so the storage event escapes it and a
+ * Studio-issued upload lands with NO `actor` — silently misattributed as
+ * app-session traffic.
+ *
+ * THE INTERLEAVING HAZARD (why "just widen the window to await fn" is wrong):
+ * two ops from different issuers can be in flight concurrently. If the window
+ * stayed open across awaits, op A's window would still be ambient when op B's
+ * event emits — swapping actors. The fix must BIND provenance at issue time
+ * and thread it through the async dispatch explicitly, so concurrent ops never
+ * cross-contaminate.
+ *
+ * FIX UNDER TEST: `handleMessage`/`handleOp` capture the op's provenance
+ * (issuer → actor, actAs → authLens) at issue time and pass it EXPLICITLY into
+ * the storage op, which forwards it to its emit — independent of the ambient
+ * window. Provenance is bound at the moment the op is issued, immutable
+ * thereafter.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox, type SandboxEvent } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { getStorageSandbox } from 'pyric/storage';
+
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  ResMessage,
+} from '../../../src/serve/worker/protocol.js';
+import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
+
+let dbSeq = 0;
+function uniqueDbName(): string {
+  return `pyric-storage-prov-${++dbSeq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCtx(): { ctx: HostCtx; events: SandboxEvent[] } {
+  const sandbox = initializeSandbox();
+  getStorageSandbox(sandbox, { dbName: uniqueDbName() });
+  const events: SandboxEvent[] = [];
+  sandbox.onEvent((e) => events.push(e));
+  return {
+    ctx: { db: getFirestore(sandbox), sandbox, instanceId: 'storage-prov-test', subs: new Map() },
+    events,
+  };
+}
+
+let opSeq = 0;
+function op(ctx: HostCtx, payload: Record<string, unknown>): Promise<ResMessage> {
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'res') resolve(msg);
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...payload,
+      t: 'op',
+      id: `spop-${++opSeq}`,
+    } as InboundMessage);
+  });
+}
+
+const DATA = bytesToBase64(new TextEncoder().encode('payload'));
+
+/** All `object_put` mutation events for a given path. */
+function putsFor(events: SandboxEvent[], path: string): SandboxEvent[] {
+  return events.filter(
+    (e) =>
+      e.kind === 'service_mutation' &&
+      (e as { op?: string }).op === 'object_put' &&
+      (e as { path?: string }).path === path,
+  );
+}
+
+describe('worker host: storage op provenance survives async dispatch', () => {
+  it('stamps actor:{kind:"studio"} on a Studio-issued upload event', async () => {
+    const { ctx, events } = makeCtx();
+    const res = await op(ctx, {
+      method: 'storage.putBytes',
+      path: 'studio/blob.bin',
+      dataB64: DATA,
+      issuer: 'studio',
+    });
+    expect(res.ok).toBe(true);
+
+    const puts = putsFor(events, 'studio/blob.bin');
+    expect(puts.length).toBeGreaterThan(0);
+    for (const e of puts) {
+      expect(e.actor).toEqual({ kind: 'studio' });
+    }
+  });
+
+  it('a served-app upload (no issuer) stays untagged — no studio actor', async () => {
+    const { ctx, events } = makeCtx();
+    const res = await op(ctx, {
+      method: 'storage.putBytes',
+      path: 'app/blob.bin',
+      dataB64: DATA,
+    });
+    expect(res.ok).toBe(true);
+
+    const puts = putsFor(events, 'app/blob.bin');
+    expect(puts.length).toBeGreaterThan(0);
+    for (const e of puts) {
+      // Untagged: no studio actor. (Absent, or an explicit app default —
+      // never studio.)
+      expect(e.actor?.kind).not.toBe('studio');
+    }
+  });
+
+  it('two concurrent uploads from different issuers do not swap actors', async () => {
+    const { ctx, events } = makeCtx();
+    // Issue BOTH before awaiting either — their async backend windows overlap.
+    // A naive "widen the ambient window across awaits" fix would let the
+    // app op's event emit while the studio window is still ambient (or vice
+    // versa), swapping actors. Explicit per-op binding must keep them distinct.
+    const [studioRes, appRes] = await Promise.all([
+      op(ctx, { method: 'storage.putBytes', path: 'race/studio.bin', dataB64: DATA, issuer: 'studio' }),
+      op(ctx, { method: 'storage.putBytes', path: 'race/app.bin', dataB64: DATA }),
+    ]);
+    expect(studioRes.ok).toBe(true);
+    expect(appRes.ok).toBe(true);
+
+    const studioPuts = putsFor(events, 'race/studio.bin');
+    const appPuts = putsFor(events, 'race/app.bin');
+    expect(studioPuts.length).toBeGreaterThan(0);
+    expect(appPuts.length).toBeGreaterThan(0);
+    for (const e of studioPuts) expect(e.actor).toEqual({ kind: 'studio' });
+    for (const e of appPuts) expect(e.actor?.kind).not.toBe('studio');
+  });
+
+  it('an admin-lens delete carries authLens:{mode:"admin"} on its event (bypass classification)', async () => {
+    const { ctx, events } = makeCtx();
+    // Seed then delete under the admin lens; the delete event must carry the
+    // lens it ran under so Traffic classifies the BYPASS correctly — the
+    // storage mirror of the Firestore lens-provenance guarantee.
+    await op(ctx, { method: 'storage.putBytes', path: 'admin/gone.bin', dataB64: DATA, actAs: { mode: 'admin' } });
+    const res = await op(ctx, {
+      method: 'storage.deleteObject',
+      path: 'admin/gone.bin',
+      actAs: { mode: 'admin' },
+    });
+    expect(res.ok).toBe(true);
+
+    const deletes = events.filter(
+      (e) =>
+        e.kind === 'service_mutation' &&
+        (e as { op?: string }).op === 'object_delete' &&
+        (e as { path?: string }).path === 'admin/gone.bin',
+    );
+    expect(deletes.length).toBeGreaterThan(0);
+    for (const e of deletes) {
+      expect(e.authLens).toEqual({ mode: 'admin' });
+    }
+  });
+});

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -18,6 +18,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored } from './rules.js';
@@ -70,8 +71,16 @@ export async function getBlob(
  * `storage/object-not-found` when the path is missing. The v1 scope
  * keeps the persistence-layer no-op behavior for now; Slice 8 will
  * reconsider whether to mirror the strict throw.
+ *
+ * `provenance` (host-only): op {@link EventProvenance} bound at ISSUE time,
+ * threaded EXPLICITLY onto the emitted `object_delete` event. The delete
+ * awaits the backend before emitting, so it escapes the sandbox's
+ * synchronous ambient-provenance window — see the note on `uploadBytes`.
  */
-export async function deleteObject(ref: StorageReference): Promise<void> {
+export async function deleteObject(
+  ref: StorageReference,
+  provenance?: EventProvenance,
+): Promise<void> {
   guardNonRoot(ref, 'deleteObject');
   const target = targetOf(ref.storage);
   if (target.kind === 'prod') {
@@ -100,7 +109,7 @@ export async function deleteObject(ref: StorageReference): Promise<void> {
         before: existing ?? undefined,
         detail: { bucket: ref.bucket },
       }),
-      { service: 'storage' },
+      { ...provenance, service: 'storage' },
     );
   } catch {
     // Observational — never let event emission break a storage delete.

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -17,6 +17,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
@@ -157,10 +158,16 @@ export async function getMetadata(ref: StorageReference): Promise<FullMetadata> 
  * place. To explicitly clear a field, the JS SDK accepts `null` —
  * we don't model that in the v1 scope to keep the patch logic simple.
  * Documented for Slice 9's deferred-features section.
+ *
+ * `provenance` (host-only): op {@link EventProvenance} bound at ISSUE time,
+ * threaded EXPLICITLY onto the emitted `metadata_update` event. Emit runs
+ * after the backend awaits, escaping the sandbox's synchronous
+ * ambient-provenance window — see the note on `uploadBytes`.
  */
 export async function updateMetadata(
   ref: StorageReference,
   patch: SettableMetadata,
+  provenance?: EventProvenance,
 ): Promise<FullMetadata> {
   guardNonRoot(ref, 'updateMetadata');
   const target = targetOf(ref.storage);
@@ -208,7 +215,7 @@ export async function updateMetadata(
           after: next,
           detail: { bucket: ref.bucket },
         }),
-        { service: 'storage' },
+        { ...provenance, service: 'storage' },
       );
     } catch {
       // Observational — never let event emission break a metadata update.

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -25,6 +25,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
@@ -46,11 +47,22 @@ export type StringFormat = 'raw' | 'base64' | 'data_url';
  * Throws when the reference targets the root (`fullPath === ''`) —
  * uploads need a non-empty path, matching Firebase's
  * `invalid-root-operation` precondition.
+ *
+ * `provenance` (host-only) is the op's {@link EventProvenance} bound at
+ * ISSUE time by the worker host — `actor`/`authLens` threaded EXPLICITLY
+ * onto the emitted `service_mutation` event. Storage dispatch is async
+ * (the awaits above), so it escapes the sandbox's synchronous
+ * ambient-provenance window (`runWithProvenance`); the window has already
+ * closed by the time this emit runs. Passing provenance through the call
+ * binds it immutably to THIS op, so concurrent uploads from different
+ * issuers can never swap actors. `service: 'storage'` always wins. Omitted
+ * ⇒ the app-session default (a served-app write stays untagged).
  */
 export async function uploadBytes(
   ref: StorageReference,
   data: Blob | Uint8Array | ArrayBuffer,
   metadata?: SettableMetadata,
+  provenance?: EventProvenance,
 ): Promise<UploadResult> {
   guardNonRoot(ref, 'uploadBytes');
   const target = targetOf(ref.storage);
@@ -99,7 +111,7 @@ export async function uploadBytes(
           overwrite: existing != null,
         },
       }),
-      { service: 'storage' },
+      { ...provenance, service: 'storage' },
     );
   } catch {
     // Observational — never let event emission break a storage write.


### PR DESCRIPTION
## Problem

Op provenance (`actor`, `authLens`) is stamped via the sandbox's **synchronous** ambient-provenance window: `handleMessage` opens `runWithProvenance(prov, () => dispatchMessage(...))`. Firestore/RTDB/auth emit their events synchronously inside `dispatchMessage` (before any `await`), so the stamp lands.

**Where the context was lost:** storage ops dispatch asynchronously. `uploadBytes`/`deleteObject` `await` the backend (`getStorageService` → `getMetadata` → `put`/`delete`) *before* emitting their `service_mutation` event. `runWithProvenance` restores the ambient window in a `finally` the moment `dispatchMessage` returns its promise — long before those awaits resolve. So the storage emit runs with the window already closed:

- a Studio-issued upload lost `actor: { kind: 'studio' }` and was silently misattributed as app-session traffic;
- an admin-lens storage op lost `authLens: { mode: 'admin' }`, so Traffic's `verdictFor` mislabeled the rules **bypass** as a rules **allow** (the storage mirror of the Firestore lens-provenance bug).

The loss is a promise-chain hop, not a postMessage boundary: the provenance never leaves the worker, it just outlives the synchronous window that carried it.

## The interleaving hazard

The naive fix — make `runWithProvenance` `await fn` so the window stays open across the storage awaits — is wrong. Two ops from different issuers can be in flight concurrently; a widened window would still be ambient when the *other* op's event emits, swapping actors. Misattribution is worse than missing attribution, so the fix cannot rely on ambient state that outlives a synchronous frame.

## The fix (binding invariant)

Capture provenance at **issue time** (`opProvenance(msg)`: `issuer → actor`, `actAs → authLens`) and thread it **explicitly** through the async dispatch — passed as an argument into `uploadBytes`/`deleteObject`/`updateMetadata`, which forward it onto their emit (`{ ...provenance, service: 'storage' }`, so `service` always wins). Provenance is bound the moment the op is issued and immutable thereafter; each op carries its own object, so concurrent ops from different issuers can never cross-contaminate. `opProvenance` is now the single source of truth for both the ambient window (firestore/rtdb/auth) and the explicit storage thread.

- Served-app ops (no `issuer`, no `actAs`) return `undefined` → the event keeps the app-session default and stays **untagged**.
- Admin-lens bypass ops now carry `authLens` on their storage events, matching Firestore semantics under the same lens.

## Tests

New: `packages/pyric-tools/test/serve/worker/storage-provenance.test.ts`

- `stamps actor:{kind:"studio"} on a Studio-issued upload event`
- `a served-app upload (no issuer) stays untagged — no studio actor`
- `two concurrent uploads from different issuers do not swap actors` (the interleaving hazard)
- `an admin-lens delete carries authLens:{mode:"admin"} on its event (bypass classification)`

All four fail before the change (studio → app, admin → app-session) and pass after. Full `packages/pyric/test/storage` (149) and `packages/pyric-tools/test/serve` (387) suites green; `pyric-tools` typecheck clean.

## Overlap with #106 (`serve-storage-rules-enforcement`)

Both branches touch `packages/pyric-tools/src/serve/worker/host.ts`, but in **different regions with no textual conflict**: #106 edits the `lensStorage`/`ensureStorage` doc comment (~line 621) to describe serve-init configuring storage rules; this change edits `handleMessage`/`opProvenance` (~line 1700) and the `storage.putBytes`/`storage.deleteObject` dispatch cases. Conceptually complementary — #106 enforces rules at serve-init, this stamps provenance at dispatch. No overlap in the storage source files (`upload.ts`/`download.ts`/`metadata.ts`).

Addresses issue #84 item 3 (async provenance for service ops).
