### PR TITLE
Static-site suite: assert reload persistence now that the gap is closed

### DIFF
--- a/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
+++ b/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
@@ -121,25 +121,14 @@ test('a Firestore write via the worker port is visible to a second, independent 
   expect((result.read.value as { marker?: string } | null)?.marker).toBe(marker);
 });
 
-test.fail(
-  'KNOWN GAP: a write does not reliably survive a full page reload (SharedWorker teardown races the IDB flush)',
+test(
+  'a write survives a full page reload (IndexedDB durability through SharedWorker teardown)',
   async ({ page }) => {
-    // STILL OPEN as of the recompose-on-main pass (2026-07-09). #62 ("acked
-    // writes now durable before reply") IS merged to main and this build
-    // includes it (buildWorkerCtx + sandbox.enablePersistence, awaited flush
-    // before ack for admin.setDocument) — yet a write acked over the worker
-    // port is NOT found after a full reload in the composed static site.
-    // Reproduced directly against dist/site: the write acks ok:true, the IDB
-    // databases exist (pyric-shared-worker, …), and even with 3s of settle
-    // before the reload and 4s after, the post-reload read comes back
-    // value:null. So the durable-write path (#62) is in place but the
-    // restore-from-IDB-on-reboot path in the composed worker bundle does not
-    // rehydrate user writes — a pyric-tools serve/worker persistence issue,
-    // out of scope for the site composition to fix. The seed (init.json) is
-    // re-applied on every boot, so demo data is always present regardless.
-    //
-    // `test.fail(...)` keeps this documented + runnable (green suite) and will
-    // flip loudly the moment reboot-restore starts working.
+    // Closed by main's persistence work (durable acked writes in #62,
+    // then the RTDB/event-history durability stack): an acked write now
+    // survives a full reload of the composed static site, so this
+    // asserts it for real. IDB is the only durable tier here
+    // (init.json ships persist: false).
     await page.goto('/');
     await page.waitForTimeout(1000);
 


### PR DESCRIPTION
The suite pinned "a write does not survive a full page reload" as a documented `test.fail` while the gap was real. Main's persistence stack closed it (durable acked writes in #62, then the RTDB/event-history durability work), so the case now passes, and a passing `test.fail` flips the whole suite red.

This flips it to a real assertion: an acked write over the worker port survives a full reload of the composed static site (IndexedDB is the only durable tier there; `init.json` ships `persist: false`). Suite is 10/10 against the current main build.

Test-only change; no runtime surface.