### PR TITLE
Land the versioning policy, conventions doc, and the fb dist-tag certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 <p align="center"><a href="https://pyric.dev">pyric.dev</a></p>
 
+<p align="center">Conformance-tested against Firebase 12.13.0 — see the <a href="https://pyric.dev/docs/pyric-explanation-versioning-and-compatibility/">versioning and compatibility policy</a> and the <a href="#what-matches-firebase-and-what-doesnt">published coverage</a>.</p>
+
 <br />
 
 Pyric is Firestore, Auth, Realtime Database, Storage, *Messaging soon*, and the Security Rules engine, implemented in TypeScript and running inside the application process. In the browser, that process is the page itself: the whole backend executes in the tab. In Node, it is the Node process, so tests and scripts get the same backend with no browser involved.
@@ -137,4 +139,4 @@ Examples: [examples/vite-sandbox-app](examples/vite-sandbox-app/), the shape `py
 
 ## Stability
 
-Alpha, `0.1.0-alpha.7`, published as an experimental product. The one stability goal is the Firebase mirror: code written against mirrored surfaces is intended to keep working, tracked in the compatibility matrices. Pyric-specific APIs (sandbox lifecycle, replay, serve and bridge internals) are public-alpha and may change between releases.
+Alpha, `0.1.0-alpha.8`, published as an experimental product. The one stability goal is the Firebase mirror: code written against mirrored surfaces is intended to keep working, tracked in the compatibility matrices. Pyric-specific APIs (sandbox lifecycle, replay, serve and bridge internals) are public-alpha and may change between releases.

--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -1,0 +1,108 @@
+# Code structure conventions
+
+This document extends the ratified data-record convention to source code. It is a rulebook. It states rules and the tests that decide whether code follows them.
+
+## What this builds on
+
+The data-record convention is already ratified. These rules are settled and are not relitigated here:
+
+- Authored data is one record per file.
+- The filename is the join key and exists nowhere else.
+- The directory is the index. There are no hand-maintained barrels or aggregates over authored records.
+- Aggregation is always computed, never hand-written.
+- Generated artifacts are never edited or merged. They are regenerated.
+- Ordering uses stable keys, never global counters.
+- Captured evidence follows regenerate-don't-merge.
+
+The exemplars in the tree are the compat registry (`scripts/compat/registry/*.ts`, one record file per service), the oracle observations (`scripts/oracle/observations/*.json`, one observation per file, filename is the key, directory is the index), and the generated `COMPAT.md` documents. Source code now inherits the same discipline.
+
+## 1. Directory shape for a mirrored surface
+
+A mirrored surface is one Firebase capability the project reproduces: firestore, auth, database, storage, rules. Every surface has four parts. The rule fixes where each part lives.
+
+Rule. For a surface named `X` in `packages/pyric/src`:
+
+- The public entry is `X/index.ts`. It is a re-export barrel and nothing else. It is the package export contract.
+- The public API implementation is one file per API family under `X/`. Families are `refs`, `reads`, `writes`, `query`, `aggregation`, `listeners`, `field-values`, `transactions`, and the surface's own additions. No family file exceeds the size limit in section 2.
+- The sandbox implementation is under `X/sandbox/` or under `sandbox/X/`, one concept per file. It never lives in the public entry.
+- The types are `X/types.ts` for a small surface, or `X/types/` (one file per subsystem, computed barrel) for a large one.
+- The tests mirror the source path under `test/`, one test file per source concept.
+
+The class of defect this fixes. Today the firestore public entry is `src/firestore/index.ts` and holds the client implementation inline, while the sandbox implementation lives in `src/sandbox/firestore/` and the admin adapter lives in a third place. The public entry and its implementation must live in one directory. A reader who opens the surface directory sees the whole surface.
+
+Reference to align to. `sandbox/firestore/admin-compat/` already follows the one-concept-per-file rule: `batch.ts`, `doc-ref.ts`, `query.ts`, `snapshots.ts`, `transaction.ts`, `paths.ts`, `value-order.ts`, and a barrel. Match that shape. The database surface partly follows it too: `database/sandbox/` already separates `query.ts`, `data-tree.ts`, `normalize.ts`, `rules-eval.ts`.
+
+## 2. File size and concern discipline
+
+One concept per file. A concept is one API family, one class and its private helpers, or one coherent algorithm.
+
+Rule. A file must split when any of these is true:
+
+- It exceeds 600 lines of source.
+- It holds more than one exported class.
+- It holds more than one API family.
+- Its exports serve two audiences that change on independent schedules.
+
+600 lines is the trigger, not the target. A file well under 600 lines that mixes two concepts still splits. A generated file is exempt from the line limit because it is never read for edits.
+
+The God-object rule. A single class longer than 400 lines is a design smell, not a fact of life. Extract collaborators. The class that remains is a facade that wires collaborators and owns lifecycle. It does not own every algorithm.
+
+## 3. Naming conventions
+
+- Directories are lower-case, hyphen-free where one word suffices, hyphenated where two words are needed: `firestore`, `admin-firestore`, `field-values`. A directory name states the surface or the concept, never a role like `utils` or `helpers` or `misc`.
+- Files are lower-case, hyphenated, and name the concept: `query-execution.ts`, `token-minting.ts`, `read-translation.ts`. A file name is a noun phrase for what the file is, not where it sits.
+- The public barrel is always `index.ts`.
+- Test files are the source file name plus `.test.ts`, at the mirrored path under `test/`. A test file tests exactly one source file.
+- No file is named `utils`, `helpers`, `misc`, `common`, `shared`, or `index` with implementation in it. These names are the audit signal for a junk drawer.
+
+## 4. Barrel-file policy
+
+The ratified rule is: the directory is the index, and aggregation is computed, not hand-maintained. Source barrels align to it with one carve-out.
+
+Rule.
+
+- A barrel is a file whose only content is re-exports. A barrel holds no implementation. The moment a barrel declares a function body, it stops being a barrel and is subject to the split rules in section 2.
+- Re-export barrels are allowed only where they are the package export contract, that is, a directory `index.ts` named in `package.json` `exports`. `./firestore`, `./auth`, `./database`, `./storage` point at these. They exist to give the package a stable import path.
+- A public barrel re-exports from the family files in its own directory. It is regenerable by listing the directory. It carries no logic and no ordering that a global counter would impose. Its order follows the directory.
+- Internal grab-bag barrels that exist only to shorten imports are not allowed. Import from the concept file.
+
+The test. Open every `index.ts`. If it contains a function body, a class, or a branch, it is not a barrel and it violates section 2. `src/firestore/index.ts` fails this test today: it has 4 re-export lines and 84 inline function implementations. `src/sandbox/index.ts` passes: it re-exports a type family and one factory, with no implementation.
+
+## 5. Junk-drawer prohibition (testable)
+
+A junk drawer is a file that accumulates unrelated additions because it is the path of least resistance. It is the enemy of parallel work because every contributor appends to the same place.
+
+Rule. A file is a prohibited junk drawer if any of these holds:
+
+- It is named `utils`, `helpers`, `misc`, `common`, or `shared`.
+- It is a public entry barrel (section 4) that also contains implementation.
+- It exceeds 600 lines and its exports belong to more than one API family or subsystem.
+- Its git history shows independent features appending to it in unrelated commits (a co-change fan-out across three or more subsystems).
+
+The last clause is measurable from history and is the strongest signal. A shared type file that co-changes with five subsystems is a junk drawer even if every line in it is correct, because it is a shared write target. Split it so each subsystem owns its records.
+
+## 6. Merge-conflict design rules for parallel agent work
+
+Parallel agents implement surface gaps concurrently. The structures below make their edits land in separate files by construction.
+
+Rule: one feature, one place. The implementation of one surface gap lives in one file that the change creates or in one family file it extends. If implementing one gap requires editing three large files, the surface is mis-structured. This is why the public API surface splits by family: a new operator becomes a new file or a small edit to one family file, not an append to a 2000-line entry.
+
+Rule: append-friendly structures are per-record, not per-list. A shared list, registry, or switch that every feature must edit is a conflict generator. Replace it with one record per file and a computed aggregation. This is the data-record convention applied to code. The compat registry and the oracle observations already work this way and never conflict on additions.
+
+Rule: shared registries and lists must be computed or per-file. If the system needs a list of all X, it computes that list by reading the directory of X records at build or load time. No source file holds a hand-maintained master list that all contributors edit. A global counter for ordering is banned for the same reason; order by a stable key on each record.
+
+Rule: keep the seam stable, not the file small. Where files co-change because they implement one protocol across a boundary (client, host, wire protocol), splitting them further does not reduce conflict. Stabilize the shared contract, the protocol or type file, and change it deliberately and rarely. Treat a high-fan-out shared type file as a fragile contract.
+
+Rule: symmetric surfaces split symmetrically. When the same API is mirrored in two places, the client surface and the tools transport, both split the same way with the same family names. A contributor who learns one surface's layout knows the other's.
+
+## 7. Migration policy
+
+Restructures are not a project. They happen per surface, just in time, and never bundle behavior change with a move.
+
+Rule.
+
+- A restructure happens just before that surface's next climb, not speculatively and not all at once. The surface that is about to receive feature work is the surface that gets restructured first.
+- Characterization tests come first. Before any move, the existing behavior is pinned by tests. If the characterization net is thin, thicken it before moving. The strongest existing suites (firestore simulator, auth conformance) are the model for what a net looks like.
+- Pure mechanical moves are their own commits, separate from behavior change. A commit that moves code changes no behavior and passes the same tests it started with. A commit that changes behavior moves no files. A reviewer can tell which is which from the diff alone.
+- Shared state is hoisted before functions move. When splitting an API surface, the shared module state and symbols are lifted into one state file first, in isolation, so the family moves that follow are clean.
+- The public export path does not change during a restructure. The barrel keeps its import path; only what it re-exports from moves. Consumers see no change.

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -64,6 +64,8 @@ import { runSnapshot } from './snapshot.js';
 import { runVerify } from './verify.js';
 import { runMcpProxy } from './mcp-proxy.js';
 import { pyricVersion } from '../serve/standalone-assets.js';
+import { pyricToolsVersion } from '../pkg-version.js';
+import { FIREBASE_TESTED_AGAINST } from '../version/compat-target.js';
 
 // The standalone binary bakes the real `pyric` version onto the embedded-assets
 // global; the npm bin has no such global and falls back to '0.0.0'.
@@ -261,7 +263,10 @@ CREDENTIALS
 }
 
 function printVersion(): void {
-  process.stdout.write(`${VERSION}\n`);
+  process.stdout.write(
+    `pyric-tools ${pyricToolsVersion()}\n` +
+      `Firebase ${FIREBASE_TESTED_AGAINST} (conformance-tested against this release)\n`,
+  );
 }
 
 function splitCommaList(value: string | boolean | Array<string | boolean> | undefined): string[] {

--- a/packages/pyric-tools/src/version/compat-target.ts
+++ b/packages/pyric-tools/src/version/compat-target.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for the Firebase version pyric is conformance-
+ * tested against — the number `pyric --version` prints alongside
+ * pyric-tools' own version, and the number `scripts/publish-alpha.sh`
+ * reads to derive the `fb<major>.<minor>` dist-tag it moves on a green
+ * `compat:check` (see
+ * packages/pyric/docs/explanation/versioning-and-compatibility.md).
+ *
+ * This is a pin, not pyric-tools' own version: bumping it starts a
+ * re-snapshot of the upstream surface, and no release claims the new
+ * `fb` line until `compat:check` passes against it.
+ *
+ * TODO: once the upstream-surface snapshot lands, that snapshot becomes
+ * the source of truth for this value and this constant should read
+ * from it instead of being hand-set.
+ */
+export const FIREBASE_TESTED_AGAINST = '12.13.0';

--- a/packages/pyric-tools/test/cli/version.test.ts
+++ b/packages/pyric-tools/test/cli/version.test.ts
@@ -1,0 +1,45 @@
+/**
+ * `pyric --version` / `-v` prints two numbers, not one: pyric-tools' own
+ * version (what you installed) and the Firebase version this release is
+ * conformance-tested against (the `fb` dist-tag claim — see
+ * packages/pyric/docs/explanation/versioning-and-compatibility.md). A
+ * bare package version answers "what did I install" but not "what does
+ * it behave like," which is the question this command exists to answer.
+ */
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { FIREBASE_TESTED_AGAINST } from '../../src/version/compat-target.js';
+
+const PKG_ROOT = join(import.meta.dir, '..', '..');
+const CLI_ENTRY = join(PKG_ROOT, 'src', 'cli', 'index.ts');
+
+function runCli(args: string[]): { code: number; stdout: string; stderr: string } {
+  const res = spawnSync('bun', [CLI_ENTRY, ...args], {
+    cwd: PKG_ROOT,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  return { code: res.status ?? -1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+const ownVersion = (
+  JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')) as { version: string }
+).version;
+
+describe('pyric --version', () => {
+  it('--version prints the pyric-tools version and the tested-against Firebase version', () => {
+    const { code, stdout } = runCli(['--version']);
+    expect(code).toBe(0);
+    expect(stdout).toContain(ownVersion);
+    expect(stdout).toContain(FIREBASE_TESTED_AGAINST);
+  });
+
+  it('-v is the same as --version', () => {
+    const { code, stdout } = runCli(['-v']);
+    expect(code).toBe(0);
+    expect(stdout).toContain(ownVersion);
+    expect(stdout).toContain(FIREBASE_TESTED_AGAINST);
+  });
+});

--- a/packages/pyric/docs/explanation/versioning-and-compatibility.md
+++ b/packages/pyric/docs/explanation/versioning-and-compatibility.md
@@ -1,0 +1,64 @@
+# The versioning and compatibility policy
+
+Pyric mirrors Firebase's observable behavior. Users need one honest way to ask "which Firebase does this pyric behave like," and pyric needs one honest way to answer. This document is that answer. It defines what the claim means, where it appears, and what has to be true before it can move.
+
+## Pyric keeps its own version and never borrows Firebase's
+
+Pyric versions itself with its own semver, independent of Firebase. It does not adopt Firebase's version number.
+
+Pyric ships a large surface that Firebase does not have: the sandbox runtime, the rules tooling, the CLI. Breaking changes in that surface need their own major and minor releases. A pyric that renamed itself `12.16.0` to match Firebase would be making a promise of parity that the conformance numbers do not support. Pyric's version tracks pyric. Firebase compatibility is stated separately, below.
+
+## Firebase compatibility ships as a dist-tag
+
+The compatibility claim is an npm dist-tag of the form `fb<major>.<minor>`.
+
+```
+npm install pyric@fb12.16
+```
+
+A `fb<major>.<minor>` tag points at the newest pyric release whose conformance gates pass against that line of Firebase. Installing `pyric@fb12.16` gets you the pyric that has been conformance-tested against Firebase 12.16.
+
+The tag means "conformance-tested against Firebase 12.16." It does not mean "equal to Firebase 12.16" and it does not mean "full parity with Firebase 12.16." Those are claims pyric does not make and the conformance numbers do not back. The tag is a statement about what was tested, not a statement about how much matched.
+
+## Patch releases are not tagged
+
+Pyric tags Firebase's major and minor lines and never its patch level, so there is no `fb12.16.1`; a Firebase patch triggers a pyric release only when the upstream surface snapshot diff for that patch is non-empty, which it usually is not.
+
+## The tag is a certificate, not an opinion
+
+A `fb` tag moves only through the release script, and only when the conformance gate suite `compat:check` is green against the pinned Firebase version.
+
+Nobody moves a tag by hand because they believe pyric is ready. The tag moves because the gates passed. It is a machine-issued certificate. A green `compat:check` is the only thing that issues it, and a red one withholds it. This removes optimism from the claim: the tag says what the tests found, and the tests ran before it moved.
+
+## The certificate appears wherever a user forms an impression
+
+The tested-against version is not only an npm tag. It is stated everywhere a user decides whether to trust pyric:
+
+- The README carries a badge naming the Firebase version pyric is tested against.
+- The npm package description names it.
+- `pyric --version` prints both numbers: the pyric version and the Firebase version it was tested against.
+- The docs header names it.
+
+A user who never runs `npm dist-tag ls` still sees the claim, and sees the same claim in every place.
+
+## The claim links to numbers anyone can read
+
+"Tested against Firebase 12.16" is only honest if the result of that testing is inspectable. Pyric publishes its coverage openly: roughly 51% overall surface coverage, roughly 85% behavior conformance on the slice that is implemented, with per-service numbers in the generated COMPAT documents. The tag refers to those published numbers.
+
+Surface coverage answers "will my app's calls exist against the mirror." Behavior conformance answers "of the calls that exist, do they behave like production." They are different questions and pyric reports them separately. A reader following the tag reaches the numbers, not a slogan. "Tested against" is a link, never a vibe.
+
+## Where the numbers stand today
+
+Firebase's latest npm release is 12.16.0. Pyric's pinned oracle and conformance version is 12.13.0, so the first real tag will be `fb12.13`, the line pyric is actually tested against, not `fb12.16`. Pyric's own packages are at `0.1.0-alpha.8`, in lockstep across `pyric`, `pyric-admin`, `pyric-tools`, and `@pyric/ui`. A `fb` tag can point at an alpha release; the compatibility claim and the stability claim are separate, and the `fb` tag speaks only to the first.
+
+---
+
+## Mechanics, for maintainers
+
+**How the tag is computed and moved.** At publish time, after packages are packed and published, the release step reads the currently pinned Firebase version and runs `compat:check` against it. `compat:check` is the composite gate: registry validation, the surface census gate, a docs freshness check, and the coverage regression check. If it is green, the release script moves `fb<major>.<minor>` for the pinned line to the version being published, using the same `npm dist-tag add` mechanism the script already uses for `latest`. If it is red, the `fb` tag does not move and the release does not carry a compatibility claim. The minor is derived from the pinned version; the patch component of the pin is discarded when forming the tag.
+
+**What happens on a Firebase pin bump.** Raising the pinned Firebase version starts by re-snapshotting the upstream surface. The diff between the old snapshot and the new one is the worklist: new exports, changed signatures, removed surface. Bumping the pin does not create the new `fb` tag. The tag for the new line, for example `fb12.16`, appears only after the worklist is closed enough that `compat:check` passes against the new pin. Until then, no release claims the new line.
+
+**What happens to old tags.** A `fb` tag for a line pyric no longer pins keeps pointing at the last pyric release that was certified against that line. Old `fb` tags are never deleted and never moved backward. `pyric@fb12.13` continues to resolve to a real, once-certified release even after the pin moves to 12.16, so an install pinned to an older Firebase line stays reproducible.
+
+**Interaction with `alpha` and `latest`.** The `alpha` and `latest` tags are about pyric's own release stream and move on every publish, `alpha` to each publish and `latest` to the same version by the explicit dist-tag step. The `fb` tags are orthogonal: they move only when gates pass against their line, and only the line matching the current pin moves on a given release. Several tags can point at the same version. A single publish can leave `alpha`, `latest`, and `fb12.13` all resolving to `0.1.0-alpha.9`, each making its own separate claim: newest, default, and tested-against-Firebase-12.13.

--- a/packages/site-docs/scripts/port-content.ts
+++ b/packages/site-docs/scripts/port-content.ts
@@ -101,6 +101,12 @@ const GROUPS: GroupSpec[] = [
     ],
   },
   { pkg: 'pyric-tools', label: 'pyric-tools / deploy', dir: 'deploy', sections: DIATAXIS },
+  {
+    pkg: 'pyric',
+    label: 'pyric',
+    dir: '.',
+    sections: [{ label: 'Explanation', path: 'explanation' }],
+  },
   { pkg: 'pyric', label: 'pyric / firestore', dir: 'firestore', sections: DIATAXIS },
   { pkg: 'pyric', label: 'pyric / rules', dir: 'rules', sections: DIATAXIS },
   { pkg: 'pyric', label: 'pyric / sandbox', dir: 'sandbox', sections: DIATAXIS },

--- a/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/app"
 navLabel: "API reference"
 group: "pyric-admin / app"
 section: "Reference"
-order: 166
+order: 167
 ---
 # API reference: `pyric-admin/app`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-app.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app.md
@@ -3,7 +3,7 @@ title: "pyric-admin/app"
 navLabel: "Overview"
 group: "pyric-admin / app"
 section: ""
-order: 165
+order: 166
 ---
 # `pyric-admin/app`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/auth"
 navLabel: "API reference"
 group: "pyric-admin / auth"
 section: "Reference"
-order: 182
+order: 183
 ---
 # API reference: `pyric-admin/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth.md
@@ -3,7 +3,7 @@ title: "pyric-admin/auth"
 navLabel: "Overview"
 group: "pyric-admin / auth"
 section: ""
-order: 181
+order: 182
 ---
 # `pyric-admin/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/database"
 navLabel: "API reference"
 group: "pyric-admin / database"
 section: "Reference"
-order: 184
+order: 185
 ---
 # API reference: `pyric-admin/database`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-database.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database.md
@@ -3,7 +3,7 @@ title: "pyric-admin/database"
 navLabel: "Overview"
 group: "pyric-admin / database"
 section: ""
-order: 183
+order: 184
 ---
 # `pyric-admin/database`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
@@ -3,7 +3,7 @@ title: "Error translation and instanceof SandboxError"
 navLabel: "Error translation"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 178
+order: 179
 ---
 # Error translation and `instanceof SandboxError`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
@@ -3,7 +3,7 @@ title: "Per-call delegate construction"
 navLabel: "Per-call delegate"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 179
+order: 180
 ---
 # Per-call delegate construction
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
@@ -3,7 +3,7 @@ title: "Why mirror the admin SDK shape"
 navLabel: "Why mirror the admin SDK"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 180
+order: 181
 ---
 # Why mirror the admin SDK shape
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
@@ -3,7 +3,7 @@ title: "How to run a transaction"
 navLabel: "Run a transaction"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 169
+order: 170
 ---
 # How to run a transaction
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
@@ -3,7 +3,7 @@ title: "How to seed and set rules"
 navLabel: "Seed and set rules"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 170
+order: 171
 ---
 # How to seed and set rules
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
@@ -3,7 +3,7 @@ title: "How to translate denials with denialContext"
 navLabel: "Translate denials"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 171
+order: 172
 ---
 # How to translate denials with `denialContext`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
@@ -3,7 +3,7 @@ title: "How to use onSnapshot to watch a doc or query"
 navLabel: "Use onSnapshot"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 172
+order: 173
 ---
 # How to use `onSnapshot` to watch a doc or query
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
@@ -3,7 +3,7 @@ title: "How to write a batch"
 navLabel: "Write a batch"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 173
+order: 174
 ---
 # How to write a batch
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/firestore"
 navLabel: "API reference"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 174
+order: 175
 ---
 # API reference: `pyric-admin/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
@@ -2,7 +2,7 @@
 title: "onSnapshot overloads"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 175
+order: 176
 ---
 # `onSnapshot` overloads
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
@@ -2,7 +2,7 @@
 title: "Re-exported types"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 176
+order: 177
 ---
 # Re-exported types
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
@@ -2,7 +2,7 @@
 title: "SandboxFirestore surface"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 177
+order: 178
 ---
 # `SandboxFirestore` surface
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
@@ -3,7 +3,7 @@ title: "Your first admin-shaped Firestore session"
 navLabel: "First admin session"
 group: "pyric-admin / firestore"
 section: "Tutorials"
-order: 168
+order: 169
 ---
 # Your first admin-shaped Firestore session
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore.md
@@ -3,7 +3,7 @@ title: "pyric-admin"
 navLabel: "Overview"
 group: "pyric-admin / firestore"
 section: ""
-order: 167
+order: 168
 ---
 # `pyric-admin`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/storage"
 navLabel: "API reference"
 group: "pyric-admin / storage"
 section: "Reference"
-order: 186
+order: 187
 ---
 # API reference: `pyric-admin/storage`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage.md
@@ -3,7 +3,7 @@ title: "pyric-admin/storage"
 navLabel: "Overview"
 group: "pyric-admin / storage"
 section: ""
-order: 185
+order: 186
 ---
 # `pyric-admin/storage`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric/auth"
 navLabel: "API reference"
 group: "pyric / auth"
 section: "Reference"
-order: 156
+order: 157
 ---
 # API reference: `pyric/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-feature-matrix.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-feature-matrix.md
@@ -3,7 +3,7 @@ title: "Feature matrix: pyric/auth coverage of firebase/auth"
 navLabel: "Feature matrix"
 group: "pyric / auth"
 section: "Reference"
-order: 157
+order: 158
 ---
 # Feature matrix: `pyric/auth` coverage of `firebase/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
@@ -3,7 +3,7 @@ title: "Sandbox test driver: pyric/auth/sandbox.*"
 navLabel: "Sandbox test driver"
 group: "pyric / auth"
 section: "Reference"
-order: 158
+order: 159
 ---
 # Sandbox test driver: `pyric/auth/sandbox.*`
 

--- a/packages/site-docs/src/content/docs/pyric-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-auth.md
@@ -3,7 +3,7 @@ title: "pyric/auth"
 navLabel: "Overview"
 group: "pyric / auth"
 section: ""
-order: 155
+order: 156
 ---
 # `pyric/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
@@ -3,7 +3,7 @@ title: "Why RTDB rules authoring and deploy are separate"
 navLabel: "Authoring vs. deploy"
 group: "pyric / database"
 section: "Explanation"
-order: 164
+order: 165
 ---
 # Why RTDB rules authoring and deploy are separate
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric/database"
 navLabel: "API reference"
 group: "pyric / database"
 section: "Reference"
-order: 161
+order: 162
 ---
 # API reference: `pyric/database`
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
@@ -3,7 +3,7 @@ title: "API reference: RTDB rules constraints"
 navLabel: "API reference"
 group: "pyric / database"
 section: "Reference"
-order: 162
+order: 163
 ---
 # API reference: RTDB rules constraints
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
@@ -2,7 +2,7 @@
 title: "RTDB rules tooling"
 group: "pyric / database"
 section: "Reference"
-order: 163
+order: 164
 ---
 # RTDB rules tooling
 

--- a/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
@@ -3,7 +3,7 @@ title: "Author your first RTDB rules with constraints"
 navLabel: "Author RTDB rules"
 group: "pyric / database"
 section: "Tutorials"
-order: 160
+order: 161
 ---
 # Author your first RTDB rules with constraints
 

--- a/packages/site-docs/src/content/docs/pyric-database.md
+++ b/packages/site-docs/src/content/docs/pyric-database.md
@@ -3,7 +3,7 @@ title: "Realtime Database"
 navLabel: "Overview"
 group: "pyric / database"
 section: ""
-order: 159
+order: 160
 ---
 # Realtime Database
 

--- a/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
+++ b/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
@@ -1,0 +1,68 @@
+---
+title: "The versioning and compatibility policy"
+group: "pyric"
+section: "Explanation"
+order: 74
+---
+# The versioning and compatibility policy
+
+Pyric mirrors Firebase's observable behavior. Users need one honest way to ask "which Firebase does this pyric behave like," and pyric needs one honest way to answer. This document is that answer. It defines what the claim means, where it appears, and what has to be true before it can move.
+
+## Pyric keeps its own version and never borrows Firebase's
+
+Pyric versions itself with its own semver, independent of Firebase. It does not adopt Firebase's version number.
+
+Pyric ships a large surface that Firebase does not have: the sandbox runtime, the rules tooling, the CLI. Breaking changes in that surface need their own major and minor releases. A pyric that renamed itself `12.16.0` to match Firebase would be making a promise of parity that the conformance numbers do not support. Pyric's version tracks pyric. Firebase compatibility is stated separately, below.
+
+## Firebase compatibility ships as a dist-tag
+
+The compatibility claim is an npm dist-tag of the form `fb<major>.<minor>`.
+```
+npm install pyric@fb12.16
+```
+A `fb<major>.<minor>` tag points at the newest pyric release whose conformance gates pass against that line of Firebase. Installing `pyric@fb12.16` gets you the pyric that has been conformance-tested against Firebase 12.16.
+
+The tag means "conformance-tested against Firebase 12.16." It does not mean "equal to Firebase 12.16" and it does not mean "full parity with Firebase 12.16." Those are claims pyric does not make and the conformance numbers do not back. The tag is a statement about what was tested, not a statement about how much matched.
+
+## Patch releases are not tagged
+
+Pyric tags Firebase's major and minor lines and never its patch level, so there is no `fb12.16.1`; a Firebase patch triggers a pyric release only when the upstream surface snapshot diff for that patch is non-empty, which it usually is not.
+
+## The tag is a certificate, not an opinion
+
+A `fb` tag moves only through the release script, and only when the conformance gate suite `compat:check` is green against the pinned Firebase version.
+
+Nobody moves a tag by hand because they believe pyric is ready. The tag moves because the gates passed. It is a machine-issued certificate. A green `compat:check` is the only thing that issues it, and a red one withholds it. This removes optimism from the claim: the tag says what the tests found, and the tests ran before it moved.
+
+## The certificate appears wherever a user forms an impression
+
+The tested-against version is not only an npm tag. It is stated everywhere a user decides whether to trust pyric:
+
+- The README carries a badge naming the Firebase version pyric is tested against.
+- The npm package description names it.
+- `pyric --version` prints both numbers: the pyric version and the Firebase version it was tested against.
+- The docs header names it.
+
+A user who never runs `npm dist-tag ls` still sees the claim, and sees the same claim in every place.
+
+## The claim links to numbers anyone can read
+
+"Tested against Firebase 12.16" is only honest if the result of that testing is inspectable. Pyric publishes its coverage openly: roughly 51% overall surface coverage, roughly 85% behavior conformance on the slice that is implemented, with per-service numbers in the generated COMPAT documents. The tag refers to those published numbers.
+
+Surface coverage answers "will my app's calls exist against the mirror." Behavior conformance answers "of the calls that exist, do they behave like production." They are different questions and pyric reports them separately. A reader following the tag reaches the numbers, not a slogan. "Tested against" is a link, never a vibe.
+
+## Where the numbers stand today
+
+Firebase's latest npm release is 12.16.0. Pyric's pinned oracle and conformance version is 12.13.0, so the first real tag will be `fb12.13`, the line pyric is actually tested against, not `fb12.16`. Pyric's own packages are at `0.1.0-alpha.8`, in lockstep across `pyric`, `pyric-admin`, `pyric-tools`, and `@pyric/ui`. A `fb` tag can point at an alpha release; the compatibility claim and the stability claim are separate, and the `fb` tag speaks only to the first.
+
+---
+
+## Mechanics, for maintainers
+
+**How the tag is computed and moved.** At publish time, after packages are packed and published, the release step reads the currently pinned Firebase version and runs `compat:check` against it. `compat:check` is the composite gate: registry validation, the surface census gate, a docs freshness check, and the coverage regression check. If it is green, the release script moves `fb<major>.<minor>` for the pinned line to the version being published, using the same `npm dist-tag add` mechanism the script already uses for `latest`. If it is red, the `fb` tag does not move and the release does not carry a compatibility claim. The minor is derived from the pinned version; the patch component of the pin is discarded when forming the tag.
+
+**What happens on a Firebase pin bump.** Raising the pinned Firebase version starts by re-snapshotting the upstream surface. The diff between the old snapshot and the new one is the worklist: new exports, changed signatures, removed surface. Bumping the pin does not create the new `fb` tag. The tag for the new line, for example `fb12.16`, appears only after the worklist is closed enough that `compat:check` passes against the new pin. Until then, no release claims the new line.
+
+**What happens to old tags.** A `fb` tag for a line pyric no longer pins keeps pointing at the last pyric release that was certified against that line. Old `fb` tags are never deleted and never moved backward. `pyric@fb12.13` continues to resolve to a real, once-certified release even after the pin moves to 12.16, so an install pinned to an older Firebase line stays reproducible.
+
+**Interaction with `alpha` and `latest`.** The `alpha` and `latest` tags are about pyric's own release stream and move on every publish, `alpha` to each publish and `latest` to the same version by the explicit dist-tag step. The `fb` tags are orthogonal: they move only when gates pass against their line, and only the line matching the current pin moves on a given release. Several tags can point at the same version. A single publish can leave `alpha`, `latest`, and `fb12.13` all resolving to `0.1.0-alpha.9`, each making its own separate claim: newest, default, and tested-against-Firebase-12.13.

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
@@ -3,7 +3,7 @@ title: "Why rules tooling lives in a sibling package"
 navLabel: "Rules tooling is separate"
 group: "pyric / firestore"
 section: "Explanation"
-order: 88
+order: 89
 ---
 # Why rules tooling lives in a sibling package
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
@@ -3,7 +3,7 @@ title: "The TARGET_SYMBOL opacity contract"
 navLabel: "TARGET_SYMBOL opacity"
 group: "pyric / firestore"
 section: "Explanation"
-order: 89
+order: 90
 ---
 # The `TARGET_SYMBOL` opacity contract
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
@@ -3,7 +3,7 @@ title: "Why two backends behind one surface"
 navLabel: "Two backends, one surface"
 group: "pyric / firestore"
 section: "Explanation"
-order: 90
+order: 91
 ---
 # Why two backends behind one surface
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
@@ -3,7 +3,7 @@ title: "How to use pyric/firestore in existing code"
 navLabel: "Use in existing code"
 group: "pyric / firestore"
 section: "How-to"
-order: 77
+order: 78
 ---
 # How to use `pyric/firestore` in existing code
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
@@ -3,7 +3,7 @@ title: "How to pick a backend at init time"
 navLabel: "Pick a backend"
 group: "pyric / firestore"
 section: "How-to"
-order: 78
+order: 79
 ---
 # How to pick a backend at init time
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
@@ -3,7 +3,7 @@ title: "How to run a transaction"
 navLabel: "Run a transaction"
 group: "pyric / firestore"
 section: "How-to"
-order: 79
+order: 80
 ---
 # How to run a transaction
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
@@ -3,7 +3,7 @@ title: "How to use onSnapshot"
 navLabel: "Use onSnapshot"
 group: "pyric / firestore"
 section: "How-to"
-order: 80
+order: 81
 ---
 # How to use `onSnapshot`
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
@@ -3,7 +3,7 @@ title: "How to use sandbox-only operations"
 navLabel: "Use sandbox-only ops"
 group: "pyric / firestore"
 section: "How-to"
-order: 81
+order: 82
 ---
 # How to use sandbox-only operations
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / firestore"
 section: "Reference"
-order: 82
+order: 83
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-feature-matrix.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-feature-matrix.md
@@ -3,7 +3,7 @@ title: "Feature matrix: pyric/firestore coverage of firebase/firestore"
 navLabel: "Feature matrix"
 group: "pyric / firestore"
 section: "Reference"
-order: 83
+order: 84
 ---
 # Feature matrix: `pyric/firestore` coverage of `firebase/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
@@ -2,7 +2,7 @@
 title: "getFirestore overloads"
 group: "pyric / firestore"
 section: "Reference"
-order: 84
+order: 85
 ---
 # `getFirestore` overloads
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
@@ -2,7 +2,7 @@
 title: "Query constraints"
 group: "pyric / firestore"
 section: "Reference"
-order: 85
+order: 86
 ---
 # Query constraints
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
@@ -2,7 +2,7 @@
 title: "Sandbox-only operations"
 group: "pyric / firestore"
 section: "Reference"
-order: 86
+order: 87
 ---
 # Sandbox-only operations
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
@@ -2,7 +2,7 @@
 title: "Tool factories"
 group: "pyric / firestore"
 section: "Reference"
-order: 87
+order: 88
 ---
 # Tool factories
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
@@ -3,7 +3,7 @@ title: "Write a sandbox-backed demo"
 navLabel: "Sandbox-backed demo"
 group: "pyric / firestore"
 section: "Tutorials"
-order: 75
+order: 76
 ---
 # Write a sandbox-backed demo
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
@@ -3,7 +3,7 @@ title: "Swap the demo to the prod backend"
 navLabel: "Swap to prod backend"
 group: "pyric / firestore"
 section: "Tutorials"
-order: 76
+order: 77
 ---
 # Swap the demo to the prod backend
 

--- a/packages/site-docs/src/content/docs/pyric-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore.md
@@ -3,7 +3,7 @@ title: "pyric/firestore"
 navLabel: "Overview"
 group: "pyric / firestore"
 section: ""
-order: 74
+order: 75
 ---
 # `pyric/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
@@ -3,7 +3,7 @@ title: "Agent failure modes the linter catches"
 navLabel: "Agent failure modes"
 group: "pyric / rules"
 section: "Explanation"
-order: 110
+order: 111
 ---
 # Agent failure modes the linter catches
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-lint-vs-validate-vs-simulate-vs-test.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-lint-vs-validate-vs-simulate-vs-test.md
@@ -3,7 +3,7 @@ title: "Lint vs validate vs simulate vs test"
 navLabel: "Lint vs validate vs test"
 group: "pyric / rules"
 section: "Explanation"
-order: 111
+order: 112
 ---
 # Lint vs validate vs simulate vs test
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
@@ -3,7 +3,7 @@ title: "The runtime budget and shared gates"
 navLabel: "Runtime budget and gates"
 group: "pyric / rules"
 section: "Explanation"
-order: 112
+order: 113
 ---
 # The runtime budget and shared gates
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
@@ -3,7 +3,7 @@ title: "The sentinel expression engine ($expr)"
 navLabel: "Sentinel expression engine"
 group: "pyric / rules"
 section: "Explanation"
-order: 113
+order: 114
 ---
 # The sentinel expression engine (`$expr`)
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
@@ -2,7 +2,7 @@
 title: "Simulator vs Rules Test API"
 group: "pyric / rules"
 section: "Explanation"
-order: 114
+order: 115
 ---
 # Simulator vs Rules Test API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
@@ -2,7 +2,7 @@
 title: "The 2+modules extension"
 group: "pyric / rules"
 section: "Explanation"
-order: 115
+order: 116
 ---
 # The `2+modules` extension
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
@@ -2,7 +2,7 @@
 title: "Value wrapper design"
 group: "pyric / rules"
 section: "Explanation"
-order: 116
+order: 117
 ---
 # Value wrapper design
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-why-this-package-exists.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-why-this-package-exists.md
@@ -2,7 +2,7 @@
 title: "Why this package exists"
 group: "pyric / rules"
 section: "Explanation"
-order: 117
+order: 118
 ---
 # Why this package exists
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
@@ -3,7 +3,7 @@ title: "How to compare two rulesets for weakening"
 navLabel: "Compare rulesets"
 group: "pyric / rules"
 section: "How-to"
-order: 92
+order: 93
 ---
 # How to compare two rulesets for weakening
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
@@ -3,7 +3,7 @@ title: "How to inspect rules through the AST"
 navLabel: "Inspect rules via the AST"
 group: "pyric / rules"
 section: "How-to"
-order: 93
+order: 94
 ---
 # How to inspect rules through the AST
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
@@ -3,7 +3,7 @@ title: "How to lint a rules source"
 navLabel: "Lint a rules source"
 group: "pyric / rules"
 section: "How-to"
-order: 94
+order: 95
 ---
 # How to lint a rules source
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
@@ -3,7 +3,7 @@ title: "How to pin request.time for deterministic tests"
 navLabel: "Pin request.time"
 group: "pyric / rules"
 section: "How-to"
-order: 95
+order: 96
 ---
 # How to pin `request.time` for deterministic tests
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
@@ -3,7 +3,7 @@ title: "How to register rules tools with an agent"
 navLabel: "Register rules tools"
 group: "pyric / rules"
 section: "How-to"
-order: 96
+order: 97
 ---
 # How to register rules tools with an agent
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
@@ -3,7 +3,7 @@ title: "How to resolve 2+modules imports"
 navLabel: "Resolve 2+modules imports"
 group: "pyric / rules"
 section: "How-to"
-order: 97
+order: 98
 ---
 # How to resolve `2+modules` imports
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
@@ -3,7 +3,7 @@ title: "How to simulate rules locally"
 navLabel: "Simulate rules locally"
 group: "pyric / rules"
 section: "How-to"
-order: 98
+order: 99
 ---
 # How to simulate rules locally
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
@@ -3,7 +3,7 @@ title: "How to test rules against the Firebase Rules Test API"
 navLabel: "Test rules against Firebase"
 group: "pyric / rules"
 section: "How-to"
-order: 99
+order: 100
 ---
 # How to test rules against the Firebase Rules Test API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / rules"
 section: "Reference"
-order: 100
+order: 101
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
@@ -2,7 +2,7 @@
 title: "AST"
 group: "pyric / rules"
 section: "Reference"
-order: 101
+order: 102
 ---
 # AST
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
@@ -2,7 +2,7 @@
 title: "Rules simulator conformance gaps"
 group: "pyric / rules"
 section: "Reference"
-order: 102
+order: 103
 ---
 # Rules simulator conformance gaps
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
@@ -2,7 +2,7 @@
 title: "Errors"
 group: "pyric / rules"
 section: "Reference"
-order: 103
+order: 104
 ---
 # Errors
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-lint-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-lint-rules.md
@@ -2,7 +2,7 @@
 title: "Lint rules"
 group: "pyric / rules"
 section: "Reference"
-order: 104
+order: 105
 ---
 # Lint rules
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
@@ -3,7 +3,7 @@ title: "Simulator context and result states"
 navLabel: "Simulator context"
 group: "pyric / rules"
 section: "Reference"
-order: 105
+order: 106
 ---
 # Simulator context and result states
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
@@ -2,7 +2,7 @@
 title: "Standard library modules"
 group: "pyric / rules"
 section: "Reference"
-order: 106
+order: 107
 ---
 # Standard library modules
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
@@ -2,7 +2,7 @@
 title: "TestCase schema"
 group: "pyric / rules"
 section: "Reference"
-order: 107
+order: 108
 ---
 # `TestCase` schema
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
@@ -2,7 +2,7 @@
 title: "Validator findings"
 group: "pyric / rules"
 section: "Reference"
-order: 108
+order: 109
 ---
 # Validator findings
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
@@ -2,7 +2,7 @@
 title: "Value wrappers"
 group: "pyric / rules"
 section: "Reference"
-order: 109
+order: 110
 ---
 # Value wrappers
 

--- a/packages/site-docs/src/content/docs/pyric-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules.md
@@ -3,7 +3,7 @@ title: "pyric/rules"
 navLabel: "Overview"
 group: "pyric / rules"
 section: ""
-order: 91
+order: 92
 ---
 # `pyric/rules`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
@@ -2,7 +2,7 @@
 title: "Every operation is a request"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 135
+order: 136
 ---
 # Every operation is a request
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
@@ -3,7 +3,7 @@ title: "Identity is a context, not a sandbox"
 navLabel: "Identity is a context"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 136
+order: 137
 ---
 # Identity is a context, not a sandbox
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
@@ -3,7 +3,7 @@ title: "The /internal adapter protocol"
 navLabel: "The /internal protocol"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 137
+order: 138
 ---
 # The `/internal` adapter protocol
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
@@ -3,7 +3,7 @@ title: "Listener re-evaluation on deployRules"
 navLabel: "Listener re-evaluation"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 138
+order: 139
 ---
 # Listener re-evaluation on `deployRules`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-local-backend-vs-firestore-offline.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-local-backend-vs-firestore-offline.md
@@ -3,7 +3,7 @@ title: "A local backend, not Firestore offline persistence"
 navLabel: "Local backend vs. offline"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 139
+order: 140
 ---
 # A local backend, not Firestore offline persistence
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
@@ -3,7 +3,7 @@ title: "Why service adapters live in sibling packages"
 navLabel: "Why adapters are siblings"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 140
+order: 141
 ---
 # Why service adapters live in sibling packages
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-this-package-exists.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-this-package-exists.md
@@ -2,7 +2,7 @@
 title: "Why this package exists"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 141
+order: 142
 ---
 # Why this package exists
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
@@ -3,7 +3,7 @@ title: "How to run multiple isolated sandboxes in parallel"
 navLabel: "Run isolated sandboxes"
 group: "pyric / sandbox"
 section: "How-to"
-order: 120
+order: 121
 ---
 # How to run multiple isolated sandboxes in parallel
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
@@ -3,7 +3,7 @@ title: "How to observe sandbox events"
 navLabel: "Observe sandbox events"
 group: "pyric / sandbox"
 section: "How-to"
-order: 121
+order: 122
 ---
 # How to observe sandbox events
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
@@ -3,7 +3,7 @@ title: "How to pick between pyric-admin and pyric/firestore"
 navLabel: "Pick an adapter"
 group: "pyric / sandbox"
 section: "How-to"
-order: 122
+order: 123
 ---
 # How to pick between `pyric-admin` and `pyric/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
@@ -3,7 +3,7 @@ title: "How to replay a captured event stream"
 navLabel: "Replay events"
 group: "pyric / sandbox"
 section: "How-to"
-order: 123
+order: 124
 ---
 # How to replay a captured event stream
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
@@ -3,7 +3,7 @@ title: "How to reset between tests"
 navLabel: "Reset between tests"
 group: "pyric / sandbox"
 section: "How-to"
-order: 124
+order: 125
 ---
 # How to reset between tests
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
@@ -3,7 +3,7 @@ title: "How to seed initial data and rules"
 navLabel: "Seed data and rules"
 group: "pyric / sandbox"
 section: "How-to"
-order: 125
+order: 126
 ---
 # How to seed initial data and rules
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
@@ -3,7 +3,7 @@ title: "How to switch users with withAuth"
 navLabel: "Switch users"
 group: "pyric / sandbox"
 section: "How-to"
-order: 126
+order: 127
 ---
 # How to switch users with `withAuth`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
@@ -3,7 +3,7 @@ title: "How to use admin reads to assert in tests"
 navLabel: "Use admin reads"
 group: "pyric / sandbox"
 section: "How-to"
-order: 127
+order: 128
 ---
 # How to use admin reads to assert in tests
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / sandbox"
 section: "Reference"
-order: 128
+order: 129
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
@@ -2,7 +2,7 @@
 title: "Divergence"
 group: "pyric / sandbox"
 section: "Reference"
-order: 129
+order: 130
 ---
 # `Divergence`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
@@ -2,7 +2,7 @@
 title: "SandboxError codes"
 group: "pyric / sandbox"
 section: "Reference"
-order: 130
+order: 131
 ---
 # `SandboxError` codes
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
@@ -3,7 +3,7 @@ title: "The /internal adapter protocol"
 navLabel: "The /internal protocol"
 group: "pyric / sandbox"
 section: "Reference"
-order: 131
+order: 132
 ---
 # The `/internal` adapter protocol
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
@@ -3,7 +3,7 @@ title: "Sandbox, SandboxContext, AuthState"
 navLabel: "Sandbox and context"
 group: "pyric / sandbox"
 section: "Reference"
-order: 132
+order: 133
 ---
 # `Sandbox`, `SandboxContext`, `AuthState`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
@@ -2,7 +2,7 @@
 title: "SandboxEvent"
 group: "pyric / sandbox"
 section: "Reference"
-order: 133
+order: 134
 ---
 # `SandboxEvent`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
@@ -3,7 +3,7 @@ title: "SandboxSnapshot and admin reads"
 navLabel: "Snapshot and admin reads"
 group: "pyric / sandbox"
 section: "Reference"
-order: 134
+order: 135
 ---
 # `SandboxSnapshot` and admin reads
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
@@ -2,7 +2,7 @@
 title: "Your first sandbox session"
 group: "pyric / sandbox"
 section: "Tutorials"
-order: 119
+order: 120
 ---
 # Your first sandbox session
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox.md
@@ -3,7 +3,7 @@ title: "pyric/sandbox"
 navLabel: "Overview"
 group: "pyric / sandbox"
 section: ""
-order: 118
+order: 119
 ---
 # `pyric/sandbox`
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
@@ -3,7 +3,7 @@ title: "Implementation scope and deferred features"
 navLabel: "Implementation scope"
 group: "pyric / storage"
 section: "Explanation"
-order: 152
+order: 153
 ---
 # Implementation scope and deferred features
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
@@ -2,7 +2,7 @@
 title: "The session-archive driver"
 group: "pyric / storage"
 section: "Explanation"
-order: 153
+order: 154
 ---
 # The session-archive driver
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-why-indexeddb.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-why-indexeddb.md
@@ -2,7 +2,7 @@
 title: "Why IndexedDB"
 group: "pyric / storage"
 section: "Explanation"
-order: 154
+order: 155
 ---
 # Why IndexedDB
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
@@ -3,7 +3,7 @@ title: "How to enforce Storage rules"
 navLabel: "Enforce Storage rules"
 group: "pyric / storage"
 section: "How-to"
-order: 143
+order: 144
 ---
 # How to enforce Storage rules
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
@@ -3,7 +3,7 @@ title: "How to list and delete objects"
 navLabel: "List and delete objects"
 group: "pyric / storage"
 section: "How-to"
-order: 144
+order: 145
 ---
 # How to list and delete objects
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
@@ -3,7 +3,7 @@ title: "How to switch between sandbox and prod backends"
 navLabel: "Switch backends"
 group: "pyric / storage"
 section: "How-to"
-order: 145
+order: 146
 ---
 # How to switch between sandbox and prod backends
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
@@ -3,7 +3,7 @@ title: "How to test rule expressions independently"
 navLabel: "Test rule expressions"
 group: "pyric / storage"
 section: "How-to"
-order: 146
+order: 147
 ---
 # How to test rule expressions independently
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / storage"
 section: "Reference"
-order: 147
+order: 148
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
@@ -2,7 +2,7 @@
 title: "Storage rules evaluator conformance gaps"
 group: "pyric / storage"
 section: "Reference"
-order: 148
+order: 149
 ---
 # Storage rules evaluator conformance gaps
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
@@ -2,7 +2,7 @@
 title: "Error codes"
 group: "pyric / storage"
 section: "Reference"
-order: 149
+order: 150
 ---
 # Error codes
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
@@ -2,7 +2,7 @@
 title: "Storage rules subset"
 group: "pyric / storage"
 section: "Reference"
-order: 150
+order: 151
 ---
 # Storage rules subset
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
@@ -2,7 +2,7 @@
 title: "StorageOptions"
 group: "pyric / storage"
 section: "Reference"
-order: 151
+order: 152
 ---
 # `StorageOptions`
 

--- a/packages/site-docs/src/content/docs/pyric-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-storage.md
@@ -3,7 +3,7 @@ title: "pyric/storage"
 navLabel: "Overview"
 group: "pyric / storage"
 section: ""
-order: 142
+order: 143
 ---
 # `pyric/storage`
 

--- a/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
@@ -3,7 +3,7 @@ title: "<AuthSignInHelper> + useAuthFlowHelper"
 navLabel: "AuthSignInHelper"
 group: "@pyric/ui"
 section: "Auth"
-order: 215
+order: 216
 ---
 # `<AuthSignInHelper>` + `useAuthFlowHelper`
 

--- a/packages/site-docs/src/content/docs/ui-auth-authusers.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authusers.md
@@ -3,7 +3,7 @@ title: "Auth users admin — useAuthUsers, <AuthUserList>, <AuthUserForm>"
 navLabel: "Auth users admin"
 group: "@pyric/ui"
 section: "Auth"
-order: 216
+order: 217
 ---
 # Auth users admin — `useAuthUsers`, `<AuthUserList>`, `<AuthUserForm>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
@@ -2,7 +2,7 @@
 title: "<CollectionList>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 195
+order: 196
 ---
 # `<CollectionList>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
@@ -2,7 +2,7 @@
 title: "<DeleteWithConfirm>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 196
+order: 197
 ---
 # `<DeleteWithConfirm>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
@@ -2,7 +2,7 @@
 title: "<DocumentEditor>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 197
+order: 198
 ---
 # `<DocumentEditor>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
@@ -2,7 +2,7 @@
 title: "<DocumentList>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 198
+order: 199
 ---
 # `<DocumentList>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
@@ -2,7 +2,7 @@
 title: "<DocumentPreview>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 199
+order: 200
 ---
 # `<DocumentPreview>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
@@ -2,7 +2,7 @@
 title: "<QueryBuilder>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 200
+order: 201
 ---
 # `<QueryBuilder>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
@@ -2,7 +2,7 @@
 title: "<ReferencePicker>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 201
+order: 202
 ---
 # `<ReferencePicker>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-badge.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-badge.md
@@ -2,7 +2,7 @@
 title: "<Badge>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 188
+order: 189
 ---
 # `<Badge>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
@@ -2,7 +2,7 @@
 title: "<ConfirmDialog> + useConfirm"
 group: "@pyric/ui"
 section: "Primitives"
-order: 189
+order: 190
 ---
 # `<ConfirmDialog>` + `useConfirm`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
@@ -2,7 +2,7 @@
 title: "<CopyButton>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 190
+order: 191
 ---
 # `<CopyButton>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
@@ -2,7 +2,7 @@
 title: "<JsonView>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 191
+order: 192
 ---
 # `<JsonView>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
@@ -2,7 +2,7 @@
 title: "<SegmentedControl>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 192
+order: 193
 ---
 # `<SegmentedControl>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-toast.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-toast.md
@@ -2,7 +2,7 @@
 title: "<ToastProvider> + useToast"
 group: "@pyric/ui"
 section: "Primitives"
-order: 193
+order: 194
 ---
 # `<ToastProvider>` + `useToast`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
@@ -2,7 +2,7 @@
 title: "<VirtualList>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 194
+order: 195
 ---
 # `<VirtualList>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
@@ -2,7 +2,7 @@
 title: "<DeleteSelectionWithConfirm>"
 group: "@pyric/ui"
 section: "Storage"
-order: 202
+order: 203
 ---
 # `<DeleteSelectionWithConfirm>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
@@ -2,7 +2,7 @@
 title: "<ObjectBrowser>"
 group: "@pyric/ui"
 section: "Storage"
-order: 203
+order: 204
 ---
 # `<ObjectBrowser>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
@@ -2,7 +2,7 @@
 title: "<ObjectInspector>"
 group: "@pyric/ui"
 section: "Storage"
-order: 204
+order: 205
 ---
 # `<ObjectInspector>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
+++ b/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
@@ -2,7 +2,7 @@
 title: "<PathBreadcrumb>"
 group: "@pyric/ui"
 section: "Storage"
-order: 205
+order: 206
 ---
 # `<PathBreadcrumb>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
+++ b/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
@@ -2,7 +2,7 @@
 title: "Rules-aware affordances"
 group: "@pyric/ui"
 section: "Storage"
-order: 208
+order: 209
 ---
 # Rules-aware affordances
 

--- a/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
+++ b/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
@@ -2,7 +2,7 @@
 title: "<UploadDropzone>"
 group: "@pyric/ui"
 section: "Storage"
-order: 207
+order: 208
 ---
 # `<UploadDropzone>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
+++ b/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
@@ -2,7 +2,7 @@
 title: "useStorageRulesGate"
 group: "@pyric/ui"
 section: "Storage"
-order: 209
+order: 210
 ---
 # `useStorageRulesGate`
 

--- a/packages/site-docs/src/content/docs/ui-storage.md
+++ b/packages/site-docs/src/content/docs/ui-storage.md
@@ -2,7 +2,7 @@
 title: "@pyric/ui/storage"
 group: "@pyric/ui"
 section: "Storage"
-order: 206
+order: 207
 ---
 # `@pyric/ui/storage`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
@@ -2,7 +2,7 @@
 title: "<RuleHeatmap>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 211
+order: 212
 ---
 # `<RuleHeatmap>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
@@ -2,7 +2,7 @@
 title: "<TrafficDetail>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 212
+order: 213
 ---
 # `<TrafficDetail>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
@@ -3,7 +3,7 @@ title: "<TrafficLog> · <TrafficRow> · <TrafficGroupRow>"
 navLabel: "TrafficLog components"
 group: "@pyric/ui"
 section: "Traffic"
-order: 213
+order: 214
 ---
 # `<TrafficLog>` · `<TrafficRow>` · `<TrafficGroupRow>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
@@ -2,7 +2,7 @@
 title: "<TrafficStats>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 214
+order: 215
 ---
 # `<TrafficStats>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic.md
+++ b/packages/site-docs/src/content/docs/ui-traffic.md
@@ -2,7 +2,7 @@
 title: "@pyric/ui/traffic"
 group: "@pyric/ui"
 section: "Traffic"
-order: 210
+order: 211
 ---
 # `@pyric/ui/traffic`
 

--- a/packages/site-docs/src/content/docs/ui.md
+++ b/packages/site-docs/src/content/docs/ui.md
@@ -3,7 +3,7 @@ title: "@pyric/ui"
 navLabel: "Overview"
 group: "@pyric/ui"
 section: ""
-order: 187
+order: 188
 ---
 # `@pyric/ui` docs
 

--- a/scripts/compat/print-fb-tag.ts
+++ b/scripts/compat/print-fb-tag.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+// Prints the `fb<major>.<minor>` dist-tag derived from the pinned Firebase
+// version, and only that — no other output, so a caller can capture stdout
+// directly (`FB_TAG="$(bun run scripts/compat/print-fb-tag.ts)"`).
+//
+// The pin is FIREBASE_TESTED_AGAINST (packages/pyric-tools/src/version/
+// compat-target.ts) — the same constant `pyric --version` prints. The patch
+// component is discarded when forming the tag: pyric tags Firebase's major
+// and minor lines, never its patch level (see
+// packages/pyric/docs/explanation/versioning-and-compatibility.md).
+import { FIREBASE_TESTED_AGAINST } from '../../packages/pyric-tools/src/version/compat-target.ts';
+
+const [major, minor] = FIREBASE_TESTED_AGAINST.split('.');
+if (!major || !minor) {
+  throw new Error(`FIREBASE_TESTED_AGAINST is not major.minor.patch: "${FIREBASE_TESTED_AGAINST}"`);
+}
+process.stdout.write(`fb${major}.${minor}\n`);

--- a/scripts/publish-alpha.sh
+++ b/scripts/publish-alpha.sh
@@ -4,7 +4,9 @@
 #   bash scripts/publish-alpha.sh 0.1.0-alpha.9
 #
 # Steps: pack (full rebuild) → publish each tarball under the `alpha`
-# dist-tag → point `latest` at the same version → print the dist-tags for
+# dist-tag → point `latest` at the same version → run `compat:check`
+# against the pinned Firebase version and move the `fb<major>.<minor>`
+# compatibility certificate tag if it is green → print the dist-tags for
 # eyeball verification. Package versions must already be bumped (lockstep)
 # and merged; this script only ships what the tree builds.
 #
@@ -17,6 +19,12 @@
 #    tag; the explicit dist-tag step is what moves `latest`. (A brand-new
 #    package gets `latest` implicitly on first publish — the registry
 #    requires one — but relying on that is what the explicit step avoids.)
+#  - The `fb` tag is a certificate, not an opinion: it moves only when
+#    `compat:check` is green against the pinned Firebase version, and it
+#    is the only thing that issues it. A red gate withholds the tag and
+#    fails the script — no release ships silently without a compatibility
+#    claim. See
+#    packages/pyric/docs/explanation/versioning-and-compatibility.md.
 set -euo pipefail
 
 V="${1:?usage: bash scripts/publish-alpha.sh <version> (e.g. 0.1.0-alpha.9)}"
@@ -30,6 +38,23 @@ done
 for p in pyric pyric-admin pyric-tools @pyric/ui; do
   npm dist-tag add "${p}@${V}" latest
 done
+
+# ─── fb<major>.<minor> compatibility certificate ───────────────────────
+# Tag only the currently pinned Firebase line (patch discarded), and only
+# on a green compat:check. Never move an fb tag backward — the loop below
+# only ever moves the CURRENT pin's tag forward to this publish.
+echo ""
+echo "━━━ compat:check (gates the fb dist-tag) ━━━"
+if bun run compat:check; then
+  FB_TAG="$(bun run scripts/compat/print-fb-tag.ts)"
+  echo "compat:check green — moving ${FB_TAG} -> ${V}"
+  for p in pyric pyric-admin pyric-tools @pyric/ui; do
+    npm dist-tag add "${p}@${V}" "${FB_TAG}"
+  done
+else
+  echo "compat:check FAILED — ${V} does not carry a compatibility claim; no fb tag moved" >&2
+  exit 1
+fi
 
 for p in pyric pyric-admin pyric-tools @pyric/ui; do
   echo "== ${p}"; npm dist-tag ls "${p}"


### PR DESCRIPTION
Implements the approved versioning-and-compatibility policy and the approved code structure conventions.

## What lands

- **The policy doc** at packages/pyric/docs/explanation/versioning-and-compatibility.md, composed onto the docs site under a new top-level Explanation group. Pyric keeps its own semver; the Firebase claim ships as fb dist-tags meaning "conformance-tested against," never parity.
- **The conventions doc** at docs/code-conventions.md: one record per file, filename as key, directory as index, computed aggregation, split thresholds, junk-drawer prohibition, just-in-time migration policy.
- **README**: stale 0.1.0-alpha.7 fixed; a plain certificate line added ("Conformance-tested against Firebase 12.13.0") linking the policy and the published coverage section.
- **`pyric --version`** now prints both numbers:
  ```
  pyric-tools 0.1.0-alpha.8
  Firebase 12.13.0 (conformance-tested against this release)
  ```
  The tested-against version has one source (src/version/compat-target.ts), shared by the publish script's tag derivation; the upstream-surface snapshot replaces it as source of truth when that lands.
- **publish-alpha.sh**: after publish, runs compat:check; on green, moves fb12.13 to the published version for the four lockstep packages; on red, exits 1 and no tag moves. A tag move is a machine-issued certificate.

## Verification

- compat:check green; compat:lint-terms clean (both docs passed the terminology lint unmodified)
- pyric-tools build green; its test suite: 1285 pass, 4 pre-existing network-dependent failures in test/register/register-child.test.ts (verified failing identically on main)
- CLI --version exercised against the built binary (output above)