### PR TITLE
site-docs: scope the sidebar order counter per nav group

### DIFF
--- a/packages/site-docs/scripts/port-content.ts
+++ b/packages/site-docs/scripts/port-content.ts
@@ -11,8 +11,9 @@
  *
  * For each markdown file this writes src/content/docs/<slug>.md:
  * generated front matter (title from the doc's h1, nav group = package /
- * subtree, section = the tree's existing subdir, global order) plus the
- * source body VERBATIM except intra-doc links:
+ * subtree, section = the tree's existing subdir, an order scoped to the
+ * doc's nav group — see GROUP_ORDER below) plus the source body VERBATIM
+ * except intra-doc links:
  *
  *   - a relative link that resolves to another ported file is rewritten
  *     to `../<slug>/` — directory-relative to the rendered HTML page,
@@ -408,7 +409,38 @@ function mdFilesIn(dir: string): string[] {
 const pages: Page[] = [];
 const bySrc = new Map<string, Page>();
 const bySlug = new Map<string, Page>();
-let order = 1;
+
+/**
+ * Order is scoped per nav group instead of one counter across the whole
+ * tree: each group gets a rank (its index among GROUP_ORDER, spaced by
+ * 1000 — comfortably above the largest group's page count) and each
+ * page an offset from 1 within its group, assigned in the same
+ * traversal order the old global counter used. `order = groupRank +
+ * offset`. Adding a doc then renumbers at most the trailing pages of
+ * its own group; adding a group renumbers nothing before it. GROUP_ORDER
+ * must list every group label the port ever assigns (GUIDE_GROUPS, the
+ * synthetic 'Compatibility' group, then GROUPS) in the exact order the
+ * nav renders them — that order is what the rendered sidebar sequence
+ * depends on, not the numeric order values.
+ */
+const GROUP_ORDER: string[] = [
+  ...GUIDE_GROUPS.map((g) => g.label),
+  'Compatibility',
+  ...GROUPS.map((g) => g.label),
+];
+const GROUP_RANK_SPACING = 1000;
+const groupRank = new Map(GROUP_ORDER.map((label, i) => [label, i * GROUP_RANK_SPACING]));
+const groupPosition = new Map<string, number>();
+function nextOrder(group: string): number {
+  const rank = groupRank.get(group);
+  if (rank === undefined) throw new Error(`group not in GROUP_ORDER: ${group}`);
+  const position = (groupPosition.get(group) ?? 0) + 1;
+  groupPosition.set(group, position);
+  if (position >= GROUP_RANK_SPACING) {
+    throw new Error(`group exceeds GROUP_RANK_SPACING (${GROUP_RANK_SPACING}): ${group}`);
+  }
+  return rank + position;
+}
 
 function addPage(src: string, group: GroupSpec, section: string) {
   if (supersededByAbs.has(src)) return; // replaced by a guide page
@@ -421,7 +453,7 @@ function addPage(src: string, group: GroupSpec, section: string) {
     slug,
     group: group.label,
     section,
-    order: order++,
+    order: nextOrder(group.label),
     title: section === '' ? shortTitle(title) : title,
     navLabel: section === '' ? 'Overview' : navLabelFor(slug, title),
   };
@@ -442,7 +474,7 @@ function addGuidePage(src: string, groupLabel: string) {
     slug,
     group: groupLabel,
     section: '',
-    order: order++,
+    order: nextOrder(groupLabel),
     title: fm.title ?? titleOf(src),
     navLabel: fm.navLabel,
     description: fm.outcome,
@@ -485,7 +517,7 @@ for (const c of COMPAT_PAGES) {
     slug,
     group: 'Compatibility',
     section: '',
-    order: order++,
+    order: nextOrder('Compatibility'),
     title: titleOf(src),
     navLabel: c.label,
   };

--- a/packages/site-docs/src/content/docs/audit-your-rules.md
+++ b/packages/site-docs/src/content/docs/audit-your-rules.md
@@ -3,7 +3,7 @@ title: "Find the holes before someone else does"
 navLabel: "Audit your rules and data"
 group: "Secure & debug"
 section: ""
-order: 17
+order: 3009
 description: "Get an evidence-backed answer to who can access what, with every serious finding proven by a simulation."
 ---
 

--- a/packages/site-docs/src/content/docs/how-the-swap-works.md
+++ b/packages/site-docs/src/content/docs/how-the-swap-works.md
@@ -2,7 +2,7 @@
 title: "How the swap works"
 group: "Get started"
 section: ""
-order: 3
+order: 1002
 description: "Understand how your firebase imports reached a local backend, and why production is untouched."
 ---
 

--- a/packages/site-docs/src/content/docs/how-we-know-it-matches-firebase.md
+++ b/packages/site-docs/src/content/docs/how-we-know-it-matches-firebase.md
@@ -3,7 +3,7 @@ title: "How we know it matches Firebase"
 navLabel: "Conformance"
 group: "Trust"
 section: ""
-order: 28
+order: 7001
 description: "Understand the evidence behind \"it behaves like the real one,\" and what a divergence means when you hit one."
 ---
 

--- a/packages/site-docs/src/content/docs/limits-that-bite.md
+++ b/packages/site-docs/src/content/docs/limits-that-bite.md
@@ -3,7 +3,7 @@ title: "Firestore rules limits, measured"
 navLabel: "Rules limits"
 group: "Secure & debug"
 section: ""
-order: 16
+order: 3008
 description: "Know the measured limits of the production rules compiler and evaluator, with exact numbers, so your rules compile the first time."
 ---
 

--- a/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/app"
 navLabel: "API reference"
 group: "pyric-admin / app"
 section: "Reference"
-order: 168
+order: 18002
 ---
 # API reference: `pyric-admin/app`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-app.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app.md
@@ -3,7 +3,7 @@ title: "pyric-admin/app"
 navLabel: "Overview"
 group: "pyric-admin / app"
 section: ""
-order: 167
+order: 18001
 ---
 # `pyric-admin/app`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/auth"
 navLabel: "API reference"
 group: "pyric-admin / auth"
 section: "Reference"
-order: 184
+order: 20002
 ---
 # API reference: `pyric-admin/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth.md
@@ -3,7 +3,7 @@ title: "pyric-admin/auth"
 navLabel: "Overview"
 group: "pyric-admin / auth"
 section: ""
-order: 183
+order: 20001
 ---
 # `pyric-admin/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/database"
 navLabel: "API reference"
 group: "pyric-admin / database"
 section: "Reference"
-order: 186
+order: 21002
 ---
 # API reference: `pyric-admin/database`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-database.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database.md
@@ -3,7 +3,7 @@ title: "pyric-admin/database"
 navLabel: "Overview"
 group: "pyric-admin / database"
 section: ""
-order: 185
+order: 21001
 ---
 # `pyric-admin/database`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
@@ -3,7 +3,7 @@ title: "Error translation and instanceof SandboxError"
 navLabel: "Error translation"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 180
+order: 19012
 ---
 # Error translation and `instanceof SandboxError`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
@@ -3,7 +3,7 @@ title: "Per-call delegate construction"
 navLabel: "Per-call delegate"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 181
+order: 19013
 ---
 # Per-call delegate construction
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
@@ -3,7 +3,7 @@ title: "Why mirror the admin SDK shape"
 navLabel: "Why mirror the admin SDK"
 group: "pyric-admin / firestore"
 section: "Explanation"
-order: 182
+order: 19014
 ---
 # Why mirror the admin SDK shape
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
@@ -3,7 +3,7 @@ title: "How to run a transaction"
 navLabel: "Run a transaction"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 171
+order: 19003
 ---
 # How to run a transaction
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
@@ -3,7 +3,7 @@ title: "How to seed and set rules"
 navLabel: "Seed and set rules"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 172
+order: 19004
 ---
 # How to seed and set rules
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
@@ -3,7 +3,7 @@ title: "How to translate denials with denialContext"
 navLabel: "Translate denials"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 173
+order: 19005
 ---
 # How to translate denials with `denialContext`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
@@ -3,7 +3,7 @@ title: "How to use onSnapshot to watch a doc or query"
 navLabel: "Use onSnapshot"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 174
+order: 19006
 ---
 # How to use `onSnapshot` to watch a doc or query
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
@@ -3,7 +3,7 @@ title: "How to write a batch"
 navLabel: "Write a batch"
 group: "pyric-admin / firestore"
 section: "How-to"
-order: 175
+order: 19007
 ---
 # How to write a batch
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/firestore"
 navLabel: "API reference"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 176
+order: 19008
 ---
 # API reference: `pyric-admin/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
@@ -2,7 +2,7 @@
 title: "onSnapshot overloads"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 177
+order: 19009
 ---
 # `onSnapshot` overloads
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
@@ -2,7 +2,7 @@
 title: "Re-exported types"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 178
+order: 19010
 ---
 # Re-exported types
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
@@ -2,7 +2,7 @@
 title: "SandboxFirestore surface"
 group: "pyric-admin / firestore"
 section: "Reference"
-order: 179
+order: 19011
 ---
 # `SandboxFirestore` surface
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
@@ -3,7 +3,7 @@ title: "Your first admin-shaped Firestore session"
 navLabel: "First admin session"
 group: "pyric-admin / firestore"
 section: "Tutorials"
-order: 170
+order: 19002
 ---
 # Your first admin-shaped Firestore session
 

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore.md
@@ -3,7 +3,7 @@ title: "pyric-admin"
 navLabel: "Overview"
 group: "pyric-admin / firestore"
 section: ""
-order: 169
+order: 19001
 ---
 # `pyric-admin`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric-admin/storage"
 navLabel: "API reference"
 group: "pyric-admin / storage"
 section: "Reference"
-order: 188
+order: 22002
 ---
 # API reference: `pyric-admin/storage`
 

--- a/packages/site-docs/src/content/docs/pyric-admin-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage.md
@@ -3,7 +3,7 @@ title: "pyric-admin/storage"
 navLabel: "Overview"
 group: "pyric-admin / storage"
 section: ""
-order: 187
+order: 22001
 ---
 # `pyric-admin/storage`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-compat.md
@@ -3,7 +3,7 @@ title: "pyric/auth compatibility matrix"
 navLabel: "Auth"
 group: "Compatibility"
 section: ""
-order: 31
+order: 8002
 ---
 <!-- Generated from scripts/compat/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric/auth"
 navLabel: "API reference"
 group: "pyric / auth"
 section: "Reference"
-order: 158
+order: 16002
 ---
 # API reference: `pyric/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-feature-matrix.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-feature-matrix.md
@@ -3,7 +3,7 @@ title: "Feature matrix: pyric/auth coverage of firebase/auth"
 navLabel: "Feature matrix"
 group: "pyric / auth"
 section: "Reference"
-order: 159
+order: 16003
 ---
 # Feature matrix: `pyric/auth` coverage of `firebase/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
@@ -3,7 +3,7 @@ title: "Sandbox test driver: pyric/auth/sandbox.*"
 navLabel: "Sandbox test driver"
 group: "pyric / auth"
 section: "Reference"
-order: 160
+order: 16004
 ---
 # Sandbox test driver: `pyric/auth/sandbox.*`
 

--- a/packages/site-docs/src/content/docs/pyric-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-auth.md
@@ -3,7 +3,7 @@ title: "pyric/auth"
 navLabel: "Overview"
 group: "pyric / auth"
 section: ""
-order: 157
+order: 16001
 ---
 # `pyric/auth`
 

--- a/packages/site-docs/src/content/docs/pyric-database-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-database-compat.md
@@ -3,7 +3,7 @@ title: "@pyric/rtdb compatibility matrix"
 navLabel: "Realtime Database"
 group: "Compatibility"
 section: ""
-order: 32
+order: 8003
 ---
 <!-- Generated from scripts/compat/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
@@ -3,7 +3,7 @@ title: "Why RTDB rules authoring and deploy are separate"
 navLabel: "Authoring vs. deploy"
 group: "pyric / database"
 section: "Explanation"
-order: 166
+order: 17006
 ---
 # Why RTDB rules authoring and deploy are separate
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-api.md
@@ -3,7 +3,7 @@ title: "API reference: pyric/database"
 navLabel: "API reference"
 group: "pyric / database"
 section: "Reference"
-order: 163
+order: 17003
 ---
 # API reference: `pyric/database`
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
@@ -3,7 +3,7 @@ title: "API reference: RTDB rules constraints"
 navLabel: "API reference"
 group: "pyric / database"
 section: "Reference"
-order: 164
+order: 17004
 ---
 # API reference: RTDB rules constraints
 

--- a/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
@@ -2,7 +2,7 @@
 title: "RTDB rules tooling"
 group: "pyric / database"
 section: "Reference"
-order: 165
+order: 17005
 ---
 # RTDB rules tooling
 

--- a/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
@@ -3,7 +3,7 @@ title: "Author your first RTDB rules with constraints"
 navLabel: "Author RTDB rules"
 group: "pyric / database"
 section: "Tutorials"
-order: 162
+order: 17002
 ---
 # Author your first RTDB rules with constraints
 

--- a/packages/site-docs/src/content/docs/pyric-database.md
+++ b/packages/site-docs/src/content/docs/pyric-database.md
@@ -3,7 +3,7 @@ title: "Realtime Database"
 navLabel: "Overview"
 group: "pyric / database"
 section: ""
-order: 161
+order: 17001
 ---
 # Realtime Database
 

--- a/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
+++ b/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
@@ -2,7 +2,7 @@
 title: "The versioning and compatibility policy"
 group: "pyric"
 section: "Explanation"
-order: 75
+order: 11001
 ---
 # The versioning and compatibility policy
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-compat.md
@@ -3,7 +3,7 @@ title: "pyric/firestore compatibility matrix"
 navLabel: "Firestore"
 group: "Compatibility"
 section: ""
-order: 30
+order: 8001
 ---
 <!-- Generated from scripts/compat/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
@@ -3,7 +3,7 @@ title: "Why rules tooling lives in a sibling package"
 navLabel: "Rules tooling is separate"
 group: "pyric / firestore"
 section: "Explanation"
-order: 90
+order: 12015
 ---
 # Why rules tooling lives in a sibling package
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
@@ -3,7 +3,7 @@ title: "The TARGET_SYMBOL opacity contract"
 navLabel: "TARGET_SYMBOL opacity"
 group: "pyric / firestore"
 section: "Explanation"
-order: 91
+order: 12016
 ---
 # The `TARGET_SYMBOL` opacity contract
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
@@ -3,7 +3,7 @@ title: "Why two backends behind one surface"
 navLabel: "Two backends, one surface"
 group: "pyric / firestore"
 section: "Explanation"
-order: 92
+order: 12017
 ---
 # Why two backends behind one surface
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
@@ -3,7 +3,7 @@ title: "How to use pyric/firestore in existing code"
 navLabel: "Use in existing code"
 group: "pyric / firestore"
 section: "How-to"
-order: 79
+order: 12004
 ---
 # How to use `pyric/firestore` in existing code
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
@@ -3,7 +3,7 @@ title: "How to pick a backend at init time"
 navLabel: "Pick a backend"
 group: "pyric / firestore"
 section: "How-to"
-order: 80
+order: 12005
 ---
 # How to pick a backend at init time
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
@@ -3,7 +3,7 @@ title: "How to run a transaction"
 navLabel: "Run a transaction"
 group: "pyric / firestore"
 section: "How-to"
-order: 81
+order: 12006
 ---
 # How to run a transaction
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
@@ -3,7 +3,7 @@ title: "How to use onSnapshot"
 navLabel: "Use onSnapshot"
 group: "pyric / firestore"
 section: "How-to"
-order: 82
+order: 12007
 ---
 # How to use `onSnapshot`
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
@@ -3,7 +3,7 @@ title: "How to use sandbox-only operations"
 navLabel: "Use sandbox-only ops"
 group: "pyric / firestore"
 section: "How-to"
-order: 83
+order: 12008
 ---
 # How to use sandbox-only operations
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / firestore"
 section: "Reference"
-order: 84
+order: 12009
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-feature-matrix.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-feature-matrix.md
@@ -3,7 +3,7 @@ title: "Feature matrix: pyric/firestore coverage of firebase/firestore"
 navLabel: "Feature matrix"
 group: "pyric / firestore"
 section: "Reference"
-order: 85
+order: 12010
 ---
 # Feature matrix: `pyric/firestore` coverage of `firebase/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
@@ -2,7 +2,7 @@
 title: "getFirestore overloads"
 group: "pyric / firestore"
 section: "Reference"
-order: 86
+order: 12011
 ---
 # `getFirestore` overloads
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
@@ -2,7 +2,7 @@
 title: "Query constraints"
 group: "pyric / firestore"
 section: "Reference"
-order: 87
+order: 12012
 ---
 # Query constraints
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
@@ -2,7 +2,7 @@
 title: "Sandbox-only operations"
 group: "pyric / firestore"
 section: "Reference"
-order: 88
+order: 12013
 ---
 # Sandbox-only operations
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
@@ -2,7 +2,7 @@
 title: "Tool factories"
 group: "pyric / firestore"
 section: "Reference"
-order: 89
+order: 12014
 ---
 # Tool factories
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
@@ -3,7 +3,7 @@ title: "Write a sandbox-backed demo"
 navLabel: "Sandbox-backed demo"
 group: "pyric / firestore"
 section: "Tutorials"
-order: 77
+order: 12002
 ---
 # Write a sandbox-backed demo
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
@@ -3,7 +3,7 @@ title: "Swap the demo to the prod backend"
 navLabel: "Swap to prod backend"
 group: "pyric / firestore"
 section: "Tutorials"
-order: 78
+order: 12003
 ---
 # Swap the demo to the prod backend
 

--- a/packages/site-docs/src/content/docs/pyric-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore.md
@@ -3,7 +3,7 @@ title: "pyric/firestore"
 navLabel: "Overview"
 group: "pyric / firestore"
 section: ""
-order: 76
+order: 12001
 ---
 # `pyric/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-messaging-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-messaging-compat.md
@@ -3,7 +3,7 @@ title: "pyric messaging compatibility matrix"
 navLabel: "Messaging"
 group: "Compatibility"
 section: ""
-order: 34
+order: 8005
 ---
 <!-- Generated from scripts/compat/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
@@ -3,7 +3,7 @@ title: "Agent failure modes the linter catches"
 navLabel: "Agent failure modes"
 group: "pyric / rules"
 section: "Explanation"
-order: 112
+order: 13020
 ---
 # Agent failure modes the linter catches
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-lint-vs-validate-vs-simulate-vs-test.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-lint-vs-validate-vs-simulate-vs-test.md
@@ -3,7 +3,7 @@ title: "Lint vs validate vs simulate vs test"
 navLabel: "Lint vs validate vs test"
 group: "pyric / rules"
 section: "Explanation"
-order: 113
+order: 13021
 ---
 # Lint vs validate vs simulate vs test
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
@@ -3,7 +3,7 @@ title: "The runtime budget and shared gates"
 navLabel: "Runtime budget and gates"
 group: "pyric / rules"
 section: "Explanation"
-order: 114
+order: 13022
 ---
 # The runtime budget and shared gates
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
@@ -3,7 +3,7 @@ title: "The sentinel expression engine ($expr)"
 navLabel: "Sentinel expression engine"
 group: "pyric / rules"
 section: "Explanation"
-order: 115
+order: 13023
 ---
 # The sentinel expression engine (`$expr`)
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
@@ -2,7 +2,7 @@
 title: "Simulator vs Rules Test API"
 group: "pyric / rules"
 section: "Explanation"
-order: 116
+order: 13024
 ---
 # Simulator vs Rules Test API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
@@ -2,7 +2,7 @@
 title: "The 2+modules extension"
 group: "pyric / rules"
 section: "Explanation"
-order: 117
+order: 13025
 ---
 # The `2+modules` extension
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
@@ -2,7 +2,7 @@
 title: "Value wrapper design"
 group: "pyric / rules"
 section: "Explanation"
-order: 118
+order: 13026
 ---
 # Value wrapper design
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-why-this-package-exists.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-why-this-package-exists.md
@@ -2,7 +2,7 @@
 title: "Why this package exists"
 group: "pyric / rules"
 section: "Explanation"
-order: 119
+order: 13027
 ---
 # Why this package exists
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
@@ -3,7 +3,7 @@ title: "How to compare two rulesets for weakening"
 navLabel: "Compare rulesets"
 group: "pyric / rules"
 section: "How-to"
-order: 94
+order: 13002
 ---
 # How to compare two rulesets for weakening
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
@@ -3,7 +3,7 @@ title: "How to inspect rules through the AST"
 navLabel: "Inspect rules via the AST"
 group: "pyric / rules"
 section: "How-to"
-order: 95
+order: 13003
 ---
 # How to inspect rules through the AST
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
@@ -3,7 +3,7 @@ title: "How to lint a rules source"
 navLabel: "Lint a rules source"
 group: "pyric / rules"
 section: "How-to"
-order: 96
+order: 13004
 ---
 # How to lint a rules source
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
@@ -3,7 +3,7 @@ title: "How to pin request.time for deterministic tests"
 navLabel: "Pin request.time"
 group: "pyric / rules"
 section: "How-to"
-order: 97
+order: 13005
 ---
 # How to pin `request.time` for deterministic tests
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
@@ -3,7 +3,7 @@ title: "How to register rules tools with an agent"
 navLabel: "Register rules tools"
 group: "pyric / rules"
 section: "How-to"
-order: 98
+order: 13006
 ---
 # How to register rules tools with an agent
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
@@ -3,7 +3,7 @@ title: "How to resolve 2+modules imports"
 navLabel: "Resolve 2+modules imports"
 group: "pyric / rules"
 section: "How-to"
-order: 99
+order: 13007
 ---
 # How to resolve `2+modules` imports
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
@@ -3,7 +3,7 @@ title: "How to simulate rules locally"
 navLabel: "Simulate rules locally"
 group: "pyric / rules"
 section: "How-to"
-order: 100
+order: 13008
 ---
 # How to simulate rules locally
 

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
@@ -3,7 +3,7 @@ title: "How to test rules against the Firebase Rules Test API"
 navLabel: "Test rules against Firebase"
 group: "pyric / rules"
 section: "How-to"
-order: 101
+order: 13009
 ---
 # How to test rules against the Firebase Rules Test API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / rules"
 section: "Reference"
-order: 102
+order: 13010
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
@@ -2,7 +2,7 @@
 title: "AST"
 group: "pyric / rules"
 section: "Reference"
-order: 103
+order: 13011
 ---
 # AST
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
@@ -2,7 +2,7 @@
 title: "Rules simulator conformance gaps"
 group: "pyric / rules"
 section: "Reference"
-order: 104
+order: 13012
 ---
 # Rules simulator conformance gaps
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
@@ -2,7 +2,7 @@
 title: "Errors"
 group: "pyric / rules"
 section: "Reference"
-order: 105
+order: 13013
 ---
 # Errors
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-lint-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-lint-rules.md
@@ -2,7 +2,7 @@
 title: "Lint rules"
 group: "pyric / rules"
 section: "Reference"
-order: 106
+order: 13014
 ---
 # Lint rules
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
@@ -3,7 +3,7 @@ title: "Simulator context and result states"
 navLabel: "Simulator context"
 group: "pyric / rules"
 section: "Reference"
-order: 107
+order: 13015
 ---
 # Simulator context and result states
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
@@ -2,7 +2,7 @@
 title: "Standard library modules"
 group: "pyric / rules"
 section: "Reference"
-order: 108
+order: 13016
 ---
 # Standard library modules
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
@@ -2,7 +2,7 @@
 title: "TestCase schema"
 group: "pyric / rules"
 section: "Reference"
-order: 109
+order: 13017
 ---
 # `TestCase` schema
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
@@ -2,7 +2,7 @@
 title: "Validator findings"
 group: "pyric / rules"
 section: "Reference"
-order: 110
+order: 13018
 ---
 # Validator findings
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
@@ -2,7 +2,7 @@
 title: "Value wrappers"
 group: "pyric / rules"
 section: "Reference"
-order: 111
+order: 13019
 ---
 # Value wrappers
 

--- a/packages/site-docs/src/content/docs/pyric-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules.md
@@ -3,7 +3,7 @@ title: "pyric/rules"
 navLabel: "Overview"
 group: "pyric / rules"
 section: ""
-order: 93
+order: 13001
 ---
 # `pyric/rules`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
@@ -2,7 +2,7 @@
 title: "Every operation is a request"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 137
+order: 14018
 ---
 # Every operation is a request
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
@@ -3,7 +3,7 @@ title: "Identity is a context, not a sandbox"
 navLabel: "Identity is a context"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 138
+order: 14019
 ---
 # Identity is a context, not a sandbox
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
@@ -3,7 +3,7 @@ title: "The /internal adapter protocol"
 navLabel: "The /internal protocol"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 139
+order: 14020
 ---
 # The `/internal` adapter protocol
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
@@ -3,7 +3,7 @@ title: "Listener re-evaluation on deployRules"
 navLabel: "Listener re-evaluation"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 140
+order: 14021
 ---
 # Listener re-evaluation on `deployRules`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-local-backend-vs-firestore-offline.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-local-backend-vs-firestore-offline.md
@@ -3,7 +3,7 @@ title: "A local backend, not Firestore offline persistence"
 navLabel: "Local backend vs. offline"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 141
+order: 14022
 ---
 # A local backend, not Firestore offline persistence
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
@@ -3,7 +3,7 @@ title: "Why service adapters live in sibling packages"
 navLabel: "Why adapters are siblings"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 142
+order: 14023
 ---
 # Why service adapters live in sibling packages
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-this-package-exists.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-this-package-exists.md
@@ -2,7 +2,7 @@
 title: "Why this package exists"
 group: "pyric / sandbox"
 section: "Explanation"
-order: 143
+order: 14024
 ---
 # Why this package exists
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
@@ -3,7 +3,7 @@ title: "How to run multiple isolated sandboxes in parallel"
 navLabel: "Run isolated sandboxes"
 group: "pyric / sandbox"
 section: "How-to"
-order: 122
+order: 14003
 ---
 # How to run multiple isolated sandboxes in parallel
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
@@ -3,7 +3,7 @@ title: "How to observe sandbox events"
 navLabel: "Observe sandbox events"
 group: "pyric / sandbox"
 section: "How-to"
-order: 123
+order: 14004
 ---
 # How to observe sandbox events
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
@@ -3,7 +3,7 @@ title: "How to pick between pyric-admin and pyric/firestore"
 navLabel: "Pick an adapter"
 group: "pyric / sandbox"
 section: "How-to"
-order: 124
+order: 14005
 ---
 # How to pick between `pyric-admin` and `pyric/firestore`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
@@ -3,7 +3,7 @@ title: "How to replay a captured event stream"
 navLabel: "Replay events"
 group: "pyric / sandbox"
 section: "How-to"
-order: 125
+order: 14006
 ---
 # How to replay a captured event stream
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
@@ -3,7 +3,7 @@ title: "How to reset between tests"
 navLabel: "Reset between tests"
 group: "pyric / sandbox"
 section: "How-to"
-order: 126
+order: 14007
 ---
 # How to reset between tests
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
@@ -3,7 +3,7 @@ title: "How to seed initial data and rules"
 navLabel: "Seed data and rules"
 group: "pyric / sandbox"
 section: "How-to"
-order: 127
+order: 14008
 ---
 # How to seed initial data and rules
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
@@ -3,7 +3,7 @@ title: "How to switch users with withAuth"
 navLabel: "Switch users"
 group: "pyric / sandbox"
 section: "How-to"
-order: 128
+order: 14009
 ---
 # How to switch users with `withAuth`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
@@ -3,7 +3,7 @@ title: "How to use admin reads to assert in tests"
 navLabel: "Use admin reads"
 group: "pyric / sandbox"
 section: "How-to"
-order: 129
+order: 14010
 ---
 # How to use admin reads to assert in tests
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / sandbox"
 section: "Reference"
-order: 130
+order: 14011
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
@@ -2,7 +2,7 @@
 title: "Divergence"
 group: "pyric / sandbox"
 section: "Reference"
-order: 131
+order: 14012
 ---
 # `Divergence`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
@@ -2,7 +2,7 @@
 title: "SandboxError codes"
 group: "pyric / sandbox"
 section: "Reference"
-order: 132
+order: 14013
 ---
 # `SandboxError` codes
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
@@ -3,7 +3,7 @@ title: "The /internal adapter protocol"
 navLabel: "The /internal protocol"
 group: "pyric / sandbox"
 section: "Reference"
-order: 133
+order: 14014
 ---
 # The `/internal` adapter protocol
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
@@ -3,7 +3,7 @@ title: "Sandbox, SandboxContext, AuthState"
 navLabel: "Sandbox and context"
 group: "pyric / sandbox"
 section: "Reference"
-order: 134
+order: 14015
 ---
 # `Sandbox`, `SandboxContext`, `AuthState`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
@@ -2,7 +2,7 @@
 title: "SandboxEvent"
 group: "pyric / sandbox"
 section: "Reference"
-order: 135
+order: 14016
 ---
 # `SandboxEvent`
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
@@ -3,7 +3,7 @@ title: "SandboxSnapshot and admin reads"
 navLabel: "Snapshot and admin reads"
 group: "pyric / sandbox"
 section: "Reference"
-order: 136
+order: 14017
 ---
 # `SandboxSnapshot` and admin reads
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
@@ -2,7 +2,7 @@
 title: "Your first sandbox session"
 group: "pyric / sandbox"
 section: "Tutorials"
-order: 121
+order: 14002
 ---
 # Your first sandbox session
 

--- a/packages/site-docs/src/content/docs/pyric-sandbox.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox.md
@@ -3,7 +3,7 @@ title: "pyric/sandbox"
 navLabel: "Overview"
 group: "pyric / sandbox"
 section: ""
-order: 120
+order: 14001
 ---
 # `pyric/sandbox`
 

--- a/packages/site-docs/src/content/docs/pyric-storage-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-compat.md
@@ -3,7 +3,7 @@ title: "pyric/storage compatibility matrix"
 navLabel: "Storage"
 group: "Compatibility"
 section: ""
-order: 33
+order: 8004
 ---
 <!-- Generated from scripts/compat/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
@@ -3,7 +3,7 @@ title: "Implementation scope and deferred features"
 navLabel: "Implementation scope"
 group: "pyric / storage"
 section: "Explanation"
-order: 154
+order: 15011
 ---
 # Implementation scope and deferred features
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
@@ -2,7 +2,7 @@
 title: "The session-archive driver"
 group: "pyric / storage"
 section: "Explanation"
-order: 155
+order: 15012
 ---
 # The session-archive driver
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-why-indexeddb.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-why-indexeddb.md
@@ -2,7 +2,7 @@
 title: "Why IndexedDB"
 group: "pyric / storage"
 section: "Explanation"
-order: 156
+order: 15013
 ---
 # Why IndexedDB
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
@@ -3,7 +3,7 @@ title: "How to enforce Storage rules"
 navLabel: "Enforce Storage rules"
 group: "pyric / storage"
 section: "How-to"
-order: 145
+order: 15002
 ---
 # How to enforce Storage rules
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
@@ -3,7 +3,7 @@ title: "How to list and delete objects"
 navLabel: "List and delete objects"
 group: "pyric / storage"
 section: "How-to"
-order: 146
+order: 15003
 ---
 # How to list and delete objects
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
@@ -3,7 +3,7 @@ title: "How to switch between sandbox and prod backends"
 navLabel: "Switch backends"
 group: "pyric / storage"
 section: "How-to"
-order: 147
+order: 15004
 ---
 # How to switch between sandbox and prod backends
 

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
@@ -3,7 +3,7 @@ title: "How to test rule expressions independently"
 navLabel: "Test rule expressions"
 group: "pyric / storage"
 section: "How-to"
-order: 148
+order: 15005
 ---
 # How to test rule expressions independently
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric / storage"
 section: "Reference"
-order: 149
+order: 15006
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
@@ -2,7 +2,7 @@
 title: "Storage rules evaluator conformance gaps"
 group: "pyric / storage"
 section: "Reference"
-order: 150
+order: 15007
 ---
 # Storage rules evaluator conformance gaps
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
@@ -2,7 +2,7 @@
 title: "Error codes"
 group: "pyric / storage"
 section: "Reference"
-order: 151
+order: 15008
 ---
 # Error codes
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
@@ -2,7 +2,7 @@
 title: "Storage rules subset"
 group: "pyric / storage"
 section: "Reference"
-order: 152
+order: 15009
 ---
 # Storage rules subset
 

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
@@ -2,7 +2,7 @@
 title: "StorageOptions"
 group: "pyric / storage"
 section: "Reference"
-order: 153
+order: 15010
 ---
 # `StorageOptions`
 

--- a/packages/site-docs/src/content/docs/pyric-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-storage.md
@@ -3,7 +3,7 @@ title: "pyric/storage"
 navLabel: "Overview"
 group: "pyric / storage"
 section: ""
-order: 144
+order: 15001
 ---
 # `pyric/storage`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-bridge.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-bridge.md
@@ -2,7 +2,7 @@
 title: "pyric-tools/bridge"
 group: "pyric-tools"
 section: "Bridge"
-order: 47
+order: 9013
 ---
 # `pyric-tools/bridge`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-primitives-vs-orchestrators.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-primitives-vs-orchestrators.md
@@ -3,7 +3,7 @@ title: "Primitives throw, orchestrators return"
 navLabel: "Primitives vs. orchestrators"
 group: "pyric-tools / deploy"
 section: "Explanation"
-order: 71
+order: 10024
 ---
 # Primitives throw, orchestrators return
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-token-caching.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-token-caching.md
@@ -2,7 +2,7 @@
 title: "Token caching and memoizeTtl"
 group: "pyric-tools / deploy"
 section: "Explanation"
-order: 72
+order: 10025
 ---
 # Token caching and `memoizeTtl`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-why-no-firebase-cli.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-why-no-firebase-cli.md
@@ -3,7 +3,7 @@ title: "Why no firebase CLI dependency"
 navLabel: "Why no Firebase CLI"
 group: "pyric-tools / deploy"
 section: "Explanation"
-order: 73
+order: 10026
 ---
 # Why no `firebase` CLI dependency
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-why-this-package-exists.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-explanation-why-this-package-exists.md
@@ -2,7 +2,7 @@
 title: "Why this package exists"
 group: "pyric-tools / deploy"
 section: "Explanation"
-order: 74
+order: 10027
 ---
 # Why this package exists
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-build-projectscope-from-firebase-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-build-projectscope-from-firebase-auth.md
@@ -3,7 +3,7 @@ title: "How to build a ProjectScope from Firebase Auth (browser)"
 navLabel: "Scope from Firebase Auth"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 50
+order: 10003
 ---
 # How to build a `ProjectScope` from Firebase Auth (browser)
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-build-projectscope-from-service-account.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-build-projectscope-from-service-account.md
@@ -3,7 +3,7 @@ title: "How to build a ProjectScope from a service account"
 navLabel: "Scope from service account"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 51
+order: 10004
 ---
 # How to build a `ProjectScope` from a service account
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-bundle-and-deploy-a-function.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-bundle-and-deploy-a-function.md
@@ -3,7 +3,7 @@ title: "How to bundle and deploy a Cloud Function"
 navLabel: "Bundle & deploy a function"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 52
+order: 10005
 ---
 # How to bundle and deploy a Cloud Function
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-firestore-indexes.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-firestore-indexes.md
@@ -3,7 +3,7 @@ title: "How to deploy Firestore indexes"
 navLabel: "Deploy Firestore indexes"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 53
+order: 10006
 ---
 # How to deploy Firestore indexes
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-firestore-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-firestore-rules.md
@@ -3,7 +3,7 @@ title: "How to deploy Firestore rules"
 navLabel: "Deploy Firestore rules"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 54
+order: 10007
 ---
 # How to deploy Firestore rules
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-hosting-rewrites.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-hosting-rewrites.md
@@ -3,7 +3,7 @@ title: "How to deploy Hosting rewrites that route to Cloud Functions"
 navLabel: "Deploy Hosting rewrites"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 55
+order: 10008
 ---
 # How to deploy Hosting rewrites that route to Cloud Functions
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-realtime-database-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-realtime-database-rules.md
@@ -3,7 +3,7 @@ title: "How to deploy Realtime Database rules"
 navLabel: "Deploy RTDB rules"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 56
+order: 10009
 ---
 # How to deploy Realtime Database rules
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-to-a-preview-channel.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-deploy-to-a-preview-channel.md
@@ -3,7 +3,7 @@ title: "How to deploy to a Hosting preview channel"
 navLabel: "Deploy to a preview channel"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 57
+order: 10010
 ---
 # How to deploy to a Hosting preview channel
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-handle-errors-and-outcomes.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-handle-errors-and-outcomes.md
@@ -3,7 +3,7 @@ title: "How to handle AdminApiError and Outcome failures"
 navLabel: "Handle errors and outcomes"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 58
+order: 10011
 ---
 # How to handle `AdminApiError` and `Outcome` failures
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-provision-a-firestore-database.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-provision-a-firestore-database.md
@@ -3,7 +3,7 @@ title: "How to provision a Firestore database"
 navLabel: "Provision a database"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 59
+order: 10012
 ---
 # How to provision a Firestore database
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-register-tools-with-an-agent.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-how-to-register-tools-with-an-agent.md
@@ -3,7 +3,7 @@ title: "How to register deploy tools with an agent"
 navLabel: "Register deploy tools"
 group: "pyric-tools / deploy"
 section: "How-to"
-order: 60
+order: 10013
 ---
 # How to register deploy tools with an agent
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-api.md
@@ -2,7 +2,7 @@
 title: "Public API"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 61
+order: 10014
 ---
 # Public API
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-cli-agent-io.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-cli-agent-io.md
@@ -3,7 +3,7 @@ title: "pyric deploy agent I/O: --schema and --json"
 navLabel: "pyric deploy agent I/O"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 62
+order: 10015
 ---
 # `pyric deploy` agent I/O: `--schema` and `--json`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-error-codes.md
@@ -2,7 +2,7 @@
 title: "Error codes by operation"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 63
+order: 10016
 ---
 # Error codes by operation
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-firestore-namespace.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-firestore-namespace.md
@@ -2,7 +2,7 @@
 title: "firestore namespace"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 64
+order: 10017
 ---
 # `firestore` namespace
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-functions-namespace.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-functions-namespace.md
@@ -2,7 +2,7 @@
 title: "functions namespace"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 65
+order: 10018
 ---
 # `functions` namespace
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-hosting-config.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-hosting-config.md
@@ -3,7 +3,7 @@ title: "firebase.json hosting config: supported keys and REST translation"
 navLabel: "firebase.json hosting config"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 66
+order: 10019
 ---
 # firebase.json hosting config: supported keys and REST translation
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-hosting-namespace.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-hosting-namespace.md
@@ -2,7 +2,7 @@
 title: "hosting namespace"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 67
+order: 10020
 ---
 # `hosting` namespace
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-rtdb-namespace.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-rtdb-namespace.md
@@ -2,7 +2,7 @@
 title: "rtdb namespace"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 68
+order: 10021
 ---
 # `rtdb` namespace
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-scope-and-outcome.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-scope-and-outcome.md
@@ -3,7 +3,7 @@ title: "ProjectScope, Outcome, AdminApiError"
 navLabel: "Scope and Outcome"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 69
+order: 10022
 ---
 # `ProjectScope`, `Outcome`, `AdminApiError`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-tool-factories.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-reference-tool-factories.md
@@ -2,7 +2,7 @@
 title: "Tool factories"
 group: "pyric-tools / deploy"
 section: "Reference"
-order: 70
+order: 10023
 ---
 # Tool factories
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy-tutorials-01-deploy-a-cloud-function.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy-tutorials-01-deploy-a-cloud-function.md
@@ -2,7 +2,7 @@
 title: "Deploy a Cloud Function"
 group: "pyric-tools / deploy"
 section: "Tutorials"
-order: 49
+order: 10002
 ---
 # Deploy a Cloud Function
 

--- a/packages/site-docs/src/content/docs/pyric-tools-deploy.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-deploy.md
@@ -3,7 +3,7 @@ title: "pyric-tools/deploy"
 navLabel: "Overview"
 group: "pyric-tools / deploy"
 section: ""
-order: 48
+order: 10001
 ---
 # `pyric-tools/deploy`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-build-a-standalone-binary.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-build-a-standalone-binary.md
@@ -3,7 +3,7 @@ title: "Build a standalone pyric binary"
 navLabel: "Build a standalone binary"
 group: "pyric-tools"
 section: "How-to"
-order: 38
+order: 9004
 ---
 # Build a standalone `pyric` binary
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-configure-auth-providers-and-domains.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-configure-auth-providers-and-domains.md
@@ -3,7 +3,7 @@ title: "How to configure auth providers and authorised domains"
 navLabel: "Configure auth providers"
 group: "pyric-tools"
 section: "How-to"
-order: 39
+order: 9005
 ---
 # How to configure auth providers and authorised domains
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-discover-a-schema-from-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-discover-a-schema-from-firestore.md
@@ -3,7 +3,7 @@ title: "How to infer a schema from an existing Firestore"
 navLabel: "Infer a schema"
 group: "pyric-tools"
 section: "How-to"
-order: 40
+order: 9006
 ---
 # How to infer a schema from an existing Firestore
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-promote-sandbox-state-to-a-fixture.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-promote-sandbox-state-to-a-fixture.md
@@ -3,7 +3,7 @@ title: "How to promote sandbox state to a committable fixture"
 navLabel: "Promote sandbox state"
 group: "pyric-tools"
 section: "How-to"
-order: 41
+order: 9007
 ---
 # How to promote sandbox state to a committable fixture
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-serve-persistence-and-multi-tab.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-serve-persistence-and-multi-tab.md
@@ -3,7 +3,7 @@ title: "Persistence and multi-tab with pyric dev"
 navLabel: "Persistence & multi-tab"
 group: "pyric-tools"
 section: "How-to"
-order: 42
+order: 9008
 ---
 # Persistence and multi-tab with `pyric dev`
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-use-the-vite-plugin.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-use-the-vite-plugin.md
@@ -3,7 +3,7 @@ title: "Use the Vite plugin (pyric-tools/vite)"
 navLabel: "Use the Vite plugin"
 group: "pyric-tools"
 section: "How-to"
-order: 43
+order: 9009
 ---
 # Use the Vite plugin (`pyric-tools/vite`)
 

--- a/packages/site-docs/src/content/docs/pyric-tools-how-to-verify-against-a-captured-session.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-how-to-verify-against-a-captured-session.md
@@ -3,7 +3,7 @@ title: "How to verify your rules against a captured session"
 navLabel: "Verify rules against prod"
 group: "pyric-tools"
 section: "How-to"
-order: 44
+order: 9010
 ---
 # How to verify your rules against a captured session
 

--- a/packages/site-docs/src/content/docs/pyric-tools-reference-cli.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-reference-cli.md
@@ -2,7 +2,7 @@
 title: "pyric CLI reference"
 group: "pyric-tools"
 section: "Reference"
-order: 45
+order: 9011
 ---
 # `pyric` CLI reference
 

--- a/packages/site-docs/src/content/docs/pyric-tools-reference-verify.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-reference-verify.md
@@ -2,7 +2,7 @@
 title: "Verify API"
 group: "pyric-tools"
 section: "Reference"
-order: 46
+order: 9012
 ---
 # Verify API
 

--- a/packages/site-docs/src/content/docs/pyric-tools-tutorials-server-adoption.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-tutorials-server-adoption.md
@@ -2,7 +2,7 @@
 title: "Run your firebase-admin app on the pyric sandbox"
 group: "pyric-tools"
 section: "Tutorials"
-order: 36
+order: 9002
 ---
 # Run your firebase-admin app on the pyric sandbox
 

--- a/packages/site-docs/src/content/docs/pyric-tools-tutorials-wire-claude-code.md
+++ b/packages/site-docs/src/content/docs/pyric-tools-tutorials-wire-claude-code.md
@@ -3,7 +3,7 @@ title: "Wire Claude Code to your pyric sandbox (manual MCP wiring)"
 navLabel: "Wire Claude Code"
 group: "pyric-tools"
 section: "Tutorials"
-order: 37
+order: 9003
 ---
 # Wire Claude Code to your pyric sandbox (manual MCP wiring)
 

--- a/packages/site-docs/src/content/docs/pyric-tools.md
+++ b/packages/site-docs/src/content/docs/pyric-tools.md
@@ -3,7 +3,7 @@ title: "pyric-tools"
 navLabel: "Overview"
 group: "pyric-tools"
 section: ""
-order: 35
+order: 9001
 ---
 # pyric-tools documentation
 

--- a/packages/site-docs/src/content/docs/read-a-denial.md
+++ b/packages/site-docs/src/content/docs/read-a-denial.md
@@ -3,7 +3,7 @@ title: "Never debug a bare permission-denied again"
 navLabel: "Read a denial and understand it"
 group: "Secure & debug"
 section: ""
-order: 12
+order: 3004
 description: "See which rule denied an operation, on what path, with what data, the moment it happens."
 ---
 

--- a/packages/site-docs/src/content/docs/rtdb-rules-in-typescript.md
+++ b/packages/site-docs/src/content/docs/rtdb-rules-in-typescript.md
@@ -3,7 +3,7 @@ title: "Write Realtime Database rules in TypeScript"
 navLabel: "RTDB rules in TypeScript"
 group: "Secure & debug"
 section: ""
-order: 15
+order: 3007
 description: "Compose RTDB rules from typed constraints, prove them in-process, and deploy the compiled JSON."
 ---
 

--- a/packages/site-docs/src/content/docs/rules-patterns.md
+++ b/packages/site-docs/src/content/docs/rules-patterns.md
@@ -3,7 +3,7 @@ title: "The techniques hard rules are built from"
 navLabel: "Rules patterns"
 group: "Secure & debug"
 section: ""
-order: 14
+order: 3006
 description: "Learn the five moves that turn \"rules can't do that\" into a ruleset that deploys."
 ---
 

--- a/packages/site-docs/src/content/docs/rules-standard-library.md
+++ b/packages/site-docs/src/content/docs/rules-standard-library.md
@@ -3,7 +3,7 @@ title: "Build your rules from tested parts"
 navLabel: "The rules standard library"
 group: "Secure & debug"
 section: ""
-order: 13
+order: 3005
 description: "Compose security rules from tested modules, with an import system that compiles away before Firebase ever sees it."
 ---
 

--- a/packages/site-docs/src/content/docs/secure-it-with-rules.md
+++ b/packages/site-docs/src/content/docs/secure-it-with-rules.md
@@ -3,7 +3,7 @@ title: "Prove a user can touch only their own data"
 navLabel: "Security Rules"
 group: "Secure & debug"
 section: ""
-order: 9
+order: 3001
 description: "Write a rule, simulate a request against it, read the verdict, and deploy knowing what it allows."
 ---
 

--- a/packages/site-docs/src/content/docs/see-whats-happening.md
+++ b/packages/site-docs/src/content/docs/see-whats-happening.md
@@ -3,7 +3,7 @@ title: "Watch every read, write, and denial live"
 navLabel: "Traffic & rule verdicts"
 group: "Observe & shape"
 section: ""
-order: 19
+order: 4001
 description: "See every operation your backend performs, with its rules verdict, without writing a log line."
 ---
 

--- a/packages/site-docs/src/content/docs/set-up-the-project.md
+++ b/packages/site-docs/src/content/docs/set-up-the-project.md
@@ -3,7 +3,7 @@ title: "Stand up the real Firebase project without leaving the terminal"
 navLabel: "Set up the project"
 group: "Ship & test"
 section: ""
-order: 22
+order: 5002
 description: "Enable providers, authorize domains, and provision databases, Storage, and hosting sites from the CLI or a script."
 ---
 

--- a/packages/site-docs/src/content/docs/set-up-your-agent.md
+++ b/packages/site-docs/src/content/docs/set-up-your-agent.md
@@ -3,7 +3,7 @@ title: "Point your agent at the sandbox"
 navLabel: "Set up your agent"
 group: "Work with an agent"
 section: ""
-order: 24
+order: 6001
 description: "Connect Claude Code, Cursor, Codex, or any MCP client to your backend in minutes."
 ---
 

--- a/packages/site-docs/src/content/docs/shape-your-data.md
+++ b/packages/site-docs/src/content/docs/shape-your-data.md
@@ -3,7 +3,7 @@ title: "Seed, snapshot, reset, and replay the backend like source"
 navLabel: "Seed, snapshot, replay"
 group: "Observe & shape"
 section: ""
-order: 20
+order: 4002
 description: "Put the backend in any state you want, capture the good ones, and get them back on demand."
 ---
 

--- a/packages/site-docs/src/content/docs/ship-to-production.md
+++ b/packages/site-docs/src/content/docs/ship-to-production.md
@@ -3,7 +3,7 @@ title: "The same code goes live"
 navLabel: "Ship to production"
 group: "Ship & test"
 section: ""
-order: 21
+order: 5001
 description: "Deploy rules, indexes, hosting, and functions, and learn what would change before production does."
 ---
 

--- a/packages/site-docs/src/content/docs/sign-in-and-manage-users.md
+++ b/packages/site-docs/src/content/docs/sign-in-and-manage-users.md
@@ -3,7 +3,7 @@ title: "Sign users in and manage them"
 navLabel: "Sign in and manage users"
 group: "Build"
 section: ""
-order: 4
+order: 2001
 description: "Run real auth flows against a local user database, seed test users with claims, and design an identity model your rules can trust."
 ---
 

--- a/packages/site-docs/src/content/docs/simulate-and-lint.md
+++ b/packages/site-docs/src/content/docs/simulate-and-lint.md
@@ -3,7 +3,7 @@ title: "Catch the error before Firebase's opaque 400"
 navLabel: "Simulate and lint before you deploy"
 group: "Secure & debug"
 section: ""
-order: 10
+order: 3002
 description: "Get a rules verdict and a lint report locally, before production answers with an unexplained 400 or 403."
 ---
 

--- a/packages/site-docs/src/content/docs/skills.md
+++ b/packages/site-docs/src/content/docs/skills.md
@@ -3,7 +3,7 @@ title: "Teach your agent the hard Firebase things"
 navLabel: "Skills"
 group: "Work with an agent"
 section: ""
-order: 26
+order: 6003
 description: "Packaged expert procedures for the problems that need a method, not more tools."
 ---
 

--- a/packages/site-docs/src/content/docs/start-building.md
+++ b/packages/site-docs/src/content/docs/start-building.md
@@ -3,7 +3,7 @@ title: "Your backend in one command"
 navLabel: "Quickstart"
 group: "Get started"
 section: ""
-order: 2
+order: 1001
 description: "Run a working Firebase backend locally, in a new app or the one you already have."
 ---
 

--- a/packages/site-docs/src/content/docs/store-and-query-data.md
+++ b/packages/site-docs/src/content/docs/store-and-query-data.md
@@ -2,7 +2,7 @@
 title: "Store and query data"
 group: "Build"
 section: ""
-order: 5
+order: 2002
 description: "Read, write, query, and stream Firestore documents locally, and derive the composite indexes your queries need from your source."
 ---
 

--- a/packages/site-docs/src/content/docs/store-files.md
+++ b/packages/site-docs/src/content/docs/store-files.md
@@ -2,7 +2,7 @@
 title: "Store files"
 group: "Build"
 section: ""
-order: 7
+order: 2004
 description: "Upload, list, download, and delete files locally, with storage rules enforced in-process."
 ---
 

--- a/packages/site-docs/src/content/docs/sync-realtime-data.md
+++ b/packages/site-docs/src/content/docs/sync-realtime-data.md
@@ -2,7 +2,7 @@
 title: "Sync realtime data"
 group: "Build"
 section: ""
-order: 6
+order: 2003
 description: "Store and watch a Realtime Database tree locally, model it around your reads, and guard writes with schema and rules checks."
 ---
 

--- a/packages/site-docs/src/content/docs/test-in-node.md
+++ b/packages/site-docs/src/content/docs/test-in-node.md
@@ -3,7 +3,7 @@ title: "The same backend in tests and scripts"
 navLabel: "Test in Node"
 group: "Ship & test"
 section: ""
-order: 23
+order: 5003
 description: "Run your rules and data logic in a Node test suite, with no browser and no emulator."
 ---
 

--- a/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
@@ -3,7 +3,7 @@ title: "<AuthSignInHelper> + useAuthFlowHelper"
 navLabel: "AuthSignInHelper"
 group: "@pyric/ui"
 section: "Auth"
-order: 217
+order: 23029
 ---
 # `<AuthSignInHelper>` + `useAuthFlowHelper`
 

--- a/packages/site-docs/src/content/docs/ui-auth-authusers.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authusers.md
@@ -3,7 +3,7 @@ title: "Auth users admin — useAuthUsers, <AuthUserList>, <AuthUserForm>"
 navLabel: "Auth users admin"
 group: "@pyric/ui"
 section: "Auth"
-order: 218
+order: 23030
 ---
 # Auth users admin — `useAuthUsers`, `<AuthUserList>`, `<AuthUserForm>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
@@ -2,7 +2,7 @@
 title: "<CollectionList>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 197
+order: 23009
 ---
 # `<CollectionList>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
@@ -2,7 +2,7 @@
 title: "<DeleteWithConfirm>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 198
+order: 23010
 ---
 # `<DeleteWithConfirm>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
@@ -2,7 +2,7 @@
 title: "<DocumentEditor>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 199
+order: 23011
 ---
 # `<DocumentEditor>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
@@ -2,7 +2,7 @@
 title: "<DocumentList>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 200
+order: 23012
 ---
 # `<DocumentList>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
@@ -2,7 +2,7 @@
 title: "<DocumentPreview>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 201
+order: 23013
 ---
 # `<DocumentPreview>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
@@ -2,7 +2,7 @@
 title: "<QueryBuilder>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 202
+order: 23014
 ---
 # `<QueryBuilder>`
 

--- a/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
@@ -2,7 +2,7 @@
 title: "<ReferencePicker>"
 group: "@pyric/ui"
 section: "Firestore"
-order: 203
+order: 23015
 ---
 # `<ReferencePicker>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-badge.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-badge.md
@@ -2,7 +2,7 @@
 title: "<Badge>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 190
+order: 23002
 ---
 # `<Badge>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
@@ -2,7 +2,7 @@
 title: "<ConfirmDialog> + useConfirm"
 group: "@pyric/ui"
 section: "Primitives"
-order: 191
+order: 23003
 ---
 # `<ConfirmDialog>` + `useConfirm`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
@@ -2,7 +2,7 @@
 title: "<CopyButton>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 192
+order: 23004
 ---
 # `<CopyButton>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
@@ -2,7 +2,7 @@
 title: "<JsonView>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 193
+order: 23005
 ---
 # `<JsonView>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
@@ -2,7 +2,7 @@
 title: "<SegmentedControl>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 194
+order: 23006
 ---
 # `<SegmentedControl>`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-toast.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-toast.md
@@ -2,7 +2,7 @@
 title: "<ToastProvider> + useToast"
 group: "@pyric/ui"
 section: "Primitives"
-order: 195
+order: 23007
 ---
 # `<ToastProvider>` + `useToast`
 

--- a/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
@@ -2,7 +2,7 @@
 title: "<VirtualList>"
 group: "@pyric/ui"
 section: "Primitives"
-order: 196
+order: 23008
 ---
 # `<VirtualList>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
@@ -2,7 +2,7 @@
 title: "<DeleteSelectionWithConfirm>"
 group: "@pyric/ui"
 section: "Storage"
-order: 204
+order: 23016
 ---
 # `<DeleteSelectionWithConfirm>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
@@ -2,7 +2,7 @@
 title: "<ObjectBrowser>"
 group: "@pyric/ui"
 section: "Storage"
-order: 205
+order: 23017
 ---
 # `<ObjectBrowser>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
@@ -2,7 +2,7 @@
 title: "<ObjectInspector>"
 group: "@pyric/ui"
 section: "Storage"
-order: 206
+order: 23018
 ---
 # `<ObjectInspector>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
+++ b/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
@@ -2,7 +2,7 @@
 title: "<PathBreadcrumb>"
 group: "@pyric/ui"
 section: "Storage"
-order: 207
+order: 23019
 ---
 # `<PathBreadcrumb>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
+++ b/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
@@ -2,7 +2,7 @@
 title: "Rules-aware affordances"
 group: "@pyric/ui"
 section: "Storage"
-order: 210
+order: 23022
 ---
 # Rules-aware affordances
 

--- a/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
+++ b/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
@@ -2,7 +2,7 @@
 title: "<UploadDropzone>"
 group: "@pyric/ui"
 section: "Storage"
-order: 209
+order: 23021
 ---
 # `<UploadDropzone>`
 

--- a/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
+++ b/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
@@ -2,7 +2,7 @@
 title: "useStorageRulesGate"
 group: "@pyric/ui"
 section: "Storage"
-order: 211
+order: 23023
 ---
 # `useStorageRulesGate`
 

--- a/packages/site-docs/src/content/docs/ui-storage.md
+++ b/packages/site-docs/src/content/docs/ui-storage.md
@@ -2,7 +2,7 @@
 title: "@pyric/ui/storage"
 group: "@pyric/ui"
 section: "Storage"
-order: 208
+order: 23020
 ---
 # `@pyric/ui/storage`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
@@ -2,7 +2,7 @@
 title: "<RuleHeatmap>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 213
+order: 23025
 ---
 # `<RuleHeatmap>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
@@ -2,7 +2,7 @@
 title: "<TrafficDetail>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 214
+order: 23026
 ---
 # `<TrafficDetail>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
@@ -3,7 +3,7 @@ title: "<TrafficLog> · <TrafficRow> · <TrafficGroupRow>"
 navLabel: "TrafficLog components"
 group: "@pyric/ui"
 section: "Traffic"
-order: 215
+order: 23027
 ---
 # `<TrafficLog>` · `<TrafficRow>` · `<TrafficGroupRow>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
@@ -2,7 +2,7 @@
 title: "<TrafficStats>"
 group: "@pyric/ui"
 section: "Traffic"
-order: 216
+order: 23028
 ---
 # `<TrafficStats>`
 

--- a/packages/site-docs/src/content/docs/ui-traffic.md
+++ b/packages/site-docs/src/content/docs/ui-traffic.md
@@ -2,7 +2,7 @@
 title: "@pyric/ui/traffic"
 group: "@pyric/ui"
 section: "Traffic"
-order: 212
+order: 23024
 ---
 # `@pyric/ui/traffic`
 

--- a/packages/site-docs/src/content/docs/ui.md
+++ b/packages/site-docs/src/content/docs/ui.md
@@ -3,7 +3,7 @@ title: "@pyric/ui"
 navLabel: "Overview"
 group: "@pyric/ui"
 section: ""
-order: 189
+order: 23001
 ---
 # `@pyric/ui` docs
 

--- a/packages/site-docs/src/content/docs/watch-and-review.md
+++ b/packages/site-docs/src/content/docs/watch-and-review.md
@@ -3,7 +3,7 @@ title: "Watch the agent work, then check it"
 navLabel: "Review agent activity"
 group: "Work with an agent"
 section: ""
-order: 27
+order: 6004
 description: "See every operation your agent performs, live, with the verdict that decided it."
 ---
 

--- a/packages/site-docs/src/content/docs/what-your-agent-can-do.md
+++ b/packages/site-docs/src/content/docs/what-your-agent-can-do.md
@@ -3,7 +3,7 @@ title: "Hand your agent the whole backend"
 navLabel: "What your agent can do"
 group: "Work with an agent"
 section: ""
-order: 25
+order: 6002
 description: "Every backend capability, callable as a tool: inspect, query, simulate, shape, ship, verify."
 ---
 

--- a/packages/site-docs/src/content/docs/whats-experimental.md
+++ b/packages/site-docs/src/content/docs/whats-experimental.md
@@ -2,7 +2,7 @@
 title: "What's experimental"
 group: "Trust"
 section: ""
-order: 29
+order: 7002
 description: "Know exactly which parts of Pyric are v1 and which are still earning it."
 ---
 

--- a/packages/site-docs/src/content/docs/whats-possible.md
+++ b/packages/site-docs/src/content/docs/whats-possible.md
@@ -3,7 +3,7 @@ title: "Case studies in pure security rules"
 navLabel: "Case studies"
 group: "Secure & debug"
 section: ""
-order: 18
+order: 3010
 description: "See working, deployed rulesets that enforce chess, checkers, connect four, and US tax math, built from the patterns this wing teaches."
 ---
 

--- a/packages/site-docs/src/content/docs/which-data-service.md
+++ b/packages/site-docs/src/content/docs/which-data-service.md
@@ -3,7 +3,7 @@ title: "Which data service should I use?"
 navLabel: "Which data service?"
 group: "Build"
 section: ""
-order: 8
+order: 2005
 description: "Pick between Firestore and Realtime Database in one short read."
 ---
 

--- a/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
+++ b/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
@@ -3,7 +3,7 @@ title: "Rules you trust because they are tested"
 navLabel: "Write a rules test suite"
 group: "Secure & debug"
 section: ""
-order: 11
+order: 3003
 description: "A suite of allow/deny cases that runs in-process, gates CI, and can escalate to Google's own engine."
 ---
 


### PR DESCRIPTION
Closes #164. The port script assigned sidebar order from one global counter, so adding any doc renumbered every generated doc after it in the whole tree (a one-line messaging claim recently touched ~44 generated files; a fake-doc probe measured 70). Order is now group-scoped: groupRank (index x 1000) + position within group, with a guard against overflow.

- Rendered sidebar order proven identical: the sorted (order, slug) sequence across all 218 public docs is byte-identical before and after.
- Empirical footprint: the same fake mid-list doc that touched 70 files under the global counter touches 9 under the scoped scheme, all inside its own group.
- The one-time renumbering of generated content is its own commit, separate from the script change.
- site-docs build green; the verify-dist and rhythm-audit failures that exist are pre-existing on main (confirmed by stash-based comparison) and untouched here.