### PR TITLE
test: execute core commands from the packed CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,8 +181,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ci-packaging')
     # Package managers resolve exports / scoped names / local tarballs differently;
     # a lib that installs under npm can fail under pnpm or bun. Each leg installs
-    # the REAL tarballs and imports every advertised subpath. fail-fast off so one
-    # manager's failure doesn't hide the others'.
+    # the REAL tarballs, imports every advertised subpath, and executes a small
+    # no-network CLI smoke. fail-fast off so one manager's failure doesn't hide
+    # the others'.
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/install-matrix.sh
+++ b/scripts/install-matrix.sh
@@ -4,8 +4,9 @@
 # Package managers resolve `exports`, scoped names, and local tarballs with
 # meaningfully different algorithms (npm's hoisting vs pnpm's strict symlinked
 # store vs bun's layout). A package that resolves cleanly under npm can fail under
-# pnpm/bun — so the publishable libs are installed from their REAL tarballs and
-# every advertised subpath is imported, under each manager in turn.
+# pnpm/bun — so the publishable libs are installed from their REAL tarballs,
+# every advertised subpath is imported, and the installed CLI is executed under
+# each manager in turn.
 #
 # This is the resolution-portability leg; the full runtime/serve/contract proof
 # lives in scripts/packaging-test.sh (npm). Peer deps (react/react-dom/firebase)
@@ -121,4 +122,10 @@ console.log(`  ✓ all ${total} advertised subpaths resolve under ${process.env.
 NODECHECK
 PM_LABEL="$PM" node __matrix-resolve.mjs
 
-echo "✓ install matrix PASS ($PM) — all four libraries install + every subpath resolves"
+# 5. Execute a small public-command proof through this package manager's bin
+# link. The helper owns only command behavior; this script remains the single
+# source of truth for packing and installing the consumer.
+node "$ROOT/scripts/packed-cli-smoke.mjs" \
+  "$CONSUMER/node_modules/.bin/pyric" "$WORK/cli-smoke"
+
+echo "✓ install matrix PASS ($PM) — libraries install, subpaths resolve, CLI executes"

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -337,7 +337,7 @@ SHAPEJS
 
 # ─── Phase 5: bin checks ───────────────────────────────────────────────
 echo ""
-echo "━━━ Phase 5: bins ━━━"
+echo "━━━ Phase 5: packed CLI smoke ━━━"
 
 check_bin_executable() {
   local bin="$1"
@@ -349,52 +349,9 @@ check_bin_executable() {
   echo "  ✓ $bin executable"
 }
 
-check_bin_help() {
-  local bin="$1"
-  local path="$WORK/consumer/node_modules/.bin/$bin"
-  # Bin should print SOMETHING for --help and exit 0
-  local out
-  set +e
-  out=$("$path" --help 2>&1)
-  local exit=$?
-  set -e
-  if [ "$exit" -ne 0 ]; then
-    echo "  ✗ $bin --help exited $exit"
-    echo "    output: $out"
-    exit 1
-  fi
-  if [ -z "$out" ]; then
-    echo "  ✗ $bin --help printed nothing"
-    exit 1
-  fi
-  echo "  ✓ $bin --help works"
-}
-
-check_bin_runtime_failure() {
-  # Run bin with no args / no env; expect a controlled non-zero exit
-  # with a clear remediation message, NOT an import error.
-  local bin="$1"
-  local expected_substring="$2"
-  local path="$WORK/consumer/node_modules/.bin/$bin"
-  set +e
-  local out
-  out=$("$path" 2>&1)
-  local exit=$?
-  set -e
-  if [ "$exit" -eq 0 ]; then
-    echo "  ✗ $bin (no args) — unexpectedly exited 0"
-    exit 1
-  fi
-  if ! echo "$out" | grep -q "$expected_substring"; then
-    echo "  ✗ $bin (no args) — output did not contain expected '$expected_substring'"
-    echo "    output: $out"
-    exit 1
-  fi
-  echo "  ✓ $bin (no args) — controlled failure with expected message"
-}
-
 check_bin_executable "pyric"
-check_bin_help "pyric"
+PYRIC_BIN="$WORK/consumer/node_modules/.bin/pyric"
+node "$ROOT/scripts/packed-cli-smoke.mjs" "$PYRIC_BIN" "$WORK/cli-smoke"
 
 # ─── Phase 5.5: serve smoke (init + serve from the packed bin) ─────────
 # The subpath + bin checks above prove imports resolve, but they never boot
@@ -413,7 +370,6 @@ check_bin_help "pyric"
 # smoke exercises. (The Vite-plugin path is covered by @pyric/cli' own tests.)
 echo ""
 echo "━━━ Phase 5.5: serve smoke ━━━"
-PYRIC_BIN="$WORK/consumer/node_modules/.bin/pyric"
 SMOKE="$WORK/serve-smoke"
 mkdir -p "$SMOKE"
 ( cd "$SMOKE" && "$PYRIC_BIN" init --template static --json >/dev/null )
@@ -453,22 +409,6 @@ echo "  ✓ pyric dev booted ($SERVE_URL) and /__pyric/init.json resolved"
 kill "$SERVE_PID" 2>/dev/null
 wait "$SERVE_PID" 2>/dev/null || true
 SERVE_PID=""
-
-# `pyric rules:lint` from the installed bin — exercises the rules grammar asset
-# (FirestoreRules.ohm) through the published @pyric/cli CLI, not just serve.
-cat > "$SMOKE/firestore.rules" <<'RULES'
-rules_version = '2';
-service cloud.firestore {
-  match /databases/{db}/documents {
-    match /users/{uid} { allow read, write: if request.auth != null && request.auth.uid == uid; }
-  }
-}
-RULES
-if ( cd "$SMOKE" && "$PYRIC_BIN" rules:lint firestore.rules >/dev/null 2>&1 ); then
-  echo "  ✓ pyric rules:lint parsed a ruleset (grammar asset via the published CLI)"
-else
-  echo "  ✗ pyric rules:lint failed from the installed bin"; exit 1
-fi
 
 # ─── Phase 5.6: runtime smoke (RUN the installed packages, don't just import) ──
 # Phases 4/5 prove imports + the bin resolve; this RUNS the asset-dependent code

--- a/scripts/packed-cli-smoke.mjs
+++ b/scripts/packed-cli-smoke.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+/**
+ * Exercise the public `pyric` binary after a caller has installed the real
+ * @pyric/cli tarball into a clean consumer.
+ *
+ * This script deliberately does not pack or install anything. The packaging
+ * gate and install matrix already own those expensive, package-manager-specific
+ * steps; keeping this runner focused lets both gates reuse the same behavioral
+ * proof without introducing another publishing path.
+ *
+ * Usage: node scripts/packed-cli-smoke.mjs <absolute-pyric-bin> <work-dir>
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const [binArg, workArg] = process.argv.slice(2);
+if (!binArg || !workArg) {
+  process.stderr.write(
+    'usage: node scripts/packed-cli-smoke.mjs <absolute-pyric-bin> <work-dir>\n',
+  );
+  process.exit(2);
+}
+
+const bin = isAbsolute(binArg) ? binArg : resolve(binArg);
+const workDir = isAbsolute(workArg) ? workArg : resolve(workArg);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+
+const childEnv = { ...process.env, CI: '1', HOME: workDir, USERPROFILE: workDir };
+for (const name of [
+  'FIREBASE_SA_BASE64',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'PYRIC_REFRESH_TOKEN',
+  'PYRIC_SA_PATH',
+]) {
+  delete childEnv[name];
+}
+
+function run(args) {
+  const result = spawnSync(bin, args, {
+    cwd: workDir,
+    encoding: 'utf8',
+    env: childEnv,
+    shell: process.platform === 'win32',
+    timeout: 30_000,
+  });
+  if (result.error) {
+    throw new Error(`pyric ${args.join(' ')} could not start: ${result.error.message}`);
+  }
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function expect(condition, message, result) {
+  if (condition) return;
+  const detail = result
+    ? `\nexit: ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    : '';
+  throw new Error(`${message}${detail}`);
+}
+
+function parseJson(result, command) {
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(
+      `${command} did not print JSON: ${error instanceof Error ? error.message : String(error)}` +
+        `\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+}
+
+// Slice 1: the installed bin starts, dispatches a global flag, and reports the
+// package identity plus its conformance target.
+const version = run(['--version']);
+expect(version.code === 0, 'pyric --version must exit 0', version);
+expect(version.stderr === '', 'pyric --version must not write stderr', version);
+expect(version.stdout.includes('@pyric/cli '), 'pyric --version must name @pyric/cli', version);
+expect(version.stdout.includes('Firebase '), 'pyric --version must report its Firebase target', version);
+process.stdout.write('  ✓ packed pyric starts and reports its package + Firebase versions\n');
+
+// The one fixture shared by both retained `verify` commands captures an
+// anonymous request and its committed write. Keeping auth null is intentional:
+// the packed smoke must never require Firebase, gcloud, or service-account
+// credentials.
+const allowAnonymous = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /notes/{noteId} {
+      allow create: if request.auth == null;
+    }
+  }
+}`;
+writeFileSync(resolve(workDir, 'firestore.rules'), `${allowAnonymous}\n`);
+const fixture = {
+  schema: 'pyric.verify.fixture.v1',
+  description: 'anonymous note creation from a packed CLI smoke',
+  events: [
+    {
+      kind: 'request',
+      id: 'request-1',
+      at: 1,
+      evalMs: 0,
+      method: 'create',
+      path: 'notes/welcome',
+      auth: null,
+      result: 'allow',
+      reasons: ['Rule #0 (create) → ALLOW'],
+      origin: 'user',
+      request: { resourceData: { title: 'Welcome' } },
+      resourceBefore: { data: null, exists: false },
+      resourceAfter: { data: { title: 'Welcome' }, exists: true },
+    },
+    {
+      kind: 'write',
+      id: 'write-1',
+      at: 1,
+      method: 'create',
+      path: 'notes/welcome',
+      auth: null,
+      data: { title: 'Welcome' },
+      priorState: null,
+      nextState: { title: 'Welcome' },
+      requestTime: { seconds: 1, nanoseconds: 0 },
+    },
+  ],
+  services: {
+    firestore: {
+      rules: { format: 'firestore.rules', source: allowAnonymous },
+      state: { documents: { 'notes/welcome': { title: 'Welcome' } } },
+    },
+  },
+};
+writeFileSync(resolve(workDir, 'session.json'), `${JSON.stringify(fixture, null, 2)}\n`);
+
+// Slice 2: the stable nested command generates a local Rules Test API artifact
+// through the packed binary, proving argument routing and output-file handling.
+const cases = run([
+  'verify',
+  'cases',
+  'session.json',
+  '--service',
+  'firestore',
+  '--out',
+  'derived-cases.json',
+]);
+expect(cases.code === 0, 'pyric verify cases must exit 0 for a supported fixture', cases);
+expect(cases.stderr === '', 'pyric verify cases must not write stderr on success', cases);
+const derivedCases = JSON.parse(readFileSync(resolve(workDir, 'derived-cases.json'), 'utf8'));
+expect(derivedCases.ok === true, 'pyric verify cases artifact must report ok: true', cases);
+expect(
+  derivedCases.testCases?.length === 1 &&
+    derivedCases.testCases[0]?.method === 'create' &&
+    derivedCases.testCases[0]?.auth === null,
+  'pyric verify cases must derive the captured anonymous create',
+  cases,
+);
+process.stdout.write('  ✓ packed pyric verify cases writes the expected local artifact\n');
+
+// Slice 3: replay the anonymous write through the local assurance engine. No
+// credential source is available in this process. Re-running against deny-all
+// rules proves the command preserves its regression exit code rather than
+// merely loading the fixture.
+
+const verifyArgs = [
+  'verify',
+  'session.json',
+  '--engine',
+  'sandbox',
+  '--rules',
+  'firestore=firestore.rules',
+  '--json',
+];
+const verified = run(verifyArgs);
+expect(verified.code === 0, 'pyric verify must exit 0 for an unchanged anonymous write', verified);
+expect(verified.stderr === '', 'successful pyric verify must not write stderr', verified);
+const verifiedResult = parseJson(verified, 'pyric verify');
+expect(verifiedResult.ok === true, 'pyric verify JSON must report ok: true', verified);
+expect(
+  verifiedResult.results?.[0]?.services?.firestore?.checkedEvents === 1,
+  'pyric verify must replay the captured anonymous write',
+  verified,
+);
+
+const denyAll = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}`;
+writeFileSync(resolve(workDir, 'firestore.rules'), `${denyAll}\n`);
+const regressed = run(verifyArgs);
+expect(regressed.code === 1, 'pyric verify must exit 1 when candidate rules regress', regressed);
+const regressedResult = parseJson(regressed, 'regressing pyric verify');
+expect(regressedResult.ok === false, 'regressing pyric verify JSON must report ok: false', regressed);
+process.stdout.write('  ✓ packed pyric verify replays locally without auth and preserves exit 0/1\n');
+
+process.stdout.write('✓ packed CLI smoke PASS\n');


### PR DESCRIPTION
Runs retained verification commands through the installed `@pyric/cli` tarball so package-manager gates prove more than import resolution.

```sh
node scripts/packed-cli-smoke.mjs \
  ./consumer/node_modules/.bin/pyric \
  ./consumer/cli-smoke
# ✓ packed pyric starts and reports its package + Firebase versions
# ✓ packed pyric verify cases writes the expected local artifact
# ✓ packed pyric verify replays locally without auth and preserves exit 0/1
```

## The same command proof runs after npm, Bun, and pnpm installation

The runner creates its own anonymous Firestore fixture, derives Rules Test API cases, replays the captured write through the sandbox engine, then installs deny-all rules and requires the regression exit code. It clears Firebase credential variables and isolates `HOME`, so the smoke cannot pass by borrowing local authentication.

The existing packed `init` and `dev` readiness proof remains in the packaging gate. The old packed `rules:lint` invocation is removed because that spelling is scheduled to change; the new runner pins retained top-level verification behavior instead.

## Risk

This adds three short CLI subprocesses to each install-matrix leg. Each command has a 30-second timeout. The runner handles Windows shell invocation, but the Windows bin shim was not exercised locally.

<details>
<summary>Implementation notes and verification</summary>

- `bun run test:packaging`
- `bash scripts/install-matrix.sh npm`
- `bash scripts/install-matrix.sh bun`
- `bash scripts/install-matrix.sh pnpm`
- 38 focused CLI and verification tests
- Standards review: zero findings
- Spec review: zero findings
- The broader CLI suite recorded 1,376 passes and 59 restricted-sandbox socket binding failures; the packed `init`/`dev` server smoke passed with network permission.

</details>