### PR TITLE
fix: preserve admin lens for Firestore listeners

### DIFF
--- a/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
+++ b/packages/pyric-tools/test/e2e/soak/bridge-soak.soak.ts
@@ -509,27 +509,10 @@ for (;;) {
     }
   });
 
-  test('7. FINDING (expected fail): admin-lens Firestore listener is rules-evaluated as unauthenticated', async ({ browser }) => {
-    // Found by this suite on its first live run. The `actAs: { mode: 'admin' }`
-    // lens is documented (worker protocol, FirestoreSubMessage.actAs) to
-    // register a snapshot listener "through the rule-bypass handle", and the
-    // worker host resolves it via the same lensDb path ops use. Ops DO bypass
-    // rules (the admin setDoc below succeeds against `allow write: if
-    // request.auth != null`). But the LISTENER's rule evaluation
-    // (LocalEnvironment.silentReadDoc → addSnapshotListener's ListenerAuth)
-    // has no bypass: the admin handle registers with a null auth, the
-    // listener-init read simulates `get` as UNAUTHENTICATED, and the
-    // subscription dies with `permission-denied: get <path> denied by rules`.
-    //
-    // Reproduces headlessly in-process too (getAdminFirestore + onSnapshot
-    // under any auth-gated ruleset), so the fix's regression test can live in
-    // the unit suite. Until fixed, `pyric-admin`'s remote onSnapshot (admin
-    // plane) errors on every project whose rules require auth.
-    //
-    // test.fail(): this test PASSES only while the bug exists; when the
-    // listener bypass is fixed it will flip to "expected to fail but passed",
-    // flagging that this pin (and OBSERVER_LENS above) should be retired.
-    test.fail();
+  test('7. admin-lens Firestore listener bypasses rules', async ({ browser }) => {
+    // The worker pins `actAs: { mode: 'admin' }` on the subscription. The
+    // listener must preserve that bypass for its initial read and later
+    // re-evaluations, just as one-shot admin operations do.
     const serve = await startSoakServe();
     const context = await newInstrumentedContext(browser);
     let sb: RemoteSandbox | null = null;

--- a/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
@@ -47,6 +47,11 @@ import {
  */
 export const CONTEXT_SYMBOL: unique symbol = Symbol('pyric/sandbox/context');
 
+/** Hidden property carried by wrapped local admin handles and every ref/query
+ * they produce. Snapshot listeners read it back so the rules-bypass contract
+ * survives registration and every later listener re-evaluation. */
+export const BYPASS_RULES_SYMBOL: unique symbol = Symbol('pyric/sandbox/bypassRules');
+
 /**
  * Late-bound reference to the free `onSnapshot(ref, ...args)` function
  * from `index.ts`. Synthesized into wrapped refs as a `.onSnapshot(...)`
@@ -176,12 +181,14 @@ export function toSandboxError(err: unknown, ctx: SandboxContext): unknown {
 export function wrapWithErrorTranslation<T extends object>(
   target: T,
   ctx: SandboxContext,
+  bypassRules = false,
 ): T {
   return new Proxy(target, {
     get(t, prop, receiver) {
       // Hidden context recovery — must come before any other property
       // resolution. Symbol-keyed so it can't collide with real props.
       if (prop === CONTEXT_SYMBOL) return ctx;
+      if (prop === BYPASS_RULES_SYMBOL) return bypassRules;
 
       // Synthesize a chainable `.onSnapshot(...)` method on every
       // ref-shaped wrapped value. The underlying compat ref doesn't
@@ -219,11 +226,13 @@ export function wrapWithErrorTranslation<T extends object>(
         }
         if (result instanceof Promise) {
           return result
-            .then((v) => (v && typeof v === 'object' ? wrapWithErrorTranslation(v as object, ctx) : v))
+            .then((v) => (v && typeof v === 'object'
+              ? wrapWithErrorTranslation(v as object, ctx, bypassRules)
+              : v))
             .catch((e) => { throw toSandboxError(e, ctx); });
         }
         if (result && typeof result === 'object') {
-          return wrapWithErrorTranslation(result as object, ctx);
+          return wrapWithErrorTranslation(result as object, ctx, bypassRules);
         }
         return result;
       };

--- a/packages/pyric/src/sandbox/admin-firestore/get-admin-firestore.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/get-admin-firestore.ts
@@ -70,7 +70,7 @@ export function getAdminFirestore(target: SandboxContext | Sandbox): SandboxFire
   // the normalised ctx's auth is irrelevant, exactly like the local path.
   const fresh = isRemoteSandbox(ctx.sandbox)
     ? createRemoteFirestore(ctx.sandbox, { mode: 'admin' })
-    : wrapWithErrorTranslation(buildFirestoreHandle(ctx, true), ctx);
+    : wrapWithErrorTranslation(buildFirestoreHandle(ctx, true), ctx, true);
   adminHandleCache.set(ctx, fresh);
   return fresh;
 }

--- a/packages/pyric/src/sandbox/admin-firestore/listeners.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/listeners.ts
@@ -34,7 +34,11 @@ import type {
   SnapshotListenerOptions,
 } from 'pyric/sandbox/admin-compat';
 import { getInternalEnv } from 'pyric/sandbox/internal';
-import { CONTEXT_SYMBOL, registerOnSnapshotImpl } from './error-translation.js';
+import {
+  BYPASS_RULES_SYMBOL,
+  CONTEXT_SYMBOL,
+  registerOnSnapshotImpl,
+} from './error-translation.js';
 import { getRemoteSnapshotRegistrar, registerRemoteOnSnapshotImpl } from './remote/listeners.js';
 import type { SnapshotObserver, Unsubscribe } from './types.js';
 
@@ -306,6 +310,8 @@ export function onSnapshot(
   // (the safe default for any direct chainable-adapter caller).
   const followsCurrentUser =
     (options as { [FOLLOWS_CURRENT_USER]?: boolean })[FOLLOWS_CURRENT_USER] === true;
+  const bypassRules =
+    (reference as { [BYPASS_RULES_SYMBOL]?: boolean })[BYPASS_RULES_SYMBOL] === true;
   if (FOLLOWS_CURRENT_USER in options) {
     const { [FOLLOWS_CURRENT_USER]: _omit, ...rest } = options as Record<PropertyKey, unknown>;
     options = rest as SnapshotListenOptions;
@@ -315,7 +321,13 @@ export function onSnapshot(
   // so the listener machinery stays on its non-optional callback contract;
   // denials still route to `onError` (FS-B14).
   return env.addSnapshotListener(
-    target, onNext ?? (() => {}), options, ctx.auth, onError, followsCurrentUser,
+    target,
+    onNext ?? (() => {}),
+    options,
+    ctx.auth,
+    onError,
+    followsCurrentUser,
+    bypassRules,
   );
 }
 

--- a/packages/pyric/src/sandbox/firestore/local-environment.ts
+++ b/packages/pyric/src/sandbox/firestore/local-environment.ts
@@ -832,6 +832,8 @@ export class LocalEnvironment {
      * which stay pinned to the auth they captured at registration.
      */
     followsCurrentUser = false,
+    /** Preserve the admin lens for the listener's full lifetime. */
+    bypassRules = false,
   ): () => void {
     const id = String(this.nextListenerId++);
     const record: ListenerRecord = {
@@ -839,6 +841,7 @@ export class LocalEnvironment {
       target,
       callback,
       auth,
+      bypassRules,
       followsCurrentUser,
       options,
       currentSnapshot: undefined,
@@ -903,7 +906,11 @@ export class LocalEnvironment {
    */
   private fireInitialSnapshot(record: ListenerRecord): void {
     if (record.target.kind === 'doc') {
-      const result = this.silentReadDoc(record.target.path, record.auth);
+      const result = this.silentReadDoc(
+        record.target.path,
+        record.auth,
+        record.bypassRules,
+      );
       if (!result.allowed) {
         this.markErrored(record, result.error);
         return;
@@ -935,7 +942,10 @@ export class LocalEnvironment {
 
     // Query target.
     const result = this.silentReadCollection(
-      record.target.collection, record.auth, record.target.constraints,
+      record.target.collection,
+      record.auth,
+      record.target.constraints,
+      record.bypassRules,
     );
     if (!result.allowed) {
       this.markErrored(record, result.error);
@@ -1071,7 +1081,11 @@ export class LocalEnvironment {
     if (record.target.kind !== 'doc') return;
     if (!touchedPaths.has(record.target.path)) return;
 
-    const result = this.silentReadDoc(record.target.path, record.auth);
+    const result = this.silentReadDoc(
+      record.target.path,
+      record.auth,
+      record.bypassRules,
+    );
     if (!result.allowed) {
       this.markErrored(record, result.error);
       return;
@@ -1181,7 +1195,10 @@ export class LocalEnvironment {
     if (!anyPathInCollection(touchedPaths, record.target.collection)) return;
 
     const result = this.silentReadCollection(
-      record.target.collection, record.auth, record.target.constraints,
+      record.target.collection,
+      record.auth,
+      record.target.constraints,
+      record.bypassRules,
     );
     if (!result.allowed) {
       this.markErrored(record, result.error);
@@ -1296,7 +1313,25 @@ export class LocalEnvironment {
   private silentReadDoc(
     path: string,
     auth: ListenerAuth,
+    bypassRules = false,
   ): { allowed: true; data: DocumentData | null } | { allowed: false; error: FirestoreSimError } {
+    if (bypassRules) {
+      const data = this.state.get(path);
+      this.emitRequest({
+        at: Date.now(),
+        evalMs: 0,
+        method: 'get',
+        path,
+        auth,
+        result: 'allow',
+        debugMessages: ['admin lens — rules bypassed'],
+        origin: 'listener',
+        resourceBefore: { data, exists: data !== null },
+        detail: { admin: true },
+        ...(this.currentTrigger ? { triggeredBy: this.currentTrigger } : {}),
+      });
+      return { allowed: true, data };
+    }
     const readServerTime = Timestamp.fromMillis(Date.now());
     const testCase = this.buildTestCase({ method: 'get', path, auth }, readServerTime);
     // Issue #307 — time the simulate call for listener-origin RequestEvents.
@@ -1397,6 +1432,7 @@ export class LocalEnvironment {
     collection: string,
     auth: ListenerAuth,
     constraints?: QueryConstraintApplier,
+    bypassRules = false,
   ): { allowed: true; docs: { path: string; data: DocumentData }[] } | { allowed: false; error: FirestoreSimError } {
     const readServerTime = Timestamp.fromMillis(Date.now());
     // List rules are defined at the document-match level, so the
@@ -1407,9 +1443,32 @@ export class LocalEnvironment {
     const listPath = `${collection}/__listPlaceholder__`;
     const structured: QueryConstraints = constraints?.structured ?? {};
     const requestQuery = listQueryFromStructured(structured);
-    const requestDetail = requestQuery ? { query: requestQuery } : undefined;
+    const detailFields = {
+      ...(bypassRules ? { admin: true } : {}),
+      ...(requestQuery ? { query: requestQuery } : {}),
+    };
+    const requestDetail = Object.keys(detailFields).length > 0 ? detailFields : undefined;
     const evalAt = Date.now();
     const evalStart = performance.now();
+    if (bypassRules) {
+      const docs = this.state.list(collection)
+        .filter((document) => !document.phantom)
+        .map((document) => ({ path: document.path, data: document.data }));
+      const constrained = constraints ? constraints(docs) : docs;
+      this.emitRequest({
+        at: evalAt,
+        evalMs: 0,
+        method: 'list',
+        path: collection,
+        auth,
+        result: 'allow',
+        debugMessages: ['admin lens — rules bypassed'],
+        origin: 'listener',
+        ...(requestDetail ? { detail: requestDetail } : {}),
+        ...(this.currentTrigger ? { triggeredBy: this.currentTrigger } : {}),
+      });
+      return { allowed: true, docs: constrained };
+    }
     // ── RULES-B11 gate: prove the query before evaluating the rule. ──
     const proof = proveListQuery(this.rulesAst(), listPath, auth, structured);
     if (proof.kind === 'unprovable') {
@@ -1728,7 +1787,11 @@ export class LocalEnvironment {
    */
   private reEvaluateDocListener(record: ListenerRecord): void {
     if (record.target.kind !== 'doc') return;
-    const result = this.silentReadDoc(record.target.path, record.auth);
+    const result = this.silentReadDoc(
+      record.target.path,
+      record.auth,
+      record.bypassRules,
+    );
     if (!result.allowed) {
       if (record.errored) return;
       this.markErrored(record, result.error);
@@ -1769,7 +1832,10 @@ export class LocalEnvironment {
   private reEvaluateQueryListener(record: ListenerRecord): void {
     if (record.target.kind !== 'query') return;
     const result = this.silentReadCollection(
-      record.target.collection, record.auth, record.target.constraints,
+      record.target.collection,
+      record.auth,
+      record.target.constraints,
+      record.bypassRules,
     );
     if (!result.allowed) {
       if (record.errored) return;

--- a/packages/pyric/src/sandbox/firestore/snapshot-listeners.ts
+++ b/packages/pyric/src/sandbox/firestore/snapshot-listeners.ts
@@ -119,6 +119,9 @@ export interface ListenerRecord {
   errorCallback?: SnapshotErrorCallback;
   /** Captured at registration; see {@link ListenerAuth}. */
   auth: ListenerAuth;
+  /** `true` for the Studio/admin lens. Rules stay bypassed for the initial
+   * snapshot and every write- or rules-driven re-evaluation. */
+  bypassRules: boolean;
   /**
    * `true` when this listener was registered through a `sandbox-live`
    * Firestore handle (`getFirestore(sandbox)`), whose identity follows

--- a/packages/pyric/test/firestore/admin-bypass-target.test.ts
+++ b/packages/pyric/test/firestore/admin-bypass-target.test.ts
@@ -17,6 +17,7 @@ import {
   collection,
   getDoc,
   getDocs,
+  onSnapshot,
   setDoc,
   updateDoc,
   deleteDoc,
@@ -88,6 +89,51 @@ describe('deny-vs-bypass: getDoc / getDocs', () => {
     const admin = getAdminFirestore(sandbox);
     const snap = await getDocs(collection(admin, 'items'));
     expect(snap.docs.map((d) => d.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('admin listeners read documents and collections despite deny-all rules', () => {
+    const sandbox = denyAllSandbox();
+    sandbox.admin.setDocument('items/a', { n: 1 });
+    sandbox.admin.setDocument('items/b', { n: 2 });
+    const admin = getAdminFirestore(sandbox);
+    const errors: unknown[] = [];
+    const documents: unknown[] = [];
+    const collections: string[][] = [];
+    const listenerRequests: Array<{ result: string; detail?: { admin?: boolean } }> = [];
+    sandbox.onEvent((event) => {
+      if (event.kind === 'request' && event.origin === 'listener') {
+        listenerRequests.push(event);
+      }
+    });
+
+    const unsubscribeDocument = onSnapshot(doc(admin, 'items/a'), {
+      next: (snapshot) => documents.push(snapshot.data()),
+      error: (error) => errors.push(error),
+    });
+    const unsubscribeCollection = onSnapshot(collection(admin, 'items'), {
+      next: (snapshot) => collections.push(snapshot.docs.map((item) => item.id).sort()),
+      error: (error) => errors.push(error),
+    });
+
+    getInternalEnv(sandbox).flushListeners();
+
+    expect(errors).toEqual([]);
+    expect(documents).toEqual([{ n: 1 }]);
+    expect(collections).toEqual([['a', 'b']]);
+
+    sandbox.admin.setDocument('items/a', { n: 3 });
+    sandbox.admin.setDocument('items/c', { n: 4 });
+    getInternalEnv(sandbox).flushListeners();
+
+    expect(errors).toEqual([]);
+    expect(documents.at(-1)).toEqual({ n: 3 });
+    expect(collections.at(-1)).toEqual(['a', 'b', 'c']);
+    expect(listenerRequests.length).toBeGreaterThanOrEqual(4);
+    expect(listenerRequests.every(
+      (request) => request.result === 'allow' && request.detail?.admin === true,
+    )).toBe(true);
+    unsubscribeDocument();
+    unsubscribeCollection();
   });
 });
 

--- a/packages/studio/src/clients/worker-live.test.ts
+++ b/packages/studio/src/clients/worker-live.test.ts
@@ -19,6 +19,7 @@ import { createStudioEnvironment } from '../env.js';
 import type { SandboxEvent } from 'pyric/sandbox';
 import {
   getFirestore as workerGetFirestore,
+  setLens as resetWorkerLens,
   type ClientDb,
 } from '@pyric/cli/serve/worker';
 
@@ -55,6 +56,7 @@ describe('connectWorkerLive', () => {
   afterEach(() => {
     restore?.();
     restore = null;
+    resetWorkerLens(undefined);
   });
 
   it('returns null when no SharedWorker is available (HTTP-fallback contract)', () => {
@@ -139,6 +141,36 @@ function fakeWrite(id: string): SandboxEvent {
     requestTime: { seconds: 0, nanoseconds: 0 },
   } as SandboxEvent;
 }
+
+describe('Studio Firestore data lens', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+    resetWorkerLens(undefined);
+  });
+
+  it('pins admin before the first data-view subscription is registered', () => {
+    const sw = controllableSharedWorker();
+    restore = sw.restore;
+    const plane = connectWorkerLive('worker://test')!;
+    const users = plane.firestoreApi.collection(
+      plane.db as never,
+      'users',
+    );
+
+    const unsubscribe = plane.firestoreApi.onSnapshot(users, () => {});
+    const subscription = sw.port.sent.find(
+      (message): message is { t: 'sub'; target: object; actAs?: { mode: string } } =>
+        (message as { t?: string }).t === 'sub' &&
+        typeof (message as { target?: unknown }).target === 'object',
+    );
+
+    expect(plane.getLens()).toEqual({ mode: 'admin' });
+    expect(subscription?.actAs).toEqual({ mode: 'admin' });
+    unsubscribe();
+  });
+});
 
 describe('workerEventFeed (F1 live-feed adapter)', () => {
   let restore: (() => void) | null = null;

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -293,6 +293,11 @@ export function connectWorkerLive(
     // treat as "no live plane" so the env falls back cleanly.
     return null;
   }
+  // Data viewers are admin-only. Pin the lens synchronously, before React can
+  // mount a child hook and register its first onSnapshot subscription. The
+  // previous effect-time initialization raced child passive effects, leaving
+  // the first collection/document listeners frozen to the app session.
+  workerSetLens({ mode: 'admin' });
 
   // One feed shared by F1 and the auth `subscribeUsers` re-list signal. One auth
   // handle reusing the same port (the single-backend invariant).


### PR DESCRIPTION
Makes Studio Firestore data viewers and admin Firestore snapshot listeners preserve the admin lens for the listener's full lifetime.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import {
  collection,
  getAdminFirestore,
  getFirestore,
  onSnapshot,
  sandbox as firestoreSandbox,
} from 'pyric/firestore';

const DENY_ALL = `rules_version = '2';
service cloud.firestore {
  match /databases/{db}/documents {
    match /{document=**} {
      allow read, write: if false;
    }
  }
}`;

const sandbox = initializeSandbox();
firestoreSandbox.setRules(getFirestore(sandbox), DENY_ALL);
sandbox.admin.setDocument('users/alice', { name: 'Alice' });

const adminDb = getAdminFirestore(sandbox);
onSnapshot(collection(adminDb, 'users'), (snapshot) => {
  console.log(snapshot.docs.map((doc) => doc.id));
  // ['alice'] — admin listeners bypass rules, including later re-evaluations.
});
```

## Studio pins admin before its first listener registers

Studio previously selected its admin lens in a React effect. A child data-view effect could register first, freezing the collection and document listeners to the app session and rendering `denied by rules` in an admin-only surface.

The live plane now pins admin synchronously when it connects. The local admin adapter also carries the bypass marker through wrapped references into listener registration, initial reads, write-driven updates, and rules-reload re-evaluation. Listener traffic remains observable and is classified as `ADMIN`, not as a rules allow.

## Risk

The behavioral change is limited to listeners created through an explicit admin handle and Studio's intentionally admin-only live data plane. Ordinary app-session, anonymous, and impersonated listeners continue through rules evaluation.

The main review point is provenance: bypassed listener reads must remain visible in Traffic as admin operations without introducing a synthetic rules decision.

<details>
<summary>Implementation notes and verification</summary>

- Converts the existing expected-failure remote admin-listener soak into a passing contract.
- Adds document and collection coverage under deny-all rules, including later writes and admin Traffic provenance.
- Adds an adapter regression proving Studio selects admin before the first subscription message is posted.
- `bun run build`
- `bun run test`
- `bun run --cwd packages/pyric-tools test:soak -- --grep "admin-lens Firestore listener bypasses rules"`
- Browser verification on the original Studio Firestore route found no `denied by rules` text.

</details>
