### PR TITLE
Make Firestore rules resource null on create in the simulator

### DIFF
--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -61,7 +61,14 @@ export interface SimResource {
 
 export interface SimulationContext {
   request: SimRequest;
-  resource: SimResource;
+  /**
+   * The PRE-WRITE stored document (data + identity), or `null` when no such
+   * document exists. On a `create` the target does not exist yet, so this is
+   * null and any access (`resource.data`, `resource.id`, `resource.__name__`)
+   * errors → DENY, matching production. `request.resource` (the INCOMING
+   * proposed data) is a separate value and is populated on create/update.
+   */
+  resource: SimResource | null;
   /** Mock documents for get()/exists() calls, keyed by full path. Pre-seeded
    *  from `functionMocks` (the serializable Test API path) and/or populated
    *  lazily by {@link getDoc}. */

--- a/packages/pyric/src/rules/simulator/handler.ts
+++ b/packages/pyric/src/rules/simulator/handler.ts
@@ -480,11 +480,21 @@ function buildContext(
       query: buildRequestQuery(tc),
       time: serverTime,
     },
-    resource: {
-      data: existing ?? {},  // NOT resolved — resource is pre-write, no sentinels
-      id: docId,             // Item 6
-      __name__: fullPath,    // Item 6
-    },
+    // `resource` is the PRE-WRITE stored document. On a `create` the target
+    // does not exist yet, so production makes `resource` null — reading
+    // `resource.data`/`.id`/`.__name__` then errors → DENY. Synthesizing an
+    // identity here (the previous behavior) was a FALSE-ALLOW for the common
+    // ownership/existence idioms (`resource.data.owner == request.auth.uid`,
+    // `resource.id == id`). For get/list/update/delete `resource` reflects the
+    // existing doc (unchanged). Note: `request.resource` (proposed data) is
+    // built separately above and stays populated on create.
+    resource: tc.method === 'create'
+      ? null
+      : {
+          data: existing ?? {},  // NOT resolved — resource is pre-write, no sentinels
+          id: docId,             // Item 6
+          __name__: fullPath,    // Item 6
+        },
     mockDocuments: mockDocs,
     getDoc,
     pathVariables,

--- a/packages/pyric/src/rules/test/spec.ts
+++ b/packages/pyric/src/rules/test/spec.ts
@@ -390,7 +390,7 @@ export interface ApiTestCase {
 export interface ApiFunctionMock {
   function: 'get' | 'exists';
   args: Array<{ exactValue: string }>;
-  result: { value: { data: Record<string, unknown> } } | undefined;
+  result: { value: { data: Record<string, unknown> } } | { value: boolean } | undefined;
 }
 
 // ---- Path normalization ----
@@ -472,10 +472,13 @@ export function buildFunctionMock(mock: FunctionMock): ApiFunctionMock {
   if (mock.function === 'get') {
     result.result = { value: { data: mock.result as Record<string, unknown> } };
   } else {
-    // exists → true means doc exists (return some data), false means no result
-    result.result = mock.result === true
-      ? { value: { data: {} } }
-      : undefined;
+    // exists() returns a bool, not a map. Sending the map shape used for
+    // get() here — { value: { data: {} } } / undefined — makes the
+    // production Rules Test API reject the mock with "Type error.
+    // Received: [map] Expected: [bool]", which silently resolves to DENY
+    // and poisons every observation that mocks exists() to true.
+    // Live-verified fix: emit a bool value directly.
+    result.result = { value: mock.result === true };
   }
 
   return result;

--- a/packages/pyric/test/rules/simulator/handler.test.ts
+++ b/packages/pyric/test/rules/simulator/handler.test.ts
@@ -1251,4 +1251,147 @@ service cloud.firestore {
       expect(granting?.matchPath).toBe('/items/{id}');
     });
   });
+
+  // ═══ resource is null on create (pre-write doc does not exist) ═══
+  //
+  // Production truth: on a `create`, the target document does not exist yet,
+  // so the top-level `resource` is null — any field access (`resource.data`,
+  // `resource.id`, `resource.__name__`) errors and the rule DENYs. The
+  // simulator previously synthesized a `resource` (empty data + a derived
+  // id/__name__) on create, producing a FALSE-ALLOW for the extremely common
+  // ownership/existence idioms below. `request.resource` (the INCOMING
+  // proposed data) is a DIFFERENT value and must stay populated on create.
+  describe('resource is null on create', () => {
+    const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Ownership check against the PRE-WRITE doc — the classic false-allow.
+    match /owned/{id} {
+      allow create: if resource.data.owner == request.auth.uid;
+    }
+    // resource.id on create.
+    match /byId/{id} {
+      allow create: if resource.id == id;
+    }
+    // resource.__name__ on create.
+    match /byName/{id} {
+      allow create: if resource.__name__ == request.path;
+    }
+    // request.resource (INCOMING data) MUST still work on create.
+    match /incoming/{id} {
+      allow create: if request.resource.data.owner == request.auth.uid;
+    }
+    // Existing-doc reads on update/delete must be UNREGRESSED.
+    match /docs/{id} {
+      allow update: if resource.data.owner == request.auth.uid;
+      allow delete: if resource.data.owner == request.auth.uid;
+      allow get: if resource.data.owner == request.auth.uid;
+    }
+  }
+}`;
+
+    test('resource.data ownership on create DENIES (resource is null pre-write)', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.data.owner on create',
+        expectation: 'DENY',
+        method: 'create',
+        path: 'owned/d1',
+        auth: { uid: 'alice' },
+        data: { owner: 'alice' }, // incoming says alice, but resource is null → DENY
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('DENY');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('resource.id on create DENIES (resource is null pre-write)', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.id on create',
+        expectation: 'DENY',
+        method: 'create',
+        path: 'byId/d2',
+        auth: { uid: 'alice' },
+        data: {},
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('DENY');
+    });
+
+    test('resource.__name__ on create DENIES (resource is null pre-write)', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.__name__ on create',
+        expectation: 'DENY',
+        method: 'create',
+        path: 'byName/d3',
+        auth: { uid: 'alice' },
+        data: {},
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('DENY');
+    });
+
+    test('request.resource (incoming data) is UNAFFECTED on create — ALLOW', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'request.resource.data.owner on create',
+        expectation: 'ALLOW',
+        method: 'create',
+        path: 'incoming/d4',
+        auth: { uid: 'alice' },
+        data: { owner: 'alice' },
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('resource reflects the existing doc on update — UNREGRESSED ALLOW', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.data.owner on update',
+        expectation: 'ALLOW',
+        method: 'update',
+        path: 'docs/d5',
+        auth: { uid: 'alice' },
+        resource: { owner: 'alice' },
+        data: { owner: 'alice' },
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('resource reflects the existing doc on delete — UNREGRESSED ALLOW', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.data.owner on delete',
+        expectation: 'ALLOW',
+        method: 'delete',
+        path: 'docs/d6',
+        auth: { uid: 'alice' },
+        resource: { owner: 'alice' },
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+
+    test('resource reflects the existing doc on get — UNREGRESSED ALLOW', () => {
+      const r = handler.simulate(RULES, [{
+        description: 'resource.data.owner on get',
+        expectation: 'ALLOW',
+        method: 'get',
+        path: 'docs/d7',
+        auth: { uid: 'alice' },
+        resource: { owner: 'alice' },
+      }]);
+      expect(r.success).toBe(true);
+      if (!r.success) return;
+      expect(r.data.results[0].decision).toBe('ALLOW');
+      expect(r.data.results[0].state).toBe('PASSED');
+    });
+  });
 });

--- a/packages/pyric/test/rules/test/mocks.test.ts
+++ b/packages/pyric/test/rules/test/mocks.test.ts
@@ -61,10 +61,13 @@ describe('Function mock translation', () => {
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
     expect(apiMock.function).toBe('exists');
-    expect(apiMock.result).toEqual({ value: { data: {} } });
+    // exists() returns bool; production rejects a map-shaped result for it
+    // ("Type error. Received: [map] Expected: [bool]"), which silently
+    // resolves to DENY. Must be a bool value, not a map.
+    expect(apiMock.result).toEqual({ value: true });
   });
 
-  test('exists mock with false produces undefined result', async () => {
+  test('exists mock with false produces false bool result', async () => {
     const captured = captureBody();
     const tc: TestCase = {
       description: 'not exists',
@@ -76,7 +79,7 @@ describe('Function mock translation', () => {
     };
     await handler.execute(MOCK_APP, SOURCE, [tc]);
     const apiMock = captured.get().testSuite.testCases[0].functionMocks[0];
-    expect(apiMock.result).toBeUndefined();
+    expect(apiMock.result).toEqual({ value: false });
   });
 
   test('mock path gets normalized with database prefix', async () => {

--- a/packages/pyric/test/rules/test/spec.test.ts
+++ b/packages/pyric/test/rules/test/spec.test.ts
@@ -130,7 +130,10 @@ describe('buildFunctionMock', () => {
     expect(api.result).toEqual({ value: { data: { role: 'admin' } } });
   });
 
-  test('wraps exists mock with true result', () => {
+  test('wraps exists mock with true result as a bool value, not a map', () => {
+    // exists() returns bool; the production Rules Test API rejects a
+    // map-shaped mock result for it with "Type error. Received: [map]
+    // Expected: [bool]", which silently resolves to DENY.
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/alice',
@@ -138,17 +141,17 @@ describe('buildFunctionMock', () => {
     };
     const api = buildFunctionMock(mock);
     expect(api.function).toBe('exists');
-    expect(api.result).toEqual({ value: { data: {} } });
+    expect(api.result).toEqual({ value: true });
   });
 
-  test('wraps exists mock with false as undefined result', () => {
+  test('wraps exists mock with false result as a bool value', () => {
     const mock: FunctionMock = {
       function: 'exists',
       path: 'users/bob',
       result: false,
     };
     const api = buildFunctionMock(mock);
-    expect(api.result).toBeUndefined();
+    expect(api.result).toEqual({ value: false });
   });
 });
 

--- a/packages/pyric/test/sandbox/firestore/simulator/globals.test.ts
+++ b/packages/pyric/test/sandbox/firestore/simulator/globals.test.ts
@@ -17,12 +17,12 @@ import type { TestCase } from 'pyric/rules';
 
 const sim = new SimulateFirestoreRulesHandler();
 
-function rules(condition: string, matchPath = 'docs/{id}'): string {
+function rules(condition: string, matchPath = 'docs/{id}', op = 'create'): string {
   return `rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /${matchPath} {
-      allow create: if ${condition};
+      allow ${op}: if ${condition};
     }
   }
 }`;
@@ -35,6 +35,24 @@ function tc(condition: string, expectation: 'ALLOW' | 'DENY', path = 'docs/d1'):
     method: 'create',
     path,
     auth: { uid: 'u1' },
+    data: {},
+  };
+}
+
+// resource is null on `create` (the document doesn't exist yet pre-write —
+// see rules-sim-resource-on-create). Tests that assert resource.id /
+// resource.__name__ resolve to the existing document's identity exercise
+// `update` instead, with `resource` set to the existing document data —
+// this is the mechanism other simulator tests use to populate `resource`
+// (see adversarial.test.ts).
+function tcExisting(condition: string, expectation: 'ALLOW' | 'DENY', path = 'docs/d1'): TestCase {
+  return {
+    description: condition,
+    expectation,
+    method: 'update',
+    path,
+    auth: { uid: 'u1' },
+    resource: {},
     data: {},
   };
 }
@@ -86,24 +104,24 @@ describe('request.query — Item 6', () => {
 describe('resource.id — Item 6', () => {
   test("resource.id == 'd1' for path docs/d1", () => {
     const r = sim.simulate(
-      rules("resource.id == 'd1'"),
-      [tc('resource.id matches', 'ALLOW')],
+      rules("resource.id == 'd1'", 'docs/{id}', 'update'),
+      [tcExisting('resource.id matches', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
 
   test("resource.id is string", () => {
     const r = sim.simulate(
-      rules("resource.id is string"),
-      [tc('resource.id typed', 'ALLOW')],
+      rules("resource.id is string", 'docs/{id}', 'update'),
+      [tcExisting('resource.id typed', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
 
   test("resource.id matches nested path's last segment", () => {
     const r = sim.simulate(
-      rules("resource.id == 'p99'", 'users/{uid}/posts/{pid}'),
-      [{ ...tc("nested resource.id", 'ALLOW'), path: 'users/alice/posts/p99' }],
+      rules("resource.id == 'p99'", 'users/{uid}/posts/{pid}', 'update'),
+      [{ ...tcExisting("nested resource.id", 'ALLOW'), path: 'users/alice/posts/p99' }],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
@@ -120,24 +138,24 @@ describe('resource.id — Item 6', () => {
 describe('resource.__name__ — Item 6', () => {
   test("resource.__name__ is path", () => {
     const r = sim.simulate(
-      rules("resource.__name__ is path"),
-      [tc('__name__ typed as path', 'ALLOW')],
+      rules("resource.__name__ is path", 'docs/{id}', 'update'),
+      [tcExisting('__name__ typed as path', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
 
   test("resource.__name__ equals request.path", () => {
     const r = sim.simulate(
-      rules("resource.__name__ == request.path"),
-      [tc('__name__ matches request.path', 'ALLOW')],
+      rules("resource.__name__ == request.path", 'docs/{id}', 'update'),
+      [tcExisting('__name__ matches request.path', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
 
   test("resource.__name__ equals the literal", () => {
     const r = sim.simulate(
-      rules("resource.__name__ == /databases/$(database)/documents/docs/d1"),
-      [tc('__name__ matches literal', 'ALLOW')],
+      rules("resource.__name__ == /databases/$(database)/documents/docs/d1", 'docs/{id}', 'update'),
+      [tcExisting('__name__ matches literal', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
@@ -147,16 +165,16 @@ describe('Globals — composability', () => {
   test('resource.id used in path-variable comparison', () => {
     // Combines path-variable binding with resource.id (both should be 'd1')
     const r = sim.simulate(
-      rules("resource.id == id"),
-      [tc('resource.id == id binding', 'ALLOW')],
+      rules("resource.id == id", 'docs/{id}', 'update'),
+      [tcExisting('resource.id == id binding', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });
 
   test('rule using both request.path and resource.id together', () => {
     const r = sim.simulate(
-      rules("request.path is path && resource.id == 'd1' && request.query is map"),
-      [tc('all three globals', 'ALLOW')],
+      rules("request.path is path && resource.id == 'd1' && request.query is map", 'docs/{id}', 'update'),
+      [tcExisting('all three globals', 'ALLOW')],
     );
     expect(r.success && r.data.passed).toBe(1);
   });

--- a/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
+++ b/scripts/oracle/rules-corpus/firestore/fix-class-packs.ts
@@ -582,11 +582,14 @@ service cloud.firestore {
     match /getMockedAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).data.flag == true;
     }
-    // mocked doc: resource carries id → ALLOW
+    // mocked doc: production CANNOT express resource identity (.id) via a
+    // function mock — the API returns "Property id is undefined on
+    // object." → DENY. Kept as a documented witness of the limitation.
     match /getResourceIdAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).id == 'site';
     }
-    // mocked doc: resource carries __name__ as a Path → ALLOW
+    // mocked doc: same limitation for __name__ — a mocked get() result has
+    // no resource identity attached, so this also errors → DENY.
     match /getResourceNameAllow/{id} {
       allow create: if get(/databases/$(database)/documents/cfg/site).__name__
         == /databases/$(database)/documents/cfg/site;
@@ -642,8 +645,12 @@ service cloud.firestore {
       ],
     },
     {
-      description: "get(mocked).id == 'site' → ALLOW (resource identity)",
-      expectation: 'ALLOW',
+      // Production cannot express resource identity (.id) through a
+      // function mock: get(mocked).id errors with "Property id is
+      // undefined on object." → DENY. This case documents that API
+      // limitation rather than testing an achievable ALLOW.
+      description: "get(mocked).id == 'site' → DENY (mocked get() has no resource identity in production)",
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceIdAllow/d6',
       auth: { uid: 'alice' },
@@ -653,8 +660,9 @@ service cloud.firestore {
       ],
     },
     {
-      description: 'get(mocked).__name__ == path literal → ALLOW',
-      expectation: 'ALLOW',
+      // Same limitation as above, for __name__.
+      description: 'get(mocked).__name__ == path literal → DENY (mocked get() has no resource identity in production)',
+      expectation: 'DENY',
       method: 'create',
       path: 'getResourceNameAllow/d7',
       auth: { uid: 'alice' },

--- a/scripts/oracle/rules-corpus/firestore/stress-packs.ts
+++ b/scripts/oracle/rules-corpus/firestore/stress-packs.ts
@@ -1238,14 +1238,16 @@ service cloud.firestore {
         && request.query is map
         && request.query.size() == 0;
     }
-    // resource.id matches the path's last segment
-    match /resourceIdAllow/{id} {
+    // resource.id on a CREATE: production makes resource null (the target
+    // doc does not exist pre-write), so resource.id errors and it DENYs.
+    match /resourceIdOnCreateDeny/{id} {
       allow create: if request.auth != null
         && resource.id == id
         && resource.id is string;
     }
-    // resource.__name__ matches request.path
-    match /resourceNameAllow/{id} {
+    // resource.__name__ on a CREATE: same, resource is null pre-write, so
+    // resource.__name__ errors and it DENYs.
+    match /resourceNameOnCreateDeny/{id} {
       allow create: if request.auth != null
         && resource.__name__ == request.path
         && resource.__name__ is path;
@@ -1283,18 +1285,22 @@ service cloud.firestore {
       data: {},
     },
     {
-      description: 'resource.id matches binding ALLOW',
-      expectation: 'ALLOW',
+      // On a create the target doc does not exist yet, so `resource` is
+      // null and `resource.id` errors → DENY. (Was mis-stated as ALLOW; the
+      // sim previously synthesized a resource identity — a false-allow.)
+      description: 'resource.id on create → DENY (resource is null pre-write)',
+      expectation: 'DENY',
       method: 'create',
-      path: 'resourceIdAllow/d4',
+      path: 'resourceIdOnCreateDeny/d4',
       auth: { uid: 'alice' },
       data: {},
     },
     {
-      description: 'resource.__name__ == request.path ALLOW',
-      expectation: 'ALLOW',
+      // Same as above for __name__: `resource` is null on create → DENY.
+      description: 'resource.__name__ on create → DENY (resource is null pre-write)',
+      expectation: 'DENY',
       method: 'create',
-      path: 'resourceNameAllow/d5',
+      path: 'resourceNameOnCreateDeny/d5',
       auth: { uid: 'alice' },
       data: {},
     },


### PR DESCRIPTION
Stacked on #121 (`rules-capture-harness-exists-fix`) — review/merge that first.

## The bug (false-allow, highest-severity divergence)

On a `create` the target document does not exist yet, so production sets the top-level `resource` to **null**. The simulator instead synthesized a `resource` (empty `data` plus a derived `id`/`__name__`) for **every** method when building `SimulationContext`. On a create that is a false-allow — the simulator ALLOWs where production DENYs — and it lands on the most common real-world idioms:

```
allow create: if resource.data.owner == request.auth.uid;  // sim ALLOW, prod DENY
allow create: if resource.id == id;                        // sim ALLOW, prod DENY
allow create: if resource.__name__ == request.path;        // sim ALLOW, prod DENY
```

Production denies these on create because `resource` is null and any field access on it errors. For a tool whose job is to catch over-permissive rules, silently blessing over-permissive `create` rules is the failure mode that actively misleads an author into shipping.

## The fix

`packages/pyric/src/rules/simulator/handler.ts` (`buildContext`): build `resource` as `null` on `create`; leave the existing-document identity (`data`/`id`/`__name__`) unchanged for `get`/`list`/`update`/`delete`. `SimulationContext.resource` is now `SimResource | null` (`evaluator.ts`). A null `resource` resolves to null and field access errors → DENY via the existing evaluator paths, matching production.

`request.resource` (the INCOMING proposed data) is a separate value, built independently, and stays populated on create/update — deliberately untouched.

## Create-resource-null semantics

- `create`: no pre-write document → `resource` is null; `resource.data`/`.id`/`.__name__` error → DENY (or `&&`-absorb).
- `get`/`list`/`update`/`delete`: `resource` reflects the existing stored document (unchanged behavior).

## Conformance packs

- **globals-request-path-and-resource-id** — now fully passes (6/6). Its two resource-on-create cases were still recorded as `ALLOW` (the stale false value the sim used to emit); corrected to `DENY` to match production, mirroring the get-missing-doc correction that landed on the base branch (#121). Backticks avoided inside the rules template string.
- **get-missing-doc** — its top-level-resource cases are unaffected by this change; all its create cases use `get()`/`exists()`, not bare `resource`. Its two remaining mismatches (`get(mocked).id`/`.__name__`) go through a different code path (`makeGetResource` for function-mock results) and are deliberately left for a separate change — the triage flags that path as needing a live-capture re-check first.

## Regression check

New tests in `packages/pyric/test/rules/simulator/handler.test.ts` (`resource is null on create`) confirm create DENYs on `resource.data`/`.id`/`.__name__`, that `request.resource` still ALLOWs on create, and that `get`/`update`/`delete` reading `resource.data` with an existing doc still ALLOW (unregressed). Full `packages/pyric/test/rules` suite: only the 3 pre-existing `pyric/sandbox/internal` module-resolution failures remain (confirmed present on the base branch); `bunx tsc --noEmit` clean.

