### PR TITLE
refactor: rename tooling package to @pyric/cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 # (the same orchestrator developers use locally) so CI and local
 # build behavior can't drift.
 #
-# Workspace packages: pyric, pyric-admin, pyric-tools, @pyric/ui,
+# Workspace packages: pyric, pyric-admin, @pyric/cli, @pyric/ui,
 # and @pyric/studio.
 
 name: Build & Test
@@ -125,7 +125,7 @@ jobs:
         run: set -o pipefail; bun run compat:coverage | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Run tests
-        # `npm run test` cycles through pyric, pyric-admin, pyric-tools,
+        # `npm run test` cycles through pyric, pyric-admin, @pyric/cli,
         # and @pyric/ui.
         run: npm run test
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "mdast-util-to-string": "^4.0.0",
         "publint": "^0.3.21",
         "pyric": "workspace:*",
-        "pyric-tools": "workspace:*",
+        "@pyric/cli": "workspace:*",
         "typescript": "^5.7.0",
         "zod": "^3.23.0",
       },
@@ -49,7 +49,7 @@
         "firebase": "^12.12.0",
       },
       "devDependencies": {
-        "pyric-tools": "workspace:*",
+        "@pyric/cli": "workspace:*",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
       },
@@ -62,7 +62,7 @@
         "firebase-admin": "^13.0.0",
         "pyric": "workspace:*",
         "pyric-admin": "workspace:*",
-        "pyric-tools": "workspace:*",
+        "@pyric/cli": "workspace:*",
         "zod": "^3.23.0",
       },
       "devDependencies": {
@@ -108,7 +108,7 @@
         "just-bash": "^3.0.1",
         "pyric": "workspace:*",
         "pyric-admin": "workspace:*",
-        "pyric-tools": "workspace:*",
+        "@pyric/cli": "workspace:*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^9",
@@ -162,7 +162,7 @@
       },
     },
     "packages/pyric-tools": {
-      "name": "pyric-tools",
+      "name": "@pyric/cli",
       "version": "0.1.0-alpha.8",
       "bin": {
         "pyric": "./dist/cli/index.js",
@@ -224,7 +224,7 @@
         "@pyric/ui": "workspace:*",
         "codemirror": "^6.0.2",
         "pyric": "workspace:*",
-        "pyric-tools": "workspace:*",
+        "@pyric/cli": "workspace:*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -2081,7 +2081,7 @@
 
     "pyric-admin": ["pyric-admin@workspace:packages/pyric-admin"],
 
-    "pyric-tools": ["pyric-tools@workspace:packages/pyric-tools"],
+    "@pyric/cli": ["@pyric/cli@workspace:packages/pyric-tools"],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
@@ -2669,7 +2669,7 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "pyric-tools/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+    "@pyric/cli/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -2819,9 +2819,9 @@
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "pyric-tools/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+    "@pyric/cli/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
-    "pyric-tools/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "@pyric/cli/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -2913,51 +2913,51 @@
 
     "gtoken/gaxios/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+    "@pyric/cli/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+    "@pyric/cli/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+    "@pyric/cli/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+    "@pyric/cli/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+    "@pyric/cli/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+    "@pyric/cli/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+    "@pyric/cli/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+    "@pyric/cli/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+    "@pyric/cli/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+    "@pyric/cli/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+    "@pyric/cli/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+    "@pyric/cli/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
-    "pyric-tools/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+    "@pyric/cli/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/examples/vite-sandbox-app/package.json
+++ b/examples/vite-sandbox-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "private": true,
-  "description": "Reference: a Vite app on the pyric-tools/vite plugin — `vite dev` runs on the in-process sandbox, `vite build` ships real firebase. This is the shape `pyric init --template web` scaffolds.",
+  "description": "Reference: a Vite app on the @pyric/cli/vite plugin — `vite dev` runs on the in-process sandbox, `vite build` ships real firebase. This is the shape `pyric init --template web` scaffolds.",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -16,7 +16,7 @@
     "firebase": "^12.12.0"
   },
   "devDependencies": {
-    "pyric-tools": "workspace:*",
+    "@pyric/cli": "workspace:*",
     "vite": "^6.0.0",
     "typescript": "^5.7.0"
   }

--- a/examples/vite-sandbox-app/src/main.ts
+++ b/examples/vite-sandbox-app/src/main.ts
@@ -1,5 +1,5 @@
 // Canonical firebase/* imports — UNCHANGED between dev and prod.
-// In `vite dev` the `pyric-tools/vite` plugin swaps these to an in-process
+// In `vite dev` the `@pyric/cli/vite` plugin swaps these to an in-process
 // sandbox (the config below is accepted but ignored). `vite build` ships the
 // real `firebase` package and uses the SAME config. Graduation is a build, not
 // a code edit.

--- a/examples/vite-sandbox-app/vite.config.ts
+++ b/examples/vite-sandbox-app/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import { pyricSandbox } from 'pyric-tools/vite';
+import { pyricSandbox } from '@pyric/cli/vite';
 
 // Under `vite dev` pyricSandbox() swaps firebase/* to the in-process pyric
 // sandbox and deploys + hot-reloads firestore.rules — no Firebase project,

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mdast-util-to-string": "^4.0.0",
     "publint": "^0.3.21",
     "pyric": "workspace:*",
-    "pyric-tools": "workspace:*",
+    "@pyric/cli": "workspace:*",
     "typescript": "^5.7.0",
     "zod": "^3.23.0"
   }

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -12,7 +12,7 @@
     "firebase-admin": "^13.0.0",
     "pyric": "workspace:*",
     "pyric-admin": "workspace:*",
-    "pyric-tools": "workspace:*",
+    "@pyric/cli": "workspace:*",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/conformance/src/assurance-capabilities.ts
+++ b/packages/conformance/src/assurance-capabilities.ts
@@ -179,7 +179,7 @@ const CAPABILITY_DIR = join(HERE, '..', 'assurance-capabilities');
 const LANGUAGE_DIR = join(HERE, '..', 'rules-language');
 export const ARTIFACT_PATH = join(CAPABILITY_DIR, 'capabilities.json');
 export const GENERATED_TS_PATH = join(CAPABILITY_DIR, 'generated.ts');
-/** The assurance runtime's copy. `pyric-tools` does not depend on this private
+/** The assurance runtime's copy. `@pyric/cli` does not depend on this private
  *  package, so the generator writes the capabilities into it directly. Checked
  *  alongside the other outputs: drift here fails CI too. */
 export const RUNTIME_TS_PATH = join(
@@ -445,7 +445,7 @@ export function renderArtifactJson(artifact: AssuranceCapabilityArtifact): strin
  * The read-time renderer, emitted INTO each generated module.
  *
  * It is emitted rather than imported because the consumer that needs it most —
- * the assurance runtime in `pyric-tools` — cannot import from this package
+ * the assurance runtime in `@pyric/cli` — cannot import from this package
  * (`conformance` is private and is not one of its dependencies). Emitting it
  * keeps one definition (this constant) and gives every generated copy the same
  * wording, whatever package it lands in. It depends on nothing but the record's
@@ -498,7 +498,7 @@ const EMITTED_RENDERER = [
  * The one definition of the capability-literal format. Emits each capability as
  * an object literal carrying the structured `dependencies` FACTS (never a
  * rendered sentence, never a count). Both generated copies — the conformance
- * module and the self-contained pyric-tools module — render their literals here,
+ * module and the self-contained @pyric/cli module — render their literals here,
  * so the two cannot drift.
  */
 function renderCapabilityLiterals(capabilities: DerivedCapability[]): string[] {
@@ -599,9 +599,9 @@ export function renderGeneratedTs(capabilities: DerivedCapability[]): string {
 
 /**
  * The same capabilities, emitted a second time into the assurance runtime
- * (`pyric-tools`).
+ * (`@pyric/cli`).
  *
- * The dependency runs one way — `pyric-tools` does not depend on this private
+ * The dependency runs one way — `@pyric/cli` does not depend on this private
  * conformance package — so the runtime cannot import the module above. Instead
  * the generator writes a self-contained copy it CAN import: no imports at all,
  * the service and status unions inlined. Both outputs are checked by
@@ -616,7 +616,7 @@ export function renderRuntimeTs(capabilities: DerivedCapability[]): string {
     '// The assurance engine\'s capabilities, DERIVED from the conformance graph by',
     '// packages/conformance/src/assurance-capabilities.ts (see that file\'s header for',
     '// the derivation rules). This is the assurance runtime\'s copy: the conformance',
-    '// package is private and is NOT a dependency of pyric-tools, so the generator',
+    '// package is private and is NOT a dependency of @pyric/cli, so the generator',
     '// emits this self-contained module here rather than have the runtime import it.',
     '//',
     '// A capability status is never authorable. It is derived from the graph, and',

--- a/packages/conformance/src/capture/messaging-web/e2e-sandbox.ts
+++ b/packages/conformance/src/capture/messaging-web/e2e-sandbox.ts
@@ -45,7 +45,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-// The REAL pyric dev worker bundle path (imported from pyric-tools SOURCE so
+// The REAL pyric dev worker bundle path (imported from @pyric/cli SOURCE so
 // the freshly-edited worker host — messaging ops included — is what bundles).
 import { bundleWorker } from '../../../../../packages/pyric-tools/src/serve/bundler.ts';
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -60,7 +60,7 @@
     "just-bash": "^3.0.1",
     "pyric": "workspace:*",
     "pyric-admin": "workspace:*",
-    "pyric-tools": "workspace:*",
+    "@pyric/cli": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9",

--- a/packages/playground/scripts/authorize-domain.ts
+++ b/packages/playground/scripts/authorize-domain.ts
@@ -18,8 +18,8 @@
  *   bun scripts/authorize-domain.ts --domain=staging.example.com
  *   bun scripts/authorize-domain.ts --list   # just print current list
  */
-import { fromServiceAccount } from 'pyric-tools/deploy';
-import { ManageDomainsHandler } from 'pyric-tools/auth';
+import { fromServiceAccount } from '@pyric/cli/deploy';
+import { ManageDomainsHandler } from '@pyric/cli/auth';
 
 const DEFAULT_DOMAIN = 'pyric-playground.web.app';
 

--- a/packages/playground/scripts/deploy.ts
+++ b/packages/playground/scripts/deploy.ts
@@ -26,7 +26,7 @@
  *   bun run deploy
  *   DEPLOY_SA_PATH=/abs/path/sa.json bun run deploy
  */
-import { fromServiceAccount, functions, hosting } from 'pyric-tools/deploy';
+import { fromServiceAccount, functions, hosting } from '@pyric/cli/deploy';
 import { existsSync, writeFileSync, copyFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/playground/scripts/fn-logs.ts
+++ b/packages/playground/scripts/fn-logs.ts
@@ -18,7 +18,7 @@
  *   bun scripts/fn-logs.ts --since=1h     # last hour
  *   bun scripts/fn-logs.ts --since=45m
  */
-import { fromServiceAccount } from 'pyric-tools/deploy';
+import { fromServiceAccount } from '@pyric/cli/deploy';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/playground/scripts/probe-discover.ts
+++ b/packages/playground/scripts/probe-discover.ts
@@ -41,7 +41,7 @@
 import { readFileSync } from 'node:fs';
 import { createSign } from 'node:crypto';
 import { resolve } from 'node:path';
-import { createRestCrawlerFirestore, crawl } from 'pyric-tools/discover';
+import { createRestCrawlerFirestore, crawl } from '@pyric/cli/discover';
 
 /**
  * Mint a short-lived Firestore-scoped access token from a service-

--- a/packages/playground/scripts/smoke-sandbox-discover.ts
+++ b/packages/playground/scripts/smoke-sandbox-discover.ts
@@ -14,7 +14,7 @@
  */
 import { createSandboxCrawlerFirestore } from '../src/lib/sandbox/crawler-firestore.ts';
 import { trimDiscoverResult } from '../src/lib/tools/diagnostics/firestore-discover.ts';
-import { createFirestoreDiscoverTools } from 'pyric-tools/discover';
+import { createFirestoreDiscoverTools } from '@pyric/cli/discover';
 
 // `gameConfig` mimics the production failure mode: a config doc that
 // uses a map as a dictionary (a move table keyed by hundreds of

--- a/packages/playground/src/lib/auth/bff-config.ts
+++ b/packages/playground/src/lib/auth/bff-config.ts
@@ -2,14 +2,14 @@
  * BFF auth config (server-side). The browser can't do Google's code exchange
  * (the client_secret is required and Google has no public client type), so the
  * exchange + the refresh token live here, on the Astro server. Reuses
- * pyric-tools' isomorphic credential core.
+ * @pyric/cli' isomorphic credential core.
  *
  * Activation is gated on `GIS_CLIENT_SECRET` (server-only env var, NOT PUBLIC_):
  * absent -> `bffClient()` returns null -> the endpoints 503 -> the browser falls
  * back to the existing GIS token client. Also register
  * `<origin>/api/auth/callback` as an authorized redirect URI on the OAuth client.
  */
-import { oauthClient, type OAuthClient } from 'pyric-tools/credentials';
+import { oauthClient, type OAuthClient } from '@pyric/cli/credentials';
 
 /** Same scopes the GIS client requested — the playground deploy needs cloud-platform. */
 export const BFF_SCOPES = [

--- a/packages/playground/src/lib/deploy/extractIndexes.ts
+++ b/packages/playground/src/lib/deploy/extractIndexes.ts
@@ -8,7 +8,7 @@
  * the static AST pass is browser-safe, no tool-handler envelope
  * needed for direct programmatic callers.
  */
-import type { IndexesConfigEntry } from 'pyric-tools/deploy';
+import type { IndexesConfigEntry } from '@pyric/cli/deploy';
 import { extractIndexes } from 'pyric/rules/internal/extract';
 
 export async function extractIndexesFromAppSource(

--- a/packages/playground/src/lib/deploy/useDeployAll.ts
+++ b/packages/playground/src/lib/deploy/useDeployAll.ts
@@ -35,7 +35,7 @@ import {
   type IndexOperation,
   type PreflightCheckResult,
   type ProjectScope,
-} from 'pyric-tools/deploy';
+} from '@pyric/cli/deploy';
 
 import { useWorkspaceStore } from '~/lib/store/workspace';
 

--- a/packages/playground/src/lib/deploy/useDeployPreflight.ts
+++ b/packages/playground/src/lib/deploy/useDeployPreflight.ts
@@ -25,7 +25,7 @@ import {
   type PreflightCheckResult,
   type PreflightOptions,
   type ProjectScope,
-} from 'pyric-tools/deploy';
+} from '@pyric/cli/deploy';
 
 import { useAccessToken } from './useAccessToken';
 import { useTargetProject } from './useTargetProject';

--- a/packages/playground/src/lib/deploy/useHostingDeploy.ts
+++ b/packages/playground/src/lib/deploy/useHostingDeploy.ts
@@ -28,11 +28,11 @@ import { useCallback, useState } from 'react';
 // but takes a `ProjectScope` (`projectId` + `resolveToken()`) so
 // callers don't have to wire token resolution themselves. Resolves
 // through `@pyric/deploy`'s barrel; no path alias needed.
-import { hosting, type ProjectScope } from 'pyric-tools/deploy';
+import { hosting, type ProjectScope } from '@pyric/cli/deploy';
 import type {
   DeployHostingResult,
   HostingErrorCode,
-} from 'pyric-tools/deploy';
+} from '@pyric/cli/deploy';
 
 import { useWorkspaceStore } from '~/lib/store/workspace';
 

--- a/packages/playground/src/lib/deploy/useIndexesDeploy.ts
+++ b/packages/playground/src/lib/deploy/useIndexesDeploy.ts
@@ -29,7 +29,7 @@ import {
   type IndexesConfigEntry,
   type IndexOperation,
   type ProjectScope,
-} from 'pyric-tools/deploy';
+} from '@pyric/cli/deploy';
 
 import { useAccessToken } from '~/lib/deploy/useAccessToken';
 import { useTargetProject } from '~/lib/deploy/useTargetProject';

--- a/packages/playground/src/lib/deploy/useIndexesProgress.ts
+++ b/packages/playground/src/lib/deploy/useIndexesProgress.ts
@@ -19,7 +19,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { firestore, type ProjectScope } from 'pyric-tools/deploy';
+import { firestore, type ProjectScope } from '@pyric/cli/deploy';
 
 import { useAccessToken } from './useAccessToken';
 import {

--- a/packages/playground/src/lib/deploy/useRulesDeploy.ts
+++ b/packages/playground/src/lib/deploy/useRulesDeploy.ts
@@ -16,7 +16,7 @@
  */
 import { useCallback, useState } from 'react';
 
-import { firestore, AdminApiError, type ProjectScope } from 'pyric-tools/deploy';
+import { firestore, AdminApiError, type ProjectScope } from '@pyric/cli/deploy';
 
 import { useAccessToken } from '~/lib/deploy/useAccessToken';
 import { useTargetProject } from '~/lib/deploy/useTargetProject';

--- a/packages/playground/src/lib/sandbox/crawler-firestore.ts
+++ b/packages/playground/src/lib/sandbox/crawler-firestore.ts
@@ -25,7 +25,7 @@ import type {
   CrawlerDocumentRef,
   CrawlerFirestore,
   WireDocumentSnapshot,
-} from 'pyric-tools/discover';
+} from '@pyric/cli/discover';
 
 type Snapshot = Record<string, unknown>;
 

--- a/packages/playground/src/lib/sandbox/runtime.ts
+++ b/packages/playground/src/lib/sandbox/runtime.ts
@@ -1,4 +1,4 @@
-import * as WorkerRuntime from 'pyric-tools/serve/worker';
+import * as WorkerRuntime from '@pyric/cli/serve/worker';
 import { readPlaygroundSandboxMode, type PlaygroundSandboxMode } from '~/lib/studio-embed';
 import {
   getRunner,

--- a/packages/playground/src/lib/sandbox/tab-sync-wiring.ts
+++ b/packages/playground/src/lib/sandbox/tab-sync-wiring.ts
@@ -2,7 +2,7 @@
  * Cross-tab auth synchronization for the playground workspace sandbox.
  *
  * Mirrors `packages/pyric-tools/src/serve/entries/tab-sync-wiring.ts` —
- * that file is an internal of `pyric-tools` and CANNOT be imported here
+ * that file is an internal of `@pyric/cli` and CANNOT be imported here
  * (the playground is a consumer, not a peer). The logic is identical;
  * only the default channel name differs (`pyric:playground:auth-sync:*`
  * vs. `pyric:serve:auth-sync`).

--- a/packages/playground/src/lib/tools/core/sandboxDiscover.ts
+++ b/packages/playground/src/lib/tools/core/sandboxDiscover.ts
@@ -21,7 +21,7 @@
  *     doesn't surface that tool today.
  */
 import type { ToolHandler } from '@inbrowser/agent';
-import { createFirestoreDiscoverTools } from 'pyric-tools/discover';
+import { createFirestoreDiscoverTools } from '@pyric/cli/discover';
 import { trimDiscoverResult } from '../diagnostics/firestore-discover';
 import { createSandboxCrawlerFirestore } from '~/lib/sandbox/crawler-firestore';
 import { readFirestoreState } from '~/lib/sandbox/runtime';

--- a/packages/playground/src/lib/tools/diagnostics/firestore-discover.ts
+++ b/packages/playground/src/lib/tools/diagnostics/firestore-discover.ts
@@ -21,7 +21,7 @@ import {
   createRestCrawlerFirestore,
   createFirestoreDiscoverTools,
   type DiscoverPathsToolResult,
-} from 'pyric-tools/discover';
+} from '@pyric/cli/discover';
 import type { ToolContext, ToolHandler, ToolResult } from '@inbrowser/agent';
 
 /**

--- a/packages/playground/src/pages/api/auth/callback.ts
+++ b/packages/playground/src/pages/api/auth/callback.ts
@@ -4,7 +4,7 @@
  * survives reloads. Then redirect back to the app.
  */
 import type { APIRoute } from 'astro';
-import { completeAuth } from 'pyric-tools/credentials';
+import { completeAuth } from '@pyric/cli/credentials';
 import { COOKIE, bffClient, callbackUri } from '~/lib/auth/bff-config';
 
 export const prerender = false;

--- a/packages/playground/src/pages/api/auth/start.ts
+++ b/packages/playground/src/pages/api/auth/start.ts
@@ -3,7 +3,7 @@
  * the user to Google's consent screen. The callback completes the exchange.
  */
 import type { APIRoute } from 'astro';
-import { startAuth } from 'pyric-tools/credentials';
+import { startAuth } from '@pyric/cli/credentials';
 import { BFF_SCOPES, COOKIE, bffClient, callbackUri } from '~/lib/auth/bff-config';
 
 export const prerender = false;

--- a/packages/playground/src/pages/api/auth/token.ts
+++ b/packages/playground/src/pages/api/auth/token.ts
@@ -5,7 +5,7 @@
  * GIS); 401 when not signed in; clears the cookie + 401 on an expired refresh.
  */
 import type { APIRoute } from 'astro';
-import { refreshAccess, AuthExpired } from 'pyric-tools/credentials';
+import { refreshAccess, AuthExpired } from '@pyric/cli/credentials';
 import { COOKIE, bffClient } from '~/lib/auth/bff-config';
 
 export const prerender = false;

--- a/packages/playground/src/pages/api/local-auth/token.ts
+++ b/packages/playground/src/pages/api/local-auth/token.ts
@@ -14,7 +14,7 @@
  * network) — the same exposure as an in-browser GIS token, but durable.
  */
 import type { APIRoute } from 'astro';
-import { resolveLocalAccessToken } from 'pyric-tools/credentials/node';
+import { resolveLocalAccessToken } from '@pyric/cli/credentials/node';
 
 export const prerender = false;
 

--- a/packages/pyric-admin/src/app/index.ts
+++ b/packages/pyric-admin/src/app/index.ts
@@ -53,12 +53,12 @@
  *     delegate to `firebase-admin/app.initializeApp()` (FIREBASE_CONFIG
  *     env + application-default credentials), register the prod arm.
  *   - `PYRIC_SANDBOX=remote` or `remote:<url>` → obtain a remote sandbox
- *     handle from the factory installed by `pyric-tools/register` at
+ *     handle from the factory installed by `@pyric/cli/register` at
  *     `globalThis[REMOTE_SANDBOX_FACTORY]`
  *     (`Symbol.for('pyric.remote.sandboxFactory')`) and register the
  *     sandbox arm. One activation line is logged to stderr. If the env
  *     is set but no factory is installed, throw with remediation (run
- *     under `pyric dev`, or add `--import pyric-tools/register` to
+ *     under `pyric dev`, or add `--import @pyric/cli/register` to
  *     NODE_OPTIONS).
  *   - Production guard: refuses to route to a sandbox when
  *     `NODE_ENV === 'production'`, unless `PYRIC_SANDBOX_FORCE=1`.
@@ -332,7 +332,7 @@ function initializeAmbientApp(name: string): PyricAdminApp {
       `pyric-admin: PYRIC_SANDBOX=${env} is set but no remote sandbox ` +
         'factory is installed (globalThis[Symbol.for(' +
         "'pyric.remote.sandboxFactory')] is absent). Run your server " +
-        'under `pyric dev`, or add `--import pyric-tools/register` to ' +
+        'under `pyric dev`, or add `--import @pyric/cli/register` to ' +
         'NODE_OPTIONS.',
     );
   }

--- a/packages/pyric-admin/src/auth/index.ts
+++ b/packages/pyric-admin/src/auth/index.ts
@@ -25,7 +25,7 @@
  *
  *   - **Remote sandbox arm** — when the sandbox carries `pyric/sandbox`'s
  *     remote brand (a Node-side handle onto the browser-hosted
- *     SharedWorker sandbox from `pyric-tools`' `connectRemoteSandbox()`),
+ *     SharedWorker sandbox from `@pyric/cli`' `connectRemoteSandbox()`),
  *     user CRUD relays over the handle's worker channel instead of the
  *     in-memory store, so server-created users land in the ONE user pool
  *     the browser app + Studio share. See the "Remote sandbox arm"

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -61,7 +61,7 @@
  *
  *   - **Remote sandbox arm** (sandbox target whose `Sandbox` carries the
  *     `pyric/sandbox` remote brand — a Node-side handle onto the
- *     browser-hosted SharedWorker sandbox, built by `pyric-tools`'
+ *     browser-hosted SharedWorker sandbox, built by `@pyric/cli`'
  *     `connectRemoteSandbox()`) — every `Reference` data operation routes
  *     through the handle's worker-relay channel (`rtdb.get/set/update/
  *     remove/push` ops with `actAs: { mode: 'admin' }` pinned — firebase-

--- a/packages/pyric-admin/src/storage/index.ts
+++ b/packages/pyric-admin/src/storage/index.ts
@@ -12,7 +12,7 @@
  *     production `Storage`, so every method on `Storage` / `Bucket` /
  *     `File` (from `@google-cloud/storage`) is present unchanged.
  *
- *   - **Remote sandbox path** — a handle branded by `pyric-tools`'
+ *   - **Remote sandbox path** — a handle branded by `@pyric/cli`'
  *     `connectRemoteSandbox()`/`remoteSandbox()` relays every data
  *     operation over the bridge to the browser-hosted SharedWorker's
  *     object store (admin lens pinned — rules bypass). Single bucket;
@@ -432,10 +432,10 @@ const STORAGE_REMOTE_ADMIN_LENS = { mode: 'admin' } as const;
 
 /**
  * Raw per-op byte cap for relayed storage payloads. MUST mirror
- * `pyric-tools`' `MAX_STORAGE_OP_BYTES` (serve/worker/protocol.ts) — the
+ * `@pyric/cli`' `MAX_STORAGE_OP_BYTES` (serve/worker/protocol.ts) — the
  * worker host enforces the same cap on its end. Inlined (like the RTDB
  * push-id generator) because `pyric-admin` deliberately does not depend on
- * `pyric-tools`.
+ * `@pyric/cli`.
  */
 const MAX_REMOTE_STORAGE_OP_BYTES = 8 * 1024 * 1024;
 

--- a/packages/pyric-admin/test/app/ambient-init.test.ts
+++ b/packages/pyric-admin/test/app/ambient-init.test.ts
@@ -2,10 +2,10 @@
  * Ambient init — bare `initializeApp()` + environment (adoption
  * experience, layer 3). The user's server code contains zero pyric
  * identifiers; `PYRIC_SANDBOX` decides the backend, and the remote
- * handle comes from the factory `pyric-tools/register` installs at
+ * handle comes from the factory `@pyric/cli/register` installs at
  * `globalThis[Symbol.for('pyric.remote.sandboxFactory')]`.
  *
- * These tests install a FAKE factory (the real one is `pyric-tools`'
+ * These tests install a FAKE factory (the real one is `@pyric/cli`'
  * concern — the global symbol is the seam) and cover:
  *   - env unset → prod arm, factory never consulted
  *   - `remote` / `remote:<url>` parsing (url after the FIRST colon)
@@ -179,10 +179,10 @@ describe('ambient init — PYRIC_SANDBOX set', () => {
 // ─── Missing factory ────────────────────────────────────────────────────
 
 describe('ambient init — factory global absent', () => {
-  it('throws with the pyric dev / --import pyric-tools/register remediation', () => {
+  it('throws with the pyric dev / --import @pyric/cli/register remediation', () => {
     process.env.PYRIC_SANDBOX = 'remote';
     expect(() => initializeApp()).toThrow(
-      /pyric\.remote\.sandboxFactory.*pyric dev.*--import pyric-tools\/register.*NODE_OPTIONS/s,
+      /pyric\.remote\.sandboxFactory.*pyric dev.*--import @pyric\/cli\/register.*NODE_OPTIONS/s,
     );
     expect(getApps()).toHaveLength(0); // nothing half-registered
     expect(stderrLines).toHaveLength(0); // no activation log on failure

--- a/packages/pyric-admin/test/remote/remote-dispatch.test.ts
+++ b/packages/pyric-admin/test/remote/remote-dispatch.test.ts
@@ -3,7 +3,7 @@
  * (remote sandbox, slice 1 / checkpoint 2).
  *
  * Extends checkpoint 1's headless harness (see
- * `pyric-tools/test/bridge/worker-relay.test.ts`): the REAL worker host
+ * `packages/pyric-tools/test/bridge/worker-relay.test.ts`): the REAL worker host
  * (`handleMessage` + fake `{ postMessage }` ports) behind the REAL bridge
  * core and consumer session, fronted by the EXACT branded handle
  * `connectRemoteSandbox()` returns (`createRemoteSandboxHandle`) — no
@@ -481,7 +481,7 @@ describe('remote dispatch — ambient init (bare initializeApp + no-arg handles)
   it('routes no-arg getDatabase()/getAuth() through the worker via the factory global', async () => {
     // Same headless stack, but the app comes from a BARE initializeApp():
     // PYRIC_SANDBOX activates, and the factory global (here: a fake
-    // installed the way `pyric-tools/register` would) mints the real
+    // installed the way `@pyric/cli/register` would) mints the real
     // branded remote handle.
     const bridge = createBridge({ mode: 'sandbox', version: 'test' });
     const ctx = makeWorkerCtx();

--- a/packages/pyric-tools/package.json
+++ b/packages/pyric-tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pyric-tools",
+  "name": "@pyric/cli",
   "version": "0.1.0-alpha.8",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",

--- a/packages/pyric-tools/scripts/compile.ts
+++ b/packages/pyric-tools/scripts/compile.ts
@@ -5,7 +5,7 @@
  * `pyric dev` normally bundles its SDK shims with esbuild at runtime, reading
  * the on-disk `pyric` dist. Neither esbuild's native helper nor that dist exist
  * inside a compiled binary's `/$bunfs`. The bundles are deterministic, though
- * (a pure function of pyric-tools' wrapper entries + the bundled `pyric`
+ * (a pure function of @pyric/cli's wrapper entries + the bundled `pyric`
  * version), so we run the bundler ONCE here on the build host and embed the
  * output into the binary via a generated entry that sets
  * `globalThis.__PYRIC_EMBEDDED__` before handing off to the CLI. At runtime
@@ -137,10 +137,10 @@ process.stdout.write(
     `(pyric ${version}, worker ${workerVersion})\n`,
 );
 
-// ── 2b. Pack pyric + pyric-tools into installable tarballs ────────────
+// ── 2b. Pack pyric + @pyric/cli into installable tarballs ────────────
 // `pyric init --deps vendor` lays these into a scaffold so `bun install`
 // resolves the still-unpublished packages offline (no registry 404). `pyric`
-// packs clean (no workspace deps); `pyric-tools` depends on `pyric` via
+// packs clean (no workspace deps); `@pyric/cli` depends on `pyric` via
 // workspace:* — rewrite that to `*` so it resolves from the co-installed local
 // `pyric` tarball under npm/bun/pnpm alike (^0.0.0 doesn't resolve everywhere).
 const MONO_ROOT = resolve(PKG_ROOT, '..', '..');
@@ -160,26 +160,26 @@ function npmPack(pkgDir: string): string {
 }
 
 const pyricTgz = npmPack(PYRIC_DIR);
-// pyric-tools: temporarily rewrite its `pyric` dep, pack, restore.
-const toolsPkgJson = join(PKG_ROOT, 'package.json');
-const toolsPkgOrig = readFileSync(toolsPkgJson, 'utf8');
-let toolsTgz: string;
+// @pyric/cli: temporarily rewrite its `pyric` dep, pack, restore.
+const cliPkgJson = join(PKG_ROOT, 'package.json');
+const cliPkgOrig = readFileSync(cliPkgJson, 'utf8');
+let cliTgz: string;
 try {
-  const parsed = JSON.parse(toolsPkgOrig) as { dependencies?: Record<string, string> };
+  const parsed = JSON.parse(cliPkgOrig) as { dependencies?: Record<string, string> };
   if (parsed.dependencies?.pyric) parsed.dependencies.pyric = '*';
-  writeFileSync(toolsPkgJson, JSON.stringify(parsed, null, 2) + '\n');
-  toolsTgz = npmPack(PKG_ROOT);
+  writeFileSync(cliPkgJson, JSON.stringify(parsed, null, 2) + '\n');
+  cliTgz = npmPack(PKG_ROOT);
 } finally {
-  writeFileSync(toolsPkgJson, toolsPkgOrig); // restore exact bytes
+  writeFileSync(cliPkgJson, cliPkgOrig); // restore exact bytes
 }
 
 const tarballBlob: Record<string, string> = {
   'pyric.tgz': readFileSync(pyricTgz).toString('base64'),
-  'pyric-tools.tgz': readFileSync(toolsTgz).toString('base64'),
+  'pyric-cli.tgz': readFileSync(cliTgz).toString('base64'),
 };
 process.stdout.write(
   `  embedded tarballs: pyric.tgz (${(statSync(pyricTgz).size / 1e6).toFixed(1)} MB), ` +
-    `pyric-tools.tgz (${(statSync(toolsTgz).size / 1e6).toFixed(1)} MB)\n`,
+    `pyric-cli.tgz (${(statSync(cliTgz).size / 1e6).toFixed(1)} MB)\n`,
 );
 
 // ── 3. Generate the embedded modules + the compile entry ──────────────

--- a/packages/pyric-tools/scripts/release.ts
+++ b/packages/pyric-tools/scripts/release.ts
@@ -80,7 +80,7 @@ if (!dryRun) {
 }
 
 // ── 3. notes ──────────────────────────────────────────────────────────
-const notes = `Self-contained \`pyric\` CLI built with \`bun build --compile\`: no Node, no npm. \`serve\` runs fully offline; \`pyric init\` vendors the unpublished \`pyric\`/\`pyric-tools\` so a scaffold installs without publishing.
+const notes = `Self-contained \`pyric\` CLI built with \`bun build --compile\`: no Node, no npm. \`serve\` runs fully offline; \`pyric init\` vendors the unpublished \`pyric\`/\`@pyric/cli\` so a scaffold installs without publishing.
 
 ### Download (macOS Apple Silicon)
 \`\`\`bash

--- a/packages/pyric-tools/scripts/standalone-vendor-smoke.ts
+++ b/packages/pyric-tools/scripts/standalone-vendor-smoke.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 /**
  * Prove the standalone binary scaffolds a project that installs + builds with
- * the still-unpublished `pyric` / `pyric-tools` — no registry 404. Runs the real
+ * the still-unpublished `pyric` / `@pyric/cli` — no registry 404. Runs the real
  * chain a user hits: `pyric init --template web` (vendor mode) -> `bun install`
  * -> `vite build`. Needs network for the published deps (firebase, vite, …);
- * `pyric`/`pyric-tools` come from the embedded tarballs.
+ * `pyric`/`@pyric/cli` come from the embedded tarballs.
  *
  *   bun scripts/compile.ts host && bun scripts/standalone-vendor-smoke.ts
  *
@@ -38,17 +38,17 @@ process.stdout.write(`standalone vendor smoke (in ${work}):\n`);
 
 const init = run(BIN, ['init', '--template', 'web', '--name', 'vendor-smoke']);
 check('pyric init (vendor mode)', init.code === 0 && /vendored/.test(init.out + init.err));
-check('vendor/ tarballs written', existsSync(join(work, 'vendor', 'pyric-tools.tgz')) && existsSync(join(work, 'vendor', 'pyric.tgz')));
+check('vendor/ tarballs written', existsSync(join(work, 'vendor', 'pyric-cli.tgz')) && existsSync(join(work, 'vendor', 'pyric.tgz')));
 const pkg = JSON.parse(readFileSync(join(work, 'package.json'), 'utf8')) as {
   devDependencies?: Record<string, string>;
   overrides?: Record<string, string>;
 };
-check('package.json uses file: deps', pkg.devDependencies?.['pyric-tools'] === 'file:vendor/pyric-tools.tgz');
+check('package.json uses file: deps', pkg.devDependencies?.['@pyric/cli'] === 'file:vendor/pyric-cli.tgz');
 check('package.json pins pyric override', pkg.overrides?.['pyric'] === 'file:vendor/pyric.tgz');
 
 const install = run('bun', ['install']);
 check('bun install (no registry 404)', install.code === 0, install.code === 0 ? '' : install.err.split('\n').slice(-3).join(' '));
-check('pyric resolved from tarball (no nested stub)', !existsSync(join(work, 'node_modules', 'pyric-tools', 'node_modules', 'pyric')));
+check('pyric resolved from tarball (no nested stub)', !existsSync(join(work, 'node_modules', '@pyric/cli', 'node_modules', 'pyric')));
 check('pyric/rules/node present', existsSync(join(work, 'node_modules', 'pyric', 'dist', 'rules', 'node.js')));
 
 const build = run('bun', ['run', 'build']);

--- a/packages/pyric-tools/src/assurance/generated-capabilities.ts
+++ b/packages/pyric-tools/src/assurance/generated-capabilities.ts
@@ -3,7 +3,7 @@
 // The assurance engine's capabilities, DERIVED from the conformance graph by
 // packages/conformance/src/assurance-capabilities.ts (see that file's header for
 // the derivation rules). This is the assurance runtime's copy: the conformance
-// package is private and is NOT a dependency of pyric-tools, so the generator
+// package is private and is NOT a dependency of @pyric/cli, so the generator
 // emits this self-contained module here rather than have the runtime import it.
 //
 // A capability status is never authorable. It is derived from the graph, and

--- a/packages/pyric-tools/src/auth/domains/handler.ts
+++ b/packages/pyric-tools/src/auth/domains/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import type { ManageDomainsInput, ManageDomainsResult } from './spec.js';
 
 export class ManageDomainsHandler {

--- a/packages/pyric-tools/src/auth/provider/handler.ts
+++ b/packages/pyric-tools/src/auth/provider/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import type { ConfigureProviderInput, ConfigureAuthResult, ProviderId } from './spec.js';
 
 export class ConfigureProviderHandler {

--- a/packages/pyric-tools/src/auth/resolver.ts
+++ b/packages/pyric-tools/src/auth/resolver.ts
@@ -10,7 +10,7 @@
  * inlines here as a thin Bearer-token fetch wrapper — that's all the
  * old `app.fetchIdentityToolkit` was.
  */
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import type { AuthTools, AuthIR } from './types.js';
 import { AuthMapper } from './mapper.js';
 import { ConfigureProviderHandler } from './provider/handler.js';

--- a/packages/pyric-tools/src/auth/tools.ts
+++ b/packages/pyric-tools/src/auth/tools.ts
@@ -15,7 +15,7 @@
  * surface.
  */
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import { getAuthTools } from './resolver.js';
 import type { ConfigureProviderInput } from './provider/spec.js';
 import type { ManageDomainsInput } from './domains/spec.js';

--- a/packages/pyric-tools/src/bridge/client.ts
+++ b/packages/pyric-tools/src/bridge/client.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric-tools/bridge` — browser-side entry.
+ * `@pyric/cli/bridge` — browser-side entry.
  *
  * Resolved by the `browser` condition in `package.json`'s exports map.
  * Exports `connectBridge`, which the host app calls to register its
@@ -10,7 +10,7 @@
  * The Node-side server entry lives in `./server.ts`. Wire format
  * shared by both lives in `./protocol.ts`.
  *
- * ALSO reachable as `pyric-tools/bridge/client` — an explicit, condition-free
+ * ALSO reachable as `@pyric/cli/bridge/client` — an explicit, condition-free
  * subpath for browser apps whose TYPE resolution doesn't apply the `browser`
  * condition (Pyric Studio's `moduleResolution: bundler` tsconfig resolves the
  * `./bridge` subpath's top-level `types` to the SERVER entry). Same file,

--- a/packages/pyric-tools/src/bridge/protocol.ts
+++ b/packages/pyric-tools/src/bridge/protocol.ts
@@ -1,6 +1,6 @@
 /**
- * Wire protocol shared by `pyric-tools/bridge` (Node bridge) and
- * `pyric-tools/bridge` (in-browser sandbox connector).
+ * Wire protocol shared by `@pyric/cli/bridge` (Node bridge) and
+ * `@pyric/cli/bridge` (in-browser sandbox connector).
  *
  * The bridge process speaks MCP HTTP to external agents (Claude Code,
  * Cursor) on `/mcp` and WebSocket to the in-browser sandbox on
@@ -181,7 +181,7 @@ export interface AttachAckFromBridge {
   /** Whether a browser tab is currently registered as the sandbox peer. */
   peerConnected: boolean;
   /**
-   * The `pyric-tools` package version the serve/bridge process runs
+   * The `@pyric/cli` package version the serve/bridge process runs
    * (version-skew stamp). ADDITIVE + OPTIONAL: old servers omit it and
    * the client stays silent. When present and different from the
    * client's own version, the client warns once at attach and enriches

--- a/packages/pyric-tools/src/bridge/server.ts
+++ b/packages/pyric-tools/src/bridge/server.ts
@@ -1,10 +1,10 @@
 /**
- * `pyric-tools/bridge` — Node-side entry.
+ * `@pyric/cli/bridge` — Node-side entry.
  *
  * Resolved by the `node` condition in `package.json`'s exports map.
  * Exports the bridge core (`createBridge`) and the standalone server
  * (`startServer`). The Vite integration is the `pyricSandbox({ bridge })`
- * plugin in `pyric-tools/vite` (the firebase→sandbox swap AND the bridge in
+ * plugin in `@pyric/cli/vite` (the firebase→sandbox swap AND the bridge in
  * one plugin), not a bridge-only plugin here.
  *
  * The browser-side `connectBridge` lives in `./client.ts` and is

--- a/packages/pyric-tools/src/bridge/server/peer.ts
+++ b/packages/pyric-tools/src/bridge/server/peer.ts
@@ -21,7 +21,7 @@ import {
   PEER_REPLACED_CLOSE_REASON,
   type BridgeMessage,
 } from '../protocol.js';
-import { pyricToolsVersion } from '../../pkg-version.js';
+import { cliVersion } from '../../pkg-version.js';
 
 export function attachPeer(
   bridge: ReturnType<typeof createBridge>,
@@ -149,13 +149,13 @@ export function createConsumerSession(
         case 'attach': {
           // Idempotent re-attach: just re-ack. `serveVersion` is the
           // version-skew stamp (bridge/protocol.ts) — this process's own
-          // pyric-tools version, compared client-side at attach.
+          // @pyric/cli version, compared client-side at attach.
           send({
             type: 'attach-ack',
             protocol: 1,
             bridgeVersion: bridge.version,
             peerConnected: bridge.isSandboxConnected(),
-            serveVersion: pyricToolsVersion(),
+            serveVersion: cliVersion(),
           });
           return;
         }

--- a/packages/pyric-tools/src/bridge/server/tool-metadata.ts
+++ b/packages/pyric-tools/src/bridge/server/tool-metadata.ts
@@ -89,7 +89,7 @@ export function getSandboxToolMetadata(): ToolMetadata[] {
 export function getRulesToolHandlers(scope?: unknown): ToolHandler[] {
   // Factory accepts { scope } per packages/pyric/src/rules/tools.ts.
   // The cast is because pyric/rules's ProjectScope type is re-exported
-  // from pyric-tools/deploy and we'd otherwise force a type-only import
+  // from @pyric/cli/deploy and we'd otherwise force a type-only import
   // here. Bridge level we don't need the type.
   // Includes simulate / lint / resolve_modules / stdlib_list /
   // stdlib_get + (when scope is supplied) extract + deploy gates —

--- a/packages/pyric-tools/src/cli/auth.ts
+++ b/packages/pyric-tools/src/cli/auth.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric auth:*` subcommands — thin wrappers over `pyric-tools/auth`.
+ * `pyric auth:*` subcommands — thin wrappers over `@pyric/cli/auth`.
  *
  *   - `auth:configure-provider <provider> <enabled>` — toggle one of
  *     the Identity Toolkit providers (anonymous / email / phone /
@@ -7,7 +7,7 @@
  *   - `auth:manage-domains <add|remove|list> [domain]` — manage
  *     authorized domains for the project's auth config.
  *
- * Both call `getAuthTools(scope)` from `pyric-tools/auth`. ProjectScope
+ * Both call `getAuthTools(scope)` from `@pyric/cli/auth`. ProjectScope
  * is resolved from env (FIREBASE_SA_BASE64 / GOOGLE_APPLICATION_CREDENTIALS)
  * by the shared `resolveScope` helper.
  */

--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -1230,7 +1230,7 @@ describe('runInit', () => {
     expect(written.scripts.dev).toBe('bun --watch src/app.ts');
     expect(written.scripts['deploy:rules']).toBe('pyric deploy rules');
     expect(written.dependencies.pyric).toBe('*');
-    expect(written.dependencies['pyric-tools']).toBe('*');
+    expect(written.dependencies['@pyric/cli']).toBe('*');
     expect(written.devDependencies.typescript).toBe('^5.7.0');
 
     // User-facing report mentions the conflict on `start`.
@@ -1255,7 +1255,7 @@ describe('runInit', () => {
           bridge: 'pyric bridge',
           'deploy:rules': 'pyric deploy rules',
         },
-        dependencies: { pyric: '*', 'pyric-tools': '*' },
+        dependencies: { pyric: '*', '@pyric/cli': '*' },
         devDependencies: { '@types/bun': 'latest', typescript: '^5.7.0' },
       },
       null,

--- a/packages/pyric-tools/src/cli/deploy.ts
+++ b/packages/pyric-tools/src/cli/deploy.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric deploy [target]` — thin wrapper over `pyric-tools/deploy`'s
+ * `pyric deploy [target]` — thin wrapper over `@pyric/cli/deploy`'s
  * programmatic surface. Reads `firebase.json` for paths (rules /
  * indexes / hosting); resolves the project id from `--project` /
  * `PYRIC_PROJECT` / `.firebaserc`; resolves a service-account scope

--- a/packages/pyric-tools/src/cli/dev-runner.ts
+++ b/packages/pyric-tools/src/cli/dev-runner.ts
@@ -5,7 +5,7 @@
  * pyric sandbox:
  *
  *   PYRIC_SANDBOX=remote:<serve url>          (the activator)
- *   NODE_OPTIONS += --import pyric-tools/register   (the substitution seam)
+ *   NODE_OPTIONS += --import @pyric/cli/register   (the substitution seam)
  *
  * Child-command precedence: explicit `pyric dev -- <cmd>` wins; else the
  * project package.json `dev` script (via the detected package manager); else
@@ -129,7 +129,7 @@ export function resolveDevChild(opts: {
 
 /**
  * The absolute `file:` URL of the register module, resolved from
- * pyric-tools' OWN installed location — `import.meta.resolve` walks this
+ * @pyric/cli' OWN installed location — `import.meta.resolve` walks this
  * package's `exports` (self-reference), so it lands on the right file no
  * matter how the user's node_modules are laid out (hoisted, pnpm-isolated,
  * vendored). Fallback: relative to this compiled file (dist/cli/ →
@@ -137,7 +137,7 @@ export function resolveDevChild(opts: {
  */
 export function registerModuleUrl(): string {
   try {
-    const url = import.meta.resolve('pyric-tools/register');
+    const url = import.meta.resolve('@pyric/cli/register');
     if (typeof url === 'string' && url.length > 0) return url;
   } catch {
     // fall through

--- a/packages/pyric-tools/src/cli/discover.ts
+++ b/packages/pyric-tools/src/cli/discover.ts
@@ -1,6 +1,6 @@
 /**
  * `pyric firestore:discover [collection?]` — thin wrapper over
- * `pyric-tools/discover`'s `crawl` against the project's Firestore.
+ * `@pyric/cli/discover`'s `crawl` against the project's Firestore.
  *
  * Uses the REST-backed `CrawlerFirestore` so this works from any Node
  * environment with a service-account token (no firebase-admin

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -45,7 +45,7 @@
  *   2  runtime error
  */
 
-import { startServer, type BridgeMode } from 'pyric-tools/bridge';
+import { startServer, type BridgeMode } from '@pyric/cli/bridge';
 import { parseArgs, type ParsedArgs } from './parse-args.js';
 import { runDeploy, runHostingChannelDeploy } from './deploy.js';
 import { runLoginCommand, runLogoutCommand, runWhoamiCommand } from './login.js';
@@ -64,7 +64,7 @@ import { runSnapshot } from './snapshot.js';
 import { runVerify } from './verify.js';
 import { runMcpProxy } from './mcp-proxy.js';
 import { pyricVersion } from '../serve/standalone-assets.js';
-import { pyricToolsVersion } from '../pkg-version.js';
+import { cliVersion } from '../pkg-version.js';
 import { FIREBASE_TESTED_AGAINST } from '../version/compat-target.js';
 
 // The standalone binary bakes the real `pyric` version onto the embedded-assets
@@ -108,12 +108,12 @@ COMMANDS
                              with your firestore.rules deployed. Also runs your own dev
                              command (\`-- <cmd>\`, else the package.json \`dev\` script) with
                              unchanged firebase-admin/firebase imports routed to the
-                             sandbox (PYRIC_SANDBOX + \`--import pyric-tools/register\`).
+                             sandbox (PYRIC_SANDBOX + \`--import @pyric/cli/register\`).
   init [dir]                 Scaffold a pyric project. --template=web (default; canonical
                              firebase/* app served by \`pyric dev\`) or node (script-style).
                              --name=NAME --force (overwrite scaffold files) --json (machine
                              output on stdout). Never prompts; rerunning is safe.
-  vendor [dir]               Retrofit: vendor pyric + pyric-tools into an existing
+  vendor [dir]               Retrofit: vendor pyric + @pyric/cli into an existing
                              project (lay file: tarballs into vendor/ + merge their
                              deps into package.json). Scaffolds nothing. Then run
                              bun install. Standalone binary only.
@@ -216,7 +216,7 @@ CORE FLAGS (dev)
                      browser store (Studio → Settings → Reset, or an
                      incognito window) for a full reset.
   -- <cmd>           Run <cmd> once the host is up, with PYRIC_SANDBOX set and
-                     NODE_OPTIONS extended with --import pyric-tools/register
+                     NODE_OPTIONS extended with --import @pyric/cli/register
                      so firebase-admin/firebase resolve to the sandbox. When
                      omitted, the package.json \`dev\` script runs (via the
                      detected package manager); no script → host-only.
@@ -264,7 +264,7 @@ CREDENTIALS
 
 function printVersion(): void {
   process.stdout.write(
-    `pyric-tools ${pyricToolsVersion()}\n` +
+    `@pyric/cli ${cliVersion()}\n` +
       `Firebase ${FIREBASE_TESTED_AGAINST} (conformance-tested against this release)\n`,
   );
 }

--- a/packages/pyric-tools/src/cli/init-templates.ts
+++ b/packages/pyric-tools/src/cli/init-templates.ts
@@ -1,7 +1,7 @@
 /**
  * Scaffold templates for `pyric init` (engine in `./init.js`).
  *
- * `web` (the default) scaffolds a **Vite app** wired to the `pyric-tools/vite`
+ * `web` (the default) scaffolds a **Vite app** wired to the `@pyric/cli/vite`
  * plugin: `vite dev` runs the app's CANONICAL `firebase/*` imports against the
  * in-process sandbox; `vite build` ships the real `firebase` package. One
  * toolchain, no graduation cliff — the sandbox↔Firebase swap is environmental
@@ -370,7 +370,7 @@ Graduation is an env change, not a code edit:
    \`PYRIC_TARGET=firebase bun start\`
 `;
 
-// ─── web template (Vite + pyric-tools/vite) ───────────────────────────
+// ─── web template (Vite + @pyric/cli/vite) ───────────────────────────
 
 const VITE_INDEX_HTML = (name: string): string => `<!doctype html>
 <html>
@@ -405,7 +405,7 @@ const VITE_INDEX_HTML = (name: string): string => `<!doctype html>
 `;
 
 const VITE_MAIN_TS = `// Canonical firebase/* imports — UNCHANGED between dev and prod.
-// In \`vite dev\` the \`pyric-tools/vite\` plugin swaps these to an in-process
+// In \`vite dev\` the \`@pyric/cli/vite\` plugin swaps these to an in-process
 // sandbox (the config below is accepted but ignored). \`vite build\` ships the
 // real \`firebase\` package and uses the SAME config. Graduation is a build, not
 // a code edit.
@@ -489,7 +489,7 @@ onSnapshot(collection(db, 'posts'), (snap) => {
 `;
 
 const VITE_CONFIG = `import { defineConfig } from 'vite';
-import { pyricSandbox } from 'pyric-tools/vite';
+import { pyricSandbox } from '@pyric/cli/vite';
 
 // Under \`vite dev\` pyricSandbox() swaps firebase/* to the in-process pyric
 // sandbox and deploys + hot-reloads firestore.rules — no Firebase project,
@@ -574,7 +574,7 @@ A Firebase web app built with Vite. In development it runs entirely on pyric's
 in-process sandbox — no Firebase project, credentials, or emulators.
 
 - **Develop:** \`bun install && bun run dev\` — \`vite dev\` with the
-  \`pyric-tools/vite\` plugin swapping \`firebase/*\` to the sandbox: seeded data,
+  \`@pyric/cli/vite\` plugin swapping \`firebase/*\` to the sandbox: seeded data,
   your \`firestore.rules\` deployed + hot-reloaded, popup sign-in.
 - **Build for production:** \`bun run build\` — \`vite build\` ships the real
   \`firebase\` package. Fill \`.env\` from the Firebase console (see
@@ -596,7 +596,7 @@ later releases. For a pre-built / no-build app, use \`pyric init --template stat
 // ─── the registry ─────────────────────────────────────────────────────
 
 export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
-  // web (default) — a Vite app on the pyric-tools/vite plugin. `vite dev` runs
+  // web (default) — a Vite app on the @pyric/cli/vite plugin. `vite dev` runs
   // on the sandbox; `vite build` ships real firebase. One toolchain.
   web: {
     scripts: {
@@ -610,7 +610,7 @@ export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
     // The real firebase package ships day one so the production `vite build`
     // resolves the same canonical imports against it — no code edit at graduation.
     dependencies: { firebase: '^12.12.0' },
-    devDependencies: { 'pyric-tools': '*', vite: '^6.0.0', typescript: '^5.7.0' },
+    devDependencies: { '@pyric/cli': '*', vite: '^6.0.0', typescript: '^5.7.0' },
     dirs: ['src'],
     files: (name) => [
       { name: 'index.html', content: VITE_INDEX_HTML(name) },
@@ -638,7 +638,7 @@ export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
       bridge: 'pyric bridge',
       'deploy:rules': 'pyric deploy rules',
     },
-    dependencies: { pyric: '*', 'pyric-tools': '*' },
+    dependencies: { pyric: '*', '@pyric/cli': '*' },
     devDependencies: { '@types/bun': 'latest', typescript: '^5.7.0' },
     dirs: ['src'],
     files: (name) => [
@@ -664,7 +664,7 @@ export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
       'deploy:hosting': 'pyric deploy hosting',
     },
     dependencies: { firebase: '^12.12.0' },
-    devDependencies: { 'pyric-tools': '*' },
+    devDependencies: { '@pyric/cli': '*' },
     dirs: ['public'],
     files: (name) => [
       { name: 'public/index.html', content: WEB_INDEX_HTML(name) },

--- a/packages/pyric-tools/src/cli/init.ts
+++ b/packages/pyric-tools/src/cli/init.ts
@@ -4,14 +4,14 @@
  *   pyric init [dir] [--name N] [--template web|node|static] [--force] [--json]
  *              [--deps vendor|npm] [--pyric-version X]
  *
- * `--deps` picks where `pyric` / `pyric-tools` resolve from. The standalone
+ * `--deps` picks where `pyric` / `@pyric/cli` resolve from. The standalone
  * binary defaults to `vendor`: it lays packed tarballs into `vendor/` and points
  * the deps at them (`file:vendor/*.tgz`), so `bun install` works with the
  * packages still unpublished. `--deps npm` writes registry ranges instead (pinned
  * to the binary's version, or `--pyric-version`) for once they're published.
  *
  * Templates live in `./init-templates.js`. `web` (default) scaffolds a Vite app
- * on the `pyric-tools/vite` plugin: `vite dev` runs canonical `firebase/*`
+ * on the `@pyric/cli/vite` plugin: `vite dev` runs canonical `firebase/*`
  * imports against the in-process sandbox, `vite build` ships the real `firebase`
  * package — one toolchain, the swap is environmental (dev vs build), never a
  * code edit. `static` is the serve-era no-bundler scaffold (`pyric dev`).
@@ -37,7 +37,7 @@ import {
   materializeVendorTarballs,
 } from '../serve/standalone-assets.js';
 
-/** Where the scaffold's `pyric` / `pyric-tools` deps come from.
+/** Where the scaffold's `pyric` / `@pyric/cli` deps come from.
  *  - `vendor`: file: refs to tarballs the standalone binary lays down in
  *    `vendor/` — installs offline, no registry. Default in the binary.
  *  - `npm`: registry refs (`^<version>` or `*`) — for once the packages are
@@ -57,14 +57,14 @@ export function resolveDepsMode(
   return isStandalone() && hasEmbeddedTarballs() ? 'vendor' : 'npm';
 }
 
-/** Return a copy of `t` with `pyric` / `pyric-tools` deps rewritten for `mode`.
+/** Return a copy of `t` with `pyric` / `@pyric/cli` deps rewritten for `mode`.
  *  Pure — caller does the tarball I/O and passes `vendorSpecs`. */
 export function applyDepsMode(
   t: ScaffoldTemplate,
   mode: DepsMode,
   opts: { vendorSpecs?: Record<string, string>; version?: string | null },
 ): ScaffoldTemplate {
-  const WORKSPACE_PKGS = ['pyric', 'pyric-tools'];
+  const WORKSPACE_PKGS = ['pyric', '@pyric/cli'];
   const rewrite = (section: Record<string, string>): Record<string, string> => {
     const next = { ...section };
     for (const pkg of WORKSPACE_PKGS) {
@@ -76,16 +76,16 @@ export function applyDepsMode(
             ? `^${opts.version}`
             : next[pkg]; // npm with no pin: keep the template's range (e.g. '*')
     }
-    // Vendor mode: `pyric-tools` needs `pyric` co-installed (its own dep on
+    // Vendor mode: `@pyric/cli` needs `pyric` co-installed (its own dep on
     // pyric is `*`, resolved from the root file: dep). The web/static templates
-    // only list `pyric-tools`, so add `pyric` alongside it.
-    if (mode === 'vendor' && 'pyric-tools' in next && !('pyric' in next) && opts.vendorSpecs?.pyric) {
+    // only list `@pyric/cli`, so add `pyric` alongside it.
+    if (mode === 'vendor' && '@pyric/cli' in next && !('pyric' in next) && opts.vendorSpecs?.pyric) {
       next.pyric = opts.vendorSpecs.pyric;
     }
     return next;
   };
   // Vendor mode pins `pyric` via overrides: a placeholder `pyric` IS published
-  // to npm at a higher version than the local 0.0.0, so pyric-tools' `pyric@*`
+  // to npm at a higher version than the local 0.0.0, so @pyric/cli' `pyric@*`
   // would otherwise resolve to that empty stub instead of the vendored tarball.
   const overrides =
     mode === 'vendor' && opts.vendorSpecs?.pyric ? { pyric: opts.vendorSpecs.pyric } : t.overrides;
@@ -218,7 +218,7 @@ function packageJsonFor(name: string, t: ScaffoldTemplate): string {
 export interface InitResult {
   template: 'web' | 'node' | 'static';
   dir: string;
-  /** Where pyric/pyric-tools deps resolve from: vendored tarballs or npm. */
+  /** Where pyric/@pyric/cli deps resolve from: vendored tarballs or npm. */
   depsMode: DepsMode;
   created: string[];
   merged: string[];
@@ -331,7 +331,7 @@ export async function runInit(parsed: ParsedArgs, deps: InitDeps = {}): Promise<
   };
 
   // ─── deps mode: vendor the embedded tarballs, or pin npm versions ───
-  // `effective` is the template with `pyric` / `pyric-tools` deps rewritten;
+  // `effective` is the template with `pyric` / `@pyric/cli` deps rewritten;
   // it (not `template`) drives package.json below. Everything else — files,
   // dirs, nextSteps — is identical across modes.
   let effective = template;
@@ -417,8 +417,8 @@ export async function runInit(parsed: ParsedArgs, deps: InitDeps = {}): Promise<
 
   report.write(
     depsMode === 'vendor'
-      ? '\n  deps: vendored pyric + pyric-tools into vendor/ — installs offline, no registry\n'
-      : `\n  deps: pyric + pyric-tools from npm${pinVersion ? ` (^${pinVersion})` : ''}\n`,
+      ? '\n  deps: vendored pyric + @pyric/cli into vendor/ — installs offline, no registry\n'
+      : `\n  deps: pyric + @pyric/cli from npm${pinVersion ? ` (^${pinVersion})` : ''}\n`,
   );
 
   report.write('\nNext steps:\n');
@@ -431,7 +431,7 @@ export async function runInit(parsed: ParsedArgs, deps: InitDeps = {}): Promise<
 // ─── pyric vendor: retrofit the vendored packages into any project ─────────
 
 /**
- * The deps-only "template" for `pyric vendor`: `pyric-tools` as a devDependency.
+ * The deps-only "template" for `pyric vendor`: `@pyric/cli` as a devDependency.
  * `applyDepsMode(..., 'vendor', { vendorSpecs })` rewrites it to a `file:` ref and
  * adds `pyric` + the `overrides.pyric` pin alongside it. No scripts, dirs, or
  * scaffold files — vendoring touches package.json deps only.
@@ -439,14 +439,14 @@ export async function runInit(parsed: ParsedArgs, deps: InitDeps = {}): Promise<
 export const VENDOR_TEMPLATE: ScaffoldTemplate = {
   scripts: {},
   dependencies: {},
-  devDependencies: { 'pyric-tools': '*' },
+  devDependencies: { '@pyric/cli': '*' },
   dirs: [],
   files: () => [],
   nextSteps: [],
 };
 
 /**
- * `pyric vendor [dir]` — lay the vendored `pyric` / `pyric-tools` tarballs into an
+ * `pyric vendor [dir]` — lay the vendored `pyric` / `@pyric/cli` tarballs into an
  * existing project and merge their `file:` deps into its package.json. The
  * retrofit counterpart to `init`: it scaffolds nothing, so any Firebase app can
  * adopt the sandbox without `init --template web`. Standalone-binary only (the
@@ -468,7 +468,7 @@ export async function runVendor(parsed: ParsedArgs, deps: InitDeps = {}): Promis
   if (!(isStandalone() && hasEmbeddedTarballs())) {
     err.write(
       'pyric vendor: needs the standalone binary (it carries the embedded pyric / ' +
-        'pyric-tools tarballs). A monorepo/npm checkout has nothing to vendor; depend ' +
+        '@pyric/cli tarballs). A monorepo/npm checkout has nothing to vendor; depend ' +
         'on the packages directly instead.\n',
     );
     return 1;
@@ -513,7 +513,7 @@ export async function runVendor(parsed: ParsedArgs, deps: InitDeps = {}): Promis
     return 2;
   }
 
-  report.write(`pyric vendor: vendored pyric + pyric-tools into ${join(dir, 'vendor')}\n`);
+  report.write(`pyric vendor: vendored pyric + @pyric/cli into ${join(dir, 'vendor')}\n`);
   for (const spec of Object.values(vendorSpecs)) {
     report.write(`  + ${spec.replace(/^file:/, '')}\n`);
   }

--- a/packages/pyric-tools/src/cli/serve.ts
+++ b/packages/pyric-tools/src/cli/serve.ts
@@ -192,7 +192,7 @@ export async function startServe(opts: {
         `pyric dev: ${inlined[0]} bundles the REAL firebase SDK, so this dist cannot be ` +
           `sandboxed — its firebase/* calls would reach LIVE Google endpoints, not the ` +
           `pyric sandbox. Two ways forward:\n` +
-          `  (a) plain \`pyric dev\` runs the child dev-server flow (the pyric-tools/vite ` +
+          `  (a) plain \`pyric dev\` runs the child dev-server flow (the @pyric/cli/vite ` +
           `plugin swaps firebase/* live) — use \`bun run dev\`;\n` +
           `  (b) rebuild as a self-contained sandbox bundle and serve THAT: ` +
           `\`vite build --mode development\` (or pyricSandbox({ swapInBuild: true })) then ` +

--- a/packages/pyric-tools/src/credentials/index.ts
+++ b/packages/pyric-tools/src/credentials/index.ts
@@ -1,5 +1,5 @@
 /**
- * Public credential surface (`pyric-tools/credentials`) for consumers that build
+ * Public credential surface (`@pyric/cli/credentials`) for consumers that build
  * their own auth flow on the isomorphic core — notably the playground's BFF
  * server endpoints. The core (auth-url + PKCE, token exchange, scope policy) plus
  * the framework-agnostic BFF helpers. Browser-safe core; the BFF helpers are

--- a/packages/pyric-tools/src/credentials/node/index.ts
+++ b/packages/pyric-tools/src/credentials/node/index.ts
@@ -1,7 +1,7 @@
 /**
- * Node-only credential surface (`pyric-tools/credentials/node`): the filesystem
+ * Node-only credential surface (`@pyric/cli/credentials/node`): the filesystem
  * adapters + the local-token resolver. Separate from the browser-safe
- * `pyric-tools/credentials` barrel because these touch the filesystem
+ * `@pyric/cli/credentials` barrel because these touch the filesystem
  * (`~/.pyric/credentials.json`, ADC). Server-side only.
  */
 export {

--- a/packages/pyric-tools/src/deploy/from-service-account.ts
+++ b/packages/pyric-tools/src/deploy/from-service-account.ts
@@ -10,8 +10,8 @@
  * **Node-only inside a browser-safe package**: the function itself
  * requires `node:fs/promises` + `node:crypto`. Those modules are
  * imported via dynamic `import()` inside the function body so the
- * top-level pyric-tools/deploy entry stays browser-bundle safe. A
- * browser host that imports `pyric-tools/deploy` but never calls
+ * top-level @pyric/cli/deploy entry stays browser-bundle safe. A
+ * browser host that imports `@pyric/cli/deploy` but never calls
  * `fromServiceAccount` will not have `node:*` modules in its
  * bundle graph.
  */
@@ -21,7 +21,7 @@ import { memoizeTtl } from './memoize-ttl.js';
 
 const GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token';
 const SCOPE = [
-  // Broad scopes covering everything `pyric-tools/deploy` touches:
+  // Broad scopes covering everything `@pyric/cli/deploy` touches:
   // Firebase Hosting, Cloud Functions, Firestore Admin, Storage,
   // Identity Toolkit, Cloud Resource Manager.
   'https://www.googleapis.com/auth/firebase',

--- a/packages/pyric-tools/src/deploy/index.ts
+++ b/packages/pyric-tools/src/deploy/index.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric-tools/deploy` — Firebase control-plane primitives + tool
+ * `@pyric/cli/deploy` — Firebase control-plane primitives + tool
  * factories. Pure-fetch over OAuth access tokens; works in browser
  * and Node alike. Service-account flow via `fromServiceAccount`;
  * browser hosts wrap Firebase Auth's `getIdToken`.
@@ -40,7 +40,7 @@ export { withResolvedScope } from './with-resolved-scope.js';
 // `hosting` and `functions` are the scope-shaped groupings consumers
 // reach for. They wrap the existing portable primitives so every
 // operation takes a ProjectScope and resolves the token internally
-// per F4. The previous `pyric-tools/deploy/{hosting,functions}` sub-path
+// per F4. The previous `@pyric/cli/deploy/{hosting,functions}` sub-path
 // exports are removed.
 
 export { hosting, functions, firestore, rtdb, recipes } from './namespaces.js';

--- a/packages/pyric-tools/src/deploy/namespaces.ts
+++ b/packages/pyric-tools/src/deploy/namespaces.ts
@@ -1,5 +1,5 @@
 /**
- * Named-object groupings at the pyric-tools/deploy root entry. Each
+ * Named-object groupings at the @pyric/cli/deploy root entry. Each
  * group bundles the primitives for one Firebase product (hosting,
  * functions, etc.) under a typed namespace.
  *

--- a/packages/pyric-tools/src/deploy/scope.ts
+++ b/packages/pyric-tools/src/deploy/scope.ts
@@ -1,6 +1,6 @@
 /**
  * `ProjectScope`, `Outcome`, `AdminApiError` — the foundation
- * primitives every control-plane operation in `pyric-tools/deploy` (and
+ * primitives every control-plane operation in `@pyric/cli/deploy` (and
  * the factories built on top) shares.
  *
  * See the design rationale,

--- a/packages/pyric-tools/src/deploy/tools.ts
+++ b/packages/pyric-tools/src/deploy/tools.ts
@@ -1,5 +1,5 @@
 /**
- * Tool factories for `pyric-tools/deploy` per F1.
+ * Tool factories for `@pyric/cli/deploy` per F1.
  *
  * Each factory wraps the namespaced primitives (firestore, hosting,
  * functions, storage) as `ToolHandler[]` consumable by

--- a/packages/pyric-tools/src/discover/crawler-adapter.ts
+++ b/packages/pyric-tools/src/discover/crawler-adapter.ts
@@ -34,13 +34,13 @@ import type {
   CrawlerCollectionRef,
   CrawlerDocumentRef,
   CrawlerFirestore,
-} from 'pyric-tools/discover';
+} from '@pyric/cli/discover';
 import type {
   CollectionGroupCapableFirestore,
   CollectionGroupQuery,
   CollectionGroupSnapshot,
-} from 'pyric-tools/discover';
-import type { WireDocumentSnapshot } from 'pyric-tools/discover';
+} from '@pyric/cli/discover';
+import type { WireDocumentSnapshot } from '@pyric/cli/discover';
 import { encodeFieldsProto } from 'pyric/sandbox/internal';
 
 /**

--- a/packages/pyric-tools/src/pkg-version.ts
+++ b/packages/pyric-tools/src/pkg-version.ts
@@ -1,5 +1,5 @@
 /**
- * pyric-tools' OWN package version, resolved at runtime — the version-skew
+ * @pyric/cli' OWN package version, resolved at runtime — the version-skew
  * stamp both ends of the worker relay compare (integration-smoke fix: an old
  * `pyric dev` accepting a newer client's frame and dying mid-handling used to
  * surface as a bare 30s timeout with no hint).
@@ -8,7 +8,7 @@
  *   1. A standalone `bun build --compile` binary's baked version
  *      (`globalThis.__PYRIC_EMBEDDED__.version` — see serve/standalone-assets).
  *   2. The nearest `package.json` walking up from THIS module (dist/ or src/),
- *      i.e. the pyric-tools install actually executing.
+ *      i.e. the @pyric/cli install actually executing.
  *   3. `'0.0.0'` when neither resolves (never throws).
  *
  * Node-only (node:fs / node:url) — do NOT import from browser-bundled modules
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 
 let cached: string | null = null;
 
-export function pyricToolsVersion(): string {
+export function cliVersion(): string {
   if (cached !== null) return cached;
   const embedded = (
     globalThis as { __PYRIC_EMBEDDED__?: { version?: string } }

--- a/packages/pyric-tools/src/register/esm-exports.ts
+++ b/packages/pyric-tools/src/register/esm-exports.ts
@@ -1,6 +1,6 @@
 /**
  * Minimal `exports`-field walker for the CJS→ESM seam in
- * `pyric-tools/register`.
+ * `@pyric/cli/register`.
  *
  * Why it exists: a rewritten CJS `require('firebase-admin/app')` resolves
  * `pyric-admin/app` under the `require` condition, but the pyric mirrors are

--- a/packages/pyric-tools/src/register/exempt.ts
+++ b/packages/pyric-tools/src/register/exempt.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { mapFirebaseSpecifier } from './mapping.js';
 
 /** The packages whose own Firebase imports must stay Firebase. */
-const EXEMPT_PACKAGES: ReadonlySet<string> = new Set(['pyric', 'pyric-admin', 'pyric-tools']);
+const EXEMPT_PACKAGES: ReadonlySet<string> = new Set(['pyric', 'pyric-admin', '@pyric/cli']);
 
 /** dir → owning package name (null = none found up to the fs root).
  *  Resolution runs on every import in the child process — cache it. */

--- a/packages/pyric-tools/src/register/index.ts
+++ b/packages/pyric-tools/src/register/index.ts
@@ -1,7 +1,7 @@
 /**
- * `pyric-tools/register` — the Node substitution seam (adoption layer 2).
+ * `@pyric/cli/register` — the Node substitution seam (adoption layer 2).
  *
- * Loaded via `node --import pyric-tools/register` (which `pyric dev` injects
+ * Loaded via `node --import @pyric/cli/register` (which `pyric dev` injects
  * through NODE_OPTIONS), it makes the user's UNCHANGED `firebase-admin` /
  * `firebase` imports resolve to `pyric-admin` / `pyric`, every subpath 1:1,
  * and installs the sandbox-factory global that `pyric-admin`'s ambient
@@ -92,7 +92,7 @@ function activate(): void {
     moduleApi.registerHooks({
       resolve(specifier, context, nextResolve) {
         // The rewrite decision includes the mirror-package exemption:
-        // Firebase imports made FROM WITHIN pyric/pyric-admin/pyric-tools
+        // Firebase imports made FROM WITHIN pyric/pyric-admin/@pyric/cli
         // are their prod arms and must keep resolving to real Firebase
         // (see exempt.ts).
         const mapped = rewriteSpecifier(specifier, context.parentURL);
@@ -114,7 +114,7 @@ function activate(): void {
     });
   } else {
     process.stderr.write(
-      'pyric-tools/register: this Node version lacks module.registerHooks (needs >= 22.15) — ' +
+      '@pyric/cli/register: this Node version lacks module.registerHooks (needs >= 22.15) — ' +
         'falling back to module.register: ESM imports of firebase-admin/firebase are rewritten, ' +
         "but CJS require('firebase-admin') is NOT intercepted. Upgrade Node to >= 22.15 for full coverage.\n",
     );
@@ -127,7 +127,7 @@ function activate(): void {
     remoteSandbox(opts);
 
   process.stderr.write(
-    `pyric-tools/register: active — firebase-admin/firebase imports now resolve to the ` +
+    `@pyric/cli/register: active — firebase-admin/firebase imports now resolve to the ` +
       `pyric sandbox (PYRIC_SANDBOX=${process.env.PYRIC_SANDBOX}).\n`,
   );
 }
@@ -140,7 +140,7 @@ export let active = false;
 if (process.env.PYRIC_SANDBOX) {
   if (process.env.NODE_ENV === 'production' && process.env.PYRIC_SANDBOX_FORCE !== '1') {
     process.stderr.write(
-      'pyric-tools/register: refusing to activate under NODE_ENV=production — ' +
+      '@pyric/cli/register: refusing to activate under NODE_ENV=production — ' +
         'firebase-admin/firebase imports are NOT rewritten. ' +
         'Set PYRIC_SANDBOX_FORCE=1 to override (dev/CI only).\n',
     );

--- a/packages/pyric-tools/src/register/mapping.ts
+++ b/packages/pyric-tools/src/register/mapping.ts
@@ -1,5 +1,5 @@
 /**
- * The specifier map behind `pyric-tools/register`: unmodified Firebase
+ * The specifier map behind `@pyric/cli/register`: unmodified Firebase
  * imports resolve to their pyric mirrors, 1:1 including every subpath
  * (`firebase-admin/app` → `pyric-admin/app`, `firebase/firestore` →
  * `pyric/firestore`, …).

--- a/packages/pyric-tools/src/registry/index.ts
+++ b/packages/pyric-tools/src/registry/index.ts
@@ -1,5 +1,5 @@
 /**
- * Prod/admin tool-registry composition for pyric-tools. Composes the
+ * Prod/admin tool-registry composition for @pyric/cli. Composes the
  * per-domain factories (deploy / rules / firestore / discover / rtdb) into a
  * registry, and bootstraps the admin inputs from a service account.
  *

--- a/packages/pyric-tools/src/remote/index.ts
+++ b/packages/pyric-tools/src/remote/index.ts
@@ -27,7 +27,7 @@
  * consumers are last-value-wins).
  *
  * NODE-ONLY: uses `ws` and `node:fs` — exported via a `node`-conditional
- * subpath (`pyric-tools/remote`), never bundled for the browser.
+ * subpath (`@pyric/cli/remote`), never bundled for the browser.
  */
 import { WebSocket } from 'ws';
 import type { AuthUserRecord, CreateUserRequest, UpdateUserRequest } from 'pyric/auth';
@@ -45,7 +45,7 @@ import type {
   WorkerSubPayload,
 } from '../bridge/protocol.js';
 import { isBridgeMessage, NO_SANDBOX_ERROR_MESSAGE } from '../bridge/protocol.js';
-import { pyricToolsVersion } from '../pkg-version.js';
+import { cliVersion } from '../pkg-version.js';
 import { MAX_STORAGE_OP_BYTES, storagePayloadTooLarge } from '../serve/worker/protocol.js';
 import { discoverServe } from '../serve/discovery.js';
 
@@ -277,7 +277,7 @@ export function createRemoteSandboxCore(
   /**
    * Version-skew guidance (integration-smoke fix). Set once when the
    * `attach-ack`'s `serveVersion` stamp is present AND differs from this
-   * client's own pyric-tools version: an old worker can accept a newer op
+   * client's own @pyric/cli version: an old worker can accept a newer op
    * frame and die mid-handling, which surfaces as a bare timeout — so the
    * mismatch warns ONCE on stderr at attach, and op-timeout errors append
    * the same guidance. Old servers omit the stamp → stays null → silent.
@@ -370,15 +370,15 @@ export function createRemoteSandboxCore(
     switch (msg.type) {
       case 'attach-ack': {
         // Version-skew stamp: warn ONCE when the serve process runs a
-        // different pyric-tools version (absent stamp = old server = silent).
+        // different @pyric/cli version (absent stamp = old server = silent).
         if (
           versionSkewGuidance === null &&
           typeof msg.serveVersion === 'string' &&
-          msg.serveVersion !== pyricToolsVersion()
+          msg.serveVersion !== cliVersion()
         ) {
           versionSkewGuidance =
             `pyric dev is running version ${msg.serveVersion}, this client is ` +
-            `${pyricToolsVersion()} — restart pyric dev and reload the browser tab.`;
+            `${cliVersion()} — restart pyric dev and reload the browser tab.`;
           process.stderr.write(`pyric: ${versionSkewGuidance}\n`);
         }
         if (msg.peerConnected) readyResolve();
@@ -858,7 +858,7 @@ export interface LazyRemoteSandbox extends RemoteSandbox {
 /**
  * Synchronous construction, lazy connection — the ambient-init seam.
  *
- * `pyric-tools/register` installs this behind the
+ * `@pyric/cli/register` installs this behind the
  * `Symbol.for('pyric.remote.sandboxFactory')` global so `pyric-admin`'s bare
  * `initializeApp()` can mint a full branded handle without awaiting anything.
  * The wire connection (discovery → WS attach) happens on the FIRST op (or

--- a/packages/pyric-tools/src/serve/bundler.ts
+++ b/packages/pyric-tools/src/serve/bundler.ts
@@ -48,7 +48,7 @@ export const SDK_MODULES = [
 ] as const;
 
 /**
- * The wrapper entries shipped with pyric-tools, located relative to this
+ * The wrapper entries shipped with @pyric/cli, located relative to this
  * module: compiled `.js` siblings when running from dist (npx install), `.ts`
  * sources in the workspace (tests / dev). esbuild bundles either.
  */
@@ -74,7 +74,7 @@ export function defaultSdkEntries(): Record<string, string> {
 
 /**
  * Resolve the built Studio app dir (the plugin's `ui` option + the CLI's
- * `--ui`). Reached by file path so pyric-tools never imports `@pyric/studio`:
+ * `--ui`). Reached by file path so @pyric/cli never imports `@pyric/studio`:
  * the packaged location (`dist/serve/studio-ui`, copied at build) or, in the
  * monorepo, the sibling studio build. Null when neither exists. The standalone
  * binary embeds these same bytes instead (see `standalone-assets.ts`).
@@ -129,7 +129,7 @@ export function resolveDocsUiDir(): string | null {
 // ─── pyric dist discovery ─────────────────────────────────────────────
 
 /** Locate the installed pyric package root (works in the workspace and when
- *  pyric-tools is npm-installed — pyric is a direct dependency). */
+ *  @pyric/cli is npm-installed — pyric is a direct dependency). */
 export function pyricPackageRoot(): string {
   // Resolve a real exported subpath, then walk up to the package root.
   const entry = fileURLToPath(import.meta.resolve('pyric/firestore'));
@@ -266,7 +266,7 @@ function firebaseStubPlugin(bindings: Map<string, Set<string>>): esbuild.Plugin 
 /** Resolve `pyric/*` specifiers from THIS package's own dependency context
  *  (`import.meta.resolve`) rather than from the entry file's directory —
  *  entries may live in a temp dir or the user's project, neither of which
- *  has pyric in scope; pyric-tools always does (direct dependency). */
+ *  has pyric in scope; @pyric/cli always does (direct dependency). */
 function pyricResolvePlugin(): esbuild.Plugin {
   return {
     name: 'pyric-serve-resolve-pyric',

--- a/packages/pyric-tools/src/serve/entries/runtime.ts
+++ b/packages/pyric-tools/src/serve/entries/runtime.ts
@@ -9,7 +9,7 @@
  * "first write raced the ruleset" class of bugs.
  *
  * This file is BUNDLED FOR THE BROWSER by `../bundler.ts` (esbuild) — it is
- * never imported by node-side pyric-tools code. Bundle splitting must keep it
+ * never imported by node-side @pyric/cli code. Bundle splitting must keep it
  * a single shared chunk: two copies would mean two sandboxes (P0 validation
  * constraint, design rationale section 9).
  */
@@ -51,7 +51,7 @@ import { buildVerifyFixture } from '../../verify/fixture.js';
  * NOT serve the worker bundle (`/__pyric/sdk/worker.js`) sets it before this
  * module evaluates so the page takes the in-page path instead of trying to load
  * a worker that 404s. `pyric dev` always serves the worker and never sets it;
- * the `pyric-tools/vite` plugin sets it until it serves the worker (M2).
+ * the `@pyric/cli/vite` plugin sets it until it serves the worker (M2).
  */
 export const useWorker =
   typeof SharedWorker !== 'undefined' &&

--- a/packages/pyric-tools/src/serve/namespace.ts
+++ b/packages/pyric-tools/src/serve/namespace.ts
@@ -125,7 +125,7 @@ export interface NamespaceOptions {
    *  that `@pyric/studio`'s `local` mode talks to. */
   studio?: StudioRouteOptions;
   /** `--ui` (Pyric Studio): the dir of the built Studio app, served under
-   *  `/__pyric/ui/`. Resolved by file path in the CLI (pyric-tools never
+   *  `/__pyric/ui/`. Resolved by file path in the CLI (@pyric/cli never
    *  imports `@pyric/studio`). Absent when `--ui` is off or the build is
    *  missing. */
   studioUiDir?: string;

--- a/packages/pyric-tools/src/serve/standalone-assets.ts
+++ b/packages/pyric-tools/src/serve/standalone-assets.ts
@@ -4,8 +4,8 @@
  * In a `bun build --compile` binary, `pyric dev` cannot run its esbuild SDK
  * bundler: esbuild's native helper and the on-disk `pyric` dist it scans both
  * live outside the embedded `/$bunfs` filesystem. The bundle is deterministic,
- * though — a pure function of pyric-tools' wrapper entries and the `pyric`
- * version baked into pyric-tools — so the compile step (`scripts/compile.ts`)
+ * though — a pure function of @pyric/cli' wrapper entries and the `pyric`
+ * version baked into @pyric/cli — so the compile step (`scripts/compile.ts`)
  * runs the bundler ONCE on the build host and embeds the output (the SDK +
  * worker bundles and the Studio UI) into the binary via
  * `globalThis.__PYRIC_EMBEDDED__`. At runtime we materialize those bytes to a
@@ -39,7 +39,7 @@ export interface EmbeddedAssets {
    *  compiled binaries; missing means the Studio Docs tab 404s in standalone. */
   docs?: () => Promise<Record<string, string>>;
   /** Lazy: packed npm tarballs of the unpublished workspace packages
-   *  (`pyric.tgz`, `pyric-tools.tgz`) -> base64. Used by `pyric init` to vendor
+   *  (`pyric.tgz`, `pyric-cli.tgz`) -> base64. Used by `pyric init` to vendor
    *  them into a scaffolded project so `bun install` resolves them offline
    *  instead of 404-ing on the registry. Optional so a binary built before this
    *  existed degrades gracefully. */
@@ -69,7 +69,7 @@ export function embeddedWorkerVersion(): string {
   return embedded().workerVersion;
 }
 
-/** The `pyric`/`pyric-tools` version baked into this binary (for npm-mode pinning). */
+/** The `pyric`/`@pyric/cli` version baked into this binary (for npm-mode pinning). */
 export function embeddedVersion(): string {
   return embedded().version;
 }
@@ -90,11 +90,11 @@ export function hasEmbeddedTarballs(): boolean {
 }
 
 /**
- * Vendor the embedded `pyric` + `pyric-tools` tarballs into `<projectDir>/vendor/`
+ * Vendor the embedded `pyric` + `@pyric/cli` tarballs into `<projectDir>/vendor/`
  * and return the `package.json` dep spec for each (`file:vendor/<name>.tgz`). The
  * scaffold's `.gitignore` ignores `.pyric/`, so we use `vendor/` to keep the
  * tarballs committable — a clone then `bun install`s offline. Filenames are
- * stable (`pyric.tgz`, `pyric-tools.tgz`) regardless of version.
+ * stable (`pyric.tgz`, `pyric-cli.tgz`) regardless of version.
  */
 export async function materializeVendorTarballs(
   projectDir: string,
@@ -108,8 +108,7 @@ export async function materializeVendorTarballs(
   const specs: Record<string, string> = {};
   for (const [filename, b64] of Object.entries(await e.tarballs())) {
     writeFileSync(join(vendorDir, filename), Buffer.from(b64, 'base64'));
-    // `pyric.tgz` -> package name `pyric`; `pyric-tools.tgz` -> `pyric-tools`.
-    const pkg = filename.replace(/\.tgz$/, '');
+    const pkg = filename === 'pyric-cli.tgz' ? '@pyric/cli' : filename.replace(/\.tgz$/, '');
     specs[pkg] = `file:vendor/${filename}`;
   }
   return specs;

--- a/packages/pyric-tools/src/serve/state-store.ts
+++ b/packages/pyric-tools/src/serve/state-store.ts
@@ -96,8 +96,8 @@ export function createStateStore(projectDir: string): StateStore {
     const file = parsed as PyricStateFile;
     if (file.version !== STATE_FILE_VERSION) {
       throw new StateFileError(
-        `state file at ${path} has version ${String(file.version)}; this pyric-tools expects ` +
-          `${STATE_FILE_VERSION}. Delete it (or promote it with a matching pyric-tools) to continue.`,
+        `state file at ${path} has version ${String(file.version)}; this @pyric/cli expects ` +
+          `${STATE_FILE_VERSION}. Delete it (or promote it with a matching @pyric/cli) to continue.`,
       );
     }
     // Inner controller-blob version (pre-mortem #6): the page's

--- a/packages/pyric-tools/src/serve/studio/store-types.ts
+++ b/packages/pyric-tools/src/serve/studio/store-types.ts
@@ -1,7 +1,7 @@
 /**
  * Studio storage port shapes — server-side MIRROR of `@pyric/studio/ports`.
  *
- * `@pyric/studio` is a CONSUMER of pyric-tools' serve routes, not a dependency
+ * `@pyric/studio` is a CONSUMER of @pyric/cli' serve routes, not a dependency
  * of it; adding a `@pyric/studio` dep here would invert the layering (and risk
  * a cycle). So the disk impls in this directory type-check against these local
  * copies, which are structurally identical to the port interfaces. Keep them in

--- a/packages/pyric-tools/src/serve/vite-plugin.ts
+++ b/packages/pyric-tools/src/serve/vite-plugin.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric-tools/vite` — the firebase→pyric-sandbox swap as a Vite plugin.
+ * `@pyric/cli/vite` — the firebase→pyric-sandbox swap as a Vite plugin.
  *
  * The serve analog for SOURCE-driven apps: instead of `vite build && pyric dev
  * dist`, a team keeps `vite dev` (HMR, source maps) with the in-process sandbox
@@ -109,7 +109,7 @@ function bindingsFor(pyricRoot: string): Map<string, Set<string>> {
     const distDir = path.join(pyricRoot, 'dist');
     if (!existsSync(distDir)) {
       throw new Error(
-        `pyric-tools/vite: pyric is not built — run \`bun run build\` first ` +
+        `@pyric/cli/vite: pyric is not built — run \`bun run build\` first ` +
           `(expected pyric dist at ${distDir}).`,
       );
     }
@@ -168,7 +168,7 @@ export interface PyricSandboxOptions {
 /**
  * The dev-only Vite plugin. Add to `vite.config`:
  *
- *   import { pyricSandbox } from 'pyric-tools/vite';
+ *   import { pyricSandbox } from '@pyric/cli/vite';
  *   export default defineConfig({ plugins: [pyricSandbox()] });
  */
 export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
@@ -178,9 +178,9 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
   const entries = defaultSdkEntries(); // { app, auth, firestore, init } → abs paths
   const pyricRoot = pyricPackageRoot();
   const bindings = bindingsFor(pyricRoot); // memoized; throws an actionable error if pyric isn't built
-  // The pyric-TOOLS package root — covers the served entries AND their siblings
+  // The @pyric/cli package root — covers the served entries AND their siblings
   // (`worker/client.js`, the bridge client) that the entries statically import.
-  const pyricToolsRoot = packageRootOf(entries.init);
+  const cliRoot = packageRootOf(entries.init);
 
   // section 8 refinement: a firebase import is "pyric-internal" iff its importer lives
   // under the resolved pyric package root — keyed on the root, not a `/pyric/`
@@ -198,7 +198,7 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
     if (!importer) return false;
     if (isPyricImporter(importer)) return true;
     const f = importer.split('?')[0];
-    return f === pyricToolsRoot || f.startsWith(pyricToolsRoot + path.sep);
+    return f === cliRoot || f.startsWith(cliRoot + path.sep);
   };
   const stubFor = (spec: string): string => stubModuleSource(spec, bindings.get(spec) ?? new Set());
   const shimFor = (spec: string): string => NODE_BUILTIN_SHIMS[spec.replace(/^node:/, '')]!;
@@ -314,15 +314,15 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
     },
 
     configResolved(resolved) {
-      // AUGMENT (don't replace) the fs allow-list: pyric dist + the pyric-tools
+      // AUGMENT (don't replace) the fs allow-list: pyric dist + the @pyric/cli
       // tree live outside the app root, but setting `server.fs.allow` in config()
       // would clobber Vite's auto-added root/workspace entries and 403 the app's
-      // own source. Push the two PACKAGE ROOTS — pyric-tools' root (not just the
+      // own source. Push the two PACKAGE ROOTS — @pyric/cli' root (not just the
       // entries dir) is needed because the served init entry statically imports
       // siblings (`worker/client.js`, the bridge client) outside entries/.
       const allow = resolved.server?.fs?.allow;
       if (allow) {
-        for (const dir of [pyricRoot, pyricToolsRoot]) {
+        for (const dir of [pyricRoot, cliRoot]) {
           if (!allow.includes(dir)) allow.push(dir);
         }
       }
@@ -404,10 +404,10 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
         try {
           parsed = JSON.parse(readFileSync(seedPath, 'utf8'));
         } catch (e) {
-          throw new Error(`pyric-tools/vite: failed to read seed ${seedPath}: ${e instanceof Error ? e.message : String(e)}`);
+          throw new Error(`@pyric/cli/vite: failed to read seed ${seedPath}: ${e instanceof Error ? e.message : String(e)}`);
         }
         if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          throw new Error('pyric-tools/vite: seed must be a JSON object of "collection/doc" → fields');
+          throw new Error('@pyric/cli/vite: seed must be a JSON object of "collection/doc" → fields');
         }
         const obj = parsed as Record<string, unknown>;
         if (obj.version === STATE_FILE_VERSION && ('firestore' in obj || 'auth' in obj)) {
@@ -520,13 +520,13 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
         if (!studioUiDir) {
           server.config.logger.warn(
             '[pyric] ui: built Studio app not found; /__pyric/ui/ will 404 ' +
-              '(run the full build, or reinstall pyric-tools).',
+              '(run the full build, or reinstall @pyric/cli).',
           );
         }
         if (!playgroundUiDir) {
           server.config.logger.warn(
             '[pyric] ui: built Playground app not found; /__pyric/playground/ will 404 ' +
-              '(run the full build, or reinstall pyric-tools).',
+              '(run the full build, or reinstall @pyric/cli).',
           );
         }
       }

--- a/packages/pyric-tools/src/serve/worker/client.ts
+++ b/packages/pyric-tools/src/serve/worker/client.ts
@@ -22,7 +22,7 @@
  *   - `storage`         worker-backed storage mirror
  *
  * The barrel is part of the worker's PUBLIC shape: `serve/worker/index.ts`
- * re-exports from here for the `pyric-tools/serve/worker` package subpath.
+ * re-exports from here for the `@pyric/cli/serve/worker` package subpath.
  */
 
 // Shared core: lens/issuer controls + the handle and snapshot types.

--- a/packages/pyric-tools/src/serve/worker/index.ts
+++ b/packages/pyric-tools/src/serve/worker/index.ts
@@ -13,9 +13,9 @@
  * and type-only `pyric/sandbox` (erased at build), so this entry stays free of
  * the ~10 MB rules/sandbox engine — safe to import from any browser app.
  *
- * Exposed by `pyric-tools`'s `./serve/worker` package export so Studio can
+ * Exposed by `@pyric/cli`'s `./serve/worker` package export so Studio can
  * `import { getFirestore, subscribeEvents, setLens, setPolicy } from
- * 'pyric-tools/serve/worker'` and reach the live SharedWorker backend.
+ * '@pyric/cli/serve/worker'` and reach the live SharedWorker backend.
  */
 
 export {

--- a/packages/pyric-tools/src/serve/worker/protocol.ts
+++ b/packages/pyric-tools/src/serve/worker/protocol.ts
@@ -368,7 +368,7 @@ export type AuthPersistenceMode = 'LOCAL' | 'SESSION' | 'NONE';
 
 /**
  * The four `ConfirmPolicy` levels the bridge's governance engine recognises.
- * Mirrors `pyric-tools/src/bridge/server/confirm-policy.ts`'s `ConfirmPolicy`
+ * Mirrors `packages/pyric-tools/src/bridge/server/confirm-policy.ts`'s `ConfirmPolicy`
  * and Studio's `permission-dial/policy.ts` — kept structurally identical so a
  * `PolicyRequest` produced by the dial crosses the port without translation.
  */

--- a/packages/pyric-tools/src/version/compat-target.ts
+++ b/packages/pyric-tools/src/version/compat-target.ts
@@ -1,12 +1,12 @@
 /**
  * Single source of truth for the Firebase version pyric is conformance-
  * tested against — the number `pyric --version` prints alongside
- * pyric-tools' own version, and the number `scripts/publish-alpha.sh`
+ * @pyric/cli' own version, and the number `scripts/publish-alpha.sh`
  * reads to derive the `fb<major>.<minor>` dist-tag it moves on a green
  * `compat:check` (see
  * packages/pyric/docs/explanation/versioning-and-compatibility.md).
  *
- * This is a pin, not pyric-tools' own version: bumping it starts a
+ * This is a pin, not @pyric/cli' own version: bumping it starts a
  * re-snapshot of the upstream surface, and no release claims the new
  * `fb` line until `compat:check` passes against it.
  *

--- a/packages/pyric-tools/src/vite.ts
+++ b/packages/pyric-tools/src/vite.ts
@@ -1,9 +1,9 @@
 /**
- * `pyric-tools/vite` — the dev-only Vite plugin that swaps `firebase/*` to the
+ * `@pyric/cli/vite` — the dev-only Vite plugin that swaps `firebase/*` to the
  * in-process pyric sandbox during `vite dev` (the serve analog for source-driven
  * apps). See `./serve/vite-plugin.ts` and the design rationale.
  *
- *   import { pyricSandbox } from 'pyric-tools/vite';
+ *   import { pyricSandbox } from '@pyric/cli/vite';
  *   export default defineConfig({ plugins: [pyricSandbox()] });
  */
 export { pyricSandbox } from './serve/vite-plugin.js';
@@ -12,6 +12,6 @@ export type { PyricSandboxOptions } from './serve/vite-plugin.js';
 // The benign node-builtin shims serve's bundler and this plugin apply when
 // bundling pyric's browser graph (`fs`/`path`/`url` reached via the rules
 // module resolver — see `serve/bundler.ts`). Exported so a browser app that
-// bundles pyric-tools' browser-side bridge client (Pyric Studio registers as
+// bundles @pyric/cli' browser-side bridge client (Pyric Studio registers as
 // the bridge peer) applies the SAME shims instead of re-deriving them.
 export { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from './serve/bundler.js';

--- a/packages/pyric-tools/test/auth/domains/handler.test.ts
+++ b/packages/pyric-tools/test/auth/domains/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { ManageDomainsHandler } from '../../../src/auth/domains/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 
 const originalFetch = global.fetch;
 function restoreFetch() { global.fetch = originalFetch; }

--- a/packages/pyric-tools/test/auth/provider/handler.test.ts
+++ b/packages/pyric-tools/test/auth/provider/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { ConfigureProviderHandler } from '../../../src/auth/provider/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 
 let capturedUrl = '';
 let capturedMethod = '';

--- a/packages/pyric-tools/test/auth/resolver.test.ts
+++ b/packages/pyric-tools/test/auth/resolver.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe, afterEach } from "bun:test";
 import { getAuthTools } from "../../src/auth/resolver.js";
-import type { ProjectScope } from "pyric-tools/deploy";
+import type { ProjectScope } from "@pyric/cli/deploy";
 
 const SCOPE: ProjectScope = {
   projectId: "test-project",

--- a/packages/pyric-tools/test/bridge/e2e.test.ts
+++ b/packages/pyric-tools/test/bridge/e2e.test.ts
@@ -167,7 +167,7 @@ async function callToolText(
 
 // ── Tests ────────────────────────────────────────────────────────
 
-describe('pyric-tools/bridge end-to-end MCP bridge', () => {
+describe('@pyric/cli/bridge end-to-end MCP bridge', () => {
   test('starts with sandboxConnected=false', async () => {
     const res = await fetch(`http://127.0.0.1:${PORT}/health`);
     expect(res.status).toBe(200);

--- a/packages/pyric-tools/test/cli/init-deps-mode.test.ts
+++ b/packages/pyric-tools/test/cli/init-deps-mode.test.ts
@@ -1,7 +1,7 @@
 /** `pyric init` deps-mode resolution + dependency rewriting.
  *
  *  Pure-function coverage for the vendor/npm split (init.ts): which mode wins
- *  given flags/env/standalone, and how `pyric` / `pyric-tools` deps are
+ *  given flags/env/standalone, and how `pyric` / `@pyric/cli` deps are
  *  rewritten in each. No binary, no tarballs — the real `bun install` proof
  *  lives in scripts/standalone-vendor-smoke against a compiled binary. */
 import { describe, expect, it } from 'bun:test';
@@ -32,11 +32,11 @@ describe('resolveDepsMode', () => {
 });
 
 describe('applyDepsMode — vendor', () => {
-  const specs = { pyric: 'file:vendor/pyric.tgz', 'pyric-tools': 'file:vendor/pyric-tools.tgz' };
+  const specs = { pyric: 'file:vendor/pyric.tgz', '@pyric/cli': 'file:vendor/pyric-cli.tgz' };
 
-  it('web template: rewrites pyric-tools and ADDS pyric (needed transitively)', () => {
+  it('web template: rewrites @pyric/cli and ADDS pyric (needed transitively)', () => {
     const out = applyDepsMode(TEMPLATES.web, 'vendor', { vendorSpecs: specs });
-    expect(out.devDependencies['pyric-tools']).toBe('file:vendor/pyric-tools.tgz');
+    expect(out.devDependencies['@pyric/cli']).toBe('file:vendor/pyric-cli.tgz');
     expect(out.devDependencies['pyric']).toBe('file:vendor/pyric.tgz');
     // unrelated deps untouched
     expect(out.dependencies['firebase']).toBe(TEMPLATES.web.dependencies['firebase']);
@@ -48,7 +48,7 @@ describe('applyDepsMode — vendor', () => {
   it('node template: rewrites both, no duplicate pyric', () => {
     const out = applyDepsMode(TEMPLATES.node, 'vendor', { vendorSpecs: specs });
     expect(out.dependencies['pyric']).toBe('file:vendor/pyric.tgz');
-    expect(out.dependencies['pyric-tools']).toBe('file:vendor/pyric-tools.tgz');
+    expect(out.dependencies['@pyric/cli']).toBe('file:vendor/pyric-cli.tgz');
   });
 
   it('does not mutate the shared template object', () => {
@@ -61,13 +61,13 @@ describe('applyDepsMode — vendor', () => {
 describe('applyDepsMode — npm', () => {
   it('pins to ^version when given, never adds pyric or overrides to the web template', () => {
     const out = applyDepsMode(TEMPLATES.web, 'npm', { version: '0.1.2' });
-    expect(out.devDependencies['pyric-tools']).toBe('^0.1.2');
+    expect(out.devDependencies['@pyric/cli']).toBe('^0.1.2');
     expect('pyric' in out.devDependencies).toBe(false); // npm resolves it transitively
     expect(out.overrides).toBeUndefined();
   });
 
   it('keeps the template range when no version is available', () => {
     const out = applyDepsMode(TEMPLATES.web, 'npm', { version: null });
-    expect(out.devDependencies['pyric-tools']).toBe(TEMPLATES.web.devDependencies['pyric-tools']);
+    expect(out.devDependencies['@pyric/cli']).toBe(TEMPLATES.web.devDependencies['@pyric/cli']);
   });
 });

--- a/packages/pyric-tools/test/cli/init.test.ts
+++ b/packages/pyric-tools/test/cli/init.test.ts
@@ -38,7 +38,7 @@ function capture() {
 const tmp = () => mkdtempSync(join(tmpdir(), 'pyric-init-'));
 
 describe('pyric init v2 — web template (default, Vite)', () => {
-  it('scaffolds a Vite app wired to pyric-tools/vite, canonical firebase imports', async () => {
+  it('scaffolds a Vite app wired to @pyric/cli/vite, canonical firebase imports', async () => {
     const dir = tmp();
     const c = capture();
     expect(await runInit(args(), c.deps(dir))).toBe(0);
@@ -70,7 +70,7 @@ describe('pyric init v2 — web template (default, Vite)', () => {
 
     // the swap lives in vite.config, not the app
     const viteConfig = readFileSync(join(dir, 'vite.config.ts'), 'utf8');
-    expect(viteConfig).toContain("from 'pyric-tools/vite'");
+    expect(viteConfig).toContain("from '@pyric/cli/vite'");
     expect(viteConfig).toContain('pyricSandbox(');
 
     // hosting serves Vite's build output
@@ -87,7 +87,7 @@ describe('pyric init v2 — web template (default, Vite)', () => {
     const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
     expect(pkg.type).toBe('module');
     expect(pkg.dependencies.firebase).toMatch(/^\^/);
-    expect(pkg.devDependencies['pyric-tools']).toBeDefined();
+    expect(pkg.devDependencies['@pyric/cli']).toBeDefined();
     expect(pkg.devDependencies.vite).toMatch(/^\^/);
     expect(pkg.scripts.dev).toBe('vite');
     expect(pkg.scripts.build).toBe('vite build');
@@ -326,16 +326,16 @@ describe('pyric init output contract', () => {
       web: {
         '.env.example': '28dfe95f880d2ef18c36d150760286eee88c09054cb5341466f3b22c0f5ff297',
         '.gitignore': '0e07b9adae44651462c122657555ef50ebd683db263aac4681417088e1a321dd',
-        'README.md': '3e2a46853813c10c2d6e9c221761d3ddc9da6892a8934decaf33fccff8245459',
+        'README.md': '4433e7e5c8c82c1f18cc9a31ca352a880619edce012fa2387cf60da2ec5862c6',
         'firebase.json': '06ed33d14b46379011c4a805299016f8c03adf5f47994624fde82b794f09ec2b',
         'firestore.indexes.json': '6742255415c36daf631b52f233039190af819205cc41fa58d07dd7d9e180c2b9',
         'firestore.rules': '5251fb08767a1a8ae2242eb6784cd96838311499bd888fe5a975f65d3a0247ac',
         'index.html': '12f621f10493b0556d5f38acc3a0625c97646e32bd2bca740098ec5715f50aad',
-        'package.json': 'd806151138164386a2bc559983da5a7ca95d564291ee78d0563dd401f7dc8a97',
-        'src/main.ts': 'db0eeeddf207bf2fe88ce32b9b2014ace6481ef8ac06bb66ae6f763fc66789b5',
+        'package.json': '992a082645627845cdedf2538f4b0a265b7abc4fd39a50f265248440d99304a3',
+        'src/main.ts': '3e165d28c4d22df0b868d26cd4071950a6c47cfd0c8944d01c2dadc66c0dfab2',
         'src/vite-env.d.ts': '65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5',
         'tsconfig.json': '5bb892360953642d2644a442a81abbad91e62be2f7fcb646505cc7f33a6bcc08',
-        'vite.config.ts': '5d30839f5dc77f0101e806bff0658bf6efc98b6ee59e63a9122aade2b7540755',
+        'vite.config.ts': '2c4fd6ee8faa56bc468283b99d587d25f89c0c26efebdbb9d5046b76c2f4a005',
       },
       node: {
         '.env.example': 'e60553a1045edd51d9df5f4057e9f920fa21fcf0742e0df945628f6958e67ddf',
@@ -344,7 +344,7 @@ describe('pyric init output contract', () => {
         'firebase.json': 'e817f89d2f9776ba460ec062be7d40f827b8f910d740cff2522b72232f1cdf5a',
         'firestore.indexes.json': '6742255415c36daf631b52f233039190af819205cc41fa58d07dd7d9e180c2b9',
         'firestore.rules': 'fb36f8e6d6e6f5fd7365316fc929a1ad3f99eeff8d624cf6bada39c619501b47',
-        'package.json': 'ad4653edc8d99217ac04d26e59f4ff6992d3e6894a094bb051f325cd25e9413b',
+        'package.json': '389d67729f3848fa9a74515c98740a303e2324c950d3e743f8d80fffff4b7995',
         'src/app.ts': '46e94dd60c6ab8ca32a3df234737780643a8826f352c448af311de190aaa3008',
         'src/seed.ts': 'cf9a890fcc9e1f4a836bf5c150573978a0af454763077fcf4aaed5199d04ded8',
       },
@@ -355,7 +355,7 @@ describe('pyric init output contract', () => {
         'firebase.json': 'da40b786caed050b30a5bb108c6e369376477e89a8e08e09c105445ef01bd0fd',
         'firestore.indexes.json': '6742255415c36daf631b52f233039190af819205cc41fa58d07dd7d9e180c2b9',
         'firestore.rules': '75a93ddd7994180a083b2f3337538eb0bcff8fa775c2edd72a13bce051dbc9f3',
-        'package.json': 'ed25a12b612cabbb7d03a1af4399f1550f1f2109e29f1952c29981b16cb3b74a',
+        'package.json': '8d2885c4be73d9901cffa294697aa796132c2ad2f78f7ae57b93e25c0d2a7e14',
         'public/app.js': '6e6b85c76d17e3f5d637afd8162233822b21c311a6f7d33ae02996d5565a3ed7',
         'public/index.html': 'a878cd6b5508217014e966a8f18ffb8be7789118602acc1c8108df244d2bef4e',
         'seed.json': 'd7d4bed7b5b88e4c30720647f630a83769edbb7eb379e5bcec05403e15148935',

--- a/packages/pyric-tools/test/cli/vendor.test.ts
+++ b/packages/pyric-tools/test/cli/vendor.test.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric vendor` — retrofit the vendored pyric/pyric-tools into any existing
+ * `pyric vendor` — retrofit the vendored pyric/@pyric/cli into any existing
  * project. The happy path lays embedded tarballs (standalone-binary only), so the
  * unit coverage is the dep-injection (the heart of it) + the non-standalone guard.
  */
@@ -13,11 +13,11 @@ import {
 
 const SPECS = {
   pyric: 'file:vendor/pyric-0.1.0.tgz',
-  'pyric-tools': 'file:vendor/pyric-tools-0.1.0.tgz',
+  '@pyric/cli': 'file:vendor/pyric-cli-0.1.0.tgz',
 };
 
 describe('pyric vendor: dep injection', () => {
-  it('merges pyric + pyric-tools file: deps into an existing package.json, preserving the rest', () => {
+  it('merges pyric + @pyric/cli file: deps into an existing package.json, preserving the rest', () => {
     const effective = applyDepsMode(VENDOR_TEMPLATE, 'vendor', { vendorSpecs: SPECS });
     const existing = JSON.stringify(
       { name: 'my-app', dependencies: { firebase: '^10.0.0' }, scripts: { dev: 'vite' } },
@@ -28,7 +28,7 @@ describe('pyric vendor: dep injection', () => {
     const pkg = JSON.parse(merge.contents);
 
     // Vendored deps land as file: refs; the pyric override pins the transitive dep.
-    expect(pkg.devDependencies['pyric-tools']).toBe(SPECS['pyric-tools']);
+    expect(pkg.devDependencies['@pyric/cli']).toBe(SPECS['@pyric/cli']);
     expect(pkg.devDependencies.pyric).toBe(SPECS.pyric);
     expect(pkg.overrides.pyric).toBe(SPECS.pyric);
     // The project's own deps + scripts are untouched.

--- a/packages/pyric-tools/test/deploy/firestore.test.ts
+++ b/packages/pyric-tools/test/deploy/firestore.test.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric-tools/deploy` Firestore unit tests. Reshaped to take
+ * `@pyric/cli/deploy` Firestore unit tests. Reshaped to take
  * `ProjectScope` per F3.
  *
  * Network calls are stubbed via `fetch` mocks. Integration against

--- a/packages/pyric-tools/test/deploy/preflight.test.ts
+++ b/packages/pyric-tools/test/deploy/preflight.test.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric-tools/deploy.preflight` unit tests. Network calls are stubbed
+ * `@pyric/cli/deploy.preflight` unit tests. Network calls are stubbed
  * via `fetch` mocks following the pattern in `firestore.test.ts`.
  * Integration against the live REST APIs is out of scope here —
  * the playground deploy track owns that.

--- a/packages/pyric-tools/test/e2e/playwright.config.ts
+++ b/packages/pyric-tools/test/e2e/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 // Manual repro for the served-mode auth bug (the worker over Tailscale / a
 // non-localhost http origin). Tests are named `*.pw.ts` so `bun test` (which
 // matches `*.test.ts` / `*.spec.ts`) never picks them up; Playwright finds them
-// via `testMatch` below. Requires the pyric-tools dist (`bun run build:pyric-tools`).
+// via `testMatch` below. Requires the @pyric/cli dist (`bun run build:pyric-tools`).
 //
 // localhost: the webServer starts `pyric dev` on the fixture automatically.
 // Tailscale repro: run your own serve and set E2E_BASE=http://<tailnet-host>:<port>.

--- a/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
+++ b/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
@@ -83,7 +83,7 @@ test('a Firestore write via the worker port is visible to a second, independent 
   page,
 }) => {
   // Drives the worker over the SAME wire protocol Studio's own live plane
-  // (`pyric-tools/serve/worker` client) uses — `admin.setDocument` /
+  // (`@pyric/cli/serve/worker` client) uses — `admin.setDocument` /
   // `admin.getDocument` are simple ack/value RPCs, so this exercises the real
   // "write is visible through the worker port" path without reaching into
   // Studio's shell/UI internals (out of scope for this change): open TWO

--- a/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
+++ b/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
@@ -4,7 +4,7 @@
  * Every scenario runs the REAL stack end to end: a spawned
  * `pyric dev --ui --bridge --no-open --port 0 --json` serve, real Chromium
  * pages (app fixture + Pyric Studio) whose SharedWorker hosts the one
- * sandbox, and a real Node-side remote client (`pyric-tools/remote`) over
+ * sandbox, and a real Node-side remote client (`@pyric/cli/remote`) over
  * the bridge WS — the exact topology where five live-only bugs hid from
  * ~7k green headless tests (Studio-tab peer, origin split, first-run child
  * race, duplicate snapshots on re-registration, perpetual peer-slot
@@ -19,7 +19,7 @@
  */
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
-import { connectRemoteSandbox, type RemoteSandbox } from 'pyric-tools/remote';
+import { connectRemoteSandbox, type RemoteSandbox } from '@pyric/cli/remote';
 import {
   CLI_PATH,
   McpHttpClient,

--- a/packages/pyric-tools/test/e2e/soak/harness.ts
+++ b/packages/pyric-tools/test/e2e/soak/harness.ts
@@ -99,7 +99,7 @@ export async function startSoakServe(
     // bundle cache key (serve/bundler.ts cacheKey) hashes the pyric version +
     // the serve/entries sources only — NOT the bridge client / worker client
     // sources the bundle also includes — so a warm ~/.pyric/serve-cache keeps
-    // serving a PRE-FIX in-page bridge client after pyric-tools-only changes
+    // serving a PRE-FIX in-page bridge client after @pyric/cli-only changes
     // (observed live: a stale client ignored the standby protocol and bounced
     // the peer slot once per replacement). The suite must test the code as
     // built, so it opts out of the cache.

--- a/packages/pyric-tools/test/e2e/soak/playwright.config.ts
+++ b/packages/pyric-tools/test/e2e/soak/playwright.config.ts
@@ -8,7 +8,7 @@ import { defineConfig } from '@playwright/test';
 // Files are named `*.soak.ts` so neither `bun test` (`*.test.ts` /
 // `*.spec.ts`) nor the sibling auth e2e config (`**/*.pw.ts`) ever picks
 // them up. Run via the root `bun run test:soak` (requires the built
-// pyric-tools dist + `bunx playwright install chromium`).
+// @pyric/cli dist + `bunx playwright install chromium`).
 export default defineConfig({
   testDir: '.',
   testMatch: '**/*.soak.ts',

--- a/packages/pyric-tools/test/e2e/soak/studio-session.soak.ts
+++ b/packages/pyric-tools/test/e2e/soak/studio-session.soak.ts
@@ -13,7 +13,7 @@
  * serve are the fix; this suite pins "the process stays alive" end to end.
  *
  * Named `*.soak.ts` so `bun test` never picks it up; runs via the root
- * `bun run test:soak` (requires the built pyric-tools dist + Chromium).
+ * `bun run test:soak` (requires the built @pyric/cli dist + Chromium).
  */
 import { test, expect, type Page } from '@playwright/test';
 import { chromium } from '@playwright/test';

--- a/packages/pyric-tools/test/register/mapping.test.ts
+++ b/packages/pyric-tools/test/register/mapping.test.ts
@@ -62,7 +62,7 @@ describe('rewriteSpecifier (mirror-package exemption)', () => {
     join(repoRoot, 'packages/pyric-admin/src/database/index.ts'),
   ).href;
   const pyricParent = pathToFileURL(join(repoRoot, 'packages/pyric/src/app/index.ts')).href;
-  const pyricToolsParent = pathToFileURL(
+  const cliParent = pathToFileURL(
     join(repoRoot, 'packages/pyric-tools/src/deploy/index.ts'),
   ).href;
 
@@ -72,7 +72,7 @@ describe('rewriteSpecifier (mirror-package exemption)', () => {
     expect(rewriteSpecifier('firebase-admin/database', pyricAdminParent)).toBeNull();
     expect(rewriteSpecifier('firebase-admin/app', pyricAdminParent)).toBeNull();
     expect(rewriteSpecifier('firebase/app', pyricParent)).toBeNull();
-    expect(rewriteSpecifier('firebase-admin/firestore', pyricToolsParent)).toBeNull();
+    expect(rewriteSpecifier('firebase-admin/firestore', cliParent)).toBeNull();
   });
 
   it('rewrites from user modules, entry points, and non-file parents', () => {

--- a/packages/pyric-tools/test/register/register-child.test.ts
+++ b/packages/pyric-tools/test/register/register-child.test.ts
@@ -1,5 +1,5 @@
 /**
- * Child-process integration for `pyric-tools/register`: real `node --import`
+ * Child-process integration for `@pyric/cli/register`: real `node --import`
  * runs against fixture scripts in a temp project whose node_modules symlinks
  * the workspace's built pyric packages (plus the real firebase/firebase-admin
  * for the inertness check). No browser, no server — resolution + activation
@@ -129,17 +129,17 @@ afterAll(() => {
   if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
 });
 
-describe('pyric-tools/register (child process)', () => {
+describe('@pyric/cli/register (child process)', () => {
   it('rewrites ESM imports and installs the factory global when PYRIC_SANDBOX is set', () => {
     const res = runNode('main.mjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
-    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stderr).toContain('@pyric/cli/register: active');
     expect(res.stdout).toContain('ESM_OK');
     expect(res.status).toBe(0);
   });
 
   it("rewrites user imports but EXEMPTS the mirrors' own prod-arm imports", () => {
     const res = runNode('prod-arm.mjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
-    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stderr).toContain('@pyric/cli/register: active');
     // The success line is only reachable when pyric-admin/database loaded,
     // i.e. its internal firebase-admin/database import stayed unrewritten.
     expect(res.stdout).toContain('PROD_ARM_OK');
@@ -148,7 +148,7 @@ describe('pyric-tools/register (child process)', () => {
 
   it.skipIf(!hasRegisterHooks)('rewrites CJS require() via the sync hooks', () => {
     const res = runNode('main.cjs', { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' });
-    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stderr).toContain('@pyric/cli/register: active');
     expect(res.stdout).toContain('CJS_OK');
     expect(res.status).toBe(0);
   });
@@ -157,7 +157,7 @@ describe('pyric-tools/register (child process)', () => {
     const res = runNode('probe.mjs', {});
     expect(res.status).toBe(0);
     expect(JSON.parse(res.stdout)).toEqual({ rewritten: false, factory: 'undefined' });
-    expect(res.stderr).not.toContain('pyric-tools/register');
+    expect(res.stderr).not.toContain('@pyric/cli/register');
   });
 
   it('refuses under NODE_ENV=production (logs, stays inert)', () => {
@@ -177,7 +177,7 @@ describe('pyric-tools/register (child process)', () => {
       PYRIC_SANDBOX_FORCE: '1',
     });
     expect(res.status).toBe(0);
-    expect(res.stderr).toContain('pyric-tools/register: active');
+    expect(res.stderr).toContain('@pyric/cli/register: active');
     expect(JSON.parse(res.stdout)).toEqual({ rewritten: true, factory: 'function' });
   });
 });

--- a/packages/pyric-tools/test/serve/canonical-url.test.ts
+++ b/packages/pyric-tools/test/serve/canonical-url.test.ts
@@ -66,7 +66,7 @@ describe('canonical serve URL (default host)', () => {
     expect(new URL(pointer.mcpUrl).hostname).toBe(bannerHost);
 
     // The runner env (`PYRIC_SANDBOX=remote:<serve url>`) — the activator the
-    // child's `pyric-tools/register` reads.
+    // child's `@pyric/cli/register` reads.
     const env = buildChildEnv({}, { serveUrl: r.handle.url, registerUrl: 'file:///register.js' });
     const activated = env.PYRIC_SANDBOX!.replace(/^remote:/, '');
     expect(new URL(activated).hostname).toBe(bannerHost);

--- a/packages/pyric-tools/test/serve/integration.test.ts
+++ b/packages/pyric-tools/test/serve/integration.test.ts
@@ -1,7 +1,7 @@
 /** `pyric dev` end-to-end over HTTP (plan step 1.7) — a real fixture
  *  project served by `startServe`, asserted the way a browser would see it.
  *  (The in-browser 6/6 behavioral check is the scripted manual gate — see
- *  the step doc; no playwright dep in pyric-tools.) */
+ *  the step doc; no playwright dep in @pyric/cli.) */
 import { afterAll, describe, expect, it } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/pyric-tools/test/serve/vite-plugin.test.ts
+++ b/packages/pyric-tools/test/serve/vite-plugin.test.ts
@@ -1,4 +1,4 @@
-/** `pyric-tools/vite` — the dev-only firebase→sandbox swap plugin. Unit-tests
+/** `@pyric/cli/vite` — the dev-only firebase→sandbox swap plugin. Unit-tests
  *  the resolver/load/config/html contract (calling the hooks directly), one
  *  resolution check through a real Vite pluginContainer (middlewareMode, binds no
  *  port), and the /__pyric runtime surface by driving the captured connect
@@ -177,7 +177,7 @@ describe('config — optimizer + fs', () => {
     expect(allow).toContain(pyricRoot); // pyric dist added
     // The regression the review caught: the init entry's SIBLING worker/client.js
     // (statically imported by runtime.ts) must fall under an allowed dir — NOT
-    // just entries/. Allowing the pyric-tools package root covers it.
+    // just entries/. Allowing the @pyric/cli package root covers it.
     const workerFile = path.join(path.dirname(path.dirname(entries.init)), 'worker', 'client.js');
     expect(allow.some((d) => workerFile.startsWith(d + path.sep))).toBe(true);
     expect(allow.some((d) => entries.init.startsWith(d + path.sep))).toBe(true);
@@ -601,7 +601,7 @@ describe('M3 — bridge fold (handler-based)', () => {
 // packages/studio/dist/app when run from src).
 //
 // Playground is different on purpose: source/dev tests must not discover
-// packages/playground/dist/client as a hidden fallback. Only packaged pyric-tools
+// packages/playground/dist/client as a hidden fallback. Only packaged @pyric/cli
 // serves embedded Playground bytes from dist/serve/playground-ui, which the
 // packaging gate verifies.
 // Skip the app-serving case (only) when the studio build is absent, with a clear

--- a/packages/pyric-tools/test/serve/worker/client-surface.test.ts
+++ b/packages/pyric-tools/test/serve/worker/client-surface.test.ts
@@ -2,7 +2,7 @@
  * Characterization guard for the worker CLIENT public surface.
  *
  * `serve/worker/client.ts` is re-exported by `serve/worker/index.ts`, which is
- * the `pyric-tools/serve/worker` package subpath export. Its export surface is
+ * the `@pyric/cli/serve/worker` package subpath export. Its export surface is
  * a published contract. This test freezes the runtime (value) export names so a
  * refactor of `client.ts` — for example splitting it into per-family modules
  * behind a barrel — cannot silently add or drop a symbol.

--- a/packages/pyric/src/database/constraints/write-rules-file.ts
+++ b/packages/pyric/src/database/constraints/write-rules-file.ts
@@ -12,7 +12,7 @@
  * Uses the SYNC `node:fs` / `node:path` specifiers (not `node:fs/promises`)
  * to match the module resolver's existing Node-builtin usage — `pyric/rules`
  * is statically reachable from Studio's browser bundle (a known wart, see
- * `modules/resolver.ts` and `pyric-tools/vite`'s `NODE_BUILTIN_SHIMS`), and
+ * `modules/resolver.ts` and `@pyric/cli/vite`'s `NODE_BUILTIN_SHIMS`), and
  * those shims only cover the bare `fs`/`path`/`url` specifiers.
  */
 

--- a/packages/pyric/src/firestore-values/index.ts
+++ b/packages/pyric/src/firestore-values/index.ts
@@ -9,7 +9,7 @@
  *
  *   1. The sandbox persistence serializer (`sandbox/persistence/serialize.ts`)
  *      — server-side, already pulls the whole engine, doesn't care about size.
- *   2. The SharedWorker CLIENT (`pyric-tools/.../worker/client.ts` via
+ *   2. The SharedWorker CLIENT (`@pyric/cli/.../worker/client.ts` via
  *      `protocol.ts`) — runs in EVERY page that opens a serve session. It only
  *      needs to reconstruct Timestamp/Bytes/LatLng instances from the JSON
  *      markers the worker host wrote; it must NOT drag the rules engine,

--- a/packages/pyric/src/firestore/index.ts
+++ b/packages/pyric/src/firestore/index.ts
@@ -13,7 +13,7 @@
  *
  * This module is a re-export barrel over the per-family modules in this
  * directory — it holds no implementation. The families mirror the
- * symmetric `pyric-tools` worker client split:
+ * symmetric `@pyric/cli` worker client split:
  *   - `state`             the TARGET_SYMBOL brand + routing/converter
  *                         WeakMaps + tag/resolve helpers + value finalizers
  *   - `types`             public handle / reference / query / snapshot /

--- a/packages/pyric/src/firestore/persistence.ts
+++ b/packages/pyric/src/firestore/persistence.ts
@@ -40,7 +40,7 @@ import { getDoc, getDocs } from './reads.js';
 //
 // The sandbox has none of that structure. It IS the backend — writes
 // land directly in the sandbox's store, with no server round-trip to
-// wait on and no network link to drop. When the host (`pyric-tools
+// wait on and no network link to drop. When the host (`@pyric/cli
 // serve`, or a bare `initializeSandbox()` call with persistence
 // enabled) turns on IndexedDB persistence, EVERY sandbox write already
 // flushes to IndexedDB by default — an app never has to ask for it.

--- a/packages/pyric/src/firestore/sandbox-ops.ts
+++ b/packages/pyric/src/firestore/sandbox-ops.ts
@@ -62,7 +62,7 @@ export const sandbox = {
     if (!isSandboxKind(target)) {
       throw new SandboxError(
         'failed-precondition',
-        'sandbox.setRules is sandbox-only; use firestore.rules.deploy from pyric-tools/deploy for prod targets.',
+        'sandbox.setRules is sandbox-only; use firestore.rules.deploy from @pyric/cli/deploy for prod targets.',
       );
     }
     return sandboxDb(target).setRules(rules);

--- a/packages/pyric/src/rules/internal/index.ts
+++ b/packages/pyric/src/rules/internal/index.ts
@@ -8,7 +8,7 @@
  *
  * This seam exists so the package's own deep consumers (the sandbox
  * simulator, the test suites) and the sibling tooling packages
- * (`pyric-tools`) can reach the engine primitives — parser, linter,
+ * (`@pyric/cli`) can reach the engine primitives — parser, linter,
  * simulator handler, resolver, wrappers, RTDB machinery — without those
  * primitives leaking onto the curated public surface. Mirrors the
  * established `pyric/sandbox/internal` / `pyric/storage/internal` pattern.

--- a/packages/pyric/src/rules/tools.ts
+++ b/packages/pyric/src/rules/tools.ts
@@ -103,7 +103,7 @@ export function createFirestoreRulesTools(
 
   if (deps.scope) {
     const scope = deps.scope;
-    // Note: `firestore_get_rules` is NOT added here. `pyric-tools/deploy`'s
+    // Note: `firestore_get_rules` is NOT added here. `@pyric/cli/deploy`'s
     // `createFirestoreDeployTools` already exposes a tool with that
     // name (returning raw rules source); composeMcpRegistry would
     // reject the duplicate. Browser callers that want the parsed

--- a/packages/pyric/src/sandbox/admin-firestore/remote/remote-firestore.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/remote/remote-firestore.ts
@@ -22,10 +22,10 @@
  * DEPENDENCY DIRECTION: this module lives in `pyric` and may only consume
  * the STRUCTURAL channel contract from `pyric/sandbox`'s remote seam
  * (`RemoteSandboxChannel` — one loose `op`, one loose `subscribe`). The
- * concrete worker-protocol unions live in `pyric-tools`, which `pyric`
+ * concrete worker-protocol unions live in `@pyric/cli`, which `pyric`
  * cannot import; ops are spelled loosely (`{ method: 'getDoc', path,
  * actAs }`) and kept structurally identical to
- * `pyric-tools/src/serve/worker/protocol.ts`.
+ * `packages/pyric-tools/src/serve/worker/protocol.ts`.
  *
  * IDENTITY: every op and every subscription pins an EXPLICIT `actAs` lens.
  * An ABSENT lens resolves worker-side to the browser tab's PORT SESSION —

--- a/packages/pyric/src/sandbox/admin-firestore/remote/wire-types.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/remote/wire-types.ts
@@ -1,12 +1,12 @@
 /**
- * Loose wire shapes — structural mirrors of the `pyric-tools` worker
+ * Loose wire shapes — structural mirrors of the `@pyric/cli` worker
  * protocol. Spelled loosely (not imported from the protocol module)
- * because `pyric` cannot depend on `pyric-tools`; ops are kept
- * structurally identical to `pyric-tools/src/serve/worker/protocol.ts`.
+ * because `pyric` cannot depend on `@pyric/cli`; ops are kept
+ * structurally identical to `packages/pyric-tools/src/serve/worker/protocol.ts`.
  */
 
 /** Wire form of a doc/collection/group/query target. Mirrors
- *  `pyric-tools`' `TargetDescriptor` — plain JSON, spelled loosely here
+ *  `@pyric/cli`' `TargetDescriptor` — plain JSON, spelled loosely here
  *  because `pyric` cannot import the protocol module. */
 export type WireTarget =
   | { __ref: 'doc'; path: string }

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -51,7 +51,7 @@ export { SandboxContextImpl } from './sandbox-context.js';
 
 // Remote sandbox (slice 1) — the brand + minimal channel contract that
 // lets `pyric-admin` recognize a Node-side handle onto the browser-hosted
-// worker sandbox (constructed by `pyric-tools`' `connectRemoteSandbox`)
+// worker sandbox (constructed by `@pyric/cli`' `connectRemoteSandbox`)
 // and route its RTDB/Auth ops over the wire instead of into local state.
 export { REMOTE_SANDBOX, REMOTE_SANDBOX_FACTORY, isRemoteSandbox } from './remote.js';
 export type {

--- a/packages/pyric/src/sandbox/remote.ts
+++ b/packages/pyric/src/sandbox/remote.ts
@@ -2,7 +2,7 @@
  * Remote-sandbox brand + channel contract (remote sandbox, slice 1).
  *
  * A REMOTE sandbox is a Node-side handle onto the browser-hosted
- * SharedWorker sandbox, constructed by `pyric-tools`'s
+ * SharedWorker sandbox, constructed by `@pyric/cli`'s
  * `connectRemoteSandbox()`. It satisfies {@link Sandbox} structurally, but
  * its data plane lives in the browser worker — so consumers that keep
  * process-local state keyed off the `Sandbox` object (`pyric-admin`'s RTDB
@@ -12,15 +12,15 @@
  *
  * This module is the dependency seam that lets `pyric-admin` (which depends
  * only on `pyric` + `firebase-admin`) recognize a handle constructed by
- * `pyric-tools` (which depends on `pyric`):
+ * `@pyric/cli` (which depends on `pyric`):
  *
  *   - {@link REMOTE_SANDBOX} — a `Symbol.for` brand, so the stamp and the
  *     check agree across package boundaries and duplicated module graphs.
  *   - {@link RemoteSandboxChannel} — a STRUCTURALLY-typed minimal op/sub
- *     relay interface matching `pyric-tools/remote`'s channel shape. The
- *     concrete op/sub payload types live in `pyric-tools`' worker protocol;
+ *     relay interface matching `@pyric/cli/remote`'s channel shape. The
+ *     concrete op/sub payload types live in `@pyric/cli`' worker protocol;
  *     this contract deliberately types them loosely (`method` + open
- *     fields) so `pyric` carries no dependency on `pyric-tools`.
+ *     fields) so `pyric` carries no dependency on `@pyric/cli`.
  *
  * No runtime imports beyond this package's own types — the only runtime
  * export is the brand symbol and its guard.
@@ -38,10 +38,10 @@ export const REMOTE_SANDBOX = Symbol.for('pyric.remote.sandbox');
 /**
  * The minimal worker-relay channel a remote sandbox handle carries.
  *
- * Structural mirror of `pyric-tools/remote`'s `RemoteSandboxChannel`: one
+ * Structural mirror of `@pyric/cli/remote`'s `RemoteSandboxChannel`: one
  * method to dispatch any SharedWorker-protocol op, one to register a
  * snap-delivering subscription. Payloads are typed openly here (the real
- * discriminated unions live in `pyric-tools`' worker protocol); callers in
+ * discriminated unions live in `@pyric/cli`' worker protocol); callers in
  * `pyric-admin` spell the concrete op objects (`rtdb.set`, `auth.listUsers`,
  * …) and pin their own `actAs` lens — nothing is pinned by the channel.
  */
@@ -86,13 +86,13 @@ export interface RemoteSandbox extends Sandbox {
 }
 
 /**
- * Well-known global key under which `pyric-tools/register` installs the
+ * Well-known global key under which `@pyric/cli/register` installs the
  * remote-sandbox factory: `globalThis[REMOTE_SANDBOX_FACTORY]`.
  *
  * This is the AMBIENT-INIT seam (adoption experience, layer 3): when
  * `pyric-admin/app`'s bare `initializeApp()` sees `PYRIC_SANDBOX=remote[:url]`
  * it reads this global and calls the installed {@link RemoteSandboxFactory}
- * to obtain the branded handle — without importing `pyric-tools` (which is
+ * to obtain the branded handle — without importing `@pyric/cli` (which is
  * a devDependency of the app, not of `pyric-admin`). `Symbol.for` so the
  * installer and the reader agree even across duplicated copies of `pyric`.
  */
@@ -107,7 +107,7 @@ export interface RemoteSandboxFactoryOptions {
 }
 
 /**
- * The factory `pyric-tools/register` installs at
+ * The factory `@pyric/cli/register` installs at
  * `globalThis[`{@link REMOTE_SANDBOX_FACTORY}`]`. SYNCHRONOUS by contract:
  * `initializeApp()` is sync in firebase-admin, so the factory must return
  * the branded handle without awaiting (connection establishment may be

--- a/packages/pyric/src/storage/admin/handler.ts
+++ b/packages/pyric/src/storage/admin/handler.ts
@@ -2,7 +2,7 @@
  * Handlers wrapping the pure-fetch `api.ts` provisioning functions
  * with a structured outcome shape. They take a `ProjectScope`
  * (`{ projectId, resolveToken }`) — the same credential value the
- * `pyric-tools/deploy` factories accept — so the storage tools share the
+ * `@pyric/cli/deploy` factories accept — so the storage tools share the
  * resolver contract with the rest of the control plane.
  *
  * Note on permissions: `resolveToken()` typically yields a Firebase

--- a/packages/pyric/src/storage/admin/tools.ts
+++ b/packages/pyric/src/storage/admin/tools.ts
@@ -4,7 +4,7 @@
  * `createStorageAdminTools({ scope })` returns the two
  * provisioning/status tools as `ToolHandler[]`, consumable by
  * `@inbrowser/agent`'s registry — including by `composeMcpRegistry`.
- * Mirrors the `createFirestoreRulesTools` / `pyric-tools/deploy` factory
+ * Mirrors the `createFirestoreRulesTools` / `@pyric/cli/deploy` factory
  * shape: a `ProjectScope` in, JSON-Schema-typed `ToolHandler`s out.
  */
 import type { ToolHandler } from '@inbrowser/agent';
@@ -14,7 +14,7 @@ import type { ProvisionStorageInput } from './spec.js';
 import type { ProvisionProgress } from './api.js';
 
 export interface StorageAdminToolDeps {
-  /** Project identity + token resolver. Same shape `pyric-tools/deploy`'s
+  /** Project identity + token resolver. Same shape `@pyric/cli/deploy`'s
    *  factories take. */
   scope: ProjectScope;
 }

--- a/packages/pyric/test/ai/broker.test.ts
+++ b/packages/pyric/test/ai/broker.test.ts
@@ -638,7 +638,7 @@ describe('openai engine (mocked fetch)', () => {
 
   it('default fetch never runs with the engine as its receiver (browser Illegal invocation guard)', async () => {
     // Regression guard for the serve e2e finding (test/e2e/ai-demo.pw.ts in
-    // pyric-tools): `options.fetch ?? fetch` stored the global BARE, so
+    // @pyric/cli): `options.fetch ?? fetch` stored the global BARE, so
     // `this.fetchImpl(...)` invoked fetch with the engine as `this` — an
     // Illegal invocation in browsers and workers (Node tolerates it, which is
     // why only a real SharedWorker surfaced it). The default must be a

--- a/packages/pyric/test/auth/sandbox-provider-config.test.ts
+++ b/packages/pyric/test/auth/sandbox-provider-config.test.ts
@@ -228,7 +228,7 @@ describe('gating matrix: sandbox.mintSession (the served-worker per-port session
   // `sandbox.mintSession` is a SEPARATE entry point from the index.ts free
   // functions above — it's what the SharedWorker host actually calls for
   // `auth.signInAnonymously` / `auth.createUser` / `auth.signInEmail`
-  // (see pyric-tools/src/serve/worker/host-auth.ts). Full fidelity requires
+  // (see packages/pyric-tools/src/serve/worker/host-auth.ts). Full fidelity requires
   // gating it too, or the Studio "Sign-in providers" toggle would have zero
   // effect in served mode — the primary product surface.
   it('kind "anonymous": disabled → auth/operation-not-allowed', () => {

--- a/packages/pyric/test/firestore/sandbox-converters/reference.test.ts
+++ b/packages/pyric/test/firestore/sandbox-converters/reference.test.ts
@@ -17,7 +17,7 @@ import { Reference } from 'pyric/rules/internal';
 import { KEEP } from 'pyric/sandbox/internal';
 import { LocalEnvironment } from 'pyric/sandbox/internal';
 import { encodeValue } from 'pyric/sandbox/internal';
-import { wireValueToFieldType } from 'pyric-tools/discover';
+import { wireValueToFieldType } from '@pyric/cli/discover';
 
 const baseCtx = (
   overrides: Partial<{

--- a/packages/pyric/test/firestore/sandbox-converters/timestamp.test.ts
+++ b/packages/pyric/test/firestore/sandbox-converters/timestamp.test.ts
@@ -25,9 +25,9 @@ import { LocalEnvironment } from 'pyric/sandbox/internal';
 import { LocalState } from 'pyric/sandbox/internal';
 import { Timestamp } from 'pyric/rules/internal';
 import { encodeValue } from 'pyric/sandbox/internal';
-import { wireValueToFieldType } from 'pyric-tools/discover';
-import { LocalEnvironmentCrawlerAdapter } from 'pyric-tools/discover';
-import { crawl } from 'pyric-tools/discover';
+import { wireValueToFieldType } from '@pyric/cli/discover';
+import { LocalEnvironmentCrawlerAdapter } from '@pyric/cli/discover';
+import { crawl } from '@pyric/cli/discover';
 
 const ALLOW_ALL =
   "rules_version = '2'; service cloud.firestore { " +

--- a/packages/pyric/test/firestore/sandbox-converters/vector.test.ts
+++ b/packages/pyric/test/firestore/sandbox-converters/vector.test.ts
@@ -15,7 +15,7 @@ import { Vector } from 'pyric/rules/internal';
 import { KEEP } from 'pyric/sandbox/internal';
 import { LocalEnvironment } from 'pyric/sandbox/internal';
 import { encodeValue, encodeFieldsProto } from 'pyric/sandbox/internal';
-import { wireValueToFieldType } from 'pyric-tools/discover';
+import { wireValueToFieldType } from '@pyric/cli/discover';
 
 const baseCtx = (
   overrides: Partial<{

--- a/packages/pyric/test/rules/inspect/handler.test.ts
+++ b/packages/pyric/test/rules/inspect/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { InspectFirestoreRulesHandler } from '../../../src/rules/inspect/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 
 const originalFetch = global.fetch;
 function restoreFetch() { global.fetch = originalFetch; }

--- a/packages/pyric/test/rules/parity/harness.ts
+++ b/packages/pyric/test/rules/parity/harness.ts
@@ -22,7 +22,7 @@
  * FIREBASE_SA_BASE64 the live-integration tests use).
  */
 import { cert } from 'firebase-admin/app';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import { SimulateFirestoreRulesHandler } from '../../../src/rules/simulator/handler.js';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
 import type { TestCase, TestFirestoreRulesResult } from '../../../src/rules/test/spec.js';

--- a/packages/pyric/test/rules/parity/map-get-parity-probe.test.ts
+++ b/packages/pyric/test/rules/parity/map-get-parity-probe.test.ts
@@ -23,7 +23,7 @@
  * holds only `firebaserules.rulesets.test`. Skips cleanly when absent.
  */
 import { describe, test, beforeAll, expect } from 'bun:test';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
 import type { TestCase } from '../../../src/rules/test/spec.js';
 import { hasParitySecret, parityScope } from './harness.js';

--- a/packages/pyric/test/rules/parity/parity-stress.test.ts
+++ b/packages/pyric/test/rules/parity/parity-stress.test.ts
@@ -29,7 +29,7 @@
  * when the secret is absent (external PRs, unit-suite CI).
  */
 import { describe, test, beforeAll, afterAll } from 'bun:test';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import {
   type Scenario,
   type CaseRow,

--- a/packages/pyric/test/rules/parity/round-fix-classes.test.ts
+++ b/packages/pyric/test/rules/parity/round-fix-classes.test.ts
@@ -28,7 +28,7 @@
  * the secret is absent.
  */
 import { describe, test, beforeAll, afterAll } from 'bun:test';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import {
   type Scenario,
   type CaseRow,

--- a/packages/pyric/test/rules/test/handler.test.ts
+++ b/packages/pyric/test/rules/test/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import type { TestCase } from '../../../src/rules/test/spec.js';
 
 const originalFetch = global.fetch;

--- a/packages/pyric/test/rules/test/mocks.test.ts
+++ b/packages/pyric/test/rules/test/mocks.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import type { TestCase, FunctionMock } from '../../../src/rules/test/spec.js';
 
 const originalFetch = global.fetch;

--- a/packages/pyric/test/rules/tools.test.ts
+++ b/packages/pyric/test/rules/tools.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'bun:test';
 import { createToolRegistry, createDispatch } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import { LocalEnvironment } from 'pyric/sandbox/internal';
 import { createFirestoreRulesTools, createFirestoreSimulatorTools } from '../../src/rules/internal/node.js';
 

--- a/packages/pyric/test/rules/write/handler.test.ts
+++ b/packages/pyric/test/rules/write/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { WriteFirestoreRulesHandler } from '../../../src/rules/write/handler.js';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 
 const MOCK_SCOPE: ProjectScope = {
   projectId: 'test-project',

--- a/packages/pyric/test/sandbox/browser-bundle/probe-entry.ts
+++ b/packages/pyric/test/sandbox/browser-bundle/probe-entry.ts
@@ -16,8 +16,8 @@ import {
 // Side-import so the bundle's node:* gate covers the hosting core
 // too. Reachable graph: core.ts → gzip.ts (CompressionStream) +
 // hash.ts (crypto.subtle). Both universal — should be zero node:*.
-// (Hosting moved to pyric-tools/deploy 2026-05-24; import path updated.)
-import { deployHostingFiles } from 'pyric-tools/deploy';
+// (Hosting moved to @pyric/cli/deploy 2026-05-24; import path updated.)
+import { deployHostingFiles } from '@pyric/cli/deploy';
 // Touch the symbol so tree-shaking can't drop it before the gate runs.
 void deployHostingFiles;
 

--- a/packages/pyric/test/storage/admin/tools.test.ts
+++ b/packages/pyric/test/storage/admin/tools.test.ts
@@ -6,7 +6,7 @@
  */
 import { afterEach, describe, it, expect } from 'bun:test';
 import { createToolRegistry, createDispatch } from '@inbrowser/agent';
-import type { ProjectScope } from 'pyric-tools/deploy';
+import type { ProjectScope } from '@pyric/cli/deploy';
 import { createStorageAdminTools } from '../../../src/storage/admin/tools.js';
 
 const fakeCtx = { signal: new AbortController().signal };

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "pyric": "workspace:*",
-    "pyric-tools": "workspace:*",
+    "@pyric/cli": "workspace:*",
     "@pyric/ui": "workspace:*",
     "@inbrowser/agent": "0.4.1",
     "@inbrowser/relay": "0.4.1",

--- a/packages/studio/src/clients/bridge-peer.test.ts
+++ b/packages/studio/src/clients/bridge-peer.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { connectStudioBridgePeer } from './bridge-peer.js';
 import { createStudioEnvironment } from '../env.js';
-import { getFirestore, type ClientDb } from 'pyric-tools/serve/worker';
+import { getFirestore, type ClientDb } from '@pyric/cli/serve/worker';
 
 // ── Fakes ──────────────────────────────────────────────────────────────────
 

--- a/packages/studio/src/clients/bridge-peer.ts
+++ b/packages/studio/src/clients/bridge-peer.ts
@@ -5,15 +5,15 @@
  * WHY: the bridge relays agent tool-calls and remote worker-ops (the MCP
  * endpoint, `connectRemoteSandbox`) through ONE registered browser peer into
  * the SharedWorker. That peer was wired only in the served APP page
- * (`connectBridgePeer` in pyric-tools' `serve/entries/runtime.ts`) — so a user
+ * (`connectBridgePeer` in @pyric/cli' `serve/entries/runtime.ts`) — so a user
  * with ONLY Studio open (exactly what `pyric dev --ui` auto-opens) got
  * "no browser tab is connected" even though Studio talks to the very same
  * SharedWorker. Studio must register too.
  *
  * WIRING (reused, not duplicated): `connectBridge` (the reconnecting WS client
- * from `pyric-tools/bridge/client`) with the SAME `dispatcher`/`workerRelay`
+ * from `@pyric/cli/bridge/client`) with the SAME `dispatcher`/`workerRelay`
  * closures the app page uses — `callTool` / `relayWorkerOp` / `relayWorkerSub`
- * from `pyric-tools/serve/worker`, forwarding every frame over the worker
+ * from `@pyric/cli/serve/worker`, forwarding every frame over the worker
  * `MessagePort` the live plane already holds. Last-connection-wins peer
  * semantics make app page + Studio both being open safe: whichever page holds
  * the peer slot fronts the one shared SharedWorker sandbox identically.
@@ -32,13 +32,13 @@ import {
   type ConnectBridgeOptions,
   type ConnectedBridge,
   type ConnectedBridgeState,
-} from 'pyric-tools/bridge/client';
+} from '@pyric/cli/bridge/client';
 import {
   callTool,
   relayWorkerOp,
   relayWorkerSub,
   type ClientDb,
-} from 'pyric-tools/serve/worker';
+} from '@pyric/cli/serve/worker';
 
 /** The slice of the serve init payload this module reads. */
 interface InitPayloadLite {
@@ -65,7 +65,7 @@ export interface StudioBridgePeerOptions {
 /**
  * Build the `ConnectBridgeOptions` wiring for a Studio peer over `db` — the
  * SAME shape the served app page passes on its worker path (see
- * `connectBridgePeer` in pyric-tools' `entries/runtime.ts`): tool-calls
+ * `connectBridgePeer` in @pyric/cli' `entries/runtime.ts`): tool-calls
  * dispatch through the worker (`callTool`), and the generic worker relay
  * forwards ops/subscriptions over the worker port. Exported for tests.
  */

--- a/packages/studio/src/clients/http-workspace.ts
+++ b/packages/studio/src/clients/http-workspace.ts
@@ -1,7 +1,7 @@
 /**
  * `httpWorkspace(baseUrl)`: a {@link WorkspaceStore} that satisfies the port
  * browser-side by talking to the pyric devr's `/__pyric/workspace` routes
- * (the disk-backed store in pyric-tools). `watch` consumes the SSE stream at
+ * (the disk-backed store in @pyric/cli). `watch` consumes the SSE stream at
  * `/__pyric/workspace/watch`.
  *
  * `baseUrl` is the server origin (e.g. `''` for same-origin, or

--- a/packages/studio/src/clients/worker-live.test.ts
+++ b/packages/studio/src/clients/worker-live.test.ts
@@ -20,7 +20,7 @@ import type { SandboxEvent } from 'pyric/sandbox';
 import {
   getFirestore as workerGetFirestore,
   type ClientDb,
-} from 'pyric-tools/serve/worker';
+} from '@pyric/cli/serve/worker';
 
 /** Install a minimal SharedWorker shim whose port records postMessages but never
  *  replies, enough to exercise client construction + the live-plane shape

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -7,7 +7,7 @@
  *
  * WHAT IT WRAPS
  * -------------
- * `pyric-tools/serve/worker` (the browser-safe worker CLIENT, leaf, engine-free)
+ * `@pyric/cli/serve/worker` (the browser-safe worker CLIENT, leaf, engine-free)
  * mirrors `pyric/firestore` + `pyric/auth` over the worker `MessagePort` and now
  * ALSO exposes:
  *   - `subscribeEvents`/`eventHistory`: the unified `onEvent`/`history()` stream,
@@ -83,7 +83,7 @@ import {
   startAfter as workerStartAfter,
   type ClientDb,
   type PolicyRequest,
-} from 'pyric-tools/serve/worker';
+} from '@pyric/cli/serve/worker';
 
 /**
  * The per-op auth lens Studio drives. Mirrors `pyric/sandbox`'s `AuthLens` /
@@ -283,7 +283,7 @@ export function connectWorkerLive(
   // client constructs (data viewers, typeahead index, seed actions) so the
   // traffic stream can attribute — and filter — Studio-driven ops. The
   // served app runs its own bundle instance and stays untagged; bridge
-  // relays forward verbatim (see pyric-tools serve/worker client).
+  // relays forward verbatim (see @pyric/cli serve/worker client).
   setOpIssuer('studio');
   let db: ClientDb;
   try {

--- a/packages/studio/src/env.ts
+++ b/packages/studio/src/env.ts
@@ -18,7 +18,7 @@
  */
 
 import { createMemoryBackend } from 'pyric/sandbox';
-import type { ConnectedBridgeState } from 'pyric-tools/bridge/client';
+import type { ConnectedBridgeState } from '@pyric/cli/bridge/client';
 
 import type {
   PersistenceBackend,

--- a/packages/studio/src/features/assurance/AssuranceSurface.tsx
+++ b/packages/studio/src/features/assurance/AssuranceSurface.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import type { AssuranceProbeResult } from "pyric-tools/assurance";
-import type { AssuranceVisualizationSnapshot } from "pyric-tools/assurance/browser";
+import type { AssuranceProbeResult } from "@pyric/cli/assurance";
+import type { AssuranceVisualizationSnapshot } from "@pyric/cli/assurance/browser";
 import { DenialDetail } from "../rules-debug/RulesDebug.js";
 import { currentPath, replacePath } from "../../shell/router.js";
 import {

--- a/packages/studio/src/features/assurance/demo.ts
+++ b/packages/studio/src/features/assurance/demo.ts
@@ -1,8 +1,8 @@
 import type {
   AssuranceProbeResult,
   FirebaseOperation,
-} from "pyric-tools/assurance";
-import type { AssuranceVisualizationSnapshot } from "pyric-tools/assurance/browser";
+} from "@pyric/cli/assurance";
+import type { AssuranceVisualizationSnapshot } from "@pyric/cli/assurance/browser";
 
 interface DemoResultInput {
   id: string;

--- a/packages/studio/src/features/assurance/model.test.ts
+++ b/packages/studio/src/features/assurance/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { AuthorizationCampaignReport } from "pyric-tools/assurance";
+import type { AuthorizationCampaignReport } from "@pyric/cli/assurance";
 import {
   projectAssuranceRows,
   summarizeStateDiff,

--- a/packages/studio/src/features/assurance/model.ts
+++ b/packages/studio/src/features/assurance/model.ts
@@ -1,7 +1,7 @@
 import type {
   AssuranceProbeResult,
   AuthorizationCampaignReport,
-} from "pyric-tools/assurance";
+} from "@pyric/cli/assurance";
 import type { Denial } from "../rules-debug/model.js";
 
 export interface AssuranceMatrixRow {

--- a/packages/studio/src/features/assurance/useAssuranceCampaigns.ts
+++ b/packages/studio/src/features/assurance/useAssuranceCampaigns.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import {
   subscribeAssuranceVisualizations,
   type AssuranceVisualizationSnapshot,
-} from "pyric-tools/assurance/browser";
+} from "@pyric/cli/assurance/browser";
 import { currentPath } from "../../shell/router.js";
 import { ASSURANCE_DEMO_CAMPAIGN } from "./demo.js";
 

--- a/packages/studio/src/features/rules-debug/rerun.ts
+++ b/packages/studio/src/features/rules-debug/rerun.ts
@@ -236,7 +236,7 @@ function parentCollection(path: string): string {
 
 /**
  * The worker-client surface {@link rerunAsUser} needs. The studio app passes the
- * real `pyric-tools` worker client here; tests pass a fake. Kept as a narrow
+ * real `@pyric/cli` worker client here; tests pass a fake. Kept as a narrow
  * structural type so this module doesn't hard-depend on the worker client (which
  * pulls in the SharedWorker path): it depends only on the `setLens` + a doc-read
  * shape it already exposes.

--- a/packages/studio/src/shell/serve-init.ts
+++ b/packages/studio/src/shell/serve-init.ts
@@ -15,7 +15,7 @@
 import { useSyncExternalStore } from 'react';
 
 /** The slice of the serve init payload Studio surfaces read. Mirrors
- *  `pyric-tools`' `InitPayload` (kept structural; no runtime import). */
+ *  `@pyric/cli`' `InitPayload` (kept structural; no runtime import). */
 export interface ServeInitPayload {
   rules?: string | null;
   rulesHash?: string | null;

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -27,7 +27,7 @@ import {
   deleteDoc as inProcessDeleteDoc,
 } from 'pyric/firestore';
 import { sandbox as authSandbox, type CreateUserRequest } from 'pyric/auth';
-import { setRules as workerSetRules } from 'pyric-tools/serve/worker';
+import { setRules as workerSetRules } from '@pyric/cli/serve/worker';
 import type {
   EventProvenance,
   RequestEvent,

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,14 +1,14 @@
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from 'pyric-tools/vite';
+import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from '@pyric/cli/vite';
 
 /**
  * Studio app build. Outputs static assets to `dist/app`, served by
  * `pyric dev --ui`. The library entry points (`./ports`, `./env`) are emitted
  * separately by `tsc` to `dist/`, kept out of this bundle.
  *
- * `base` is configurable so the packaged build (embedded in pyric-tools and
+ * `base` is configurable so the packaged build (embedded in @pyric/cli and
  * served under `/__pyric/ui/`) can set `STUDIO_BASE=/__pyric/ui/`. The default
  * `/` keeps the dev server and the in-repo review build rooted at `/`.
  *
@@ -26,9 +26,9 @@ import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from 'pyric-tools/vite';
  * Benign node-builtin shims (`fs`/`path`/`url`) — the SAME shims serve's
  * bundler and the `pyricSandbox` Vite plugin apply to pyric's browser graph.
  * Needed because Studio's bridge peer (clients/bridge-peer.ts) bundles
- * pyric-tools' browser-side bridge client, whose default dispatcher statically
+ * @pyric/cli' browser-side bridge client, whose default dispatcher statically
  * reaches the pyric rules module resolver (a Node module the browser path
- * never actually calls into — see pyric-tools' serve/bundler.ts).
+ * never actually calls into — see @pyric/cli' serve/bundler.ts).
  */
 function nodeBuiltinShims(): Plugin {
   const PREFIX = '\0pyric-node-shim:';

--- a/packages/ui/src/firestore/firestoreApi.ts
+++ b/packages/ui/src/firestore/firestoreApi.ts
@@ -18,7 +18,7 @@ import {
  *
  * WHY: the hooks default to the in-process `pyric/firestore` API, but Pyric
  * Studio's served mode drives the SAME ops over a SharedWorker via a PARALLEL
- * modular client (`pyric-tools/serve/worker`: its own `collection`/`getDocs`/...
+ * modular client (`@pyric/cli/serve/worker`: its own `collection`/`getDocs`/...
  * over a `MessagePort`, and a `ClientDb` that is not a `pyric/firestore`
  * `Firestore`). Statically importing the in-process fns hardwires the hooks to
  * the in-page sandbox; reading them from this context lets a consumer inject the

--- a/pyric-plugin/skills/pyric-start/SKILL.md
+++ b/pyric-plugin/skills/pyric-start/SKILL.md
@@ -9,7 +9,7 @@ project shape and start ONLY one. Two servers means two ports and two separate s
 is the classic failure mode.
 
 1. **Detect the launcher.**
-   - **Vite app** (there is a `vite.config.*` that imports `pyricSandbox` from `pyric-tools/vite`):
+   - **Vite app** (there is a `vite.config.*` that imports `pyricSandbox` from `@pyric/cli/vite`):
      the app's own `vite dev` IS the bridge. Start the app, NOT a separate `pyric dev`. Confirm
      the config passes `pyricSandbox({ bridge: true })` (the MCP endpoint only mounts under `bridge`).
    - **Otherwise** (a `firebase.json` with no vite plugin, or no project yet): use `pyric dev --bridge`.

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -3,7 +3,7 @@
 # actual driver (Studio + SDK/worker bundles + playground static client +
 # demo seed + docs/llms.txt placeholders → dist/site/).
 #
-# Prereq: `bun run build` (root) must have already built pyric-tools' dist/ —
+# Prereq: `bun run build` (root) must have already built @pyric/cli's dist/ —
 # the SDK/worker bundler is imported directly from
 # packages/pyric-tools/dist/serve/bundler.js, not through a running server.
 set -euo pipefail

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@
 # After ADR-001 cutover (Wave 9), packages are:
 #   pyric           — modular SDK adapters + sandbox + rules (umbrella)
 #   pyric-admin     — admin-shape adapters (umbrella)
-#   pyric-tools     — CLI + deploy + bridge + discover + auth-config
+#   @pyric/cli     — CLI + deploy + bridge + discover + auth-config
 #   @pyric/ui       — headless React components
 set -euo pipefail
 
@@ -59,11 +59,11 @@ build_pkg "pyric-admin"
 build_pkg "pyric-tools"
 build_pkg "ui"
 
-# ── Phase 3: Studio app (embedded into pyric-tools for `pyric dev --ui`) ──
+# ── Phase 3: Studio app (embedded into @pyric/cli for `pyric dev --ui`) ──
 # Built with base /__pyric/ui/ so its assets resolve under the CLI mount, then
-# copied into pyric-tools' dist (which ships via the package `files: ["dist"]`).
+# copied into @pyric/cli's dist (which ships via the package `files: ["dist"]`).
 # Runs after Phase 2: studio depends on `pyric` + `@pyric/ui`, and the copy
-# target lives inside the already-built pyric-tools dist.
+# target lives inside the already-built @pyric/cli dist.
 echo ""
 echo "━━━ Phase 3: Studio app ━━━"
 echo "▸ Building packages/studio (base /__pyric/ui/)"

--- a/scripts/install-matrix.sh
+++ b/scripts/install-matrix.sh
@@ -37,7 +37,7 @@ while IFS= read -r tb; do
 done < <(node -e "
 const path = require('path');
 const manifest = require(path.join(process.cwd(), 'dist/packages/manifest.json'));
-const names = ['pyric', 'pyric-admin', 'pyric-tools', '@pyric/ui'];
+const names = ['pyric', 'pyric-admin', '@pyric/cli', '@pyric/ui'];
 for (const name of names) {
   const entry = manifest.packages.find((p) => p.name === name);
   if (!entry) {
@@ -66,7 +66,7 @@ const fs = require("fs");
 const path = require("path");
 const dir = process.env.CONSUMER_DIR;
 const [pyric, admin, tools, ui] = process.argv.slice(1).map((p) => "file:" + p);
-const pin = { "pyric": pyric, "pyric-admin": admin, "pyric-tools": tools, "@pyric/ui": ui };
+const pin = { "pyric": pyric, "pyric-admin": admin, "@pyric/cli": tools, "@pyric/ui": ui };
 const pkg = {
   name: "pyric-install-matrix-consumer", private: true, version: "1.0.0", type: "module",
   dependencies: { ...pin, react: "^19", "react-dom": "^19", firebase: "^12" },
@@ -99,7 +99,7 @@ esac
 #    manifests (drift-free — no hardcoded list to fall out of sync).
 cat > "$CONSUMER/__matrix-resolve.mjs" <<'NODECHECK'
 import { readFileSync } from 'node:fs';
-const PKGS = ['pyric', 'pyric-admin', 'pyric-tools', '@pyric/ui'];
+const PKGS = ['pyric', 'pyric-admin', '@pyric/cli', '@pyric/ui'];
 let failed = false, total = 0;
 for (const pkg of PKGS) {
   const manifest = JSON.parse(readFileSync(`node_modules/${pkg}/package.json`, 'utf8'));

--- a/scripts/lib/check-exports.mjs
+++ b/scripts/lib/check-exports.mjs
@@ -19,14 +19,16 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const PUBLISHABLE = ['pyric', 'pyric-admin', 'pyric-tools', 'ui'].map((p) => join(REPO, 'packages', p));
+const PUBLISHABLE = ['pyric', 'pyric-admin', 'pyric-tools', 'ui'].map((p) =>
+  join(REPO, 'packages', p),
+);
 
 // dist/<dir> entrypoints that are intentionally NOT exported (internal-only build
 // artifacts a consumer should never import directly). Keyed by package name.
 const REVERSE_ALLOW = {
   // The CLI is the `pyric` bin (package.json "bin"), reachable as a command — not
   // a subpath import — so it is intentionally absent from "exports".
-  'pyric-tools': ['cli'],
+  '@pyric/cli': ['cli'],
 };
 
 /** Collect every string leaf under an exports condition tree. */

--- a/scripts/manifest-lint.sh
+++ b/scripts/manifest-lint.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-# The four publishable libraries. @pyric/studio is embedded into pyric-tools for
+# The four publishable libraries. @pyric/studio is embedded into @pyric/cli for
 # `pyric dev --ui`, not published as part of this pack gate.
 PACKAGES=(pyric pyric-admin pyric-tools ui)
 ATTW="$ROOT/node_modules/.bin/attw"

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -67,7 +67,7 @@ echo "━━━ Phase 2: pack ━━━"
 # README.md in the source tree as the in-repo doc. COPY, never symlink —
 # `npm pack` does not follow symlinks. The original is restored even on
 # failure (RETURN trap), so the working tree stays clean.
-ROOT_README_PACKAGES=("pyric" "pyric-admin" "pyric-tools")
+ROOT_README_PACKAGES=("pyric" "pyric-admin" "@pyric/cli")
 
 uses_root_readme() {
   local name="$1"

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -25,12 +25,12 @@ NPM_CACHE="${TMPDIR:-/tmp}/npm-cache-pyric-packaging-test"
 # Publishable packages, in dependency order (dependencies first).
 # - pyric is foundational (everyone else workspace:* it)
 # - pyric-admin depends on pyric
-# - pyric-tools depends on pyric
+# - @pyric/cli depends on pyric
 # - @pyric/ui peer-depends on pyric
 PACKAGES=(
   "packages/pyric"         # pyric
   "packages/pyric-admin"   # pyric-admin
-  "packages/pyric-tools"   # pyric-tools (bin: pyric)
+  "packages/pyric-tools"   # @pyric/cli (bin: pyric)
   "packages/ui"            # @pyric/ui
 )
 
@@ -56,7 +56,7 @@ exported_subpaths() {
 
 PYRIC_SUBPATHS=( $(exported_subpaths packages/pyric) )
 PYRIC_ADMIN_SUBPATHS=( $(exported_subpaths packages/pyric-admin) )
-PYRIC_TOOLS_SUBPATHS=( $(exported_subpaths packages/pyric-tools) )
+PYRIC_CLI_SUBPATHS=( $(exported_subpaths packages/pyric-tools) )
 PYRIC_UI_SUBPATHS=( $(exported_subpaths packages/ui) )
 
 # Tracks the backgrounded `pyric dev` (Phase 5.5) so a failure mid-smoke
@@ -137,7 +137,7 @@ pack_one() {
 }
 TARBALL_PYRIC=$(pack_one packages/pyric)
 TARBALL_PYRIC_ADMIN=$(pack_one packages/pyric-admin)
-TARBALL_PYRIC_TOOLS=$(pack_one packages/pyric-tools)
+TARBALL_PYRIC_CLI=$(pack_one packages/pyric-tools)
 TARBALL_UI=$(pack_one packages/ui)
 
 # ─── Phase 2.5: publish file-set + runtime-asset presence ──────────────
@@ -181,26 +181,26 @@ assert_tar_has() {
 }
 packset_check packages/pyric pyric
 packset_check packages/pyric-admin pyric-admin
-packset_check packages/pyric-tools pyric-tools
+packset_check packages/pyric-tools @pyric/cli
 packset_check packages/ui @pyric/ui
 # Load-bearing runtime assets — pass import() but break at first use if dropped.
 assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/grammar/FirestoreRules\.ohm$' "pyric ships the Firestore rules grammar (.ohm)"
 assert_tar_has "$TARBALL_PYRIC" 'package/dist/database/grammar/RtdbExpr\.ohm$' "pyric ships the RTDB rules grammar (.ohm)"
 assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/modules/stdlib/.*\.rules$' "pyric ships the rules stdlib modules (.rules)"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/cli/index\.js$' "pyric-tools ships the pyric CLI bin"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/cli/index\.js$' "@pyric/cli ships the pyric CLI bin"
 # The Vite plugin's `ui` option + `pyric dev --ui` resolve the Studio app from
 # dist/serve/studio-ui (build-embedded). The plugin's firebase swap resolves the
 # entries from dist/serve/entries. Both are `files:["dist"]`-whitelisted assets that
 # import fine but 404 / break the swap for installed users if the build drops them.
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/studio-ui/index\.html$' "pyric-tools ships the Studio app shell (vite plugin ui + dev --ui)"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/playground-ui/index\.html$' "pyric-tools ships the embedded Playground app shell (Studio Playground tab)"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/studio-ui/index\.html$' "@pyric/cli ships the Studio app shell (vite plugin ui + dev --ui)"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/playground-ui/index\.html$' "@pyric/cli ships the embedded Playground app shell (Studio Playground tab)"
 # index.html hard-references hashed assets/*.{js,css}; without them the served app
 # renders a blank root that 404s its own bundle. The index.html fallback only fires
 # for extension-less paths, so a dropped assets/ dir would pass an index-only check.
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/studio-ui/assets/.*\.js$' "pyric-tools ships the Studio app JS bundle"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/studio-ui/assets/.*\.css$' "pyric-tools ships the Studio app CSS bundle"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/playground-ui/_astro/.*\.js$' "pyric-tools ships the embedded Playground JS bundle"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/playground-ui/_astro/.*\.css$' "pyric-tools ships the embedded Playground CSS bundle"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/studio-ui/assets/.*\.js$' "@pyric/cli ships the Studio app JS bundle"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/studio-ui/assets/.*\.css$' "@pyric/cli ships the Studio app CSS bundle"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/playground-ui/_astro/.*\.js$' "@pyric/cli ships the embedded Playground JS bundle"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/playground-ui/_astro/.*\.css$' "@pyric/cli ships the embedded Playground CSS bundle"
 if ! grep -R "Shared sandbox" packages/pyric-tools/dist/serve/playground-ui/_astro >/dev/null 2>&1 ||
    ! grep -R "Isolated session" packages/pyric-tools/dist/serve/playground-ui/_astro >/dev/null 2>&1 ||
    ! grep -R "sandboxMode" packages/pyric-tools/dist/serve/playground-ui/_astro >/dev/null 2>&1; then
@@ -211,12 +211,12 @@ if ! grep -R "Shared sandbox" packages/pyric-tools/dist/serve/playground-ui/_ast
 fi
 # All swap/boot entries are load-bearing: defaultSdkEntries() throws at plugin
 # construction if any is missing. Guard each, not just firestore.
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/app\.js$' "pyric-tools ships the firebase/app swap entry"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/auth\.js$' "pyric-tools ships the firebase/auth swap entry"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/firestore\.js$' "pyric-tools ships the firebase/firestore swap entry"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/database\.js$' "pyric-tools ships the firebase/database swap entry"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/storage\.js$' "pyric-tools ships the firebase/storage swap entry"
-assert_tar_has "$TARBALL_PYRIC_TOOLS" 'package/dist/serve/entries/init\.js$' "pyric-tools ships the sandbox boot entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/app\.js$' "@pyric/cli ships the firebase/app swap entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/auth\.js$' "@pyric/cli ships the firebase/auth swap entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/firestore\.js$' "@pyric/cli ships the firebase/firestore swap entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/database\.js$' "@pyric/cli ships the firebase/database swap entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/storage\.js$' "@pyric/cli ships the firebase/storage swap entry"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/init\.js$' "@pyric/cli ships the sandbox boot entry"
 
 # ─── Phase 3: install all tarballs into a fresh consumer project ──────
 echo ""
@@ -233,7 +233,7 @@ cat > package.json <<JSON
   "dependencies": {
     "pyric": "file:${TARBALL_PYRIC}",
     "pyric-admin": "file:${TARBALL_PYRIC_ADMIN}",
-    "pyric-tools": "file:${TARBALL_PYRIC_TOOLS}",
+    "@pyric/cli": "file:${TARBALL_PYRIC_CLI}",
     "@pyric/ui": "file:${TARBALL_UI}",
     "firebase": "^12.12.0",
     "firebase-admin": "^13.0.0",
@@ -265,7 +265,7 @@ const subpaths = readFileSync('__subpaths.txt', 'utf8').split('\n').filter(Boole
 // Side-effect-only subpaths (register loaders for `node --import`): importing
 // them IS the contract; they intentionally export zero symbols. Import failure
 // still fails the gate.
-const SIDE_EFFECT_ONLY = new Set(['pyric-tools/register']);
+const SIDE_EFFECT_ONLY = new Set(['@pyric/cli/register']);
 let failed = false;
 for (const subpath of subpaths) {
   try {
@@ -297,8 +297,8 @@ run_subpath_check "${PYRIC_SUBPATHS[@]}"
 echo "▸ pyric-admin subpaths"
 run_subpath_check "${PYRIC_ADMIN_SUBPATHS[@]}"
 
-echo "▸ pyric-tools subpaths"
-run_subpath_check "${PYRIC_TOOLS_SUBPATHS[@]}"
+echo "▸ @pyric/cli subpaths"
+run_subpath_check "${PYRIC_CLI_SUBPATHS[@]}"
 
 echo "▸ @pyric/ui subpaths"
 run_subpath_check "${PYRIC_UI_SUBPATHS[@]}"
@@ -316,19 +316,19 @@ const ok = (m) => console.log('  ✓ ' + m);
 const bad = (m) => { console.error('  ✗ ' + m); failed = true; };
 
 // The Vite plugin entry exposes the swap+bridge plugin factory.
-const vite = await import('pyric-tools/vite');
-if (typeof vite.pyricSandbox === 'function') ok('pyric-tools/vite exports pyricSandbox()');
-else bad('pyric-tools/vite is MISSING pyricSandbox (named export gone/renamed)');
+const vite = await import('@pyric/cli/vite');
+if (typeof vite.pyricSandbox === 'function') ok('@pyric/cli/vite exports pyricSandbox()');
+else bad('@pyric/cli/vite is MISSING pyricSandbox (named export gone/renamed)');
 
 // The bridge Node entry must NOT re-expose the retired standalone Vite plugin —
 // the Vite integration is `pyricSandbox({ bridge })`, not a bridge-only plugin.
-const bridge = await import('pyric-tools/bridge');
-if (!('vitePlugin' in bridge)) ok('pyric-tools/bridge does NOT export vitePlugin (retired in M3)');
-else bad('pyric-tools/bridge STILL exports vitePlugin (the M3 retire regressed)');
+const bridge = await import('@pyric/cli/bridge');
+if (!('vitePlugin' in bridge)) ok('@pyric/cli/bridge does NOT export vitePlugin (retired in M3)');
+else bad('@pyric/cli/bridge STILL exports vitePlugin (the M3 retire regressed)');
 // The bridge server surface consumers do rely on stays put.
 for (const sym of ['createBridge', 'startServer']) {
-  if (typeof bridge[sym] === 'function') ok('pyric-tools/bridge exports ' + sym + '()');
-  else bad('pyric-tools/bridge is MISSING ' + sym);
+  if (typeof bridge[sym] === 'function') ok('@pyric/cli/bridge exports ' + sym + '()');
+  else bad('@pyric/cli/bridge is MISSING ' + sym);
 }
 
 if (failed) process.exit(1);
@@ -410,7 +410,7 @@ check_bin_help "pyric"
 # (served by `vite dev`, `hosting.public` → `dist` which doesn't exist until a
 # build), so it isn't what `pyric dev` consumes. The `static` template is the
 # serve-era no-bundler scaffold (a ready `public/` dir) — exactly the path this
-# smoke exercises. (The Vite-plugin path is covered by pyric-tools' own tests.)
+# smoke exercises. (The Vite-plugin path is covered by @pyric/cli' own tests.)
 echo ""
 echo "━━━ Phase 5.5: serve smoke ━━━"
 PYRIC_BIN="$WORK/consumer/node_modules/.bin/pyric"
@@ -455,7 +455,7 @@ wait "$SERVE_PID" 2>/dev/null || true
 SERVE_PID=""
 
 # `pyric rules:lint` from the installed bin — exercises the rules grammar asset
-# (FirestoreRules.ohm) through the published pyric-tools CLI, not just serve.
+# (FirestoreRules.ohm) through the published @pyric/cli CLI, not just serve.
 cat > "$SMOKE/firestore.rules" <<'RULES'
 rules_version = '2';
 service cloud.firestore {

--- a/scripts/publish-alpha.sh
+++ b/scripts/publish-alpha.sh
@@ -31,11 +31,11 @@ V="${1:?usage: bash scripts/publish-alpha.sh <version> (e.g. 0.1.0-alpha.9)}"
 
 bash scripts/pack-packages.sh
 
-for t in pyric pyric-admin pyric-tools pyric-ui; do
+for t in pyric pyric-admin pyric-cli pyric-ui; do
   npm publish "dist/packages/${t}-${V}.tgz" --tag alpha --access public
 done
 
-for p in pyric pyric-admin pyric-tools @pyric/ui; do
+for p in pyric pyric-admin @pyric/cli @pyric/ui; do
   npm dist-tag add "${p}@${V}" latest
 done
 
@@ -48,7 +48,7 @@ echo "━━━ compat:check (gates the fb dist-tag) ━━━"
 if bun run compat:check; then
   FB_TAG="$(bun run packages/conformance/src/print-fb-tag.ts)"
   echo "compat:check green — moving ${FB_TAG} -> ${V}"
-  for p in pyric pyric-admin pyric-tools @pyric/ui; do
+  for p in pyric pyric-admin @pyric/cli @pyric/ui; do
     npm dist-tag add "${p}@${V}" "${FB_TAG}"
   done
 else
@@ -56,6 +56,6 @@ else
   exit 1
 fi
 
-for p in pyric pyric-admin pyric-tools @pyric/ui; do
+for p in pyric pyric-admin @pyric/cli @pyric/ui; do
   echo "== ${p}"; npm dist-tag ls "${p}"
 done

--- a/scripts/site/build.ts
+++ b/scripts/site/build.ts
@@ -87,7 +87,7 @@ async function bundleSdkAndWorker(): Promise<void> {
   );
   if (!existsSync(bundlerModule)) {
     throw new Error(
-      `build-site: ${bundlerModule} is missing — run \`bun run build\` first (pyric-tools must be built).`,
+      `build-site: ${bundlerModule} is missing — run \`bun run build\` first (@pyric/cli must be built).`,
     );
   }
   const { bundleSdk, bundleWorker, defaultSdkEntries } = await import(bundlerModule);
@@ -164,7 +164,7 @@ async function buildPlayground(): Promise<void> {
 
 // ─── Demo seed (__pyric/init.json) ────────────────────────────────────
 
-/** Mirrors `pyric-tools`' `InitPayload` (serve/namespace.ts) — the shape the
+/** Mirrors `@pyric/cli`' `InitPayload` (serve/namespace.ts) — the shape the
  *  SharedWorker's `fetchInitPayload()` expects at `/__pyric/init.json`. Only
  *  the fields the worker actually reads are populated; everything else is
  *  explicit `null`/`false` so the worker's no-serve degrade paths (no

--- a/scripts/tool-parity.annotations.json
+++ b/scripts/tool-parity.annotations.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Exposure decisions for the tool parity audit (scripts/tool-parity.mjs). Every tool visible on any surface (MCP bridge / playground agent / pyric-tools registry) must be recorded here as 'gap' (absence is a defect to fix) or 'deliberate' (absence is design, with the reason). Unannotated tools fail `bun run tool:parity --check`. Seeded from docs/design/TOOL-SYSTEM.md's exposure matrix.",
+  "_readme": "Exposure decisions for the tool parity audit (scripts/tool-parity.mjs). Every tool visible on any surface (MCP bridge / playground agent / @pyric/cli registry) must be recorded here as 'gap' (absence is a defect to fix) or 'deliberate' (absence is design, with the reason). Unannotated tools fail `bun run tool:parity --check`. Seeded from docs/design/TOOL-SYSTEM.md's exposure matrix.",
   "tools": {
     "inspect_firestore_traffic": {
       "decision": "gap",

--- a/scripts/tool-parity.mjs
+++ b/scripts/tool-parity.mjs
@@ -16,7 +16,7 @@
  *      registers: core / auth / git / checkpoints always-on, diagnostics
  *      flag-gated, skill tools skill-gated. Profile filtering
  *      (AUTHORING_TOOL_NAMES) is parsed from source, not restated here.
- *   3. pyric-tools registry — the maximal composeMcpRegistry() surface
+ *   3. @pyric/cli registry — the maximal composeMcpRegistry() surface
  *      (profile 'full', scope + adminDeps + rtdbHost all supplied), with
  *      per-tool gates recorded.
  *
@@ -128,7 +128,7 @@ const MCP_CONTRIBUTIONS = [
   { file: `${PYRIC}/rules/stdlib-tools.ts`, factory: 'createFirestoreRulesStdlibTools', gate: 'in-process' },
 ];
 
-/** pyric-tools registry — mirrors registry/compose.ts (maximal: profile
+/** @pyric/cli registry — mirrors registry/compose.ts (maximal: profile
  *  'full' with scope + adminDeps + rtdbHost). */
 const REGISTRY_CONTRIBUTIONS = [
   { file: `${TOOLS}/deploy/tools.ts`, factory: 'createFirestoreDeployTools', gate: 'always' },
@@ -363,7 +363,7 @@ export function renderMatrix(rows) {
     '(sandbox mode), the playground agent registry, and composeMcpRegistry (maximal',
     "'full' profile). Classification source: scripts/tool-parity.annotations.json.",
     '',
-    '| Tool | MCP bridge | Playground agent | pyric-tools registry | Classification |',
+    '| Tool | MCP bridge | Playground agent | @pyric/cli registry | Classification |',
     '|---|---|---|---|---|',
   ];
   for (const r of rows) {


### PR DESCRIPTION
Publishes the existing Pyric command and programmatic tooling as `@pyric/cli`, while retaining the repository's `packages/pyric-tools` directory and the `pyric` binary.

```sh
npm install --save-dev @pyric/cli
npx pyric --help
```

```ts
import { defineConfig } from 'vite';
import { pyricSandbox } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [pyricSandbox({ bridge: true })],
});
```

## npm identity changes; repository paths do not

Package specifiers, workspace dependencies, generated scaffolds, standalone vendoring, publishing scripts, and installed-consumer gates resolve `@pyric/cli`. Repository-local paths and scripts continue to use `packages/pyric-tools` and names such as `build:pyric-tools`.

All existing commands, the `pyric` binary, and all 15 programmatic subpaths remain available. Command removal and CLI restructuring are separate reviews.

## Risk

The scoped package name must change at every package-resolution seam without changing filesystem resolution. The highest-risk paths are generated scaffolds, the standalone binary's embedded tarball map, Node registration hooks, publish scripts, and installed-package subpaths.

README and docs-site content are intentionally unchanged for the final documentation PR in this serial stack. That creates a temporary narrative mismatch on `main`; this intermediate state must not be published.

<details>
<summary>Implementation notes and verification</summary>

- `bun install --frozen-lockfile`
- Focused CLI/init/vendor/register characterization: 111 tests passed
- `bun run --cwd packages/pyric-tools typecheck`
- `bun run build`
- `bun run test`
- `bun run test:packaging`: packed and installed `@pyric/cli`, resolved all 15 advertised subpaths, ran the `pyric` binary, and verified embedded Studio/Playground assets
- `bun run compat:check`
- Focused embedded-doc route test: 12 passed
- Oracle conformance gate: 5 probes passed
- Independent standards review: no actionable findings; stale README text accepted as the documented serial-stack sequencing risk
- Independent spec review: no actionable findings
- `git diff --check origin/main...HEAD`

The diff is one commit with 167 modified files and no moves or renames. The only Markdown change is the executable plugin launcher skill, whose Vite import detection now recognizes `@pyric/cli/vite`.

</details>
