### PR TITLE
Fix Firestore rules getAfter() to see sibling writes in the same batch

### DIFF
--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -89,6 +89,26 @@ export interface SimulationContext {
   afterStatePath: Path;
   afterState: Record<string, unknown> | null;
   existsAfter: boolean;
+  /**
+   * Batch/transaction sibling-write projection (getafter-batch fix).
+   *
+   * `afterState`/`afterStatePath` above only describe the ONE document
+   * this simulate() call is evaluating a rule for. In production,
+   * `getAfter(path)` sees the post-commit state of the ENTIRE atomic
+   * batch/transaction, not just the current write — a rule on doc A can
+   * read what doc B will become once the whole batch lands. Callers that
+   * evaluate a multi-op batch/transaction build ONE projected map up
+   * front (normalized relative path → post-write data, or `null` for a
+   * doc the batch deletes) covering every op in the group, and pass the
+   * SAME map into every per-op simulate() call. Keyed the same way as
+   * `mockDocuments` (normalized relative path, no `/databases/.../documents/`
+   * prefix). A path absent from this map was not written by the batch —
+   * `getAfter` on it falls through to `get()` (current committed data),
+   * matching production. Single-op writes (execute()) omit this map
+   * entirely, so `getAfter` on any path but the op's own target falls
+   * through to `get()` exactly as before.
+   */
+  batchProjection?: Map<string, Record<string, unknown> | null>;
   /** Optional per-rule expression-trace recorder. When set, the evaluator
    *  wraps every `evaluate()` call and records the sub-expression tree;
    *  when absent (the default), the evaluator is unchanged. The handler
@@ -793,8 +813,13 @@ function evaluateFunctionCall(
     case 'getAfter': {
       // Item 7 — projected post-write state.
       // For the document being written (matches request.path), return the
-      // afterState. For unrelated paths, fall through to get() — the write
-      // under evaluation doesn't affect them.
+      // afterState. getafter-batch fix: for a SIBLING doc written earlier
+      // (or later) in the same atomic batch/transaction, consult the
+      // shared batchProjection map so the rule sees that write too — matches
+      // production, where getAfter() reflects the whole batch's post-commit
+      // state, not just the current op. Only once neither applies do we
+      // fall through to get() (current committed data) for a doc the batch
+      // doesn't touch.
       const argVal = evaluate(args[0], ctx, scope);
       const pathStr = String(argVal);
       if (pathStr === ctx.afterStatePath.toString()) {
@@ -805,16 +830,29 @@ function evaluateFunctionCall(
         }
         return makeGetResource(normalizePath(pathStr, ctx), ctx.afterState);
       }
+      const normalized = normalizePath(pathStr, ctx);
+      if (ctx.batchProjection?.has(normalized)) {
+        const projected = ctx.batchProjection.get(normalized)!;
+        if (projected === null) {
+          throw new EvalError(`getAfter() of non-existent document '${pathStr}' (guard with existsAfter() first)`);
+        }
+        return makeGetResource(normalized, projected);
+      }
       return resolveGet(pathStr, ctx);
     }
     case 'existsAfter': {
       // Item 7 — projected existence after the write.
       // Same dispatch shape as getAfter: target path uses ctx.existsAfter,
-      // other paths fall through to exists().
+      // sibling batch writes consult batchProjection, other paths fall
+      // through to exists().
       const argVal = evaluate(args[0], ctx, scope);
       const pathStr = String(argVal);
       if (pathStr === ctx.afterStatePath.toString()) {
         return ctx.existsAfter;
+      }
+      const normalized = normalizePath(pathStr, ctx);
+      if (ctx.batchProjection?.has(normalized)) {
+        return ctx.batchProjection.get(normalized) !== null;
       }
       return resolveExists(pathStr, ctx);
     }

--- a/packages/pyric/src/rules/simulator/handler.ts
+++ b/packages/pyric/src/rules/simulator/handler.ts
@@ -377,6 +377,7 @@ function buildContext(
   functions: FunctionDef[],
   pathVariables: Record<string, string>,
   getDoc?: (path: string) => Record<string, unknown> | null,
+  batchProjection?: Map<string, Record<string, unknown> | null>,
 ): SimulationContext {
   const fnMap = new Map<string, FunctionDef>();
   for (const fn of functions) fnMap.set(fn.name, fn);
@@ -496,6 +497,9 @@ function buildContext(
     afterStatePath: fullPath,
     afterState: projectedAfter,
     existsAfter,
+    // getafter-batch fix — shared batch/transaction projection, when the
+    // caller supplied one. Absent for single-op evaluation.
+    ...(batchProjection ? { batchProjection } : {}),
   };
 }
 
@@ -509,7 +513,20 @@ export class SimulateFirestoreRulesHandler {
   simulate(
     source: string,
     testCases: TestCase[],
-    opts?: { getDoc?: (path: string) => Record<string, unknown> | null },
+    opts?: {
+      getDoc?: (path: string) => Record<string, unknown> | null;
+      /**
+       * getafter-batch fix — shared post-commit projection for a batch or
+       * transaction. Keyed by normalized relative path (same shape as
+       * `getDoc`'s input); value is the post-write document, or `null` for
+       * a path the batch/transaction deletes. Every per-op simulate() call
+       * for the SAME batch/transaction passes the SAME map, built once by
+       * the caller (LocalEnvironment.batch()/transaction()) up front —
+       * mirrors how the RTDB rules projection covers a multi-path update
+       * in one shared tree. Omit for single-op evaluation.
+       */
+      batchProjection?: Map<string, Record<string, unknown> | null>;
+    },
   ): TestFirestoreRulesResult {
     // Parse rules. Give the empty-input case a distinct, actionable
     // error — agents that see "Failed to parse rules source" otherwise
@@ -641,7 +658,7 @@ export class SimulateFirestoreRulesHandler {
       for (const match of matches) {
         const allFunctions = [...match.parentFunctions, ...match.block.functions];
         const pathVars = { ...rootBindings, ...match.pathVariables };
-        const ctx = buildContext(tc, allFunctions, pathVars, opts?.getDoc);
+        const ctx = buildContext(tc, allFunctions, pathVars, opts?.getDoc, opts?.batchProjection);
 
         const blockPath = renderBlockPath(match.block);
         const res = evaluateRules(match.block, tc.method, ctx);

--- a/packages/pyric/src/sandbox/firestore/local-environment.ts
+++ b/packages/pyric/src/sandbox/firestore/local-environment.ts
@@ -2069,6 +2069,7 @@ export class LocalEnvironment {
   private runSimulate(
     testCases: TestCase[],
     bypassRules: boolean | undefined,
+    batchProjection?: Map<string, DocumentData | null>,
   ): TestFirestoreRulesResult {
     if (bypassRules) {
       const results = testCases.map((tc) => adminBypassResult(tc.description));
@@ -2079,7 +2080,31 @@ export class LocalEnvironment {
     }
     return this.simulator.simulate(this.rulesSource, testCases, {
       getDoc: (path) => this.state.get(path),
+      ...(batchProjection ? { batchProjection } : {}),
     });
+  }
+
+  /**
+   * getafter-batch fix — build the shared post-commit projection for an
+   * atomic batch/transaction, ONCE, before evaluating any per-op rule.
+   * Every op in `testCases` gets folded in: `create`/`update` project to
+   * the full post-write document (already merged by `buildTestCase`),
+   * `delete` projects to `null` (doc gone). `get`/`list` ops don't write
+   * and are skipped — they never change what `getAfter` should see.
+   *
+   * Passing the SAME map into every per-op `simulate()` call for the group
+   * is what lets doc A's rule see doc B's pending write via `getAfter(B)`
+   * — mirrors the RTDB rules multi-path projection (one shared tree built
+   * up front, read by every path's rule eval) applied to Firestore's
+   * per-document `getAfter()`.
+   */
+  private buildBatchProjection(testCases: TestCase[]): Map<string, DocumentData | null> {
+    const projection = new Map<string, DocumentData | null>();
+    for (const tc of testCases) {
+      if (tc.method === 'get' || tc.method === 'list') continue;
+      projection.set(tc.path, tc.method === 'delete' ? null : (tc.data ?? {}));
+    }
+    return projection;
   }
 
   // ═══ Single operation (rules evaluated) ═══
@@ -2553,7 +2578,18 @@ export class LocalEnvironment {
       }
     }
 
-    // Evaluate rules for each operation against CURRENT state (no cross-visibility)
+    // Evaluate rules for each operation. `request`/`resource` (the doc's
+    // OWN pre/post state) still resolve against CURRENT pre-batch state —
+    // no cross-visibility there, matching how request.resource.data works
+    // in production. `getAfter()` on a SIBLING doc is different: it must
+    // see this batch's other pending writes, so we build one shared
+    // post-commit projection up front (getafter-batch fix) and hand the
+    // same map to every op's simulate() call below.
+    const batchTestCases = resolvedOps.map((op) =>
+      this.buildTestCase({ method: op.method, path: op.path, auth, data: op.data }, serverTime),
+    );
+    const batchProjection = this.buildBatchProjection(batchTestCases);
+
     let allAllowed = true;
     for (let i = 0; i < resolvedOps.length; i++) {
       const op = resolvedOps[i]!;
@@ -2562,10 +2598,10 @@ export class LocalEnvironment {
       // so consumers see the user's INTENT (with FieldValue.* markers),
       // not the materialized values.
       const preData = operations[i]?.data;
-      const testCase = this.buildTestCase({ method: op.method, path: op.path, auth, data: op.data }, serverTime);
+      const testCase = batchTestCases[i]!;
       const evalAt = Date.now();
       const evalStart = performance.now();
-      const simResult = this.runSimulate([testCase], bypassRules);
+      const simResult = this.runSimulate([testCase], bypassRules, batchProjection);
       const evalMs = performance.now() - evalStart;
 
       if (!simResult.success) {
@@ -3015,6 +3051,21 @@ export class LocalEnvironment {
     }
 
     // ─── Step 5 — per-op rules evaluation against pre-tx state ───────
+    // getafter-batch fix: build the shared post-commit projection ONCE for
+    // the whole transaction (same approach as batch(), same helper) so
+    // `getAfter()` on a sibling write-in-progress doc sees this
+    // transaction's other pending writes, not just its own.
+    const txTestCases = resolvedOps.map((op) => {
+      const exists = this.state.get(op.path) !== null;
+      const ruleMethod = (op.method === 'set'
+        ? exists
+          ? 'update'
+          : 'create'
+        : op.method) as 'create' | 'update' | 'delete';
+      return this.buildTestCase({ method: ruleMethod, path: op.path, auth, data: op.data }, serverTime);
+    });
+    const txProjection = this.buildBatchProjection(txTestCases);
+
     const writeResults: TransactionResult<R>['writes'] = [];
     let allAllowed = true;
     for (let i = 0; i < resolvedOps.length; i++) {
@@ -3035,13 +3086,10 @@ export class LocalEnvironment {
         : op.method) as 'create' | 'update' | 'delete';
       const priorDoc = snapshot[op.path] ?? null;
 
-      const testCase = this.buildTestCase(
-        { method: ruleMethod, path: op.path, auth, data: op.data },
-        serverTime,
-      );
+      const testCase = txTestCases[i]!;
       const evalAt = Date.now();
       const evalStart = performance.now();
-      const sim = this.runSimulate([testCase], options.bypassRules);
+      const sim = this.runSimulate([testCase], options.bypassRules, txProjection);
       const evalMs = performance.now() - evalStart;
 
       if (!sim.success) {

--- a/packages/pyric/test/sandbox/firestore/simulator/get-after-batch.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/get-after-batch.test.ts
@@ -1,0 +1,188 @@
+/**
+ * getafter-batch fix.
+ *
+ * Production semantics: `getAfter(path)` inside a Firestore rule evaluates
+ * the document at `path` AS IT WILL BE once the CURRENT batch/transaction
+ * commits — it sees every OTHER write in the same atomic group, not just
+ * the write under evaluation. Before this fix, `LocalEnvironment.batch()`
+ * and `.transaction()` evaluated each op's rules with `getAfter()` only
+ * aware of that op's own pending write; a sibling doc's pending write in
+ * the same batch was invisible (fell through to pre-batch `get()`).
+ *
+ * These tests exercise the fix through `LocalEnvironment` (not the bare
+ * `SimulateFirestoreRulesHandler`, which is covered in
+ * `get-after.test.ts`) because the bug lives in how the sandbox wires
+ * per-op `simulate()` calls together for a batch/transaction, not in the
+ * rules evaluator's per-call `getAfter()` handling itself.
+ */
+import { describe, test, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+
+// doc A's write is gated on doc B's PROJECTED post-batch state — the
+// canonical getAfter-sees-sibling-write scenario.
+const RULES_CROSS_DOC = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /docs/a {
+      allow create, update: if getAfter(/databases/$(database)/documents/docs/b).data.x == 1;
+    }
+    match /docs/b {
+      allow create, update: if request.auth != null;
+    }
+  }
+}`;
+
+describe('getAfter — batch write visibility', () => {
+  test('ALLOWS when the sibling write in the same batch sets the field getAfter reads', () => {
+    const env = new LocalEnvironment();
+    env.seed({ rules: RULES_CROSS_DOC });
+
+    const result = env.batch([
+      { method: 'create', path: 'docs/a', data: { note: 'gated on b' } },
+      { method: 'create', path: 'docs/b', data: { x: 1 } },
+    ], { uid: 'u1' });
+
+    expect(result.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({ note: 'gated on b' });
+    expect(env.getDocument('docs/b')).toEqual({ x: 1 });
+  });
+
+  test('DENIES when B is not in the batch and current B data lacks x=1', () => {
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES_CROSS_DOC,
+      documents: { 'docs/b': { x: 0 } },
+    });
+
+    const result = env.batch([
+      { method: 'create', path: 'docs/a', data: { note: 'gated on b' } },
+    ], { uid: 'u1' });
+
+    expect(result.allowed).toBe(false);
+    expect(env.getDocument('docs/a')).toBe(null);
+  });
+
+  test('ALLOWS when B is not in the batch but its CURRENT data already has x=1', () => {
+    // getAfter on an untouched doc == get() of its current data.
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES_CROSS_DOC,
+      documents: { 'docs/b': { x: 1 } },
+    });
+
+    const result = env.batch([
+      { method: 'create', path: 'docs/a', data: { note: 'gated on b' } },
+    ], { uid: 'u1' });
+
+    expect(result.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({ note: 'gated on b' });
+  });
+
+  test('batch DELETE of B makes getAfter(B).exists false, even though B currently exists', () => {
+    const RULES_EXISTS_AFTER = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /docs/a {
+      allow create: if !existsAfter(/databases/$(database)/documents/docs/b);
+    }
+    match /docs/b {
+      allow delete: if request.auth != null;
+    }
+  }
+}`;
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES_EXISTS_AFTER,
+      documents: { 'docs/b': { x: 1 } },
+    });
+
+    // Sanity: B currently exists, so a batch that does NOT delete B is denied.
+    const withoutDelete = env.batch(
+      [{ method: 'create', path: 'docs/a', data: {} }],
+      { uid: 'u1' },
+    );
+    expect(withoutDelete.allowed).toBe(false);
+
+    const withDelete = env.batch([
+      { method: 'create', path: 'docs/a', data: {} },
+      { method: 'delete', path: 'docs/b' },
+    ], { uid: 'u1' });
+
+    expect(withDelete.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({});
+    expect(env.getDocument('docs/b')).toBe(null);
+  });
+
+  test('transaction: doc A rule sees doc B write queued earlier in the same transaction', () => {
+    const env = new LocalEnvironment();
+    env.seed({ rules: RULES_CROSS_DOC });
+
+    const result = env.transaction((tx) => {
+      tx.create('docs/b', { x: 1 });
+      tx.create('docs/a', { note: 'gated on b' });
+    }, { auth: { uid: 'u1' } });
+
+    expect(result.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({ note: 'gated on b' });
+    expect(env.getDocument('docs/b')).toEqual({ x: 1 });
+  });
+
+  test('transaction: doc A rule sees doc B write queued LATER in the same transaction (order-independent)', () => {
+    const env = new LocalEnvironment();
+    env.seed({ rules: RULES_CROSS_DOC });
+
+    const result = env.transaction((tx) => {
+      tx.create('docs/a', { note: 'gated on b' });
+      tx.create('docs/b', { x: 1 });
+    }, { auth: { uid: 'u1' } });
+
+    expect(result.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({ note: 'gated on b' });
+    expect(env.getDocument('docs/b')).toEqual({ x: 1 });
+  });
+
+  test('transaction: DENIES when the sibling write in the tx does not satisfy getAfter', () => {
+    const env = new LocalEnvironment();
+    env.seed({ rules: RULES_CROSS_DOC });
+
+    const result = env.transaction((tx) => {
+      tx.create('docs/a', { note: 'gated on b' });
+      tx.create('docs/b', { x: 0 }); // wrong value — getAfter(b).data.x != 1
+    }, { auth: { uid: 'u1' } });
+
+    expect(result.allowed).toBe(false);
+    expect(env.getDocument('docs/a')).toBe(null);
+    expect(env.getDocument('docs/b')).toBe(null);
+  });
+
+  test('atomicity: one denied write in the batch rejects the whole batch (getAfter-gated doc included)', () => {
+    const env = new LocalEnvironment();
+    env.seed({ rules: RULES_CROSS_DOC });
+
+    // A is gated on B's projected data; B's own rule ALSO requires auth,
+    // which it has — so A should pass. Flip B's payload so A's getAfter
+    // check fails, and confirm NEITHER write lands (not just A's).
+    const result = env.batch([
+      { method: 'create', path: 'docs/a', data: { note: 'gated on b' } },
+      { method: 'create', path: 'docs/b', data: { x: 999 } },
+    ], { uid: 'u1' });
+
+    expect(result.allowed).toBe(false);
+    expect(env.getDocument('docs/a')).toBe(null);
+    expect(env.getDocument('docs/b')).toBe(null);
+  });
+
+  test('single-op execute() is unaffected — getAfter on an unrelated path still reads current committed data', () => {
+    // Guards against a regression where batchProjection leaks into the
+    // single-write execute() path (it must stay undefined there).
+    const env = new LocalEnvironment();
+    env.seed({
+      rules: RULES_CROSS_DOC,
+      documents: { 'docs/b': { x: 1 } },
+    });
+
+    const result = env.execute({ method: 'create', path: 'docs/a', data: { note: 'solo' }, auth: { uid: 'u1' } });
+    expect(result.allowed).toBe(true);
+    expect(env.getDocument('docs/a')).toEqual({ note: 'solo' });
+  });
+});


### PR DESCRIPTION
## Semantics

Production `getAfter(path)` inside a Firestore rule evaluates the document at `path` AS IT WILL BE once the CURRENT batch/transaction commits — it sees the OTHER writes in the same atomic group, not just the write under evaluation. `get(path)` / `resource.data` continue to reflect the CURRENT, pre-commit state.

Before this fix, `LocalEnvironment.batch()` and `.transaction()` evaluated each op's rules independently: `getAfter()` only knew about the op's own pending write. A sibling doc's pending write in the same batch was invisible — `getAfter()` on it fell through to `get()` against pre-batch state, producing false denials (or false allows, in the delete case).

## Example

```
match /docs/a {
  allow create: if getAfter(/databases/$(database)/documents/docs/b).data.x == 1;
}
match /docs/b {
  allow create: if request.auth != null;
}
```

```ts
env.batch([
  { method: 'create', path: 'docs/a', data: { note: 'gated on b' } },
  { method: 'create', path: 'docs/b', data: { x: 1 } },
], { uid: 'u1' });
```

Before: denied — `getAfter(docs/b)` fell through to `get()`, and `docs/b` didn't exist yet pre-batch.
After: allowed — `getAfter(docs/b)` sees the batch's own pending write to `docs/b`.

## get() vs getAfter() now

- `get(path)` / `resource.data` — always the CURRENT, pre-batch/pre-transaction committed state. Unchanged by this fix.
- `getAfter(path)` for the document being written by the CURRENT op — projected post-write state (unchanged, this already worked).
- `getAfter(path)` for a SIBLING document written elsewhere in the SAME batch/transaction — now returns that sibling's projected post-write state (create/update/set → merged payload, delete → non-existent, `existsAfter` → false). This is the fix.
- `getAfter(path)` for a document NOT touched by the batch/transaction — falls through to `get(path)` (current data), matching production.

## Implementation

- `SimulationContext.batchProjection` (new, optional) — a shared `Map<normalizedPath, data | null>` built ONCE per batch/transaction and passed into every per-op `simulate()` call for that group. `getAfter()`/`existsAfter()` consult it for any path other than the current op's own target before falling through to `get()`/`exists()`.
- `LocalEnvironment.buildBatchProjection()` builds the map from the batch/transaction's already-resolved per-op `TestCase`s (reusing the existing create/update/delete → after-state logic already used for request.resource.data), then both `batch()` and `transaction()` thread it through their per-op `runSimulate()` calls.
- Single-op `execute()` omits the projection entirely, so unbatched `getAfter()` behavior is byte-for-byte unchanged.

Mirrors the "build the shared projected post-commit state once, read it from every per-write eval" approach used for the analogous RTDB multi-path update projection problem.

## Tests

New: `packages/pyric/test/sandbox/firestore/simulator/get-after-batch.test.ts`
- ALLOWS when the sibling write in the same batch sets the field getAfter reads
- DENIES when B is not in the batch and current B data lacks x=1
- ALLOWS when B is not in the batch but its CURRENT data already has x=1 (getAfter on an untouched doc == get())
- batch DELETE of B makes getAfter(B).exists false, even though B currently exists
- transaction: doc A rule sees doc B write queued earlier in the same transaction
- transaction: doc A rule sees doc B write queued LATER in the same transaction (order-independent)
- transaction: DENIES when the sibling write in the tx does not satisfy getAfter
- atomicity: one denied write in the batch rejects the whole batch (getAfter-gated doc included)
- single-op execute() is unaffected — getAfter on an unrelated path still reads current committed data

Verified red before the fix (4/9 failing on stashed source), green after.

`bun test --cwd packages/pyric` — 4406 pass, 0 fail (21 pre-existing skips). `bunx tsc --noEmit -p packages/pyric` — clean.

## Overlap notes

- PR #105 (Firestore OR-combine fix) — already on `main` at the base commit this branch was cut from; no conflict, this PR only touches `getAfter`/batch plumbing.
- PR #109 (RTDB multi-path projection) — still open/draft, not merged into `main`. This PR mirrors its "build one shared post-commit projection, read it from every per-write eval" approach for Firestore's per-document `getAfter()`, but the two changes touch entirely separate files (RTDB vs Firestore rules simulator) and don't conflict.