### PR TITLE
refactor(credentials): make project scope independent of deployment

### DIFF
--- a/packages/playground/scripts/authorize-domain.ts
+++ b/packages/playground/scripts/authorize-domain.ts
@@ -18,7 +18,7 @@
  *   bun scripts/authorize-domain.ts --domain=staging.example.com
  *   bun scripts/authorize-domain.ts --list   # just print current list
  */
-import { fromServiceAccount } from '@pyric/cli/deploy';
+import { fromServiceAccount } from '@pyric/cli/credentials/node';
 import { ManageDomainsHandler } from '@pyric/cli/auth';
 
 const DEFAULT_DOMAIN = 'pyric-playground.web.app';

--- a/packages/playground/scripts/fn-logs.ts
+++ b/packages/playground/scripts/fn-logs.ts
@@ -18,7 +18,7 @@
  *   bun scripts/fn-logs.ts --since=1h     # last hour
  *   bun scripts/fn-logs.ts --since=45m
  */
-import { fromServiceAccount } from '@pyric/cli/deploy';
+import { fromServiceAccount } from '@pyric/cli/credentials/node';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/pyric-tools/src/auth/domains/handler.ts
+++ b/packages/pyric-tools/src/auth/domains/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../credentials/core/types.js';
 import type { ManageDomainsInput, ManageDomainsResult } from './spec.js';
 
 export class ManageDomainsHandler {

--- a/packages/pyric-tools/src/auth/provider/handler.ts
+++ b/packages/pyric-tools/src/auth/provider/handler.ts
@@ -1,4 +1,4 @@
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../credentials/core/types.js';
 import type { ConfigureProviderInput, ConfigureAuthResult, ProviderId } from './spec.js';
 
 export class ConfigureProviderHandler {

--- a/packages/pyric-tools/src/auth/resolver.ts
+++ b/packages/pyric-tools/src/auth/resolver.ts
@@ -10,7 +10,7 @@
  * inlines here as a thin Bearer-token fetch wrapper — that's all the
  * old `app.fetchIdentityToolkit` was.
  */
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../credentials/core/types.js';
 import type { AuthTools, AuthIR } from './types.js';
 import { AuthMapper } from './mapper.js';
 import { ConfigureProviderHandler } from './provider/handler.js';

--- a/packages/pyric-tools/src/auth/tools.ts
+++ b/packages/pyric-tools/src/auth/tools.ts
@@ -15,7 +15,7 @@
  * surface.
  */
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../credentials/core/types.js';
 import { getAuthTools } from './resolver.js';
 import type { ConfigureProviderInput } from './provider/spec.js';
 import type { ManageDomainsInput } from './domains/spec.js';

--- a/packages/pyric-tools/src/cli/auth.ts
+++ b/packages/pyric-tools/src/cli/auth.ts
@@ -14,7 +14,7 @@
 
 import { getAuthTools, type AuthTools } from '../auth/index.js';
 import type { ParsedArgs } from './parse-args.js';
-import type { ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 import { resolveScope } from './scope.js';
 import { readFirebaseRc } from './firebase-json.js';
 

--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -29,7 +29,7 @@ import {
 import { runAuthConfigureProvider, runAuthManageDomains } from './auth.js';
 import { runFirestoreDiscover } from './discover.js';
 import { runInit } from './init.js';
-import type { ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 
 // ── Test helpers ──────────────────────────────────────────────────────
 

--- a/packages/pyric-tools/src/cli/discover.ts
+++ b/packages/pyric-tools/src/cli/discover.ts
@@ -22,7 +22,7 @@ import {
   type CollectionSchema,
 } from '../discover/index.js';
 import type { ParsedArgs } from './parse-args.js';
-import type { ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 import { resolveScope } from './scope.js';
 import { readFirebaseRc } from './firebase-json.js';
 

--- a/packages/pyric-tools/src/cli/scope.ts
+++ b/packages/pyric-tools/src/cli/scope.ts
@@ -16,13 +16,17 @@
  * and 5 report `'all'` (non-interactive — no incremental upgrade); only an
  * interactive login carries the narrow granted set that drives the upgrade.
  */
-import type { ProjectScope } from '../deploy/index.js';
-import { fromServiceAccount } from '../deploy/index.js';
 import { fromUserCredential } from '../credentials/core/from-user-credential.js';
 import { oauthClient } from '../credentials/core/client.js';
 import { fileCredentialStore, defaultCredentialPath } from '../credentials/node/file-store.js';
 import { fromAdc } from '../credentials/node/from-adc.js';
-import type { CredentialStore, OAuthClient, StoredCredential } from '../credentials/core/types.js';
+import { fromServiceAccount } from '../credentials/node/from-service-account.js';
+import type {
+  CredentialStore,
+  OAuthClient,
+  ProjectScope,
+  StoredCredential,
+} from '../credentials/core/types.js';
 
 /** Registered Google OAuth client baked for the published binary; env-overridable. */
 const DEFAULT_OAUTH_CLIENT_ID = '';

--- a/packages/pyric-tools/src/credentials/core/from-user-credential.ts
+++ b/packages/pyric-tools/src/credentials/core/from-user-credential.ts
@@ -7,7 +7,7 @@
  * `projectId` is passed in (a user has many projects; the project comes from
  * `--project` / `.firebaserc` via `resolveScope`, not from the credential).
  */
-import { memoizeTtl } from '../../deploy/memoize-ttl.js';
+import { memoizeTtl } from './memoize-ttl.js';
 import type { ProjectScope, StoredCredential, OAuthClient } from './types.js';
 import { exchangeRefreshToken } from './exchange.js';
 

--- a/packages/pyric-tools/src/credentials/core/memoize-ttl.ts
+++ b/packages/pyric-tools/src/credentials/core/memoize-ttl.ts
@@ -1,5 +1,5 @@
 /**
- * `memoizeTtl` — host-side caching wrapper for resolver functions.
+ * Host-side caching wrapper for credential resolvers.
  *
  * Per F4, the SDK convention is "resolvers fire per-dispatch; hosts
  * memoize via `memoizeTtl` if cost matters." This is that memoizer.

--- a/packages/pyric-tools/src/credentials/core/types.ts
+++ b/packages/pyric-tools/src/credentials/core/types.ts
@@ -4,9 +4,16 @@
  * seams the tests fake and the env adapters implement (node/ loopback + file,
  * browser/ popup + IndexedDB).
  */
-import type { ProjectScope } from '../../deploy/scope.js';
-
-export type { ProjectScope };
+/**
+ * Project identity plus a fresh-enough Google OAuth token resolver.
+ *
+ * The identity is stable for the lifetime of an operation while token
+ * acquisition remains lazy so long-running commands can refresh credentials.
+ */
+export interface ProjectScope {
+  readonly projectId: string;
+  resolveToken(): Promise<string>;
+}
 
 /** A Google OAuth client (a "Desktop" installed-app client). The secret is
  *  bundled, not confidential — PKCE is the real protection. */

--- a/packages/pyric-tools/src/credentials/index.ts
+++ b/packages/pyric-tools/src/credentials/index.ts
@@ -10,4 +10,4 @@ export { exchangeAuthCode, exchangeRefreshToken, AuthExpired } from './core/exch
 export { oauthClient, GOOGLE_AUTH_URI, GOOGLE_TOKEN_URI } from './core/client.js';
 export { SCOPES, BASE_SCOPES, missingScope } from './core/scopes.js';
 export { startAuth, completeAuth, refreshAccess } from './server/bff.js';
-export type { OAuthClient, StoredCredential, TokenResponse } from './core/types.js';
+export type { OAuthClient, ProjectScope, StoredCredential, TokenResponse } from './core/types.js';

--- a/packages/pyric-tools/src/credentials/node/admin-app-scope.ts
+++ b/packages/pyric-tools/src/credentials/node/admin-app-scope.ts
@@ -1,0 +1,47 @@
+/**
+ * Build a `ProjectScope` from an already-initialized
+ * firebase-admin App. Mirrors the modular Web SDK's `getFirestore(app)` /
+ * `getAuth(app)` shape so Firebase devs reach for it without learning
+ * a new credential lifecycle.
+ *
+ * The App must have been initialized with a `cert(...)` credential
+ * (i.e. via a service-account key). For raw base64 SA env vars without
+ * a firebase-admin App in hand, use {@link fromServiceAccount} from
+ * the Node credential surface — it builds the ProjectScope without touching
+ * firebase-admin.
+ *
+ * Resolves the OAuth access token via the credential's internal
+ * `getAccessToken()` (the stable accessor used by firebase tooling).
+ * Wraps in `memoizeTtl` so consumers get caching for free.
+ */
+import type { App as AdminApp } from 'firebase-admin/app';
+import { memoizeTtl } from '../core/memoize-ttl.js';
+import type { ProjectScope } from '../core/types.js';
+
+interface CredentialWithToken {
+  getAccessToken(): Promise<{ access_token: string; expires_in: number }>;
+}
+
+export function projectScopeFromAdminApp(
+  app: AdminApp,
+  caller = 'projectScopeFromAdminApp',
+): ProjectScope {
+  const projectId = app.options.projectId;
+  if (!projectId) {
+    throw new Error(
+      `${caller}: firebase-admin App has no projectId. Initialize with \`projectId\` in the options.`,
+    );
+  }
+  const credential = app.options.credential as unknown as CredentialWithToken | undefined;
+  if (!credential || typeof credential.getAccessToken !== 'function') {
+    throw new Error(
+      `${caller}: firebase-admin App was not initialized with a cert credential ` +
+        '(no `getAccessToken` on app.options.credential). Use admin.credential.cert(saCert) at init time.',
+    );
+  }
+  const resolveToken = memoizeTtl(async () => {
+    const tokenObj = await credential.getAccessToken();
+    return { token: tokenObj.access_token, expiresIn: tokenObj.expires_in };
+  });
+  return { projectId, resolveToken };
+}

--- a/packages/pyric-tools/src/credentials/node/from-adc.ts
+++ b/packages/pyric-tools/src/credentials/node/from-adc.ts
@@ -13,8 +13,8 @@ import { homedir } from 'node:os';
 import type { ProjectScope } from '../core/types.js';
 import { oauthClient } from '../core/client.js';
 import { exchangeRefreshToken } from '../core/exchange.js';
-import { fromServiceAccount } from '../../deploy/from-service-account.js';
-import { memoizeTtl } from '../../deploy/memoize-ttl.js';
+import { memoizeTtl } from '../core/memoize-ttl.js';
+import { fromServiceAccount } from './from-service-account.js';
 
 /** The well-known ADC file path (honours CLOUDSDK_CONFIG; %APPDATA% on Windows). */
 export function adcWellKnownPath(env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/pyric-tools/src/credentials/node/from-service-account.ts
+++ b/packages/pyric-tools/src/credentials/node/from-service-account.ts
@@ -1,5 +1,5 @@
 /**
- * `fromServiceAccount` — build a `ProjectScope` from a Google service
+ * Build a `ProjectScope` from a Google service
  * account JSON file. Exchanges the SA key for a short-lived OAuth
  * access token via the standard JWT-bearer flow, and wires
  * `memoizeTtl` internally so consumers get caching for free.
@@ -7,17 +7,14 @@
  * No `firebase-admin` dependency — uses only Node's built-in
  * `crypto` for RS256 signing and `fetch` for the token exchange.
  *
- * **Node-only inside a browser-safe package**: the function itself
+ * **Node-only credential adapter**: the function itself
  * requires `node:fs/promises` + `node:crypto`. Those modules are
  * imported via dynamic `import()` inside the function body so the
- * top-level @pyric/cli/deploy entry stays browser-bundle safe. A
- * browser host that imports `@pyric/cli/deploy` but never calls
- * `fromServiceAccount` will not have `node:*` modules in its
- * bundle graph.
+ * `@pyric/cli/credentials` entry stays browser-bundle safe.
  */
 
-import type { ProjectScope } from './scope.js';
-import { memoizeTtl } from './memoize-ttl.js';
+import { memoizeTtl } from '../core/memoize-ttl.js';
+import type { ProjectScope } from '../core/types.js';
 
 const GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token';
 const SCOPE = [

--- a/packages/pyric-tools/src/credentials/node/index.ts
+++ b/packages/pyric-tools/src/credentials/node/index.ts
@@ -12,3 +12,4 @@ export {
 } from './resolve-local-token.js';
 export { fileCredentialStore, defaultCredentialPath } from './file-store.js';
 export { fromAdc } from './from-adc.js';
+export { fromServiceAccount } from './from-service-account.js';

--- a/packages/pyric-tools/src/credentials/node/resolve-local-token.ts
+++ b/packages/pyric-tools/src/credentials/node/resolve-local-token.ts
@@ -17,12 +17,12 @@
  * `gcloud auth application-default login`" hint). Node-only: reads credential
  * files via the existing `credentials/` adapters — never by hand.
  */
-import { fromServiceAccount } from '../../deploy/index.js';
 import { oauthClient } from '../core/client.js';
 import { fromUserCredential } from '../core/from-user-credential.js';
 import type { CredentialStore, ProjectScope } from '../core/types.js';
 import { defaultCredentialPath, fileCredentialStore } from './file-store.js';
 import { fromAdc } from './from-adc.js';
+import { fromServiceAccount } from './from-service-account.js';
 
 export type LocalCredentialSource = 'service-account' | 'login' | 'adc';
 

--- a/packages/pyric-tools/src/deploy/from-admin-app.ts
+++ b/packages/pyric-tools/src/deploy/from-admin-app.ts
@@ -16,7 +16,7 @@
  */
 import type { App as AdminApp } from 'firebase-admin/app';
 import type { ProjectScope } from './scope.js';
-import { memoizeTtl } from './memoize-ttl.js';
+import { memoizeTtl } from '../credentials/core/memoize-ttl.js';
 
 interface CredentialWithToken {
   getAccessToken(): Promise<{ access_token: string; expires_in: number }>;

--- a/packages/pyric-tools/src/deploy/from-admin-app.ts
+++ b/packages/pyric-tools/src/deploy/from-admin-app.ts
@@ -1,44 +1,8 @@
-/**
- * `getDeploy(app)` — build a `ProjectScope` from an already-initialized
- * firebase-admin App. Mirrors the modular Web SDK's `getFirestore(app)` /
- * `getAuth(app)` shape so Firebase devs reach for it without learning
- * a new entry-point.
- *
- * The App must have been initialized with a `cert(...)` credential
- * (i.e. via a service-account key). For raw base64 SA env vars without
- * a firebase-admin App in hand, use {@link fromServiceAccount} from
- * the same package — it'll build the ProjectScope without touching
- * firebase-admin.
- *
- * Resolves the OAuth access token via the credential's internal
- * `getAccessToken()` (the stable accessor used by firebase tooling).
- * Wraps in `memoizeTtl` so consumers get caching for free.
- */
 import type { App as AdminApp } from 'firebase-admin/app';
-import type { ProjectScope } from './scope.js';
-import { memoizeTtl } from '../credentials/core/memoize-ttl.js';
+import { projectScopeFromAdminApp } from '../credentials/node/admin-app-scope.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 
-interface CredentialWithToken {
-  getAccessToken(): Promise<{ access_token: string; expires_in: number }>;
-}
-
+/** Active deployment-surface spelling; removed with the deployment package. */
 export function getDeploy(app: AdminApp): ProjectScope {
-  const projectId = app.options.projectId;
-  if (!projectId) {
-    throw new Error(
-      'getDeploy: firebase-admin App has no projectId. Initialize with `projectId` in the options.',
-    );
-  }
-  const credential = app.options.credential as unknown as CredentialWithToken | undefined;
-  if (!credential || typeof credential.getAccessToken !== 'function') {
-    throw new Error(
-      'getDeploy: firebase-admin App was not initialized with a cert credential ' +
-        '(no `getAccessToken` on app.options.credential). Use admin.credential.cert(saCert) at init time.',
-    );
-  }
-  const resolveToken = memoizeTtl(async () => {
-    const tokenObj = await credential.getAccessToken();
-    return { token: tokenObj.access_token, expiresIn: tokenObj.expires_in };
-  });
-  return { projectId, resolveToken };
+  return projectScopeFromAdminApp(app, 'getDeploy');
 }

--- a/packages/pyric-tools/src/deploy/index.ts
+++ b/packages/pyric-tools/src/deploy/index.ts
@@ -30,9 +30,9 @@
 
 export type { ProjectScope, Outcome } from './scope.js';
 export { AdminApiError } from './scope.js';
-export { fromServiceAccount } from './from-service-account.js';
+export { fromServiceAccount } from '../credentials/node/from-service-account.js';
 export { getDeploy } from './from-admin-app.js';
-export { memoizeTtl, type MemoizeTtlOptions } from './memoize-ttl.js';
+export { memoizeTtl, type MemoizeTtlOptions } from '../credentials/core/memoize-ttl.js';
 export { withResolvedScope } from './with-resolved-scope.js';
 
 // ─── Named-object namespaces (Slice 3) ───────────────────────────────

--- a/packages/pyric-tools/src/deploy/index.ts
+++ b/packages/pyric-tools/src/deploy/index.ts
@@ -28,7 +28,8 @@
 
 // ─── Foundation (Slice 1) ────────────────────────────────────────────
 
-export type { ProjectScope, Outcome } from './scope.js';
+export type { ProjectScope } from '../credentials/core/types.js';
+export type { Outcome } from './scope.js';
 export { AdminApiError } from './scope.js';
 export { fromServiceAccount } from '../credentials/node/from-service-account.js';
 export { getDeploy } from './from-admin-app.js';

--- a/packages/pyric-tools/src/deploy/scope.ts
+++ b/packages/pyric-tools/src/deploy/scope.ts
@@ -11,36 +11,7 @@
  * - F4: Resolvers fire per-dispatch. Hosts memoize via `memoizeTtl`.
  */
 
-/**
- * Project-level credentials threaded through every control-plane
- * call. One scope object instead of `(token, projectId, …)`
- * signatures everywhere.
- *
- * `projectId` is stable identity — doesn't change for the life of
- * an agent session. `resolveToken` is the host's promise to deliver
- * a fresh-enough OAuth access token (with the `firebase` scope) on
- * demand. Per F4, callers invoke `resolveToken()` inside each
- * primitive call, not at construction time; hosts that care about
- * cost wrap the resolver in `memoizeTtl` (which `fromServiceAccount`
- * does internally).
- *
- * @example
- * ```ts
- * // Browser host — wraps Firebase Auth.
- * const scope: ProjectScope = {
- *   projectId,
- *   resolveToken: () => firebaseAuth.currentUser!.getIdToken(),
- * };
- *
- * // Node host — wraps service-account JWT exchange (already
- * // memoized internally).
- * const scope = await fromServiceAccount(saJsonPath);
- * ```
- */
-export interface ProjectScope {
-  readonly projectId: string;
-  resolveToken(): Promise<string>;
-}
+export type { ProjectScope } from '../credentials/core/types.js';
 
 /**
  * Outcome of an orchestrator. `ok: true` carries result data;

--- a/packages/pyric-tools/src/registry/admin-deps.ts
+++ b/packages/pyric-tools/src/registry/admin-deps.ts
@@ -13,7 +13,8 @@ import { getAuth as getClientAuth, signInWithCustomToken } from 'firebase/auth';
 import { getFirestore as getClientFirestore } from 'firebase/firestore';
 import { getDatabase as getClientDatabase } from 'firebase/database';
 import { initializeDatabaseApp, type RtdbHost } from 'pyric/database';
-import { getDeploy, type ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
+import { projectScopeFromAdminApp } from '../credentials/node/admin-app-scope.js';
 import type { AdminAppDeps } from './compose.js';
 
 export interface AdminDepsResult {
@@ -44,7 +45,7 @@ export function adminDepsFromServiceAccount(opts: {
         projectId: cert.project_id,
       });
 
-  const scope = getDeploy(app);
+  const scope = projectScopeFromAdminApp(app);
   const apiKey = opts.apiKey ?? '';
   const clientApp = initializeClientApp(
     { apiKey, projectId: cert.project_id, authDomain: `${cert.project_id}.firebaseapp.com` },

--- a/packages/pyric-tools/src/registry/compose.ts
+++ b/packages/pyric-tools/src/registry/compose.ts
@@ -13,7 +13,8 @@ import type { App as AdminApp } from 'firebase-admin/app';
 import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
 import type { Firestore as WebFirestore } from 'firebase/firestore';
 import { createToolRegistry, type ToolHandler, type ToolRegistry } from '@inbrowser/agent';
-import { fromServiceAccount, type ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
+import { fromServiceAccount } from '../credentials/node/from-service-account.js';
 import {
   createFirestoreDeployTools,
   createRtdbDeployTools,

--- a/packages/pyric-tools/src/verify/index.ts
+++ b/packages/pyric-tools/src/verify/index.ts
@@ -15,7 +15,7 @@ import {
   type TestResult,
 } from 'pyric/rules/internal';
 import type { RtdbRulesDocument } from 'pyric/rules/internal/rtdb';
-import type { ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 import {
   isRtdbRulesDocument,
   parseRtdbRulesJson,

--- a/packages/pyric-tools/src/verify/tools.ts
+++ b/packages/pyric-tools/src/verify/tools.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from '@inbrowser/agent';
-import type { ProjectScope } from '../deploy/index.js';
+import type { ProjectScope } from '../credentials/core/types.js';
 import {
   deriveRulesTestCases,
   verifyFixture,

--- a/packages/pyric-tools/test/auth/domains/handler.test.ts
+++ b/packages/pyric-tools/test/auth/domains/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { ManageDomainsHandler } from '../../../src/auth/domains/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/credentials/core/types.js';
 
 const originalFetch = global.fetch;
 function restoreFetch() { global.fetch = originalFetch; }

--- a/packages/pyric-tools/test/auth/provider/handler.test.ts
+++ b/packages/pyric-tools/test/auth/provider/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { ConfigureProviderHandler } from '../../../src/auth/provider/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/credentials/core/types.js';
 
 let capturedUrl = '';
 let capturedMethod = '';

--- a/packages/pyric-tools/test/auth/resolver.test.ts
+++ b/packages/pyric-tools/test/auth/resolver.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe, afterEach } from "bun:test";
 import { getAuthTools } from "../../src/auth/resolver.js";
-import type { ProjectScope } from "@pyric/cli/deploy";
+import type { ProjectScope } from '../../src/credentials/core/types.js';
 
 const SCOPE: ProjectScope = {
   projectId: "test-project",

--- a/packages/pyric-tools/test/credentials/node/admin-app-scope.test.ts
+++ b/packages/pyric-tools/test/credentials/node/admin-app-scope.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import type { App as AdminApp } from 'firebase-admin/app';
+
+import { projectScopeFromAdminApp } from '../../../src/credentials/node/admin-app-scope.js';
+
+function adminApp(options: {
+  projectId?: string;
+  credential?: { getAccessToken(): Promise<{ access_token: string; expires_in: number }> };
+}): AdminApp {
+  return { options } as unknown as AdminApp;
+}
+
+describe('projectScopeFromAdminApp', () => {
+  it('resolves and memoizes the app credential token', async () => {
+    let calls = 0;
+    const scope = projectScopeFromAdminApp(
+      adminApp({
+        projectId: 'demo-project',
+        credential: {
+          async getAccessToken() {
+            calls += 1;
+            return { access_token: 'token', expires_in: 3600 };
+          },
+        },
+      }),
+    );
+
+    expect(scope.projectId).toBe('demo-project');
+    expect(await scope.resolveToken()).toBe('token');
+    expect(await scope.resolveToken()).toBe('token');
+    expect(calls).toBe(1);
+  });
+
+  it('requires a project id', () => {
+    expect(() => projectScopeFromAdminApp(adminApp({}))).toThrow(
+      'projectScopeFromAdminApp: firebase-admin App has no projectId',
+    );
+  });
+
+  it('requires a credential token resolver', () => {
+    expect(() => projectScopeFromAdminApp(adminApp({ projectId: 'demo-project' }))).toThrow(
+      'projectScopeFromAdminApp: firebase-admin App was not initialized with a cert credential',
+    );
+  });
+});

--- a/packages/pyric-tools/test/credentials/node/from-service-account.test.ts
+++ b/packages/pyric-tools/test/credentials/node/from-service-account.test.ts
@@ -14,7 +14,7 @@ import { createPublicKey, createVerify, generateKeyPairSync } from 'node:crypto'
 import { writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fromServiceAccount } from '../../src/deploy/index.js';
+import { fromServiceAccount } from '../../../src/credentials/node/from-service-account.js';
 
 const originalFetch = globalThis.fetch;
 beforeEach(() => { globalThis.fetch = originalFetch; });

--- a/packages/pyric-tools/test/credentials/ownership.test.ts
+++ b/packages/pyric-tools/test/credentials/ownership.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SOURCE_ROOT = join(import.meta.dir, '..', '..', 'src');
+const CREDENTIAL_BINDING = /\b(?:ProjectScope|fromServiceAccount|getDeploy|memoizeTtl)\b/;
+const STATIC_DEPENDENCY =
+  /(?:import|export)\s+(?:type\s+)?([\s\S]*?)\s+from\s+['"]([^'"]+)['"];?/g;
+const DYNAMIC_DEPENDENCY = /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+describe('credential ownership', () => {
+  it('keeps retained credential primitives out of deployment imports', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(SOURCE_ROOT)) {
+      const name = relative(SOURCE_ROOT, file);
+      if (name.startsWith('deploy/') || name === 'cli/deploy.ts') continue;
+
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(STATIC_DEPENDENCY)) {
+        const [, bindings = '', specifier = ''] = match;
+        if (
+          specifier.includes('deploy') &&
+          (CREDENTIAL_BINDING.test(bindings) || bindings.includes('*'))
+        ) {
+          offenders.push(`${name}: ${specifier}`);
+        }
+      }
+      for (const match of source.matchAll(DYNAMIC_DEPENDENCY)) {
+        const [, specifier = ''] = match;
+        if (specifier.includes('deploy') && CREDENTIAL_BINDING.test(source)) {
+          offenders.push(`${name}: ${specifier}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/pyric-tools/test/credentials/public-surface.test.ts
+++ b/packages/pyric-tools/test/credentials/public-surface.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { ProjectScope } from '../../src/credentials/index.js';
+import { fromServiceAccount } from '../../src/credentials/node/index.js';
+
+describe('@pyric/cli credential surface', () => {
+  it('builds a frozen project scope from service-account JSON without resolving a token', async () => {
+    const scope: ProjectScope = await fromServiceAccount(
+      JSON.stringify({
+        client_email: 'ci@example.test',
+        private_key: 'unused until resolveToken is called',
+        project_id: 'demo-project',
+      }),
+    );
+
+    expect(scope.projectId).toBe('demo-project');
+    expect(typeof scope.resolveToken).toBe('function');
+    expect(Object.isFrozen(scope)).toBe(true);
+  });
+});

--- a/packages/pyric-tools/test/deploy/from-admin-app.test.ts
+++ b/packages/pyric-tools/test/deploy/from-admin-app.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import type { App as AdminApp } from 'firebase-admin/app';
+
+import { getDeploy } from '../../src/deploy/from-admin-app.js';
+
+describe('getDeploy', () => {
+  it('preserves the active deployment error prefix', () => {
+    const app = { options: {} } as unknown as AdminApp;
+
+    expect(() => getDeploy(app)).toThrow('getDeploy: firebase-admin App has no projectId');
+  });
+});

--- a/packages/pyric-tools/test/verify/verify.test.ts
+++ b/packages/pyric-tools/test/verify/verify.test.ts
@@ -22,7 +22,7 @@ import {
   VerifyInputError,
   type PyricVerifyFixture,
 } from '../../src/verify/index.js';
-import type { ProjectScope } from '../../src/deploy/index.js';
+import type { ProjectScope } from '../../src/credentials/core/types.js';
 
 function uniqueDbName(label: string): string {
   return `pyric-storage-verify-${label}-${Math.random().toString(36).slice(2, 10)}`;

--- a/packages/pyric/test/rules/inspect/handler.test.ts
+++ b/packages/pyric/test/rules/inspect/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { InspectFirestoreRulesHandler } from '../../../src/rules/inspect/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 
 const originalFetch = global.fetch;
 function restoreFetch() { global.fetch = originalFetch; }

--- a/packages/pyric/test/rules/parity/harness.ts
+++ b/packages/pyric/test/rules/parity/harness.ts
@@ -22,7 +22,7 @@
  * FIREBASE_SA_BASE64 the live-integration tests use).
  */
 import { cert } from 'firebase-admin/app';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import { SimulateFirestoreRulesHandler } from '../../../src/rules/simulator/handler.js';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
 import type { TestCase, TestFirestoreRulesResult } from '../../../src/rules/test/spec.js';

--- a/packages/pyric/test/rules/parity/map-get-parity-probe.test.ts
+++ b/packages/pyric/test/rules/parity/map-get-parity-probe.test.ts
@@ -23,7 +23,7 @@
  * holds only `firebaserules.rulesets.test`. Skips cleanly when absent.
  */
 import { describe, test, beforeAll, expect } from 'bun:test';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
 import type { TestCase } from '../../../src/rules/test/spec.js';
 import { hasParitySecret, parityScope } from './harness.js';

--- a/packages/pyric/test/rules/parity/parity-stress.test.ts
+++ b/packages/pyric/test/rules/parity/parity-stress.test.ts
@@ -29,7 +29,7 @@
  * when the secret is absent (external PRs, unit-suite CI).
  */
 import { describe, test, beforeAll, afterAll } from 'bun:test';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import {
   type Scenario,
   type CaseRow,

--- a/packages/pyric/test/rules/parity/round-fix-classes.test.ts
+++ b/packages/pyric/test/rules/parity/round-fix-classes.test.ts
@@ -28,7 +28,7 @@
  * the secret is absent.
  */
 import { describe, test, beforeAll, afterAll } from 'bun:test';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import {
   type Scenario,
   type CaseRow,

--- a/packages/pyric/test/rules/test/handler.test.ts
+++ b/packages/pyric/test/rules/test/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import type { TestCase } from '../../../src/rules/test/spec.js';
 
 const originalFetch = global.fetch;

--- a/packages/pyric/test/rules/test/mocks.test.ts
+++ b/packages/pyric/test/rules/test/mocks.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { TestFirestoreRulesHandler } from '../../../src/rules/test/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import type { TestCase, FunctionMock } from '../../../src/rules/test/spec.js';
 
 const originalFetch = global.fetch;

--- a/packages/pyric/test/rules/tools.test.ts
+++ b/packages/pyric/test/rules/tools.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'bun:test';
 import { createToolRegistry, createDispatch } from '@inbrowser/agent';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../src/project-scope.js';
 import { LocalEnvironment } from 'pyric/sandbox/internal';
 import { createFirestoreRulesTools, createFirestoreSimulatorTools } from '../../src/rules/internal/node.js';
 

--- a/packages/pyric/test/rules/write/handler.test.ts
+++ b/packages/pyric/test/rules/write/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { WriteFirestoreRulesHandler } from '../../../src/rules/write/handler.js';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 
 const MOCK_SCOPE: ProjectScope = {
   projectId: 'test-project',

--- a/packages/pyric/test/storage/admin/tools.test.ts
+++ b/packages/pyric/test/storage/admin/tools.test.ts
@@ -6,7 +6,7 @@
  */
 import { afterEach, describe, it, expect } from 'bun:test';
 import { createToolRegistry, createDispatch } from '@inbrowser/agent';
-import type { ProjectScope } from '@pyric/cli/deploy';
+import type { ProjectScope } from '../../../src/project-scope.js';
 import { createStorageAdminTools } from '../../../src/storage/admin/tools.js';
 
 const fakeCtx = { signal: new AbortController().signal };


### PR DESCRIPTION
Moves `ProjectScope` and service-account token acquisition to `@pyric/cli/credentials`, so retained CLI features no longer depend on the deployment surface.

```ts
import type { ProjectScope } from '@pyric/cli/credentials';
import { fromServiceAccount } from '@pyric/cli/credentials/node';

const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
if (!credentialsPath) {
  throw new Error('GOOGLE_APPLICATION_CREDENTIALS must name a service-account JSON file');
}

const scope: ProjectScope = await fromServiceAccount(credentialsPath);
console.log(scope.projectId);
await scope.resolveToken(); // Mints and caches a short-lived Google OAuth token.
```

## Credential consumers no longer import deployment

Auth configuration, Rules Test API verification, CLI scope resolution, registry composition, and the non-deployment Playground scripts now import `ProjectScope` and token adapters from the credential surface. `ProjectScope` is public from `@pyric/cli/credentials`; the Node-only service-account adapter is public from `@pyric/cli/credentials/node`.

The active deployment surface remains functional in this PR. Removing its Playground UI, CLI commands, MCP tools, package export, and implementation stays in the next two separately reviewed PRs.

## Risk

Token exchange, memoization, and deployment behavior are intended to remain unchanged. The main review risk is import ownership: a retained caller could still reach back into deployment. `credentials/ownership.test.ts` scans static imports, re-exports, namespace imports, and dynamic imports to reject that regression.

The active deploy barrel temporarily re-exports three credential-owned symbols across a directory boundary. Adding deploy-local forwarders would create short-lived compatibility files; the barrel is deleted with the deployment surface instead.

This is rebased on #240. It does not change Firestore's sandbox-only implementation or package-resolution boundary. Published trust delta: **0**; no compatibility row, denominator, or coverage number changes.

<details>
<summary>Implementation notes and verification</summary>

- Moved `memoizeTtl` and `fromServiceAccount` under credential ownership in a behavior-preserving commit.
- Made `ProjectScope` a credential contract and rewired retained callers in a separate commit.
- Added direct characterization for the Admin App adapter and the still-active `getDeploy` spelling.
- `pyric`, `pyric-admin`, and `@pyric/cli` builds pass.
- `pyric` and `@pyric/cli` typechecks pass.
- Post-#240 focused verification: 87 passed, 3 gated; Firestore: 249 passed.
- Full `@pyric/cli` suite: 1,453 passed, 8 gated, 0 failed.
- Standards review: one accepted temporary barrel exception and one bounded middle-man smell, both deleted with the deployment surface.
- Spec review: no findings.

</details>
