### PR TITLE
Support firestore.get/exists in Storage rules evaluator

### DIFF
--- a/packages/pyric/src/storage/enforce.ts
+++ b/packages/pyric/src/storage/enforce.ts
@@ -43,7 +43,7 @@
 import { emitSandboxEvent, makeSandboxOperationEvent } from 'pyric/sandbox/internal';
 import type { EventProvenance } from 'pyric/sandbox';
 import type { StorageService, Target } from './service.js';
-import { evaluateStorageRules, type EvaluationInput } from './rules.js';
+import { evaluateStorageRules, type EvaluationInput, type FirestoreLookup } from './rules.js';
 import { unauthorized } from './errors.js';
 
 export function enforceRules(
@@ -69,7 +69,7 @@ export function enforceRules(
     emitOperation(target, input, 'allow', undefined, 'user', false, provenance);
     return;
   }
-  const result = evaluateStorageRules(service.rules, input);
+  const result = evaluateStorageRules(service.rules, input, undefined, firestoreLookupFor(target));
   if (!result.allowed) {
     emitOperation(target, input, 'deny', result.reasons, 'user', true, provenance);
     const detail = result.reasons.length > 0 ? ` — ${result.reasons.join('; ')}` : '';
@@ -117,4 +117,24 @@ function emitOperation(
   } catch {
     // Observational — never let event emission break storage enforcement.
   }
+}
+
+/**
+ * Build the {@link FirestoreLookup} a rule's `firestore.get()/exists()`
+ * calls read from. Only sandbox targets have Firestore data reachable
+ * in-process: `sandbox.admin.getDocument` is a SYNCHRONOUS, rules-bypassing
+ * in-memory read of the SAME per-sandbox store the user-plane writes to, so
+ * the enforcement seam stays synchronous AND the lookup is invoked lazily
+ * during evaluation (honoring short-circuit) exactly like production.
+ *
+ * Prod targets and rules-less services get no lookup — a rule that reaches
+ * for `firestore.*` there denies "unsupported" rather than false-allowing.
+ */
+function firestoreLookupFor(target?: Target): FirestoreLookup | undefined {
+  if (target?.kind !== 'sandbox') return undefined;
+  const admin = target.sandbox.admin;
+  return {
+    get: (path) => admin.getDocument(path) as Record<string, unknown> | null,
+    exists: (path) => admin.getDocument(path) !== null,
+  };
 }

--- a/packages/pyric/src/storage/index.ts
+++ b/packages/pyric/src/storage/index.ts
@@ -79,6 +79,7 @@ export type {
   StorageResource,
   EvaluationInput,
   EvaluationResult,
+  FirestoreLookup,
 } from './rules.js';
 
 // ─── Admin / control-plane surface ───────────────────────────────────

--- a/packages/pyric/src/storage/rules.ts
+++ b/packages/pyric/src/storage/rules.ts
@@ -135,6 +135,26 @@ export interface EvaluationResult {
   reasons: string[];
 }
 
+/**
+ * Injected capability that lets a Storage rule read Firestore documents
+ * (`firestore.get(path)` / `firestore.exists(path)`), WITHOUT the pure
+ * evaluator importing the Firestore sandbox. The enforcement layer builds
+ * one from the sandbox's admin Firestore accessor (a synchronous in-memory
+ * read) and passes it into {@link evaluateStorageRules}; pure/test callers
+ * that omit it get the deny-with-reason "unsupported" behavior instead.
+ *
+ * Paths are the document path RELATIVE to the database — the
+ * `collection/doc` form `sandbox.admin.getDocument` expects — after the
+ * evaluator has stripped the `/databases/<db>/documents/` prefix from the
+ * rule's path literal.
+ */
+export interface FirestoreLookup {
+  /** The document's fields, or `null` when the document does not exist. */
+  get(path: string): Record<string, unknown> | null;
+  /** Whether a document exists at `path`. */
+  exists(path: string): boolean;
+}
+
 /** Opaque parsed-rules handle returned by `parseStorageRules`. */
 export interface StorageRules {
   readonly _root: MatchBlock;
@@ -196,7 +216,19 @@ type Expr =
    *  `string.matches(re)` (target is any string expr) and the timestamp
    *  namespace constructors `timestamp.date(y,m,d)` / `timestamp.value(ms)`
    *  (target is the bare `timestamp` identifier). */
-  | { kind: 'methodcall'; target: Expr; method: string; args: Expr[] };
+  | { kind: 'methodcall'; target: Expr; method: string; args: Expr[] }
+  /** A Firestore path literal — the argument to `firestore.get()` /
+   *  `firestore.exists()`, e.g.
+   *  `/databases/(default)/documents/users/$(request.auth.uid)`. Segments
+   *  are either fixed text or `$(expr)` interpolations resolved at eval.
+   *  Only meaningful as a Firestore-lookup argument; evaluating one in any
+   *  other position denies (see `evalExpr`). */
+  | { kind: 'path'; segments: PathArgSegment[] };
+
+/** One segment of a {@link Expr} `path` literal. */
+type PathArgSegment =
+  | { kind: 'literal'; value: string }
+  | { kind: 'interp'; expr: Expr };
 
 // ═══════════════════════════════════════════════════════════════
 // Lexer
@@ -283,8 +315,9 @@ function tokenize(source: string): Token[] {
       i += 2;
       continue;
     }
-    // Single-char punctuation
-    if ('{}()[].,;:=*+-/<>!|&'.includes(ch)) {
+    // Single-char punctuation. `$` is here for `$(expr)` interpolation
+    // segments inside a Firestore path literal (`firestore.get(/…/$(x))`).
+    if ('{}()[].,;:=*+-/<>!|&$'.includes(ch)) {
       tokens.push({ kind: 'punct', value: ch, pos: i });
       i++;
       continue;
@@ -555,6 +588,13 @@ class Parser {
   }
   private parsePrimary(): Expr {
     const t = this.peek();
+    // A leading `/` in primary position can only be a Firestore path
+    // literal (division needs a left operand, which primary position lacks).
+    // Only `firestore.get()/exists()` accept one; anywhere else it parses
+    // fine but denies at eval (see `evalExpr` 'path').
+    if (t.kind === 'punct' && t.value === '/') {
+      return this.parsePathArg();
+    }
     if (t.kind === 'punct' && t.value === '(') {
       this.expectPunct('(');
       const e = this.parseExpression();
@@ -577,6 +617,55 @@ class Parser {
       return { kind: 'ident', name: t.value };
     }
     throw new SyntaxError(`Unexpected token "${describeToken(t)}" at offset ${t.pos}.`);
+  }
+
+  /**
+   * Parse a Firestore path literal — the `firestore.get()/exists()`
+   * argument. Grammar (each segment preceded by `/`):
+   *
+   *   - `$(expr)`      — an interpolation resolved at eval time
+   *   - `(name)`       — the parenthesized database sentinel, e.g. `(default)`
+   *   - `ident`/number — a fixed path segment (`databases`, `documents`, …)
+   *
+   * The full path is assembled and prefix-validated at eval (see
+   * `buildFirestoreDocPath`); the parser only captures structure.
+   */
+  private parsePathArg(): Expr {
+    const segments: PathArgSegment[] = [];
+    while (this.atPunct('/')) {
+      this.expectPunct('/');
+      if (this.atPunct('$')) {
+        this.expectPunct('$');
+        this.expectPunct('(');
+        const expr = this.parseExpression();
+        this.expectPunct(')');
+        segments.push({ kind: 'interp', expr });
+      } else if (this.atPunct('(')) {
+        // Database sentinel like `(default)`; kept verbatim (parens included)
+        // so the eval-time prefix check sees the exact production form.
+        this.expectPunct('(');
+        const name = this.expectIdentValue();
+        this.expectPunct(')');
+        segments.push({ kind: 'literal', value: `(${name})` });
+      } else {
+        const t = this.peek();
+        if (t.kind === 'ident') {
+          this.pos++;
+          segments.push({ kind: 'literal', value: t.value });
+        } else if (t.kind === 'number') {
+          this.pos++;
+          segments.push({ kind: 'literal', value: String(t.value) });
+        } else {
+          throw new SyntaxError(
+            `Expected a path segment after '/' at offset ${t.pos}, got "${describeToken(t)}".`,
+          );
+        }
+      }
+    }
+    if (segments.length === 0) {
+      throw new SyntaxError(`Empty Firestore path literal at offset ${this.peek().pos}.`);
+    }
+    return { kind: 'path', segments };
   }
 
   // ─── Token helpers ─────────────────────────────────────────
@@ -721,6 +810,7 @@ export function evaluateStorageRules(
   rules: StorageRules,
   input: EvaluationInput,
   now: Date = new Date(),
+  firestoreLookup?: FirestoreLookup,
 ): EvaluationResult {
   // `request.time` is the request's evaluation moment, modeled internally
   // as epoch milliseconds so it compares numerically against the
@@ -772,6 +862,7 @@ export function evaluateStorageRules(
                 locals: {},
                 funcs: block.visibleFuncs ?? new Map(),
                 depth: 0,
+                firestoreLookup,
               }))
             : true;
         } catch (err) {
@@ -894,6 +985,9 @@ interface EvalCtx {
   funcs: FunctionMap;
   /** Current call depth (0 at an allow condition). */
   depth: number;
+  /** Optional Firestore read capability for `firestore.get()/exists()`.
+   *  Absent in pure/test usage → those methods deny "unsupported". */
+  firestoreLookup?: FirestoreLookup;
 }
 
 /**
@@ -936,6 +1030,11 @@ function evalExpr(expr: Expr, ctx: EvalCtx): unknown {
       return evalCall(expr, ctx);
     case 'methodcall':
       return evalMethodCall(expr, ctx);
+    case 'path':
+      // A path literal is only meaningful as a `firestore.get()/exists()`
+      // argument (handled directly there). Reaching it anywhere else means
+      // the rule used it out of position — deny rather than coerce.
+      throw new RuleEvalError('a Firestore path literal is only valid as an argument to firestore.get()/exists()');
     case 'unary':
       return !truthy(evalExpr(expr.arg, ctx));
     case 'binary': {
@@ -1008,6 +1107,7 @@ function evalCall(expr: Extract<Expr, { kind: 'call' }>, ctx: EvalCtx): unknown 
     locals,
     funcs: fn.declScope ?? new Map(),
     depth,
+    firestoreLookup: ctx.firestoreLookup,
   };
   // `let` bindings evaluated in order; each is visible to the next and
   // to the return expression (they share the `locals` object).
@@ -1069,11 +1169,109 @@ function evalMethodCall(expr: Extract<Expr, { kind: 'methodcall' }>, ctx: EvalCt
     return evalTimestampBuiltin(expr, ctx);
   }
 
+  // Firestore namespace: `firestore.get(path)` / `firestore.exists(path)`.
+  // Detected on the bare `firestore` identifier (not a bound local/param) so
+  // a user value named `firestore` can't hijack it.
+  if (
+    expr.target.kind === 'ident' &&
+    expr.target.name === 'firestore' &&
+    !(expr.target.name in ctx.locals) &&
+    !(expr.target.name in ctx.params)
+  ) {
+    return evalFirestoreBuiltin(expr, ctx);
+  }
+
   if (expr.method === 'matches') {
     return evalMatches(expr, ctx);
   }
 
   throw new RuleEvalError(`unsupported method .${expr.method}()`);
+}
+
+/**
+ * Evaluate `firestore.get(path)` / `firestore.exists(path)`.
+ *
+ * Requires an injected {@link FirestoreLookup} (the enforcement layer
+ * supplies one from the sandbox's Firestore data). With NO capability —
+ * pure/test usage without a sandbox — this denies with an "unsupported"
+ * reason rather than ever a false allow, preserving the pre-lookup posture.
+ *
+ * Semantics (production-honest, deny-on-error):
+ *   - `firestore.get(path)` → a resource `{ data: <fields> }`. Member access
+ *     `.data.<field>` then reads the doc's fields. On a NONEXISTENT doc,
+ *     production `get()` is itself an error, so this denies with a reason.
+ *   - `firestore.exists(path)` → boolean.
+ *   - Malformed path (missing `/databases/<db>/documents/` prefix, odd
+ *     segment count), a non-string interpolation, wrong arg count, or a
+ *     non-path argument → deny with a reason.
+ */
+function evalFirestoreBuiltin(
+  expr: Extract<Expr, { kind: 'methodcall' }>,
+  ctx: EvalCtx,
+): unknown {
+  if (expr.method !== 'get' && expr.method !== 'exists') {
+    throw new RuleEvalError(`unsupported method firestore.${expr.method}()`);
+  }
+  if (!ctx.firestoreLookup) {
+    // No sandbox-backed capability injected — keep the deny-with-reason
+    // "unsupported" behavior; never a false allow.
+    throw new RuleEvalError(
+      `firestore.${expr.method}() is unsupported here — no Firestore lookup capability is configured`,
+    );
+  }
+  if (expr.args.length !== 1) {
+    throw new RuleEvalError(`firestore.${expr.method}() expects a single path argument`);
+  }
+  const arg = expr.args[0];
+  if (arg.kind !== 'path') {
+    throw new RuleEvalError(`firestore.${expr.method}() requires a /databases/.../documents/... path literal`);
+  }
+  const docPath = buildFirestoreDocPath(arg, ctx);
+  if (expr.method === 'exists') {
+    return ctx.firestoreLookup.exists(docPath);
+  }
+  const fields = ctx.firestoreLookup.get(docPath);
+  if (fields === null) {
+    // Production: `get()` on a missing document errors, and errors deny.
+    throw new RuleEvalError(`firestore.get() targeted a nonexistent document: ${docPath}`);
+  }
+  return { data: fields };
+}
+
+/**
+ * Assemble a {@link PathArgSegment} list into the document path the
+ * {@link FirestoreLookup} expects, then validate + strip the required
+ * `/databases/<db>/documents/` prefix. Interpolations must resolve to a
+ * string or number; anything else (e.g. `request.auth.uid` when auth is
+ * null → undefined) throws → deny.
+ */
+function buildFirestoreDocPath(
+  pathExpr: Extract<Expr, { kind: 'path' }>,
+  ctx: EvalCtx,
+): string {
+  const parts = pathExpr.segments.map((seg) => {
+    if (seg.kind === 'literal') return seg.value;
+    const v = evalExpr(seg.expr, ctx);
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number') return String(v);
+    throw new RuleEvalError(
+      `Firestore path interpolation resolved to ${describeType(v)} (expected a string)`,
+    );
+  });
+  // Required production shape: databases / <db> / documents / <doc path…>.
+  if (parts.length < 4 || parts[0] !== 'databases' || parts[2] !== 'documents') {
+    throw new RuleEvalError(
+      `malformed Firestore path — expected /databases/<db>/documents/... , got /${parts.join('/')}`,
+    );
+  }
+  const docSegments = parts.slice(3);
+  // A document path is collection/doc pairs — an even, non-zero segment count.
+  if (docSegments.length === 0 || docSegments.length % 2 !== 0) {
+    throw new RuleEvalError(
+      `Firestore path does not point at a document (needs an even segment count): ${docSegments.join('/')}`,
+    );
+  }
+  return docSegments.join('/');
 }
 
 /** `timestamp.date(year, month, day)` (UTC midnight) and

--- a/packages/pyric/test/storage/denial-events.test.ts
+++ b/packages/pyric/test/storage/denial-events.test.ts
@@ -108,7 +108,9 @@ describe('storage rules denial lands on the unified event stream', () => {
 
     const denies = operations(events).filter((e) => e.service === 'storage' && e.result === 'deny');
     expect(denies.length).toBe(1);
-    expect(denies[0]!.method).toBe('read');
+    // Granular verbs (storage-rules-granular-verbs): download enforces the
+    // precise `get` verb, not the coarse `read` umbrella.
+    expect(denies[0]!.method).toBe('get');
   });
 
   it('a denied op issued with Studio provenance carries actor "studio" on the deny event', async () => {

--- a/packages/pyric/test/storage/rules.test.ts
+++ b/packages/pyric/test/storage/rules.test.ts
@@ -412,6 +412,129 @@ describe('evaluateStorageRules — matches()', () => {
   });
 });
 
+// ─── firestore.get() / firestore.exists() cross-service lookups ───
+//
+// Storage rules may read Firestore documents to authorize an op:
+//
+//   firestore.get(/databases/(default)/documents/users/$(request.auth.uid))
+//     .data.premium == true
+//
+// The evaluator stays PURE — it never imports the Firestore sandbox.
+// A lookup capability is injected (4th arg). Path syntax:
+// `/databases/<db>/documents/<collection>/<doc>` with `$(expr)`
+// interpolation segments; the `/databases/<db>/documents/` prefix is
+// stripped and the remaining document path is handed to the lookup
+// (matching `sandbox.admin.getDocument`'s `collection/doc` form).
+//
+// Failure posture is deny-with-reason (never a false allow):
+//   - no lookup injected             → deny "unsupported"
+//   - get() on a nonexistent doc     → deny (production errors, errors deny)
+//   - malformed path / wrong arg type → deny
+describe('evaluateStorageRules — firestore.get / firestore.exists', () => {
+  const path = 'b/pyric-default/o/docs/d1.json';
+
+  function evalFs(
+    cond: string,
+    docs: Record<string, Record<string, unknown>>,
+    auth: { uid: string } | null = { uid: 'alice' },
+  ): { allowed: boolean; reasons: string[] } {
+    const rules = parseStorageRules(`service firebase.storage {
+      match /b/{bucket}/o {
+        match /docs/{docId} { allow read: if ${cond}; }
+      }
+    }`);
+    const lookup = {
+      get(p: string) {
+        return p in docs ? docs[p] : null;
+      },
+      exists(p: string) {
+        return p in docs;
+      },
+    };
+    return evaluateStorageRules(
+      rules,
+      { request: { auth, method: 'read', path }, resource: { size: 1 } },
+      undefined,
+      lookup,
+    );
+  }
+
+  it('allows when an interpolated firestore.get reads .data.premium == true', () => {
+    const r = evalFs(
+      'firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.premium == true',
+      { 'users/alice': { premium: true } },
+    );
+    expect(r.allowed).toBe(true);
+  });
+
+  it('denies when the looked-up field is false', () => {
+    const r = evalFs(
+      'firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.premium == true',
+      { 'users/alice': { premium: false } },
+    );
+    expect(r.allowed).toBe(false);
+  });
+
+  it('firestore.exists returns true for a present document', () => {
+    const r = evalFs(
+      'firestore.exists(/databases/(default)/documents/members/$(request.auth.uid))',
+      { 'members/alice': { since: 1 } },
+    );
+    expect(r.allowed).toBe(true);
+  });
+
+  it('firestore.exists returns false for an absent document', () => {
+    const r = evalFs(
+      'firestore.exists(/databases/(default)/documents/members/$(request.auth.uid))',
+      {},
+    );
+    expect(r.allowed).toBe(false);
+  });
+
+  it('denies (with reason) when firestore.get targets a nonexistent doc', () => {
+    // Production: get() on a missing doc is an error, and errors deny.
+    const r = evalFs(
+      'firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.premium == true',
+      {},
+    );
+    expect(r.allowed).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/firestore\.get|nonexistent|does not exist/i);
+  });
+
+  it('denies "unsupported" when NO lookup capability is injected', () => {
+    const rules = parseStorageRules(`service firebase.storage {
+      match /b/{bucket}/o {
+        match /docs/{docId} {
+          allow read: if firestore.exists(/databases/(default)/documents/users/$(request.auth.uid));
+        }
+      }
+    }`);
+    // No 4th arg — pure/test usage with no sandbox.
+    const r = evaluateStorageRules(rules, {
+      request: { auth: { uid: 'alice' }, method: 'read', path },
+      resource: { size: 1 },
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/unsupported|firestore/i);
+  });
+
+  it('denies on a malformed path (missing /databases/<db>/documents prefix)', () => {
+    const r = evalFs('firestore.exists(/users/$(request.auth.uid))', {
+      'users/alice': { x: 1 },
+    });
+    expect(r.allowed).toBe(false);
+  });
+
+  it('denies when an interpolation segment resolves to a non-string (auth is null)', () => {
+    const r = evalFs(
+      'firestore.exists(/databases/(default)/documents/users/$(request.auth.uid))',
+      { 'users/alice': { x: 1 } },
+      null,
+    );
+    expect(r.allowed).toBe(false);
+  });
+});
+
 // ─── Granular verbs (get/list/create/update/delete) ──────────────
 //
 // Production Storage semantics:
@@ -1011,5 +1134,62 @@ service firebase.storage {
     expect(() =>
       getStorageSandbox(sandbox.withAuth({ uid: 'bob' }), { dbName, rules: DENY_ALL }),
     ).not.toThrow();
+  });
+});
+
+// ─── firestore lookups thread through real storage enforcement ────
+//
+// End-to-end: a storage rule reads a Firestore document from the SAME
+// sandbox to authorize an upload (the premium-user pattern). Enforcement
+// (`enforce.ts`) builds the lookup capability from the sandbox's admin
+// Firestore accessor (`sandbox.admin.getDocument`, a synchronous
+// in-memory read) and injects it into the pure evaluator.
+const PREMIUM_UPLOAD_RULES = `
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /uploads/{file} {
+      allow write: if firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.premium == true;
+    }
+  }
+}`;
+
+describe('firestore lookups thread through real storage enforcement', () => {
+  const path = 'b/pyric-default/o/uploads/report.json';
+
+  it('allows an upload when the user\'s Firestore doc says premium == true', async () => {
+    const sandbox = initializeSandbox({});
+    // Seed the acting user's Firestore doc via the admin plane.
+    sandbox.admin.setDocument('users/alice', { premium: true });
+    const alice = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
+      dbName: uniqueDbName('fs-premium-allow'),
+      rules: PREMIUM_UPLOAD_RULES,
+    });
+    await uploadBytes(ref(alice, path), new Blob(['{}']), {
+      contentType: 'application/json',
+    });
+    // No throw = allowed.
+  });
+
+  it('denies an upload when the user\'s Firestore doc is not premium', async () => {
+    const sandbox = initializeSandbox({});
+    sandbox.admin.setDocument('users/bob', { premium: false });
+    const bob = getStorageSandbox(sandbox.withAuth({ uid: 'bob' }), {
+      dbName: uniqueDbName('fs-premium-deny'),
+      rules: PREMIUM_UPLOAD_RULES,
+    });
+    await expect(
+      uploadBytes(ref(bob, path), new Blob(['{}']), { contentType: 'application/json' }),
+    ).rejects.toThrow(/unauthorized/);
+  });
+
+  it('denies an upload when the user has no Firestore doc (get on missing doc errors → deny)', async () => {
+    const sandbox = initializeSandbox({});
+    const carol = getStorageSandbox(sandbox.withAuth({ uid: 'carol' }), {
+      dbName: uniqueDbName('fs-premium-missing'),
+      rules: PREMIUM_UPLOAD_RULES,
+    });
+    await expect(
+      uploadBytes(ref(carol, path), new Blob(['{}']), { contentType: 'application/json' }),
+    ).rejects.toThrow(/unauthorized/);
   });
 });

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
@@ -38,12 +38,17 @@ Path variables bind to the surrounding scope — `uid` from the parent match is 
 
 ## Allow conditions
 
-Two verbs:
+Coarse umbrellas and granular verbs, matching production Storage semantics.
 
-- `allow read: if <expr>` — matches `getBytes`, `getBlob`, `getMetadata`.
-- `allow write: if <expr>` — matches `uploadBytes`, `uploadString`, `updateMetadata`, `deleteObject`.
+- `allow read: if <expr>` — the umbrella for `get` + `list`.
+- `allow write: if <expr>` — the umbrella for `create` + `update` + `delete`.
+- `allow get` — `getBlob` / `getBytes` / `getMetadata`.
+- `allow list` — `listAll`.
+- `allow create` — `uploadBytes` / `uploadString` to a path with no existing object.
+- `allow update` — `uploadBytes` / `uploadString` over an existing object, and `updateMetadata`.
+- `allow delete` — `deleteObject`.
 
-The granular forms (`get`, `list`, `create`, `update`, `delete`) are deferred. The parser rejects them.
+A granular grant covers only its own verb: `allow get` does not grant `list`, and `allow create` does not grant `update` or `delete`. Verbs may be comma-separated in one clause (`allow get, list: if <expr>`). A verb with no applicable grant is denied.
 
 ## Request bindings
 
@@ -86,7 +91,6 @@ These produce parse errors:
 - `matches()` / regex predicates.
 - Rule function definitions (`function isOwner() { return ... }`).
 - Deep dotted access into `customMetadata.<field>` — use the bracket form.
-- Granular verbs (`get`, `list`, `create`, `update`, `delete`).
 
 See [Implementation scope and deferred features](../pyric-storage-explanation-implementation-scope/) for the reasoning.
 


### PR DESCRIPTION
Stacked on #113 (`storage-rules-expressions`, itself stacked on #111/#107). Merge that first.

## What

Implements `firestore.get(path)` and `firestore.exists(path)` in the Storage rules evaluator, so a Storage rule can read a Firestore document to authorize an operation — the premium-user pattern:

```
allow write: if firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.premium == true;
```

## Design — pure evaluator, injected capability

`evaluateStorageRules` stays pure (it never imports the Firestore sandbox). It gains an optional 4th arg — a `FirestoreLookup` capability — alongside the existing optional `now`:

```ts
export interface FirestoreLookup {
  get(path: string): Record<string, unknown> | null; // fields, or null if absent
  exists(path: string): boolean;
}
```

The shape maps 1:1 onto the sandbox's admin Firestore accessor, so the enforcement adapter is trivial. Paths passed to the lookup are the `collection/doc` form (the `/databases/<db>/documents/` prefix is stripped by the evaluator).

**No-capability posture:** when no lookup is injected (pure/test usage without a sandbox), `firestore.get/exists` deny with an "unsupported" reason — never a false allow, preserving the pre-existing behavior.

## Parser

Adds Firestore path-literal parsing for the `get/exists` argument: `/databases/<db>/documents/<collection>/<doc>` with `$(expr)` interpolation segments (`$` is now a lexer punct). A new `path` Expr node carries the segments; evaluating one anywhere other than a Firestore lookup denies.

## Semantics (production-honest, deny-on-error)

- `get()` returns a resource whose `.data` is the doc's fields; `get()` on a **nonexistent** doc is an error in production, so it denies with a reason.
- `exists()` returns a boolean.
- Malformed path (missing `/databases/<db>/documents/` prefix, odd segment count), a non-string interpolation (e.g. `request.auth.uid` when auth is null), or a wrong-typed/absent argument → deny with a reason.

## Sync vs async seam

**Synchronous — no async refactor, no divergence.** `enforce.ts` builds the lookup from `sandbox.admin.getDocument`, which is a synchronous, rules-bypassing in-memory read of the same per-sandbox store the user plane writes to. Because the evaluator invokes the lookup lazily during expression evaluation, short-circuiting is honored exactly like production (a `firestore.get` behind a false `&&` is never called). Prod targets and rules-less services get no lookup.

## Tests

`packages/pyric/test/storage/rules.test.ts`:

Unit (`evaluateStorageRules — firestore.get / firestore.exists`, injected lookup):
- allows when an interpolated `firestore.get` reads `.data.premium == true`
- denies when the looked-up field is false
- `firestore.exists` returns true for a present document
- `firestore.exists` returns false for an absent document
- denies (with reason) when `firestore.get` targets a nonexistent doc
- denies "unsupported" when NO lookup capability is injected
- denies on a malformed path (missing prefix)
- denies when an interpolation segment resolves to a non-string (auth null)

End-to-end (`firestore lookups thread through real storage enforcement`, real sandbox + seeded Firestore doc):
- allows an upload when the user's Firestore doc says `premium == true`
- denies an upload when the doc is not premium
- denies an upload when the user has no Firestore doc (get on missing doc → deny)

`bun test` (packages/pyric): 4468 pass, 0 fail. Typecheck (tsc) clean.