### PR TITLE
Fix destructive actions across Pyric Studio

### DIFF
--- a/packages/pyric-tools/src/serve/worker/client/firestore-reads.ts
+++ b/packages/pyric-tools/src/serve/worker/client/firestore-reads.ts
@@ -24,7 +24,7 @@ export async function getDoc(ref: DocRefHandle): Promise<ClientDocSnapshot> {
     method: 'getDoc',
     path: ref.descriptor.path,
   }) as RawDocResult;
-  return makeDocSnapshot(result);
+  return makeDocSnapshot(result, ref.port);
 }
 
 export async function getDocs(
@@ -38,7 +38,7 @@ export async function getDocs(
       ? (source as CollRefHandle).descriptor
       : (source as QueryHandle).descriptor,
   }) as RawQueryResult;
-  return makeQuerySnapshot(result);
+  return makeQuerySnapshot(result, source.port);
 }
 
 /**
@@ -140,9 +140,9 @@ export function onSnapshot(
     next: (raw) => {
       const r = raw as Record<string, unknown>;
       if ('docs' in r) {
-        callback(makeQuerySnapshot(r as unknown as RawQueryResult));
+        callback(makeQuerySnapshot(r as unknown as RawQueryResult, port));
       } else {
-        callback(makeDocSnapshot(r as unknown as RawDocResult));
+        callback(makeDocSnapshot(r as unknown as RawDocResult, port));
       }
     },
     error: errorCallback,

--- a/packages/pyric-tools/src/serve/worker/client/firestore-writes.ts
+++ b/packages/pyric-tools/src/serve/worker/client/firestore-writes.ts
@@ -185,7 +185,7 @@ export async function runTransaction<R>(
           data: (rawResult.exists && rawResult.data) ? rawResult.data : null,
         });
 
-        return makeDocSnapshot(rawResult);
+        return makeDocSnapshot(rawResult, ref.port);
       },
       set(ref, data, options) {
         writes.push({ method: 'set', path: ref.descriptor.path, data, options });

--- a/packages/pyric-tools/src/serve/worker/client/snapshots.ts
+++ b/packages/pyric-tools/src/serve/worker/client/snapshots.ts
@@ -5,6 +5,7 @@
  */
 import type { SerializedDocData } from '../protocol.js';
 import { deserializeDocData } from '../protocol.js';
+import type { DocRefHandle } from './handles.js';
 
 // ─── Rehydration (class instance restoration) ─────────────────────────────
 
@@ -33,17 +34,22 @@ export interface RawDocResult {
   data?: SerializedDocData;
 }
 
-export function makeDocSnapshot(raw: RawDocResult): ClientDocSnapshot {
+export function makeDocSnapshot(raw: RawDocResult, port: MessagePort): ClientDocSnapshot {
   const data = raw.exists && raw.data ? rehydrateDocData(raw.data) : undefined;
   const path = raw.path ?? raw.id;
+  const ref: DocRefHandle = {
+    __kind: 'doc-ref',
+    descriptor: { __ref: 'doc', path },
+    port,
+    id: raw.id,
+    path,
+  };
   return {
     id: raw.id,
     path,
-    // The modular SDK contract (and `@pyric/ui`'s grids) read `snap.ref.path`
-    // off query docs; mirror it so the worker snapshot is a drop-in. A
-    // lightweight ref (id + path) is all consumers read; a full handle is
-    // rebuilt from the path when an op is needed.
-    ref: { id: raw.id, path },
+    // Query snapshot refs are real worker handles, not path-only lookalikes:
+    // Firebase callers may pass `snapshot.ref` straight into deleteDoc/setDoc.
+    ref,
     exists: () => raw.exists,
     data: () => data,
   };
@@ -53,8 +59,8 @@ export interface RawQueryResult {
   docs: RawDocResult[];
 }
 
-export function makeQuerySnapshot(raw: RawQueryResult): ClientQuerySnapshot {
-  const docs = raw.docs.map(makeDocSnapshot);
+export function makeQuerySnapshot(raw: RawQueryResult, port: MessagePort): ClientQuerySnapshot {
+  const docs = raw.docs.map((doc) => makeDocSnapshot(doc, port));
   return {
     size: docs.length,
     empty: docs.length === 0,
@@ -67,9 +73,8 @@ export function makeQuerySnapshot(raw: RawQueryResult): ClientQuerySnapshot {
 export interface ClientDocSnapshot {
   readonly id: string;
   readonly path: string;
-  /** Lightweight document ref (id + path), mirroring the modular SDK's
-   *  `snap.ref` that `@pyric/ui` reads off query docs. */
-  readonly ref: { readonly id: string; readonly path: string };
+  /** Full port-carrying reference, usable by write APIs. */
+  readonly ref: DocRefHandle;
   exists(): boolean;
   data(): Record<string, unknown> | undefined;
 }

--- a/packages/pyric-tools/test/serve/worker/client/snapshots.test.ts
+++ b/packages/pyric-tools/test/serve/worker/client/snapshots.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import type { InboundMessage, OutboundMessage } from '../../../../src/serve/worker/protocol.js';
+import { wirePort } from '../../../../src/serve/worker/client/core.js';
+import { deleteDoc } from '../../../../src/serve/worker/client/firestore-writes.js';
+import { makeQuerySnapshot } from '../../../../src/serve/worker/client/snapshots.js';
+
+describe('worker query snapshot references', () => {
+  it('returns a full reference that can be passed directly to deleteDoc', async () => {
+    const sent: InboundMessage[] = [];
+    const port = {
+      onmessage: null as ((event: MessageEvent<OutboundMessage>) => void) | null,
+      postMessage(message: InboundMessage) {
+        sent.push(message);
+        if (message.t === 'op') {
+          queueMicrotask(() => {
+            port.onmessage?.({
+              data: { t: 'res', id: message.id, ok: true, value: undefined },
+            } as MessageEvent<OutboundMessage>);
+          });
+        }
+      },
+      start() {},
+      addEventListener() {},
+    } as unknown as MessagePort;
+    wirePort(port);
+    const snapshot = makeQuerySnapshot(
+      {
+        docs: [
+          {
+            id: 'delete-me',
+            path: 'notes/delete-me',
+            exists: true,
+            data: { json: '{}' },
+          },
+        ],
+      },
+      port,
+    );
+
+    await deleteDoc(snapshot.docs[0]!.ref);
+
+    expect(snapshot.docs[0]!.ref.descriptor.path).toBe('notes/delete-me');
+    expect(sent).toContainEqual(
+      expect.objectContaining({ t: 'op', method: 'deleteDoc', path: 'notes/delete-me' }),
+    );
+  });
+});

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -42,6 +42,7 @@ import {
   getMetadata as workerStorageGetMetadata,
   getBlob as workerStorageGetBlob,
   uploadBytes as workerStorageUploadBytes,
+  deleteObject as workerStorageDeleteObject,
   getSnapshot as workerGetSnapshot,
   getWorkerInstanceId,
   exportWorkerState,
@@ -388,6 +389,7 @@ export function connectWorkerLive(
       getMetadata: workerStorageGetMetadata,
       getBlob: workerStorageGetBlob,
       uploadBytes: workerStorageUploadBytes,
+      deleteObject: workerStorageDeleteObject,
     } as unknown as StorageApi,
     getSnapshot: () => workerGetSnapshot(db),
   };

--- a/packages/studio/src/features/auth/AuthSurface.tsx
+++ b/packages/studio/src/features/auth/AuthSurface.tsx
@@ -219,7 +219,7 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
             }}
             renderIdentifier={renderIdentifier}
             formatDate={clockTime}
-            renderActionsHeader={
+            renderSelectionHeader={
               <label className="auth-select" title="Select all shown users">
                 <input
                   type="checkbox"
@@ -229,7 +229,7 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
                 />
               </label>
             }
-            renderActions={(user) => (
+            renderSelection={(user) => (
               <label className="auth-select" title={`Select ${user.uid}`}>
                 <input
                   type="checkbox"

--- a/packages/studio/src/features/auth/AuthSurface.tsx
+++ b/packages/studio/src/features/auth/AuthSurface.tsx
@@ -35,15 +35,18 @@ import {
   AuthUserList,
   AuthUserForm,
   AuthApiProvider,
+  DeleteUserWithConfirm,
   providerLabel,
   useAuthUsers,
   type AuthUserFormSubmit,
 } from '@pyric/ui/auth';
+import { ConfirmProvider } from '@pyric/ui/primitives';
 import { FEDERATED_PROVIDER_IDS } from 'pyric/auth';
 import type { Auth, AuthUserRecord, CreateUserRequest, ProviderUserInfo } from 'pyric/auth';
 import { useDevSeed } from '../../dev/DevSeedProvider.js';
 import { useDataNav } from '../data/navigation.js';
 import { useStudioDataSource } from '../../shell/studio-data.js';
+import { DeleteSelectedUsers, useVisibleUserSelection } from './auth-bulk-delete.js';
 import './auth.css';
 
 /** Compact "11m ago" / "just now" relative time for the list + detail. */
@@ -112,7 +115,11 @@ export function AuthSurface({ auth: authProp }: AuthSurfaceProps = {}) {
       </div>
     );
   }
-  const body = <AuthSurfaceBody auth={auth} />;
+  const body = (
+    <ConfirmProvider>
+      <AuthSurfaceBody auth={auth} />
+    </ConfirmProvider>
+  );
   return authApi ? <AuthApiProvider value={authApi}>{body}</AuthApiProvider> : body;
 }
 
@@ -127,7 +134,6 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
     createUser,
     updateUser,
     deleteUser,
-    clearUsers,
   } = useAuthUsers(auth);
 
   const nav = useDataNav();
@@ -144,6 +150,7 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
   // "Add user" discloses the create form in the detail pane (one create at a
   // time; selecting a user closes it).
   const [creating, setCreating] = useState(false);
+  const selection = useVisibleUserSelection(users);
 
   return (
     <div className="auth-surface" data-pyric-ui="auth-surface">
@@ -160,27 +167,40 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
           aria-label="Filter users"
         />
         <div className="auth-sub__right">
-          <button
-            type="button"
-            className="auth-sub__add"
-            onClick={() => {
-              setCreating(true);
-              selectUser(null);
-            }}
-          >
-            Add user
-          </button>
-          <button
-            type="button"
-            className="auth-sub__clear"
-            onClick={() => {
-              clearUsers();
-              selectUser(null);
-            }}
-            disabled={totalCount === 0}
-          >
-            Clear all
-          </button>
+          {selection.selectedUsers.length > 0 ? (
+            <>
+              <span className="studio-selection-count">
+                {selection.selectedUsers.length} selected
+              </span>
+              <DeleteSelectedUsers
+                users={selection.selectedUsers}
+                filter={filter}
+                onDelete={(uid) => Promise.resolve(deleteUser(uid))}
+                onComplete={(failedUids) => {
+                  selection.replace(failedUids);
+                  if (selectedUid && !failedUids.includes(selectedUid)) selectUser(null);
+                }}
+              />
+              <button
+                type="button"
+                className="auth-sub__clear"
+                onClick={selection.clear}
+              >
+                Clear selection
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="auth-sub__add"
+              onClick={() => {
+                setCreating(true);
+                selectUser(null);
+              }}
+            >
+              Add user
+            </button>
+          )}
         </div>
       </div>
 
@@ -199,6 +219,26 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
             }}
             renderIdentifier={renderIdentifier}
             formatDate={clockTime}
+            renderActionsHeader={
+              <label className="auth-select" title="Select all shown users">
+                <input
+                  type="checkbox"
+                  aria-label="Select all shown users"
+                  checked={selection.allVisibleSelected}
+                  onChange={(event) => selection.selectAll(event.currentTarget.checked)}
+                />
+              </label>
+            }
+            renderActions={(user) => (
+              <label className="auth-select" title={`Select ${user.uid}`}>
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${user.uid}`}
+                  checked={selection.isSelected(user.uid)}
+                  onChange={() => selection.toggle(user.uid)}
+                />
+              </label>
+            )}
             emptyState={
               <p className="auth-zero">
                 No users yet. Sign-ins from the app, agent-seeded users, and
@@ -466,9 +506,11 @@ function UserDetail({
       </AuthUserForm>
 
       <div className="auth-editor__foot">
-        <button type="button" className="auth-del" onClick={onDelete}>
-          Delete user
-        </button>
+        <DeleteUserWithConfirm
+          user={user}
+          onDelete={onDelete}
+          className="auth-del"
+        />
       </div>
     </div>
   );

--- a/packages/studio/src/features/auth/auth-bulk-delete.tsx
+++ b/packages/studio/src/features/auth/auth-bulk-delete.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { AuthUserRecord } from 'pyric/auth';
+import { useConfirm } from '@pyric/ui/primitives';
+
+export function retainVisibleUserIds(
+  selected: ReadonlySet<string>,
+  users: AuthUserRecord[],
+): Set<string> {
+  const visible = new Set(users.map((user) => user.uid));
+  return new Set([...selected].filter((uid) => visible.has(uid)));
+}
+
+export async function deleteAuthUsers(
+  users: AuthUserRecord[],
+  onDelete: (uid: string) => Promise<void>,
+): Promise<string[]> {
+  const failed: string[] = [];
+  for (const user of users) {
+    try {
+      await onDelete(user.uid);
+    } catch {
+      failed.push(user.uid);
+    }
+  }
+  return failed;
+}
+
+/** Selection is always intersected with the users currently rendered. The
+ *  Auth surface passes the hook's filtered `users` array, so hidden users can
+ *  never survive a filter change into a bulk delete. */
+export function useVisibleUserSelection(users: AuthUserRecord[]) {
+  const [selectedUids, setSelectedUids] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setSelectedUids((previous) => {
+      const next = retainVisibleUserIds(previous, users);
+      return next.size === previous.size && [...next].every((uid) => previous.has(uid))
+        ? previous
+        : next;
+    });
+  }, [users]);
+
+  const selectedUsers = useMemo(
+    () => users.filter((user) => selectedUids.has(user.uid)),
+    [selectedUids, users],
+  );
+
+  return {
+    selectedUsers,
+    allVisibleSelected: users.length > 0 && selectedUsers.length === users.length,
+    isSelected: (uid: string) => selectedUids.has(uid),
+    toggle(uid: string) {
+      setSelectedUids((previous) => {
+        const next = new Set(previous);
+        if (next.has(uid)) next.delete(uid);
+        else next.add(uid);
+        return next;
+      });
+    },
+    selectAll(select: boolean) {
+      setSelectedUids(select ? new Set(users.map((user) => user.uid)) : new Set());
+    },
+    replace(uids: string[]) {
+      setSelectedUids(new Set(uids));
+    },
+    clear() {
+      setSelectedUids(new Set());
+    },
+  };
+}
+
+export function DeleteSelectedUsers({
+  users,
+  filter,
+  onDelete,
+  onComplete,
+}: {
+  users: AuthUserRecord[];
+  filter: string;
+  onDelete: (uid: string) => Promise<void>;
+  onComplete: (failedUids: string[]) => void;
+}) {
+  const confirm = useConfirm();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const run = async () => {
+    const filtered = filter.trim().length > 0;
+    const ok = await confirm({
+      title: `Delete ${users.length} ${users.length === 1 ? 'user' : 'users'}?`,
+      body: filtered
+        ? `Only the ${users.length} users shown by the current filter will be deleted.`
+        : `This will permanently delete the ${users.length} selected users.`,
+      destructive: true,
+      confirmLabel: 'Delete users',
+    });
+    if (!ok) return;
+
+    setIsDeleting(true);
+    setDeleteError(null);
+    const failed = await deleteAuthUsers(users, onDelete);
+    setIsDeleting(false);
+    setDeleteError(
+      failed.length > 0 ? `Could not delete ${failed.length} selected user(s).` : null,
+    );
+    onComplete(failed);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="studio-selection-delete"
+        disabled={isDeleting}
+        onClick={() => void run()}
+      >
+        {isDeleting ? 'Deleting…' : 'Delete'}
+      </button>
+      {deleteError ? <span className="auth-sub__error">{deleteError}</span> : null}
+    </>
+  );
+}

--- a/packages/studio/src/features/auth/auth.css
+++ b/packages/studio/src/features/auth/auth.css
@@ -234,12 +234,26 @@
 [data-pyric-ui='auth-user-list'] [data-pyric-user-header],
 [data-pyric-ui='auth-user-list'] [data-pyric-user-entry] {
   display: grid;
-  grid-template-columns: 1fr 200px 96px 100px 32px;
+  grid-template-columns: 1fr 200px 96px 100px;
   gap: 16px;
   align-items: baseline;
   padding: 10px var(--auth-gutter);
 }
 
+[data-pyric-ui='auth-user-list'][data-pyric-selection]
+  :is([data-pyric-user-header], [data-pyric-user-entry]) {
+  grid-template-columns: 32px 1fr 200px 96px 100px;
+}
+[data-pyric-ui='auth-user-list'][data-pyric-actions]
+  :is([data-pyric-user-header], [data-pyric-user-entry]) {
+  grid-template-columns: 1fr 200px 96px 100px 32px;
+}
+[data-pyric-ui='auth-user-list'][data-pyric-selection][data-pyric-actions]
+  :is([data-pyric-user-header], [data-pyric-user-entry]) {
+  grid-template-columns: 32px 1fr 200px 96px 100px 32px;
+}
+
+[data-pyric-user-cell='selection'],
 [data-pyric-user-cell='actions'] {
   display: grid;
   place-items: center;
@@ -649,8 +663,20 @@
   /* List collapses to identifier + created (provider / signed-in drop). */
   [data-pyric-ui='auth-user-list'] [data-pyric-user-header],
   [data-pyric-ui='auth-user-list'] [data-pyric-user-entry] {
-    grid-template-columns: 1fr auto 32px;
+    grid-template-columns: 1fr auto;
     gap: 10px;
+  }
+  [data-pyric-ui='auth-user-list'][data-pyric-selection]
+    :is([data-pyric-user-header], [data-pyric-user-entry]) {
+    grid-template-columns: 32px 1fr auto;
+  }
+  [data-pyric-ui='auth-user-list'][data-pyric-actions]
+    :is([data-pyric-user-header], [data-pyric-user-entry]) {
+    grid-template-columns: 1fr auto 32px;
+  }
+  [data-pyric-ui='auth-user-list'][data-pyric-selection][data-pyric-actions]
+    :is([data-pyric-user-header], [data-pyric-user-entry]) {
+    grid-template-columns: 32px 1fr auto 32px;
   }
   [data-pyric-ui='auth-user-list'] [data-pyric-user-cell='providers'],
   [data-pyric-ui='auth-user-list'] [data-pyric-user-cell='signed-in'] {

--- a/packages/studio/src/features/auth/auth.css
+++ b/packages/studio/src/features/auth/auth.css
@@ -91,6 +91,10 @@
   opacity: 0.45;
   cursor: default;
 }
+.auth-sub__error {
+  font-size: 11.5px;
+  color: var(--diff-remove);
+}
 
 /* ════════════════════════════════════════════════════════════════════════
  * PER-USER SIGN-IN PROVIDERS (ProvidersEditor, in the detail pane)
@@ -230,10 +234,26 @@
 [data-pyric-ui='auth-user-list'] [data-pyric-user-header],
 [data-pyric-ui='auth-user-list'] [data-pyric-user-entry] {
   display: grid;
-  grid-template-columns: 1fr 200px 96px 100px;
+  grid-template-columns: 1fr 200px 96px 100px 32px;
   gap: 16px;
   align-items: baseline;
   padding: 10px var(--auth-gutter);
+}
+
+[data-pyric-user-cell='actions'] {
+  display: grid;
+  place-items: center;
+}
+.auth-select {
+  display: inline-flex;
+  align-items: center;
+}
+.auth-select input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 /* The library's extra `uid` column is folded into the identifier cell. */
@@ -629,7 +649,7 @@
   /* List collapses to identifier + created (provider / signed-in drop). */
   [data-pyric-ui='auth-user-list'] [data-pyric-user-header],
   [data-pyric-ui='auth-user-list'] [data-pyric-user-entry] {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto 32px;
     gap: 10px;
   }
   [data-pyric-ui='auth-user-list'] [data-pyric-user-cell='providers'],

--- a/packages/studio/src/features/data/FirestorePane.tsx
+++ b/packages/studio/src/features/data/FirestorePane.tsx
@@ -18,7 +18,6 @@ import {
   useFirestoreApi,
   type FirestoreApi,
 } from '@pyric/ui/firestore';
-import { useRecursiveDelete } from '@pyric/ui/firestore/hooks';
 import type {
   CollectionReference,
   DocumentReference,
@@ -31,11 +30,11 @@ import { ConfirmProvider, useConfirm, useContainerSize } from '@pyric/ui/primiti
 import { useDataNav, parseDocPath, type NavigationPathSegment } from './navigation.js';
 import { PANEL_BREAKPOINTS, panelWindow } from './panelLayout.js';
 import type { StudioDataHandles } from './sandbox.js';
-import { ImportJsonPanel } from './FirestoreImportPanel.js';
 import { FirestoreCreateModal, type FirestoreCreateSubmit } from './FirestoreCreateModal.js';
 import { FirestoreDocumentTree, SubcollectionsSection } from './FirestoreDocumentTree.js';
 import { OverflowMenu } from './OverflowMenu.js';
-import { makeRecursiveDeleteImpl } from './recursiveDelete.js';
+import { deleteRecursively, makeRecursiveDeleteImpl } from './recursiveDelete.js';
+import { confirmDocumentDelete } from './document-delete.js';
 import './firestore.css';
 
 /**
@@ -382,7 +381,6 @@ function DocumentColumn({
     hasMore,
     loadMore,
     createDocument,
-    deleteDocument,
   } = useDocumentList({ collection, mode: 'live' });
   // "Missing" parents come from the phantom-inclusive listDocuments seam —
   // the paged getDocs above can't see them (queries match stored docs only).
@@ -416,31 +414,23 @@ function DocumentColumn({
     ];
   }, [documents, phantomIds, api, firestore, collectionPath]);
   const collId = collectionPath.split('/').pop() ?? collectionPath;
-  // Per-row delete: plain click arms an inline confirm; shift-click deletes
-  // immediately (rapid bulk delete). Only one row arms at a time.
-  const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<Error | null>(null);
-  // "+ New" opens the create-document MODAL (the same composable modal the
-  // collection flow uses, opened at the document step — the collection is
-  // fixed). Import JSON stays an inline disclosure: bulk paste wants room.
+  // "+ New" opens the create-document modal (the collection is fixed).
   const [creating, setCreating] = useState(false);
-  const [importing, setImporting] = useState(false);
-  const doDelete = useCallback(
-    async (r: DocumentReference) => {
-      setDeleteError(null);
-      try {
-        await deleteDocument(r);
-        setConfirmingId((id) => (id === r.id ? null : id));
-      } catch (e) {
-        setDeleteError(e instanceof Error ? e : new Error(String(e)));
-      }
-    },
-    [deleteDocument],
-  );
 
   const confirm = useConfirm();
   const recursiveImpl = useMemo(() => makeRecursiveDeleteImpl(api, handles), [api, handles]);
-  const { delete: runCollectionDelete } = useRecursiveDelete(recursiveImpl);
+  const doDelete = useCallback(
+    async (ref: DocumentReference) => {
+      setDeleteError(null);
+      try {
+        await confirmDocumentDelete({ confirm, ref, api, recursiveImpl });
+      } catch (error) {
+        setDeleteError(error instanceof Error ? error : new Error(String(error)));
+      }
+    },
+    [api, confirm, recursiveImpl],
+  );
   const onDeleteCollection = useCallback(async () => {
     const ok = await confirm({
       title: `Delete collection "${collId}"?`,
@@ -449,24 +439,24 @@ function DocumentColumn({
       confirmLabel: 'Delete collection',
     });
     if (!ok) return;
-    await runCollectionDelete(collection);
-    onCollectionDeleted();
-  }, [confirm, runCollectionDelete, collection, collId, onCollectionDeleted]);
+    setDeleteError(null);
+    try {
+      await deleteRecursively(recursiveImpl, collection);
+      onCollectionDeleted();
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error : new Error(String(error)));
+    }
+  }, [confirm, recursiveImpl, collection, collId, onCollectionDeleted]);
 
   return (
     <section data-pyric-ui="fs-documents" className="fs-pane fs-col">
       <div className="fs-phead">
         <span className="fs-phead-title">{collId}</span>
-        {!importing ? (
-          <span className="fs-phead-actions">
-            <button type="button" className="fs-add" onClick={() => setCreating(true)}>
-              + New
-            </button>
-            <button type="button" className="fs-add" onClick={() => setImporting(true)}>
-              Import JSON
-            </button>
-          </span>
-        ) : null}
+        <span className="fs-phead-actions">
+          <button type="button" className="fs-add" onClick={() => setCreating(true)}>
+            + New
+          </button>
+        </span>
         <OverflowMenu
           items={[
             { label: 'Delete collection', onSelect: () => void onDeleteCollection(), destructive: true },
@@ -488,17 +478,7 @@ function DocumentColumn({
           onClose={() => setCreating(false)}
         />
       ) : null}
-      {importing ? (
-        <ImportJsonPanel
-          existingIds={documents.map((d) => d.id)}
-          createDocument={createDocument}
-          onDone={() => setImporting(false)}
-          onCancel={() => setImporting(false)}
-        />
-      ) : null}
-
-      {!importing ? (
-        <DocumentList
+      <DocumentList
         documents={rows}
         isLoading={isLoading}
         error={error}
@@ -526,46 +506,15 @@ function DocumentColumn({
           // Its subtree deletes through the detail column / delete-collection.
           if (isPhantomRow(snap)) return null;
           const r = (snap as unknown as { ref: DocumentReference }).ref;
-          if (confirmingId === r.id) {
-            return (
-              <span className="fs-doc-del-confirm">
-                <button
-                  type="button"
-                  className="fs-doc-del-yes"
-                  title="Confirm delete"
-                  aria-label={`Confirm delete ${r.id}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void doDelete(r);
-                  }}
-                >
-                  ✓
-                </button>
-                <button
-                  type="button"
-                  className="fs-doc-del-no"
-                  title="Cancel"
-                  aria-label="Cancel delete"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setConfirmingId(null);
-                  }}
-                >
-                  ✕
-                </button>
-              </span>
-            );
-          }
           return (
             <button
               type="button"
               className="fs-doc-del"
-              title="Delete document (shift-click to skip confirmation)"
-              aria-label={`Delete ${r.id} (shift-click to skip confirmation)`}
+              title="Delete document"
+              aria-label={`Delete ${r.id}`}
               onClick={(e) => {
                 e.stopPropagation();
-                if (e.shiftKey) void doDelete(r);
-                else setConfirmingId(r.id);
+                void doDelete(r);
               }}
             >
               ×
@@ -573,8 +522,7 @@ function DocumentColumn({
           );
         }}
         emptyState={<p className="fs-empty">No documents.</p>}
-        />
-      ) : null}
+      />
       {deleteError ? <p className="fs-empty fs-doc-del-err">{deleteError.message}</p> : null}
     </section>
   );
@@ -618,18 +566,16 @@ function DocumentDetailColumn({
 
   const confirm = useConfirm();
   const recursiveImpl = useMemo(() => makeRecursiveDeleteImpl(api, handles), [api, handles]);
-  const { delete: runDocDelete } = useRecursiveDelete(recursiveImpl);
+  const [deleteError, setDeleteError] = useState<Error | null>(null);
   const onDeleteDocument = useCallback(async () => {
-    const ok = await confirm({
-      title: `Delete document "${ref.id}"?`,
-      body: 'This also deletes its subcollections.',
-      destructive: true,
-      confirmLabel: 'Delete document',
-    });
-    if (!ok) return;
-    await runDocDelete(ref);
-    onDeleted();
-  }, [confirm, runDocDelete, ref, onDeleted]);
+    setDeleteError(null);
+    try {
+      const deleted = await confirmDocumentDelete({ confirm, ref, api, recursiveImpl });
+      if (deleted) onDeleted();
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error : new Error(String(error)));
+    }
+  }, [api, confirm, recursiveImpl, ref, onDeleted]);
 
   const onDeleteDocumentFields = useCallback(async () => {
     await api.setDoc(ref, {});
@@ -683,6 +629,7 @@ function DocumentDetailColumn({
           />
         </>
       )}
+      {deleteError ? <p className="fs-empty fs-doc-del-err">{deleteError.message}</p> : null}
     </section>
   );
 }

--- a/packages/studio/src/features/data/StoragePane.tsx
+++ b/packages/studio/src/features/data/StoragePane.tsx
@@ -43,8 +43,10 @@ import {
   ObjectInspector,
   PathBreadcrumb,
   UploadDropzone,
+  DeleteSelectionWithConfirm,
   useObjectUpload,
   useStorageList,
+  useStorageSelection,
   useStorageRulesGate,
   usePathState,
   normalizeStoragePath,
@@ -57,6 +59,7 @@ import {
   type DroppedFile,
   type StorageListEntry,
 } from '@pyric/ui/storage';
+import { ConfirmProvider, ToastProvider } from '@pyric/ui/primitives';
 import type { FirebaseStorage, FullMetadata, StorageReference } from 'pyric/storage';
 import { useDataNav } from './navigation.js';
 import './storage.css';
@@ -209,6 +212,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
     nav.navigate({ view: 'storage', objectPath });
   };
   const list = useStorageList(storage, pathState.path);
+  const selection = useStorageSelection();
   // Pre-flight read verdicts → the read-denied row treatment (advisory).
   const gate = useStorageRulesGate(storage);
 
@@ -269,6 +273,8 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
     ].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
     return [...folders, ...list.entries.filter((e) => e.kind === 'object')];
   }, [list.entries, pending, pathState.path]);
+  const allSelected =
+    entries.length > 0 && entries.every((entry) => selection.isSelected(entry.fullPath));
 
   // Upload a batch into the browsed folder, OS-copy renaming collisions
   // against the folder's direct children (real + pending + this batch).
@@ -309,6 +315,10 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusPath]);
 
+  // Selection is scoped to the directory currently on screen. Navigating to
+  // another prefix starts a fresh selection, matching the Firebase console.
+  useEffect(() => selection.clear(), [pathState.path, selection.clear]);
+
   const failed = uploader.tasks.filter((t) => t.status === 'error');
   // Advisory pre-flight for the drop target (the gate's canonical wiring —
   // see UploadDropzone's `disabledReason` doc). Conservative: no size or
@@ -316,6 +326,8 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
   const writeVerdict = gate.verdictFor(pathState.path);
 
   return (
+    <ToastProvider>
+      <ConfirmProvider>
     <div className="storage">
       <div className="storage__sub">
         <PathBreadcrumb
@@ -327,6 +339,48 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
           }}
         />
         <div className="storage__actions">
+          {selection.size > 0 ? (
+            <>
+              <span className="studio-selection-count">{selection.size} selected</span>
+              <DeleteSelectionWithConfirm
+                storage={storage}
+                entries={selection.selected}
+                list={list}
+                gate={gate}
+                className="studio-selection-delete"
+                onDeleted={(outcome) => {
+                  for (const entry of selection.selected) {
+                    if (entry.kind === 'folder' && outcome.deleted.includes(entry.fullPath)) {
+                      dispatchPending({ type: 'discard', path: entry.fullPath });
+                    }
+                  }
+                  if (
+                    selectedPath &&
+                    selection.selected.some((entry) =>
+                      entry.kind === 'object'
+                        ? entry.fullPath === selectedPath
+                        : selectedPath.startsWith(`${entry.fullPath}/`),
+                    )
+                  ) {
+                    selectObject(null);
+                  }
+                  selection.clear();
+                  list.refresh();
+                }}
+                onFailed={(outcome) => {
+                  const failed = new Set(outcome.failed.map((entry) => entry.fullPath));
+                  selection.selectAll(
+                    selection.selected.filter((entry) => failed.has(entry.fullPath)),
+                  );
+                  list.refresh();
+                }}
+              />
+              <button type="button" className="storage__action" onClick={selection.clear}>
+                Clear selection
+              </button>
+            </>
+          ) : (
+            <>
           <button
             type="button"
             className="storage__action"
@@ -358,6 +412,8 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
               e.currentTarget.value = '';
             }}
           />
+            </>
+          )}
         </div>
       </div>
 
@@ -423,6 +479,16 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
           disabledReason={writeVerdict.reasons.write.join('; ')}
         >
           <div className="storage__lhead">
+            <label className="storage__select-all" title="Select all in this folder">
+              <input
+                type="checkbox"
+                aria-label="Select all in this folder"
+                checked={allSelected}
+                onChange={(event) =>
+                  event.currentTarget.checked ? selection.selectAll(entries) : selection.clear()
+                }
+              />
+            </label>
             <span>name</span>
             <span>type</span>
             <span>size</span>
@@ -435,6 +501,16 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
             gate={gate}
             selectedPath={selectedPath ?? undefined}
             renderEntry={renderEntry}
+            renderRowAction={(entry) => (
+              <label className="storage__select-row" title={`Select ${entry.name}`}>
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${entry.name}`}
+                  checked={selection.isSelected(entry.fullPath)}
+                  onChange={() => selection.toggle(entry)}
+                />
+              </label>
+            )}
             onNavigate={(p) => {
               pathState.enter(p);
               selectObject(null);
@@ -480,5 +556,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
         </div>
       </div>
     </div>
+      </ConfirmProvider>
+    </ToastProvider>
   );
 }

--- a/packages/studio/src/features/data/document-delete.tsx
+++ b/packages/studio/src/features/data/document-delete.tsx
@@ -1,0 +1,41 @@
+import type { DocumentReference } from 'pyric/firestore';
+import type { FirestoreApi } from '@pyric/ui/firestore';
+import type { RecursiveDeleteImpl } from '@pyric/ui/firestore/hooks';
+import type { ConfirmFn } from '@pyric/ui/primitives';
+import { deleteRecursively } from './recursiveDelete.js';
+
+/** One document-delete contract for every Studio entry point: modal confirm,
+ *  non-recursive by default, explicit opt-in for descendant deletion. */
+export async function confirmDocumentDelete({
+  confirm,
+  ref,
+  api,
+  recursiveImpl,
+}: {
+  confirm: ConfirmFn;
+  ref: DocumentReference;
+  api: FirestoreApi;
+  recursiveImpl: RecursiveDeleteImpl;
+}): Promise<boolean> {
+  let recursive = false;
+  const ok = await confirm({
+    title: `Delete document "${ref.id}"?`,
+    body: (
+      <label className="fs-delete-recursive">
+        <input
+          type="checkbox"
+          onChange={(event) => {
+            recursive = event.currentTarget.checked;
+          }}
+        />
+        <span>Also delete subcollections recursively. Leave this off to keep nested data.</span>
+      </label>
+    ),
+    destructive: true,
+    confirmLabel: 'Delete document',
+  });
+  if (!ok) return false;
+  if (recursive) await deleteRecursively(recursiveImpl, ref);
+  else await api.deleteDoc(ref);
+  return true;
+}

--- a/packages/studio/src/features/data/firestore.css
+++ b/packages/studio/src/features/data/firestore.css
@@ -34,6 +34,21 @@
   background: var(--color-content-bg);
 }
 
+.fs-delete-recursive {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  color: var(--ink);
+  cursor: pointer;
+}
+.fs-delete-recursive input {
+  width: 15px;
+  height: 15px;
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+  flex: none;
+}
+
 /* clickable path bar */
 [data-pyric-ui='fs-breadcrumb'] {
   display: flex;
@@ -148,7 +163,7 @@
   cursor: pointer;
 }
 
-/* multiple secondary header actions (e.g. "+ New" + "Import JSON") sit as a
+/* multiple secondary header actions sit as a
    gap-separated row pinned to the trailing edge — gap, not margin, between
    the buttons themselves (L2). */
 [data-pyric-ui='fs-browser'] .fs-phead-actions {
@@ -441,37 +456,6 @@
   opacity: 1;
   color: var(--color-danger, #ff6b6b);
   background: var(--color-sidebar-bg);
-}
-/* armed inline confirm: ✓ delete / ✕ cancel (stays visible while armed) */
-[data-pyric-ui='fs-browser'] .fs-doc-del-confirm {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-}
-[data-pyric-ui='fs-browser'] .fs-doc-del-yes,
-[data-pyric-ui='fs-browser'] .fs-doc-del-no {
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 13px;
-  line-height: 1;
-  padding: 3px 7px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-[data-pyric-ui='fs-browser'] .fs-doc-del-yes {
-  color: var(--color-danger, #ff6b6b);
-}
-[data-pyric-ui='fs-browser'] .fs-doc-del-yes:hover {
-  background: var(--color-danger, #ff6b6b);
-  color: var(--color-soft-white);
-}
-[data-pyric-ui='fs-browser'] .fs-doc-del-no {
-  color: var(--color-muted, #8a8f98);
-}
-[data-pyric-ui='fs-browser'] .fs-doc-del-no:hover {
-  background: var(--color-sidebar-bg);
-  color: var(--color-soft-white);
 }
 [data-pyric-ui='fs-browser'] .fs-doc-del-err {
   color: var(--color-danger, #ff6b6b);

--- a/packages/studio/src/features/data/firestore.css
+++ b/packages/studio/src/features/data/firestore.css
@@ -919,6 +919,12 @@
   position: relative;
   margin-left: auto;
 }
+/* When + New precedes the menu, its actions group already owns the trailing
+   auto margin. Keep the overflow trigger beside it instead of splitting the
+   spare header width between two auto margins. */
+.fs-phead-actions + .fs-overflow {
+  margin-left: 0;
+}
 .fs-overflow__trigger {
   appearance: none;
   border: none;

--- a/packages/studio/src/features/data/panelLayout.ts
+++ b/packages/studio/src/features/data/panelLayout.ts
@@ -8,7 +8,7 @@
  * so the same policy holds whether Studio is full-screen or embedded in a
  * split view. Breakpoints (see `PANEL_BREAKPOINTS`) are chosen from content,
  * not device sizes: a context column needs ~240px before its header row
- * ("collection name + ⋮ + New + Import JSON") stops wrapping/clipping, and
+ * ("collection name + ⋮ + New") stops wrapping/clipping, and
  * the detail column carries a 1.7x flex share — three readable panels
  * therefore need ≈ 240×3.7/1 ≈ 900px, two need ≈ 240×2.7 ≈ 650px.
  *

--- a/packages/studio/src/features/data/recursiveDelete.ts
+++ b/packages/studio/src/features/data/recursiveDelete.ts
@@ -85,3 +85,16 @@ export function makeRecursiveDeleteImpl(
     },
   };
 }
+
+/** Run a recursive implementation to completion and let failures reject.
+ *  The generic UI hook intentionally captures errors as state; Studio's
+ *  destructive flows need a rejecting promise so they only navigate away
+ *  after the subtree is actually gone. */
+export async function deleteRecursively(
+  impl: RecursiveDeleteImpl,
+  target: DocumentReference | CollectionReference,
+): Promise<void> {
+  for await (const progress of impl.start(target)) {
+    if (progress.done) return;
+  }
+}

--- a/packages/studio/src/features/data/storage.css
+++ b/packages/studio/src/features/data/storage.css
@@ -214,17 +214,43 @@
 
 /* ── ObjectBrowser: column header + folders-first rows ───────────────── */
 .storage__lhead {
+  position: relative;
   display: grid;
   grid-template-columns: var(--storage-cols);
   gap: 16px;
   align-items: baseline;
-  padding: 10px var(--storage-gutter);
+  padding: 10px var(--storage-gutter) 10px calc(var(--storage-gutter) + 34px);
   background: var(--panel);
   border-bottom: 1px solid var(--line);
   font-size: 10.5px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--faint);
+}
+.storage__lhead,
+.storage [data-pyric-entry-select] {
+  padding-left: calc(var(--storage-gutter) + 34px);
+}
+.storage__select-all,
+.storage [data-pyric-storage-action] {
+  position: absolute;
+  left: var(--storage-gutter);
+  top: 50%;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  transform: translateY(-50%);
+}
+.storage [data-pyric-storage-entry] {
+  position: relative;
+}
+.storage__select-all input,
+.storage__select-row input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .storage [data-pyric-ui="object-browser"] [data-pyric-object-browser-items] {
@@ -245,7 +271,7 @@
   border: none;
   border-bottom: 1px solid var(--line);
   border-left: 2px solid transparent;
-  padding: 10px var(--storage-gutter);
+  padding: 10px var(--storage-gutter) 10px calc(var(--storage-gutter) + 34px);
   font: inherit;
   text-align: left;
   cursor: pointer;

--- a/packages/studio/src/styles/index.css
+++ b/packages/studio/src/styles/index.css
@@ -151,6 +151,117 @@
   }
 }
 
+/* Shared portal chrome for the headless @pyric/ui destructive-action
+   primitives. Portals mount under <body>, so feature-scoped selectors cannot
+   reach them; Studio owns their visual treatment here. */
+[data-pyric-ui='confirm-portal'] {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+[data-pyric-ui='confirm-overlay'] {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  backdrop-filter: blur(2px);
+}
+[data-pyric-ui='confirm-dialog'] {
+  position: relative;
+  width: min(440px, 100%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 20px;
+  background: var(--elevated);
+  color: var(--ink);
+  box-shadow: 0 18px 60px color-mix(in srgb, var(--bg) 75%, transparent);
+}
+[data-pyric-confirm-title] {
+  font-size: 16px;
+  font-weight: 650;
+}
+[data-pyric-confirm-body] {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+[data-pyric-confirm-body] ul {
+  max-height: 180px;
+  margin: 0;
+  padding-left: 20px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+[data-pyric-confirm-actions] {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+[data-pyric-confirm-actions] button {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  border-radius: 7px;
+  padding: 7px 13px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+[data-pyric-confirm-confirm][data-pyric-destructive] {
+  border-color: var(--diff-remove);
+  background: var(--diff-remove);
+  color: var(--deny-ink);
+}
+
+[data-pyric-ui='toast-region'] {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 2100;
+  display: grid;
+  width: min(360px, calc(100vw - 36px));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+[data-pyric-toast] {
+  position: relative;
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  padding: 12px 36px 12px 14px;
+  background: var(--elevated);
+  color: var(--ink);
+  box-shadow: 0 12px 36px color-mix(in srgb, var(--bg) 65%, transparent);
+}
+[data-pyric-toast][data-pyric-toast-kind='error'] {
+  border-color: color-mix(in srgb, var(--diff-remove) 55%, var(--line));
+}
+[data-pyric-toast-title] {
+  font-weight: 600;
+}
+[data-pyric-toast-body] {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12px;
+}
+[data-pyric-toast-dismiss] {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  border: 0;
+  background: none;
+  color: var(--faint);
+  cursor: pointer;
+}
+
 .studio-chip {
   display: inline-flex;
   align-items: center;
@@ -164,6 +275,26 @@
   line-height: 1.2;
   white-space: nowrap;
   text-decoration: none;
+}
+.studio-selection-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink);
+}
+.studio-selection-delete {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--diff-remove) 45%, var(--line));
+  border-radius: 7px;
+  background: var(--elevated);
+  color: var(--diff-remove);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 11px;
+  cursor: pointer;
+}
+.studio-selection-delete:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 a.studio-chip:hover {
   border-color: var(--line-2);

--- a/packages/studio/test/features/auth/auth-bulk-delete.test.ts
+++ b/packages/studio/test/features/auth/auth-bulk-delete.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import type { AuthUserRecord } from 'pyric/auth';
+import {
+  deleteAuthUsers,
+  retainVisibleUserIds,
+} from '../../../src/features/auth/auth-bulk-delete.js';
+
+const user = (uid: string) => ({ uid }) as AuthUserRecord;
+
+describe('Auth filtered bulk deletion', () => {
+  it('select-all retains only ids present in the filtered user list', () => {
+    const previouslySelected = new Set(['alice', 'amy', 'bob']);
+    const filteredUsers = [user('alice'), user('amy')];
+
+    expect([...retainVisibleUserIds(previouslySelected, filteredUsers)]).toEqual([
+      'alice',
+      'amy',
+    ]);
+  });
+
+  it('deletes only the filtered users supplied by the selection', async () => {
+    const deleted: string[] = [];
+    const filteredUsers = [user('alice'), user('amy')];
+
+    const failed = await deleteAuthUsers(filteredUsers, async (uid) => {
+      deleted.push(uid);
+    });
+
+    expect(deleted).toEqual(['alice', 'amy']);
+    expect(deleted).not.toContain('bob');
+    expect(failed).toEqual([]);
+  });
+});

--- a/packages/studio/test/features/data/document-delete.test.tsx
+++ b/packages/studio/test/features/data/document-delete.test.tsx
@@ -1,0 +1,63 @@
+import { Children, type ReactElement, type ReactNode } from 'react';
+import { describe, expect, it } from 'bun:test';
+import type { DocumentReference } from 'pyric/firestore';
+import type { FirestoreApi } from '@pyric/ui/firestore';
+import type { RecursiveDeleteImpl } from '@pyric/ui/firestore/hooks';
+import type { ConfirmFn, ConfirmOptions } from '@pyric/ui/primitives';
+import { confirmDocumentDelete } from '../../../src/features/data/document-delete.js';
+
+const ref = { id: 'parent', path: 'things/parent' } as DocumentReference;
+
+function harness(confirm: ConfirmFn) {
+  const calls: string[] = [];
+  const api = {
+    deleteDoc: async (target: DocumentReference) => {
+      calls.push(`plain:${target.path}`);
+    },
+  } as FirestoreApi;
+  const recursiveImpl: RecursiveDeleteImpl = {
+    async *start(target) {
+      calls.push(`recursive:${target.path}`);
+      yield { deletedCount: 1, done: true };
+    },
+  };
+  return {
+    calls,
+    run: () => confirmDocumentDelete({ confirm, ref, api, recursiveImpl }),
+  };
+}
+
+describe('confirmDocumentDelete', () => {
+  it('opens a modal and preserves subcollections by default', async () => {
+    let options: ConfirmOptions | undefined;
+    const subject = harness(async (next) => {
+      options = next;
+      return true;
+    });
+
+    expect(await subject.run()).toBe(true);
+    expect(options?.title).toBe('Delete document "parent"?');
+    expect(options?.body).toBeDefined();
+    expect(subject.calls).toEqual(['plain:things/parent']);
+  });
+
+  it('recursively deletes only after the modal checkbox is enabled', async () => {
+    const subject = harness(async (options) => {
+      const label = options.body as ReactElement<{ children: unknown }>;
+      const input = Children.toArray(label.props.children as ReactNode)[0] as ReactElement<{
+        onChange: (event: { currentTarget: { checked: boolean } }) => void;
+      }>;
+      input.props.onChange({ currentTarget: { checked: true } });
+      return true;
+    });
+
+    expect(await subject.run()).toBe(true);
+    expect(subject.calls).toEqual(['recursive:things/parent']);
+  });
+
+  it('does nothing when the modal is cancelled', async () => {
+    const subject = harness(async () => false);
+    expect(await subject.run()).toBe(false);
+    expect(subject.calls).toEqual([]);
+  });
+});

--- a/packages/studio/test/vite-config.test.ts
+++ b/packages/studio/test/vite-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import type { PluginOption, UserConfig } from 'vite';
-import config from '../vite.config';
+import config, { studioSandboxOptions } from '../vite.config';
 
 function pluginNames(options: PluginOption[]): string[] {
   return options.flatMap((option) => {
@@ -17,5 +17,11 @@ describe('Studio Vite development config', () => {
     // The runtime plugin serves /__pyric/sdk/worker.js. Without it, Vite's SPA
     // fallback returns index.html and SharedWorker fails on the leading "<".
     expect(names).toContain('pyric:sandbox');
+  });
+
+  it('serves the embedded Playground instead of recursing into Studio', () => {
+    // `ui: true` owns /__pyric/playground/. With it disabled, Vite's SPA
+    // fallback serves Studio at that URL, and Studio embeds itself forever.
+    expect(studioSandboxOptions.ui).toBe(true);
   });
 });

--- a/packages/studio/test/vite-config.test.ts
+++ b/packages/studio/test/vite-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import type { PluginOption, UserConfig } from 'vite';
+import config from '../vite.config';
+
+function pluginNames(options: PluginOption[]): string[] {
+  return options.flatMap((option) => {
+    if (!option) return [];
+    if (Array.isArray(option)) return pluginNames(option);
+    return [option.name];
+  });
+}
+
+describe('Studio Vite development config', () => {
+  it('mounts the Pyric runtime that owns the default SharedWorker URL', () => {
+    const names = pluginNames((config as UserConfig).plugins ?? []);
+
+    // The runtime plugin serves /__pyric/sdk/worker.js. Without it, Vite's SPA
+    // fallback returns index.html and SharedWorker fails on the leading "<".
+    expect(names).toContain('pyric:sandbox');
+  });
+});

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS, pyricSandbox } from '@pyric/cli/vite';
+import {
+  NODE_BUILTIN_RE,
+  NODE_BUILTIN_SHIMS,
+  pyricSandbox,
+  type PyricSandboxOptions,
+} from '@pyric/cli/vite';
 
 /**
  * Studio app build. Outputs static assets to `dist/app`, served by
@@ -45,14 +50,19 @@ function nodeBuiltinShims(): Plugin {
   };
 }
 
+export const studioSandboxOptions = {
+  ui: true,
+  capture: false,
+} satisfies PyricSandboxOptions;
+
 export default defineConfig({
   base: process.env.STUDIO_BASE ?? '/',
   plugins: [
     // `bun run dev` serves Studio directly, outside `pyric dev`. Mount the
-    // runtime namespace here so Studio's default SharedWorker URL resolves to
-    // JavaScript instead of falling through to Vite's index.html response.
-    // Studio is already the UI, and review sessions should not write captures.
-    pyricSandbox({ ui: false, capture: false }),
+    // runtime namespace here so the SharedWorker and embedded Playground URLs
+    // cannot fall through to Vite's Studio index.html response. Review
+    // sessions should still avoid writing capture files.
+    pyricSandbox(studioSandboxOptions),
     nodeBuiltinShims(),
     react(),
     tailwindcss(),

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS } from '@pyric/cli/vite';
+import { NODE_BUILTIN_RE, NODE_BUILTIN_SHIMS, pyricSandbox } from '@pyric/cli/vite';
 
 /**
  * Studio app build. Outputs static assets to `dist/app`, served by
@@ -47,7 +47,16 @@ function nodeBuiltinShims(): Plugin {
 
 export default defineConfig({
   base: process.env.STUDIO_BASE ?? '/',
-  plugins: [nodeBuiltinShims(), react(), tailwindcss()],
+  plugins: [
+    // `bun run dev` serves Studio directly, outside `pyric dev`. Mount the
+    // runtime namespace here so Studio's default SharedWorker URL resolves to
+    // JavaScript instead of falling through to Vite's index.html response.
+    // Studio is already the UI, and review sessions should not write captures.
+    pyricSandbox({ ui: false, capture: false }),
+    nodeBuiltinShims(),
+    react(),
+    tailwindcss(),
+  ],
   define: {
     'import.meta.env.STUDIO_STATIC': JSON.stringify(process.env.STUDIO_STATIC === '1'),
   },

--- a/packages/ui/src/auth/components/AuthUserList.tsx
+++ b/packages/ui/src/auth/components/AuthUserList.tsx
@@ -21,6 +21,12 @@ export interface AuthUserListProps {
    *  per linked provider with its text label (`anonymous` for anonymous
    *  users) — hook icons off the attribute. */
   renderProviders?: (user: AuthUserRecord) => ReactNode;
+  /** Per-row selection control. Rendered in the leading cell so bulk
+   *  selection stays visually separate from trailing row actions. */
+  renderSelection?: (user: AuthUserRecord) => ReactNode;
+  /** Optional content for the leading selection column header (for example,
+   *  a select-all checkbox). Only rendered with `renderSelection`. */
+  renderSelectionHeader?: ReactNode;
   /** Per-row action slot (edit / disable / delete menu). Rendered in a
    *  trailing cell; column header is added when this is provided. */
   renderActions?: (user: AuthUserRecord) => ReactNode;
@@ -83,6 +89,8 @@ export function AuthUserList({
   onSelect,
   renderIdentifier,
   renderProviders,
+  renderSelection,
+  renderSelectionHeader,
   renderActions,
   renderActionsHeader,
   formatDate = defaultFormatDate,
@@ -129,6 +137,11 @@ export function AuthUserList({
       data-pyric-user-uid={user.uid}
       data-pyric-user-disabled={user.disabled ? '' : undefined}
     >
+      {renderSelection ? (
+        <span role="cell" data-pyric-user-cell="selection">
+          {renderSelection(user)}
+        </span>
+      ) : null}
       <span role="cell" data-pyric-user-cell="identifier">
         {onSelect ? (
           <button type="button" data-pyric-user-select onClick={() => onSelect(user)}>
@@ -165,8 +178,15 @@ export function AuthUserList({
       aria-label="Authentication users"
       data-pyric-ui="auth-user-list"
       data-pyric-virtualized={virtualized ? '' : undefined}
+      data-pyric-selection={renderSelection ? '' : undefined}
+      data-pyric-actions={renderActions ? '' : undefined}
     >
       <div role="row" data-pyric-user-header>
+        {renderSelection ? (
+          <span role="columnheader" data-pyric-user-cell="selection" aria-label="Selection">
+            {renderSelectionHeader}
+          </span>
+        ) : null}
         <span role="columnheader" data-pyric-user-cell="identifier">Identifier</span>
         <span role="columnheader" data-pyric-user-cell="providers">Provider</span>
         <span role="columnheader" data-pyric-user-cell="created">Created</span>

--- a/packages/ui/src/auth/components/AuthUserList.tsx
+++ b/packages/ui/src/auth/components/AuthUserList.tsx
@@ -24,6 +24,9 @@ export interface AuthUserListProps {
   /** Per-row action slot (edit / disable / delete menu). Rendered in a
    *  trailing cell; column header is added when this is provided. */
   renderActions?: (user: AuthUserRecord) => ReactNode;
+  /** Optional content for the trailing actions column header (for example,
+   *  a select-all checkbox). Only rendered with `renderActions`. */
+  renderActionsHeader?: ReactNode;
   /** Timestamp formatter for Created / Signed In. Default: locale date,
    *  em dash for null. */
   formatDate?: (iso: string | null) => ReactNode;
@@ -81,6 +84,7 @@ export function AuthUserList({
   renderIdentifier,
   renderProviders,
   renderActions,
+  renderActionsHeader,
   formatDate = defaultFormatDate,
   emptyState,
   noResultsState,
@@ -169,7 +173,9 @@ export function AuthUserList({
         <span role="columnheader" data-pyric-user-cell="signed-in">Signed In</span>
         <span role="columnheader" data-pyric-user-cell="uid">User UID</span>
         {renderActions ? (
-          <span role="columnheader" data-pyric-user-cell="actions" aria-label="Actions" />
+          <span role="columnheader" data-pyric-user-cell="actions" aria-label="Actions">
+            {renderActionsHeader}
+          </span>
         ) : null}
       </div>
       {virtualized ? (

--- a/packages/ui/src/storage/components/ObjectBrowser.tsx
+++ b/packages/ui/src/storage/components/ObjectBrowser.tsx
@@ -41,6 +41,9 @@ export interface ObjectBrowserProps {
    * component — the slot only owns the label content.
    */
   renderEntry?: (entry: StorageListEntry) => ReactNode;
+  /** Optional per-row action rendered as a sibling of the navigation/select
+   *  button. Use this for independent controls such as selection checkboxes. */
+  renderRowAction?: (entry: StorageListEntry) => ReactNode;
   emptyState?: ReactNode;
   className?: string;
   /**
@@ -76,6 +79,7 @@ export interface ObjectBrowserProps {
  *   (rules gate; reason on `data-pyric-denied-reason`)
  * - `[data-pyric-entry-select]` — the row button
  * - `[data-pyric-entry-select][data-pyric-selected]` — the selected object
+ * - `[data-pyric-storage-action]` — optional sibling row action
  */
 export function ObjectBrowser({
   entries,
@@ -86,6 +90,7 @@ export function ObjectBrowser({
   selectedPath,
   gate,
   renderEntry,
+  renderRowAction,
   emptyState,
   className,
   virtualizeThreshold = 100,
@@ -138,19 +143,24 @@ export function ObjectBrowser({
   const renderRow = (entry: StorageListEntry) => {
     const selected = entry.kind === 'object' && entry.fullPath === selectedPath;
     return (
-      <button
-        type="button"
-        onClick={() =>
-          entry.kind === 'folder'
-            ? onNavigate?.(entry.fullPath)
-            : onSelect?.(entry.ref)
-        }
-        data-pyric-entry-select
-        data-pyric-selected={selected ? '' : undefined}
-        aria-selected={selected || undefined}
-      >
-        {renderEntry ? renderEntry(entry) : entry.name}
-      </button>
+      <>
+        <button
+          type="button"
+          onClick={() =>
+            entry.kind === 'folder'
+              ? onNavigate?.(entry.fullPath)
+              : onSelect?.(entry.ref)
+          }
+          data-pyric-entry-select
+          data-pyric-selected={selected ? '' : undefined}
+          aria-selected={selected || undefined}
+        >
+          {renderEntry ? renderEntry(entry) : entry.name}
+        </button>
+        {renderRowAction ? (
+          <span data-pyric-storage-action>{renderRowAction(entry)}</span>
+        ) : null}
+      </>
     );
   };
 

--- a/packages/ui/src/storage/folderPlaceholder.ts
+++ b/packages/ui/src/storage/folderPlaceholder.ts
@@ -19,11 +19,22 @@ export function folderPlaceholderRef(
     storage,
     bucket: folder.bucket,
     fullPath: `${folder.fullPath}/`,
-    // GCS semantics: the segment after the final slash — empty for a
-    // placeholder.
     name: '',
     parent: folder,
     root: folder.root,
     toString: () => `${folder.toString()}/`,
+  };
+}
+
+/** Preserve whichever backend identity a reference carries (in-process
+ *  storage handle or worker MessagePort) while targeting its trailing-slash
+ *  GCS folder placeholder. */
+export function asFolderPlaceholder<T extends { fullPath: string; name: string }>(
+  folder: T,
+): T {
+  return {
+    ...folder,
+    fullPath: `${folder.fullPath}/`,
+    name: '',
   };
 }

--- a/packages/ui/src/storage/hooks/useStorageDelete.ts
+++ b/packages/ui/src/storage/hooks/useStorageDelete.ts
@@ -1,14 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
 import {
-  deleteObject,
-  listAll,
-  ref as refFn,
+  deleteObject as defaultDeleteObject,
+  listAll as defaultListAll,
   type FirebaseStorage,
   type StorageReference,
 } from 'pyric/storage';
-import { folderPlaceholderRef } from '../folderPlaceholder.js';
 import type { StorageSelectionEntry } from './useStorageSelection.js';
 import type { UseStorageListResult } from './useStorageList.js';
+import { useStorageApi, type StorageApi } from '../storageApi.js';
+import { asFolderPlaceholder } from '../folderPlaceholder.js';
 
 export interface StorageDeleteProgress {
   /** Objects deleted so far in this folder walk. */
@@ -39,26 +39,32 @@ export interface StorageRecursiveDeleteImpl {
  * so the walk alone would leave ghost folders). Placeholder sweeps
  * are best-effort — `deletedCount` counts listed objects only.
  */
-export function createListAllDeleteImpl(): StorageRecursiveDeleteImpl {
+export function createListAllDeleteImpl(
+  api?: Pick<StorageApi, 'listAll' | 'deleteObject'>,
+): StorageRecursiveDeleteImpl {
   return {
     async *start(target: StorageReference) {
+      const operations = api ?? {
+        listAll: defaultListAll,
+        deleteObject: defaultDeleteObject,
+      };
       let deletedCount = 0;
       const stack: StorageReference[] = [target];
       const visited: StorageReference[] = [];
       while (stack.length > 0) {
         const folder = stack.pop()!;
         visited.push(folder);
-        const result = await listAll(folder);
+        const result = await operations.listAll(folder);
         stack.push(...result.prefixes);
         for (const item of result.items) {
-          await deleteObject(item);
+          await operations.deleteObject(item);
           deletedCount++;
           yield { deletedCount, done: false };
         }
       }
       for (const folder of visited) {
         try {
-          await deleteObject(folderPlaceholderRef(folder.storage, folder.fullPath));
+          await operations.deleteObject(asFolderPlaceholder(folder));
         } catch {
           // Best-effort: a strict backend may reject the structural
           // placeholder or throw not-found. Neither should fail the
@@ -122,6 +128,7 @@ export function useStorageDelete(
   storage: FirebaseStorage | null | undefined,
   options: UseStorageDeleteOptions = {},
 ): UseStorageDeleteResult {
+  const api = useStorageApi();
   const [progress, setProgress] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);
@@ -139,7 +146,7 @@ export function useStorageDelete(
       const outcome: StorageDeleteOutcome = { deleted: [], failed: [] };
       if (storage == null || entries.length === 0) return outcome;
       setIsRunning(true);
-      const impl = optionsRef.current.impl ?? createListAllDeleteImpl();
+      const impl = optionsRef.current.impl ?? createListAllDeleteImpl(api);
       let count = 0;
       try {
         for (const entry of entries) {
@@ -147,10 +154,10 @@ export function useStorageDelete(
           optionsRef.current.list?.removeItem(entry.fullPath);
           try {
             if (entry.kind === 'object') {
-              await deleteObject(refFn(storage, entry.fullPath));
+              await api.deleteObject(api.ref(storage, entry.fullPath));
               count++;
             } else {
-              for await (const evt of impl.start(refFn(storage, entry.fullPath))) {
+              for await (const evt of impl.start(api.ref(storage, entry.fullPath))) {
                 if (myGen !== generationRef.current) return outcome;
                 // The impl reports counts local to its walk; add the
                 // objects already deleted by earlier entries.
@@ -181,7 +188,7 @@ export function useStorageDelete(
         if (myGen === generationRef.current) setIsRunning(false);
       }
     },
-    [storage],
+    [api, storage],
   );
 
   return { deleteEntries, progress, isRunning, error };

--- a/packages/ui/src/storage/pendingPrefixes.ts
+++ b/packages/ui/src/storage/pendingPrefixes.ts
@@ -46,6 +46,8 @@ export type PendingPrefixAction =
   /** An object now exists directly under `path`: drop `path` and its
    *  ancestors from pending (they are real prefixes now). */
   | { type: 'materialize'; path: string }
+  /** Remove a session-only folder and every pending descendant beneath it. */
+  | { type: 'discard'; path: string }
   | { type: 'clear' };
 
 /** `'a/b/c'` → `['a', 'a/b', 'a/b/c']`; `''` → `[]`. */
@@ -72,6 +74,12 @@ export function pendingPrefixReducer(
       const real = new Set(expandPathChain(action.path));
       if (real.size === 0) return state;
       const next = state.filter((p) => !real.has(p));
+      return next.length === state.length ? state : next;
+    }
+    case 'discard': {
+      const path = normalizeStoragePath(action.path);
+      if (path === '') return state;
+      const next = state.filter((entry) => entry !== path && !entry.startsWith(`${path}/`));
       return next.length === state.length ? state : next;
     }
     case 'clear':

--- a/packages/ui/src/storage/storageApi.ts
+++ b/packages/ui/src/storage/storageApi.ts
@@ -1,5 +1,5 @@
 import { createContext, createElement, useContext, type ReactNode } from 'react';
-import { ref, listAll, getMetadata, getBlob, uploadBytes } from 'pyric/storage';
+import { ref, listAll, getMetadata, getBlob, uploadBytes, deleteObject } from 'pyric/storage';
 
 /**
  * The modular Storage fns the browse/inspect hooks call, as an INJECTABLE
@@ -23,10 +23,17 @@ import { ref, listAll, getMetadata, getBlob, uploadBytes } from 'pyric/storage';
  */
 export type StorageApi = Pick<
   typeof import('pyric/storage'),
-  'ref' | 'listAll' | 'getMetadata' | 'getBlob' | 'uploadBytes'
+  'ref' | 'listAll' | 'getMetadata' | 'getBlob' | 'uploadBytes' | 'deleteObject'
 >;
 
-const inProcessStorageApi: StorageApi = { ref, listAll, getMetadata, getBlob, uploadBytes };
+const inProcessStorageApi: StorageApi = {
+  ref,
+  listAll,
+  getMetadata,
+  getBlob,
+  uploadBytes,
+  deleteObject,
+};
 
 const StorageApiContext = createContext<StorageApi>(inProcessStorageApi);
 

--- a/packages/ui/test/auth/components/AuthUserList.test.tsx
+++ b/packages/ui/test/auth/components/AuthUserList.test.tsx
@@ -52,6 +52,7 @@ describe('<AuthUserList>', () => {
     const { container } = render(
       <AuthUserList
         users={[user({ uid: 'u1' })]}
+        renderActionsHeader={<span data-actions-header>Select</span>}
         renderActions={(u) => <button data-row-action>{u.uid}</button>}
       />,
     );
@@ -59,6 +60,7 @@ describe('<AuthUserList>', () => {
     expect(
       (container.querySelector('[data-row-action]') as HTMLElement).textContent,
     ).toBe('u1');
+    expect(container.querySelector('[data-actions-header]')?.textContent).toBe('Select');
   });
 
   it('renders one row per user with identifier fallbacks + provider labels', () => {

--- a/packages/ui/test/auth/components/AuthUserList.test.tsx
+++ b/packages/ui/test/auth/components/AuthUserList.test.tsx
@@ -63,6 +63,36 @@ describe('<AuthUserList>', () => {
     expect(container.querySelector('[data-actions-header]')?.textContent).toBe('Select');
   });
 
+  it('renders selection before identifiers while keeping actions trailing', () => {
+    const { container } = render(
+      <AuthUserList
+        users={[user({ uid: 'u1' })]}
+        renderSelectionHeader={<span data-selection-header>Select all</span>}
+        renderSelection={(u) => <input data-row-selection aria-label={`Select ${u.uid}`} />}
+        renderActions={(u) => <button data-row-action>{u.uid}</button>}
+      />,
+    );
+
+    const headerCells = Array.from(
+      container.querySelectorAll('[data-pyric-user-header] [data-pyric-user-cell]'),
+    ).map((cell) => cell.getAttribute('data-pyric-user-cell'));
+    const rowCells = Array.from(
+      container.querySelectorAll('[data-pyric-user-entry] [data-pyric-user-cell]'),
+    ).map((cell) => cell.getAttribute('data-pyric-user-cell'));
+
+    expect(headerCells).toEqual([
+      'selection',
+      'identifier',
+      'providers',
+      'created',
+      'signed-in',
+      'uid',
+      'actions',
+    ]);
+    expect(rowCells).toEqual(headerCells);
+    expect(container.querySelector('[data-selection-header]')?.textContent).toBe('Select all');
+  });
+
   it('renders one row per user with identifier fallbacks + provider labels', () => {
     const users = [
       user({ uid: 'u1', email: 'a@example.com', providerUserInfo: [{ providerId: 'google.com' }] }),

--- a/packages/ui/test/storage/components/DeleteSelectionWithConfirm.test.tsx
+++ b/packages/ui/test/storage/components/DeleteSelectionWithConfirm.test.tsx
@@ -38,7 +38,9 @@ import { ConfirmProvider } from '../../../src/primitives/useConfirm.js';
 import { ToastProvider } from '../../../src/primitives/Toast.js';
 import {
   DeleteSelectionWithConfirm,
+  StorageApiProvider,
   useStorageRulesGate,
+  type StorageApi,
   type StorageRecursiveDeleteImpl,
 } from '../../../src/storage/index.js';
 
@@ -132,6 +134,51 @@ describe('DeleteSelectionWithConfirm', () => {
     const listed = await listAll(ref(storage, 'docs'));
     expect(listed.items).toEqual([]);
     expect(listed.prefixes).toEqual([]);
+  });
+
+  it('uses the injected Storage API for worker-backed file and folder deletion', async () => {
+    const deleted: string[] = [];
+    const storage = { __kind: 'client-storage' } as unknown as FirebaseStorage;
+    const makeRef = (fullPath: string) => ({
+      storage,
+      fullPath,
+      name: fullPath.split('/').at(-1) ?? '',
+      bucket: 'pyric-default',
+    });
+    const api = {
+      ref: (_storage: FirebaseStorage, fullPath = '') => makeRef(fullPath),
+      listAll: async (target: { fullPath: string }) =>
+        target.fullPath === 'docs/sub'
+          ? { prefixes: [], items: [makeRef('docs/sub/nested.txt')] }
+          : { prefixes: [], items: [] },
+      deleteObject: async (target: { fullPath: string }) => {
+        deleted.push(target.fullPath);
+      },
+      getMetadata: async () => ({}),
+      getBlob: async () => new Blob(),
+      uploadBytes: async () => ({}),
+    } as unknown as StorageApi;
+
+    render(
+      withProviders(
+        <StorageApiProvider value={api}>
+          <DeleteSelectionWithConfirm
+            storage={storage}
+            entries={[
+              { kind: 'object', fullPath: 'docs/a.txt' },
+              { kind: 'folder', fullPath: 'docs/sub' },
+            ]}
+          />
+        </StorageApiProvider>,
+      ),
+    );
+
+    fireEvent.click(q('[data-pyric-ui="delete-selection"]')!);
+    await waitFor(() => expect(q('[data-pyric-ui="confirm-dialog"]')).not.toBeNull());
+    fireEvent.click(q('[data-pyric-confirm-confirm]')!);
+
+    await waitFor(() => expect(deleted).toContain('docs/a.txt'));
+    expect(deleted).toContain('docs/sub/nested.txt');
   });
 
   it('failures toast an error listing each failed path', async () => {

--- a/packages/ui/test/storage/components/ObjectBrowser.test.tsx
+++ b/packages/ui/test/storage/components/ObjectBrowser.test.tsx
@@ -121,6 +121,32 @@ describe('ObjectBrowser', () => {
     expect(navigated).toEqual(['docs/sub']);
   });
 
+  it('renders row actions beside the navigation button', () => {
+    const navigated: string[] = [];
+    const acted: string[] = [];
+    const { container } = render(
+      <ObjectBrowser
+        entries={ENTRIES}
+        onNavigate={(p) => navigated.push(p)}
+        renderRowAction={(entry) => (
+          <button type="button" onClick={() => acted.push(entry.fullPath)}>
+            Select
+          </button>
+        )}
+      />,
+    );
+
+    const firstRow = container.querySelector('[data-pyric-storage-entry]')!;
+    const action = firstRow.querySelector('[data-pyric-storage-action] button')!;
+    fireEvent.click(action);
+
+    expect(acted).toEqual(['docs/sub']);
+    expect(navigated).toEqual([]);
+    expect(
+      action.parentElement?.previousElementSibling?.hasAttribute('data-pyric-entry-select'),
+    ).toBe(true);
+  });
+
   it('renders loading, idle, empty, and error states', () => {
     const { container: loading } = render(
       <ObjectBrowser entries={[]} status="loading" />,

--- a/packages/ui/test/storage/logic/pendingPrefixes.test.ts
+++ b/packages/ui/test/storage/logic/pendingPrefixes.test.ts
@@ -16,6 +16,8 @@ const create = (state: PendingPrefixState, path: string) =>
   pendingPrefixReducer(state, { type: 'create', path });
 const materialize = (state: PendingPrefixState, path: string) =>
   pendingPrefixReducer(state, { type: 'materialize', path });
+const discard = (state: PendingPrefixState, path: string) =>
+  pendingPrefixReducer(state, { type: 'discard', path });
 
 describe('expandPathChain', () => {
   it('expands every ancestor level', () => {
@@ -62,6 +64,12 @@ describe('pendingPrefixReducer', () => {
   it('materialize at root is a no-op', () => {
     const state = create(initialPendingPrefixes, 'a');
     expect(materialize(state, '')).toBe(state);
+  });
+
+  it('discard removes an empty pending folder and its descendants', () => {
+    let state = create(initialPendingPrefixes, 'stuff/things/cool');
+    state = create(state, 'stuff/keep');
+    expect(discard(state, 'stuff/things')).toEqual(['stuff', 'stuff/keep']);
   });
 
   it('clear empties', () => {


### PR DESCRIPTION
Makes destructive actions in Pyric Studio explicit and selectable across Firestore, Storage, and Auth.

```text
Firestore > users > alice > Delete
☐ Also delete subcollections
Delete document
→ users/alice is removed; users/alice/posts remains

Firestore > users > alice > Delete
☑ Also delete subcollections
Delete document
→ users/alice and every nested subcollection are removed

Storage > photos/
☑ Select all
Delete selected
→ Every selected file and directory is removed; selected directories are recursive

Auth > filter users by "example.com"
☑ Select all
Delete selected
→ Only users still visible through that filter are removed
```

## Firestore document deletes preserve subcollections unless recursive deletion is selected

Document and field confirmations now use the shared centered modal instead of rendering unstyled controls at the page edge. Every document-delete entry point presents the same unchecked recursive option, collection deletion propagates failures instead of navigating away, and worker-backed snapshots carry the complete document reference required by `deleteDoc`.

The documents-panel Import JSON action is removed because it was both uncommon and difficult to use.

## Storage and Auth delete exactly the current selection

Storage rows and Auth users now expose individual selection and select-all controls. Storage selection can include files and directories; directory deletion walks descendants before removing the placeholder. Auth selection is continuously intersected with the filtered result set, so changing a filter cannot leave hidden users queued for deletion.

## Standalone Studio development serves its worker and embedded Playground

```sh
cd packages/studio
bun run dev -- --port 5180
curl -I http://127.0.0.1:5180/__pyric/sdk/worker.js
# HTTP 200; Content-Type: text/javascript

curl http://127.0.0.1:5180/__pyric/playground/?embed=studio
# <title>Playground — Home</title>
```

The Studio Vite config now mounts the Pyric runtime namespace and packaged UI routes during development. The SharedWorker URL returns JavaScript instead of Vite's `index.html` fallback, so RTDB and the other live services connect normally.

The packaged UI mount is also load-bearing for Prototype: with it disabled, `/__pyric/playground/` fell through to Studio's own HTML. Studio then mounted its hidden Prototype iframe inside that response, recursively loading another Studio and roughly 337 modules every 600–850 ms. The route now returns the real Playground app, bounding the frame tree at one iframe. Review sessions still suppress capture-file writes, and the plugin remains inactive for production builds.

## Risk

- Recursive Storage and Firestore deletion is intentionally destructive and can enumerate large trees. The Firestore option defaults off, while Storage requires explicit row selection and confirmation.
- Auth deletion can partially succeed when a backend request fails. Failed user IDs remain selected so the operator can retry without reselecting successful deletions.
- The confirmation portal receives shared Studio styling; reviewers should check that existing confirmation dialogs still match their surrounding surfaces.
- Standalone Studio development now owns the reserved `/__pyric/*` namespace, serves the packaged Playground/Studio assets there, and performs a cold worker bundle on the first start.

<details>
<summary>Implementation notes and verification</summary>

- Added complete worker `DocRefHandle` reconstruction so query snapshots can be passed directly to Firestore writes.
- Routed Storage deletion through the injected Storage API, including worker-backed `deleteObject`.
- Added reusable Firestore document-delete and Auth bulk-delete flows, plus row-action extension points in the shared UI package.
- Added Studio Vite-config regressions requiring the runtime worker and the UI mount that owns `/__pyric/playground/`.
- The affected HAR contained 1,398 complete requests in 2.172 seconds: one Studio document followed by three recursively embedded Studio documents and their module graphs.
- The live worker endpoint returned a 770 KB JavaScript bundle with no HTML fallback; the Playground URL returned the distinct built Playground document and all checked assets returned 200.
- Browser verification held at one iframe after three seconds with no errors; RTDB reached its live root.
- Full workspace test command passed for the deletion changes.
- Studio tests: 305 passed, 0 failed across 34 files.
- Studio production build passed; Vite retains the existing large-chunk warning.
- Affected Studio, UI, and worker typechecks/builds passed.
- Independent standards and specification reviews found no remaining deletion-flow issues.

</details>
