### PR TITLE
Add a pull request template: lead with the code, not the report

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,10 @@ Write this for a reviewer, not for a log. Delete these instructions when you pos
 
 THE SHAPE:
 
-1. OPEN WITH THE CODE. A hero example, first thing, no preamble. Real imports, real
+1. ONE LINE, THEN THE CODE. Start with a single sentence naming what the PR adds or
+   changes and what it is ("Adds `pyric-tools/assurance`, a library that ..."), then
+   the hero example immediately. The line orients; the code teaches. Do not open cold
+   on a code block, and do not pad the line into a paragraph. Real imports, real
    values, runnable, from the consumer's seat. If the change is a behavior fix, show
    what the consumer writes and what they get. If it is an API, show the API being
    used. A reviewer should understand what changed before reading a single sentence

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,50 +1,66 @@
 <!--
 Write this for a reviewer, not for a log. Delete these instructions when you post.
 
+THE ONE TEST THAT CATCHES MOST OF IT: read each sentence and ask "could this appear,
+unchanged, in a different PR?" If yes, cut it. Generic openings, category headings, and
+filler about the work all fail this test. What survives is specific to THIS change.
+
 THE SHAPE:
 
 1. ONE LINE, THEN THE CODE. Start with a single sentence naming what the PR adds or
-   changes and what it is ("Adds `pyric-tools/assurance`, a library that ..."), then
-   the hero example immediately. The line orients; the code teaches. Do not open cold
-   on a code block, and do not pad the line into a paragraph. Real imports, real
-   values, runnable, from the consumer's seat. If the change is a behavior fix, show
-   what the consumer writes and what they get. If it is an API, show the API being
-   used. A reviewer should understand what changed before reading a single sentence
-   of prose.
+   changes and what it is ("Adds `pyric-tools/assurance`, a library that ..."), then the
+   hero example immediately. The line orients; the code teaches. Do not open cold on a
+   code block, and do not pad the line into a paragraph. Real imports, real values,
+   runnable, from the consumer's seat. If the change is a behavior fix, show what the
+   consumer writes and what they get; if it is docs, show what the reader now reads. Name
+   the subject concretely: a bare `update(...)` that could belong to any service teaches
+   nothing. A reviewer should know what changed before a sentence of prose.
 
-   THE SAMPLE DEFINES EVERYTHING IT USES. No `myCampaign`, no `...`, no "assume a
-   config". If the input is the interesting part of the change, the input goes in the
-   sample in full. A reader who does not already know the system must be able to run
-   it. A placeholder variable is a confession that you hid the thing worth showing.
+   THE SAMPLE DEFINES EVERYTHING IT USES. No `myCampaign`, no `...`, no "assume a config".
+   If the input is the interesting part of the change, the input goes in the sample in
+   full. A reader who does not already know the system must be able to run it. A
+   placeholder variable is a confession that you hid the thing worth showing.
 
-   AND IT EXPLAINS ITS OWN TERMS. If a result is `local-counterexample` or
-   `engine-gap`, the comment says what pyric actually DID to produce it, in plain
-   words. A term the reader cannot define from the sample is noise, however precise.
+   AND IT EXPLAINS ITS OWN TERMS. If a result is `local-counterexample` or `engine-gap`,
+   the comment says what pyric actually DID to produce it, in plain words. A term the
+   reader cannot define from the sample is noise, however precise.
 
-2. NARRATIVE HEADINGS. A heading states a fact, not a category. "Two capabilities now
-   abstain" beats "Behavior changes". "resource.id no longer allows what Firebase
-   denies" beats "Bug fix".
+2. SHOW THE WHOLE SURFACE, BY USING IT. If the change has more API than the hero example,
+   cover the rest the same way: as code a consumer runs. Every entry point the reader
+   would reach for, the programmatic API, the MCP/agent path, the CLI. A bulleted list of
+   type names or tool names is not usage; it is an index, and an index teaches nobody how
+   to use the thing. Be exhaustive in use, not in enumeration.
 
-3. SHOW, THEN EXPLAIN. Code sample, output, or table first; the paragraph after it, if
-   one is needed at all. Highlight the lines that matter.
+3. NARRATIVE HEADINGS STATE A FACT ABOUT THIS CHANGE. "resource.id no longer allows what
+   Firebase denies" beats "Bug fix". Not a category ("Behavior changes"), not a
+   dramatization ("a member can seize the room"), not an assumption about the reader ("the
+   kind a developer writes without thinking"), and, on a PR that introduces something new,
+   not delta-framing ("This PR's change:"), because there is nothing before it to delta
+   against.
 
-4. THE REVIEWER'S QUESTIONS. What is the risk? What is held for judgment? What could
-   this break? Say it plainly, near the top, not buried.
+4. SAY IT PRECISELY, NOT BIGGER THAN IT IS. State the mechanism as it works. Do not reach
+   for a sentence that, read literally, claims something false or alarmist to make the
+   change sound larger ("security rules routinely allow what they deny" indicts the engine
+   for a bug that is not there). Use the codebase's own vocabulary, not a casual synonym in
+   its place (we deny, we do not "forbid").
 
-5. VERIFICATION IS ONE LINE, AT THE BOTTOM. Exit codes and test counts are not the
-   story. Put them in the details block.
+5. SHOW, THEN EXPLAIN. Code, output, or table first; the paragraph after it, if one is
+   needed at all. Highlight the lines that matter.
 
-6. FINDINGS AND PROCESS NOTES GO IN <details>. What the author discovered, what they
-   declined to do, what they verified — collapse it. The reviewer opens it if they
-   want it.
+6. THE REVIEWER'S QUESTIONS, NEAR THE TOP. What is the risk? What is held for judgment?
+   What could this break? Say it plainly, not buried at the bottom.
+
+7. VERIFICATION AND FINDINGS GO IN <details>. Exit codes, test counts, what the author
+   discovered, what they declined to do, collapse it. The reviewer opens it if they want
+   it. It is not the story.
 
 WHAT THIS IS NOT: a report of what an agent did. Nobody is reviewing the work session.
 They are reviewing the change.
 
-COVERAGE PRs: if this moves a published number, state the delta AND its cause
-("verified +4: two new scenarios captured, zero reclassifications"). A number that
-moved because a denominator shrank is not an improvement, and the description must
-not let a reviewer mistake it for one.
+COVERAGE PRs: if this moves a published number, state the delta AND its cause ("verified
++4: two new scenarios captured, zero reclassifications"). A number that moved because a
+denominator shrank is not an improvement, and the description must not let a reviewer
+mistake it for one.
 -->
 
 ```ts

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+<!--
+Write this for a reviewer, not for a log. Delete these instructions when you post.
+
+THE SHAPE:
+
+1. OPEN WITH THE CODE. A hero example, first thing, no preamble. Real imports, real
+   values, runnable, from the consumer's seat. If the change is a behavior fix, show
+   what the consumer writes and what they get. If it is an API, show the API being
+   used. A reviewer should understand what changed before reading a single sentence
+   of prose.
+
+2. NARRATIVE HEADINGS. A heading states a fact, not a category. "Two capabilities now
+   abstain" beats "Behavior changes". "resource.id no longer allows what Firebase
+   denies" beats "Bug fix".
+
+3. SHOW, THEN EXPLAIN. Code sample, output, or table first; the paragraph after it, if
+   one is needed at all. Highlight the lines that matter.
+
+4. THE REVIEWER'S QUESTIONS. What is the risk? What is held for judgment? What could
+   this break? Say it plainly, near the top, not buried.
+
+5. VERIFICATION IS ONE LINE, AT THE BOTTOM. Exit codes and test counts are not the
+   story. Put them in the details block.
+
+6. FINDINGS AND PROCESS NOTES GO IN <details>. What the author discovered, what they
+   declined to do, what they verified — collapse it. The reviewer opens it if they
+   want it.
+
+WHAT THIS IS NOT: a report of what an agent did. Nobody is reviewing the work session.
+They are reviewing the change.
+
+COVERAGE PRs: if this moves a published number, state the delta AND its cause
+("verified +4: two new scenarios captured, zero reclassifications"). A number that
+moved because a denominator shrank is not an improvement, and the description must
+not let a reviewer mistake it for one.
+-->
+
+```ts
+// The change, as a consumer writes it. Replace this block.
+```
+
+## A heading that states what changed
+
+<!-- What a reader needs to know, after they have seen the code. -->
+
+## Risk
+
+<!-- What could break. What needs judgment. Delete if genuinely nothing. -->
+
+<details>
+<summary>Implementation notes</summary>
+
+<!-- Findings, decisions declined, verification, exit codes. -->
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,15 @@ THE SHAPE:
    used. A reviewer should understand what changed before reading a single sentence
    of prose.
 
+   THE SAMPLE DEFINES EVERYTHING IT USES. No `myCampaign`, no `...`, no "assume a
+   config". If the input is the interesting part of the change, the input goes in the
+   sample in full. A reader who does not already know the system must be able to run
+   it. A placeholder variable is a confession that you hid the thing worth showing.
+
+   AND IT EXPLAINS ITS OWN TERMS. If a result is `local-counterexample` or
+   `engine-gap`, the comment says what pyric actually DID to produce it, in plain
+   words. A term the reader cannot define from the sample is noise, however precise.
+
 2. NARRATIVE HEADINGS. A heading states a fact, not a category. "Two capabilities now
    abstain" beats "Behavior changes". "resource.id no longer allows what Firebase
    denies" beats "Bug fix".


### PR DESCRIPTION
```md
<!-- Every PR opens with this block, filled in: -->
```ts
// The change, as a consumer writes it.
const cred = await signInWithEmailLink(auth, 'ada@example.com', mail.link);
cred.user.emailVerified;   // true — redeeming the link proves control
```

## A heading that states what changed

## Risk

<details><summary>Implementation notes</summary></details>
```

## Every PR description tonight has been an agent's notes

They open with what the author did, not with what changed. They bury the API. They lead with verification counts and findings the reviewer did not ask for. The reviewer's actual question — *what does this look like to use, and what could it break* — gets answered on line 40, if at all.

The template makes the shape structural instead of remembered: hero example first with no preamble, narrative headings that state facts rather than label categories, risk near the top, verification compressed to the bottom, and findings collapsed into a details block. It also carries the coverage rule: a PR that moves a published number must state the delta **and its cause**, so a reviewer cannot mistake a shrunken denominator for an improvement.

PR #207 is rewritten to this shape as the worked example.

## Risk

None to code. The risk is that it is ignored, which is why it also goes into every agent brief that produces a PR body — the agent has the code, so the agent shows the code.