### PR TITLE
Close the auth net holes found by the mutation review

### DIFF
--- a/packages/pyric/src/auth/sandbox-token.ts
+++ b/packages/pyric/src/auth/sandbox-token.ts
@@ -12,6 +12,14 @@
  * back-to-back refreshes for the same uid + claims also get
  * different tokens. NOT a cryptographic primitive. The
  * `sandbox-id-token-` prefix is grepable in logs.
+ *
+ * Claims-sensitivity is locked with uid AND serial held fixed (two
+ * independent fresh backends, each at its first mint) in
+ * `test/auth/sandbox-token-refresh.test.ts` — "token string is
+ * sensitive to claims, not just the mint serial". Every other token
+ * test compares mints across a serial bump (refresh, re-sign-in),
+ * which alone can't distinguish "claims changed the hash" from "serial
+ * changed the hash".
  */
 export function sandboxTokenFor(uid: string, claims: Record<string, unknown>, serial: number): string {
   let hash = 5381;

--- a/packages/pyric/test/auth/sandbox-backend-surface.test.ts
+++ b/packages/pyric/test/auth/sandbox-backend-surface.test.ts
@@ -17,6 +17,8 @@
 import { describe, expect, it } from 'bun:test';
 import * as backendModule from '../../src/auth/sandbox-backend.js';
 import { SandboxBackend } from '../../src/auth/sandbox-backend.js';
+import { makeAuthError as originalMakeAuthError } from '../../src/auth/auth-errors.js';
+import { NO_PASSWORD_SENTINEL as originalNoPasswordSentinel } from '../../src/auth/sandbox-backend-types.js';
 
 /** Every runtime (value) export of the barrel. Type-only exports are
  *  erased at runtime and are guarded by `tsc` on the consumers instead. */
@@ -113,5 +115,17 @@ describe('sandbox-backend export surface (frozen)', () => {
       .filter((name) => name !== 'constructor')
       .sort();
     expect(actual).toEqual(FROZEN_PROTOTYPE_METHODS);
+  });
+
+  // A re-export can be re-pointed at a look-alike (a local shim, a
+  // differently-configured factory) without changing its name or
+  // typeof — the two checks above wouldn't notice. Assert value
+  // identity against the origin modules so a future re-export fork
+  // (barrel re-exports a DIFFERENT `makeAuthError` /
+  // `NO_PASSWORD_SENTINEL` than the one the rest of the codebase
+  // imports) breaks this test instead of silently diverging.
+  it('re-exports are the SAME binding as their origin modules, not a fork', () => {
+    expect(backendModule.makeAuthError).toBe(originalMakeAuthError);
+    expect(backendModule.NO_PASSWORD_SENTINEL).toBe(originalNoPasswordSentinel);
   });
 });

--- a/packages/pyric/test/auth/sandbox-email-password.test.ts
+++ b/packages/pyric/test/auth/sandbox-email-password.test.ts
@@ -187,6 +187,22 @@ describe('sandbox email/password sign-in', () => {
     expect(auth.currentUser).toBeNull();
   });
 
+  it('createUserWithEmailAndPassword throws auth/invalid-email for empty local-part', async () => {
+    // `@` at index 0 — no local-part before the `@`. Guards against the
+    // `atIdx <= 0` -> `atIdx < 0` mutant, which would let `@example.com`
+    // through (an `@` at the very start is still `>= 0`, so a strict
+    // "no `@` at all" check misses this shape).
+    const sandbox = initializeSandbox();
+    const auth = getAuth(sandbox);
+    try {
+      await createUserWithEmailAndPassword(auth, '@example.com', 'pw123456');
+      throw new Error('expected throw');
+    } catch (e) {
+      expect((e as { code: string }).code).toBe('auth/invalid-email');
+    }
+    expect(auth.currentUser).toBeNull();
+  });
+
   it('signInWithEmailAndPassword throws auth/invalid-email for malformed email', async () => {
     const sandbox = initializeSandbox();
     const auth = getAuth(sandbox);

--- a/packages/pyric/test/auth/sandbox-token-refresh.test.ts
+++ b/packages/pyric/test/auth/sandbox-token-refresh.test.ts
@@ -119,6 +119,64 @@ describe('getIdToken(forceRefresh) — sandbox', () => {
   });
 });
 
+describe('token string is sensitive to claims, not just the mint serial', () => {
+  // `sandboxTokenFor(uid, claims, serial)` hashes claims + serial; every
+  // adversarial-review test elsewhere compares tokens ACROSS mints
+  // (refresh, re-sign-in), where the monotonic serial always advances
+  // too — so a mutant that dropped `claims` from the hash and hashed
+  // only `uid + serial` would still pass every one of those. Isolate
+  // the claims effect by holding uid AND serial fixed: two freshly
+  // initialized sandboxes each have their own independent
+  // `nextTokenSerial` counter starting at 1, so the FIRST `getIdToken()`
+  // call in each (the first cache-miss mint) lands on serial 1. Seed
+  // the SAME uid with DIFFERENT customClaims in each sandbox and take
+  // that first token — uid and serial are pinned equal, so any
+  // difference in the token string is attributable to the claims alone.
+  it('same uid + same mint-serial, different customClaims -> different token', async () => {
+    const sandboxX = initializeSandbox();
+    const authX = getAuth(sandboxX);
+    authSandbox.seedUsers(authX, [
+      { uid: 'twin', email: 'twin@example.com', password: 'pw', customClaims: { role: 'admin' } },
+    ]);
+    await signInWithEmailAndPassword(authX, 'twin@example.com', 'pw');
+    const tokenX = await authX.currentUser!.getIdToken();
+
+    const sandboxY = initializeSandbox();
+    const authY = getAuth(sandboxY);
+    authSandbox.seedUsers(authY, [
+      { uid: 'twin', email: 'twin@example.com', password: 'pw', customClaims: { role: 'guest' } },
+    ]);
+    await signInWithEmailAndPassword(authY, 'twin@example.com', 'pw');
+    const tokenY = await authY.currentUser!.getIdToken();
+
+    expect(tokenX).not.toBe(tokenY);
+  });
+
+  it('same uid + same mint-serial, same customClaims -> same token (determinism control)', async () => {
+    // Companion to the test above: proves the two-sandbox setup itself
+    // holds uid + serial equal (so the prior test's divergence really
+    // is the claims), by showing identical claims collapse back to an
+    // identical token.
+    const sandboxX = initializeSandbox();
+    const authX = getAuth(sandboxX);
+    authSandbox.seedUsers(authX, [
+      { uid: 'twin', email: 'twin@example.com', password: 'pw', customClaims: { role: 'admin' } },
+    ]);
+    await signInWithEmailAndPassword(authX, 'twin@example.com', 'pw');
+    const tokenX = await authX.currentUser!.getIdToken();
+
+    const sandboxY = initializeSandbox();
+    const authY = getAuth(sandboxY);
+    authSandbox.seedUsers(authY, [
+      { uid: 'twin', email: 'twin@example.com', password: 'pw', customClaims: { role: 'admin' } },
+    ]);
+    await signInWithEmailAndPassword(authY, 'twin@example.com', 'pw');
+    const tokenY = await authY.currentUser!.getIdToken();
+
+    expect(tokenX).toBe(tokenY);
+  });
+});
+
 describe('onIdTokenChanged fires on forced refresh — sandbox', () => {
   it('fires once on subscribe + once on signIn + once on getIdToken(true)', async () => {
     // Mirrors `auth-onidtokenchanged-force-refresh.json` shape:


### PR DESCRIPTION
The adversarial review of #188 planted 11 mutations in the moved auth code; 8 died to existing tests, 3 survived. This closes them, each with kill-proof evidence (mutation applied, new test goes red; reverted, green).

- **Empty-local-part email** (the one real hole): createUserWithEmailAndPassword(auth, '@example.com', ...) now pins the auth/invalid-email rejection. The surviving mutant (atIdx <= 0 becoming atIdx < 0) fails this test.
- **Token claims sensitivity**: the documented "different claims produce different tokens" property was untestable through the usual seams because the serial increment masks it. Isolated instead by minting in two fresh sandboxes where uid and serial are pinned identical, so divergence is attributable to claims alone — plus a determinism control proving the harness itself holds those fixed. The mutant that dropped claims from the hash fails it.
- **Surface test hardening**: value-identity assertions on the re-exported bindings, so a future re-export fork breaks the test rather than passing on names and typeof alone.

Auth suites: 264 pass, 0 fail. compat:check green.