### PR TITLE
rules sim: abstain on Set.difference/union/intersection

### DIFF
--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -994,10 +994,21 @@ function evaluateMethodCall(
       case 'hasAll': return obj.hasAll(argValues[0] as string[] | FirestoreSet);
       case 'hasAny': return obj.hasAny(argValues[0] as string[] | FirestoreSet);
       case 'size': return obj.size();
-      // Set algebra (Item 5.1) — per REBUILD_PLAN type table.
-      case 'difference': return obj.difference(argValues[0] as string[] | FirestoreSet);
-      case 'union': return obj.union(argValues[0] as string[] | FirestoreSet);
-      case 'intersection': return obj.intersection(argValues[0] as string[] | FirestoreSet);
+      // Set.difference/union/intersection: the sim CAN compute these (see
+      // FirestoreSet.difference/union/intersection), but oracle capture
+      // shows production denies every call that reaches them — these
+      // methods don't behave as modeled in the real Firestore Rules CEL
+      // dialect (see triage: set-algebra-difference-union-intersection /
+      // list-methods-concat-removeall-toset packs, both false-ALLOW
+      // against a prod DENY). Abstain rather than emit a confident wrong
+      // verdict; do not "fix" this by re-deriving semantics without a
+      // fresh oracle capture that actually isolates correct behavior.
+      case 'difference':
+      case 'union':
+      case 'intersection':
+        throw new UnsupportedError(
+          `Set.${method}() is not faithfully modeled by the simulator (oracle capture shows production denies calls that reach it) — abstaining rather than guessing`,
+        );
     }
   }
 

--- a/packages/pyric/src/rules/test/spec.ts
+++ b/packages/pyric/src/rules/test/spec.ts
@@ -390,7 +390,7 @@ export interface ApiTestCase {
 export interface ApiFunctionMock {
   function: 'get' | 'exists';
   args: Array<{ exactValue: string }>;
-  result: { value: { data: Record<string, unknown> } } | undefined;
+  result: { value: { data: Record<string, unknown> } } | { value: boolean } | undefined;
 }
 
 // ---- Path normalization ----
@@ -472,10 +472,13 @@ export function buildFunctionMock(mock: FunctionMock): ApiFunctionMock {
   if (mock.function === 'get') {
     result.result = { value: { data: mock.result as Record<string, unknown> } };
   } else {
-    // exists → true means doc exists (return some data), false means no result
-    result.result = mock.result === true
-      ? { value: { data: {} } }
-      : undefined;
+    // exists() returns a bool, not a map. Sending the map shape used for
+    // get() here — { value: { data: {} } } / undefined — makes the
+    // production Rules Test API reject the mock with "Type error.
+    // Received: [map] Expected: [bool]", which silently resolves to DENY
+    // and poisons every observation that mocks exists() to true.
+    // Live-verified fix: emit a bool value directly.
+    result.result = { value: mock.result === true };
   }
 
   return result;

--- a/packages/pyric/test/rules/simulator/set-algebra-abstain.test.ts
+++ b/packages/pyric/test/rules/simulator/set-algebra-abstain.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Set.difference / Set.union / Set.intersection — abstain, don't guess.
+ *
+ * Oracle capture (set-algebra-difference-union-intersection and
+ * list-methods-concat-removeall-toset corpus packs) showed the simulator
+ * computing a plausible-looking result for these three methods while
+ * production DENIES every request that reaches them (false-ALLOW: the
+ * most dangerous divergence for a rules-assurance tool). The methods
+ * don't behave as modeled in the real Firestore Rules CEL dialect.
+ *
+ * Rather than reverse-engineer the true semantics blind, the simulator
+ * now abstains (UNSUPPORTED) whenever `.difference()`, `.union()`, or
+ * `.intersection()` is called on a FirestoreSet, mirroring the existing
+ * abstention path used elsewhere for unimplemented features (see
+ * unsupported-feature-witness corpus pack / UnsupportedError in
+ * evaluator.ts). hasOnly/hasAll/hasAny/size/equals on FirestoreSet, and
+ * List.concat/removeAll/toSet, are unaffected — those are prod-verified
+ * and must keep working.
+ */
+import { describe, expect, test } from 'bun:test';
+import { SimulateFirestoreRulesHandler } from '../../../src/rules/simulator/handler.js';
+import type { TestCase } from '../../../src/rules/test/spec.js';
+
+const handler = new SimulateFirestoreRulesHandler();
+
+function run(rules: string, tc: TestCase) {
+  const res = handler.simulate(rules, [tc]);
+  if (!res.success || !res.data) throw new Error('simulate failed');
+  return res.data.results[0]!;
+}
+
+describe('Set.difference/union/intersection abstain (UNSUPPORTED), not a guessed verdict', () => {
+  test('difference() with a list arg abstains', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /diffListAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().difference(['a','b']).hasOnly(['c']);
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'set difference (list arg)',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'diffListAllow/d1',
+      auth: { uid: 'alice' },
+      data: { m: { a: 1, b: 2, c: 3 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('difference() with a Set arg (via .keys()) abstains', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /diffSetAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.a.keys().difference(request.resource.data.b.keys()).hasOnly(['x']);
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'set difference (set arg)',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'diffSetAllow/d2',
+      auth: { uid: 'alice' },
+      data: { a: { x: 1, y: 2 }, b: { y: 2, z: 3 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('union() abstains', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /unionAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().union(['c','d']).size() == 4;
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'set union',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'unionAllow/d3',
+      auth: { uid: 'alice' },
+      data: { m: { a: 1, b: 2 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('intersection() abstains', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /interAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().intersection(['b','c','d']).hasOnly(['b','c']);
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'set intersection',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'interAllow/d5',
+      auth: { uid: 'alice' },
+      data: { m: { a: 1, b: 2, c: 3 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('chained union().difference() abstains (fails on the first unsupported call it hits)', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /chainAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().union(['c']).difference(['a']).hasOnly(['b','c']);
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'chained union+difference',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'chainAllow/d7',
+      auth: { uid: 'alice' },
+      data: { m: { a: 1, b: 2 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('List.toSet().difference() abstains (list-methods pack 5.1/5.2 wiring case)', () => {
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /toSetChainAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.a.toSet().difference(['a']).hasOnly(['b','c']);
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'toSet().difference() chain',
+      expectation: 'ALLOW',
+      method: 'create',
+      path: 'toSetChainAllow/d1',
+      auth: { uid: 'alice' },
+      data: { a: ['a', 'b', 'c'] },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+
+  test('DENY witness with difference() also abstains, not a coincidental DENY match', () => {
+    // Before the fix this happened to match expectation=DENY because the
+    // sim's computed size (1) != 99 — a right answer for the wrong reason.
+    // Abstaining here is still correct: the sim cannot faithfully evaluate
+    // Set.difference(), regardless of which verdict the corpus expects.
+    const rules = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /diffDeny/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().difference(['a']).size() == 99;
+    }
+  }
+}`;
+    const result = run(rules, {
+      description: 'difference with wrong expected size',
+      expectation: 'DENY',
+      method: 'create',
+      path: 'diffDeny/d8',
+      auth: { uid: 'alice' },
+      data: { m: { a: 1, b: 2 } },
+    } as TestCase);
+    expect(result.state).toBe('UNSUPPORTED');
+  });
+});
+
+describe('Set/List operations NOT affected by the abstain gate (must keep working)', () => {
+  function ok(rules: string, tc: TestCase) {
+    const result = run(rules, tc);
+    expect(result.state).toBe('PASSED');
+  }
+
+  test('FirestoreSet.hasOnly/hasAll/hasAny/size still evaluate (no over-abstain)', () => {
+    ok(
+      `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /hasOnlyAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.m.keys().hasOnly(['a','b','c']);
+    }
+  }
+}`,
+      {
+        description: 'hasOnly still works',
+        expectation: 'ALLOW',
+        method: 'create',
+        path: 'hasOnlyAllow/d1',
+        auth: { uid: 'alice' },
+        data: { m: { a: 1, b: 2 } },
+      } as TestCase,
+    );
+  });
+
+  test('List.concat still evaluates (no over-abstain)', () => {
+    ok(
+      `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /concatAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.a.concat(request.resource.data.b).size() == 4;
+    }
+  }
+}`,
+      {
+        description: 'concat still works',
+        expectation: 'ALLOW',
+        method: 'create',
+        path: 'concatAllow/d1',
+        auth: { uid: 'alice' },
+        data: { a: ['a', 'b'], b: ['c', 'd'] },
+      } as TestCase,
+    );
+  });
+
+  test('List.removeAll still evaluates (no over-abstain)', () => {
+    ok(
+      `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /removeAllAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.a.removeAll(['b']).size() == 2;
+    }
+  }
+}`,
+      {
+        description: 'removeAll still works',
+        expectation: 'ALLOW',
+        method: 'create',
+        path: 'removeAllAllow/d1',
+        auth: { uid: 'alice' },
+        data: { a: ['a', 'b', 'c'] },
+      } as TestCase,
+    );
+  });
+
+  test('List.toSet() alone (no difference/union/intersection chain) still evaluates', () => {
+    ok(
+      `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /toSetAllow/{id} {
+      allow create: if request.auth != null
+        && request.resource.data.a.toSet().size() == 3;
+    }
+  }
+}`,
+      {
+        description: 'toSet still works',
+        expectation: 'ALLOW',
+        method: 'create',
+        path: 'toSetAllow/d1',
+        auth: { uid: 'alice' },
+        data: { a: ['a', 'b', 'c'] },
+      } as TestCase,
+    );
+  });
+});

--- a/packages/pyric/test/rules/test/mocks.test.ts
+++ b/packages/pyric/test/rules/test/mocks.test.ts
@@ -61,10 +61,13 @@ describe('Function mock translation', () => {
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
     expect(apiMock.function).toBe('exists');
-    expect(apiMock.result).toEqual({ value: { data: {} } });
+    // exists() returns bool; production rejects a map-shaped result for it
+    // ("Type error. Received: [map] Expected: [bool]"), which silently
+    // resolves to DENY. Must be a bool value, not a map.
+    expect(apiMock.result).toEqual({ value: true });
   });
 
-  test('exists mock with false produces undefined result', async () => {
+  test('exists mock with false produces false bool result', async () => {
     const captured = captureBody();
     const tc: TestCase = {
       description: 'not exists',
@@ -76,7 +79,7 @@ describe('Function mock translation', () => {
     };
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
-    expect(apiMock.result).toBeUndefined();
+    expect(apiMock.result).toEqual({ value: false });
   });
 
   test('mock path gets normalized with database prefix', async () => {

--- a/packages/pyric/test/rules/test/spec.test.ts
+++ b/packages/pyric/test/rules/test/spec.test.ts
@@ -130,7 +130,10 @@ describe('buildFunctionMock', () => {
     expect(api.result).toEqual({ value: { data: { role: 'admin' } } });
   });
 
-  test('wraps exists mock with true result', () => {
+  test('wraps exists mock with true result as a bool value, not a map', () => {
+    // exists() returns bool; the production Rules Test API rejects a
+    // map-shaped mock result for it with "Type error. Received: [map]
+    // Expected: [bool]", which silently resolves to DENY.
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/alice',
@@ -138,17 +141,17 @@ describe('buildFunctionMock', () => {
     };
     const api = buildFunctionMock(mock);
     expect(api.function).toBe('exists');
-    expect(api.result).toEqual({ value: { data: {} } });
+    expect(api.result).toEqual({ value: true });
   });
 
-  test('wraps exists mock with false as undefined result', () => {
+  test('wraps exists mock with false result as a bool value', () => {
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/bob',
       result: false,
     };
     const api = buildFunctionMock(mock);
-    expect(api.result).toBeUndefined();
+    expect(api.result).toEqual({ value: false });
   });
 });
 

--- a/packages/pyric/test/sandbox/firestore/simulator/list-methods.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/list-methods.test.ts
@@ -8,6 +8,10 @@
  *
  * The parity-stress pack `list-methods-concat-removeall-toset` provides
  * the prod-comparison receipt (gated on FIREBASE_SA_BASE64).
+ *
+ * toSet().difference()/.union()/.intersection() chaining is not exercised
+ * here — the simulator abstains (UNSUPPORTED) on those three FirestoreSet
+ * methods; see test/rules/simulator/set-algebra-abstain.test.ts.
  */
 import { describe, test, expect } from 'bun:test';
 import { SimulateFirestoreRulesHandler } from 'pyric/rules';
@@ -168,26 +172,11 @@ describe('List.toSet', () => {
     );
   });
 
-  test('toSet result supports difference (chaining 5.1 + 5.2)', () => {
-    expectAllow(
-      "request.resource.data.a.toSet().difference(['a']).hasOnly(['b','c'])",
-      { a: ['a', 'b', 'c', 'a'] },
-    );
-  });
-
-  test('toSet result supports union', () => {
-    expectAllow(
-      "request.resource.data.a.toSet().union(['d']).size() == 4",
-      { a: ['a', 'b', 'c'] },
-    );
-  });
-
-  test('toSet result supports intersection', () => {
-    expectAllow(
-      "request.resource.data.a.toSet().intersection(['b','c','x']).hasOnly(['b','c'])",
-      { a: ['a', 'b', 'c'] },
-    );
-  });
+  // toSet().difference()/.union()/.intersection() chaining is NOT covered
+  // here. The simulator abstains (UNSUPPORTED) on all three set-algebra
+  // methods regardless of what materialized the Set — see
+  // test/rules/simulator/set-algebra-abstain.test.ts ("List.toSet().difference()
+  // abstains" covers the toSet() chaining case specifically).
 
   test('toSet on empty list', () => {
     expectAllow(

--- a/packages/pyric/test/sandbox/firestore/simulator/set-methods.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/set-methods.test.ts
@@ -1,18 +1,14 @@
 /**
  * Unit tests for Set algebra — Item 5.1 of REBUILD_PLAN.md.
  *
- * Per type table:
- *   Set.difference(other: Set) → Set    items in this not in other
- *   Set.union(other: Set) → Set         items in either
- *   Set.intersection(other: Set) → Set  items in both
+ * Set.difference(other)/union(other)/intersection(other) are NOT covered
+ * here. The simulator now abstains (UNSUPPORTED) on all three — every
+ * production call to these three FirestoreSet methods hits an unsupported
+ * path, so the sim can't faithfully evaluate them. See
+ * test/rules/simulator/set-algebra-abstain.test.ts for that coverage.
  *
- * Sets are constructed via `Map.keys()` or MapDiff methods. Tests chain
- * through `.keys()` to materialize a FirestoreSet, then exercise the new
- * methods. The result is itself a Set so we follow with `.size()` /
- * `.hasOnly(...)` / `.hasAll(...)` to assert contents.
- *
- * Per the impl, `other` may be a Set or a List of strings (matching
- * hasOnly/hasAll/hasAny's signature flexibility).
+ * hasOnly/hasAll/hasAny (which also accept a FirestoreSet arg) are
+ * unaffected and still exercised below.
  */
 import { describe, test, expect } from 'bun:test';
 import { SimulateFirestoreRulesHandler } from 'pyric/rules';
@@ -46,113 +42,6 @@ function expectAllow(condition: string, data: Record<string, unknown>) {
     throw new Error(`Expected ALLOW for \`${condition}\`, got ${r.data.results[0].state}: ${r.data.results[0].debugMessages.join(' | ')}`);
   }
 }
-
-describe('Set.difference', () => {
-  test('items in this not in other (list arg)', () => {
-    expectAllow(
-      "request.resource.data.m.keys().difference(['a','b']).hasOnly(['c'])",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-
-  test('full overlap → empty set', () => {
-    expectAllow(
-      "request.resource.data.m.keys().difference(['a','b','c']).size() == 0",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-
-  test('no overlap → original set', () => {
-    expectAllow(
-      "request.resource.data.m.keys().difference(['x','y']).size() == 3",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-
-  test('Set arg (chained .keys() difference)', () => {
-    // Use diff(...).addedKeys() (a Set) as the other arg
-    expectAllow(
-      "request.resource.data.a.keys().difference(request.resource.data.b.keys()).hasOnly(['x'])",
-      { a: { x: 1, y: 2 }, b: { y: 2, z: 3 } },
-    );
-  });
-});
-
-describe('Set.union', () => {
-  test('items in either (list arg)', () => {
-    expectAllow(
-      "request.resource.data.m.keys().union(['c','d']).size() == 4",
-      { m: { a: 1, b: 2 } },
-    );
-  });
-
-  test('union with overlap dedupes', () => {
-    expectAllow(
-      "request.resource.data.m.keys().union(['b','c']).size() == 3",
-      { m: { a: 1, b: 2 } },
-    );
-  });
-
-  test('union of two key sets', () => {
-    expectAllow(
-      "request.resource.data.a.keys().union(request.resource.data.b.keys()).size() == 3",
-      { a: { x: 1, y: 2 }, b: { y: 2, z: 3 } },
-    );
-  });
-
-  test('union with empty list returns same set', () => {
-    expectAllow(
-      "request.resource.data.m.keys().union([]).size() == 2",
-      { m: { a: 1, b: 2 } },
-    );
-  });
-});
-
-describe('Set.intersection', () => {
-  test('items in both (list arg)', () => {
-    expectAllow(
-      "request.resource.data.m.keys().intersection(['b','c','d']).hasOnly(['b','c'])",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-
-  test('no overlap → empty set', () => {
-    expectAllow(
-      "request.resource.data.m.keys().intersection(['x','y']).size() == 0",
-      { m: { a: 1, b: 2 } },
-    );
-  });
-
-  test('full overlap → original set', () => {
-    expectAllow(
-      "request.resource.data.m.keys().intersection(['a','b','c']).size() == 3",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-
-  test('Set arg', () => {
-    expectAllow(
-      "request.resource.data.a.keys().intersection(request.resource.data.b.keys()).hasOnly(['y'])",
-      { a: { x: 1, y: 2 }, b: { y: 2, z: 3 } },
-    );
-  });
-});
-
-describe('Set methods — composability', () => {
-  test('chained: union then difference', () => {
-    expectAllow(
-      "request.resource.data.m.keys().union(['c']).difference(['a']).hasOnly(['b','c'])",
-      { m: { a: 1, b: 2 } },
-    );
-  });
-
-  test('intersection result feeds into hasAll', () => {
-    expectAllow(
-      "request.resource.data.m.keys().intersection(['a','b','x']).hasAll(['a','b'])",
-      { m: { a: 1, b: 2, c: 3 } },
-    );
-  });
-});
 
 describe('Existing has* methods accept FirestoreSet (added in 5.1)', () => {
   test('hasOnly with set arg', () => {

--- a/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
+++ b/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
@@ -582,11 +582,14 @@ service cloud.firestore {
     match /getMockedAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).data.flag == true;
     }
-    // mocked doc: resource carries id → ALLOW
+    // mocked doc: production CANNOT express resource identity (.id) via a
+    // function mock — the API returns "Property id is undefined on
+    // object." → DENY. Kept as a documented witness of the limitation.
     match /getResourceIdAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).id == 'site';
     }
-    // mocked doc: resource carries __name__ as a Path → ALLOW
+    // mocked doc: same limitation for __name__ — a mocked get() result has
+    // no resource identity attached, so this also errors → DENY.
     match /getResourceNameAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).__name__
         == /databases/$(database)/documents/cfg/site;
@@ -642,8 +645,12 @@ service cloud.firestore {
       ],
     },
     {
-      description: "get(mocked).id == 'site' → ALLOW (resource identity)",
-      expectation: 'ALLOW',
+      // Production cannot express resource identity (.id) through a
+      // function mock: get(mocked).id errors with "Property id is
+      // undefined on object." → DENY. This case documents that API
+      // limitation rather than testing an achievable ALLOW.
+      description: "get(mocked).id == 'site' → DENY (mocked get() has no resource identity in production)",
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceIdAllow/d6',
       auth: { uid: 'alice' },
@@ -653,8 +660,9 @@ service cloud.firestore {
       ],
     },
     {
-      description: 'get(mocked).__name__ == path literal → ALLOW',
-      expectation: 'ALLOW',
+      // Same limitation as above, for __name__.
+      description: 'get(mocked).__name__ == path literal → DENY (mocked get() has no resource identity in production)',
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceNameAllow/d7',
       auth: { uid: 'alice' },


### PR DESCRIPTION
Stacked on #121 (rules-capture-harness-exists-fix).

## Problem

Oracle capture triage flagged two conformance packs as false-allows:
`set-algebra-difference-union-intersection` and
`list-methods-concat-removeall-toset` (shared root cause). The simulator
implements `FirestoreSet.difference/union/intersection` and computes an
internally-consistent result for them, but production DENIES every
captured case that reaches these methods — they don't behave as modeled
in the real Firestore Rules CEL dialect. That's a confident wrong verdict
(sim ALLOW where prod DENIES), the worst failure mode for a rules-
assurance tool: it tells an author their rule is safe when it isn't.

## Fix

Per the project's posture that honest gaps beat silent wrong verdicts,
`difference()`, `union()`, and `intersection()` on FirestoreSet now throw
`UnsupportedError` at the point they're dispatched in
`packages/pyric/src/rules/simulator/evaluator.ts`, reusing the existing
abstention mechanism already used for other unimplemented features (see
`unsupported-feature-witness`). The handler already maps `UnsupportedError`
to the `UNSUPPORTED` verdict, which the conformance replay suite treats as
a legitimate sim gap rather than a pass/fail mismatch.

This is deliberately NOT an attempt to implement correct Set algebra
semantics — that's a larger feature requiring its own oracle capture to
pin down what production actually does. The fix here is narrowly: detect
the unsupported shape and abstain instead of guessing.

## Scope check (no over-abstain)

Only `difference`/`union`/`intersection` are gated. Confirmed still
evaluating normally (not swept into the abstain):
- `FirestoreSet.hasOnly` / `hasAll` / `hasAny` / `size` / `equals`
- `List.concat` / `removeAll` / `toSet`

## Testing

New file: `packages/pyric/test/rules/simulator/set-algebra-abstain.test.ts`
- 7 cases mirroring the two corpus packs' failing cases, including the
  `toSet().difference()` wiring case and the DENY-witness case (which
  used to pass by getting the right size for the wrong reason) — all now
  assert `state === 'UNSUPPORTED'`.
- 4 cases confirming the untouched set/list methods still `PASSED`.

`bun test packages/pyric/test/rules` — 2000 pass, 3 pre-existing failures
unrelated to this change (missing `pyric/sandbox/internal` module,
present on the base branch before this change too). Typecheck clean.