### PR TITLE
Stage storage rules conformance corpus and capture machinery

### DIFF
--- a/packages/pyric/src/rules/test/handler.ts
+++ b/packages/pyric/src/rules/test/handler.ts
@@ -4,11 +4,13 @@ import type {
   ExpressionReportLevel,
   RulesTestApiResultDetails,
   RulesTestIssue,
+  StorageApiTestCase,
+  StorageTestCase,
   TestCase,
   TestFirestoreRulesResult,
   TestResult,
 } from './spec.js';
-import { buildApiTestCase } from './spec.js';
+import { buildApiTestCase, buildStorageApiTestCase } from './spec.js';
 
 const RULES_API = 'https://firebaserules.googleapis.com/v1';
 
@@ -139,6 +141,113 @@ export class TestFirestoreRulesHandler {
           passed,
           failed,
           unsupported,
+          results,
+          ...(data.issues ? { issues: data.issues } : {}),
+        },
+      };
+    } catch (e) {
+      return {
+        success: false,
+        error: { code: 'FETCH_FAILED', message: e instanceof Error ? e.message : String(e), recoverable: false },
+      };
+    }
+  }
+}
+
+/**
+ * Firebase Rules Test API client for `service firebase.storage` rulesets.
+ *
+ * A near-mirror of {@link TestFirestoreRulesHandler}: it POSTs to the SAME
+ * `projects.test` endpoint (live-confirmed to accept Storage rulesets), but
+ * uses {@link buildStorageApiTestCase} for the wire shape and a `storage.rules`
+ * source filename. The result envelope is identical, so the oracle capture
+ * runner and any caller can treat Firestore and Storage rule tests uniformly.
+ */
+export class TestStorageRulesHandler {
+  async execute(
+    scope: ProjectScope,
+    source: string,
+    testCases: StorageTestCase[],
+  ): Promise<TestFirestoreRulesResult> {
+    try {
+      const token = await scope.resolveToken();
+
+      const apiTestCases: StorageApiTestCase[] = testCases.map(buildStorageApiTestCase);
+
+      const res = await fetch(`${RULES_API}/projects/${scope.projectId}:test`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          source: { files: [{ name: 'storage.rules', content: source }] },
+          testSuite: { testCases: apiTestCases },
+        }),
+      });
+
+      if (res.status === 403) {
+        return {
+          success: false,
+          error: { code: 'PERMISSION_DENIED', message: 'Service account lacks permission to test Storage rules', recoverable: false },
+        };
+      }
+
+      if (res.status === 400) {
+        const body = await res.text().catch(() => '');
+        return {
+          success: false,
+          error: { code: 'INVALID_REQUEST', message: `Invalid request: ${body}`, recoverable: true },
+        };
+      }
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return {
+          success: false,
+          error: { code: 'FETCH_FAILED', message: `Rules test failed: ${res.status} ${body}`, recoverable: false },
+        };
+      }
+
+      const data = await res.json() as {
+        issues?: RulesTestIssue[];
+        testResults?: ApiTestResult[];
+      };
+
+      if (data.issues && data.issues.length > 0 && (!data.testResults || data.testResults.length === 0)) {
+        const messages = data.issues.map(i => i.description).join('; ');
+        return {
+          success: false,
+          error: { code: 'RULES_ERROR', message: messages, recoverable: true },
+        };
+      }
+
+      const testResults = data.testResults ?? [];
+      const results: TestResult[] = testCases.map((tc, i) => {
+        const apiResult = testResults[i];
+        const state: 'PASSED' | 'FAILED' = apiResult?.state === 'SUCCESS' ? 'PASSED' : 'FAILED';
+        const decision: 'ALLOW' | 'DENY' = state === 'PASSED' ? tc.expectation : oppositeOf(tc.expectation);
+        const details = apiDetails(apiResult);
+        return {
+          description: tc.description,
+          expectation: tc.expectation,
+          state,
+          decision,
+          trace: [],
+          notes: apiResult?.debugMessages ?? [],
+          ...(details ? { api: details } : {}),
+        };
+      });
+
+      const passed = results.filter(r => r.state === 'PASSED').length;
+      const failed = results.filter(r => r.state === 'FAILED').length;
+
+      return {
+        success: true,
+        data: {
+          passed,
+          failed,
+          unsupported: 0,
           results,
           ...(data.issues ? { issues: data.issues } : {}),
         },

--- a/packages/pyric/src/rules/test/spec.ts
+++ b/packages/pyric/src/rules/test/spec.ts
@@ -455,6 +455,178 @@ export function buildApiTestCase(tc: TestCase, opts: BuildApiTestCaseOptions = {
   return result;
 }
 
+// ═══════════════════════════════════════════════════════════════
+// Storage rules test surface
+// ═══════════════════════════════════════════════════════════════
+//
+// Storage rules ride the SAME `projects.test` endpoint as Firestore
+// (live-confirmed against firebaserules.googleapis.com/v1/projects/<p>:test),
+// but the request shape is Storage-shaped, not Firestore-shaped:
+//   - the ruleset header is `service firebase.storage`
+//   - the path is a resource name `/b/{bucket}/o/{object}` (NOT the
+//     `/databases/(default)/documents/...` Firestore prefix)
+//   - `method` is a short verb (get/list/create/update/delete)
+//   - `resource` carries `size`/`contentType`/`metadata` directly, with no
+//     `.data` wrapper (production tolerates `size` as a string too)
+//   - cross-service function mocks use the QUALIFIED names `firestore.get` /
+//     `firestore.exists` (Firestore-internal mocks use the bare `get`/`exists`);
+//     and — same fix as `buildFunctionMock` — an `exists()` mock must send a
+//     bool `{ value: true/false }`, never a map, or the API rejects it and the
+//     mock silently resolves to DENY.
+//
+// These builders live BESIDE the Firestore ones and share nothing mutable with
+// them, so adding the Storage surface can't regress Firestore.
+
+/** The rules methods a Storage test case may exercise — short verbs only.
+ *  The coarse umbrellas (`read`/`write`) are a GRANT-side vocabulary; a
+ *  request is always one precise granular verb. */
+export const STORAGE_TEST_METHODS = ['get', 'list', 'create', 'update', 'delete'] as const;
+export type StorageTestMethod = (typeof STORAGE_TEST_METHODS)[number];
+
+/** Default bucket used when a case omits one. The bucket name is opaque to
+ *  the rules engine (matched by the `{bucket}` path param), so any stable
+ *  value works; keep it constant so observation paths are reproducible. */
+export const DEFAULT_STORAGE_BUCKET = 'demo-pyric.appspot.com';
+
+/** `request.resource.*` / `resource.*` binding shape the Storage rules
+ *  language sees: object size, content type, and custom metadata. */
+export interface StorageResourceShape {
+  size?: number;
+  contentType?: string;
+  metadata?: Record<string, string>;
+}
+
+export const StorageFunctionMockSchema = z.object({
+  function: z.enum(['get', 'exists']).describe('Cross-service Firestore function to mock'),
+  path: z.string().describe('Firestore document path in collection/doc form, e.g. "users/alice"'),
+  result: z.union([z.record(z.unknown()), z.boolean()]).describe('Document fields for get, boolean for exists'),
+});
+export type StorageFunctionMock = z.infer<typeof StorageFunctionMockSchema>;
+
+/**
+ * A single Storage rules conformance case. Mirrors the Firestore {@link TestCase}
+ * but with the Storage request shape. `path` is the OBJECT path within the
+ * bucket (e.g. `"images/alice.png"`); `normalizeStoragePath` lifts it to the
+ * `/b/{bucket}/o/{object}` resource name that BOTH the production API and the
+ * in-process evaluator match against.
+ */
+export interface StorageTestCase {
+  description: string;
+  expectation: 'ALLOW' | 'DENY';
+  method: StorageTestMethod;
+  /** Object path within the bucket, e.g. `"images/alice.png"`. */
+  path: string;
+  /** Bucket name; defaults to {@link DEFAULT_STORAGE_BUCKET}. */
+  bucket?: string;
+  /** Auth context; `null`/omitted for anonymous. */
+  auth?: TestIdentity | null;
+  /** `request.resource` — the about-to-write object (writes only). */
+  resource?: StorageResourceShape;
+  /** `resource` — the existing object. `null`/omitted means no object yet
+   *  (the create case), which the evaluator reads as `resource == null`. */
+  existingResource?: StorageResourceShape | null;
+  /** Override for `request.time` (ISO-8601). Set whenever the rule reads
+   *  `request.time`, so date-gated cases are deterministic. */
+  requestTime?: string;
+  /** Cross-service `firestore.get()/exists()` mocks. */
+  functionMocks?: StorageFunctionMock[];
+  /**
+   * Marks a case whose in-process EVALUATOR verdict is KNOWN to diverge from
+   * production because the evaluator does not implement the feature the rule
+   * uses (e.g. `resource.timeCreated`). The capture still records production's
+   * real verdict; the replay suite records but does NOT assert these, exactly
+   * as the Firestore replay skips its simulator's `UNSUPPORTED` abstentions.
+   * The string is the reason, for the record.
+   */
+  knownGap?: string;
+}
+
+export interface StorageApiFunctionMock {
+  /** QUALIFIED cross-service name: `firestore.get` / `firestore.exists`. */
+  function: string;
+  args: Array<{ exactValue: string }>;
+  result: { value: { data: Record<string, unknown> } } | { value: boolean } | undefined;
+}
+
+export interface StorageApiTestCase {
+  expectation: 'ALLOW' | 'DENY';
+  request: {
+    auth: { uid: string; token: Record<string, unknown> } | undefined;
+    method: string;
+    path: string;
+    /** ISO-8601 — forwarded from `StorageTestCase.requestTime`. */
+    time?: string;
+    /** `request.resource` for writes. */
+    resource?: StorageResourceShape;
+  };
+  /** Existing-object `resource`. */
+  resource?: StorageResourceShape;
+  functionMocks?: StorageApiFunctionMock[];
+}
+
+/**
+ * Lift an object path to the Storage resource-name form the rules engine and
+ * the evaluator both match against: `/b/{bucket}/o/{object}`. A path that is
+ * already absolute has its leading slash stripped before the object segment so
+ * `"images/x"` and `"/images/x"` normalize identically.
+ */
+export function normalizeStoragePath(objectPath: string, bucket: string = DEFAULT_STORAGE_BUCKET): string {
+  const clean = objectPath.startsWith('/') ? objectPath.slice(1) : objectPath;
+  return `/b/${bucket}/o/${clean}`;
+}
+
+/** Convert a {@link StorageTestCase} into the production Rules Test API wire
+ *  shape. Symmetric with {@link buildApiTestCase} for Firestore. */
+export function buildStorageApiTestCase(tc: StorageTestCase): StorageApiTestCase {
+  const request: StorageApiTestCase['request'] = {
+    auth: tc.auth === null || tc.auth === undefined
+      ? undefined
+      : { uid: tc.auth.uid, token: tc.auth.token ?? {} },
+    // Short verb — same class of bug as Firestore's request.method: sending
+    // anything but get/list/create/update/delete makes the engine map the
+    // request to no allow rule, silently denying every ALLOW case.
+    method: tc.method,
+    path: normalizeStoragePath(tc.path, tc.bucket),
+  };
+  if (tc.resource) request.resource = tc.resource;
+  if (tc.requestTime) request.time = tc.requestTime;
+
+  const result: StorageApiTestCase = { expectation: tc.expectation, request };
+  if (tc.existingResource) result.resource = tc.existingResource;
+  if (tc.functionMocks && tc.functionMocks.length > 0) {
+    result.functionMocks = tc.functionMocks.map(buildStorageFunctionMock);
+  }
+  return result;
+}
+
+/**
+ * Build a cross-service Firestore function mock for a Storage ruleset. Unlike
+ * the Firestore-internal {@link buildFunctionMock} (bare `get`/`exists`), a
+ * Storage rule reaching into Firestore names the function with its service
+ * QUALIFIER — `firestore.get` / `firestore.exists` — live-confirmed against the
+ * production endpoint. The `exists()` result is a bool `{ value }`, never the
+ * `{ value: { data } }` map shape (the same fix `buildFunctionMock` carries):
+ * a map there is rejected with a bool/map type error and silently denies.
+ */
+export function buildStorageFunctionMock(mock: StorageFunctionMock): StorageApiFunctionMock {
+  const fnName = mock.function === 'get' ? 'firestore.get' : 'firestore.exists';
+  // The rule's path literal resolves to the full Firestore resource name
+  // (/databases/(default)/documents/<doc>); the mock's exactValue must match
+  // it. `normalizeDocPath` produces exactly that from the collection/doc form.
+  const normalizedPath = normalizeDocPath(mock.path);
+  const result: StorageApiFunctionMock = {
+    function: fnName,
+    args: [{ exactValue: normalizedPath }],
+    result: undefined,
+  };
+  if (mock.function === 'get') {
+    result.result = { value: { data: mock.result as Record<string, unknown> } };
+  } else {
+    result.result = { value: mock.result === true };
+  }
+  return result;
+}
+
 export function buildFunctionMock(mock: FunctionMock): ApiFunctionMock {
   // Function name must be the short verb ('get' | 'exists') — the same class
   // of bug as request.method. The Rules Test API rejects 'firestore.get' /

--- a/packages/pyric/test/storage/rules-oracle-conformance.test.ts
+++ b/packages/pyric/test/storage/rules-oracle-conformance.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Oracle conformance — Storage rules.
+ *
+ * The Storage counterpart of test/rules/oracle-conformance.test.ts. It wires
+ * `scripts/oracle/observations/rules-storage-*.json` into the test suite so
+ * captured production Rules-Test-API verdicts are MACHINE-CHECKED against the
+ * in-process storage evaluator (`evaluateStorageRules`), not merely cited.
+ *
+ * Data-driven by design: each observation's name is `rules-storage-<id>`,
+ * where `<id>` is a corpus pack id. For every captured observation the suite
+ * loads the matching pack, runs the LOCAL evaluator over the same ruleset +
+ * cases, and asserts the evaluator's per-case decision equals the captured
+ * production verdict. Coverage is structural: an observation whose id has no
+ * corresponding pack FAILS loudly (a capture can't silently go un-checked) —
+ * this completeness check is live even before any data exists.
+ *
+ * KNOWN-GAP CASES: the storage evaluator has no `UNSUPPORTED` verdict channel
+ * (it returns allow/deny), so a case exercising a field the evaluator does not
+ * model (e.g. resource.timeCreated) is marked `knownGap` in the corpus. Those
+ * cases are RECORDED but NOT ASSERTED here — the exact analogue of the
+ * Firestore replay skipping its simulator's UNSUPPORTED abstentions.
+ *
+ * STAGING STATE: no `rules-storage-*` observation has been captured yet (no
+ * credentials were available to the staging branch, and no observation files
+ * were fabricated). While the observation set is empty this suite SKIPS the
+ * replay with a clear message and passes. The moment a capture lands, the
+ * assertions go live verdict-for-verdict with no further edits — run
+ * `scripts/oracle/run-rules-storage.ts` with PARITY_SA_BASE64 to produce them.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ALL_RULES_STORAGE_PACKS,
+  RULES_STORAGE_OBSERVATION_PREFIX,
+  storageObservationName,
+  type StoragePack,
+} from '../../../../scripts/oracle/rules-corpus/storage/index.ts';
+import {
+  normalizeStoragePath,
+  type StorageTestCase,
+} from '../../src/rules/test/spec.ts';
+import {
+  parseStorageRules,
+  evaluateStorageRules,
+  type EvaluationInput,
+  type FirestoreLookup,
+} from '../../src/storage/rules.ts';
+
+const OBS_DIR = join(import.meta.dir, '..', '..', '..', '..', 'scripts', 'oracle', 'observations');
+
+/** name (no extension) → pack, for O(1) observation→pack resolution. */
+const PACK_BY_OBSERVATION = new Map<string, StoragePack>(
+  ALL_RULES_STORAGE_PACKS.map((pack) => [storageObservationName(pack), pack]),
+);
+
+interface RulesObservation {
+  name: string;
+  behavior: Record<string, unknown>;
+}
+
+function loadObservation(file: string): RulesObservation {
+  const raw = JSON.parse(readFileSync(join(OBS_DIR, file), 'utf8')) as {
+    name?: string;
+    behavior?: Record<string, unknown>;
+  };
+  return {
+    name: raw.name ?? file.replace(/\.json$/, ''),
+    behavior: raw.behavior ?? {},
+  };
+}
+
+/** Every captured `rules-storage-*.json` in the observations directory. */
+function capturedObservationFiles(): string[] {
+  return readdirSync(OBS_DIR)
+    .filter((f) => f.startsWith(RULES_STORAGE_OBSERVATION_PREFIX) && f.endsWith('.json'))
+    .sort();
+}
+
+/** Build a FirestoreLookup from a case's function mocks. The evaluator keys
+ *  lookups by the doc path in `collection/doc` form — exactly the corpus mock
+ *  `path`. Mocks with no matching entry read as absent (get → null → the rule
+ *  denies, exists → false). */
+function lookupFromCase(tc: StorageTestCase): FirestoreLookup | undefined {
+  if (!tc.functionMocks || tc.functionMocks.length === 0) return undefined;
+  const gets = new Map<string, Record<string, unknown>>();
+  const exists = new Set<string>();
+  for (const m of tc.functionMocks) {
+    if (m.function === 'get' && typeof m.result === 'object' && m.result !== null) {
+      gets.set(m.path, m.result as Record<string, unknown>);
+    } else if (m.function === 'exists' && m.result === true) {
+      exists.add(m.path);
+    }
+  }
+  return {
+    get: (path) => gets.get(path) ?? null,
+    exists: (path) => exists.has(path),
+  };
+}
+
+/** Map a corpus case to the evaluator's EvaluationInput. */
+function toEvaluationInput(tc: StorageTestCase): EvaluationInput {
+  const path = normalizeStoragePath(tc.path, tc.bucket);
+  const request: EvaluationInput['request'] = {
+    auth: tc.auth ?? null,
+    method: tc.method,
+    path,
+  };
+  if (tc.resource) {
+    request.resource = {
+      size: tc.resource.size ?? 0,
+      contentType: tc.resource.contentType,
+      metadata: tc.resource.metadata,
+    };
+  }
+  const existing = tc.existingResource
+    ? {
+        size: tc.existingResource.size ?? 0,
+        contentType: tc.existingResource.contentType,
+        metadata: tc.existingResource.metadata,
+      }
+    : null;
+  return { request, resource: existing };
+}
+
+/** Evaluator decision per case, keyed by case description (the same key the
+ *  capture uses) so the two tables line up 1:1. */
+function evaluatorVerdicts(pack: StoragePack): Record<string, 'ALLOW' | 'DENY'> {
+  const rules = parseStorageRules(pack.rules);
+  const table: Record<string, 'ALLOW' | 'DENY'> = {};
+  for (const tc of pack.cases) {
+    const now = tc.requestTime ? new Date(tc.requestTime) : undefined;
+    const res = evaluateStorageRules(rules, toEvaluationInput(tc), now, lookupFromCase(tc));
+    table[tc.description] = res.allowed ? 'ALLOW' : 'DENY';
+  }
+  return table;
+}
+
+describe('oracle conformance (rules-storage)', () => {
+  const files = capturedObservationFiles();
+
+  // Corpus sanity: every pack must parse. This runs even with no observations,
+  // so a malformed ruleset is caught at staging time, not only at capture.
+  it('every storage corpus pack parses', () => {
+    for (const pack of ALL_RULES_STORAGE_PACKS) {
+      expect(() => parseStorageRules(pack.rules), `pack "${pack.id}" must parse`).not.toThrow();
+    }
+  });
+
+  // ── empty-set guard: pass + skip the replay while nothing is captured ──────
+  if (files.length === 0) {
+    it('no rules-storage observations captured yet (staging) — skipping replay', () => {
+      // Intentionally passes: the machinery is staged, the corpus is in place,
+      // but no captures have been run. Run `scripts/oracle/run-rules-storage.ts`
+      // with PARITY_SA_BASE64 to produce observations, after which these
+      // assertions go live automatically.
+      expect(files.length).toBe(0);
+    });
+  }
+
+  // ── verdict-for-verdict replay (live the moment observations exist) ────────
+  for (const file of files) {
+    const obs = loadObservation(file);
+    const pack = PACK_BY_OBSERVATION.get(obs.name);
+
+    it(`${obs.name}: evaluator matches captured production verdicts`, () => {
+      // Completeness is structural: an observation with no corpus pack is a
+      // silent-gap failure — either the pack was removed or the file is stale.
+      expect(
+        pack,
+        `observation "${obs.name}" has no matching corpus pack — coverage gap`,
+      ).toBeDefined();
+      if (!pack) return;
+
+      // Cases marked knownGap are exercised but not asserted (the evaluator has
+      // no UNSUPPORTED channel; it denies a field it does not model).
+      const knownGap = new Set(
+        pack.cases.filter((c) => c.knownGap).map((c) => c.description),
+      );
+
+      const evalTable = evaluatorVerdicts(pack);
+      for (const [caseKey, prodVerdict] of Object.entries(obs.behavior)) {
+        if (knownGap.has(caseKey)) continue;
+        expect(evalTable[caseKey], `${obs.name} :: ${caseKey}`).toBe(prodVerdict);
+      }
+    });
+  }
+
+  // ── coverage: no captured observation is left un-replayed ──────────────────
+  it('every captured rules-storage observation maps to a corpus pack', () => {
+    const uncovered = capturedObservationFiles()
+      .map((f) => f.replace(/\.json$/, ''))
+      .filter((name) => !PACK_BY_OBSERVATION.has(name));
+    expect(uncovered).toEqual([]);
+  });
+});

--- a/scripts/compat/registry/index.ts
+++ b/scripts/compat/registry/index.ts
@@ -35,6 +35,19 @@ export const surfaceDescriptors: SurfaceDescriptor[] = [
   // `observationExceptions` below (the replay suite enforces coverage
   // structurally).
   { surface: 'firestore', registry: firestoreRegistry, observationPrefix: 'rules-firestore-' },
+  // `rules-storage-` observations are captures of the production Storage Rules
+  // Test API replaying the conformance corpus in
+  // `scripts/oracle/rules-corpus/storage/`. They are produced on-demand by
+  // `scripts/oracle/run-rules-storage.ts` (credentialed; see the runner). No
+  // captures exist yet — this staging branch fabricates none — and the stale
+  // storage matrix rows (#96/#104) are reconciled only AFTER capture proves the
+  // new truth, so this descriptor only teaches the validator that
+  // `rules-storage-` is a recognized observation filename prefix. It reuses the
+  // existing `storage` registry — it adds NO new COMPAT.md doc and NO matrix
+  // rows. Any captured observation will then need either a matrix row citing it
+  // or an entry in `observationExceptions` (the replay suite enforces coverage
+  // structurally).
+  { surface: 'storage', registry: storageRegistry, observationPrefix: 'rules-storage-' },
 ];
 
 /** One registry per generated COMPAT.md doc (shared registries deduped). */

--- a/scripts/oracle/rules-corpus/storage/index.ts
+++ b/scripts/oracle/rules-corpus/storage/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Storage rules conformance corpus — public entry point.
+ *
+ * Mirror of ../firestore/index.ts for the `service firebase.storage` surface.
+ * Consumers:
+ *   - scripts/oracle/run-rules-storage.ts                       (capture runner)
+ *   - packages/pyric/test/storage/rules-oracle-conformance.test.ts (replay)
+ *
+ * The observation filename for a pack is `rules-storage-<pack.id>.json`
+ * (see `storageObservationName`). Keep pack ids stable — they are the join key
+ * between the corpus, the captured observations, and the replay suite.
+ */
+import { STORAGE_PACKS } from './packs.ts';
+import type { StoragePack } from './types.ts';
+
+export type { StoragePack } from './types.ts';
+export { STORAGE_PACKS } from './packs.ts';
+
+/** The observation filename prefix for every Storage rules capture. */
+export const RULES_STORAGE_OBSERVATION_PREFIX = 'rules-storage-';
+
+/** Every Storage rules pack in the corpus. */
+export const ALL_RULES_STORAGE_PACKS: StoragePack[] = [...STORAGE_PACKS];
+
+/** The observation stem (no extension) a given pack captures into. */
+export function storageObservationName(pack: StoragePack): string {
+  return `${RULES_STORAGE_OBSERVATION_PREFIX}${pack.id}`;
+}

--- a/scripts/oracle/rules-corpus/storage/packs.ts
+++ b/scripts/oracle/rules-corpus/storage/packs.ts
@@ -1,0 +1,303 @@
+/**
+ * Storage rules conformance corpus — packs.
+ *
+ * One pack per feature area of the MERGED storage evaluator
+ * (packages/pyric/src/storage/rules.ts): umbrella-vs-granular verbs,
+ * user-defined functions (let + scoping), request.time / timestamp
+ * constructors, string.matches(), custom-metadata access, cross-service
+ * firestore.get()/exists(), plus a witness pack for the still-unsupported
+ * resource.timeCreated / resource.updated fields.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ EXPECTATIONS ARE UNVERIFIED UNTIL CAPTURE.                               │
+ * │                                                                         │
+ * │ Every case's `expectation` is a BEST-KNOWN production truth, written    │
+ * │ from the evaluator's documented behavior and the live-probed facts      │
+ * │ about the Storage Rules Test API. It is NOT ground truth yet. The       │
+ * │ capture run (scripts/oracle/run-rules-storage.ts, credentialed) posts   │
+ * │ each pack to the PRODUCTION endpoint; that verdict is the source of     │
+ * │ truth. A capture that disagrees with an `expectation` here flags a BAD  │
+ * │ PACK (wrong rule, wrong case, or a wrong belief about production) — fix  │
+ * │ the pack before drawing any conclusion. Do not treat these values as    │
+ * │ settled.                                                                 │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * Rulesets are kept COMPILE-VALID for production on purpose: an invalid
+ * ruleset makes the Rules Test API return `issues` with no results, which
+ * aborts the whole capture. Constructs the evaluator guards against but
+ * production rejects at COMPILE time (recursion / depth-cap, undefined-function
+ * calls, duplicate function names) are therefore left to the evaluator's unit
+ * tests, NOT the oracle — they cannot be captured as a clean production
+ * verdict. What IS captured here is every runtime-observable behavior.
+ */
+import type { StoragePack } from './types.ts';
+
+// ─── Pack 1: verbs-umbrella-granular ────────────────────────────────────────
+// The stale storage matrix (#96/#104) claims granular verbs are unsupported.
+// This pack proves the evaluator's read→{get,list} / write→{create,update,
+// delete} expansion, granular single-verb grants, comma-separated verbs,
+// per-verb deny-by-default, and create-vs-update keyed on object existence.
+const VERBS_PACK: StoragePack = {
+  id: 'verbs-umbrella-granular',
+  fm: 'STORAGE-VERBS',
+  rationale:
+    'Umbrella read/write expansion, granular verb grants, comma-separated verbs, per-verb default-deny, and create-vs-update on resource existence.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /readonly/{fileId} {
+      allow read: if true;
+    }
+    match /writeonly/{fileId} {
+      allow write: if true;
+    }
+    match /getonly/{fileId} {
+      allow get: if true;
+    }
+    match /pair/{fileId} {
+      allow get, delete: if true;
+    }
+    match /existence/{fileId} {
+      allow create: if resource == null;
+      allow update: if resource != null;
+    }
+  }
+}`,
+  cases: [
+    // read → get + list
+    { description: 'read grant covers get', expectation: 'ALLOW', method: 'get', path: 'readonly/a.txt' },
+    { description: 'read grant covers list', expectation: 'ALLOW', method: 'list', path: 'readonly/a.txt' },
+    { description: 'read grant denies create (no write grant)', expectation: 'DENY', method: 'create', path: 'readonly/a.txt', resource: { size: 1024, contentType: 'text/plain' } },
+    { description: 'read grant denies delete', expectation: 'DENY', method: 'delete', path: 'readonly/a.txt', existingResource: { size: 1024 } },
+    // write → create + update + delete
+    { description: 'write grant covers create', expectation: 'ALLOW', method: 'create', path: 'writeonly/b.png', resource: { size: 2048, contentType: 'image/png' } },
+    { description: 'write grant covers update', expectation: 'ALLOW', method: 'update', path: 'writeonly/b.png', resource: { size: 2048, contentType: 'image/png' }, existingResource: { size: 1000 } },
+    { description: 'write grant covers delete', expectation: 'ALLOW', method: 'delete', path: 'writeonly/b.png', existingResource: { size: 1000 } },
+    { description: 'write grant denies get', expectation: 'DENY', method: 'get', path: 'writeonly/b.png', existingResource: { size: 1000 } },
+    // granular single verb
+    { description: 'get grant covers get', expectation: 'ALLOW', method: 'get', path: 'getonly/c.txt', existingResource: { size: 5 } },
+    { description: 'get grant denies list (get is not read)', expectation: 'DENY', method: 'list', path: 'getonly/c.txt' },
+    // comma-separated verbs
+    { description: 'comma verbs grant get', expectation: 'ALLOW', method: 'get', path: 'pair/d.txt', existingResource: { size: 5 } },
+    { description: 'comma verbs grant delete', expectation: 'ALLOW', method: 'delete', path: 'pair/d.txt', existingResource: { size: 5 } },
+    { description: 'comma verbs deny create (not listed)', expectation: 'DENY', method: 'create', path: 'pair/d.txt', resource: { size: 5, contentType: 'text/plain' } },
+    // create-vs-update keyed on existence
+    { description: 'create allowed when object does not exist (resource == null)', expectation: 'ALLOW', method: 'create', path: 'existence/e.txt', resource: { size: 10, contentType: 'text/plain' }, existingResource: null },
+    { description: 'update allowed when object exists (resource != null)', expectation: 'ALLOW', method: 'update', path: 'existence/e.txt', resource: { size: 20, contentType: 'text/plain' }, existingResource: { size: 10 } },
+    { description: 'create denied when object already exists (create rule requires resource == null)', expectation: 'DENY', method: 'create', path: 'existence/e.txt', resource: { size: 20, contentType: 'text/plain' }, existingResource: { size: 10 } },
+  ],
+};
+
+// ─── Pack 2: functions-let-scope ────────────────────────────────────────────
+// #96/#104 also claim user-defined functions are unsupported. This proves
+// `let` bindings, functions calling functions, and match-block-scoped helper
+// functions (lexical scoping). Same-name shadowing and undefined-function
+// calls are deliberately omitted: production rejects those at compile, so they
+// cannot be captured as a clean verdict (they live in the evaluator unit tests).
+const FUNCTIONS_PACK: StoragePack = {
+  id: 'functions-let-scope',
+  fm: 'STORAGE-FUNC',
+  rationale:
+    'User-defined functions with let bindings, functions calling functions, and a match-block-scoped helper — the evaluator surface #96/#104 wrongly call unsupported.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    function sizeUnder(limitMb) {
+      let mb = 1024 * 1024;
+      return request.resource.size < limitMb * mb;
+    }
+    function isImage() {
+      return request.resource.contentType == 'image/png';
+    }
+    function allowedUpload() {
+      return sizeUnder(5) && isImage();
+    }
+    match /uploads/{fileId} {
+      allow create: if allowedUpload();
+    }
+    match /scoped/{fileId} {
+      function tooBig() {
+        return request.resource.size > 1024;
+      }
+      allow create: if !tooBig();
+    }
+  }
+}`,
+  cases: [
+    { description: 'let + nested calls: small png under 5MB', expectation: 'ALLOW', method: 'create', path: 'uploads/a.png', resource: { size: 1048576, contentType: 'image/png' } },
+    { description: 'let + nested calls: oversized png denied', expectation: 'DENY', method: 'create', path: 'uploads/a.png', resource: { size: 10485760, contentType: 'image/png' } },
+    { description: 'nested call isImage(): wrong content type denied', expectation: 'DENY', method: 'create', path: 'uploads/a.png', resource: { size: 1048576, contentType: 'image/jpeg' } },
+    { description: 'block-scoped helper tooBig(): small file allowed', expectation: 'ALLOW', method: 'create', path: 'scoped/b.bin', resource: { size: 500, contentType: 'application/octet-stream' } },
+    { description: 'block-scoped helper tooBig(): large file denied', expectation: 'DENY', method: 'create', path: 'scoped/b.bin', resource: { size: 5000, contentType: 'application/octet-stream' } },
+  ],
+};
+
+// ─── Pack 3: request-time-timestamp ─────────────────────────────────────────
+// request.time compared against the timestamp constructors timestamp.date()
+// (UTC midnight) and timestamp.value() (epoch millis). #96/#104 mark time
+// unsupported.
+const TIME_PACK: StoragePack = {
+  id: 'request-time-timestamp',
+  fm: 'STORAGE-TIME',
+  rationale:
+    'request.time compared against timestamp.date(y,m,d) and timestamp.value(ms) — the time surface #96/#104 wrongly call unsupported.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /deadline/{fileId} {
+      allow create: if request.time < timestamp.date(2030, 1, 1);
+    }
+    match /epoch/{fileId} {
+      allow create: if request.time > timestamp.value(1000000000000);
+    }
+  }
+}`,
+  cases: [
+    { description: 'timestamp.date(): before deadline allowed', expectation: 'ALLOW', method: 'create', path: 'deadline/a.txt', resource: { size: 10, contentType: 'text/plain' }, requestTime: '2025-06-01T00:00:00Z' },
+    { description: 'timestamp.date(): after deadline denied', expectation: 'DENY', method: 'create', path: 'deadline/a.txt', resource: { size: 10, contentType: 'text/plain' }, requestTime: '2035-06-01T00:00:00Z' },
+    { description: 'timestamp.value(): after epoch bound allowed', expectation: 'ALLOW', method: 'create', path: 'epoch/b.txt', resource: { size: 10, contentType: 'text/plain' }, requestTime: '2025-06-01T00:00:00Z' },
+    { description: 'timestamp.value(): before epoch bound denied', expectation: 'DENY', method: 'create', path: 'epoch/b.txt', resource: { size: 10, contentType: 'text/plain' }, requestTime: '1990-01-01T00:00:00Z' },
+  ],
+};
+
+// ─── Pack 4: matches-regex ──────────────────────────────────────────────────
+// string.matches() — whole-string anchoring (a partial match denies) and RE2
+// inexpressibility (a lookaround pattern production's RE2 rejects → deny).
+const MATCHES_PACK: StoragePack = {
+  id: 'matches-regex',
+  fm: 'STORAGE-MATCHES',
+  rationale:
+    'string.matches() whole-string anchoring (partial match denies) and RE2-inexpressible lookaround → deny.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /typed/{fileId} {
+      allow create: if request.resource.contentType.matches('image/.*');
+    }
+    match /lookaround/{fileId} {
+      allow create: if request.resource.contentType.matches('image/(?=png).*');
+    }
+  }
+}`,
+  cases: [
+    { description: 'matches whole string: image/png accepted', expectation: 'ALLOW', method: 'create', path: 'typed/a.png', resource: { size: 100, contentType: 'image/png' } },
+    { description: 'matches whole string: text/plain rejected', expectation: 'DENY', method: 'create', path: 'typed/a.txt', resource: { size: 100, contentType: 'text/plain' } },
+    { description: 'anchoring: leading-prefixed ximage/png rejected (not a partial match)', expectation: 'DENY', method: 'create', path: 'typed/a.png', resource: { size: 100, contentType: 'ximage/png' } },
+    { description: 'RE2-inexpressible lookahead pattern denies', expectation: 'DENY', method: 'create', path: 'lookaround/a.png', resource: { size: 100, contentType: 'image/png' } },
+  ],
+};
+
+// ─── Pack 5: metadata-access ────────────────────────────────────────────────
+// Custom metadata in BOTH dotted (resource.metadata.owner) and bracket
+// (resource.metadata['owner']) form — they must resolve identically — and a
+// missing key (undefined → deny).
+const METADATA_PACK: StoragePack = {
+  id: 'metadata-access',
+  fm: 'STORAGE-META',
+  rationale:
+    'resource.metadata custom-metadata access in dotted and bracket form (identical resolution) and missing-key deny.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /dotted/{fileId} {
+      allow get: if resource.metadata.owner == request.auth.uid;
+    }
+    match /bracket/{fileId} {
+      allow get: if resource.metadata['owner'] == request.auth.uid;
+    }
+  }
+}`,
+  cases: [
+    { description: 'dotted metadata: owner matches → allow', expectation: 'ALLOW', method: 'get', path: 'dotted/a.txt', auth: { uid: 'alice' }, existingResource: { size: 10, metadata: { owner: 'alice' } } },
+    { description: 'dotted metadata: owner mismatch → deny', expectation: 'DENY', method: 'get', path: 'dotted/a.txt', auth: { uid: 'bob' }, existingResource: { size: 10, metadata: { owner: 'alice' } } },
+    { description: 'dotted metadata: missing owner key → deny', expectation: 'DENY', method: 'get', path: 'dotted/a.txt', auth: { uid: 'alice' }, existingResource: { size: 10, metadata: {} } },
+    { description: 'bracket metadata: owner matches → allow', expectation: 'ALLOW', method: 'get', path: 'bracket/b.txt', auth: { uid: 'alice' }, existingResource: { size: 10, metadata: { owner: 'alice' } } },
+    { description: 'bracket metadata: owner mismatch → deny', expectation: 'DENY', method: 'get', path: 'bracket/b.txt', auth: { uid: 'bob' }, existingResource: { size: 10, metadata: { owner: 'alice' } } },
+  ],
+};
+
+// ─── Pack 6: firestore-lookup ───────────────────────────────────────────────
+// Cross-service firestore.get()/exists() with $(expr) path interpolation
+// (path param and request.auth.uid). Mocks use the QUALIFIED firestore.get /
+// firestore.exists names; exists() mock is a bool.
+const FIRESTORE_LOOKUP_PACK: StoragePack = {
+  id: 'firestore-lookup',
+  fm: 'STORAGE-XSVC',
+  rationale:
+    'firestore.get()/exists() cross-service lookups with $(expr) interpolation, qualified function-mock names, and bool exists() results.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /profiles/{userId}/{fileId} {
+      allow get: if firestore.get(/databases/(default)/documents/users/$(userId)).data.uid == request.auth.uid;
+      allow create: if firestore.exists(/databases/(default)/documents/members/$(request.auth.uid));
+    }
+  }
+}`,
+  cases: [
+    {
+      description: 'firestore.get(): profile uid matches caller → allow',
+      expectation: 'ALLOW', method: 'get', path: 'profiles/alice/avatar.png', auth: { uid: 'alice' }, existingResource: { size: 100 },
+      functionMocks: [{ function: 'get', path: 'users/alice', result: { uid: 'alice' } }],
+    },
+    {
+      description: 'firestore.get(): profile uid mismatch → deny',
+      expectation: 'DENY', method: 'get', path: 'profiles/alice/avatar.png', auth: { uid: 'bob' }, existingResource: { size: 100 },
+      functionMocks: [{ function: 'get', path: 'users/alice', result: { uid: 'alice' } }],
+    },
+    {
+      description: 'firestore.exists(): membership present → allow create',
+      expectation: 'ALLOW', method: 'create', path: 'profiles/alice/avatar.png', auth: { uid: 'alice' }, resource: { size: 100, contentType: 'image/png' },
+      functionMocks: [{ function: 'exists', path: 'members/alice', result: true }],
+    },
+    {
+      description: 'firestore.exists(): membership absent → deny create',
+      expectation: 'DENY', method: 'create', path: 'profiles/bob/avatar.png', auth: { uid: 'bob' }, resource: { size: 100, contentType: 'image/png' },
+      functionMocks: [{ function: 'exists', path: 'members/bob', result: false }],
+    },
+  ],
+};
+
+// ─── Pack 7: resource-timestamp-witness (KNOWN GAP) ─────────────────────────
+// The evaluator's resource model carries only size/contentType/metadata, so
+// resource.timeCreated / resource.updated read `undefined` and any comparison
+// DENIES in-process, while production evaluates a real server timestamp. These
+// cases are the witness for that gap: their `knownGap` marker tells the replay
+// suite to RECORD but NOT ASSERT the evaluator verdict (mirroring how the
+// Firestore replay skips its simulator's UNSUPPORTED abstentions). The
+// `expectation` is production's expected verdict, and stays UNVERIFIED until
+// capture confirms it — at which point this pack is the evidence the field is
+// still unsupported in the evaluator.
+const TIMESTAMP_WITNESS_PACK: StoragePack = {
+  id: 'resource-timestamp-witness',
+  fm: 'STORAGE-RES-TS',
+  rationale:
+    'Witness: resource.timeCreated / resource.updated are production Storage fields the evaluator does not model (reads undefined → deny) — records the known gap.',
+  rules: `service firebase.storage {
+  match /b/{bucket}/o {
+    match /created/{fileId} {
+      allow get: if resource.timeCreated < request.time;
+    }
+    match /updated/{fileId} {
+      allow get: if resource.updated < request.time;
+    }
+  }
+}`,
+  cases: [
+    {
+      description: 'resource.timeCreated < request.time (prod: real timestamp)',
+      expectation: 'ALLOW', method: 'get', path: 'created/a.txt', existingResource: { size: 10 }, requestTime: '2025-06-01T00:00:00Z',
+      knownGap: 'resource.timeCreated is not modeled by the evaluator (reads undefined → deny)',
+    },
+    {
+      description: 'resource.updated < request.time (prod: real timestamp)',
+      expectation: 'ALLOW', method: 'get', path: 'updated/b.txt', existingResource: { size: 10 }, requestTime: '2025-06-01T00:00:00Z',
+      knownGap: 'resource.updated is not modeled by the evaluator (reads undefined → deny)',
+    },
+  ],
+};
+
+/** Every Storage rules pack in the corpus, in a stable order. */
+export const STORAGE_PACKS: StoragePack[] = [
+  VERBS_PACK,
+  FUNCTIONS_PACK,
+  TIME_PACK,
+  MATCHES_PACK,
+  METADATA_PACK,
+  FIRESTORE_LOOKUP_PACK,
+  TIMESTAMP_WITNESS_PACK,
+];

--- a/scripts/oracle/rules-corpus/storage/types.ts
+++ b/scripts/oracle/rules-corpus/storage/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared corpus types for the Storage rules conformance chain.
+ *
+ * Mirrors the Firestore corpus (../firestore/types.ts). The `StoragePack`
+ * shape is the SINGLE source consumed by:
+ *   - the capture runner (scripts/oracle/run-rules-storage.ts), and
+ *   - the replay suite (packages/pyric/test/storage/rules-oracle-conformance.test.ts).
+ *
+ * A pack is a self-contained conformance unit: one `service firebase.storage`
+ * ruleset plus the cases that exercise it. It reuses the Firestore corpus's
+ * `Pack` provenance fields (`id` / `fm` / `rationale` / `rules`) verbatim; the
+ * only shape difference is `cases`, which are Storage-shaped
+ * (`StorageTestCase`, the request carries `size`/`contentType`/`metadata`
+ * rather than Firestore's `resource.data`) and hand off directly to either the
+ * production Rules Test API client or the in-process `evaluateStorageRules`.
+ */
+import type { Pack } from '../firestore/types.ts';
+import type { StorageTestCase } from '../../../../packages/pyric/src/rules/test/spec.ts';
+
+/**
+ * A Storage rules conformance pack. Same provenance fields as the Firestore
+ * {@link Pack} (so the two corpora stay legible side by side), with
+ * Storage-shaped cases.
+ */
+export interface StoragePack extends Omit<Pack, 'cases'> {
+  /** Stable identifier. Doubles as the observation filename stem:
+   *  `rules-storage-<id>.json`. Must be unique across the corpus. */
+  id: string;
+  /** Failure-mode / ledger tag. */
+  fm: string;
+  /** One line: why this pack should reveal something. */
+  rationale: string;
+  /** The `service firebase.storage` ruleset under test. */
+  rules: string;
+  /** The cases to run against `rules`. Each `description` is unique within the
+   *  pack and is the verdict-table key in observations. */
+  cases: StorageTestCase[];
+}
+
+export type { StorageTestCase };

--- a/scripts/oracle/run-rules-storage.ts
+++ b/scripts/oracle/run-rules-storage.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env bun
+/**
+ * Storage rules oracle capture runner.
+ *
+ * Sibling of run-rules.ts for the `service firebase.storage` surface. Reads the
+ * conformance corpus (scripts/oracle/rules-corpus/storage/) and, when
+ * credentialed, replays each pack against the PRODUCTION Rules Test API via
+ * `TestStorageRulesHandler` (the SAME `projects.test` endpoint the Firestore
+ * runner uses — live-confirmed to accept Storage rulesets). One observation
+ * JSON is written per pack into
+ * `scripts/oracle/observations/rules-storage-<pack.id>.json`. Production is the
+ * source of truth: the captured `behavior` is a verdict table keyed by case
+ * description (ALLOW / DENY), which the in-process replay suite then checks the
+ * storage evaluator against.
+ *
+ * CREDENTIAL CONTRACT (identical to the Firestore runner / parity harness):
+ *   PARITY_SA_BASE64 — base64-encoded service-account JSON holding only
+ *   `firebaserules.rulesets.test`. The project the SA belongs to is the
+ *   project the rules are tested against.
+ *
+ * RUNNABLE-BUT-INERT WITHOUT CREDENTIALS:
+ *   With PARITY_SA_BASE64 absent, this runner makes NO network calls. It prints
+ *   exactly what it WOULD capture (every pack, its case count, and the
+ *   observation file path each pack lands in) plus the env var name it needs,
+ *   then exits 0. This is the intended state of the staging branch: the
+ *   machinery is in place, but no captures have been run and no observation
+ *   files have been fabricated.
+ *
+ * Usage:
+ *   # inert preview (no secret):
+ *   bun run scripts/oracle/run-rules-storage.ts
+ *   # real capture (credentialed):
+ *   PARITY_SA_BASE64="$(base64 < firebaserules-sa.json)" \
+ *     bun run scripts/oracle/run-rules-storage.ts
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { TestFirestoreRulesResult } from '../../packages/pyric/src/rules/test/spec.ts';
+import {
+  ALL_RULES_STORAGE_PACKS,
+  RULES_STORAGE_OBSERVATION_PREFIX,
+  storageObservationName,
+  type StoragePack,
+} from './rules-corpus/storage/index.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OBS_DIR = join(HERE, 'observations');
+
+/** Resolved (installed) firebase version — the value the observation-version
+ *  guard compares every observation against. */
+function resolvedFirebaseVersion(): string {
+  const pkgPath = fileURLToPath(import.meta.resolve('firebase/package.json'));
+  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+  if (!meta.version) throw new Error('could not resolve installed firebase version');
+  return meta.version;
+}
+
+interface Observation {
+  name: string;
+  matrixRow: string;
+  rowIds: string[];
+  description: string;
+  observedAt: string;
+  fbSdkVersion: string;
+  projectId: string;
+  behavior: Record<string, unknown>;
+}
+
+/** Absolute path an observation for `pack` writes to. */
+function observationPath(pack: StoragePack): string {
+  return join(OBS_DIR, `${storageObservationName(pack)}.json`);
+}
+
+/** Build the verdict table (case description → prod decision) for a pack. */
+function verdictTable(
+  pack: StoragePack,
+  res: TestFirestoreRulesResult,
+): Record<string, 'ALLOW' | 'DENY' | 'UNSUPPORTED'> {
+  if (!res.success) {
+    throw new Error(
+      `Production Rules Test API failed for pack "${pack.id}": ` +
+        `${res.error.code} ${res.error.message}`,
+    );
+  }
+  const table: Record<string, 'ALLOW' | 'DENY' | 'UNSUPPORTED'> = {};
+  res.data.results.forEach((r, i) => {
+    table[pack.cases[i].description] = r.decision;
+  });
+  return table;
+}
+
+function printInertPlan(): void {
+  console.log('[oracle:rules-storage] PARITY_SA_BASE64 not set — INERT preview, no network calls.\n');
+  console.log(`  Credential env var expected: PARITY_SA_BASE64`);
+  console.log(`    (base64-encoded service-account JSON with firebaserules.rulesets.test)\n`);
+  console.log(`  Observation output directory: ${OBS_DIR}`);
+  console.log(`  Observation filename prefix:  ${RULES_STORAGE_OBSERVATION_PREFIX}\n`);
+  console.log(`  Would capture ${ALL_RULES_STORAGE_PACKS.length} pack(s):`);
+  let totalCases = 0;
+  for (const pack of ALL_RULES_STORAGE_PACKS) {
+    totalCases += pack.cases.length;
+    console.log(
+      `    - ${pack.id.padEnd(28)} [${pack.fm.padEnd(13)}] ` +
+        `${String(pack.cases.length).padStart(2)} cases → ${storageObservationName(pack)}.json`,
+    );
+  }
+  console.log(`\n  Total: ${ALL_RULES_STORAGE_PACKS.length} packs, ${totalCases} cases.`);
+  console.log('\n  To capture for real:');
+  console.log('    PARITY_SA_BASE64="$(base64 < firebaserules-sa.json)" \\');
+  console.log('      bun run scripts/oracle/run-rules-storage.ts');
+}
+
+async function capture(): Promise<void> {
+  // Heavy imports (firebase-admin credential + handler) deferred to the
+  // credentialed path so the inert preview stays dependency-light.
+  const { parityScope } = await import(
+    '../../packages/pyric/test/rules/parity/harness.ts'
+  );
+  const { TestStorageRulesHandler } = await import(
+    '../../packages/pyric/src/rules/test/handler.ts'
+  );
+  const scope = parityScope();
+  const fbSdkVersion = resolvedFirebaseVersion();
+  const handler = new TestStorageRulesHandler();
+  mkdirSync(OBS_DIR, { recursive: true });
+
+  console.log(`[oracle:rules-storage] capturing ${ALL_RULES_STORAGE_PACKS.length} pack(s) against project "${scope.projectId}"`);
+  console.log(`[oracle:rules-storage] firebase ${fbSdkVersion}\n`);
+
+  for (const pack of ALL_RULES_STORAGE_PACKS) {
+    const res = await handler.execute(scope, pack.rules, pack.cases);
+    const behavior = verdictTable(pack, res);
+    const obs: Observation = {
+      name: storageObservationName(pack),
+      matrixRow: '',
+      rowIds: [],
+      description: `Storage Rules Test API verdicts for corpus pack "${pack.id}" (${pack.fm}). ${pack.rationale}`,
+      observedAt: new Date().toISOString(),
+      fbSdkVersion,
+      projectId: scope.projectId,
+      behavior,
+    };
+    const path = observationPath(pack);
+    writeFileSync(path, JSON.stringify(obs, null, 2) + '\n');
+    const allows = Object.values(behavior).filter((v) => v === 'ALLOW').length;
+    const denies = Object.values(behavior).filter((v) => v === 'DENY').length;
+    console.log(
+      `  ✓ ${pack.id.padEnd(28)} allow=${allows} deny=${denies} → ${storageObservationName(pack)}.json`,
+    );
+  }
+
+  console.log('\n[oracle:rules-storage] capture complete.');
+  console.log('[oracle:rules-storage] NEXT: reconcile the stale storage matrix rows (#96/#104)');
+  console.log('               against the captured truth, wire each observation into the');
+  console.log('               compat registry (a matrix row citing it, or an');
+  console.log('               observationExceptions entry), then run `bun run compat:validate`.');
+}
+
+if (import.meta.main) {
+  if (!process.env.PARITY_SA_BASE64) {
+    printInertPlan();
+    process.exit(0);
+  }
+  await capture();
+}


### PR DESCRIPTION
## What this stages

Mirrors the Firestore rules conformance chain for the storage rules evaluator (`packages/pyric/src/storage/rules.ts`), staging everything up to but **not including** live capture. No credentials were used; the capture runner is inert without them.

### Corpus — `scripts/oracle/rules-corpus/storage/` (7 packs, 40 cases)

| Pack | fm | Feature area |
| --- | --- | --- |
| `verbs-umbrella-granular` | STORAGE-VERBS | read/write umbrella expansion, granular get/list/create/update/delete grants, comma-separated verbs, per-verb default-deny, create-vs-update on object existence |
| `functions-let-scope` | STORAGE-FUNC | user-defined functions with `let`, functions calling functions, match-block-scoped helper (lexical scoping) |
| `request-time-timestamp` | STORAGE-TIME | `request.time` vs `timestamp.date(y,m,d)` and `timestamp.value(ms)` |
| `matches-regex` | STORAGE-MATCHES | `string.matches()` whole-string anchoring; RE2-inexpressible lookaround -> deny |
| `metadata-access` | STORAGE-META | custom metadata dotted + bracket form (identical resolution); missing key -> deny |
| `firestore-lookup` | STORAGE-XSVC | `firestore.get()/exists()` with `$(expr)` interpolation, qualified mock names, bool `exists()` results |
| `resource-timestamp-witness` | STORAGE-RES-TS | witness for the still-unsupported `resource.timeCreated` / `resource.updated` fields (marked `knownGap`) |

Every case `expectation` is a best-known production truth and is **UNVERIFIED until capture** — the capture run is the source of truth; a capture that disagrees flags a bad pack. Rulesets are kept compile-valid so no pack aborts the capture run. Constructs production rejects at compile (recursion/depth-cap, undefined-function calls, same-name shadowing) are left to the evaluator unit tests, since they cannot be captured as a clean verdict.

As a de-risking check, the in-process evaluator already agrees with all 38 non-gap expectations; only the 2 witness cases diverge (as intended).

### Machinery

- **Wire-shaping** (`packages/pyric/src/rules/test/spec.ts`): `buildStorageApiTestCase` + `normalizeStoragePath` (`/b/{bucket}/o/{object}`), short-verb methods, `size`/`contentType`/`metadata` resource shape, and `buildStorageFunctionMock` using the qualified `firestore.get`/`firestore.exists` names with bool-shaped `exists()` results. Firestore builders untouched.
- **Handler** (`handler.ts`): `TestStorageRulesHandler` posts `service firebase.storage` rulesets to the same `projects.test` endpoint.
- **Runner** (`scripts/oracle/run-rules-storage.ts`): captures the corpus into `scripts/oracle/observations/rules-storage-<id>.json`. Inert without `PARITY_SA_BASE64` (prints plan + env var + output paths, exits 0, no network).
- **Replay** (`packages/pyric/test/storage/rules-oracle-conformance.test.ts`): replays observations through `evaluateStorageRules`, asserts verdict-for-verdict, records `knownGap` cases without asserting, enforces completeness (an observation without a pack fails loudly), and passes/skips while no observations exist.
- Registers the `rules-storage-` observation prefix in the compat registry (reusing the `storage` registry; no new COMPAT.md, no matrix rows).

### First-capture command (a human runs this once credentials exist)

```
PARITY_SA_BASE64="$(base64 < firebaserules-sa.json)" \
  bun run scripts/oracle/run-rules-storage.ts
```

- Env var: `PARITY_SA_BASE64` — base64-encoded service-account JSON holding only `firebaserules.rulesets.test`.
- Output paths: `scripts/oracle/observations/rules-storage-<pack.id>.json` (one per pack).

### What is deliberately NOT done

- No captures were run and **no observation files were fabricated**.
- The stale storage matrix rows (#96/#104, which wrongly claim granular verbs / functions / time / matches unsupported) are **untouched** — they get reconciled only after capture proves the new truth.

### Validation (green)

`compat:validate` (0 problems), storage replay skeleton (pass/skip), full `bun test packages/pyric` (the only failures are pre-existing bridge-SIGINT / dev-command tests unrelated to this change), and pyric `src` typecheck.

Serves #134's reconcile-the-stale-storage-matrix goal.
