### PR TITLE
Fix exists() mock type error in rules capture harness

### DIFF
--- a/packages/pyric/src/rules/test/spec.ts
+++ b/packages/pyric/src/rules/test/spec.ts
@@ -390,7 +390,7 @@ export interface ApiTestCase {
 export interface ApiFunctionMock {
   function: 'get' | 'exists';
   args: Array<{ exactValue: string }>;
-  result: { value: { data: Record<string, unknown> } } | undefined;
+  result: { value: { data: Record<string, unknown> } } | { value: boolean } | undefined;
 }
 
 // ---- Path normalization ----
@@ -472,10 +472,13 @@ export function buildFunctionMock(mock: FunctionMock): ApiFunctionMock {
   if (mock.function === 'get') {
     result.result = { value: { data: mock.result as Record<string, unknown> } };
   } else {
-    // exists → true means doc exists (return some data), false means no result
-    result.result = mock.result === true
-      ? { value: { data: {} } }
-      : undefined;
+    // exists() returns a bool, not a map. Sending the map shape used for
+    // get() here — { value: { data: {} } } / undefined — makes the
+    // production Rules Test API reject the mock with "Type error.
+    // Received: [map] Expected: [bool]", which silently resolves to DENY
+    // and poisons every observation that mocks exists() to true.
+    // Live-verified fix: emit a bool value directly.
+    result.result = { value: mock.result === true };
   }
 
   return result;

--- a/packages/pyric/test/rules/test/mocks.test.ts
+++ b/packages/pyric/test/rules/test/mocks.test.ts
@@ -61,10 +61,13 @@ describe('Function mock translation', () => {
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
     expect(apiMock.function).toBe('exists');
-    expect(apiMock.result).toEqual({ value: { data: {} } });
+    // exists() returns bool; production rejects a map-shaped result for it
+    // ("Type error. Received: [map] Expected: [bool]"), which silently
+    // resolves to DENY. Must be a bool value, not a map.
+    expect(apiMock.result).toEqual({ value: true });
   });
 
-  test('exists mock with false produces undefined result', async () => {
+  test('exists mock with false produces false bool result', async () => {
     const captured = captureBody();
     const tc: TestCase = {
       description: 'not exists',
@@ -76,7 +79,7 @@ describe('Function mock translation', () => {
     };
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
-    expect(apiMock.result).toBeUndefined();
+    expect(apiMock.result).toEqual({ value: false });
   });
 
   test('mock path gets normalized with database prefix', async () => {

--- a/packages/pyric/test/rules/test/spec.test.ts
+++ b/packages/pyric/test/rules/test/spec.test.ts
@@ -130,7 +130,10 @@ describe('buildFunctionMock', () => {
     expect(api.result).toEqual({ value: { data: { role: 'admin' } } });
   });
 
-  test('wraps exists mock with true result', () => {
+  test('wraps exists mock with true result as a bool value, not a map', () => {
+    // exists() returns bool; the production Rules Test API rejects a
+    // map-shaped mock result for it with "Type error. Received: [map]
+    // Expected: [bool]", which silently resolves to DENY.
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/alice',
@@ -138,17 +141,17 @@ describe('buildFunctionMock', () => {
     };
     const api = buildFunctionMock(mock);
     expect(api.function).toBe('exists');
-    expect(api.result).toEqual({ value: { data: {} } });
+    expect(api.result).toEqual({ value: true });
   });
 
-  test('wraps exists mock with false as undefined result', () => {
+  test('wraps exists mock with false result as a bool value', () => {
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/bob',
       result: false,
     };
     const api = buildFunctionMock(mock);
-    expect(api.result).toBeUndefined();
+    expect(api.result).toEqual({ value: false });
   });
 });
 

--- a/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
+++ b/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
@@ -582,11 +582,14 @@ service cloud.firestore {
     match /getMockedAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).data.flag == true;
     }
-    // mocked doc: resource carries id → ALLOW
+    // mocked doc: production CANNOT express resource identity (.id) via a
+    // function mock — the API returns "Property id is undefined on
+    // object." → DENY. Kept as a documented witness of the limitation.
     match /getResourceIdAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).id == 'site';
     }
-    // mocked doc: resource carries __name__ as a Path → ALLOW
+    // mocked doc: same limitation for __name__ — a mocked get() result has
+    // no resource identity attached, so this also errors → DENY.
     match /getResourceNameAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).__name__
         == /databases/$(database)/documents/cfg/site;
@@ -642,8 +645,12 @@ service cloud.firestore {
       ],
     },
     {
-      description: "get(mocked).id == 'site' → ALLOW (resource identity)",
-      expectation: 'ALLOW',
+      // Production cannot express resource identity (.id) through a
+      // function mock: get(mocked).id errors with "Property id is
+      // undefined on object." → DENY. This case documents that API
+      // limitation rather than testing an achievable ALLOW.
+      description: "get(mocked).id == 'site' → DENY (mocked get() has no resource identity in production)",
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceIdAllow/d6',
       auth: { uid: 'alice' },
@@ -653,8 +660,9 @@ service cloud.firestore {
       ],
     },
     {
-      description: 'get(mocked).__name__ == path literal → ALLOW',
-      expectation: 'ALLOW',
+      // Same limitation as above, for __name__.
+      description: 'get(mocked).__name__ == path literal → DENY (mocked get() has no resource identity in production)',
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceNameAllow/d7',
       auth: { uid: 'alice' },


### PR DESCRIPTION
## Bug 1: buildFunctionMock exists() branch sends the wrong type

`packages/pyric/src/rules/test/spec.ts` — `buildFunctionMock` mocks a
`firestore.exists()` call by sending a map-shaped result:

```ts
// before
result.result = mock.result === true
  ? { value: { data: {} } }
  : undefined;
```

`exists()` returns a `bool`, not a map. Live-verified against the production
Rules Test API: sending the map shape gets rejected with

```
Type error. Received: [map] Expected: [bool]
```

which silently resolves to DENY. Every observation that mocked `exists()` to
true was poisoned by this — the mock was never actually honored.

Fix:

```ts
// after
result.result = { value: mock.result === true };
```

emits `{ value: true }` / `{ value: false }`. The `get()` branch
(`{ value: { data: mock.result } }`) is unchanged — it was already correct.

`ApiFunctionMock.result` type widened to allow `{ value: boolean }` alongside
the existing `{ value: { data: ... } }` shape.

## Bug 2: two corpus cases had wrong baked-in expectations

`scripts/oracle/rules-corpus/firestore/fix-class-packs.ts`, pack
`get-missing-doc` (RULES-B8):

- `get(mocked).id == 'site'` — expected ALLOW
- `get(mocked).__name__ == <path>` — expected ALLOW

Live-verified against production: a function-mocked `get()` result has no
resource identity attached. Both error with

```
Property id is undefined on object.
```

which resolves to DENY. Production genuinely cannot express resource
identity through a function mock — these expectations were wrong. Rewrote
both cases to expect DENY, with comments documenting the API limitation, so
they stay as regression witnesses instead of being deleted.

## Test coverage

Added/updated unit test assertions for `buildFunctionMock`'s exists() branch
in `packages/pyric/test/rules/test/spec.test.ts` and
`packages/pyric/test/rules/test/mocks.test.ts`, asserting `{ value: true }` /
`{ value: false }` instead of the map/undefined shape.

## Scope

Capture-harness + corpus only. Simulator (`packages/pyric/src/rules/simulator/*`)
and observation JSON files are untouched.

**Important: observation JSON files were captured under the buggy exists()
behavior and must be re-captured after this merges.**

## Test plan
- [x] `bun test packages/pyric/test/rules/test/` — 39 pass
- [x] `bunx tsc --noEmit` for packages/pyric — no new errors (pre-existing
      failures from missing `js-md5`/`ohm-js`/`@inbrowser/agent` deps in this
      sandbox, confirmed present on origin/main too)
- [ ] Re-capture rules conformance observations after merge