### PR TITLE
Report unparseable RTDB rules as unsupported, not silent pass

### DIFF
--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -39,9 +39,22 @@ import { resolveSentinels } from './sentinels.js';
 import {
   RulesEvaluator,
   permissionDenied,
+  type RuleCheck,
   type RuleEvaluationDetails,
 } from './rules-eval.js';
 import { executeQuery, type QueryRow, type QuerySpec } from './query.js';
+
+/**
+ * Maps a non-`'allow'` rule check to the event-stream `result` value.
+ * `'unsupported'` (a simulator gap) is surfaced distinctly from a real
+ * `'deny'` so Studio's traffic view can tell "the rules engine said no"
+ * apart from "the rules engine couldn't tell" — but both still deny the
+ * operation itself (abstain, never grant), matching the Firestore
+ * simulator's posture.
+ */
+function denyResultFor(check: RuleCheck): 'deny' | 'unsupported' {
+  return check === 'unsupported' ? 'unsupported' : 'deny';
+}
 import { normalizeWrite, coerceArrays } from './normalize.js';
 
 /**
@@ -516,7 +529,7 @@ export class RtdbBackend {
       mockData: this.tree.snapshot() as Record<string, unknown>,
     });
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, 'get', path, 'deny', evaluation, {
+      this.emitOperation(auth, 'get', path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         resourceBefore: { data: before, exists: before !== null },
@@ -571,7 +584,7 @@ export class RtdbBackend {
     const resourceBefore = { data: before, exists: before !== null };
     const resourceAfter = { data: resolved, exists: resolved !== null };
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, op, path, 'deny', evaluation, {
+      this.emitOperation(auth, op, path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         request: { data: value, resourceData: value },
@@ -659,7 +672,7 @@ export class RtdbBackend {
           detail: { multiPath: true, rootPath: canonicalPath(path) },
         };
         if (evaluation.check !== 'allow') {
-          this.emitOperation(auth, 'update', absPath, 'deny', evaluation, common);
+          this.emitOperation(auth, 'update', absPath, denyResultFor(evaluation.check), evaluation, common);
           throw permissionDenied();
         }
         this.emitOperation(auth, 'update', absPath, 'allow', evaluation, common);
@@ -722,7 +735,7 @@ export class RtdbBackend {
         detail: { multiPath: false, rootPath: canonicalPath(path), key: k },
       };
       if (evaluation.check !== 'allow') {
-        this.emitOperation(auth, 'update', sub, 'deny', evaluation, common);
+        this.emitOperation(auth, 'update', sub, denyResultFor(evaluation.check), evaluation, common);
         throw permissionDenied();
       }
       this.emitOperation(auth, 'update', sub, 'allow', evaluation, common);
@@ -781,7 +794,7 @@ export class RtdbBackend {
       mockData: this.tree.snapshot() as Record<string, unknown>,
     });
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, 'listen', path, 'deny', evaluation, {
+      this.emitOperation(auth, 'listen', path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         request: query ? { query } : undefined,
@@ -880,7 +893,7 @@ export class RtdbBackend {
       mockData: this.tree.snapshot() as Record<string, unknown>,
     });
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, 'get', path, 'deny', evaluation, {
+      this.emitOperation(auth, 'get', path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         request: { query: spec },
@@ -1113,7 +1126,7 @@ export class RtdbBackend {
         newData: resolved,
       });
       if (evaluation.check !== 'allow') {
-        this.emitOperation(auth, 'transaction', path, 'deny', evaluation, {
+        this.emitOperation(auth, 'transaction', path, denyResultFor(evaluation.check), evaluation, {
           at,
           durationMs: Date.now() - at,
           origin: 'transaction',
@@ -1166,7 +1179,7 @@ export class RtdbBackend {
       newData: resolved,
     });
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, 'transaction', path, 'deny', evaluation, {
+      this.emitOperation(auth, 'transaction', path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         origin: 'transaction',
@@ -1259,7 +1272,7 @@ export class RtdbBackend {
       mockData: this.tree.snapshot() as Record<string, unknown>,
     });
     if (evaluation.check !== 'allow') {
-      this.emitOperation(auth, 'listen', path, 'deny', evaluation, {
+      this.emitOperation(auth, 'listen', path, denyResultFor(evaluation.check), evaluation, {
         at,
         durationMs: Date.now() - at,
         origin: 'listener',

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -52,8 +52,17 @@ export function permissionDenied(): Error {
  * matching RTDB's implicit-deny default ("nothing matched → no
  * permission"). The wrapper itself stays neutral so admin-mode callers
  * (which bypass rules entirely) can use a different fold.
+ *
+ * `'unsupported'` is a distinct third outcome: the simulator hit a rule
+ * expression it cannot parse/evaluate and abstained rather than granting
+ * or denying. It is folded to deny by user-mode callers (same as
+ * `'no-rule'` — abstain, never grant) but reported separately on the
+ * event stream so Studio's traffic view can show it as a simulator gap
+ * instead of a real rules decision. Matches the Firestore simulator's
+ * posture: `UNSUPPORTED` never counts as a real evaluation and never
+ * grants access.
  */
-export type RuleCheck = 'allow' | 'deny' | 'no-rule';
+export type RuleCheck = 'allow' | 'deny' | 'no-rule' | 'unsupported';
 
 export interface RuleEvaluationDetails {
   check: RuleCheck;
@@ -160,6 +169,16 @@ export class RulesEvaluator {
         reasons: [result.error.message],
         errorCode: result.error.code,
         errorMessage: result.error.message,
+      };
+    }
+    if (result.data.unsupported) {
+      return {
+        check: 'unsupported',
+        reasons: [`${result.data.matchedPath} ${operation} UNSUPPORTED: ${result.data.reason}`],
+        matchedPath: result.data.matchedPath,
+        matchedRule: result.data.matchedRule,
+        reason: result.data.reason,
+        pathVariableBindings: result.data.pathVariableBindings,
       };
     }
     return {

--- a/packages/pyric/src/database/simulation/handler.ts
+++ b/packages/pyric/src/database/simulation/handler.ts
@@ -26,6 +26,12 @@ interface ValidateFailure {
   node: RtdbNode;
   rule: RtdbRuleExpression;
   bindings: Record<string, string>;
+  /** True when this "failure" is a simulator gap (the grammar could not
+   *  parse the `.validate` expression) rather than a genuine `false`
+   *  evaluation. A real failure found anywhere in the tree always takes
+   *  priority over an unsupported one (AND-semantics: a confirmed DENY
+   *  is stronger evidence than an abstention). */
+  unsupported?: boolean;
 }
 
 /** Own-enumerable keys of a snapshot's object value; empty for non-objects. */
@@ -73,12 +79,19 @@ function findWriteLocationNode(
  * `.validate` on the post-write value at the write location and at every
  * descendant present in that value; unlike `.read`/`.write` these rules do
  * NOT cascade — ALL must evaluate true, and a single failure denies the
- * whole write. Nodes whose proposed value is null (a delete) are skipped,
- * and an unparseable `.validate` expression is skipped rather than denied
- * (never flip a prod-legal write to a sandbox denial over a rule the
- * grammar can't reason about). Ancestor `.validate` rules ABOVE the write
- * location are not evaluated. Returns the first failing node, or `null`
- * when every applicable `.validate` passes.
+ * whole write. Nodes whose proposed value is null (a delete) are skipped.
+ *
+ * An unparseable `.validate` expression is a simulator gap, not a pass:
+ * production would still evaluate it and may reject the write, so treating
+ * it as "no rule" would be a fidelity lie. It is reported as `unsupported`
+ * (an abstention) rather than fabricated as either ALLOW or DENY — mirrors
+ * the Firestore simulator's posture where an `UnsupportedError` never
+ * counts as a real evaluation. A genuine `false` found anywhere in the
+ * tree still wins over an unsupported node elsewhere (a confirmed DENY is
+ * stronger evidence than an abstention). Ancestor `.validate` rules ABOVE
+ * the write location are not evaluated. Returns the first real failure,
+ * else the first unsupported node, else `null` when every applicable
+ * `.validate` passes.
  */
 function findFailingValidate(
   node: RtdbNode,
@@ -87,49 +100,60 @@ function findFailingValidate(
   bindings: Record<string, string>,
   buildContext: ContextBuilder,
 ): ValidateFailure | null {
-  // A null proposed value is a delete — RTDB does not validate deletes.
-  if (!newData.exists()) return null;
+  let firstUnsupported: ValidateFailure | null = null;
 
-  const rule = node.validate;
-  if (rule && rule.parsed.valid) {
-    const match = grammar.match(rule.raw.trim());
-    const result = evaluateExpression(match, buildContext(data, newData, bindings));
-    if (!result) return { node, rule, bindings };
-  }
+  function walk(
+    node: RtdbNode,
+    data: DataSnapshot,
+    newData: DataSnapshot,
+    bindings: Record<string, string>,
+  ): ValidateFailure | null {
+    // A null proposed value is a delete — RTDB does not validate deletes.
+    if (!newData.exists()) return null;
 
-  for (const child of node.children) {
-    const childSegments = child.path.split('/').filter(Boolean);
-    if (childSegments.length === 0) continue;
+    const rule = node.validate;
+    if (rule) {
+      if (!rule.parsed.valid) {
+        if (!firstUnsupported) {
+          firstUnsupported = { node, rule, bindings, unsupported: true };
+        }
+      } else {
+        const match = grammar.match(rule.raw.trim());
+        const result = evaluateExpression(match, buildContext(data, newData, bindings));
+        if (!result) return { node, rule, bindings };
+      }
+    }
 
-    const lastSegment = childSegments[childSegments.length - 1];
-    const isPathVar = lastSegment.startsWith('$');
+    for (const child of node.children) {
+      const childSegments = child.path.split('/').filter(Boolean);
+      if (childSegments.length === 0) continue;
 
-    if (isPathVar) {
-      // Bind the path variable to each key actually present in the new
-      // data — a `$var` node validates every child of the written value.
-      for (const key of snapshotChildKeys(newData)) {
-        const failure = findFailingValidate(
-          child,
-          data.child(key),
-          newData.child(key),
-          { ...bindings, [lastSegment]: key },
-          buildContext,
-        );
+      const lastSegment = childSegments[childSegments.length - 1];
+      const isPathVar = lastSegment.startsWith('$');
+
+      if (isPathVar) {
+        // Bind the path variable to each key actually present in the new
+        // data — a `$var` node validates every child of the written value.
+        for (const key of snapshotChildKeys(newData)) {
+          const failure = walk(
+            child,
+            data.child(key),
+            newData.child(key),
+            { ...bindings, [lastSegment]: key },
+          );
+          if (failure) return failure;
+        }
+      } else {
+        const failure = walk(child, data.child(lastSegment), newData.child(lastSegment), bindings);
         if (failure) return failure;
       }
-    } else {
-      const failure = findFailingValidate(
-        child,
-        data.child(lastSegment),
-        newData.child(lastSegment),
-        bindings,
-        buildContext,
-      );
-      if (failure) return failure;
     }
+
+    return null;
   }
 
-  return null;
+  const realFailure = walk(node, data, newData, bindings);
+  return realFailure ?? firstUnsupported;
 }
 
 /**
@@ -265,10 +289,22 @@ export class SimulateHandler {
         };
       };
 
+      // Tracks the first ancestor whose `.write`/`.read` rule the grammar
+      // couldn't parse. Unlike `.validate`, `.write`/`.read` rules cascade
+      // (any ancestor granting `true` wins), so an unparseable rule is not
+      // simply "no rule here" — production would still evaluate it and
+      // might grant on it. If no ancestor grants and no real deny is
+      // found either, this reported as `unsupported` rather than a
+      // fabricated deny.
+      let firstUnsupportedAncestor: AncestorMatch | undefined;
+
       for (const ancestor of ancestors) {
         const ruleExpr: RtdbRuleExpression | undefined = ancestor.node[operation];
         if (!ruleExpr) continue;
-        if (!ruleExpr.parsed.valid) continue;
+        if (!ruleExpr.parsed.valid) {
+          if (!firstUnsupportedAncestor) firstUnsupportedAncestor = ancestor;
+          continue;
+        }
 
         const ancestorSegments = pathSegments.slice(0, ancestor.depth).join('/');
         const dataAtAncestor = rootData.child(ancestorSegments);
@@ -302,9 +338,12 @@ export class SimulateHandler {
                 success: true,
                 data: {
                   allowed: false,
+                  unsupported: failure.unsupported === true,
                   matchedPath: failure.node.path,
                   matchedRule: failure.rule.raw,
-                  reason: 'Validation rule evaluated to false',
+                  reason: failure.unsupported
+                    ? `Validation rule at '${failure.node.path}' contains an expression the simulator cannot evaluate: ${failure.rule.raw} — not evaluated; production may reject this write.`
+                    : 'Validation rule evaluated to false',
                   pathVariableBindings: failure.bindings,
                 },
               };
@@ -323,7 +362,25 @@ export class SimulateHandler {
         }
       }
 
-      // No ancestor rule evaluated to true. Use the deepest match for the denial.
+      // No ancestor rule evaluated to true. If an ancestor's rule couldn't
+      // be parsed, we can't rule out that production would have granted on
+      // it — report the gap instead of fabricating a deny.
+      if (firstUnsupportedAncestor) {
+        const rule = firstUnsupportedAncestor.node[operation] as RtdbRuleExpression;
+        return {
+          success: true,
+          data: {
+            allowed: false,
+            unsupported: true,
+            matchedPath: firstUnsupportedAncestor.node.path,
+            matchedRule: rule.raw,
+            reason: `'${operation}' rule at '${firstUnsupportedAncestor.node.path}' contains an expression the simulator cannot evaluate: ${rule.raw} — not evaluated; production may reject or allow this ${operation}.`,
+            pathVariableBindings: firstUnsupportedAncestor.pathVariableBindings,
+          },
+        };
+      }
+
+      // Use the deepest match for the denial.
       const deepest = ancestors[ancestors.length - 1];
       const deepestRule = deepest.node[operation];
 

--- a/packages/pyric/src/database/simulation/spec.ts
+++ b/packages/pyric/src/database/simulation/spec.ts
@@ -21,6 +21,10 @@ export const SimulateErrorCode = z.enum([
 
 export const SimulationResultSchema = z.object({
   allowed: z.boolean(),
+  /** True when this outcome is a simulator gap — an unparseable/unevaluable
+   *  rule expression the engine abstained on rather than genuinely denied.
+   *  `allowed` is always `false` alongside this (abstain, never grant). */
+  unsupported: z.boolean().optional(),
   matchedPath: z.string(),
   matchedRule: z.string(),
   reason: z.string(),

--- a/packages/pyric/test/database/simulation/handler.test.ts
+++ b/packages/pyric/test/database/simulation/handler.test.ts
@@ -187,6 +187,42 @@ describe('SimulateHandler', () => {
       expect(result.data.matchedPath).toBe('/');
     }
   });
+
+  test('an unparseable .write rule is reported unsupported, not silently skipped', () => {
+    // An ancestor `.write` the grammar can't parse must not be treated as
+    // "no rule here" — production would still evaluate it and might grant
+    // on it. No other ancestor grants, so this must surface as a reported
+    // gap rather than a fabricated deny.
+    const expr = (raw: string, valid = true) => ({
+      raw,
+      parsed: { raw, valid, errors: [], warnings: [], referencedIdentifiers: [] },
+    });
+    const badWriteIR: RtdbIR = {
+      service: 'realtime-database',
+      databaseUrl: 'https://test.firebaseio.com',
+      rules: {
+        path: '/',
+        pathVariables: [],
+        exists: true,
+        write: expr('!! not parseable @@', false),
+        children: [{ path: '/data', pathVariables: [], exists: true, children: [] }],
+      },
+    };
+    const result = handler.execute(badWriteIR, {
+      operation: 'write',
+      path: '/data',
+      auth: { uid: 'user1', token: {} },
+      mockData: {},
+      newData: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(false);
+      expect(result.data.unsupported).toBe(true);
+      expect(result.data.matchedPath).toBe('/');
+      expect(result.data.reason).toContain('!! not parseable @@');
+    }
+  });
 });
 
 // ── .validate enforcement on the write path (non-cascading) ────────────
@@ -395,9 +431,12 @@ describe('SimulateHandler — .validate (write path)', () => {
     expect(result.success && result.data.allowed).toBe(true);
   });
 
-  test('an unparseable .validate is skipped, never denied', () => {
+  test('an unparseable .validate is reported unsupported, not silently passed', () => {
     // A `.validate` the grammar can't reason about must not flip a
-    // prod-legal write into a sandbox denial (the reverse-divergence trap).
+    // prod-legal write into a fabricated sandbox denial, and it must not
+    // silently pass either — production would still evaluate it and may
+    // reject the write. It is a reported simulator gap: `allowed: false`,
+    // `unsupported: true`, naming the rule path and the construct.
     const badIR = ir(
       node({
         path: '/',
@@ -412,7 +451,77 @@ describe('SimulateHandler — .validate (write path)', () => {
       mockData: {},
       newData: { anything: 1 },
     });
-    expect(result.success && result.data.allowed).toBe(true);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(false);
+      expect(result.data.unsupported).toBe(true);
+      expect(result.data.matchedPath).toBe('/entry');
+      expect(result.data.reason).toContain('/entry');
+      expect(result.data.reason).toContain('!! not parseable @@');
+    }
+  });
+
+  test('a real deny elsewhere still wins over an unsupported .validate', () => {
+    // AND-semantics: a confirmed failing .validate is stronger evidence
+    // than an abstention, so it must be reported (not masked by the gap).
+    const mixedIR = ir(
+      node({
+        path: '/',
+        write: expr('auth !== null'),
+        children: [
+          node({
+            path: '/entry',
+            children: [
+              node({ path: '/entry/a', validate: expr('!! not parseable @@', false) }),
+              node({ path: '/entry/b', validate: expr('newData.isString()') }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const result = handler.execute(mixedIR, {
+      operation: 'write',
+      path: '/entry',
+      auth: authed,
+      mockData: {},
+      newData: { a: 1, b: 123 }, // b fails: not a string
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(false);
+      expect(result.data.unsupported).toBeFalsy();
+      expect(result.data.matchedPath).toBe('/entry/b');
+    }
+  });
+
+  test('a parseable failing .validate still denies as today', () => {
+    const result = handler.execute(structureIR, {
+      operation: 'write',
+      path: '/entry',
+      auth: authed,
+      mockData: {},
+      newData: { title: 't' }, // missing `body`
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(false);
+      expect(result.data.unsupported).toBeFalsy();
+    }
+  });
+
+  test('a parseable passing .validate still allows as today', () => {
+    const result = handler.execute(structureIR, {
+      operation: 'write',
+      path: '/entry',
+      auth: authed,
+      mockData: {},
+      newData: { title: 't', body: 'b' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowed).toBe(true);
+      expect(result.data.unsupported).toBeFalsy();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The RTDB rules simulator silently skipped `.validate` expressions it couldn't parse — the write proceeded as if validation had passed, with no signal anywhere. Ancestor `.write`/`.read` rules had the same swallow during the cascade walk: an unparseable rule was silently skipped (treated as "no rule at this ancestor") and evaluation fell through to the next ancestor or default-deny. Both are fidelity lies: production would still evaluate the rule and could reject (or grant) the operation.

### Swallow sites found (`packages/pyric/src/database/simulation/handler.ts`, pre-change)

- `findFailingValidate` (line 94): `if (rule && rule.parsed.valid) { ... }` — an unparseable `.validate` skipped the check entirely, treated as passing.
- `SimulateHandler.execute` ancestor-walk loop (line 271): `if (!ruleExpr.parsed.valid) continue;` — an unparseable `.write`/`.read` at a would-be-granting ancestor was silently skipped, falling through to the next ancestor or default-deny.
- One layer up, `RulesEvaluator.evaluate` (`packages/pyric/src/database/sandbox/rules-eval.ts`) collapsed all non-`allow` outcomes (including genuine evaluator gaps thrown as `EVALUATION_ERROR`) into a single `'no-rule'` check, with no way to distinguish "real deny" from "couldn't evaluate."

### Disposition (matches Firestore simulator precedent exactly)

The Firestore rules simulator (`packages/pyric/src/rules/simulator/`) already has a third outcome for this: `UnsupportedError` → `verdict: 'UNSUPPORTED'` → `Decision: 'UNSUPPORTED'`, which only wins over `DENY`, never over `ALLOW` (an abstention is not a grant). RTDB now follows the same posture:

- `SimulationResult` gained `unsupported?: boolean`. When set, `allowed` is always `false` — abstain, never fabricate a grant, and never invent a deny that overrides a real evaluated verdict found elsewhere in the tree (a confirmed `DENY` still wins over an `UNSUPPORTED` sibling, per AND-semantics for `.validate`).
- `RuleCheck` (`rules-eval.ts`) gained `'unsupported'`, distinct from `'no-rule'`/`'deny'`. User-mode callers still deny the operation on `'unsupported'` (abstain, never grant), but it's now a distinguishable signal.
- The sandbox backend (`packages/pyric/src/database/sandbox/backend.ts`) forwards this to the event stream as `result: 'unsupported'` (via a new `denyResultFor(check)` helper at all 9 call sites that previously hardcoded `'deny'`). Studio's traffic verdict mapping (`packages/studio/src/features/traffic/verdict.ts`) already treats `result === 'unsupported'` as a blank (non-rules) verdict — no Studio changes were needed, it was already future-proofed for this value.

### Reasons text

Reported reasons name the rule path and the unparseable construct, e.g.:
`Validation rule at '/rooms/$id' contains an expression the simulator cannot evaluate: <raw expr> — not evaluated; production may reject this write.`

## Tests

`packages/pyric/test/database/simulation/handler.test.ts`:
- `an unparseable .validate is reported unsupported, not silently passed`
- `a real deny elsewhere still wins over an unsupported .validate`
- `a parseable failing .validate still denies as today`
- `a parseable passing .validate still allows as today`
- `an unparseable .write rule is reported unsupported, not silently skipped`

## Test plan

- [x] `bun test packages/pyric` — green (527/527 in `test/database`, full suite 4359 pass / 3 pre-existing unrelated failures from an unbuilt sibling package's `pyric-tools/discover` import, present on main before this change)
- [x] `bun run typecheck` (packages/pyric) — clean
- [x] `bun test` in `packages/studio/src/features/traffic` — verdict mapping tests still green, no changes needed there