### PR TITLE
Carry derived facts, not derived prose, in the assurance artifacts

### DIFF
--- a/packages/conformance/assurance-capabilities/capabilities.json
+++ b/packages/conformance/assurance-capabilities/capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generatedNote": "GENERATED from the conformance graph by packages/conformance/src/assurance-capabilities.ts. Do not edit by hand; run bun run compat:assurance. Each capability declares its dependencies in packages/conformance/assurance-capabilities/<id>.ts; the status here is DERIVED, never asserted. A capability that is not \"supported\" means an assurance probe depending on it must abstain (engine-gap), not report a security conclusion.",
+  "generatedNote": "GENERATED from the conformance graph by packages/conformance/src/assurance-capabilities.ts. Do not edit by hand; run bun run compat:assurance. Each capability declares its dependencies in packages/conformance/assurance-capabilities/<id>.ts; the status here is DERIVED, never asserted. A capability that is not \"supported\" means an assurance probe depending on it must abstain (engine-gap), not report a security conclusion. Every dependency carries the FACTS behind its verdict and no count, total, or other whole-population aggregate: an aggregate would move this file whenever anything anywhere in the corpus moved, so these records change only when a verdict changes. Sentences (with counts, if a human wants them) are rendered on read: bun run compat:assurance.",
   "generator": "packages/conformance/src/assurance-capabilities.ts",
   "inputs": [
     "packages/conformance/assurance-capabilities/<capability-id>.ts (authored dependency records)",
@@ -14,114 +14,110 @@
       "service": "auth",
       "status": "qualified",
       "description": "Password, anonymous-account, anonymous-request, fixture-user, and synthetic lenses.",
-      "reasons": [
-        "auth#7: registry row auth#7 (auth) status \"diverged-documented\"; divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical"
-      ],
       "dependencies": [
         {
           "kind": "registry-row",
           "id": "auth#6",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#6 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#7",
           "verdict": "qualified",
-          "evidence": [
-            "registry row auth#7 (auth) status \"diverged-documented\"",
-            "divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical"
-          ]
+          "surface": "auth",
+          "status": "diverged-documented",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#8",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#8 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#9",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#9 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#11",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#11 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#13",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#13 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#14",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#14 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#15",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#15 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#16",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#16 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#69",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#69 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#63",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#63 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#73",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#73 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#75",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#75 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         }
       ]
     },
@@ -130,51 +126,44 @@
       "service": "auth",
       "status": "unsupported",
       "description": "OAuth provider, custom-token, MFA, revocation, and email-action acquisition flows are outside v1.",
-      "reasons": [
-        "auth#49: registry row auth#49 (auth) status \"unsupported\"",
-        "custom-token sign-in, MFA enrollment/resolution, refresh-token revocation, and email-action link acquisition: the conformance graph does not model this behavior: the auth registry has no rows for these flows: they are unmirrored surface, so the graph holds no evidence that an actor acquired through them matches production"
-      ],
       "dependencies": [
         {
           "kind": "registry-row",
           "id": "auth#44",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#44 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#45",
           "verdict": "supported",
-          "evidence": [
-            "registry row auth#45 (auth) status \"conforms\""
-          ]
+          "surface": "auth",
+          "status": "conforms",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#48",
           "verdict": "qualified",
-          "evidence": [
-            "registry row auth#48 (auth) status \"diverged-documented\"",
-            "divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical"
-          ]
+          "surface": "auth",
+          "status": "diverged-documented",
+          "rulesEngineSurface": false
         },
         {
           "kind": "registry-row",
           "id": "auth#49",
           "verdict": "unsupported",
-          "evidence": [
-            "registry row auth#49 (auth) status \"unsupported\""
-          ]
+          "surface": "auth",
+          "status": "unsupported",
+          "rulesEngineSurface": false
         },
         {
           "kind": "unbacked",
           "id": "custom-token sign-in, MFA enrollment/resolution, refresh-token revocation, and email-action link acquisition",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: the auth registry has no rows for these flows: they are unmirrored surface, so the graph holds no evidence that an actor acquired through them matches production"
-          ]
+          "reason": "the auth registry has no rows for these flows: they are unmirrored surface, so the graph holds no evidence that an actor acquired through them matches production"
         }
       ]
     },
@@ -183,42 +172,36 @@
       "service": "firestore",
       "status": "unsupported",
       "description": "Cross-write getAfter visibility in batches and transactions.",
-      "reasons": [
-        "firestore.function.getAfter: snapshot status \"rejected\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#164",
-        "firestore.function.existsAfter: snapshot status \"rejected\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#164",
-        "firestore-rules#164: registry row firestore-rules#164 (firestore-rules) status \"diverged-documented\"; divergence is in the rules engine itself: the verdict machinery is known wrong here"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.function.getAfter",
           "verdict": "unsupported",
-          "evidence": [
-            "snapshot status \"rejected\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)",
-            "covered by rules-engine divergence firestore-rules#164"
+          "snapshot": "rejected",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": [
+            "firestore-rules#164"
           ]
         },
         {
           "kind": "construct",
           "id": "firestore.function.existsAfter",
           "verdict": "unsupported",
-          "evidence": [
-            "snapshot status \"rejected\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)",
-            "covered by rules-engine divergence firestore-rules#164"
+          "snapshot": "rejected",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": [
+            "firestore-rules#164"
           ]
         },
         {
           "kind": "registry-row",
           "id": "firestore-rules#164",
           "verdict": "unsupported",
-          "evidence": [
-            "registry row firestore-rules#164 (firestore-rules) status \"diverged-documented\"",
-            "divergence is in the rules engine itself: the verdict machinery is known wrong here"
-          ]
+          "surface": "firestore-rules",
+          "status": "diverged-documented",
+          "rulesEngineSurface": true
         }
       ]
     },
@@ -227,27 +210,21 @@
       "service": "firestore",
       "status": "unsupported",
       "description": "Atomic multi-write batches, transaction retries, and contention behavior.",
-      "reasons": [
-        "authorization of an atomic multi-write commit as one unit, including transaction retry re-evaluation and contention: the conformance graph does not model this behavior: no rules-language construct models cross-write atomicity and no rules-engine registry row adjudicates commit-level (as opposed to per-write) authorization against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-write",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "authorization of an atomic multi-write commit as one unit, including transaction retry re-evaluation and contention",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: no rules-language construct models cross-write atomicity and no rules-engine registry row adjudicates commit-level (as opposed to per-write) authorization against production"
-          ]
+          "reason": "no rules-language construct models cross-write atomicity and no rules-engine registry row adjudicates commit-level (as opposed to per-write) authorization against production"
         }
       ]
     },
@@ -256,37 +233,30 @@
       "service": "firestore",
       "status": "unsupported",
       "description": "Collection-group authorization and listener re-evaluation are not probe operations in v1.",
-      "reasons": [
-        "collection-group match scoping and rules re-evaluation on every listener snapshot delivery: the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates collection-group match scope or listener re-authorization against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-list",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.semantic.recursive-wildcard",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "collection-group match scoping and rules re-evaluation on every listener snapshot delivery",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates collection-group match scope or listener re-authorization against production"
-          ]
+          "reason": "neither is a language construct, and no registry row adjudicates collection-group match scope or listener re-authorization against production"
         }
       ]
     },
@@ -295,316 +265,258 @@
       "service": "firestore",
       "status": "supported",
       "description": "Rules-respecting get, create, set, merge, update, and delete operations.",
-      "reasons": [
-        "firestore.rule-kind.match: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-        "firestore.rule-kind.allow-read: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "firestore.rule-kind.allow-write: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "firestore.rule-kind.allow-get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "firestore.rule-kind.allow-create: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 20 captured scenario(s)",
-        "firestore.rule-kind.allow-update: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "firestore.rule-kind.allow-delete: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "firestore.binding.request: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 23 captured scenario(s)",
-        "firestore.binding.request.auth: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 18 captured scenario(s)",
-        "firestore.binding.request.auth.uid: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "firestore.binding.request.auth.token: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "firestore.binding.request.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 15 captured scenario(s)",
-        "firestore.binding.request.resource.data: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 15 captured scenario(s)",
-        "firestore.binding.request.method: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "firestore.binding.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "firestore.binding.resource.data: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "firestore.binding.path-variable: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-        "firestore.operator.eq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 17 captured scenario(s)",
-        "firestore.operator.neq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 18 captured scenario(s)",
-        "firestore.operator.and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 20 captured scenario(s)",
-        "firestore.operator.or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 5 captured scenario(s)",
-        "firestore.operator.not: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-        "firestore.operator.member: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-        "firestore.operator.in: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "firestore.semantic.hierarchical-match-cascade: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-        "firestore.semantic.recursive-wildcard: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "firestore.semantic.error-absorption-and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "firestore.semantic.error-absorption-or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.rule-kind.match",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-read",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-write",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-get",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-create",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 20 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-update",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-delete",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 23 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.auth",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 18 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.auth.uid",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.auth.token",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.resource",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 15 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.resource.data",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 15 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.method",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.resource",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.resource.data",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.path-variable",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.eq",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 17 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.neq",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 18 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.and",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 20 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.or",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 5 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.not",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 6 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.member",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.in",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.semantic.hierarchical-match-cascade",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.semantic.recursive-wildcard",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.semantic.error-absorption-and",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.semantic.error-absorption-or",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         }
       ]
     },
@@ -613,37 +525,30 @@
       "service": "firestore",
       "status": "unsupported",
       "description": "Multiple matching allow blocks with production OR composition.",
-      "reasons": [
-        "OR composition across multiple allow-bearing match blocks that match the same path: the conformance graph does not model this behavior: the language snapshot enumerates the hierarchical-match cascade (parent/child nesting) but has no construct for multi-block OR composition, and no rules-engine registry row adjudicates it against the production Rules Test API"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.semantic.hierarchical-match-cascade",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.rule-kind.match",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 24 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "OR composition across multiple allow-bearing match blocks that match the same path",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: the language snapshot enumerates the hierarchical-match cascade (parent/child nesting) but has no construct for multi-block OR composition, and no rules-engine registry row adjudicates it against the production Rules Test API"
-          ]
+          "reason": "the language snapshot enumerates the hierarchical-match cascade (parent/child nesting) but has no construct for multi-block OR composition, and no rules-engine registry row adjudicates it against the production Rules Test API"
         }
       ]
     },
@@ -652,70 +557,61 @@
       "service": "firestore",
       "status": "unsupported",
       "description": "Collection queries whose rules proof uses the supported equality subset.",
-      "reasons": [
-        "firestore.binding.request.query: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#166",
-        "firestore-rules#166: registry row firestore-rules#166 (firestore-rules) status \"diverged-documented\"; divergence is in the rules engine itself: the verdict machinery is known wrong here"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "firestore.rule-kind.allow-list",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.binding.request.query",
           "verdict": "unsupported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)",
-            "covered by rules-engine divergence firestore-rules#166"
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": [
+            "firestore-rules#166"
           ]
         },
         {
           "kind": "construct",
           "id": "firestore.binding.resource.data",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.eq",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 17 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "firestore.operator.and",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 20 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "registry-row",
           "id": "firestore-rules#166",
           "verdict": "unsupported",
-          "evidence": [
-            "registry row firestore-rules#166 (firestore-rules) status \"diverged-documented\"",
-            "divergence is in the rules engine itself: the verdict machinery is known wrong here"
-          ]
+          "surface": "firestore-rules",
+          "status": "diverged-documented",
+          "rulesEngineSurface": true
         }
       ]
     },
@@ -724,47 +620,39 @@
       "service": "rtdb",
       "status": "unsupported",
       "description": "Multi-child updates evaluated against one atomic projected tree.",
-      "reasons": [
-        "one projected future tree shared by every rule a multi-path update touches: the conformance graph does not model this behavior: atomicity across a multi-child update is not a language construct and no registry row adjudicates whole-update (as opposed to per-leaf) evaluation against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.write",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.validate",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 7 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.newData",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 7 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "one projected future tree shared by every rule a multi-path update touches",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: atomicity across a multi-child update is not a language construct and no registry row adjudicates whole-update (as opposed to per-leaf) evaluation against production"
-          ]
+          "reason": "atomicity across a multi-child update is not a language construct and no registry row adjudicates whole-update (as opposed to per-leaf) evaluation against production"
         }
       ]
     },
@@ -773,47 +661,39 @@
       "service": "rtdb",
       "status": "unsupported",
       "description": "Local ordering, bounds, equality, and limits; index enforcement is not modeled.",
-      "reasons": [
-        "query constraints (orderBy/startAt/endAt/equalTo/limit) visible to a `.read` expression, and index enforcement rejecting an unindexed query: the conformance graph does not model this behavior: the RTDB language snapshot enumerates no query bindings, so the constraints a production `.read` rule can authorize against are not modeled by any construct, and no registry row adjudicates query-shape authorization"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.read",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.indexOn",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.read-cascade",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#5, rtdb-rules#8, rtdb-rules#10"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "query constraints (orderBy/startAt/endAt/equalTo/limit) visible to a `.read` expression, and index enforcement rejecting an unindexed query",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: the RTDB language snapshot enumerates no query bindings, so the constraints a production `.read` rule can authorize against are not modeled by any construct, and no registry row adjudicates query-shape authorization"
-          ]
+          "reason": "the RTDB language snapshot enumerates no query bindings, so the constraints a production `.read` rule can authorize against are not modeled by any construct, and no registry row adjudicates query-shape authorization"
         }
       ]
     },
@@ -822,195 +702,159 @@
       "service": "rtdb",
       "status": "qualified",
       "description": "Rules-respecting get, set, single-child update, and remove operations.",
-      "reasons": [
-        "rtdb.rule-kind.read: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 14 captured scenario(s)",
-        "rtdb.rule-kind.write: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 14 captured scenario(s)",
-        "rtdb.rule-kind.location-wildcard: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "rtdb.binding.auth: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 13 captured scenario(s)",
-        "rtdb.binding.auth.uid: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "rtdb.binding.auth.token: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "rtdb.binding.path-variable: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "rtdb.method.snapshot.val: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-        "rtdb.method.snapshot.child: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "rtdb.method.snapshot.exists: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "rtdb.operator.strictEq: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-        "rtdb.operator.and: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-        "rtdb.operator.or: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "rtdb.operator.not: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "rtdb.semantic.read-cascade: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#5, rtdb-rules#8, rtdb-rules#10",
-        "rtdb.semantic.write-cascade: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#4, rtdb-rules#5",
-        "rtdb.semantic.deny-by-default: snapshot status \"unprobed\"; capability probe \"implemented\"; no production-captured scenario and no conforming oracle-backed row verifies it"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.read",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.write",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.location-wildcard",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.auth",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 13 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.auth.uid",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.auth.token",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.path-variable",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.method.snapshot.val",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 4 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.method.snapshot.child",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.method.snapshot.exists",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.operator.strictEq",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 8 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.operator.and",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 6 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.operator.or",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.operator.not",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.read-cascade",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#5, rtdb-rules#8, rtdb-rules#10"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.write-cascade",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#4, rtdb-rules#5"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.deny-by-default",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "no production-captured scenario and no conforming oracle-backed row verifies it"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": false,
+          "divergedBy": []
         }
       ]
     },
@@ -1019,67 +863,57 @@
       "service": "rtdb",
       "status": "unsupported",
       "description": "Ancestor data/newData bindings and merged future-tree semantics.",
-      "reasons": [
-        "`data`/`newData` bound to an ANCESTOR rule location, with `newData` as the merged future tree of the whole write: the conformance graph does not model this behavior: the snapshot enumerates the data/newData bindings but not their rule-location binding or future-tree projection, and no registry row adjudicates ancestor-location binding against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "rtdb.binding.data",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.newData",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 7 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.binding.root",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.write-cascade",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#4, rtdb-rules#5"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.semantic.validate-non-cascade",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"unprobeable\"",
-            "production-verified by conforming oracle-backed rules-engine row rtdb-rules#4, rtdb-rules#10"
-          ]
+          "snapshot": "unprobed",
+          "probe": "unprobeable",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "`data`/`newData` bound to an ANCESTOR rule location, with `newData` as the merged future tree of the whole write",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: the snapshot enumerates the data/newData bindings but not their rule-location binding or future-tree projection, and no registry row adjudicates ancestor-location binding against production"
-          ]
+          "reason": "the snapshot enumerates the data/newData bindings but not their rule-location binding or future-tree projection, and no registry row adjudicates ancestor-location binding against production"
         }
       ]
     },
@@ -1088,37 +922,30 @@
       "service": "rtdb",
       "status": "unsupported",
       "description": "Transaction retries, push-key allocation, and listener re-evaluation are not probe operations in v1.",
-      "reasons": [
-        "rules re-evaluation on transaction retry, on push-key allocation, and on every listener event delivery: the conformance graph does not model this behavior: none of the three is a language construct, and no registry row adjudicates re-authorization on retry or on listener delivery against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.read",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "rtdb.rule-kind.write",
           "verdict": "qualified",
-          "evidence": [
-            "snapshot status \"unprobed\"",
-            "capability probe \"implemented\"",
-            "production-verified by 14 captured scenario(s)"
-          ]
+          "snapshot": "unprobed",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "rules re-evaluation on transaction retry, on push-key allocation, and on every listener event delivery",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: none of the three is a language construct, and no registry row adjudicates re-authorization on retry or on listener delivery against production"
-          ]
+          "reason": "none of the three is a language construct, and no registry row adjudicates re-authorization on retry or on listener delivery against production"
         }
       ]
     },
@@ -1127,215 +954,176 @@
       "service": "storage",
       "status": "supported",
       "description": "Granular verbs, functions, time, regex, object identity, and Firestore rule lookups.",
-      "reasons": [
-        "storage.rule-kind.allow-get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-        "storage.rule-kind.allow-list: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.rule-kind.allow-create: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-        "storage.rule-kind.allow-update: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.rule-kind.allow-delete: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "storage.rule-kind.function: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.rule-kind.let: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.method.string.matches: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.function.timestamp.date: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.function.timestamp.value: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.function.duration.value: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.function.firestore.get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.function.firestore.exists: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.request.time: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "storage.binding.resource.name: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource.bucket: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource.timeCreated: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource.updated: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage-rules#116: registry row storage-rules#116 (storage-rules) status \"conforms\""
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-get",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 4 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-list",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-create",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 6 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-update",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-delete",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.function",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.let",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.method.string.matches",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.function.timestamp.date",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.function.timestamp.value",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.function.duration.value",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.function.firestore.get",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.function.firestore.exists",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.time",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.name",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.bucket",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.timeCreated",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.updated",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#116",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#116 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         }
       ]
     },
@@ -1344,357 +1132,296 @@
       "service": "storage",
       "status": "supported",
       "description": "Coarse read/write with auth, size, content type, metadata, and path matching.",
-      "reasons": [
-        "storage.rule-kind.match: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-        "storage.rule-kind.allow-read: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "storage.rule-kind.allow-write: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.request: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 7 captured scenario(s)",
-        "storage.binding.request.auth: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.binding.request.auth.uid: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.binding.request.auth.token: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.request.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.binding.request.resource.size: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "storage.binding.request.resource.contentType: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.binding.request.resource.metadata: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-        "storage.binding.resource.size: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource.contentType: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.resource.metadata: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.binding.path-variable: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-        "storage.operator.eq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-        "storage.operator.neq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.operator.lt: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-        "storage.operator.and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-        "storage.operator.or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.operator.not: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.semantic.read-umbrella: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-        "storage.semantic.write-umbrella: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.semantic.recursive-wildcard: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-        "storage.semantic.deny-by-default: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row storage-rules#96",
-        "storage-rules#98: registry row storage-rules#98 (storage-rules) status \"conforms\"",
-        "storage-rules#99: registry row storage-rules#99 (storage-rules) status \"conforms\"",
-        "storage-rules#100: registry row storage-rules#100 (storage-rules) status \"conforms\"",
-        "storage-rules#101: registry row storage-rules#101 (storage-rules) status \"conforms\"",
-        "storage-rules#102: registry row storage-rules#102 (storage-rules) status \"conforms\"",
-        "storage-rules#103: registry row storage-rules#103 (storage-rules) status \"conforms\"",
-        "storage-rules#114: registry row storage-rules#114 (storage-rules) status \"conforms\""
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "storage.rule-kind.match",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 8 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-read",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-write",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 7 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.auth",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.auth.uid",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.auth.token",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.resource",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.resource.size",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.resource.contentType",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.request.resource.metadata",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 4 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.size",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.contentType",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.resource.metadata",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.binding.path-variable",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 8 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.eq",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 6 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.neq",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.lt",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 4 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.and",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 3 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.or",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.operator.not",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.semantic.read-umbrella",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 2 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.semantic.write-umbrella",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.semantic.recursive-wildcard",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "construct",
           "id": "storage.semantic.deny-by-default",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by conforming oracle-backed rules-engine row storage-rules#96"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#98",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#98 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#99",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#99 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#100",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#100 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#101",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#101 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#102",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#102 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#103",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#103 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         },
         {
           "kind": "registry-row",
           "id": "storage-rules#114",
           "verdict": "supported",
-          "evidence": [
-            "registry row storage-rules#114 (storage-rules) status \"conforms\""
-          ]
+          "surface": "storage-rules",
+          "status": "conforms",
+          "rulesEngineSurface": true
         }
       ]
     },
@@ -1703,27 +1430,21 @@
       "service": "storage",
       "status": "unsupported",
       "description": "Resumable transfer state and paginated list semantics are not probe operations in v1.",
-      "reasons": [
-        "authorization of resumable-upload session state across chunks, and of a paginated list against its prefix: the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates resumable-session or pagination authorization against production"
-      ],
       "dependencies": [
         {
           "kind": "construct",
           "id": "storage.rule-kind.allow-list",
           "verdict": "supported",
-          "evidence": [
-            "snapshot status \"accepted\"",
-            "capability probe \"implemented\"",
-            "production-verified by 1 captured scenario(s)"
-          ]
+          "snapshot": "accepted",
+          "probe": "implemented",
+          "productionVerified": true,
+          "divergedBy": []
         },
         {
           "kind": "unbacked",
           "id": "authorization of resumable-upload session state across chunks, and of a paginated list against its prefix",
           "verdict": "unsupported",
-          "evidence": [
-            "the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates resumable-session or pagination authorization against production"
-          ]
+          "reason": "neither is a language construct, and no registry row adjudicates resumable-session or pagination authorization against production"
         }
       ]
     }

--- a/packages/conformance/assurance-capabilities/generated.ts
+++ b/packages/conformance/assurance-capabilities/generated.ts
@@ -3,18 +3,63 @@
 // The assurance engine's capabilities, DERIVED from the conformance graph by
 // packages/conformance/src/assurance-capabilities.ts (see that file's header for
 // the derivation rules). The assurance runtime consumes this module directly:
-// each record is structurally an AssuranceEngineCapability, and `reasons` carries
-// the graph evidence a probe cites when it abstains.
+// each record is structurally an AssuranceEngineCapability.
+//
+// Each dependency carries the FACTS behind its verdict, never a sentence and
+// never a count: a count is a property of the corpus, so freezing one here would
+// rewrite unrelated records every time anyone captured a scenario. A probe that
+// abstains renders its reasons on read with `capabilityReasons(capability)`.
 import type { AssuranceCapabilityService, AssuranceCapabilityStatus } from './types.ts';
+
+export type CapabilityVerdict = AssuranceCapabilityStatus;
+
+export interface GeneratedConstructDependency {
+  kind: 'construct';
+  /** The rules-language construct id. */
+  id: string;
+  verdict: CapabilityVerdict;
+  /** The construct's status in the production language snapshot. */
+  snapshot: string;
+  /** What the local simulator's capability probe did with it. */
+  probe: 'implemented' | 'unsupported' | 'error' | 'unprobeable' | 'absent';
+  /** Whether any evidence path compares it against production. A BOOLEAN: how
+   *  many scenarios do so is a fact about the corpus, not about this construct. */
+  productionVerified: boolean;
+  /** Rules-engine rows whose documented divergence names this construct. */
+  divergedBy: string[];
+}
+
+export interface GeneratedRegistryRowDependency {
+  kind: 'registry-row';
+  id: string;
+  verdict: CapabilityVerdict;
+  surface: string;
+  status: string;
+  rulesEngineSurface: boolean;
+}
+
+export interface GeneratedUnbackedDependency {
+  kind: 'unbacked';
+  /** The behavior the capability needs. */
+  id: string;
+  verdict: CapabilityVerdict;
+  /** Why the graph cannot back it. */
+  reason: string;
+}
+
+export type GeneratedCapabilityDependency =
+  | GeneratedConstructDependency
+  | GeneratedRegistryRowDependency
+  | GeneratedUnbackedDependency;
 
 export interface GeneratedAssuranceCapability {
   id: string;
   service: AssuranceCapabilityService;
   status: AssuranceCapabilityStatus;
   description: string;
-  /** The graph evidence that pinned the status: the dependencies whose verdict
-   *  equals it. A probe that abstains reports these. */
-  reasons: string[];
+  /** Everything the status rests on. The ones that pinned it are the ones whose
+   *  verdict equals the status; `capabilityReasons` selects and renders them. */
+  dependencies: GeneratedCapabilityDependency[];
 }
 
 export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapability[] = [
@@ -23,8 +68,20 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "auth",
     status: "qualified",
     description: "Password, anonymous-account, anonymous-request, fixture-user, and synthetic lenses.",
-    reasons: [
-      "auth#7: registry row auth#7 (auth) status \"diverged-documented\"; divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical",
+    dependencies: [
+      {"kind":"registry-row","id":"auth#6","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#7","verdict":"qualified","surface":"auth","status":"diverged-documented","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#8","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#9","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#11","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#13","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#14","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#15","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#16","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#69","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#63","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#73","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#75","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
     ],
   },
   {
@@ -32,9 +89,12 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "auth",
     status: "unsupported",
     description: "OAuth provider, custom-token, MFA, revocation, and email-action acquisition flows are outside v1.",
-    reasons: [
-      "auth#49: registry row auth#49 (auth) status \"unsupported\"",
-      "custom-token sign-in, MFA enrollment/resolution, refresh-token revocation, and email-action link acquisition: the conformance graph does not model this behavior: the auth registry has no rows for these flows: they are unmirrored surface, so the graph holds no evidence that an actor acquired through them matches production",
+    dependencies: [
+      {"kind":"registry-row","id":"auth#44","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#45","verdict":"supported","surface":"auth","status":"conforms","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#48","verdict":"qualified","surface":"auth","status":"diverged-documented","rulesEngineSurface":false},
+      {"kind":"registry-row","id":"auth#49","verdict":"unsupported","surface":"auth","status":"unsupported","rulesEngineSurface":false},
+      {"kind":"unbacked","id":"custom-token sign-in, MFA enrollment/resolution, refresh-token revocation, and email-action link acquisition","verdict":"unsupported","reason":"the auth registry has no rows for these flows: they are unmirrored surface, so the graph holds no evidence that an actor acquired through them matches production"},
     ],
   },
   {
@@ -42,10 +102,10 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "unsupported",
     description: "Cross-write getAfter visibility in batches and transactions.",
-    reasons: [
-      "firestore.function.getAfter: snapshot status \"rejected\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#164",
-      "firestore.function.existsAfter: snapshot status \"rejected\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#164",
-      "firestore-rules#164: registry row firestore-rules#164 (firestore-rules) status \"diverged-documented\"; divergence is in the rules engine itself: the verdict machinery is known wrong here",
+    dependencies: [
+      {"kind":"construct","id":"firestore.function.getAfter","verdict":"unsupported","snapshot":"rejected","probe":"implemented","productionVerified":true,"divergedBy":["firestore-rules#164"]},
+      {"kind":"construct","id":"firestore.function.existsAfter","verdict":"unsupported","snapshot":"rejected","probe":"implemented","productionVerified":true,"divergedBy":["firestore-rules#164"]},
+      {"kind":"registry-row","id":"firestore-rules#164","verdict":"unsupported","surface":"firestore-rules","status":"diverged-documented","rulesEngineSurface":true},
     ],
   },
   {
@@ -53,8 +113,9 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "unsupported",
     description: "Atomic multi-write batches, transaction retries, and contention behavior.",
-    reasons: [
-      "authorization of an atomic multi-write commit as one unit, including transaction retry re-evaluation and contention: the conformance graph does not model this behavior: no rules-language construct models cross-write atomicity and no rules-engine registry row adjudicates commit-level (as opposed to per-write) authorization against production",
+    dependencies: [
+      {"kind":"construct","id":"firestore.rule-kind.allow-write","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"authorization of an atomic multi-write commit as one unit, including transaction retry re-evaluation and contention","verdict":"unsupported","reason":"no rules-language construct models cross-write atomicity and no rules-engine registry row adjudicates commit-level (as opposed to per-write) authorization against production"},
     ],
   },
   {
@@ -62,8 +123,10 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "unsupported",
     description: "Collection-group authorization and listener re-evaluation are not probe operations in v1.",
-    reasons: [
-      "collection-group match scoping and rules re-evaluation on every listener snapshot delivery: the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates collection-group match scope or listener re-authorization against production",
+    dependencies: [
+      {"kind":"construct","id":"firestore.rule-kind.allow-list","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.semantic.recursive-wildcard","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"collection-group match scoping and rules re-evaluation on every listener snapshot delivery","verdict":"unsupported","reason":"neither is a language construct, and no registry row adjudicates collection-group match scope or listener re-authorization against production"},
     ],
   },
   {
@@ -71,35 +134,35 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "supported",
     description: "Rules-respecting get, create, set, merge, update, and delete operations.",
-    reasons: [
-      "firestore.rule-kind.match: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-      "firestore.rule-kind.allow-read: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "firestore.rule-kind.allow-write: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "firestore.rule-kind.allow-get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "firestore.rule-kind.allow-create: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 20 captured scenario(s)",
-      "firestore.rule-kind.allow-update: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "firestore.rule-kind.allow-delete: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "firestore.binding.request: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 23 captured scenario(s)",
-      "firestore.binding.request.auth: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 18 captured scenario(s)",
-      "firestore.binding.request.auth.uid: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "firestore.binding.request.auth.token: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "firestore.binding.request.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 15 captured scenario(s)",
-      "firestore.binding.request.resource.data: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 15 captured scenario(s)",
-      "firestore.binding.request.method: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "firestore.binding.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "firestore.binding.resource.data: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "firestore.binding.path-variable: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-      "firestore.operator.eq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 17 captured scenario(s)",
-      "firestore.operator.neq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 18 captured scenario(s)",
-      "firestore.operator.and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 20 captured scenario(s)",
-      "firestore.operator.or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 5 captured scenario(s)",
-      "firestore.operator.not: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-      "firestore.operator.member: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-      "firestore.operator.in: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "firestore.semantic.hierarchical-match-cascade: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 24 captured scenario(s)",
-      "firestore.semantic.recursive-wildcard: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "firestore.semantic.error-absorption-and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "firestore.semantic.error-absorption-or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
+    dependencies: [
+      {"kind":"construct","id":"firestore.rule-kind.match","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-read","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-write","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-get","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-create","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-update","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.allow-delete","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.auth","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.auth.uid","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.auth.token","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.resource","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.resource.data","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.method","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.resource","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.resource.data","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.path-variable","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.eq","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.neq","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.and","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.or","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.not","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.member","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.in","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.semantic.hierarchical-match-cascade","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.semantic.recursive-wildcard","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.semantic.error-absorption-and","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.semantic.error-absorption-or","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
     ],
   },
   {
@@ -107,8 +170,10 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "unsupported",
     description: "Multiple matching allow blocks with production OR composition.",
-    reasons: [
-      "OR composition across multiple allow-bearing match blocks that match the same path: the conformance graph does not model this behavior: the language snapshot enumerates the hierarchical-match cascade (parent/child nesting) but has no construct for multi-block OR composition, and no rules-engine registry row adjudicates it against the production Rules Test API",
+    dependencies: [
+      {"kind":"construct","id":"firestore.semantic.hierarchical-match-cascade","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.rule-kind.match","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"OR composition across multiple allow-bearing match blocks that match the same path","verdict":"unsupported","reason":"the language snapshot enumerates the hierarchical-match cascade (parent/child nesting) but has no construct for multi-block OR composition, and no rules-engine registry row adjudicates it against the production Rules Test API"},
     ],
   },
   {
@@ -116,9 +181,13 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "firestore",
     status: "unsupported",
     description: "Collection queries whose rules proof uses the supported equality subset.",
-    reasons: [
-      "firestore.binding.request.query: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s); covered by rules-engine divergence firestore-rules#166",
-      "firestore-rules#166: registry row firestore-rules#166 (firestore-rules) status \"diverged-documented\"; divergence is in the rules engine itself: the verdict machinery is known wrong here",
+    dependencies: [
+      {"kind":"construct","id":"firestore.rule-kind.allow-list","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.binding.request.query","verdict":"unsupported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":["firestore-rules#166"]},
+      {"kind":"construct","id":"firestore.binding.resource.data","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.eq","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"firestore.operator.and","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"registry-row","id":"firestore-rules#166","verdict":"unsupported","surface":"firestore-rules","status":"diverged-documented","rulesEngineSurface":true},
     ],
   },
   {
@@ -126,8 +195,11 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "rtdb",
     status: "unsupported",
     description: "Multi-child updates evaluated against one atomic projected tree.",
-    reasons: [
-      "one projected future tree shared by every rule a multi-path update touches: the conformance graph does not model this behavior: atomicity across a multi-child update is not a language construct and no registry row adjudicates whole-update (as opposed to per-leaf) evaluation against production",
+    dependencies: [
+      {"kind":"construct","id":"rtdb.rule-kind.write","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.rule-kind.validate","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.newData","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"one projected future tree shared by every rule a multi-path update touches","verdict":"unsupported","reason":"atomicity across a multi-child update is not a language construct and no registry row adjudicates whole-update (as opposed to per-leaf) evaluation against production"},
     ],
   },
   {
@@ -135,8 +207,11 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "rtdb",
     status: "unsupported",
     description: "Local ordering, bounds, equality, and limits; index enforcement is not modeled.",
-    reasons: [
-      "query constraints (orderBy/startAt/endAt/equalTo/limit) visible to a `.read` expression, and index enforcement rejecting an unindexed query: the conformance graph does not model this behavior: the RTDB language snapshot enumerates no query bindings, so the constraints a production `.read` rule can authorize against are not modeled by any construct, and no registry row adjudicates query-shape authorization",
+    dependencies: [
+      {"kind":"construct","id":"rtdb.rule-kind.read","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.rule-kind.indexOn","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.read-cascade","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"query constraints (orderBy/startAt/endAt/equalTo/limit) visible to a `.read` expression, and index enforcement rejecting an unindexed query","verdict":"unsupported","reason":"the RTDB language snapshot enumerates no query bindings, so the constraints a production `.read` rule can authorize against are not modeled by any construct, and no registry row adjudicates query-shape authorization"},
     ],
   },
   {
@@ -144,24 +219,24 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "rtdb",
     status: "qualified",
     description: "Rules-respecting get, set, single-child update, and remove operations.",
-    reasons: [
-      "rtdb.rule-kind.read: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 14 captured scenario(s)",
-      "rtdb.rule-kind.write: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 14 captured scenario(s)",
-      "rtdb.rule-kind.location-wildcard: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "rtdb.binding.auth: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 13 captured scenario(s)",
-      "rtdb.binding.auth.uid: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "rtdb.binding.auth.token: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "rtdb.binding.path-variable: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "rtdb.method.snapshot.val: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-      "rtdb.method.snapshot.child: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "rtdb.method.snapshot.exists: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "rtdb.operator.strictEq: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-      "rtdb.operator.and: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-      "rtdb.operator.or: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "rtdb.operator.not: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "rtdb.semantic.read-cascade: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#5, rtdb-rules#8, rtdb-rules#10",
-      "rtdb.semantic.write-cascade: snapshot status \"unprobed\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row rtdb-rules#3, rtdb-rules#4, rtdb-rules#5",
-      "rtdb.semantic.deny-by-default: snapshot status \"unprobed\"; capability probe \"implemented\"; no production-captured scenario and no conforming oracle-backed row verifies it",
+    dependencies: [
+      {"kind":"construct","id":"rtdb.rule-kind.read","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.rule-kind.write","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.rule-kind.location-wildcard","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.auth","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.auth.uid","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.auth.token","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.path-variable","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.method.snapshot.val","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.method.snapshot.child","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.method.snapshot.exists","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.operator.strictEq","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.operator.and","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.operator.or","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.operator.not","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.read-cascade","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.write-cascade","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.deny-by-default","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":false,"divergedBy":[]},
     ],
   },
   {
@@ -169,8 +244,13 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "rtdb",
     status: "unsupported",
     description: "Ancestor data/newData bindings and merged future-tree semantics.",
-    reasons: [
-      "`data`/`newData` bound to an ANCESTOR rule location, with `newData` as the merged future tree of the whole write: the conformance graph does not model this behavior: the snapshot enumerates the data/newData bindings but not their rule-location binding or future-tree projection, and no registry row adjudicates ancestor-location binding against production",
+    dependencies: [
+      {"kind":"construct","id":"rtdb.binding.data","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.newData","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.binding.root","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.write-cascade","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.semantic.validate-non-cascade","verdict":"qualified","snapshot":"unprobed","probe":"unprobeable","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"`data`/`newData` bound to an ANCESTOR rule location, with `newData` as the merged future tree of the whole write","verdict":"unsupported","reason":"the snapshot enumerates the data/newData bindings but not their rule-location binding or future-tree projection, and no registry row adjudicates ancestor-location binding against production"},
     ],
   },
   {
@@ -178,8 +258,10 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "rtdb",
     status: "unsupported",
     description: "Transaction retries, push-key allocation, and listener re-evaluation are not probe operations in v1.",
-    reasons: [
-      "rules re-evaluation on transaction retry, on push-key allocation, and on every listener event delivery: the conformance graph does not model this behavior: none of the three is a language construct, and no registry row adjudicates re-authorization on retry or on listener delivery against production",
+    dependencies: [
+      {"kind":"construct","id":"rtdb.rule-kind.read","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"rtdb.rule-kind.write","verdict":"qualified","snapshot":"unprobed","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"rules re-evaluation on transaction retry, on push-key allocation, and on every listener event delivery","verdict":"unsupported","reason":"none of the three is a language construct, and no registry row adjudicates re-authorization on retry or on listener delivery against production"},
     ],
   },
   {
@@ -187,26 +269,26 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "storage",
     status: "supported",
     description: "Granular verbs, functions, time, regex, object identity, and Firestore rule lookups.",
-    reasons: [
-      "storage.rule-kind.allow-get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-      "storage.rule-kind.allow-list: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.rule-kind.allow-create: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-      "storage.rule-kind.allow-update: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.rule-kind.allow-delete: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "storage.rule-kind.function: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.rule-kind.let: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.method.string.matches: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.function.timestamp.date: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.function.timestamp.value: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.function.duration.value: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.function.firestore.get: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.function.firestore.exists: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.request.time: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "storage.binding.resource.name: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource.bucket: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource.timeCreated: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource.updated: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage-rules#116: registry row storage-rules#116 (storage-rules) status \"conforms\"",
+    dependencies: [
+      {"kind":"construct","id":"storage.rule-kind.allow-get","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-list","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-create","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-update","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-delete","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.function","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.let","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.method.string.matches","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.function.timestamp.date","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.function.timestamp.value","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.function.duration.value","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.function.firestore.get","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.function.firestore.exists","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.time","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.name","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.bucket","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.timeCreated","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.updated","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"registry-row","id":"storage-rules#116","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
     ],
   },
   {
@@ -214,40 +296,40 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "storage",
     status: "supported",
     description: "Coarse read/write with auth, size, content type, metadata, and path matching.",
-    reasons: [
-      "storage.rule-kind.match: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-      "storage.rule-kind.allow-read: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "storage.rule-kind.allow-write: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.request: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 7 captured scenario(s)",
-      "storage.binding.request.auth: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.binding.request.auth.uid: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.binding.request.auth.token: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.request.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.binding.request.resource.size: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "storage.binding.request.resource.contentType: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.binding.request.resource.metadata: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-      "storage.binding.resource.size: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource.contentType: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.resource.metadata: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.binding.path-variable: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 8 captured scenario(s)",
-      "storage.operator.eq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 6 captured scenario(s)",
-      "storage.operator.neq: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.operator.lt: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 4 captured scenario(s)",
-      "storage.operator.and: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 3 captured scenario(s)",
-      "storage.operator.or: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.operator.not: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.semantic.read-umbrella: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 2 captured scenario(s)",
-      "storage.semantic.write-umbrella: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.semantic.recursive-wildcard: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by 1 captured scenario(s)",
-      "storage.semantic.deny-by-default: snapshot status \"accepted\"; capability probe \"implemented\"; production-verified by conforming oracle-backed rules-engine row storage-rules#96",
-      "storage-rules#98: registry row storage-rules#98 (storage-rules) status \"conforms\"",
-      "storage-rules#99: registry row storage-rules#99 (storage-rules) status \"conforms\"",
-      "storage-rules#100: registry row storage-rules#100 (storage-rules) status \"conforms\"",
-      "storage-rules#101: registry row storage-rules#101 (storage-rules) status \"conforms\"",
-      "storage-rules#102: registry row storage-rules#102 (storage-rules) status \"conforms\"",
-      "storage-rules#103: registry row storage-rules#103 (storage-rules) status \"conforms\"",
-      "storage-rules#114: registry row storage-rules#114 (storage-rules) status \"conforms\"",
+    dependencies: [
+      {"kind":"construct","id":"storage.rule-kind.match","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-read","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.rule-kind.allow-write","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.auth","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.auth.uid","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.auth.token","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.resource","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.resource.size","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.resource.contentType","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.request.resource.metadata","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.size","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.contentType","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.resource.metadata","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.binding.path-variable","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.eq","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.neq","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.lt","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.and","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.or","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.operator.not","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.semantic.read-umbrella","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.semantic.write-umbrella","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.semantic.recursive-wildcard","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"construct","id":"storage.semantic.deny-by-default","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"registry-row","id":"storage-rules#98","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#99","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#100","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#101","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#102","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#103","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
+      {"kind":"registry-row","id":"storage-rules#114","verdict":"supported","surface":"storage-rules","status":"conforms","rulesEngineSurface":true},
     ],
   },
   {
@@ -255,8 +337,47 @@ export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapabilit
     service: "storage",
     status: "unsupported",
     description: "Resumable transfer state and paginated list semantics are not probe operations in v1.",
-    reasons: [
-      "authorization of resumable-upload session state across chunks, and of a paginated list against its prefix: the conformance graph does not model this behavior: neither is a language construct, and no registry row adjudicates resumable-session or pagination authorization against production",
+    dependencies: [
+      {"kind":"construct","id":"storage.rule-kind.allow-list","verdict":"supported","snapshot":"accepted","probe":"implemented","productionVerified":true,"divergedBy":[]},
+      {"kind":"unbacked","id":"authorization of resumable-upload session state across chunks, and of a paginated list against its prefix","verdict":"unsupported","reason":"neither is a language construct, and no registry row adjudicates resumable-session or pagination authorization against production"},
     ],
   },
 ];
+
+/** One dependency, as a sentence. The facts are the record; this is a view of
+ *  them, built on read. */
+export function describeCapabilityDependency(dependency: GeneratedCapabilityDependency): string {
+  if (dependency.kind === "construct") {
+    const facts = [
+      `snapshot status "${dependency.snapshot}"`,
+      `capability probe "${dependency.probe}"`,
+      dependency.productionVerified
+        ? "production-verified against captured production behavior"
+        : "no production-captured scenario and no conforming oracle-backed row verifies it",
+    ];
+    if (dependency.divergedBy.length > 0) {
+      facts.push(`covered by rules-engine divergence ${dependency.divergedBy.join(", ")}`);
+    }
+    return `${dependency.id}: ${facts.join("; ")}`;
+  }
+  if (dependency.kind === "registry-row") {
+    const facts = [`registry row ${dependency.id} (${dependency.surface}) status "${dependency.status}"`];
+    if (dependency.status === "diverged-documented") {
+      facts.push(
+        dependency.rulesEngineSurface
+          ? "divergence is in the rules engine itself: the verdict machinery is known wrong here"
+          : "divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical",
+      );
+    }
+    return `${dependency.id}: ${facts.join("; ")}`;
+  }
+  return `${dependency.id}: the conformance graph does not model this behavior: ${dependency.reason}`;
+}
+
+/** The reasons a probe cites when it abstains: the dependencies whose verdict
+ *  pinned the capability's status, each rendered as a sentence. */
+export function capabilityReasons(capability: GeneratedAssuranceCapability): string[] {
+  return capability.dependencies
+    .filter((dependency) => dependency.verdict === capability.status)
+    .map(describeCapabilityDependency);
+}

--- a/packages/conformance/assurance-capabilities/types.ts
+++ b/packages/conformance/assurance-capabilities/types.ts
@@ -91,27 +91,85 @@ export interface AssuranceCapabilityRecord {
  *  dependencies. */
 export type DependencyVerdict = AssuranceCapabilityStatus;
 
-/** One dependency, with the graph evidence that produced its verdict. */
-export interface DerivedDependency {
-  kind: CapabilityDependency['kind'];
-  /** Construct id, row id, or the unbacked behavior. */
+/** What the simulator's capability probe did with a construct. `absent` means the
+ *  probe report does not mention it at all. */
+export type ProbeClassification = 'implemented' | 'unsupported' | 'error' | 'unprobeable' | 'absent';
+
+/**
+ * The evidence for a construct dependency: the FACTS the verdict is computed
+ * from, each one a property of THIS construct.
+ *
+ * `productionVerified` is a BOOLEAN, never a count and never the scenario ids.
+ * How MANY corpus scenarios happen to exercise a construct is a property of the
+ * corpus, not of the construct: it moves whenever anyone captures a scenario
+ * anywhere, so freezing it here would rewrite this record for a change that did
+ * not touch this construct. The predicate is what the derivation reads, so the
+ * predicate is what the record carries. A human who wants the scenarios reads
+ * them from the coverage report at print time.
+ */
+export interface DerivedConstructDependency {
+  kind: 'construct';
   id: string;
   verdict: DependencyVerdict;
-  /** The graph facts behind the verdict, in the order the derivation read
-   *  them. */
-  evidence: string[];
+  /** The construct's status in its engine's language snapshot. */
+  snapshot: string;
+  /** The local simulator's capability-probe classification. */
+  probe: ProbeClassification;
+  /** The shared predicate (`production-verification.ts`): does at least one
+   *  evidence path compare this construct against production? */
+  productionVerified: boolean;
+  /** The rules-engine rows whose documented divergence covers this construct.
+   *  Authored, construct-scoped, and causal: a row lands in this list only by
+   *  naming the construct. */
+  divergedBy: string[];
 }
 
-/** One capability as the graph computes it: the authored record's `service` and
- *  `description`, a DERIVED `status`, and the full evidence chain. */
+/** The evidence for a registry-row dependency: the row's own adjudicated state. */
+export interface DerivedRegistryRowDependency {
+  kind: 'registry-row';
+  id: string;
+  verdict: DependencyVerdict;
+  /** The registry the row lives on, or `missing` if no registry declares it. */
+  surface: string;
+  /** The row's compatibility status, or `missing`. */
+  status: string;
+  /** Whether the surface IS a rules engine (decides what a `diverged-documented`
+   *  row contaminates: the verdict machinery, or only the probe's setup). */
+  rulesEngineSurface: boolean;
+}
+
+/** The evidence for an unbacked dependency: the authored declaration itself. The
+ *  graph models nothing here, so there is nothing to look up. */
+export interface DerivedUnbackedDependency {
+  kind: 'unbacked';
+  /** The behavior the capability needs. */
+  id: string;
+  verdict: DependencyVerdict;
+  /** Why the graph cannot back it. */
+  reason: string;
+}
+
+/** One dependency, with the graph facts that produced its verdict. */
+export type DerivedDependency =
+  | DerivedConstructDependency
+  | DerivedRegistryRowDependency
+  | DerivedUnbackedDependency;
+
+/**
+ * One capability as the graph computes it: the authored record's `service` and
+ * `description`, a DERIVED `status`, and the facts behind every dependency.
+ *
+ * There is no `reasons` field. A reason is a SENTENCE, and a sentence is a
+ * rendering of these facts — it belongs to whoever prints it, not to the
+ * artifact. The dependencies that pinned the status are exactly
+ * `dependencies.filter((d) => d.verdict === status)`; a reader derives that
+ * rather than reading a frozen copy of it.
+ */
 export interface DerivedCapability {
   id: string;
   service: AssuranceCapabilityService;
   status: AssuranceCapabilityStatus;
   description: string;
-  /** The dependencies that pinned the status (every dependency whose verdict
-   *  equals the capability's status), summarized for a report line. */
-  reasons: string[];
   dependencies: DerivedDependency[];
 }
 

--- a/packages/conformance/src/assurance-capabilities.test.ts
+++ b/packages/conformance/src/assurance-capabilities.test.ts
@@ -12,11 +12,13 @@ import {
   deriveAllCapabilities,
   deriveCapability,
   loadConformanceGraph,
+  pinningDependencies,
   renderArtifactJson,
   renderGeneratedTs,
   validationProblems,
   type ConformanceGraph,
 } from './assurance-capabilities.ts';
+import { capabilityReasons } from '../assurance-capabilities/generated.ts';
 import {
   capabilityRecordProblems,
   loadAssuranceCapabilityRecords,
@@ -196,7 +198,34 @@ describe('construct derivation', () => {
     const g = fakeGraph({ ...supported, divergedBy: new Map([['firestore.operator.eq', ['firestore-rules#166']]]) });
     const derived = deriveCapability(g, capability({ dependencies: dep }));
     expect(derived.status).toBe('unsupported');
-    expect(derived.reasons.join(' ')).toContain('firestore-rules#166');
+    expect(pinningDependencies(derived)).toEqual([
+      {
+        kind: 'construct',
+        id: 'firestore.operator.eq',
+        verdict: 'unsupported',
+        snapshot: 'accepted',
+        probe: 'implemented',
+        productionVerified: true,
+        divergedBy: ['firestore-rules#166'],
+      },
+    ]);
+  });
+
+  it('records production verification as a boolean, never the scenarios that produced it', () => {
+    const many = fakeGraph({
+      ...supported,
+      verifiedBy: new Map([['firestore.operator.eq', ['s1', 's2', 's3']]]),
+    });
+    const [dependency] = deriveCapability(many, capability({ dependencies: dep })).dependencies;
+    expect(dependency).toEqual({
+      kind: 'construct',
+      id: 'firestore.operator.eq',
+      verdict: 'supported',
+      snapshot: 'accepted',
+      probe: 'implemented',
+      productionVerified: true,
+      divergedBy: [],
+    });
   });
 });
 
@@ -279,7 +308,15 @@ describe('the shipped derivation', () => {
   });
 
   it('cites the graph evidence that pinned each status', () => {
-    for (const item of derived) expect(item.reasons.length).toBeGreaterThan(0);
+    for (const item of derived) expect(pinningDependencies(item).length).toBeGreaterThan(0);
+  });
+
+  it('renders an abstention reason on READ from the facts, for every capability a probe must abstain on', () => {
+    for (const item of ASSURANCE_ENGINE_CAPABILITIES.filter((c) => c.status !== 'supported')) {
+      const reasons = capabilityReasons(item);
+      expect(reasons.length).toBeGreaterThan(0);
+      for (const reason of reasons) expect(reason.length).toBeGreaterThan(0);
+    }
   });
 
   it('the committed artifact and generated module match the graph (no drift)', () => {
@@ -288,5 +325,74 @@ describe('the shipped derivation', () => {
       derived.map((c) => `${c.id}:${c.status}`),
     );
     expect(renderGeneratedTs(derived)).toContain('ASSURANCE_ENGINE_CAPABILITIES');
+  });
+});
+
+/**
+ * THE STANDING CONSTRAINT (see the generator header): a durable artifact carries
+ * facts about the thing it describes, never a whole-population aggregate.
+ *
+ * The artifacts once baked the corpus scenario COUNT into each construct's
+ * evidence sentence ("production-verified by 19 captured scenario(s)"). That
+ * count belongs to the corpus, so capturing ONE scenario anywhere rewrote dozens
+ * of capabilities that nothing had happened to: the diff lied about causality, a
+ * real `qualified -> supported` event drowned in the churn, and
+ * `compat:assurance:check` failed on branches that never touched assurance.
+ *
+ * The property these tests hold: the artifacts change IF AND ONLY IF a verdict
+ * changes. The perturbation below is the exact event that used to churn them.
+ */
+describe('churn invariance: the artifacts move only when a verdict moves', () => {
+  /** Every construct the corpus already verifies gains one more scenario, as if a
+   *  PR captured a scenario that happens to exercise it. Counts move; no verdict
+   *  can move, because `productionVerified` was already true for each of them. */
+  function withAnUnrelatedScenarioCaptured(graph: ConformanceGraph): ConformanceGraph {
+    const verifiedBy = new Map(graph.verifiedBy);
+    let perturbed = 0;
+    for (const [id, scenarios] of verifiedBy) {
+      if (scenarios.length === 0) continue;
+      verifiedBy.set(id, [...scenarios, 'synthetic-unrelated-scenario']);
+      perturbed++;
+    }
+    expect(perturbed).toBeGreaterThan(0);
+    return { ...graph, verifiedBy };
+  }
+
+  const before = deriveAllCapabilities(graph);
+  const after = deriveAllCapabilities(withAnUnrelatedScenarioCaptured(graph));
+
+  it('no verdict moves under the perturbation (it is a pure count change)', () => {
+    expect(after.map((c) => `${c.id}:${c.status}`)).toEqual(before.map((c) => `${c.id}:${c.status}`));
+    expect(after.flatMap((c) => c.dependencies.map((d) => `${c.id}/${d.id}:${d.verdict}`))).toEqual(
+      before.flatMap((c) => c.dependencies.map((d) => `${c.id}/${d.id}:${d.verdict}`)),
+    );
+  });
+
+  it('both artifacts are BYTE-IDENTICAL under the perturbation', () => {
+    expect(renderArtifactJson(buildArtifact(after))).toBe(renderArtifactJson(buildArtifact(before)));
+    expect(renderGeneratedTs(after)).toBe(renderGeneratedTs(before));
+  });
+
+  it('a verdict change DOES move the artifacts (the invariance is not vacuous)', () => {
+    // A construct some shipped capability actually depends on: break the simulator
+    // on it, and the artifacts must move.
+    const depended = before
+      .flatMap((c) => c.dependencies)
+      .find((d) => d.kind === 'construct' && d.verdict === 'supported');
+    expect(depended).toBeDefined();
+    const broken: ConformanceGraph = {
+      ...graph,
+      probeClass: new Map(graph.probeClass).set(depended!.id, 'error'),
+    };
+    expect(renderArtifactJson(buildArtifact(deriveAllCapabilities(broken)))).not.toBe(
+      renderArtifactJson(buildArtifact(before)),
+    );
+  });
+
+  it('no durable artifact carries a population aggregate', () => {
+    for (const text of [renderArtifactJson(buildArtifact(before)), renderGeneratedTs(before)]) {
+      expect(text).not.toContain('captured scenario(s)');
+      expect(text).not.toMatch(/production-verified by \d+/);
+    }
   });
 });

--- a/packages/conformance/src/assurance-capabilities.ts
+++ b/packages/conformance/src/assurance-capabilities.ts
@@ -115,11 +115,36 @@
  *
  * OUTPUT
  *
- *   `assurance-capabilities/capabilities.json` — the artifact, with the full
- *   evidence chain per dependency.
+ *   `assurance-capabilities/capabilities.json` — the artifact, with the facts
+ *   behind every dependency's verdict.
  *   `assurance-capabilities/generated.ts` — the same capabilities as a typed,
  *   inlined const (`ASSURANCE_ENGINE_CAPABILITIES`), the shape the assurance
- *   runtime consumes with no filesystem access.
+ *   runtime consumes with no filesystem access, plus the read-time renderer
+ *   (`capabilityReasons`) that turns those facts into sentences.
+ *
+ * ── THE STANDING CONSTRAINT: DERIVED FACTS, NEVER DERIVED PROSE ─────────────
+ *
+ * A generated record may carry ONLY facts whose value is determined by the thing
+ * the record is about. Never a count, a total, a percentage, a rank, or any
+ * other whole-population aggregate — and never a prose sentence containing one.
+ *
+ * WHY (this artifact learned it the hard way): each construct's evidence used to
+ * read "production-verified by 19 captured scenario(s)". That 19 is a fact about
+ * the CORPUS, not about the construct. Capture one scenario anywhere and dozens
+ * of unrelated capability records rewrite: the diff then lies about causality (a
+ * reviewer sees `firestore.operator.and` move and asks what happened to AND —
+ * nothing did), a genuine `qualified -> supported` event drowns in the noise, and
+ * `compat:assurance:check` fails on branches that never touched assurance, which
+ * turns regeneration into a reflex and lets a stale artifact through unexamined.
+ * A derived artifact that encodes a global fact churns globally.
+ *
+ * THE RULE, mechanically: a record's bytes may change only when a verdict in it
+ * changes. If you want to add a field, ask what else could move it. "Someone
+ * captured an unrelated scenario" is a NO. `assurance-capabilities.test.ts`
+ * holds this line: it perturbs the corpus counts without changing any verdict and
+ * asserts both artifacts are byte-identical. A count belongs in the printed
+ * report (`bun run compat:assurance`), which reads the corpus fresh and may say
+ * whatever a human finds useful — stdout is not a durable artifact.
  *
  * USAGE
  *
@@ -143,7 +168,9 @@ import type {
   AssuranceCapabilityArtifact,
   AssuranceCapabilityStatus,
   DerivedCapability,
+  DerivedConstructDependency,
   DerivedDependency,
+  DerivedRegistryRowDependency,
   DependencyVerdict,
 } from '../assurance-capabilities/types.ts';
 
@@ -275,15 +302,18 @@ export function validationProblems(graph: ConformanceGraph, records: LoadedCapab
   return problems;
 }
 
-function deriveConstruct(graph: ConformanceGraph, id: string): DerivedDependency {
+/**
+ * The facts about one construct. Each field is a property of THIS construct: its
+ * snapshot status, what the probe did with it, whether production verified it,
+ * and which divergences name it. Nothing here can move because of a change
+ * elsewhere in the corpus — see the standing constraint in this file's header.
+ */
+function deriveConstruct(graph: ConformanceGraph, id: string): DerivedConstructDependency {
   const snapshot = graph.snapshotStatus.get(id) ?? 'missing';
-  const probe = graph.probeClass.get(id);
-  const verified = graph.verifiedBy.get(id) ?? [];
-  const diverged = graph.divergedBy.get(id) ?? [];
-  const evidence: string[] = [];
+  const probe = graph.probeClass.get(id) ?? 'absent';
+  const divergedBy = graph.divergedBy.get(id) ?? [];
   const verdicts: DependencyVerdict[] = [];
 
-  evidence.push(`snapshot status "${snapshot}"`);
   if (snapshot === 'rejected') {
     verdicts.push('unsupported');
   } else if (snapshot === 'unprobed' || snapshot === 'unprobeable') {
@@ -292,8 +322,7 @@ function deriveConstruct(graph: ConformanceGraph, id: string): DerivedDependency
     verdicts.push('supported');
   }
 
-  evidence.push(`capability probe "${probe ?? 'absent'}"`);
-  if (probe === 'unsupported' || probe === 'error' || probe === undefined) {
+  if (probe === 'unsupported' || probe === 'error' || probe === 'absent') {
     verdicts.push('unsupported');
   } else if (probe === 'unprobeable') {
     verdicts.push('qualified');
@@ -302,40 +331,46 @@ function deriveConstruct(graph: ConformanceGraph, id: string): DerivedDependency
   }
 
   // The SHARED predicate (production-verification.ts): the same question the
-  // coverage report's `verifiedConstructs` numerator asks, answered once.
-  const productionEvidence = { scenarios: verified, provingRows: graph.oracleProvedBy.get(id) ?? [] };
-  evidence.push(describeProductionEvidence(productionEvidence));
-  verdicts.push(isProductionVerified(productionEvidence) ? 'supported' : 'qualified');
+  // coverage report's `verifiedConstructs` numerator asks, answered once. The
+  // artifact records the ANSWER (a boolean), never the evidence population that
+  // produced it.
+  const productionVerified = isProductionVerified({
+    scenarios: graph.verifiedBy.get(id) ?? [],
+    provingRows: graph.oracleProvedBy.get(id) ?? [],
+  });
+  verdicts.push(productionVerified ? 'supported' : 'qualified');
 
-  if (diverged.length > 0) {
-    evidence.push(`covered by rules-engine divergence ${diverged.join(', ')}`);
-    verdicts.push('unsupported');
-  }
+  if (divergedBy.length > 0) verdicts.push('unsupported');
 
-  return { kind: 'construct', id, verdict: weakest(verdicts), evidence };
+  return { kind: 'construct', id, verdict: weakest(verdicts), snapshot, probe, productionVerified, divergedBy };
 }
 
-function deriveRow(graph: ConformanceGraph, id: string): DerivedDependency {
+function deriveRow(graph: ConformanceGraph, id: string): DerivedRegistryRowDependency {
   const row = graph.rows.get(id);
-  if (!row) return { kind: 'registry-row', id, verdict: 'unsupported', evidence: ['row not found in any registry'] };
-  const engineRow = RULES_ENGINE_SURFACES.has(row.surface);
-  const evidence = [`registry row ${row.id} (${row.surface}) status "${row.status}"`];
+  if (!row) {
+    return {
+      kind: 'registry-row',
+      id,
+      verdict: 'unsupported',
+      surface: 'missing',
+      status: 'missing',
+      rulesEngineSurface: false,
+    };
+  }
+  const rulesEngineSurface = RULES_ENGINE_SURFACES.has(row.surface);
   let verdict: DependencyVerdict;
   if (row.status === 'bug' || row.status === 'unsupported') {
     verdict = 'unsupported';
   } else if (row.status === 'diverged-documented') {
-    verdict = engineRow ? 'unsupported' : 'qualified';
-    evidence.push(
-      engineRow
-        ? 'divergence is in the rules engine itself: the verdict machinery is known wrong here'
-        : 'divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical',
-    );
+    // A divergence in the verdict machinery itself is disqualifying; a divergence
+    // in an SDK surface only qualifies the probe's setup.
+    verdict = rulesEngineSurface ? 'unsupported' : 'qualified';
   } else if (row.status === 'unverified') {
     verdict = 'qualified';
   } else {
     verdict = 'supported';
   }
-  return { kind: 'registry-row', id, verdict, evidence };
+  return { kind: 'registry-row', id, verdict, surface: row.surface, status: row.status, rulesEngineSurface };
 }
 
 /** Derive one capability from the graph. */
@@ -343,25 +378,21 @@ export function deriveCapability(graph: ConformanceGraph, record: LoadedCapabili
   const dependencies: DerivedDependency[] = record.dependencies.map((dep) => {
     if (dep.kind === 'construct') return deriveConstruct(graph, dep.id);
     if (dep.kind === 'registry-row') return deriveRow(graph, dep.id);
-    return {
-      kind: 'unbacked',
-      id: dep.behavior,
-      verdict: 'unsupported',
-      evidence: [`the conformance graph does not model this behavior: ${dep.reason}`],
-    };
+    return { kind: 'unbacked', id: dep.behavior, verdict: 'unsupported', reason: dep.reason };
   });
 
   const status = weakest(dependencies.map((dep) => dep.verdict));
-  const reasons = dependencies
-    .filter((dep) => dep.verdict === status)
-    .map((dep) => `${dep.id}: ${dep.evidence.join('; ')}`);
+  return { id: record.id, service: record.service, status, description: record.description, dependencies };
+}
 
-  return { id: record.id, service: record.service, status, description: record.description, reasons, dependencies };
+/** The dependencies that pinned a capability's status: derived on read, never
+ *  frozen (a frozen copy is a second thing to keep in sync). */
+export function pinningDependencies(capability: DerivedCapability): DerivedDependency[] {
+  return capability.dependencies.filter((dep) => dep.verdict === capability.status);
 }
 
 /** Derive every capability. Throws on any validation problem. */
-export function deriveAllCapabilities(): DerivedCapability[] {
-  const graph = loadConformanceGraph();
+export function deriveAllCapabilities(graph: ConformanceGraph = loadConformanceGraph()): DerivedCapability[] {
   const records = loadAssuranceCapabilityRecords();
   const problems = validationProblems(graph, records);
   if (problems.length > 0) {
@@ -371,7 +402,7 @@ export function deriveAllCapabilities(): DerivedCapability[] {
 }
 
 const GENERATED_NOTE =
-  'GENERATED from the conformance graph by packages/conformance/src/assurance-capabilities.ts. Do not edit by hand; run bun run compat:assurance. Each capability declares its dependencies in packages/conformance/assurance-capabilities/<id>.ts; the status here is DERIVED, never asserted. A capability that is not "supported" means an assurance probe depending on it must abstain (engine-gap), not report a security conclusion.';
+  'GENERATED from the conformance graph by packages/conformance/src/assurance-capabilities.ts. Do not edit by hand; run bun run compat:assurance. Each capability declares its dependencies in packages/conformance/assurance-capabilities/<id>.ts; the status here is DERIVED, never asserted. A capability that is not "supported" means an assurance probe depending on it must abstain (engine-gap), not report a security conclusion. Every dependency carries the FACTS behind its verdict and no count, total, or other whole-population aggregate: an aggregate would move this file whenever anything anywhere in the corpus moved, so these records change only when a verdict changes. Sentences (with counts, if a human wants them) are rendered on read: bun run compat:assurance.';
 
 export function buildArtifact(capabilities: DerivedCapability[]): AssuranceCapabilityArtifact {
   return {
@@ -392,6 +423,59 @@ export function renderArtifactJson(artifact: AssuranceCapabilityArtifact): strin
   return `${JSON.stringify(artifact, null, 2)}\n`;
 }
 
+/**
+ * The read-time renderer, emitted INTO each generated module.
+ *
+ * It is emitted rather than imported because the consumer that needs it most —
+ * the assurance runtime in `pyric-tools` — cannot import from this package
+ * (`conformance` is private and is not one of its dependencies). Emitting it
+ * keeps one definition (this constant) and gives every generated copy the same
+ * wording, whatever package it lands in. It depends on nothing but the record's
+ * own fields, so it is paste-able into a self-contained copy unchanged.
+ *
+ * This is where the sentences live now. The artifact carries facts; a reader who
+ * wants prose calls `capabilityReasons` at read time.
+ */
+const EMITTED_RENDERER = [
+  '/** One dependency, as a sentence. The facts are the record; this is a view of',
+  ' *  them, built on read. */',
+  'export function describeCapabilityDependency(dependency: GeneratedCapabilityDependency): string {',
+  '  if (dependency.kind === "construct") {',
+  '    const facts = [',
+  '      `snapshot status "${dependency.snapshot}"`,',
+  '      `capability probe "${dependency.probe}"`,',
+  '      dependency.productionVerified',
+  '        ? "production-verified against captured production behavior"',
+  '        : "no production-captured scenario and no conforming oracle-backed row verifies it",',
+  '    ];',
+  '    if (dependency.divergedBy.length > 0) {',
+  '      facts.push(`covered by rules-engine divergence ${dependency.divergedBy.join(", ")}`);',
+  '    }',
+  '    return `${dependency.id}: ${facts.join("; ")}`;',
+  '  }',
+  '  if (dependency.kind === "registry-row") {',
+  '    const facts = [`registry row ${dependency.id} (${dependency.surface}) status "${dependency.status}"`];',
+  '    if (dependency.status === "diverged-documented") {',
+  '      facts.push(',
+  '        dependency.rulesEngineSurface',
+  '          ? "divergence is in the rules engine itself: the verdict machinery is known wrong here"',
+  '          : "divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical",',
+  '      );',
+  '    }',
+  '    return `${dependency.id}: ${facts.join("; ")}`;',
+  '  }',
+  '  return `${dependency.id}: the conformance graph does not model this behavior: ${dependency.reason}`;',
+  '}',
+  '',
+  '/** The reasons a probe cites when it abstains: the dependencies whose verdict',
+  ' *  pinned the capability\'s status, each rendered as a sentence. */',
+  'export function capabilityReasons(capability: GeneratedAssuranceCapability): string[] {',
+  '  return capability.dependencies',
+  '    .filter((dependency) => dependency.verdict === capability.status)',
+  '    .map(describeCapabilityDependency);',
+  '}',
+];
+
 /** The generated TypeScript module: the same capabilities, inlined, in the shape
  *  the assurance runtime consumes (no filesystem, no JSON import). */
 export function renderGeneratedTs(capabilities: DerivedCapability[]): string {
@@ -401,18 +485,63 @@ export function renderGeneratedTs(capabilities: DerivedCapability[]): string {
     '// The assurance engine\'s capabilities, DERIVED from the conformance graph by',
     '// packages/conformance/src/assurance-capabilities.ts (see that file\'s header for',
     '// the derivation rules). The assurance runtime consumes this module directly:',
-    '// each record is structurally an AssuranceEngineCapability, and `reasons` carries',
-    '// the graph evidence a probe cites when it abstains.',
+    '// each record is structurally an AssuranceEngineCapability.',
+    '//',
+    '// Each dependency carries the FACTS behind its verdict, never a sentence and',
+    '// never a count: a count is a property of the corpus, so freezing one here would',
+    '// rewrite unrelated records every time anyone captured a scenario. A probe that',
+    '// abstains renders its reasons on read with `capabilityReasons(capability)`.',
     "import type { AssuranceCapabilityService, AssuranceCapabilityStatus } from './types.ts';",
+    '',
+    'export type CapabilityVerdict = AssuranceCapabilityStatus;',
+    '',
+    'export interface GeneratedConstructDependency {',
+    "  kind: 'construct';",
+    '  /** The rules-language construct id. */',
+    '  id: string;',
+    '  verdict: CapabilityVerdict;',
+    '  /** The construct\'s status in the production language snapshot. */',
+    '  snapshot: string;',
+    '  /** What the local simulator\'s capability probe did with it. */',
+    "  probe: 'implemented' | 'unsupported' | 'error' | 'unprobeable' | 'absent';",
+    '  /** Whether any evidence path compares it against production. A BOOLEAN: how',
+    '   *  many scenarios do so is a fact about the corpus, not about this construct. */',
+    '  productionVerified: boolean;',
+    '  /** Rules-engine rows whose documented divergence names this construct. */',
+    '  divergedBy: string[];',
+    '}',
+    '',
+    'export interface GeneratedRegistryRowDependency {',
+    "  kind: 'registry-row';",
+    '  id: string;',
+    '  verdict: CapabilityVerdict;',
+    '  surface: string;',
+    '  status: string;',
+    '  rulesEngineSurface: boolean;',
+    '}',
+    '',
+    'export interface GeneratedUnbackedDependency {',
+    "  kind: 'unbacked';",
+    '  /** The behavior the capability needs. */',
+    '  id: string;',
+    '  verdict: CapabilityVerdict;',
+    '  /** Why the graph cannot back it. */',
+    '  reason: string;',
+    '}',
+    '',
+    'export type GeneratedCapabilityDependency =',
+    '  | GeneratedConstructDependency',
+    '  | GeneratedRegistryRowDependency',
+    '  | GeneratedUnbackedDependency;',
     '',
     'export interface GeneratedAssuranceCapability {',
     '  id: string;',
     '  service: AssuranceCapabilityService;',
     '  status: AssuranceCapabilityStatus;',
     '  description: string;',
-    '  /** The graph evidence that pinned the status: the dependencies whose verdict',
-    '   *  equals it. A probe that abstains reports these. */',
-    '  reasons: string[];',
+    '  /** Everything the status rests on. The ones that pinned it are the ones whose',
+    '   *  verdict equals the status; `capabilityReasons` selects and renders them. */',
+    '  dependencies: GeneratedCapabilityDependency[];',
     '}',
     '',
     'export const ASSURANCE_ENGINE_CAPABILITIES: readonly GeneratedAssuranceCapability[] = [',
@@ -423,25 +552,73 @@ export function renderGeneratedTs(capabilities: DerivedCapability[]): string {
     lines.push(`    service: ${JSON.stringify(capability.service)},`);
     lines.push(`    status: ${JSON.stringify(capability.status)},`);
     lines.push(`    description: ${JSON.stringify(capability.description)},`);
-    lines.push('    reasons: [');
-    for (const reason of capability.reasons) lines.push(`      ${JSON.stringify(reason)},`);
+    lines.push('    dependencies: [');
+    for (const dependency of capability.dependencies) {
+      lines.push(`      ${JSON.stringify(dependency)},`);
+    }
     lines.push('    ],');
     lines.push('  },');
   }
-  lines.push('];', '');
+  lines.push('];', '', ...EMITTED_RENDERER, '');
   return lines.join('\n');
 }
 
-function renderTable(capabilities: DerivedCapability[]): string {
+/**
+ * The printed report. This is READ TIME: the graph is open, so the sentences may
+ * cite anything a human finds useful — including the scenario COUNT that must
+ * never be frozen into an artifact. Nothing downstream parses stdout.
+ */
+function renderTable(graph: ConformanceGraph, capabilities: DerivedCapability[]): string {
   const width = Math.max(...capabilities.map((c) => c.id.length));
   return capabilities
-    .map((c) => `${c.id.padEnd(width)}  ${c.status.padEnd(11)}  ${c.reasons[0] ?? ''}`)
+    .map((capability) => {
+      const reason = pinningDependencies(capability).map((dep) => describeForReport(graph, dep))[0] ?? '';
+      return `${capability.id.padEnd(width)}  ${capability.status.padEnd(11)}  ${reason}`;
+    })
     .join('\n');
+}
+
+/**
+ * A dependency as a sentence for the REPORT. The generated module carries its own
+ * renderer (`EMITTED_RENDERER`) for consumers that only have the record; this one
+ * exists separately because it can still see the graph, and it says more with it:
+ * the construct's production evidence is spelled out (how many scenarios, which
+ * rows) rather than collapsed to the boolean the artifact carries. That extra
+ * detail is exactly what may not be frozen, which is why it lives only here.
+ */
+function describeForReport(graph: ConformanceGraph, dependency: DerivedDependency): string {
+  if (dependency.kind === 'unbacked') {
+    return `${dependency.id}: the conformance graph does not model this behavior: ${dependency.reason}`;
+  }
+  if (dependency.kind === 'registry-row') {
+    const facts = [`registry row ${dependency.id} (${dependency.surface}) status "${dependency.status}"`];
+    if (dependency.status === 'diverged-documented') {
+      facts.push(
+        dependency.rulesEngineSurface
+          ? 'divergence is in the rules engine itself: the verdict machinery is known wrong here'
+          : 'divergence is in an SDK surface: the verdict machinery is sound, the probe setup is not production-identical',
+      );
+    }
+    return `${dependency.id}: ${facts.join('; ')}`;
+  }
+  const facts = [
+    `snapshot status "${dependency.snapshot}"`,
+    `capability probe "${dependency.probe}"`,
+    describeProductionEvidence({
+      scenarios: graph.verifiedBy.get(dependency.id) ?? [],
+      provingRows: graph.oracleProvedBy.get(dependency.id) ?? [],
+    }),
+  ];
+  if (dependency.divergedBy.length > 0) {
+    facts.push(`covered by rules-engine divergence ${dependency.divergedBy.join(', ')}`);
+  }
+  return `${dependency.id}: ${facts.join('; ')}`;
 }
 
 function main(): void {
   const args = new Set(process.argv.slice(2));
-  const capabilities = deriveAllCapabilities();
+  const graph = loadConformanceGraph();
+  const capabilities = deriveAllCapabilities(graph);
   const artifactJson = renderArtifactJson(buildArtifact(capabilities));
   const generatedTs = renderGeneratedTs(capabilities);
 
@@ -477,7 +654,7 @@ function main(): void {
     return;
   }
 
-  console.log(renderTable(capabilities));
+  console.log(renderTable(graph, capabilities));
 }
 
 if (import.meta.main) main();


### PR DESCRIPTION
The generated assurance artifacts baked a COUNT into each evidence sentence ("production-verified by 19 captured scenario(s)"). That count is a property of the whole corpus, not of the capability — so any PR capturing any scenario anywhere rewrote dozens of unrelated lines. Three harms: the diff LIED ABOUT CAUSALITY (a reviewer sees `firestore.operator.and` change and asks what happened to AND — nothing did), the real signal drowned (a capability moving qualified to supported is a genuine event, buried in 39 lines of churn), and compat:assurance:check failed on PRs that never touched assurance, making regeneration a reflex — which is how a stale artifact slips through unexamined.

Same disease as a global ordering counter: a derived artifact encoding a global fact churns globally.

## The fix

Each dependency now carries structured FACTS determined only by the thing the record is about: snapshot status, probe classification, `productionVerified` as a BOOLEAN, and `divergedBy` (rules-engine rows whose divergence NAMES the construct — causal, so it belongs). `reasons` is gone from the durable artifacts; the human-readable sentences render at READ time via `capabilityReasons()`, emitted alongside the data.

Scenario ids were considered and rejected: a construct verified by 19 scenarios gaining a 20th would rewrite its line with no verdict change. That is the same disease in a smaller font. And no reader needs them — a probe abstains only when productionVerified is false, in which case there are no scenarios to cite.

## The invariance, proven

Perturbation: append a synthetic scenario to every construct the corpus already verifies (236 of them). Counts move; no verdict can.

- Before: compat:assurance:check exits 1; regenerating rewrites 284 lines with zero verdict changes.
- After: exits 0, "artifact up to date". Regenerating and byte-comparing against the pre-perturbation snapshot gives identical SHA256 on both files.
- Not vacuous: the printed report still shows the moved count, and a test asserts a real verdict change DOES move the artifacts.

Held by a test ("the artifacts move only when a verdict moves") plus a guard asserting no durable artifact contains a count string.

## The standing constraint, written into the generator

A generated record may carry ONLY facts whose value is determined by the thing the record is about. Never a count, total, percentage, rank, or any whole-population aggregate — and never a prose sentence containing one. A record's bytes may change only when a verdict in it changes. Counts belong in the printed report, which reads the corpus fresh; stdout is not a durable artifact.

## For the held assurance-runtime branch

`capability.reasons` is a compile-time break, by design. The swap is one line: `capabilityReasons(capability).join(' ')` — same sentences, rendered on read, from the same import.

Verification (unmasked): compat:assurance --check 0; compat:check 0; conformance 165 pass. The pyric-tools failures are pre-existing on clean main (child-process import-rewriting tests), reproduced identically there.