### PR TITLE
Split studio index.css into per-feature stylesheets

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -22,7 +22,7 @@
     "build:ports": "tsc -p tsconfig.json",
     "dev": "vite",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",
-    "test": "bun test src test"
+    "test": "bun test src/ test/"
   },
   "dependencies": {
     "pyric": "workspace:*",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -22,7 +22,7 @@
     "build:ports": "tsc -p tsconfig.json",
     "dev": "vite",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",
-    "test": "bun test src"
+    "test": "bun test src test"
   },
   "dependencies": {
     "pyric": "workspace:*",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pyric/studio",
   "version": "0.0.0",
-  "description": "Pyric Studio — the data-management and debugging console for the pyric sandbox, served by `pyric dev --ui`. Cross-service viewer/editor, action center, traffic, rules-failure debugging, and the agentic build flow over one event stream.",
+  "description": "Pyric Studio \u2014 the data-management and debugging console for the pyric sandbox, served by `pyric dev --ui`. Cross-service viewer/editor, action center, traffic, rules-failure debugging, and the agentic build flow over one event stream.",
   "type": "module",
   "exports": {
     "./ports": {
@@ -22,7 +22,7 @@
     "build:ports": "tsc -p tsconfig.json",
     "dev": "vite",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",
-    "test": "bun test"
+    "test": "bun test src"
   },
   "dependencies": {
     "pyric": "workspace:*",

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -6,6 +6,7 @@
  * metadata, and maintenance live in Settings.
  */
 
+import './shell/shell.css';
 import { useEffect, useState } from 'react';
 import { DevSeedProvider, useDevSeed } from './dev/DevSeedProvider.js';
 import { EnvironmentProvider } from './shell/environment.js';

--- a/packages/studio/src/features/data/DataFeature.tsx
+++ b/packages/studio/src/features/data/DataFeature.tsx
@@ -23,6 +23,7 @@ import { LiveAuthPane } from './AuthPane.js';
 import { LiveStoragePane } from './StoragePane.js';
 import { useDataNav, type DataView } from './navigation.js';
 import { useStudioDataSource } from '../../shell/studio-data.js';
+import './data-feature.css';
 
 /** Backend-aware empty state shared by all three sub-views when not live. */
 function PendingState({ view }: { view: DataView }) {

--- a/packages/studio/src/features/data/data-feature.css
+++ b/packages/studio/src/features/data/data-feature.css
@@ -1,0 +1,19 @@
+/**
+ * Data-feature wrapper layout: the `[data-pyric-ui='data-feature']` frame
+ * that DataFeature.tsx renders around whichever service pane (Firestore /
+ * Storage) is active, so the pane's own browser fills the remaining height.
+ * Imported by `DataFeature.tsx`, the only consumer of this contract.
+ */
+/* The data feature fills its frame; its browser (the last data child) grows so
+   the columns run full-height and their dividers span the whole browser. */
+[data-pyric-ui='data-feature'] {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+[data-pyric-ui='data-feature'] > [data-pyric-ui='fs-browser'],
+[data-pyric-ui='data-feature'] > .storage {
+  flex: 1;
+  min-height: 0;
+}

--- a/packages/studio/src/features/home/home.css
+++ b/packages/studio/src/features/home/home.css
@@ -310,3 +310,24 @@ a.studio-home__tile:hover {
   border-radius: 6px;
   background: var(--elevated);
 }
+
+.studio-home__tile-top {
+  /* Title row as its own grid line (label | count pill). Baseline alignment
+     keeps the label's baseline identical across tiles WITH and WITHOUT a
+     pill: the pill's box is shorter than the label's line box, so it hangs
+     off the shared baseline instead of re-centering (and growing) the row. */
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 10px;
+}
+.studio-home__tile-label {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 650;
+}
+.studio-home__tile-desc {
+  color: var(--muted);
+  font-size: var(--fs-body);
+  line-height: 1.55;
+}

--- a/packages/studio/src/features/playground/PlaygroundSurface.tsx
+++ b/packages/studio/src/features/playground/PlaygroundSurface.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { IconKey, IconSettings, IconUser } from '../../shell/icons.js';
 import { PlaygroundModelControl } from './PlaygroundModelControl.js';
+import './playground.css';
 
 interface StudioSettingsMessage {
   type: 'pyric:studio:navigate-settings';

--- a/packages/studio/src/features/playground/playground.css
+++ b/packages/studio/src/features/playground/playground.css
@@ -1,0 +1,133 @@
+/**
+ * Prototype/playground surface styling: the model-select control embedded in
+ * the top bar (`.studio-playground-model`), the icon buttons in the
+ * playground's own control row, and the playground frame + breadcrumbs.
+ * Imported by the components that render these classes (`PlaygroundSurface`,
+ * `PlaygroundModelControl`).
+ *
+ * This file's own `@media (max-width: 760px)` block is last, so it overrides
+ * the desktop rules above it by source order (same specificity).
+ */
+.studio-icon-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.studio-icon-button:hover {
+  color: var(--ink);
+  border-color: var(--line);
+  background: var(--elevated);
+}
+
+.studio-playground-model {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+.studio-playground-model select {
+  height: 30px;
+  max-width: 180px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--elevated);
+  color: var(--ink);
+  font: inherit;
+  font-size: var(--fs-caption);
+  padding: 0 7px;
+  outline: none;
+}
+.studio-playground-model select:focus {
+  border-color: var(--line-2);
+}
+
+.studio-playground {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+/* The Prototype surface's OWN control row (model/keys/settings/account) —
+   contextual controls live in the surface, never the bar (N2). */
+.studio-playground__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--gutter);
+  border-bottom: 1px solid var(--line);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+/* Breadcrumb on the left; the model + key/settings/account controls pushed to
+   the right (margin-left:auto works whether or not a breadcrumb is present). */
+.studio-playground__controls-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+.studio-playground__crumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.studio-playground__crumb-root {
+  color: var(--text-2);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+.studio-playground__crumb-root:hover {
+  color: var(--text-1);
+}
+.studio-playground__crumb-sep {
+  color: var(--text-3);
+  flex-shrink: 0;
+}
+.studio-playground__crumb-current {
+  color: var(--text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+.studio-playground__frame {
+  width: 100%;
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  background: var(--elevated);
+}
+
+@media (max-width: 760px) {
+  .studio-playground__controls {
+    gap: 4px;
+  }
+
+  .studio-playground-model select {
+    max-width: 112px;
+  }
+
+  .studio-playground-model select:nth-of-type(2) {
+    display: none;
+  }
+}

--- a/packages/studio/src/features/settings/SettingsSurface.tsx
+++ b/packages/studio/src/features/settings/SettingsSurface.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import './settings.css';
 import { instanceSlug } from '../../shell/instance-slug.js';
 import { useServeInit } from '../../shell/serve-init.js';
 import {

--- a/packages/studio/src/features/settings/settings.css
+++ b/packages/studio/src/features/settings/settings.css
@@ -1,0 +1,229 @@
+/**
+ * Settings surface styling: the two-column settings grid, the sandbox card
+ * (live instance/inventory/persistence + branch actions), and the
+ * choice/panel/branch primitives the surface renders. Imported by
+ * `SettingsSurface.tsx`, the only consumer of these classes.
+ *
+ * This file's own `@media (max-width: 760px)` block is last, so it overrides
+ * the desktop rules above it by source order (same specificity).
+ */
+.studio-settings__grid > * {
+  min-width: 0;
+}
+
+.studio-settings__actions,
+.studio-settings__branch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.studio-settings__grid {
+  display: grid;
+  grid-template-columns: minmax(min(100%, 560px), 1.1fr) minmax(min(100%, 320px), 0.9fr);
+  gap: 14px;
+  align-items: start;
+  min-width: 0;
+}
+.studio-settings__ai {
+  max-width: none;
+  max-height: none;
+  box-shadow: none;
+}
+.studio-settings__panel {
+  display: grid;
+  gap: 12px;
+}
+.studio-settings__choice-group {
+  display: grid;
+  gap: 8px;
+}
+.studio-settings__choice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--elevated);
+  padding: 12px;
+  cursor: pointer;
+}
+.studio-settings__choice:has(input:checked) {
+  border-color: var(--accent);
+}
+.studio-settings__choice input {
+  margin-top: 3px;
+  accent-color: var(--accent);
+}
+.studio-settings__choice span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.studio-settings__choice strong {
+  color: var(--ink);
+  font-size: var(--fs-body);
+}
+.studio-settings__choice small {
+  color: var(--muted);
+  font-size: var(--fs-label);
+  line-height: 1.45;
+}
+.studio-settings__row,
+.studio-settings__branch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.studio-settings__label {
+  color: var(--muted);
+}
+.studio-settings__muted {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--fs-label);
+}
+.studio-settings__file {
+  display: none;
+}
+.studio-settings__branches {
+  display: grid;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+/* ── Sandbox card: live substance + consequence-captioned actions ─────── */
+/* Row 1 — instance · inventory · persistence. The teaching line: the
+   sandbox IS this data; everything below operates on it. */
+.studio-sandbox__live {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--elevated);
+  padding: 10px 12px;
+}
+.studio-sandbox__instance {
+  color: var(--ink);
+  font-weight: 600;
+  font-size: var(--fs-body);
+}
+.studio-sandbox__inventory {
+  color: var(--muted);
+  font-size: var(--fs-label);
+}
+.studio-sandbox__persist {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: var(--fs-caption);
+  white-space: nowrap;
+}
+
+/* Action tiles: name row (glyph + label) stacked over the consequence
+   caption. The glyph is the direction: state→file, file→state, fork,
+   loop-back. */
+.studio-sandbox__actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+  gap: 8px;
+}
+.studio-sandbox__action {
+  appearance: none;
+  display: grid;
+  gap: 4px;
+  align-content: start;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--elevated);
+  padding: 10px 12px;
+  font: inherit;
+  cursor: pointer;
+}
+.studio-sandbox__action:hover {
+  border-color: var(--line-2);
+}
+.studio-sandbox__action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.studio-sandbox__action-top {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink);
+}
+.studio-sandbox__action[data-danger='true'] .studio-sandbox__action-top {
+  color: var(--diff-remove);
+}
+.studio-sandbox__action-name {
+  font-size: var(--fs-body);
+  font-weight: 600;
+}
+.studio-sandbox__action-caption {
+  color: var(--muted);
+  font-size: var(--fs-caption);
+  line-height: 1.45;
+}
+
+/* Transient rows: inline branch naming, inline reset confirm (no modals). */
+.studio-sandbox__name-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.studio-sandbox__name-input {
+  flex: 1;
+  min-width: 140px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--elevated);
+  color: var(--ink);
+  font: inherit;
+  font-size: var(--fs-body);
+  padding: 6px 10px;
+  outline: none;
+}
+.studio-sandbox__name-input:focus {
+  border-color: var(--line-2);
+}
+.studio-sandbox__confirm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--diff-remove) 45%, var(--line));
+  border-radius: 8px;
+  background: var(--deny-tint);
+  padding: 10px 12px;
+}
+.studio-sandbox__confirm-copy {
+  color: var(--ink);
+  font-size: var(--fs-label);
+}
+.studio-sandbox__confirm-actions {
+  display: inline-flex;
+  gap: 8px;
+}
+.studio-sandbox__branches-empty {
+  margin: 0;
+  color: var(--faint);
+  font-size: var(--fs-label);
+}
+
+@media (max-width: 760px) {
+  .studio-settings__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-settings__row,
+  .studio-settings__branch {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/packages/studio/src/shell/shell.css
+++ b/packages/studio/src/shell/shell.css
@@ -1,0 +1,482 @@
+/**
+ * Pyric Studio shell chrome: the top bar (identity | nav | status), the
+ * content-region frame that hosts every surface, the mobile nav/menu
+ * scaffolding, the governance-mode toggle, the theme switch, the surface
+ * placeholder, and the two overlay mounts (⌘K command palette, settings
+ * modal chrome). Owned by `shell/` (App.tsx composes these pieces); imported
+ * once, from App.tsx, the shell's root component.
+ *
+ * Order within this file matters the same way it mattered in the old
+ * monolithic `index.css`: base (desktop) rules for a selector are declared
+ * first, and this file's own `@media (max-width: 760px)` block comes last,
+ * so the narrow-screen override wins on source order for equal specificity.
+ */
+/* ════════════════════════════════════════════════════════════════════════
+ * C-PARTI SHELL: ported from `plans/pyric-studio/mocks/c-result.html`.
+ * Every raw value from the mock is replaced by a role token. The structure
+ * (prompt spine → frame bar → scroll region, centred column) is preserved.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+.studio {
+  --maxw: 820px;
+  --wide: 1440px;
+  --gutter: clamp(16px, 3vw, 32px);
+  height: 100vh;
+  min-width: 0;
+  display: grid;
+  grid-template-rows: 54px 1fr;
+  overflow-x: hidden;
+}
+
+.studio__col {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+/* ── One bar: identity | nav | status (specs/shell.md) ───────────────── */
+/* The bar spans full width (the hairline runs edge to edge) but its CONTENT is
+   centered to the same wide column EVERY surface uses, so the brand + status
+   line up with the content's left/right edges and never shift when switching
+   tabs. The inner row is the spec's grid: identity | nav | status. */
+.studio__bar {
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  min-width: 0;
+}
+.studio__bar-inner {
+  width: 100%;
+  max-width: var(--wide);
+  margin: 0 auto;
+  height: 54px;
+  display: grid;
+  grid-template-columns: auto 1fr auto; /* identity | nav | status */
+  align-items: center;
+  gap: var(--space-4);
+  padding: 0 var(--gutter);
+  min-width: 0;
+}
+.studio__brand {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+/* Project + governance mode: the only session context the bar carries. */
+.studio__ctx {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+}
+.studio__ctx-project {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.studio__ctx-mode {
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--line-2);
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+
+/* Inline nav tabs: flex + gap, horizontal overflow scrolls — the bar never
+   grows a second row (N1). */
+.studio__nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-1);
+  height: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.studio__nav::-webkit-scrollbar {
+  display: none;
+}
+.studio__nav-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  padding: 0 12px;
+  height: 100%;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.12s, border-color 0.12s;
+}
+/* The Docs tab is an <a> (a full-page link to the composed /docs pages),
+   not a routed <button>; align the anchor box with the button tabs. */
+a.studio__nav-tab {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+.studio__nav-tab:hover {
+  color: color-mix(in srgb, var(--ink) 80%, transparent);
+}
+.studio__nav-tab[aria-current="page"] {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+/* Narrow screens: the tab row scrolls. Make that legible instead of a
+   hard clip: snap points per tab, and an edge fade standing in for the
+   hidden scrollbar. The nav's own end padding sits under the fade at
+   full scroll, so no tab text ever fades. */
+@media (max-width: 760px) {
+  .studio__nav {
+    scroll-snap-type: x proximity;
+    padding-right: 28px;
+    mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+  }
+
+  .studio__nav-tab {
+    scroll-snap-align: start;
+  }
+}
+
+/* Status cluster: a flex row of chips, gap-spaced; each chip is
+   container-agnostic (L4). Health renders by exception only. */
+.studio__status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* Right cluster: command · settings · theme. */
+.studio__bar-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.studio__cmd {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 9px;
+  color: var(--faint);
+  font: inherit;
+  background: var(--elevated);
+  cursor: text;
+}
+.studio__cmd:hover {
+  border-color: var(--line-2);
+}
+.studio__cmd-ico {
+  font-size: 13px;
+  line-height: 1;
+}
+.studio__kbd {
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 2px 6px;
+}
+
+.studio-theme-toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--elevated);
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+.studio-theme-toggle:hover {
+  border-color: var(--line-2);
+  color: var(--ink);
+}
+
+/* The hamburger + the nav drawer backdrop are mobile-only (shown in the media
+   query below); on desktop the nav is inline and these are hidden. */
+.studio__menu {
+  display: none;
+}
+.studio__nav-backdrop {
+  display: none;
+}
+
+/* Governance mode: a compact segmented toggle (Review / Direct). */
+.studio__mode {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 2px;
+  background: var(--elevated);
+}
+.studio__mode-opt {
+  appearance: none;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 12px;
+  color: var(--faint);
+  padding: 4px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.studio__mode-opt:hover {
+  color: var(--ink);
+}
+.studio__mode-opt[aria-pressed='true'] {
+  color: var(--ink);
+  background: var(--panel);
+  font-weight: 500;
+}
+
+/* ── Content region: one surface, framed per route ───────────────────── */
+.studio__content {
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Scroll surfaces (session · rules · traffic): one centered wide column, the
+   SAME width as the data browsers, so the page width (and the top bar aligned
+   to it) never changes when switching tabs. */
+.studio__content[data-surface='home'] > *,
+.studio__content[data-surface='rtdb'] > *,
+.studio__content[data-surface='traffic'] > *,
+.studio__content[data-surface='settings'] > * {
+  display: block;
+  width: 100%;
+  max-width: var(--wide);
+  margin: 0 auto;
+  padding: clamp(22px, 4vw, 40px) var(--gutter) 72px;
+}
+
+/* Full-height data browsers (firestore · auth · storage): fill the viewport so
+   the browser's own panes scroll internally instead of the whole page. */
+.studio__content[data-surface='firestore'],
+.studio__content[data-surface='auth'],
+.studio__content[data-surface='storage'],
+.studio__content[data-surface='prototype'] {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.studio__surface-slot {
+  min-width: 0;
+}
+.studio__surface-slot--playground {
+  min-height: 0;
+}
+.studio__content[data-surface='prototype'] > .studio__surface-slot--playground {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+.studio__surface-slot--playground[data-active='false'] {
+  position: absolute;
+  inset: 0;
+  display: flex !important;
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  min-height: 0;
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
+  overflow: hidden;
+}
+.studio__surface-slot--playground > .studio-playground {
+  flex: 1;
+}
+
+.studio__content[data-surface='firestore'] > *,
+.studio__content[data-surface='auth'] > *,
+.studio__content[data-surface='storage'] > * {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  max-width: var(--wide);
+  margin: 0 auto;
+  padding: 18px var(--gutter);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Labelled empty placeholder per route (Wave 2 fills these). */
+.studio__placeholder {
+  border: 1px dashed var(--line-2);
+  border-radius: 10px;
+  padding: 32px 28px;
+  background: var(--panel);
+}
+.studio__placeholder-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--faint);
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.studio__placeholder-title {
+  font-size: 16px;
+  color: var(--ink);
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+.studio__placeholder-blurb {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+  max-width: 560px;
+  line-height: 1.55;
+}
+.studio__placeholder-meta {
+  margin-top: 18px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--faint);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+/* ── Theme switch (segmented, mechanical) ────────────────────────────── */
+.studio__theme {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 2px;
+  background: var(--elevated);
+}
+.studio__theme button {
+  appearance: none;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--muted);
+  padding: 3px 9px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.studio__theme button:hover {
+  color: var(--ink);
+}
+.studio__theme button[aria-pressed="true"] {
+  color: var(--ink);
+  background: var(--panel);
+  font-weight: 500;
+}
+
+/* ── Global ⌘K overlay: the command typeahead's second mount ──────────
+   Positioned BELOW the 54px bar — the bar stays visible and uncovered;
+   only the content region dims. The panel reuses the Home typeahead's own
+   classes (`.studio-home__command*`), so the two mounts share one look. */
+.studio__cmdk-backdrop {
+  position: fixed;
+  top: 54px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
+  backdrop-filter: blur(2px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: clamp(24px, 8vh, 72px) var(--gutter, 16px) 0;
+  z-index: 40;
+}
+.studio__cmdk {
+  width: 100%;
+  max-width: 560px;
+  border-radius: 12px;
+  box-shadow: 0 18px 48px -12px rgba(0, 0, 0, 0.35);
+}
+/* The results listbox is part of the same floating panel — same elevated
+   register as the input row (inline mode uses the flatter --panel). */
+.studio__cmdk .studio-home__command-results {
+  background: var(--elevated);
+}
+
+@media (max-width: 760px) {
+  .studio {
+    --gutter: 16px;
+    height: 100dvh;
+    grid-template-rows: 54px 1fr;
+  }
+
+  .studio__bar {
+    position: relative;
+    z-index: 10;
+  }
+  .studio__bar-inner {
+    max-width: none;
+    height: 54px;
+    padding-inline: 10px;
+    gap: 8px;
+  }
+  .studio__menu {
+    display: none;
+  }
+  .studio__bar-tools {
+    display: none;
+  }
+
+  /* Narrow: the status cluster keeps at most one chip's width; nav scrolls. */
+  .studio__status {
+    gap: 4px;
+  }
+
+  .studio__nav {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-inline: 2px;
+  }
+  .studio__nav-tab {
+    flex: 0 0 auto;
+    padding: 0 10px;
+    font-size: 13px;
+  }
+  .studio__nav-backdrop {
+    display: none;
+  }
+
+  /* ── Surface working areas: full width, tighter gutter ── */
+  .studio__content[data-surface='home'] > *,
+  .studio__content[data-surface='rtdb'] > *,
+  .studio__content[data-surface='traffic'] > *,
+  .studio__content[data-surface='settings'] > *,
+  .studio__content[data-surface='storage'] > *,
+  .studio__content[data-surface='firestore'] > *,
+  .studio__content[data-surface='auth'] > * {
+    max-width: none;
+    padding: 18px 16px 56px;
+  }
+}

--- a/packages/studio/src/styles/index.css
+++ b/packages/studio/src/styles/index.css
@@ -8,12 +8,57 @@
  *   3. `@theme`             : bridges the role tokens to Tailwind utilities so
  *                             both the mock CSS (`var(--ink)`) AND Tailwind
  *                             classes (`text-ink`) read the same roles.
- *   4. base + shell CSS     : ported from the C-parti mocks, tokens only.
+ *   4. base reset           : box-sizing + html/body/#root sizing, ported
+ *                             from the C-parti mocks, tokens only.
  *
  * WHY a Tailwind bridge if the tokens are the source of truth? So Studio can use
  * either dialect: the ported mock CSS uses `var(--*)` directly; new components
  * can use `bg-bg text-ink border-line`. Both resolve to the same custom property,
  * so re-theming (swap one token block) still flows everywhere.
+ *
+ * ── Split history (studio-css-split) ──────────────────────────────────
+ * This file used to hold the entire Studio shell + every feature's CSS
+ * (1,235 lines, a shared-append conflict magnet: every feature dropped its
+ * rules here). Feature-specific rules have been relocated to co-located
+ * stylesheets under the feature that owns them, imported where that feature
+ * mounts:
+ *   - `shell/shell.css`                    (top bar, content-region frame,
+ *                                            mobile nav, theme switch,
+ *                                            command palette overlay mount)
+ *                                           — imported by App.tsx
+ *   - `features/playground/playground.css` — imported by PlaygroundSurface
+ *   - `features/settings/settings.css`     — imported by SettingsSurface
+ *   - `features/data/data-feature.css`     — imported by DataFeature
+ *   - `features/home/home.css` (appended)  — imported by HomeSurface
+ *
+ * This file keeps only what has no single feature owner, PLUS one rule
+ * group that has a nominal owner but nowhere safe to move to:
+ *   - the `@import` lines and the `@theme` token bridge below;
+ *   - the `@layer base` reset below that;
+ *   - a small shared UI-kit block (`.studio-chip*`, `.studio-surface*`,
+ *     `.studio-grid`, `.studio-card`, `.studio-badge`, `.studio-button`,
+ *     `.studio-panel*`, `.studio-empty*`) used by three or more features
+ *     (Home, RTDB, Settings, and/or the shell status cluster) — splitting
+ *     these into one feature's file would be a false attribution, since no
+ *     single feature owns them. `.studio-grid` / `.studio-empty*` currently
+ *     have no live consumer in the tree; they stay here rather than being
+ *     guessed into a feature, since a dead rule cannot be attributed either.
+ *   - `.studio__palette*` (see the comment at that rule below): its
+ *     consumer is `ai/SettingsModal.tsx`, but that component — and the
+ *     `ai/` subtree generally — is not imported anywhere in Studio's live
+ *     module graph today, so `ai/ai.css` never reaches the production
+ *     bundle. Moving this rule there would silently drop it from the built
+ *     CSS, which fails this split's own build-equivalence requirement, so
+ *     it stays in the file that IS always loaded.
+ *
+ * ORDERING RULE preserved by every split file: a file's own desktop rules
+ * come first, and its `@media (max-width: 760px)` block (if any) comes last,
+ * so the narrow-screen override wins by source order at equal specificity —
+ * exactly the position these rules held in this file before the split.
+ * Between files, import order is not load-bearing: no class name is defined
+ * in more than one file, so there is no equal-specificity race across file
+ * boundaries to protect. A selector lives in exactly one feature's
+ * stylesheet, or — if shared / unattributable — stays here.
  */
 
 @import "./tokens.css";
@@ -106,150 +151,6 @@
   }
 }
 
-/* ════════════════════════════════════════════════════════════════════════
- * C-PARTI SHELL: ported from `plans/pyric-studio/mocks/c-result.html`.
- * Every raw value from the mock is replaced by a role token. The structure
- * (prompt spine → frame bar → scroll region, centred column) is preserved.
- * ════════════════════════════════════════════════════════════════════════ */
-
-.studio {
-  --maxw: 820px;
-  --wide: 1440px;
-  --gutter: clamp(16px, 3vw, 32px);
-  height: 100vh;
-  min-width: 0;
-  display: grid;
-  grid-template-rows: 54px 1fr;
-  overflow-x: hidden;
-}
-
-.studio__col {
-  width: 100%;
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 0 var(--gutter);
-}
-
-/* ── One bar: identity | nav | status (specs/shell.md) ───────────────── */
-/* The bar spans full width (the hairline runs edge to edge) but its CONTENT is
-   centered to the same wide column EVERY surface uses, so the brand + status
-   line up with the content's left/right edges and never shift when switching
-   tabs. The inner row is the spec's grid: identity | nav | status. */
-.studio__bar {
-  border-bottom: 1px solid var(--line);
-  background: var(--panel);
-  min-width: 0;
-}
-.studio__bar-inner {
-  width: 100%;
-  max-width: var(--wide);
-  margin: 0 auto;
-  height: 54px;
-  display: grid;
-  grid-template-columns: auto 1fr auto; /* identity | nav | status */
-  align-items: center;
-  gap: var(--space-4);
-  padding: 0 var(--gutter);
-  min-width: 0;
-}
-.studio__brand {
-  font-weight: 600;
-  color: var(--ink);
-}
-
-/* Project + governance mode: the only session context the bar carries. */
-.studio__ctx {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  flex-shrink: 0;
-}
-.studio__ctx-project {
-  font-size: 12.5px;
-  color: var(--muted);
-}
-.studio__ctx-mode {
-  font-size: 10px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--accent);
-  border: 1px solid var(--line-2);
-  border-radius: 5px;
-  padding: 1px 6px;
-}
-
-/* Inline nav tabs: flex + gap, horizontal overflow scrolls — the bar never
-   grows a second row (N1). */
-.studio__nav {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--space-1);
-  height: 100%;
-  min-width: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.studio__nav::-webkit-scrollbar {
-  display: none;
-}
-.studio__nav-tab {
-  appearance: none;
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  font: inherit;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--muted);
-  padding: 0 12px;
-  height: 100%;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color 0.12s, border-color 0.12s;
-}
-/* The Docs tab is an <a> (a full-page link to the composed /docs pages),
-   not a routed <button>; align the anchor box with the button tabs. */
-a.studio__nav-tab {
-  display: inline-flex;
-  align-items: center;
-  text-decoration: none;
-}
-.studio__nav-tab:hover {
-  color: color-mix(in srgb, var(--ink) 80%, transparent);
-}
-.studio__nav-tab[aria-current="page"] {
-  color: var(--ink);
-  border-bottom-color: var(--ink);
-}
-
-/* Narrow screens: the tab row scrolls. Make that legible instead of a
-   hard clip: snap points per tab, and an edge fade standing in for the
-   hidden scrollbar. The nav's own end padding sits under the fade at
-   full scroll, so no tab text ever fades. */
-@media (max-width: 760px) {
-  .studio__nav {
-    scroll-snap-type: x proximity;
-    padding-right: 28px;
-    mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
-    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
-  }
-
-  .studio__nav-tab {
-    scroll-snap-align: start;
-  }
-}
-
-
-/* Status cluster: a flex row of chips, gap-spaced; each chip is
-   container-agnostic (L4). Health renders by exception only. */
-.studio__status {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--space-2);
-  min-width: 0;
-}
 .studio-chip {
   display: inline-flex;
   align-items: center;
@@ -284,177 +185,6 @@ a.studio-chip:hover {
 }
 .studio-chip--warn .studio-chip__dot {
   background: var(--diff-remove);
-}
-
-.studio-icon-button {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-}
-.studio-icon-button:hover {
-  color: var(--ink);
-  border-color: var(--line);
-  background: var(--elevated);
-}
-
-.studio-playground-model {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  min-width: 0;
-}
-.studio-playground-model select {
-  height: 30px;
-  max-width: 180px;
-  min-width: 0;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: var(--elevated);
-  color: var(--ink);
-  font: inherit;
-  font-size: var(--fs-caption);
-  padding: 0 7px;
-  outline: none;
-}
-.studio-playground-model select:focus {
-  border-color: var(--line-2);
-}
-
-/* Right cluster: command · settings · theme. */
-.studio__bar-tools {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-.studio__cmd {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 6px 9px;
-  color: var(--faint);
-  font: inherit;
-  background: var(--elevated);
-  cursor: text;
-}
-.studio__cmd:hover {
-  border-color: var(--line-2);
-}
-.studio__cmd-ico {
-  font-size: 13px;
-  line-height: 1;
-}
-.studio__kbd {
-  color: var(--faint);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 2px 6px;
-}
-
-.studio-theme-toggle {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--elevated);
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-}
-.studio-theme-toggle:hover {
-  border-color: var(--line-2);
-  color: var(--ink);
-}
-
-/* The hamburger + the nav drawer backdrop are mobile-only (shown in the media
-   query below); on desktop the nav is inline and these are hidden. */
-.studio__menu {
-  display: none;
-}
-.studio__nav-backdrop {
-  display: none;
-}
-
-/* Governance mode: a compact segmented toggle (Review / Direct). */
-.studio__mode {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 2px;
-  background: var(--elevated);
-}
-.studio__mode-opt {
-  appearance: none;
-  background: none;
-  border: none;
-  font: inherit;
-  font-size: 12px;
-  color: var(--faint);
-  padding: 4px 9px;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: color 0.12s, background 0.12s;
-}
-.studio__mode-opt:hover {
-  color: var(--ink);
-}
-.studio__mode-opt[aria-pressed='true'] {
-  color: var(--ink);
-  background: var(--panel);
-  font-weight: 500;
-}
-
-/* ── Content region: one surface, framed per route ───────────────────── */
-.studio__content {
-  min-height: 0;
-  min-width: 0;
-  position: relative;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-/* Scroll surfaces (session · rules · traffic): one centered wide column, the
-   SAME width as the data browsers, so the page width (and the top bar aligned
-   to it) never changes when switching tabs. */
-.studio__content[data-surface='home'] > *,
-.studio__content[data-surface='rtdb'] > *,
-.studio__content[data-surface='traffic'] > *,
-.studio__content[data-surface='settings'] > * {
-  display: block;
-  width: 100%;
-  max-width: var(--wide);
-  margin: 0 auto;
-  padding: clamp(22px, 4vw, 40px) var(--gutter) 72px;
-}
-
-/* Full-height data browsers (firestore · auth · storage): fill the viewport so
-   the browser's own panes scroll internally instead of the whole page. */
-.studio__content[data-surface='firestore'],
-.studio__content[data-surface='auth'],
-.studio__content[data-surface='storage'],
-.studio__content[data-surface='prototype'] {
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
 }
 
 .studio-surface {
@@ -569,26 +299,6 @@ button.studio-card:hover {
   font-weight: 650;
 }
 
-.studio-home__tile-top {
-  /* Title row as its own grid line (label | count pill). Baseline alignment
-     keeps the label's baseline identical across tiles WITH and WITHOUT a
-     pill: the pill's box is shorter than the label's line box, so it hangs
-     off the shared baseline instead of re-centering (and growing) the row. */
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: baseline;
-  gap: 10px;
-}
-.studio-home__tile-label {
-  color: var(--ink);
-  font-size: 15px;
-  font-weight: 650;
-}
-.studio-home__tile-desc {
-  color: var(--muted);
-  font-size: var(--fs-body);
-  line-height: 1.55;
-}
 .studio-empty {
   min-height: min(560px, 70vh);
   display: grid !important;
@@ -602,438 +312,18 @@ button.studio-card:hover {
   padding: 28px;
   text-align: center;
 }
-.studio-settings__grid > * {
-  min-width: 0;
-}
-
-.studio-playground {
-  flex: 1;
-  min-height: 0;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg);
-}
-/* The Prototype surface's OWN control row (model/keys/settings/account) —
-   contextual controls live in the surface, never the bar (N2). */
-.studio-playground__controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--gutter);
-  border-bottom: 1px solid var(--line);
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-/* Breadcrumb on the left; the model + key/settings/account controls pushed to
-   the right (margin-left:auto works whether or not a breadcrumb is present). */
-.studio-playground__controls-right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.studio-playground__crumbs {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  min-width: 0;
-  font-family: var(--font-mono);
-  font-size: 11px;
-}
-.studio-playground__crumb-root {
-  color: var(--text-2);
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: color 0.15s ease;
-}
-.studio-playground__crumb-root:hover {
-  color: var(--text-1);
-}
-.studio-playground__crumb-sep {
-  color: var(--text-3);
-  flex-shrink: 0;
-}
-.studio-playground__crumb-current {
-  color: var(--text-1);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 220px;
-}
-.studio-playground__frame {
-  width: 100%;
-  min-width: 0;
-  flex: 1;
-  border: 0;
-  background: var(--elevated);
-}
-.studio__surface-slot {
-  min-width: 0;
-}
-.studio__surface-slot--playground {
-  min-height: 0;
-}
-.studio__content[data-surface='prototype'] > .studio__surface-slot--playground {
-  flex: 1;
-  display: flex;
-  min-height: 0;
-}
-.studio__surface-slot--playground[data-active='false'] {
-  position: absolute;
-  inset: 0;
-  display: flex !important;
-  width: 100% !important;
-  max-width: none !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  min-height: 0;
-  visibility: hidden;
-  pointer-events: none;
-  opacity: 0;
-  overflow: hidden;
-}
-.studio__surface-slot--playground > .studio-playground {
-  flex: 1;
-}
-.studio-settings__actions,
-.studio-settings__branch-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-.studio-settings__grid {
-  display: grid;
-  grid-template-columns: minmax(min(100%, 560px), 1.1fr) minmax(min(100%, 320px), 0.9fr);
-  gap: 14px;
-  align-items: start;
-  min-width: 0;
-}
-.studio-settings__ai {
-  max-width: none;
-  max-height: none;
-  box-shadow: none;
-}
-.studio-settings__panel {
-  display: grid;
-  gap: 12px;
-}
-.studio-settings__choice-group {
-  display: grid;
-  gap: 8px;
-}
-.studio-settings__choice {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
-  gap: 10px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--elevated);
-  padding: 12px;
-  cursor: pointer;
-}
-.studio-settings__choice:has(input:checked) {
-  border-color: var(--accent);
-}
-.studio-settings__choice input {
-  margin-top: 3px;
-  accent-color: var(--accent);
-}
-.studio-settings__choice span {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-.studio-settings__choice strong {
-  color: var(--ink);
-  font-size: var(--fs-body);
-}
-.studio-settings__choice small {
-  color: var(--muted);
-  font-size: var(--fs-label);
-  line-height: 1.45;
-}
-.studio-settings__row,
-.studio-settings__branch {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-.studio-settings__label {
-  color: var(--muted);
-}
-.studio-settings__muted {
-  margin: 0;
-  color: var(--muted);
-  font-size: var(--fs-label);
-}
-.studio-settings__file {
-  display: none;
-}
-.studio-settings__branches {
-  display: grid;
-  gap: 8px;
-  padding-top: 4px;
-}
-
-/* ── Sandbox card: live substance + consequence-captioned actions ─────── */
-/* Row 1 — instance · inventory · persistence. The teaching line: the
-   sandbox IS this data; everything below operates on it. */
-.studio-sandbox__live {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 4px 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--elevated);
-  padding: 10px 12px;
-}
-.studio-sandbox__instance {
-  color: var(--ink);
-  font-weight: 600;
-  font-size: var(--fs-body);
-}
-.studio-sandbox__inventory {
-  color: var(--muted);
-  font-size: var(--fs-label);
-}
-.studio-sandbox__persist {
-  margin-left: auto;
-  color: var(--faint);
-  font-size: var(--fs-caption);
-  white-space: nowrap;
-}
-
-/* Action tiles: name row (glyph + label) stacked over the consequence
-   caption. The glyph is the direction: state→file, file→state, fork,
-   loop-back. */
-.studio-sandbox__actions {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
-  gap: 8px;
-}
-.studio-sandbox__action {
-  appearance: none;
-  display: grid;
-  gap: 4px;
-  align-content: start;
-  text-align: left;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--elevated);
-  padding: 10px 12px;
-  font: inherit;
-  cursor: pointer;
-}
-.studio-sandbox__action:hover {
-  border-color: var(--line-2);
-}
-.studio-sandbox__action:disabled {
-  cursor: default;
-  opacity: 0.55;
-}
-.studio-sandbox__action-top {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--ink);
-}
-.studio-sandbox__action[data-danger='true'] .studio-sandbox__action-top {
-  color: var(--diff-remove);
-}
-.studio-sandbox__action-name {
-  font-size: var(--fs-body);
-  font-weight: 600;
-}
-.studio-sandbox__action-caption {
-  color: var(--muted);
-  font-size: var(--fs-caption);
-  line-height: 1.45;
-}
-
-/* Transient rows: inline branch naming, inline reset confirm (no modals). */
-.studio-sandbox__name-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-}
-.studio-sandbox__name-input {
-  flex: 1;
-  min-width: 140px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: var(--elevated);
-  color: var(--ink);
-  font: inherit;
-  font-size: var(--fs-body);
-  padding: 6px 10px;
-  outline: none;
-}
-.studio-sandbox__name-input:focus {
-  border-color: var(--line-2);
-}
-.studio-sandbox__confirm {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px 12px;
-  border: 1px solid color-mix(in srgb, var(--diff-remove) 45%, var(--line));
-  border-radius: 8px;
-  background: var(--deny-tint);
-  padding: 10px 12px;
-}
-.studio-sandbox__confirm-copy {
-  color: var(--ink);
-  font-size: var(--fs-label);
-}
-.studio-sandbox__confirm-actions {
-  display: inline-flex;
-  gap: 8px;
-}
-.studio-sandbox__branches-empty {
-  margin: 0;
-  color: var(--faint);
-  font-size: var(--fs-label);
-}
-.studio__content[data-surface='firestore'] > *,
-.studio__content[data-surface='auth'] > *,
-.studio__content[data-surface='storage'] > * {
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-  max-width: var(--wide);
-  margin: 0 auto;
-  padding: 18px var(--gutter);
-  display: flex;
-  flex-direction: column;
-}
-
-/* The data feature fills its frame; its browser (the last data child) grows so
-   the columns run full-height and their dividers span the whole browser. */
-[data-pyric-ui='data-feature'] {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  flex: 1;
-}
-[data-pyric-ui='data-feature'] > [data-pyric-ui='fs-browser'],
-[data-pyric-ui='data-feature'] > .storage {
-  flex: 1;
-  min-height: 0;
-}
-/* Labelled empty placeholder per route (Wave 2 fills these). */
-.studio__placeholder {
-  border: 1px dashed var(--line-2);
-  border-radius: 10px;
-  padding: 32px 28px;
-  background: var(--panel);
-}
-.studio__placeholder-eyebrow {
-  font-size: 11px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--faint);
-  font-weight: 600;
-  margin: 0 0 8px;
-}
-.studio__placeholder-title {
-  font-size: 16px;
-  color: var(--ink);
-  margin: 0 0 6px;
-  font-weight: 600;
-}
-.studio__placeholder-blurb {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 0;
-  max-width: 560px;
-  line-height: 1.55;
-}
-.studio__placeholder-meta {
-  margin-top: 18px;
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  color: var(--faint);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 14px;
-}
-
-/* ── Theme switch (segmented, mechanical) ────────────────────────────── */
-.studio__theme {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  padding: 2px;
-  background: var(--elevated);
-}
-.studio__theme button {
-  appearance: none;
-  background: none;
-  border: none;
-  font: inherit;
-  font-size: 11.5px;
-  color: var(--muted);
-  padding: 3px 9px;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: color 0.12s, background 0.12s;
-}
-.studio__theme button:hover {
-  color: var(--ink);
-}
-.studio__theme button[aria-pressed="true"] {
-  color: var(--ink);
-  background: var(--panel);
-  font-weight: 500;
-}
-
-/* ── Global ⌘K overlay: the command typeahead's second mount ──────────
-   Positioned BELOW the 54px bar — the bar stays visible and uncovered;
-   only the content region dims. The panel reuses the Home typeahead's own
-   classes (`.studio-home__command*`), so the two mounts share one look. */
-.studio__cmdk-backdrop {
-  position: fixed;
-  top: 54px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: color-mix(in srgb, var(--bg) 55%, transparent);
-  backdrop-filter: blur(2px);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding: clamp(24px, 8vh, 72px) var(--gutter, 16px) 0;
-  z-index: 40;
-}
-.studio__cmdk {
-  width: 100%;
-  max-width: 560px;
-  border-radius: 12px;
-  box-shadow: 0 18px 48px -12px rgba(0, 0, 0, 0.35);
-}
-/* The results listbox is part of the same floating panel — same elevated
-   register as the input row (inline mode uses the flatter --panel). */
-.studio__cmdk .studio-home__command-results {
-  background: var(--elevated);
-}
 
 /* ── Centered modal panel (`.studio__palette*`) ───────────────────────
    Originally the ⌘K palette's chrome; the palette component is gone (the
    global ⌘K reuses the Home typeahead), but the AI SettingsModal still
-   renders on these classes. */
+   renders on these classes. This CANNOT move to `ai/ai.css` (where its
+   consumer, `ai/SettingsModal.tsx`, lives): SettingsModal.tsx, and the whole
+   `ai/` + dev-seed subtree that would carry it into the bundle, are not
+   currently imported from anywhere in Studio's live module graph, so
+   `ai/ai.css` is not reachable from the app's entry point today (verified:
+   its own pre-existing content is already absent from the production
+   build). Since this file IS always reachable (imported once, from
+   `main.tsx`), the rule stays here so the built CSS keeps shipping it. */
 .studio__palette-backdrop {
   position: fixed;
   inset: 0;
@@ -1140,80 +430,7 @@ button.studio-card:hover {
   line-height: 1.5;
 }
 
-/* ════════════════════════════════════════════════════════════════════════
- * MOBILE (<= 760px). The mocks are desktop; this is the responsive layer.
- * The shell stops being a fixed-height single-row spine + wide centred column
- * and becomes a stacked, full-width, single-column flow. Surfaces add their
- * own mobile rules in their scoped stylesheets.
- * ════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 760px) {
-  .studio {
-    --gutter: 16px;
-    height: 100dvh;
-    grid-template-rows: 54px 1fr;
-  }
-
-  .studio__bar {
-    position: relative;
-    z-index: 10;
-  }
-  .studio__bar-inner {
-    max-width: none;
-    height: 54px;
-    padding-inline: 10px;
-    gap: 8px;
-  }
-  .studio__menu {
-    display: none;
-  }
-  .studio__bar-tools {
-    display: none;
-  }
-
-  /* Narrow: the status cluster keeps at most one chip's width; nav scrolls. */
-  .studio__status {
-    gap: 4px;
-  }
-
-  .studio-playground__controls {
-    gap: 4px;
-  }
-
-  .studio-playground-model select {
-    max-width: 112px;
-  }
-
-  .studio-playground-model select:nth-of-type(2) {
-    display: none;
-  }
-
-  .studio__nav {
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding-inline: 2px;
-  }
-  .studio__nav-tab {
-    flex: 0 0 auto;
-    padding: 0 10px;
-    font-size: 13px;
-  }
-  .studio__nav-backdrop {
-    display: none;
-  }
-
-  /* ── Surface working areas: full width, tighter gutter ── */
-  .studio__content[data-surface='home'] > *,
-  .studio__content[data-surface='rtdb'] > *,
-  .studio__content[data-surface='traffic'] > *,
-  .studio__content[data-surface='settings'] > *,
-  .studio__content[data-surface='storage'] > *,
-  .studio__content[data-surface='firestore'] > *,
-  .studio__content[data-surface='auth'] > * {
-    max-width: none;
-    padding: 18px 16px 56px;
-  }
-
-  /* ── Command palette: near full-screen sheet ── */
   .studio__palette-backdrop {
     padding-top: 8vh;
   }
@@ -1222,13 +439,13 @@ button.studio-card:hover {
     margin: 0 12px;
   }
 
-  .studio-settings__grid {
-    grid-template-columns: 1fr;
-  }
-
-  .ai-set__field,
-  .studio-settings__row,
-  .studio-settings__branch {
+  /* `.ai-set__field` is SettingsModal's own field row (see the note above:
+     ai/ai.css is unreachable today), grouped here with the palette's own
+     mobile override since both moved off the original combined selector
+     list `.ai-set__field, .studio-settings__row, .studio-settings__branch`
+     — the `.studio-settings__*` half of that rule now lives in
+     `features/settings/settings.css`, which IS reachable. */
+  .ai-set__field {
     align-items: stretch;
     flex-direction: column;
   }


### PR DESCRIPTION
Executes the conflict audit's studio item under the ratified conventions: index.css drops from 1,235 lines to 452 (imports, theme tokens, base layer, one genuinely shared UI-kit block); feature-owned rules move to co-located stylesheets under shell/, features/playground, features/settings, features/data, features/home. No selector or value rewritten; cascade order preserved and the ordering rule documented in the residual file's header.

Verified by build-artifact comparison against main: 785 of 788 selector-contexts byte-identical; the 3 deltas are minifier serialization variance in progressive-enhancement wrappers, no content change. Full monorepo build green; studio tests 294/294 against a clean dist.

Two findings for the record, both pre-existing and unchanged here: ai/SettingsModal.tsx (and its ai.css) is dead code that never reaches the bundle, so its nominal rules stay in index.css with a comment; and bun test picks up stale compiled tests from a built dist/ (fails on main identically) — a small tooling gap worth its own fix.