### PR TITLE
docs: fix broken npx pyric commands, Node version, install-step gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Install the CLI in an existing Firebase app or a new one:
 
 ```bash
 npm i -g pyric-tools            # installs the `pyric` command
-npx pyric init --template web   # scaffold, or just run pyric dev in an existing app
-npx pyric dev
+pyric init --template web       # scaffold, or skip this in an existing app
+npm install                     # install the scaffolded app's deps
+pyric dev
 ```
 
 `pyric dev` serves the app against the in-process sandbox. The app's own `firebase/*` imports resolve to the sandbox during development; nothing in the application source changes. The sandbox holds data, identities, and rules, and everything it does is observable through the mechanisms below.

--- a/docs/site-rewrite/content/agent/set-up-your-agent.md
+++ b/docs/site-rewrite/content/agent/set-up-your-agent.md
@@ -12,7 +12,7 @@ One connection and your agent has the whole backend as tools. It can read and wr
 The seam is one endpoint. `pyric dev --bridge` mounts an MCP server on your dev server at `/__pyric/mcp`, and every client below connects to it, directly or through a small stdio proxy that finds it for you.
 
 ```bash
-npx pyric dev --bridge
+pyric dev --bridge
 ```
 
 One requirement to know up front: the sandbox lives inside the served page, so keep the app open in a browser tab while the agent works. If data tools return nothing, the page is not open. Open it and try again.
@@ -30,13 +30,13 @@ Then, inside Claude Code, run `/pyric:pyric-start`. It scaffolds a project if yo
 Prefer manual wiring? Register the stdio server:
 
 ```bash
-claude mcp add pyric -- npx pyric mcp
+claude mcp add pyric -- npx pyric-tools mcp
 ```
 
 `pyric mcp` attaches to a running `pyric dev --bridge` by reading the `.pyric/serve.json` pointer the dev server writes. If nothing is running, it hosts a headless sandbox of its own and persists it to `.pyric/state/headless.json`. Or, if you pin the port, point Claude Code at the HTTP endpoint directly:
 
 ```bash
-npx pyric dev --bridge --port 5173
+pyric dev --bridge --port 5173
 claude mcp add pyric --transport http --url http://localhost:5173/__pyric/mcp
 ```
 
@@ -49,7 +49,7 @@ Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the po
 ```json
 {
   "mcpServers": {
-    "pyric": { "command": "npx", "args": ["pyric", "mcp"] }
+    "pyric": { "command": "npx", "args": ["pyric-tools", "mcp"] }
   }
 }
 ```
@@ -63,7 +63,7 @@ Same shape, Codex config. In `~/.codex/config.toml`:
 ```toml
 [mcp_servers.pyric]
 command = "npx"
-args = ["pyric", "mcp"]
+args = ["pyric-tools", "mcp"]
 ```
 
 Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
@@ -72,7 +72,7 @@ Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
 
 The generic recipe is two options, and every client above is one of them applied:
 
-- **stdio**: run `npx pyric mcp` as the server command. It finds the running dev server, or hosts a headless sandbox when there is none.
+- **stdio**: run `npx pyric-tools mcp` as the server command (or bare `pyric mcp` if you installed the CLI globally). It finds the running dev server, or hosts a headless sandbox when there is none.
 - **HTTP**: point the client at `http://localhost:<port>/__pyric/mcp` on a running `pyric dev --bridge`.
 
 Whatever your client's config file looks like, one of those two lines is the whole setup. Then ask it to inspect the sandbox and read what comes back.
@@ -85,7 +85,7 @@ One option in `vite.config.ts` makes your own `vite dev` the bridge:
 plugins: [pyricSandbox({ bridge: true })],
 ```
 
-Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx pyric mcp` finds it the same way.
+Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx pyric-tools mcp` finds it the same way.
 
 ## Where to go next
 

--- a/docs/site-rewrite/content/agent/watch-and-review.md
+++ b/docs/site-rewrite/content/agent/watch-and-review.md
@@ -14,7 +14,7 @@ An agent you cannot see is an agent you cannot trust. Pyric makes the agent's wo
 Start the sandbox with Studio on:
 
 ```bash
-npx pyric dev --ui
+pyric dev --ui
 ```
 
 Studio opens at `/__pyric/ui/`, and its Prototype tab is an agent playground running against the shared sandbox. The same sandbox your app tab uses, the same one your MCP client drives.

--- a/docs/site-rewrite/content/get-started/start-building.md
+++ b/docs/site-rewrite/content/get-started/start-building.md
@@ -9,7 +9,7 @@ status: draft
 
 ```bash
 npm i -g pyric-tools
-npx pyric dev
+pyric dev
 ```
 
 That is a full Firebase backend, running inside the browser tab you are about to open. No account. No cloud project. No emulator, no Java, no port to babysit.
@@ -22,9 +22,9 @@ No app yet? Scaffold one.
 
 ```bash
 mkdir hello-pyric && cd hello-pyric
-npx pyric init --template web
+pyric init --template web
 npm install
-npx pyric dev
+pyric dev
 ```
 
 Open <http://localhost:3473>. The scaffold is a small posts app with canonical `firebase/app`, `firebase/auth`, and `firebase/firestore` imports, owner-based rules, and a seed file with two posts already in it. Sign in and create a post. It appears.
@@ -33,7 +33,7 @@ Now prove the rules are real. Open `firestore.rules`, change the posts rule to `
 
 Put the rule back and the posts return. That loop, edit rules and watch real enforcement respond, is the loop everything else builds on.
 
-Building a script or a test suite instead of a page? `npx pyric init --template node` scaffolds the Node shape.
+Building a script or a test suite instead of a page? `pyric init --template node` scaffolds the Node shape.
 
 ## Add Pyric to an app you already have
 
@@ -70,7 +70,7 @@ The sandbox runs in a SharedWorker, so every tab shares one backend and a write 
 One flag gives your agent the same backend:
 
 ```bash
-npx pyric dev --bridge
+pyric dev --bridge
 ```
 
 `--bridge` mounts an MCP endpoint on the dev server, and any MCP client (Claude Code, Cursor, Codex) can seed data, run queries, and check rules verdicts against the exact sandbox your tabs are using. [Set up your agent](../agent/set-up-your-agent.md) walks through each client.

--- a/docs/site-rewrite/content/overview.md
+++ b/docs/site-rewrite/content/overview.md
@@ -13,7 +13,7 @@ That is the whole trick, and it starts with one command.
 
 ```bash
 npm i -g pyric-tools
-npx pyric dev
+pyric dev
 ```
 
 No account. No cloud project. No emulator, no Java, no port to babysit. You have a full Firebase stack before your coffee is warm, and it behaves like the real one because that claim is tested, not assumed. Pyric runs probes against production Firebase, records what actually happens, and replays every recorded behavior against itself in CI. When it diverges from Firebase, that is a documented row or a bug, never a surprise.

--- a/docs/site-rewrite/content/secure/limits-that-bite.md
+++ b/docs/site-rewrite/content/secure/limits-that-bite.md
@@ -51,7 +51,7 @@ The runtime expression budget is shared across all the allow rules of a match bl
 
 ## The linter remembers so you don't
 
-`npx pyric rules:lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, no deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`, and it runs before every deploy the agent attempts.
+`pyric rules:lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, no deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`, and it runs before every deploy the agent attempts.
 
 One honest note. The Firebase emulator does not reproduce the cross-rule budget and does not enforce these thresholds at production values. Rules that pass there can still fail to deploy, or deny at runtime. The numbers on this page were measured against production because that is where they apply.
 

--- a/packages/pyric-tools/docs/tutorials/getting-started.md
+++ b/packages/pyric-tools/docs/tutorials/getting-started.md
@@ -13,20 +13,26 @@ Takes about five minutes. You do not need a Firebase account.
 
 ## Prerequisites
 
-- Node 18+ and `npm` (or `bun` — commands are equivalent).
+- Node 22+ and `npm` (or `bun` — commands are equivalent).
 - For step 4: Claude Code installed (`claude --version` works).
 
 ## Step 1 — Scaffold an app
 
+Install the CLI globally, then scaffold:
+
 ```bash
+npm i -g pyric-tools            # installs the `pyric` command
 mkdir hello-pyric && cd hello-pyric
-npx pyric init --template web
+pyric init --template web
 ```
+
+(No global install? `npx pyric-tools init --template web` works the same way,
+package by package.)
 
 `init` writes a small app with **canonical Firebase imports**
 (`firebase/app`, `firebase/auth`, `firebase/firestore` — no pyric imports
 in app code), a `firestore.rules` file, a `firebase.json`, a seed file,
-and adds `pyric-tools` as a devDependency. Then install:
+and adds `pyric-tools` as a devDependency. Then install the app's deps:
 
 ```bash
 npm install
@@ -35,7 +41,7 @@ npm install
 ## Step 2 — Serve it on the sandbox
 
 ```bash
-npx pyric dev
+pyric dev
 ```
 
 Open <http://localhost:3473>. You'll see the scaffold app with two seeded
@@ -62,7 +68,7 @@ the browser — so it **survives a refresh by default**. Add `--persist` for a
 committable, git-trackable copy on disk:
 
 ```bash
-npx pyric dev --persist   # also writes .pyric/state/state.json
+pyric dev --persist       # also writes .pyric/state/state.json
 ```
 
 `--fresh` discards the on-disk state; `--seed <file>` loads a fixture set on
@@ -103,7 +109,7 @@ bridge into the *same sandbox* you're looking at, and the rules
 edit deploys live. You can inspect what it did with:
 
 ```bash
-npx pyric snapshot        # dump sandbox state to a file
+pyric snapshot            # dump sandbox state to a file
 ```
 
 ## You now have

--- a/packages/pyric-tools/docs/tutorials/wire-claude-code.md
+++ b/packages/pyric-tools/docs/tutorials/wire-claude-code.md
@@ -21,7 +21,7 @@ Should take ~10 minutes.
 
 - An existing Firebase app already retrofitted to use pyric, i.e. you've replaced the relevant `firebase/*` imports with `@pyric/*` adapter SDKs and your app boots against `initializeSandbox()` in dev. (If you haven't done the retrofit yet, do that first: see the per-package READMEs under `packages/*/README.md`.)
 - Claude Code installed and working. Verify with `claude --version`.
-- Node 18+ and `npm` / `bun`. This tutorial uses `npm` in commands; `bun` works equivalently.
+- Node 22+ and `npm` / `bun`. This tutorial uses `npm` in commands; `bun` works equivalently.
 
 ## Step 1: Install pyric
 

--- a/packages/pyric/docs/rules/tutorials/01-lint-your-first-rules-file.md
+++ b/packages/pyric/docs/rules/tutorials/01-lint-your-first-rules-file.md
@@ -2,7 +2,7 @@
 
 Install `pyric/rules`, write a small rules file with a deliberate problem in it, and use the linter to find that problem. By the end you will have seen the parse → lint cycle end-to-end, and you will know what a `LintWarning` looks like in practice.
 
-This tutorial assumes you have Node.js 18+ or Bun 1.x available. No Firebase project is required. Everything runs in-process.
+This tutorial assumes you have Node.js 22+ or Bun 1.x available. No Firebase project is required. Everything runs in-process.
 
 ## What you will build
 

--- a/packages/site-docs/src/content/docs/limits-that-bite.md
+++ b/packages/site-docs/src/content/docs/limits-that-bite.md
@@ -53,7 +53,7 @@ The runtime expression budget is shared across all the allow rules of a match bl
 
 ## The linter remembers so you don't
 
-`npx pyric rules:lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, no deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`, and it runs before every deploy the agent attempts.
+`pyric rules:lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, no deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`, and it runs before every deploy the agent attempts.
 
 One honest note. The Firebase emulator does not reproduce the cross-rule budget and does not enforce these thresholds at production values. Rules that pass there can still fail to deploy, or deny at runtime. The numbers on this page were measured against production because that is where they apply.
 

--- a/packages/site-docs/src/content/docs/overview.md
+++ b/packages/site-docs/src/content/docs/overview.md
@@ -14,7 +14,7 @@ Pyric is Firestore, Auth, Realtime Database, Storage, and the Security Rules eng
 That is the whole trick, and it starts with one command.
 ```bash
 npm i -g pyric-tools
-npx pyric dev
+pyric dev
 ```
 No account. No cloud project. No emulator, no Java, no port to babysit. You have a full Firebase stack before your coffee is warm, and it behaves like the real one because that claim is tested, not assumed. Pyric runs probes against production Firebase, records what actually happens, and replays every recorded behavior against itself in CI. When it diverges from Firebase, that is a documented row or a bug, never a surprise.
 

--- a/packages/site-docs/src/content/docs/pyric-tools-tutorials-wire-claude-code.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-tutorials-wire-claude-code.md
@@ -28,7 +28,7 @@ Should take ~10 minutes.
 
 - An existing Firebase app already retrofitted to use pyric, i.e. you've replaced the relevant `firebase/*` imports with `@pyric/*` adapter SDKs and your app boots against `initializeSandbox()` in dev. (If you haven't done the retrofit yet, do that first: see the per-package READMEs under `packages/*/README.md`.)
 - Claude Code installed and working. Verify with `claude --version`.
-- Node 18+ and `npm` / `bun`. This tutorial uses `npm` in commands; `bun` works equivalently.
+- Node 22+ and `npm` / `bun`. This tutorial uses `npm` in commands; `bun` works equivalently.
 
 ## Step 1: Install pyric
 

--- a/packages/site-docs/src/content/docs/set-up-your-agent.md
+++ b/packages/site-docs/src/content/docs/set-up-your-agent.md
@@ -13,7 +13,7 @@ One connection and your agent has the whole backend as tools. It can read and wr
 
 The seam is one endpoint. `pyric dev --bridge` mounts an MCP server on your dev server at `/__pyric/mcp`, and every client below connects to it, directly or through a small stdio proxy that finds it for you.
 ```bash
-npx pyric dev --bridge
+pyric dev --bridge
 ```
 One requirement to know up front: the sandbox lives inside the served page, so keep the app open in a browser tab while the agent works. If data tools return nothing, the page is not open. Open it and try again.
 
@@ -27,11 +27,11 @@ Then, inside Claude Code, run `/pyric:pyric-start`. It scaffolds a project if yo
 
 Prefer manual wiring? Register the stdio server:
 ```bash
-claude mcp add pyric -- npx pyric mcp
+claude mcp add pyric -- npx pyric-tools mcp
 ```
 `pyric mcp` attaches to a running `pyric dev --bridge` by reading the `.pyric/serve.json` pointer the dev server writes. If nothing is running, it hosts a headless sandbox of its own and persists it to `.pyric/state/headless.json`. Or, if you pin the port, point Claude Code at the HTTP endpoint directly:
 ```bash
-npx pyric dev --bridge --port 5173
+pyric dev --bridge --port 5173
 claude mcp add pyric --transport http --url http://localhost:5173/__pyric/mcp
 ```
 First thing to ask: "Inspect the sandbox." One tool call comes back with the current rules, a lint summary, a document census, and recent denials.
@@ -42,7 +42,7 @@ Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the po
 ```json
 {
   "mcpServers": {
-    "pyric": { "command": "npx", "args": ["pyric", "mcp"] }
+    "pyric": { "command": "npx", "args": ["pyric-tools", "mcp"] }
   }
 }
 ```
@@ -54,7 +54,7 @@ Same shape, Codex config. In `~/.codex/config.toml`:
 ```toml
 [mcp_servers.pyric]
 command = "npx"
-args = ["pyric", "mcp"]
+args = ["pyric-tools", "mcp"]
 ```
 Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
 
@@ -62,7 +62,7 @@ Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
 
 The generic recipe is two options, and every client above is one of them applied:
 
-- **stdio**: run `npx pyric mcp` as the server command. It finds the running dev server, or hosts a headless sandbox when there is none.
+- **stdio**: run `npx pyric-tools mcp` as the server command (or bare `pyric mcp` if you installed the CLI globally). It finds the running dev server, or hosts a headless sandbox when there is none.
 - **HTTP**: point the client at `http://localhost:<port>/__pyric/mcp` on a running `pyric dev --bridge`.
 
 Whatever your client's config file looks like, one of those two lines is the whole setup. Then ask it to inspect the sandbox and read what comes back.
@@ -73,7 +73,7 @@ One option in `vite.config.ts` makes your own `vite dev` the bridge:
 ```ts
 plugins: [pyricSandbox({ bridge: true })],
 ```
-Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx pyric mcp` finds it the same way.
+Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx pyric-tools mcp` finds it the same way.
 
 ## Where to go next
 

--- a/packages/site-docs/src/content/docs/start-building.md
+++ b/packages/site-docs/src/content/docs/start-building.md
@@ -10,7 +10,7 @@ description: "Run a working Firebase backend locally, in a new app or the one yo
 # Your backend in one command
 ```bash
 npm i -g pyric-tools
-npx pyric dev
+pyric dev
 ```
 That is a full Firebase backend, running inside the browser tab you are about to open. No account. No cloud project. No emulator, no Java, no port to babysit.
 
@@ -21,9 +21,9 @@ No app yet? Scaffold one.
 ## Scaffold a new app
 ```bash
 mkdir hello-pyric && cd hello-pyric
-npx pyric init --template web
+pyric init --template web
 npm install
-npx pyric dev
+pyric dev
 ```
 Open <http://localhost:3473>. The scaffold is a small posts app with canonical `firebase/app`, `firebase/auth`, and `firebase/firestore` imports, owner-based rules, and a seed file with two posts already in it. Sign in and create a post. It appears.
 
@@ -31,7 +31,7 @@ Now prove the rules are real. Open `firestore.rules`, change the posts rule to `
 
 Put the rule back and the posts return. That loop, edit rules and watch real enforcement respond, is the loop everything else builds on.
 
-Building a script or a test suite instead of a page? `npx pyric init --template node` scaffolds the Node shape.
+Building a script or a test suite instead of a page? `pyric init --template node` scaffolds the Node shape.
 
 ## Add Pyric to an app you already have
 
@@ -65,7 +65,7 @@ The sandbox runs in a SharedWorker, so every tab shares one backend and a write 
 
 One flag gives your agent the same backend:
 ```bash
-npx pyric dev --bridge
+pyric dev --bridge
 ```
 `--bridge` mounts an MCP endpoint on the dev server, and any MCP client (Claude Code, Cursor, Codex) can seed data, run queries, and check rules verdicts against the exact sandbox your tabs are using. [Set up your agent](../set-up-your-agent/) walks through each client.
 

--- a/packages/site-docs/src/content/docs/watch-and-review.md
+++ b/packages/site-docs/src/content/docs/watch-and-review.md
@@ -15,7 +15,7 @@ An agent you cannot see is an agent you cannot trust. Pyric makes the agent's wo
 
 Start the sandbox with Studio on:
 ```bash
-npx pyric dev --ui
+pyric dev --ui
 ```
 Studio opens at `/__pyric/ui/`, and its Prototype tab is an agent playground running against the shared sandbox. The same sandbox your app tab uses, the same one your MCP client drives.
 


### PR DESCRIPTION
## Three getting-started bugs, all break a fresh copy-paste run

### 1. `npx pyric` resolves the wrong package

`npx pyric` fetches/resolves the `pyric` SDK package (the `firebase` mirror), which ships no bin. There is no `pyric` command in it. The actual CLI bin (`pyric`) is shipped by `pyric-tools`. Any doc telling a fresh user (nothing installed yet) to run `npx pyric init` or `npx pyric dev` fails outright.

Fixed by switching each doc's main flow to the global-install form and bare `pyric`, and noting `npx pyric-tools <cmd>` as the no-global-install alternative.

- Before (README.md):
  ```bash
  npm i -g pyric-tools            # installs the `pyric` command
  npx pyric init --template web   # scaffold, or just run pyric dev in an existing app
  npx pyric dev
  ```
- After:
  ```bash
  npm i -g pyric-tools            # installs the `pyric` command
  pyric init --template web       # scaffold, or skip this in an existing app
  npm install                     # install the scaffolded app's deps
  pyric dev
  ```

Same pattern fixed in `packages/pyric-tools/docs/tutorials/getting-started.md`, `docs/site-rewrite/content/overview.md`, `docs/site-rewrite/content/get-started/start-building.md`, `docs/site-rewrite/content/agent/set-up-your-agent.md`, `docs/site-rewrite/content/agent/watch-and-review.md`, and `docs/site-rewrite/content/secure/limits-that-bite.md`. MCP client config snippets (Cursor `.cursor/mcp.json`, Codex `config.toml`, `claude mcp add`) that used `npx pyric mcp` were changed to `npx pyric-tools mcp` for the same reason.

Left untouched: `packages/pyric-tools/docs/tutorials/server-adoption.md` (installs `pyric-tools` locally first via `npm i -D`, so `npx pyric dev` correctly resolves the local devDep) and the standalone-binary how-to's `npx pyric` aside (describes monorepo-internal resolution, not a user-facing command).

### 2. Node version contradiction

The getting-started tutorial said "Node 18+", but `packages/pyric-tools/package.json` enforces `engines.node: ">=22.15"`, and `pyric`, `pyric-admin`, `ui` all enforce `">=22"`. A user on Node 18-21 would pass the doc's stated bar and then hit an engines failure. Updated doc text to "Node 22+" in:

- `packages/pyric-tools/docs/tutorials/getting-started.md`
- `packages/pyric-tools/docs/tutorials/wire-claude-code.md`
- `packages/pyric/docs/rules/tutorials/01-lint-your-first-rules-file.md`

**Not fixed, flagged only:** the engines floors themselves are inconsistent across packages (`pyric-tools` requires `>=22.15`, the rest require `>=22`). Per instructions this PR is docs-only and doesn't touch `engines`; a fresh user following a non-pyric-tools package's doc could still land on Node 22.0-22.14 and hit `pyric-tools`'s stricter floor. Worth reconciling separately.

### 3. README vs tutorial step mismatch

README's Getting Started went `pyric init` -> `pyric dev` with no dependency-install step in between, while `packages/pyric-tools/docs/tutorials/getting-started.md` had `npm install` between them. A fresh scaffold has no `node_modules` yet, so `pyric dev` would fail. Added the missing `npm install` line to README (see the before/after above) so both docs agree: scaffold -> install deps -> dev.

## Verification

`packages/site-docs/src/content/docs/*.md` is generated from `packages/*/docs` and `docs/site-rewrite/content` by `bun run --cwd packages/site-docs scripts/port-content.ts` (invoked via `bun run build`). Edited the true sources, then ran `bun install && bun run build` in `packages/site-docs` — build succeeded (217 pages) and the generated copies picked up the fixes automatically. Those regenerated files are included in this PR so the working tree matches what a fresh `bun run build` produces.