### PR TITLE
Emit storage rules-enforcement events on the unified sandbox stream

### DIFF
--- a/packages/pyric-tools/src/serve/worker/host.ts
+++ b/packages/pyric-tools/src/serve/worker/host.ts
@@ -88,7 +88,7 @@ import {
   type Query,
   type SetOptions,
 } from 'pyric/firestore';
-import type { Sandbox, PersistenceBackend, AuthLens } from 'pyric/sandbox';
+import type { Sandbox, PersistenceBackend, AuthLens, EventProvenance } from 'pyric/sandbox';
 // The canonical value codec (same module the protocol's read path uses) —
 // write payloads rehydrate host-side so marker-shaped scalars from the JSON
 // relay legs are STORED as real wrapper instances (see prepareWriteData).
@@ -1381,8 +1381,10 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       // Byte upload (remote sandbox, slice 2). Decode-end size cap: reject an
       // oversized base64 string BEFORE materializing its bytes, then re-check
       // the exact decoded length. Rules enforce under the op's lens; the
-      // upload emits `service_mutation` events, so server writes get Studio
-      // provenance for free.
+      // upload emits `service_mutation` events. Storage dispatch is async, so
+      // the event escapes the ambient-provenance window `handleMessage` opened;
+      // thread the op's provenance EXPLICITLY so a Studio-issued write is
+      // attributable end to end (issue #84 item 3).
       try {
         if (msg.dataB64.length > MAX_STORAGE_OP_B64_LENGTH) {
           throw storagePayloadTooLarge(
@@ -1399,6 +1401,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
           storageRef(storage, msg.path),
           bytes,
           toSettableMetadata(msg),
+          opProvenance(msg),
         );
         // FullMetadata — plain JSON, relay-safe.
         ok(port, msg.id, result.metadata);
@@ -1436,9 +1439,11 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
       // `pyric/storage`'s sandbox delete is idempotent (no-op on missing) —
       // matching the pyric-admin local arm's delete semantics. Rules enforce
       // `write` under the op's lens; deletes emit `service_mutation` events.
+      // Async dispatch escapes the ambient window — thread provenance
+      // explicitly (issue #84 item 3).
       try {
         const storage = lensStorage(ctx, msg.actAs);
-        await storageDeleteObject(storageRef(storage, msg.path));
+        await storageDeleteObject(storageRef(storage, msg.path), opProvenance(msg));
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;
@@ -1691,33 +1696,50 @@ export async function handleMessage(
   port: PortLike,
   msg: InboundMessage,
 ): Promise<void> {
-  // Op provenance, stamped MECHANICALLY at dispatch:
-  //   - `actor`: a client that DECLARED itself the issuer (`issuer: 'studio'`,
-  //     stamped by Studio's worker client — see `setOpIssuer` in client.ts)
-  //     gets `actor: { kind: 'studio' }`. Bridge-relayed frames are forwarded
-  //     verbatim without the stamp (client.ts `relayWorkerOp`), so remote
-  //     admin/agent traffic is never mislabeled as Studio's.
-  //   - `authLens`: the op's EFFECTIVE lens (`msg.actAs`) is stamped whenever
-  //     present — independent of issuer declaration, because admin is admin
-  //     regardless of who asked (an agent tool relay's admin op must classify
-  //     as a rules BYPASS in Traffic, not as a rules allow). Without this,
-  //     Firestore admin-lens ops carried no lens on their events and
-  //     `verdictFor` mislabeled the bypass as ALLOW (the RTDB/Firestore
-  //     asymmetry the traffic-metrics work flagged).
-  // Events an emitter already stamped win over the window (stampProvenance
-  // semantics: the event's own field always beats the ambient default).
-  const issuer = (msg as { issuer?: 'studio' }).issuer;
-  const actAs = (msg as { actAs?: AuthLens }).actAs;
-  if ((issuer === 'studio' || actAs) && ctx.sandbox.runWithProvenance) {
-    return ctx.sandbox.runWithProvenance(
-      {
-        ...(issuer === 'studio' ? { actor: { kind: 'studio' } } : {}),
-        ...(actAs ? { authLens: actAs } : {}),
-      },
-      () => dispatchMessage(ctx, port, msg),
-    );
+  // Op provenance, bound at dispatch by `opProvenance` (see its docs). Opened
+  // as the sandbox's SYNCHRONOUS ambient window so firestore/rtdb/auth emits —
+  // which run inside `dispatchMessage` before any await — pick it up. Storage
+  // ops emit AFTER async awaits, outside this window, so they thread the same
+  // provenance EXPLICITLY instead (see `handleOp`'s storage cases). Without the
+  // lens on admin ops, `verdictFor` mislabeled a rules BYPASS as ALLOW (the
+  // RTDB/Firestore asymmetry the traffic-metrics work flagged).
+  const prov = opProvenance(msg);
+  if (prov && ctx.sandbox.runWithProvenance) {
+    return ctx.sandbox.runWithProvenance(prov, () => dispatchMessage(ctx, port, msg));
   }
   return dispatchMessage(ctx, port, msg);
+}
+
+/**
+ * Op provenance from an inbound message, bound at ISSUE time. The single
+ * source of truth for both the SYNCHRONOUS ambient-provenance window
+ * (firestore/rtdb/auth emit inside it) and the EXPLICIT thread that storage
+ * ops need (their emits run after async awaits, outside any window — see
+ * `handleOp`'s storage cases and `uploadBytes`'s provenance note).
+ *
+ *   - `actor`: a client that DECLARED itself the issuer (`issuer: 'studio'`,
+ *     stamped by Studio's worker client — `setOpIssuer` in client.ts) gets
+ *     `actor: { kind: 'studio' }`. Bridge-relayed frames are forwarded
+ *     verbatim without the stamp (client.ts `relayWorkerOp`), so remote
+ *     admin/agent traffic is never mislabeled as Studio's.
+ *   - `authLens`: the op's EFFECTIVE lens (`msg.actAs`) whenever present —
+ *     independent of issuer, because admin is admin regardless of who asked
+ *     (an agent tool relay's admin op must classify as a rules BYPASS in
+ *     Traffic, not a rules allow).
+ *
+ * Returns `undefined` for a plain served-app op (no issuer, no lens) so the
+ * event keeps the app-session default — a served-app op stays untagged.
+ * Events an emitter already stamped win over these defaults (stampProvenance
+ * semantics: the event's own field beats the ambient/threaded default).
+ */
+function opProvenance(msg: InboundMessage): EventProvenance | undefined {
+  const issuer = (msg as { issuer?: 'studio' }).issuer;
+  const actAs = (msg as { actAs?: AuthLens }).actAs;
+  if (issuer !== 'studio' && !actAs) return undefined;
+  return {
+    ...(issuer === 'studio' ? { actor: { kind: 'studio' } } : {}),
+    ...(actAs ? { authLens: actAs } : {}),
+  };
 }
 
 async function dispatchMessage(

--- a/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
+++ b/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Storage-op PROVENANCE across the async dispatch boundary (worker host).
+ *
+ * THE BUG THIS PINS (issue #84 item 3 — async provenance for service ops):
+ * op provenance (`actor`, `authLens`) is stamped via the sandbox's SYNCHRONOUS
+ * ambient-provenance window (`runWithProvenance`), opened by `handleMessage`
+ * around `dispatchMessage`. Firestore/RTDB/auth emit their events
+ * synchronously inside that window, so the stamp lands. STORAGE ops dispatch
+ * ASYNCHRONOUSLY — `uploadBytes`/`deleteObject` await the backend
+ * (getMetadata → put/delete) before emitting the `service_mutation` event. By
+ * the time the emit runs, `runWithProvenance`'s synchronous `finally` has
+ * already restored the ambient window, so the storage event escapes it and a
+ * Studio-issued upload lands with NO `actor` — silently misattributed as
+ * app-session traffic.
+ *
+ * THE INTERLEAVING HAZARD (why "just widen the window to await fn" is wrong):
+ * two ops from different issuers can be in flight concurrently. If the window
+ * stayed open across awaits, op A's window would still be ambient when op B's
+ * event emits — swapping actors. The fix must BIND provenance at issue time
+ * and thread it through the async dispatch explicitly, so concurrent ops never
+ * cross-contaminate.
+ *
+ * FIX UNDER TEST: `handleMessage`/`handleOp` capture the op's provenance
+ * (issuer → actor, actAs → authLens) at issue time and pass it EXPLICITLY into
+ * the storage op, which forwards it to its emit — independent of the ambient
+ * window. Provenance is bound at the moment the op is issued, immutable
+ * thereafter.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox, type SandboxEvent } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { getStorageSandbox } from 'pyric/storage';
+
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  ResMessage,
+} from '../../../src/serve/worker/protocol.js';
+import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
+
+let dbSeq = 0;
+function uniqueDbName(): string {
+  return `pyric-storage-prov-${++dbSeq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCtx(): { ctx: HostCtx; events: SandboxEvent[] } {
+  const sandbox = initializeSandbox();
+  getStorageSandbox(sandbox, { dbName: uniqueDbName() });
+  const events: SandboxEvent[] = [];
+  sandbox.onEvent((e) => events.push(e));
+  return {
+    ctx: { db: getFirestore(sandbox), sandbox, instanceId: 'storage-prov-test', subs: new Map() },
+    events,
+  };
+}
+
+let opSeq = 0;
+function op(ctx: HostCtx, payload: Record<string, unknown>): Promise<ResMessage> {
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'res') resolve(msg);
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...payload,
+      t: 'op',
+      id: `spop-${++opSeq}`,
+    } as InboundMessage);
+  });
+}
+
+const DATA = bytesToBase64(new TextEncoder().encode('payload'));
+
+/** All `object_put` mutation events for a given path. */
+function putsFor(events: SandboxEvent[], path: string): SandboxEvent[] {
+  return events.filter(
+    (e) =>
+      e.kind === 'service_mutation' &&
+      (e as { op?: string }).op === 'object_put' &&
+      (e as { path?: string }).path === path,
+  );
+}
+
+describe('worker host: storage op provenance survives async dispatch', () => {
+  it('stamps actor:{kind:"studio"} on a Studio-issued upload event', async () => {
+    const { ctx, events } = makeCtx();
+    const res = await op(ctx, {
+      method: 'storage.putBytes',
+      path: 'studio/blob.bin',
+      dataB64: DATA,
+      issuer: 'studio',
+    });
+    expect(res.ok).toBe(true);
+
+    const puts = putsFor(events, 'studio/blob.bin');
+    expect(puts.length).toBeGreaterThan(0);
+    for (const e of puts) {
+      expect(e.actor).toEqual({ kind: 'studio' });
+    }
+  });
+
+  it('a served-app upload (no issuer) stays untagged — no studio actor', async () => {
+    const { ctx, events } = makeCtx();
+    const res = await op(ctx, {
+      method: 'storage.putBytes',
+      path: 'app/blob.bin',
+      dataB64: DATA,
+    });
+    expect(res.ok).toBe(true);
+
+    const puts = putsFor(events, 'app/blob.bin');
+    expect(puts.length).toBeGreaterThan(0);
+    for (const e of puts) {
+      // Untagged: no studio actor. (Absent, or an explicit app default —
+      // never studio.)
+      expect(e.actor?.kind).not.toBe('studio');
+    }
+  });
+
+  it('two concurrent uploads from different issuers do not swap actors', async () => {
+    const { ctx, events } = makeCtx();
+    // Issue BOTH before awaiting either — their async backend windows overlap.
+    // A naive "widen the ambient window across awaits" fix would let the
+    // app op's event emit while the studio window is still ambient (or vice
+    // versa), swapping actors. Explicit per-op binding must keep them distinct.
+    const [studioRes, appRes] = await Promise.all([
+      op(ctx, { method: 'storage.putBytes', path: 'race/studio.bin', dataB64: DATA, issuer: 'studio' }),
+      op(ctx, { method: 'storage.putBytes', path: 'race/app.bin', dataB64: DATA }),
+    ]);
+    expect(studioRes.ok).toBe(true);
+    expect(appRes.ok).toBe(true);
+
+    const studioPuts = putsFor(events, 'race/studio.bin');
+    const appPuts = putsFor(events, 'race/app.bin');
+    expect(studioPuts.length).toBeGreaterThan(0);
+    expect(appPuts.length).toBeGreaterThan(0);
+    for (const e of studioPuts) expect(e.actor).toEqual({ kind: 'studio' });
+    for (const e of appPuts) expect(e.actor?.kind).not.toBe('studio');
+  });
+
+  it('an admin-lens delete carries authLens:{mode:"admin"} on its event (bypass classification)', async () => {
+    const { ctx, events } = makeCtx();
+    // Seed then delete under the admin lens; the delete event must carry the
+    // lens it ran under so Traffic classifies the BYPASS correctly — the
+    // storage mirror of the Firestore lens-provenance guarantee.
+    await op(ctx, { method: 'storage.putBytes', path: 'admin/gone.bin', dataB64: DATA, actAs: { mode: 'admin' } });
+    const res = await op(ctx, {
+      method: 'storage.deleteObject',
+      path: 'admin/gone.bin',
+      actAs: { mode: 'admin' },
+    });
+    expect(res.ok).toBe(true);
+
+    const deletes = events.filter(
+      (e) =>
+        e.kind === 'service_mutation' &&
+        (e as { op?: string }).op === 'object_delete' &&
+        (e as { path?: string }).path === 'admin/gone.bin',
+    );
+    expect(deletes.length).toBeGreaterThan(0);
+    for (const e of deletes) {
+      expect(e.authLens).toEqual({ mode: 'admin' });
+    }
+  });
+});

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -96,7 +96,7 @@ export async function deleteObject(
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
-  }, target);
+  }, target, provenance);
   await service.backend.delete(ref.fullPath);
   try {
     emitSandboxEvent(

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -18,6 +18,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored } from './rules.js';
@@ -70,8 +71,16 @@ export async function getBlob(
  * `storage/object-not-found` when the path is missing. The v1 scope
  * keeps the persistence-layer no-op behavior for now; Slice 8 will
  * reconsider whether to mirror the strict throw.
+ *
+ * `provenance` (host-only): op {@link EventProvenance} bound at ISSUE time,
+ * threaded EXPLICITLY onto the emitted `object_delete` event. The delete
+ * awaits the backend before emitting, so it escapes the sandbox's
+ * synchronous ambient-provenance window — see the note on `uploadBytes`.
  */
-export async function deleteObject(ref: StorageReference): Promise<void> {
+export async function deleteObject(
+  ref: StorageReference,
+  provenance?: EventProvenance,
+): Promise<void> {
   guardNonRoot(ref, 'deleteObject');
   const target = targetOf(ref.storage);
   if (target.kind === 'prod') {
@@ -100,7 +109,7 @@ export async function deleteObject(ref: StorageReference): Promise<void> {
         before: existing ?? undefined,
         detail: { bucket: ref.bucket },
       }),
-      { service: 'storage' },
+      { ...provenance, service: 'storage' },
     );
   } catch {
     // Observational — never let event emission break a storage delete.

--- a/packages/pyric/src/storage/enforce.ts
+++ b/packages/pyric/src/storage/enforce.ts
@@ -19,7 +19,29 @@
  * contract (a denied tree was still enumerable). With no rules
  * configured the check is a no-op (open-by-default), so the
  * session-archive demo is unaffected.
+ *
+ * Studio observability (storage-denial-events): every enforcement
+ * decision — allow, deny, AND admin-plane bypass — lands on the
+ * unified sandbox `onEvent`/`history()` stream as a `kind: 'operation'`
+ * event, mirroring RTDB's `emitOperation` (see
+ * `src/database/sandbox/backend.ts`) and Firestore's `RequestEvent`
+ * deny path. Before this, a rules-denied storage op threw a plain
+ * `StorageError` with NO trace on the event stream — invisible to
+ * Studio's Traffic surface and the rules inspector. Field names are
+ * chosen to match RTDB's `SandboxOperationEvent` exactly (`result`,
+ * `reasons`, `rules.engine`/`.reason`, `origin`) so Traffic/inspector
+ * work without Studio-side changes. The storage evaluator returns a
+ * flat `{ allowed, reasons[] }` — no rule index/position is tracked —
+ * so `rules.matchedRule`/`.ruleIndex` are always omitted rather than
+ * fabricated.
+ *
+ * Emission is additive and best-effort: a throw from the emit path
+ * never blocks the real allow/deny control flow, and a denial still
+ * throws `StorageError` exactly as before — the error contract to
+ * app code is unchanged.
  */
+import { emitSandboxEvent, makeSandboxOperationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import type { StorageService, Target } from './service.js';
 import { evaluateStorageRules, type EvaluationInput } from './rules.js';
 import { unauthorized } from './errors.js';
@@ -28,13 +50,71 @@ export function enforceRules(
   service: StorageService,
   input: EvaluationInput,
   target?: Target,
+  provenance?: EventProvenance,
 ): void {
   // Admin plane (internal `getAdminStorageSandbox` handles): rules are
   // bypassed entirely — firebase-admin semantics. See `SandboxTarget.admin`.
-  if (target?.kind === 'sandbox' && target.admin === true) return;
-  if (!service.rules) return;
+  // Rules never ran; the event still lands so Studio can show the op, with
+  // `result: 'not-applicable'` + `origin: 'admin'` — the same shape RTDB's
+  // admin plane (`adminSet`/`adminGet`/...) emits, which Studio's
+  // `verdict.ts` classifies as `'admin'` regardless of `result`.
+  if (target?.kind === 'sandbox' && target.admin === true) {
+    emitOperation(target, input, 'not-applicable', undefined, 'admin', false, provenance);
+    return;
+  }
+  if (!service.rules) {
+    // Open-by-default: no rules configured, no evaluation happened.
+    // Still emit `allow` for parity — an unrestricted op is legitimately
+    // "allowed", just never evaluated.
+    emitOperation(target, input, 'allow', undefined, 'user', false, provenance);
+    return;
+  }
   const result = evaluateStorageRules(service.rules, input);
-  if (result.allowed) return;
-  const detail = result.reasons.length > 0 ? ` — ${result.reasons.join('; ')}` : '';
-  throw unauthorized(input.request.method, input.request.path, detail);
+  if (!result.allowed) {
+    emitOperation(target, input, 'deny', result.reasons, 'user', true, provenance);
+    const detail = result.reasons.length > 0 ? ` — ${result.reasons.join('; ')}` : '';
+    throw unauthorized(input.request.method, input.request.path, detail);
+  }
+  emitOperation(target, input, 'allow', result.reasons, 'user', true, provenance);
+}
+
+/**
+ * Build + emit the `SandboxOperationEvent` for one enforcement decision.
+ * No-op for prod targets (rules are server-side; nothing to observe here)
+ * and bare `StorageService` calls with no `target` (unit tests that drive
+ * `enforceRules` directly without a sandbox handle).
+ */
+function emitOperation(
+  target: Target | undefined,
+  input: EvaluationInput,
+  result: 'allow' | 'deny' | 'not-applicable',
+  reasons: string[] | undefined,
+  origin: 'user' | 'admin',
+  evaluated: boolean,
+  provenance: EventProvenance | undefined,
+): void {
+  if (!target || target.kind !== 'sandbox') return;
+  try {
+    emitSandboxEvent(
+      target.sandbox,
+      makeSandboxOperationEvent({
+        service: 'storage',
+        method: input.request.method,
+        path: input.request.path,
+        auth: input.request.auth,
+        result,
+        origin,
+        reasons,
+        rules: evaluated
+          ? {
+              engine: 'storage',
+              reason: reasons && reasons.length > 0 ? reasons.join('; ') : undefined,
+            }
+          : undefined,
+      }),
+      { ...provenance, service: 'storage' },
+    );
+  } catch {
+    // Observational — never let event emission break storage enforcement.
+  }
 }

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -196,7 +196,7 @@ export async function updateMetadata(
         : undefined,
     },
     resource: resourceFromStored(existing),
-  }, target);
+  }, target, provenance);
   if (!existing) {
     throw objectNotFound(ref.fullPath);
   }

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -17,6 +17,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
@@ -157,10 +158,16 @@ export async function getMetadata(ref: StorageReference): Promise<FullMetadata> 
  * place. To explicitly clear a field, the JS SDK accepts `null` —
  * we don't model that in the v1 scope to keep the patch logic simple.
  * Documented for Slice 9's deferred-features section.
+ *
+ * `provenance` (host-only): op {@link EventProvenance} bound at ISSUE time,
+ * threaded EXPLICITLY onto the emitted `metadata_update` event. Emit runs
+ * after the backend awaits, escaping the sandbox's synchronous
+ * ambient-provenance window — see the note on `uploadBytes`.
  */
 export async function updateMetadata(
   ref: StorageReference,
   patch: SettableMetadata,
+  provenance?: EventProvenance,
 ): Promise<FullMetadata> {
   guardNonRoot(ref, 'updateMetadata');
   const target = targetOf(ref.storage);
@@ -208,7 +215,7 @@ export async function updateMetadata(
           after: next,
           detail: { bucket: ref.bucket },
         }),
-        { service: 'storage' },
+        { ...provenance, service: 'storage' },
       );
     } catch {
       // Observational — never let event emission break a metadata update.

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -90,7 +90,7 @@ export async function uploadBytes(
       }),
     },
     resource: resourceFromStored(existing),
-  }, target);
+  }, target, provenance);
   await service.backend.put(ref.fullPath, blob, stored);
   // Land the put on the unified Studio stream. Best-effort: a throw from
   // the emit path must not fail the upload the caller just completed.
@@ -134,13 +134,14 @@ export async function uploadString(
   value: string,
   format: StringFormat = 'raw',
   metadata?: SettableMetadata,
+  provenance?: EventProvenance,
 ): Promise<UploadResult> {
   const { bytes, inferredType } = decodeString(value, format);
   const effective: SettableMetadata = {
     ...metadata,
     contentType: metadata?.contentType ?? inferredType ?? defaultRawContentType(format),
   };
-  return uploadBytes(ref, bytes, effective);
+  return uploadBytes(ref, bytes, effective, provenance);
 }
 
 /**

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -25,6 +25,7 @@
  */
 import * as fb from 'firebase/storage';
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { EventProvenance } from 'pyric/sandbox';
 import { getStorageService, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
@@ -46,11 +47,22 @@ export type StringFormat = 'raw' | 'base64' | 'data_url';
  * Throws when the reference targets the root (`fullPath === ''`) —
  * uploads need a non-empty path, matching Firebase's
  * `invalid-root-operation` precondition.
+ *
+ * `provenance` (host-only) is the op's {@link EventProvenance} bound at
+ * ISSUE time by the worker host — `actor`/`authLens` threaded EXPLICITLY
+ * onto the emitted `service_mutation` event. Storage dispatch is async
+ * (the awaits above), so it escapes the sandbox's synchronous
+ * ambient-provenance window (`runWithProvenance`); the window has already
+ * closed by the time this emit runs. Passing provenance through the call
+ * binds it immutably to THIS op, so concurrent uploads from different
+ * issuers can never swap actors. `service: 'storage'` always wins. Omitted
+ * ⇒ the app-session default (a served-app write stays untagged).
  */
 export async function uploadBytes(
   ref: StorageReference,
   data: Blob | Uint8Array | ArrayBuffer,
   metadata?: SettableMetadata,
+  provenance?: EventProvenance,
 ): Promise<UploadResult> {
   guardNonRoot(ref, 'uploadBytes');
   const target = targetOf(ref.storage);
@@ -99,7 +111,7 @@ export async function uploadBytes(
           overwrite: existing != null,
         },
       }),
-      { service: 'storage' },
+      { ...provenance, service: 'storage' },
     );
   } catch {
     // Observational — never let event emission break a storage write.

--- a/packages/pyric/test/storage/denial-events.test.ts
+++ b/packages/pyric/test/storage/denial-events.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Storage denial events (storage-denial-events).
+ *
+ * Before this change, a rules-denied storage op threw a plain
+ * `StorageError` with NO trace on the sandbox event stream — invisible
+ * to Studio's Traffic surface, the rules inspector, and `sandbox.history()`,
+ * unlike Firestore/RTDB, which emit a canonical `kind: 'operation'` event
+ * carrying `result: 'deny'` and the evaluator's `reasons`.
+ *
+ * These tests assert storage now emits a `SandboxOperationEvent` on every
+ * enforcement decision (allow, deny, and admin bypass), with field names
+ * matching RTDB's `emitOperation` exactly, AND that the thrown
+ * `StorageError` is unchanged (events are additive).
+ */
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import type { SandboxEvent, SandboxOperationEvent } from 'pyric/sandbox';
+import {
+  getStorageSandbox,
+  ref,
+  uploadBytes,
+  getBlob,
+} from '../../src/storage/index.js';
+
+function uniqueDbName(label: string): string {
+  return `pyric-storage-denial-${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function operations(events: SandboxEvent[]): SandboxOperationEvent[] {
+  return events.filter((e): e is SandboxOperationEvent => e.kind === 'operation');
+}
+
+const DENY_ALL = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if false;
+  }
+}`;
+
+const ALICE_ONLY = `
+service firebase.storage {
+  match /{allPaths=**} {
+    allow read, write: if request.auth != null && request.auth.uid == 'alice';
+  }
+}`;
+
+describe('storage rules denial lands on the unified event stream', () => {
+  it('a rules-denied upload emits exactly one operation event with result "deny", reasons, service "storage", the object path, and the op auth', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+    const storage = getStorageSandbox(sandbox.withAuth(null), {
+      dbName: uniqueDbName('deny-upload'),
+      rules: DENY_ALL,
+    });
+
+    let thrown: unknown;
+    try {
+      await uploadBytes(ref(storage, 'private/secret.txt'), new Blob(['nope']));
+    } catch (e) {
+      thrown = e;
+    }
+
+    // The error contract to app code is unchanged: it still throws.
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe('storage/unauthorized');
+
+    const denies = operations(events).filter(
+      (e) => e.service === 'storage' && e.result === 'deny',
+    );
+    expect(denies.length).toBe(1);
+    const deny = denies[0]!;
+    expect(deny.path).toBe('private/secret.txt');
+    expect(deny.auth).toBeNull();
+    expect(deny.reasons).toBeDefined();
+    expect(deny.reasons!.length).toBeGreaterThan(0);
+    expect(deny.rules?.engine).toBe('storage');
+
+    // No object_put mutation event fired — the write never happened.
+    expect(events.some((e) => e.kind === 'service_mutation')).toBe(false);
+  });
+
+  it('a rules-denied read (getBlob) emits a deny operation event — reads previously emitted nothing at all', async () => {
+    const sandbox = initializeSandbox();
+    const dbName = uniqueDbName('deny-read-setup');
+    const storage = getStorageSandbox(sandbox.withAuth(null), {
+      dbName,
+      rules: ALICE_ONLY,
+    });
+    // Seed via alice's write on the same underlying DB, then attempt a read
+    // as anonymous.
+    const asAlice = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { dbName });
+    const r = ref(storage, 'docs/note.txt');
+    await uploadBytes(ref(asAlice, 'docs/note.txt'), new Blob(['secret']));
+
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+
+    let thrown: unknown;
+    try {
+      await getBlob(r);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code?: string }).code).toBe('storage/unauthorized');
+
+    const denies = operations(events).filter((e) => e.service === 'storage' && e.result === 'deny');
+    expect(denies.length).toBe(1);
+    expect(denies[0]!.method).toBe('read');
+  });
+
+  it('a denied op issued with Studio provenance carries actor "studio" on the deny event', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+    const storage = getStorageSandbox(sandbox.withAuth(null), {
+      dbName: uniqueDbName('deny-provenance'),
+      rules: DENY_ALL,
+    });
+
+    try {
+      await uploadBytes(ref(storage, 'x/y.txt'), new Blob(['x']), undefined, {
+        actor: { kind: 'studio' },
+      });
+    } catch {
+      // Expected — denial still throws.
+    }
+
+    const deny = operations(events).find((e) => e.service === 'storage' && e.result === 'deny');
+    expect(deny).toBeDefined();
+    expect(deny!.actor).toEqual({ kind: 'studio' });
+  });
+
+  it('an allowed op emits its event with result "allow"', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+    const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
+      dbName: uniqueDbName('allow-upload'),
+      rules: ALICE_ONLY,
+    });
+
+    await uploadBytes(ref(storage, 'docs/ok.txt'), new Blob(['ok']));
+
+    const allows = operations(events).filter((e) => e.service === 'storage' && e.result === 'allow');
+    expect(allows.length).toBe(1);
+    expect(allows[0]!.path).toBe('docs/ok.txt');
+    expect((allows[0]!.auth as { uid: string }).uid).toBe('alice');
+    // The mutation event is additive, not replaced.
+    expect(events.some((e) => e.kind === 'service_mutation' && (e as { op?: string }).op === 'object_put')).toBe(true);
+  });
+
+  it('admin-lens ops bypass rules and emit result "not-applicable" with origin "admin" — rules never ran', async () => {
+    const { getAdminStorageSandbox } = await import('../../src/storage/internal.js');
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+    const dbName = uniqueDbName('admin-bypass');
+    const adminStorage = getAdminStorageSandbox(sandbox, { dbName, rules: DENY_ALL });
+
+    // DENY_ALL would reject this on the rules-honest handle; admin bypasses.
+    await uploadBytes(ref(adminStorage, 'anything.txt'), new Blob(['admin']));
+
+    const adminOps = operations(events).filter((e) => e.service === 'storage' && e.origin === 'admin');
+    expect(adminOps.length).toBeGreaterThan(0);
+    expect(adminOps[0]!.result).toBe('not-applicable');
+    expect(adminOps[0]!.rules).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #110 (storage-async-provenance) — needs that branch's explicit provenance threading merged first.

## What was invisible

When the storage rules evaluator (`packages/pyric/src/storage/rules.ts` + `enforce.ts`) denied an op, storage threw a plain `StorageError` and emitted no event at all. Firestore and RTDB, by contrast, emit a canonical `kind: 'operation'` event on every enforcement decision, carrying `result: 'deny'` and the evaluator's `reasons`. Storage denials never reached the Traffic surface, the rules inspector, or `sandbox.history()` — a denied write or read simply vanished from observability, and reads never emitted anything even on allow.

## Event shape now emitted

`enforceRules` (`packages/pyric/src/storage/enforce.ts`) now emits a `SandboxOperationEvent` for every enforcement decision:

- **Deny**: `service: 'storage'`, `method`, `path`, `auth`, `result: 'deny'`, `origin: 'user'`, `reasons: string[]` (from the evaluator), `rules: { engine: 'storage', reason }`. The `StorageError` still throws — events are additive, the error contract to app code is unchanged.
- **Allow**: same shape with `result: 'allow'`. Applies to both rules-configured and no-rules-configured (open-by-default) ops — previously reads emitted nothing at all, and allowed writes only got the separate `service_mutation` envelope (unchanged, still emitted for successful mutations).
- **Admin-plane bypass** (`getAdminStorageSandbox` handles): `result: 'not-applicable'`, `origin: 'admin'`, `rules` omitted — rules genuinely never ran, mirroring RTDB's admin plane (`adminSet`/`adminGet`/...).

The storage evaluator returns a flat `{ allowed, reasons[] }` with no rule index/position tracked, so `rules.matchedRule` / `.ruleIndex` are always omitted rather than fabricated.

## Field-name parity with firestore/rtdb

Field names match RTDB's `emitOperation` (`packages/pyric/src/database/sandbox/backend.ts`) exactly — `result`, `reasons`, `origin`, `rules.engine`/`.reason` — plus the standard `actor`/`authLens` provenance stamp every event gets via `stampProvenance`. This is the same field contract Studio's `packages/studio/src/features/traffic/verdict.ts` already reads for Firestore/RTDB, so Traffic and the rules inspector pick up storage denials with no Studio-side changes.

`uploadString` now threads the explicit `provenance` parameter already wired onto `uploadBytes` by #110, so a Studio-issued `uploadString` keeps its `actor`/`authLens` on the new event too.

## Tests

New: `packages/pyric/test/storage/denial-events.test.ts`
- a rules-denied upload emits exactly one operation event with `result: 'deny'`, `reasons`, `service: 'storage'`, the object path, and the op's auth — and the `StorageError` still throws
- a rules-denied read (`getBlob`) emits a deny operation event (reads previously emitted nothing)
- a denied op issued with Studio provenance carries `actor: { kind: 'studio' }` on the deny event
- an allowed op emits its event with `result: 'allow'` (additive to the existing `service_mutation` event)
- admin-lens ops bypass rules and emit `result: 'not-applicable'` + `origin: 'admin'` — rules never ran

`bun test packages/pyric` (6233 pass / 4 pre-existing unrelated failures in `pyric-tools/register`, confirmed failing on the base branch too) and `bun test packages/pyric-tools/test/serve` (387 pass) are green, plus `bun run typecheck` clean in both packages.