### PR TITLE
Support or()/and() composite queries over the SharedWorker

### DIFF
--- a/packages/pyric-tools/docs/how-to/serve-persistence-and-multi-tab.md
+++ b/packages/pyric-tools/docs/how-to/serve-persistence-and-multi-tab.md
@@ -158,9 +158,12 @@ tabs frees the browser's per-origin connection pool.
 **Sign-in.** Email/password, anonymous, and provider popup/redirect
 (`signInWithPopup`/`signInWithRedirect`) all work over the worker: the picker
 runs in the page and the identity is handed to the worker, and the session is
-shared across tabs. `signInWithCredential` and `or()`/`and()` composite queries
-aren't supported over the worker yet (they raise a clear error); both work on
-the in-page fallback.
+shared across tabs. `or()`/`and()` composite queries work over the worker too:
+the composite filter tree (including nested `and`/`or`/`where` and composition
+with `orderBy`/`limit`) crosses the worker protocol and evaluates against the
+one shared sandbox, matching the in-page result. `signInWithCredential` isn't
+supported over the worker yet (it raises a clear error); it works on the
+in-page fallback.
 
 ## The flags this guide uses
 

--- a/packages/pyric-tools/src/serve/entries/firestore.ts
+++ b/packages/pyric-tools/src/serve/entries/firestore.ts
@@ -59,18 +59,19 @@ export const deleteField = D.deleteField;
 //    the shared codec) ──────────────────────────────────────────────────────
 export const Timestamp = ip.Timestamp;
 
-// ── Composite filters — in-page only. The worker query protocol has no
-//    or/and yet; export a clear-error stub so the page still IMPORTS but a use
-//    fails loudly (surface parity without silent wrong results). ─────────────
-function unsupportedComposite(name: string): never {
-  throw new Error(
-    `firestore ${name}() is not supported over the pyric SharedWorker yet — ` +
-      'compose separate where() constraints instead. (The in-page fallback path ' +
-      'supports it on browsers without SharedWorker.)',
-  );
-}
-export const or = (useWorker ? (() => unsupportedComposite('or')) : ip.or) as typeof ip.or;
-export const and = (useWorker ? (() => unsupportedComposite('and')) : ip.and) as typeof ip.and;
+// ── Composite filters — path-independent (issue #144). The worker query
+//    protocol carries the composite filter tree end-to-end: the client `or`/
+//    `and` factories emit nested `FilterConstraintDescriptor`s, `query()`
+//    embeds them in the query descriptor, and the host rebuilds them through
+//    the REAL `pyric/firestore` `and`/`or` factories (see
+//    `worker/host.ts` resolveConstraint + `worker/protocol.ts`
+//    FilterConstraintDescriptor). So on BOTH paths `or`/`and` come from the
+//    chosen data impl `D` — the worker client on the worker path, in-page
+//    otherwise. Nested `and`/`or`/`where` composites and composition with
+//    orderBy/limit all cross intact; malformed composites (empty / non-filter
+//    operand) still raise the same modular-SDK TypeError. ────────────────────
+export const or = D.or;
+export const and = D.and;
 
 // ── getFirestore — the canonical bare call returns the page's shared backend:
 //    the worker ClientDb on the worker path, the in-page sandbox otherwise. ──

--- a/packages/pyric-tools/test/serve/worker/composite-filters-served-entry.test.ts
+++ b/packages/pyric-tools/test/serve/worker/composite-filters-served-entry.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Composite `or()` / `and()` over the SharedWorker THROUGH the served
+ * `firebase/firestore` entry (issue #144).
+ *
+ * `composite-filters.test.ts` proves the host rebuilds composite descriptors,
+ * and `integration.test.ts` proves the real client↔host round-trip. What was
+ * still broken is the LAST MILE: `entries/firestore.ts` — the bundle the import
+ * map serves for `firebase/firestore` — stubbed `or`/`and` on the worker path
+ * with a throwing `unsupportedComposite`, so a real app under `pyric dev`
+ * calling `or(where(...), where(...))` failed even though the whole protocol
+ * already carries the composite filter tree.
+ *
+ * This test imports that ENTRY module (not the raw worker client) with a
+ * SharedWorker shim wired to a real host, exactly as a served page would, and
+ * asserts composite queries return the correct documents over the worker.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import type { InboundMessage, OutboundMessage } from '../../../src/serve/worker/protocol.js';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore as ipGetFirestore } from 'pyric/firestore';
+
+const PERMISSIVE_RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if true; }
+  }
+}`;
+
+const sleep = (ms = 30) => new Promise((r) => setTimeout(r, ms));
+
+interface FakePort {
+  postMessage(msg: unknown): void;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  start(): void;
+  addEventListener(type: string, fn: () => void): void;
+}
+function portPair(): { a: FakePort; b: FakePort } {
+  const a: FakePort = { onmessage: null, postMessage() {}, start() {}, addEventListener() {} };
+  const b: FakePort = { onmessage: null, postMessage() {}, start() {}, addEventListener() {} };
+  a.postMessage = (msg) => setTimeout(() => b.onmessage?.({ data: msg }), 0);
+  b.postMessage = (msg) => setTimeout(() => a.onmessage?.({ data: msg }), 0);
+  return { a, b };
+}
+
+async function makeHostCtx(): Promise<HostCtx> {
+  const sandbox = initializeSandbox();
+  const { getFirestore: adm } = await import('pyric/sandbox/admin-firestore');
+  adm(sandbox.withAuth(null)).setRules(PERMISSIVE_RULES);
+  return { db: ipGetFirestore(sandbox), sandbox, instanceId: 'composite-served-entry', subs: new Map() };
+}
+
+// The served firestore entry, imported ONCE after the SharedWorker shim + host
+// are installed (runtime.ts picks the worker path at module-load and can't be
+// re-picked, so the whole file exercises the worker path).
+type FirestoreEntry = typeof import('../../../src/serve/entries/firestore.js');
+let fs: FirestoreEntry;
+let db: ReturnType<FirestoreEntry['getFirestore']>;
+let restore: () => void;
+
+beforeAll(async () => {
+  const ctx = await makeHostCtx();
+  const { a: clientPort, b: hostPort } = portPair();
+  const hostPortLike: PortLike = { postMessage: (m: OutboundMessage) => hostPort.postMessage(m) };
+  hostPort.onmessage = (ev) => { void handleMessage(ctx, hostPortLike, ev.data as InboundMessage); };
+
+  const g = globalThis as {
+    SharedWorker?: unknown;
+    fetch?: typeof fetch;
+    __PYRIC_FORCE_INPAGE__?: boolean;
+  };
+  const prevSW = g.SharedWorker;
+  const prevFetch = g.fetch;
+  // Worker path: SharedWorker present, not forced in-page.
+  g.SharedWorker = class {
+    port = clientPort;
+    constructor(_url: unknown, _opts: unknown) {}
+  };
+  // runtime.ts fires a fire-and-forget /__pyric/init.json bridge probe on the
+  // worker path; stub fetch so it resolves quietly instead of hitting the net.
+  g.fetch = (async () => ({ ok: false, json: async () => ({}) })) as unknown as typeof fetch;
+  restore = () => {
+    g.SharedWorker = prevSW;
+    g.fetch = prevFetch;
+  };
+
+  fs = await import('../../../src/serve/entries/firestore.js');
+  db = fs.getFirestore();
+  await sleep();
+
+  // Seed through the SERVED entry so the whole write path is the worker one too.
+  const items: Array<[string, Record<string, unknown>]> = [
+    ['a', { cat: 'x', n: 1 }],
+    ['b', { cat: 'x', n: 5 }],
+    ['c', { cat: 'y', n: 5 }],
+    ['d', { cat: 'z', n: 9 }],
+  ];
+  for (const [docId, data] of items) {
+    await fs.setDoc(fs.doc(db, `items/${docId}`), data);
+  }
+  await sleep();
+});
+
+afterAll(() => restore?.());
+
+async function ids(...constraints: unknown[]): Promise<string[]> {
+  const snap = await fs.getDocs(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fs.query(fs.collection(db, 'items'), ...(constraints as any[])),
+  );
+  return (snap as { docs: Array<{ id: string }> }).docs.map((d) => d.id).sort();
+}
+
+describe('composite or()/and() over the SharedWorker via the served firebase/firestore entry', () => {
+  it('does not export a throwing composite stub on the worker path', () => {
+    // The regression: these were `unsupportedComposite` stubs.
+    expect(() => fs.or(fs.where('cat', '==', 'x'), fs.where('cat', '==', 'y'))).not.toThrow();
+    expect(() => fs.and(fs.where('cat', '==', 'x'), fs.where('n', '>=', 5))).not.toThrow();
+  });
+
+  it('flat or(where, where) returns the union of matches', async () => {
+    expect(await ids(fs.or(fs.where('cat', '==', 'x'), fs.where('cat', '==', 'y'))))
+      .toEqual(['a', 'b', 'c']);
+  });
+
+  it('flat and(where, where) returns the intersection of matches', async () => {
+    expect(await ids(fs.and(fs.where('cat', '==', 'x'), fs.where('n', '>=', 5))))
+      .toEqual(['b']);
+  });
+
+  it('nested or(and(...), where) crosses the worker protocol intact', async () => {
+    // or(and(cat==x, n>=5), cat==z) → b, d
+    expect(await ids(
+      fs.or(fs.and(fs.where('cat', '==', 'x'), fs.where('n', '>=', 5)), fs.where('cat', '==', 'z')),
+    )).toEqual(['b', 'd']);
+  });
+
+  it('nested and(or(...), where) crosses the worker protocol intact', async () => {
+    // and(or(cat==x, cat==y), n==5) → b, c
+    expect(await ids(
+      fs.and(fs.or(fs.where('cat', '==', 'x'), fs.where('cat', '==', 'y')), fs.where('n', '==', 5)),
+    )).toEqual(['b', 'c']);
+  });
+
+  it('composite composes with orderBy/limit over the worker', async () => {
+    const snap = await fs.getDocs(
+      fs.query(
+        fs.collection(db, 'items'),
+        fs.or(fs.where('cat', '==', 'x'), fs.where('cat', '==', 'y')),
+        fs.orderBy('n', 'desc'),
+        fs.limit(2),
+      ),
+    );
+    // n=5 tie between b and c breaks on the implicit key ordering (DESC) → c, b.
+    expect((snap as { docs: Array<{ id: string }> }).docs.map((d) => d.id)).toEqual(['c', 'b']);
+  });
+});


### PR DESCRIPTION
Closes #144 (Top of Funnel — unblock a real app from first success under `pyric dev`).

## The rejection point

Composite Firestore queries work in the in-page sandbox but were rejected over the SharedWorker in served mode. The rejection lived at the very last mile, not in the protocol:

`packages/pyric-tools/src/serve/entries/firestore.ts:72-73` (the bundle the import map serves for `firebase/firestore`) stubbed `or`/`and` on the worker path with a throwing `unsupportedComposite`, based on a stale comment claiming "the worker query protocol has no or/and yet."

## How the composite tree already crosses the protocol

The protocol, client, and host layers were already fully built and tested for composites:

- `worker/protocol.ts` — `FilterConstraintDescriptor` = `where | and | or`, nesting arbitrarily.
- `worker/client.ts` — `or(...)`/`and(...)` factories emit nested descriptors; `query()` embeds them (`c._descriptor`) in the query descriptor that crosses the MessagePort (JSON-round-trippable plain objects).
- `worker/host.ts:283-286` — `resolveConstraint` rebuilds `and`/`or` recursively through the REAL `pyric/firestore` factories, so the same in-page evaluation runs host-side.

The one-line fix routes `or`/`and` to the chosen data impl `D` (worker client on the worker path, in-page otherwise) instead of the stub. No query semantics were reimplemented; the in-page composite representation is reused verbatim over the wire.

## In-page / worker parity

- In-page path unchanged: `or`/`and` still resolve to `ip.or`/`ip.and` (covered by oracle-backed COMPAT rows 56-64 in `packages/pyric/docs/firestore/COMPAT.md`, all passing).
- New end-to-end test `composite-filters-served-entry.test.ts` imports the SERVED entry with a SharedWorker shim wired to a real host and asserts flat `or`/`and`, nested `or(and(...))` / `and(or(...))`, and composition with `orderBy`/`limit` return the exact same documents (same order) the in-page path returns.
- Malformed composites (empty / non-filter operand) still raise the same modular-SDK `TypeError`.

## Residual unsupported sub-case

None for composites. `signInWithCredential` remains unsupported over the worker (separate, unrelated); the how-to was updated to reflect that composites now work and to narrow the remaining limitation to `signInWithCredential`.

## Note on the compat registry

No oracle-backed COMPAT row asserted a worker composite limitation, so none were hand-edited. Only the how-to prose (`serve-persistence-and-multi-tab.md`) claimed the limitation and was updated.

## Verification

- `bun test packages/pyric-tools` — 1284 pass, 0 fail (serve suite: 398 pass).
- `bun test packages/pyric` firestore sandbox — 1031 pass, 0 fail.
- `bun run typecheck` (pyric-tools) — clean.

