### PR TITLE
fix(studio): make operation provenance explicit

### DIFF
--- a/packages/pyric-tools/src/serve/worker/client/core.ts
+++ b/packages/pyric-tools/src/serve/worker/client/core.ts
@@ -157,8 +157,8 @@ export function getLens(): AuthLens | undefined {
  * viewer/editor ops out of the app's stream.
  *
  * Studio's live plane sets this once at connect (`connectWorkerLive`);
- * the served APP page never calls it (its module instance stays
- * untagged), and RELAYED frames bypass stamping entirely — the bridge
+ * the served APP page never calls it (its service handles remain the source
+ * of app attribution), and RELAYED frames bypass Studio stamping entirely — the bridge
  * relay ({@link relayWorkerOp} / {@link relayWorkerSub}) forwards remote
  * frames verbatim through {@link rawRpc} / a direct postMessage, so a
  * user's own admin-SDK traffic through the remote bridge is never

--- a/packages/pyric-tools/src/serve/worker/host/core.ts
+++ b/packages/pyric-tools/src/serve/worker/host/core.ts
@@ -320,11 +320,9 @@ export function ensureRtdb(ctx: HostCtx): Database {
 // ─── Op provenance ─────────────────────────────────────────────────────────
 
 /**
- * Op provenance from an inbound message, bound at ISSUE time. The single
- * source of truth for both the SYNCHRONOUS ambient-provenance window
- * (firestore/rtdb/auth emit inside it) and the EXPLICIT thread that storage
- * ops need (their emits run after async awaits, outside any window — see
- * `handleOp`'s storage cases and `uploadBytes`'s provenance note).
+ * Op provenance from an inbound message, bound at ISSUE time. This is the
+ * source of truth for both the synchronous ambient window used by immediate
+ * emitters and the operation-scoped Storage handle used across awaits.
  *
  *   - `actor`: a client that DECLARED itself the issuer (`issuer: 'studio'`,
  *     stamped by Studio's worker client — `setOpIssuer` in client.ts) gets
@@ -336,10 +334,8 @@ export function ensureRtdb(ctx: HostCtx): Database {
  *     (an agent tool relay's admin op must classify as a rules BYPASS in
  *     Traffic, not a rules allow).
  *
- * Returns `undefined` for a plain served-app op (no issuer, no lens) so the
- * event keeps the app-session default — a served-app op stays untagged.
- * Events an emitter already stamped win over these defaults (stampProvenance
- * semantics: the event's own field beats the ambient/threaded default).
+ * Returns `undefined` for a plain served-app op (no issuer, no lens); its
+ * app source and app-session lens come from the service handle itself.
  */
 export function opProvenance(msg: InboundMessage): EventProvenance | undefined {
   const issuer = (msg as { issuer?: 'studio' }).issuer;

--- a/packages/pyric-tools/src/serve/worker/host/storage.ts
+++ b/packages/pyric-tools/src/serve/worker/host/storage.ts
@@ -28,7 +28,10 @@ import {
 } from 'pyric/storage';
 // Host-only rules-bypass admin plane — the storage mirror of
 // `getAdminFirestore`/`getAdminDatabase`, resolved for `actAs: { mode: 'admin' }`.
-import { getAdminStorageSandbox } from 'pyric/storage/internal';
+import {
+  bindStorageOperationContext,
+  getAdminStorageSandbox,
+} from 'pyric/storage/internal';
 import { initializeApp } from 'pyric/app';
 import type { AuthLens } from 'pyric/sandbox';
 
@@ -165,7 +168,10 @@ export async function handleStorageOp(
       // Object browse. `listAll` enforces `read` rules on the scanned prefix
       // under the op's lens (admin lens bypasses — see lensStorage).
       try {
-        const storage = lensStorage(ctx, msg.actAs);
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
         const result = await storageListAll(storageRef(storage, msg.path));
         ok(port, msg.id, {
           items: result.items.map((r) => ({ fullPath: r.fullPath, name: r.name })),
@@ -177,9 +183,16 @@ export async function handleStorageOp(
 
     case 'storage.getMetadata': {
       try {
-        const storage = lensStorage(ctx, msg.actAs);
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
         // FullMetadata is plain JSON (bucket/fullPath/name/size/contentType/...).
-        ok(port, msg.id, await storageGetMetadata(storageRef(storage, msg.path)));
+        ok(
+          port,
+          msg.id,
+          await storageGetMetadata(storageRef(storage, msg.path)),
+        );
       } catch (e) { fail(port, msg.id, e); }
       break;
     }
@@ -190,8 +203,15 @@ export async function handleStorageOp(
       // bridge client rejects relaying it (binary-payload guard). Remote
       // callers use `storage.getBytes` (base64) instead.
       try {
-        const storage = lensStorage(ctx, msg.actAs);
-        ok(port, msg.id, await storageGetBlob(storageRef(storage, msg.path)));
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
+        ok(
+          port,
+          msg.id,
+          await storageGetBlob(storageRef(storage, msg.path)),
+        );
       } catch (e) { fail(port, msg.id, e); }
       break;
     }
@@ -215,12 +235,14 @@ export async function handleStorageOp(
         if (bytes.byteLength > MAX_STORAGE_OP_BYTES) {
           throw storagePayloadTooLarge(bytes.byteLength, `storage.putBytes payload for '${msg.path}'`);
         }
-        const storage = lensStorage(ctx, msg.actAs);
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
         const result = await storageUploadBytes(
           storageRef(storage, msg.path),
           bytes,
           toSettableMetadata(msg),
-          opProvenance(msg),
         );
         // FullMetadata — plain JSON, relay-safe.
         ok(port, msg.id, result.metadata);
@@ -235,7 +257,10 @@ export async function handleStorageOp(
       // run under the same lens; rule-eval order keeps `unauthorized`
       // superseding `not-found`, matching pyric/storage).
       try {
-        const storage = lensStorage(ctx, msg.actAs);
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
         const r = storageRef(storage, msg.path);
         const meta = await storageGetMetadata(r);
         if (meta.size > MAX_STORAGE_OP_BYTES) {
@@ -261,8 +286,11 @@ export async function handleStorageOp(
       // Async dispatch escapes the ambient window — thread provenance
       // explicitly (issue #84 item 3).
       try {
-        const storage = lensStorage(ctx, msg.actAs);
-        await storageDeleteObject(storageRef(storage, msg.path), opProvenance(msg));
+        const storage = bindStorageOperationContext(
+          lensStorage(ctx, msg.actAs),
+          opProvenance(msg),
+        );
+        await storageDeleteObject(storageRef(storage, msg.path));
         ok(port, msg.id, null);
       } catch (e) { fail(port, msg.id, e); }
       break;

--- a/packages/pyric-tools/src/serve/worker/index.ts
+++ b/packages/pyric-tools/src/serve/worker/index.ts
@@ -29,7 +29,7 @@ export {
   relayWorkerSub,
   // Op provenance: Studio declares itself as the issuer of the ops THIS
   // client-module instance constructs (per-bundle state; the served app's
-  // own bundle stays untagged). Traffic uses the resulting actor stamp to
+  // own bundle remains app-attributed by its service handles). Traffic uses the resulting source to
   // filter Studio-driven ops out of the app's stream.
   setOpIssuer,
   // Connect + handles

--- a/packages/pyric-tools/test/serve/worker/lens-provenance.test.ts
+++ b/packages/pyric-tools/test/serve/worker/lens-provenance.test.ts
@@ -136,4 +136,23 @@ describe('worker host: authLens provenance stamped at dispatch', () => {
     const admin = events.find((e) => e.authLens?.mode === 'admin');
     expect(admin).toBeUndefined();
   });
+
+  it('keeps the Studio issuer when an app-session handle executes the op', async () => {
+    const { ctx, events } = await makeCtx();
+    const port = fakePort();
+
+    await send(ctx, port, {
+      t: 'op', id: id(), method: 'getDoc', path: 'conversations/alice-bob',
+      issuer: 'studio',
+    } as InboundMessage);
+
+    const requests = events.filter((event) => event.kind === 'request');
+    expect(requests.length).toBeGreaterThan(0);
+    for (const event of requests) {
+      expect(event.operationContext).toEqual({
+        source: { kind: 'studio' },
+        authLens: { mode: 'app-session' },
+      });
+    }
+  });
 });

--- a/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
+++ b/packages/pyric-tools/test/serve/worker/storage-provenance.test.ts
@@ -21,15 +21,14 @@
  * cross-contaminate.
  *
  * FIX UNDER TEST: `handleMessage`/`handleOp` capture the op's provenance
- * (issuer → actor, actAs → authLens) at issue time and pass it EXPLICITLY into
- * the storage op, which forwards it to its emit — independent of the ambient
- * window. Provenance is bound at the moment the op is issued, immutable
- * thereafter.
+ * (issuer → actor, actAs → authLens) at issue time and bind it to an
+ * operation-scoped Storage handle before the first await. The service reads
+ * that immutable binding when it emits, independent of the ambient window.
  */
 
 import 'fake-indexeddb/auto';
 import { describe, it, expect } from 'bun:test';
-import { initializeSandbox, type SandboxEvent } from 'pyric/sandbox';
+import { initializeSandbox, toOperationRecord, type SandboxEvent } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
 import { getStorageSandbox } from 'pyric/storage';
 
@@ -90,6 +89,31 @@ function putsFor(events: SandboxEvent[], path: string): SandboxEvent[] {
 }
 
 describe('worker host: storage op provenance survives async dispatch', () => {
+  it('records a Studio/admin list with source and bypass disposition intact', async () => {
+    const { ctx, events } = makeCtx();
+    const res = await op(ctx, {
+      method: 'storage.listAll',
+      path: 'notes',
+      issuer: 'studio',
+      actAs: { mode: 'admin' },
+    });
+    expect(res.ok).toBe(true);
+
+    const event = events.find(
+      (candidate) =>
+        candidate.kind === 'operation'
+        && candidate.service === 'storage'
+        && candidate.method === 'list',
+    );
+    expect(event).toBeDefined();
+    const record = toOperationRecord(event!);
+    expect(record?.context).toEqual({
+      source: { kind: 'studio' },
+      authLens: { mode: 'admin' },
+    });
+    expect(record?.rules).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
   it('stamps actor:{kind:"studio"} on a Studio-issued upload event', async () => {
     const { ctx, events } = makeCtx();
     const res = await op(ctx, {
@@ -107,7 +131,7 @@ describe('worker host: storage op provenance survives async dispatch', () => {
     }
   });
 
-  it('a served-app upload (no issuer) stays untagged — no studio actor', async () => {
+  it('records a served-app upload (no issuer) as app traffic', async () => {
     const { ctx, events } = makeCtx();
     const res = await op(ctx, {
       method: 'storage.putBytes',
@@ -119,9 +143,8 @@ describe('worker host: storage op provenance survives async dispatch', () => {
     const puts = putsFor(events, 'app/blob.bin');
     expect(puts.length).toBeGreaterThan(0);
     for (const e of puts) {
-      // Untagged: no studio actor. (Absent, or an explicit app default —
-      // never studio.)
-      expect(e.actor?.kind).not.toBe('studio');
+      expect(e.actor).toEqual({ kind: 'app' });
+      expect(e.operationContext?.source).toEqual({ kind: 'app' });
     }
   });
 
@@ -143,7 +166,10 @@ describe('worker host: storage op provenance survives async dispatch', () => {
     expect(studioPuts.length).toBeGreaterThan(0);
     expect(appPuts.length).toBeGreaterThan(0);
     for (const e of studioPuts) expect(e.actor).toEqual({ kind: 'studio' });
-    for (const e of appPuts) expect(e.actor?.kind).not.toBe('studio');
+    for (const e of appPuts) {
+      expect(e.actor).toEqual({ kind: 'app' });
+      expect(e.operationContext?.source).toEqual({ kind: 'app' });
+    }
   });
 
   it('an admin-lens delete carries authLens:{mode:"admin"} on its event (bypass classification)', async () => {

--- a/packages/pyric/src/firestore/instances.ts
+++ b/packages/pyric/src/firestore/instances.ts
@@ -12,6 +12,7 @@ import {
 } from 'pyric/sandbox/admin-firestore';
 import { SandboxContextImpl } from 'pyric/sandbox';
 import type { AuthState, Sandbox, SandboxContext } from 'pyric/sandbox';
+import { bindOperationContext } from 'pyric/sandbox/internal';
 import { APP_TARGET, type PyricApp } from 'pyric/app';
 
 import {
@@ -152,10 +153,16 @@ export function getAdminFirestore(ctx: SandboxContext): Firestore;
 export function getAdminFirestore(app: PyricApp): Firestore;
 export function getAdminFirestore(target: Sandbox | SandboxContext | PyricApp): Firestore {
   if (isPyricApp(target)) {
-    return getAdminFirestore(target.sandbox);
+    return getAdminFirestore(bindOperationContext(target.sandbox.withAuth(null), {
+      source: { kind: 'app' },
+      authLens: { mode: 'admin' },
+    }));
   }
-  const sandbox: Sandbox = isSandboxContext(target) ? target.sandbox : (target as Sandbox);
-  const chainable = getChainableAdminFirestore(sandbox);
+  const context = isSandboxContext(target)
+    ? target
+    : (target as Sandbox).withAuth(null);
+  const sandbox = context.sandbox;
+  const chainable = getChainableAdminFirestore(context);
   const t: SandboxTarget = { kind: 'sandbox', db: chainable, sandbox };
   return { [TARGET_SYMBOL]: t };
 }
@@ -225,7 +232,10 @@ function isSandbox(target: SandboxContext | Sandbox | PyricApp): target is Sandb
  */
 function makeGetDb(sandbox: Sandbox): () => SandboxFirestore {
   return () => {
-    const ctx = sandbox.withAuth(sandbox.currentUser);
+    const ctx = bindOperationContext(sandbox.withAuth(sandbox.currentUser), {
+      source: { kind: 'app' },
+      authLens: { mode: 'app-session' },
+    });
     return getChainableFirestore(ctx);
   };
 }

--- a/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/error-translation.ts
@@ -37,6 +37,7 @@ import {
   type DenialContext,
   type SandboxErrorCode,
 } from 'pyric/sandbox';
+import { provenanceForOperationContext } from 'pyric/sandbox/internal';
 
 /**
  * Hidden property on every wrapped object that returns the
@@ -220,7 +221,11 @@ export function wrapWithErrorTranslation<T extends object>(
       return function (this: unknown, ...args: unknown[]): unknown {
         let result: unknown;
         try {
-          result = (value as (...a: unknown[]) => unknown).apply(t, args);
+          const invoke = () => (value as (...a: unknown[]) => unknown).apply(t, args);
+          result = ctx.sandbox.runWithProvenance?.(
+            provenanceForOperationContext(ctx.operationContext),
+            invoke,
+          ) ?? invoke();
         } catch (e) {
           throw toSandboxError(e, ctx);
         }

--- a/packages/pyric/src/sandbox/admin-firestore/get-admin-firestore.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/get-admin-firestore.ts
@@ -4,6 +4,7 @@
  */
 
 import { isRemoteSandbox, type Sandbox, type SandboxContext } from 'pyric/sandbox';
+import { bindOperationContext } from 'pyric/sandbox/internal';
 import { wrapWithErrorTranslation } from './error-translation.js';
 import { buildFirestoreHandle } from './local-handle.js';
 import { createRemoteFirestore } from './remote/remote-firestore.js';
@@ -60,18 +61,30 @@ export function getAdminFirestore(target: SandboxContext | Sandbox): SandboxFire
   // `Sandbox` is accepted as well as a `SandboxContext`. A bare sandbox is
   // normalised to an anonymous ctx — the captured auth is irrelevant since
   // no rule reads `request.auth` on the bypass path.
-  const ctx: SandboxContext = isSandboxContext(target)
+  const baseContext: SandboxContext = isSandboxContext(target)
     ? target
     : target.withAuth(null);
-  const cached = adminHandleCache.get(ctx);
+  const cached = adminHandleCache.get(baseContext);
   if (cached) return cached;
+  const ctx: SandboxContext = baseContext.operationContext.authLens.mode === 'admin'
+    ? baseContext
+    : bindOperationContext(baseContext, {
+        source: baseContext.operationContext.source,
+        authLens: { mode: 'admin' },
+        ...(baseContext.operationContext.planId === undefined
+          ? {}
+          : { planId: baseContext.operationContext.planId }),
+      });
   // REMOTE ARM: rules bypass rides the worker's `{ mode: 'admin' }` lens
   // (the same lens Studio's admin surface uses) — identity-agnostic, so
   // the normalised ctx's auth is irrelevant, exactly like the local path.
   const fresh = isRemoteSandbox(ctx.sandbox)
     ? createRemoteFirestore(ctx.sandbox, { mode: 'admin' })
     : wrapWithErrorTranslation(buildFirestoreHandle(ctx, true), ctx, true);
-  adminHandleCache.set(ctx, fresh);
+  // Cache against the caller-owned context. `bindOperationContext` creates a
+  // derived context to pin the admin lens, and keying by that fresh object
+  // would silently defeat the public per-context idempotency contract.
+  adminHandleCache.set(baseContext, fresh);
   return fresh;
 }
 

--- a/packages/pyric/src/sandbox/admin-firestore/local-handle.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/local-handle.ts
@@ -20,6 +20,7 @@ import type {
 import type { LintResult } from 'pyric/rules/internal';
 import { isRemoteSandbox, type SandboxContext } from 'pyric/sandbox';
 import { getInternalEnv } from 'pyric/sandbox/internal';
+import { provenanceForOperationContext } from 'pyric/sandbox/internal';
 import type { SandboxFirestore } from './types.js';
 
 /**
@@ -49,7 +50,11 @@ export function buildFirestoreHandle(
     );
   }
   const delegate = (): Firestore =>
-    createCompatFirestore(getInternalEnv(ctx.sandbox), { auth: ctx.auth, bypassRules });
+    createCompatFirestore(getInternalEnv(ctx.sandbox), {
+      auth: ctx.auth,
+      bypassRules,
+      provenance: provenanceForOperationContext(ctx.operationContext),
+    });
 
   return {
     // ── Production-shaped surface ────────────────────────────────────

--- a/packages/pyric/src/sandbox/firestore/admin-compat/firestore.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/firestore.ts
@@ -31,6 +31,7 @@
  */
 
 import type { LocalEnvironment } from 'pyric/sandbox/internal';
+import type { EventProvenance } from '../../types/events.js';
 import { makeError } from 'pyric/sandbox/internal';
 import { ReadAfterWriteError } from 'pyric/sandbox/internal';
 import { isCollectionPath, isDocumentPath } from './paths.js';
@@ -59,6 +60,7 @@ export class FirestoreImpl implements Firestore {
     // the LocalEnvironment skips rule evaluation. Threaded down to each
     // child impl alongside `auth`. Default false → rules enforced.
     private readonly bypassRules: boolean = false,
+    private readonly provenance?: EventProvenance,
   ) {}
 
   collection(path: string): CollectionReference {
@@ -120,6 +122,7 @@ export class FirestoreImpl implements Firestore {
         {
           auth: opts?.auth !== undefined ? opts.auth : this.auth,
           bypassRules: this.bypassRules,
+          provenance: this.provenance,
         },
       );
     } catch (e) {

--- a/packages/pyric/src/sandbox/firestore/admin-compat/index.ts
+++ b/packages/pyric/src/sandbox/firestore/admin-compat/index.ts
@@ -15,6 +15,7 @@
  */
 
 import type { LocalEnvironment } from 'pyric/sandbox/internal';
+import type { EventProvenance } from '../../types/events.js';
 import { FirestoreImpl } from './firestore.js';
 import {
   type AuthContext,
@@ -71,6 +72,9 @@ export interface CreateCompatFirestoreOptions {
    * `pyric/firestore`).
    */
   bypassRules?: boolean;
+  /** Adapter-bound operation identity. Internal constructor concern; never a
+   * Firebase operation option. */
+  provenance?: EventProvenance;
 }
 
 /**
@@ -83,5 +87,10 @@ export function createCompatFirestore(
   env: LocalEnvironment,
   opts?: CreateCompatFirestoreOptions,
 ): Firestore {
-  return new FirestoreImpl(env, opts?.auth ?? null, opts?.bypassRules ?? false);
+  return new FirestoreImpl(
+    env,
+    opts?.auth ?? null,
+    opts?.bypassRules ?? false,
+    opts?.provenance,
+  );
 }

--- a/packages/pyric/src/sandbox/firestore/local-environment.ts
+++ b/packages/pyric/src/sandbox/firestore/local-environment.ts
@@ -44,6 +44,7 @@ import type {
   TransactionOptions,
   TransactionResult,
 } from './transaction-types.js';
+import type { EventProvenance } from '../types/events.js';
 import type {
   DocumentSnapshot,
   ListenerAuth,
@@ -218,6 +219,7 @@ interface EmitRequestInput {
   groupId?: string;
   triggeredBy?: { method: string; path: string };
   detail?: { admin?: boolean } & Record<string, unknown>;
+  provenance?: EventProvenance;
 }
 
 let _requestEventSeq = 0;
@@ -297,6 +299,7 @@ function buildRequestEvent(input: EmitRequestInput): import('../types/events.js'
   }
   if (input.triggeredBy !== undefined) out.triggeredBy = input.triggeredBy;
   if (input.detail !== undefined) out.detail = input.detail;
+  if (input.provenance !== undefined) Object.assign(out, input.provenance);
   return out;
 }
 
@@ -704,6 +707,7 @@ export class LocalEnvironment {
      *  when re-resolving serverTimestamp() sentinels. */
     requestTime: Timestamp;
     detail?: { admin?: boolean } & Record<string, unknown>;
+    provenance?: EventProvenance;
   }): void {
     if (this.writeListeners.size === 0) return;
     const event: import('../types/events.js').WriteSandboxEvent = {
@@ -724,6 +728,7 @@ export class LocalEnvironment {
       ...(input.autoId !== undefined ? { autoId: input.autoId } : {}),
       requestTime: { seconds: input.requestTime.seconds, nanoseconds: input.requestTime.nanos },
       ...(input.detail !== undefined ? { detail: input.detail } : {}),
+      ...(input.provenance ?? {}),
     };
     for (const cb of this.writeListeners) {
       try {
@@ -3090,6 +3095,7 @@ export class LocalEnvironment {
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
           ...(detail ? { detail } : {}),
+          provenance: options.provenance,
         });
         return {
           allowed: false,
@@ -3174,6 +3180,7 @@ export class LocalEnvironment {
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
           ...(detail ? { detail } : {}),
+          provenance: options.provenance,
         });
         allAllowed = false;
         continue;
@@ -3190,6 +3197,7 @@ export class LocalEnvironment {
           resourceBefore: { data: priorDoc, exists: priorDoc !== null },
           origin: 'transaction', groupId: txId,
           ...(detail ? { detail } : {}),
+          provenance: options.provenance,
         });
         throw new SimulatorUnsupportedError(
           unsupportedMessage(ruleMethod, op.path, renderLegacyDebugMessages(r)),
@@ -3217,6 +3225,7 @@ export class LocalEnvironment {
         resourceBefore: { data: priorDoc, exists: priorDoc !== null },
         origin: 'transaction', groupId: txId,
         ...(detail ? { detail } : {}),
+        provenance: options.provenance,
       });
       if (!isAllowed) {
         // Per-op `request`/`resource` captured against pre-tx snapshot
@@ -3328,6 +3337,7 @@ export class LocalEnvironment {
           ...(sentinels && sentinels.length > 0 ? { sentinels } : {}),
           requestTime: serverTime,
           ...(detail ? { detail } : {}),
+          provenance: options.provenance,
         });
       }
     }

--- a/packages/pyric/src/sandbox/firestore/transaction-types.ts
+++ b/packages/pyric/src/sandbox/firestore/transaction-types.ts
@@ -21,6 +21,7 @@
 import type { DocumentData } from './local-state.js';
 import type { AgentEvent } from './event-log.js';
 import type { FirestoreSimError } from './errors.js';
+import type { EventProvenance } from '../types/events.js';
 
 /**
  * Snapshot shape returned by `tx.get` / `tx.getAll`. Matches the Admin
@@ -109,6 +110,8 @@ export interface TransactionOptions {
    * affects the write commit. Default (absent/false) enforces rules.
    */
   bypassRules?: boolean;
+  /** Immutable adapter context captured before an async callback yields. */
+  provenance?: EventProvenance;
 }
 
 /**

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -26,10 +26,12 @@ export type {
   EventActor,
   EventProvenance,
   EventService,
+  OperationContext,
   ListenerLifecycleEvent,
   LocalSandbox,
   PersistableService,
   RequestEvent,
+  RulesDisposition,
   Sandbox,
   SandboxConfig,
   SandboxContext,
@@ -49,6 +51,13 @@ export type {
 } from './types/index.js';
 export { SandboxError } from './types/index.js';
 export { SandboxContextImpl } from './sandbox-context.js';
+export {
+  isOperationEvent,
+  operationContextFor,
+  rulesDispositionFor,
+  toOperationRecord,
+} from './operation-record.js';
+export type { OperationRecord } from './operation-record.js';
 
 // Remote sandbox (slice 1) — the brand + minimal channel contract that
 // lets `pyric-admin` recognize a Node-side handle onto the browser-hosted

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -15,6 +15,12 @@
  * scope summary".
  */
 export { getInternalEnv } from './sandbox-impl.js';
+export { stampProvenance } from './provenance.js';
+export { bindOperationContext } from '../sandbox-context.js';
+export {
+  provenanceForOperationContext,
+  resolveOperationContext,
+} from '../operation-record.js';
 
 // Pyric Studio event-unification seam: the provenance-stamping emit
 // choke-point non-Firestore services (auth/storage/rtdb) call to land
@@ -27,7 +33,6 @@ export { getInternalEnv } from './sandbox-impl.js';
 export {
   emitSandboxEvent,
   primeEventHistory,
-  stampProvenance,
   makeSandboxCommitEvent,
   makeSandboxListenerEvent,
   makeSandboxOperationEvent,

--- a/packages/pyric/src/sandbox/internal/provenance.ts
+++ b/packages/pyric/src/sandbox/internal/provenance.ts
@@ -1,0 +1,173 @@
+/** Canonical provenance stamping and nested-window composition. */
+
+import type {
+  EventProvenance,
+  OperationContext,
+  SandboxEvent,
+} from '../types/events.js';
+import {
+  immutableOperationContext,
+  isOperationEvent,
+  resolveOperationContext,
+  rulesDispositionFor,
+} from '../operation-record.js';
+
+/** Stamp canonical context and Rules disposition at the unified event seam. */
+export function stampProvenance<E extends SandboxEvent>(
+  event: E,
+  overrides?: EventProvenance,
+): E {
+  const out = { ...event } as E & EventProvenance;
+  out.service = event.service ?? overrides?.service ?? 'firestore';
+
+  // Pre-context admin events used `detail.admin` as their only execution-lens
+  // marker. Normalize that one legacy shape here; new producers bind context.
+  const legacyAdmin = 'detail' in event && event.detail?.admin === true;
+  const executed: EventProvenance = legacyAdmin
+    && event.operationContext === undefined
+    && event.authLens === undefined
+    ? { ...event, authLens: { mode: 'admin' } }
+    : event;
+  // Operation producers carry an execution context. Its auth lens describes
+  // what reached the service, while the surrounding override identifies who
+  // issued it. Legacy/lifecycle events predate that distinction and retain
+  // their original per-field "event wins" behavior.
+  const context = isOperationEvent(out) || event.operationContext !== undefined
+    ? resolveOperationContext(overrides, executed)
+    : legacyEventContext(event, overrides);
+
+  out.operationContext = context;
+  out.actor = context.source;
+  out.authLens = context.authLens;
+  if (context.planId !== undefined) out.planId = context.planId;
+  if (isOperationEvent(out)) {
+    out.rulesDisposition = Object.freeze({ ...rulesDispositionFor(out) });
+  }
+  return out;
+}
+
+function legacyEventContext(
+  event: EventProvenance,
+  overrides: EventProvenance | undefined,
+): OperationContext {
+  return immutableOperationContext({
+    source:
+      event.actor
+      ?? event.operationContext?.source
+      ?? overrides?.actor
+      ?? overrides?.operationContext?.source
+      ?? { kind: 'unattributed' },
+    authLens:
+      event.authLens
+      ?? event.operationContext?.authLens
+      ?? overrides?.authLens
+      ?? overrides?.operationContext?.authLens
+      ?? { mode: 'app-session' },
+    ...((event.planId
+      ?? event.operationContext?.planId
+      ?? overrides?.planId
+      ?? overrides?.operationContext?.planId) === undefined
+      ? {}
+      : {
+          planId:
+            event.planId
+            ?? event.operationContext?.planId
+            ?? overrides?.planId
+            ?? overrides?.operationContext?.planId,
+        }),
+  });
+}
+
+/** Merge two nested ambient declarations. This is deliberately different
+ * from issue/execution composition: the innermost ambient window wins each
+ * field, preserving the public `runWithProvenance` contract. */
+export function mergeAmbientProvenance(
+  outer: EventProvenance | undefined,
+  inner: EventProvenance | undefined,
+): EventProvenance | undefined {
+  if (!outer) return inner;
+  if (!inner) return outer;
+
+  // A complete context marks an adapter execution boundary rather than an
+  // ordinary nested ambient declaration. Preserve the outer issuer while
+  // taking the lens that the bound handle actually executed with.
+  if (inner.operationContext !== undefined) {
+    return mergeProvenance(outer, inner);
+  }
+
+  const hasContext =
+    outer.operationContext !== undefined
+    || outer.actor !== undefined
+    || outer.authLens !== undefined
+    || outer.planId !== undefined
+    || inner.actor !== undefined
+    || inner.authLens !== undefined
+    || inner.planId !== undefined;
+  if (!hasContext) return { ...outer, ...inner };
+
+  const context = immutableOperationContext({
+    source:
+      inner.actor
+      ?? outer.operationContext?.source
+      ?? outer.actor
+      ?? { kind: 'unattributed' },
+    authLens:
+      inner.authLens
+      ?? outer.operationContext?.authLens
+      ?? outer.authLens
+      ?? { mode: 'app-session' },
+    ...((inner.planId
+      ?? outer.operationContext?.planId
+      ?? outer.planId) === undefined
+      ? {}
+      : {
+          planId:
+            inner.planId
+            ?? outer.operationContext?.planId
+            ?? outer.planId,
+        }),
+  });
+  return {
+    ...outer,
+    ...inner,
+    operationContext: context,
+    actor: context.source,
+    authLens: context.authLens,
+    ...(context.planId === undefined ? {} : { planId: context.planId }),
+  };
+}
+
+/**
+ * Merge nested provenance windows by domain role. The outer window is the
+ * issue-time declaration (source/plan); the inner window is the execution
+ * handle (auth lens). This prevents a prebuilt app/unattributed handle from
+ * erasing a Studio issuer while still recording the lens that actually ran.
+ */
+export function mergeProvenance(
+  issued: EventProvenance | undefined,
+  executed: EventProvenance | undefined,
+): EventProvenance | undefined {
+  if (!issued) return executed;
+  if (!executed) return issued;
+
+  const hasContext =
+    issued.operationContext !== undefined
+    || issued.actor !== undefined
+    || issued.authLens !== undefined
+    || issued.planId !== undefined
+    || executed.operationContext !== undefined
+    || executed.actor !== undefined
+    || executed.authLens !== undefined
+    || executed.planId !== undefined;
+  if (!hasContext) return { ...issued, ...executed };
+
+  const context = resolveOperationContext(issued, executed);
+  return {
+    ...issued,
+    ...executed,
+    operationContext: context,
+    actor: context.source,
+    authLens: context.authLens,
+    ...(context.planId === undefined ? {} : { planId: context.planId }),
+  };
+}

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -44,47 +44,21 @@ import {
 import type { SandboxPersistenceOptions } from '../persistence/types.js';
 import { attachTabSync } from '../tab-sync/index.js';
 import type { TabSyncOptions } from '../tab-sync/index.js';
+import {
+  mergeAmbientProvenance,
+  mergeProvenance,
+  stampProvenance,
+} from './provenance.js';
+
+// Kept for internal import compatibility; the implementation lives in the
+// focused provenance module so this class remains an orchestration shell.
+export { stampProvenance } from './provenance.js';
 
 let nextSandboxEventId = 1;
 function makeSandboxEventId(): string {
   const seq = (nextSandboxEventId++).toString(36);
   const rnd = Math.random().toString(36).slice(2, 7);
   return `sbe-${seq}-${rnd}`;
-}
-
-/**
- * Stamp {@link EventProvenance} onto a `SandboxEvent` in ONE place — the
- * single choke-point every emitter routes through (see {@link
- * SandboxImpl.emitEvent}). This is the Pyric Studio "event unification"
- * keystone: today only Firestore emits, but every service's emit path is
- * meant to funnel here so the unified `onEvent`/`history()` stream carries
- * who/what/which-service for each event.
- *
- * Semantics — **additive, override-aware, no clobber**:
- *   - `service`   defaults to `'firestore'` (the only emitter today). An
- *                 Auth/Storage/RTDB emit site passes its own service via
- *                 `overrides.service`; a value already on the event is kept.
- *   - `actor`     defaults to `{ kind: 'app' }` (the served app). Studio /
- *                 agent / app-builder emitters override.
- *   - `authLens`  defaults to `{ mode: 'app-session' }` (the app's own
- *                 signed-in user). Admin / impersonation paths override.
- *   - `planId`    only set when an override supplies it (agent-plan ops).
- *
- * A field the event ALREADY carries always wins over the default — so an
- * upstream emitter that pre-stamped provenance is never downgraded. The
- * returned object is a shallow copy; the input is not mutated.
- */
-export function stampProvenance<E extends SandboxEvent>(
-  event: E,
-  overrides?: EventProvenance,
-): E {
-  const out = { ...event } as E & EventProvenance;
-  out.service = event.service ?? overrides?.service ?? 'firestore';
-  out.actor = event.actor ?? overrides?.actor ?? { kind: 'app' };
-  out.authLens = event.authLens ?? overrides?.authLens ?? { mode: 'app-session' };
-  const planId = event.planId ?? overrides?.planId;
-  if (planId !== undefined) out.planId = planId;
-  return out;
 }
 
 /**
@@ -262,18 +236,14 @@ export class SandboxImpl implements LocalSandbox {
    *
    * `provenance` lets a non-default emitter (a future Auth/Storage/RTDB
    * emit site, or a Studio admin/agent/impersonation path) declare its
-   * `service`/`actor`/`authLens`/`planId`. Omitted ⇒ Firestore / app /
-   * app-session defaults, which is exactly today's Firestore behaviour —
-   * so routing the existing Firestore emitters through here is a no-op on
-   * what consumers observe beyond the additive provenance fields.
+   * `service`/`actor`/`authLens`/`planId`. Omitted source is recorded as
+   * `unattributed`; service handles bind known app/Studio sources explicitly.
    */
   emitEvent(event: SandboxEvent, provenance?: EventProvenance): void {
     // Ambient window values ({@link runWithProvenance}) fill in for fields
     // the explicit per-emit override doesn't name; fields the event itself
     // carries still win inside stampProvenance.
-    const merged = this.ambientProvenance
-      ? { ...this.ambientProvenance, ...provenance }
-      : provenance;
+    const merged = mergeProvenance(this.ambientProvenance, provenance);
     this.dispatch(stampProvenance(event, merged));
   }
 
@@ -284,7 +254,7 @@ export class SandboxImpl implements LocalSandbox {
    */
   runWithProvenance<T>(provenance: EventProvenance, fn: () => T): T {
     const prev = this.ambientProvenance;
-    this.ambientProvenance = prev ? { ...prev, ...provenance } : provenance;
+    this.ambientProvenance = mergeAmbientProvenance(prev, provenance);
     try {
       return fn();
     } finally {

--- a/packages/pyric/src/sandbox/operation-record.ts
+++ b/packages/pyric/src/sandbox/operation-record.ts
@@ -1,0 +1,194 @@
+/**
+ * Canonical operation records.
+ *
+ * Firestore still emits its legacy `request` shape while RTDB and Storage emit
+ * `operation`. This module is the one deep normalization seam above those
+ * adapters: activity consumers receive the same provenance and Rules model
+ * without knowing which service emitted the event or which legacy marker it
+ * used for an admin bypass.
+ */
+import type { AuthState } from './types/auth-state.js';
+import type {
+  AuthLens,
+  EventActor,
+  EventProvenance,
+  EventService,
+  OperationContext,
+  RequestEvent,
+  RulesDisposition,
+  SandboxEvent,
+  SandboxOperationEvent,
+} from './types/events.js';
+
+export interface OperationRecord {
+  readonly id: string;
+  readonly at: number;
+  readonly eventKind: 'request' | 'operation';
+  readonly service: EventService;
+  readonly method: string;
+  readonly path?: string;
+  readonly auth: AuthState;
+  readonly result: RequestEvent['result'] | SandboxOperationEvent['result'];
+  readonly context: OperationContext;
+  readonly rules: RulesDisposition;
+}
+
+type OperationEvent = (RequestEvent | SandboxOperationEvent) & EventProvenance;
+
+export function isOperationEvent(event: SandboxEvent): event is OperationEvent {
+  return event.kind === 'request' || event.kind === 'operation';
+}
+
+/** Build an immutable context. Cloning + freezing here means callers can bind
+ * one context to a handle without a later mutation changing in-flight async
+ * operations. */
+export function immutableOperationContext(context: OperationContext): OperationContext {
+  const source = Object.freeze({ ...context.source }) as EventActor;
+  const authLens = Object.freeze({ ...context.authLens }) as AuthLens;
+  return Object.freeze({
+    source,
+    authLens,
+    ...(context.planId === undefined ? {} : { planId: context.planId }),
+  });
+}
+
+/** Compatibility projection used by service adapters that still accept the
+ * flat EventProvenance shape. */
+export function provenanceForOperationContext(context: OperationContext): EventProvenance {
+  const bound = immutableOperationContext(context);
+  return {
+    actor: bound.source,
+    authLens: bound.authLens,
+    operationContext: bound,
+    ...(bound.planId === undefined ? {} : { planId: bound.planId }),
+  };
+}
+
+function knownSource(provenance: EventProvenance | undefined): EventActor | undefined {
+  const contextSource = provenance?.operationContext?.source;
+  if (contextSource && contextSource.kind !== 'unattributed') return contextSource;
+  if (provenance?.actor && provenance.actor.kind !== 'unattributed') return provenance.actor;
+  return undefined;
+}
+
+/** Resolve the canonical context from two semantically distinct inputs.
+ * `issued` owns source/plan identity; `executed` owns the auth lens that really
+ * reached the service. Unknown issue-time source falls back to the execution
+ * handle, but a prebuilt handle can never overwrite a known issuer. */
+export function resolveOperationContext(
+  issued: EventProvenance | undefined,
+  executed: EventProvenance | undefined,
+): OperationContext {
+  const issuedFallback = issued?.operationContext?.source ?? issued?.actor;
+  const executedFallback = executed?.operationContext?.source ?? executed?.actor;
+  return immutableOperationContext({
+    source:
+      knownSource(issued)
+      ?? knownSource(executed)
+      ?? issuedFallback
+      ?? executedFallback
+      ?? { kind: 'unattributed' },
+    authLens:
+      executed?.operationContext?.authLens
+      ?? executed?.authLens
+      ?? issued?.operationContext?.authLens
+      ?? issued?.authLens
+      ?? { mode: 'app-session' },
+    ...((issued?.operationContext?.planId
+      ?? issued?.planId
+      ?? executed?.operationContext?.planId
+      ?? executed?.planId) === undefined
+      ? {}
+      : {
+          planId:
+            issued?.operationContext?.planId
+            ?? issued?.planId
+            ?? executed?.operationContext?.planId
+            ?? executed?.planId,
+        }),
+  });
+}
+
+/** The canonical context on a recorded event. Old/pre-context events are
+ * explicitly unattributed rather than silently asserted to be app traffic. */
+export function operationContextFor(
+  event: Pick<EventProvenance, 'operationContext' | 'actor' | 'authLens' | 'planId'>,
+): OperationContext {
+  return resolveOperationContext(undefined, event);
+}
+
+/** Normalize the legacy per-service markers exactly once, at the sandbox
+ * stream seam. Consumers must not inspect `detail.admin`, `origin`, or the
+ * presence of a trace themselves. */
+export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
+  if (event.rulesDisposition) return event.rulesDisposition;
+  if (
+    (event.kind === 'operation' && event.origin === 'admin')
+    || event.detail?.admin === true
+  ) {
+    return { kind: 'bypassed', reason: 'admin' };
+  }
+
+  if (event.result === 'unsupported') {
+    return { kind: 'not-evaluated', reason: 'unsupported' };
+  }
+  if (event.kind === 'operation' && event.result === 'error') {
+    return { kind: 'not-evaluated', reason: 'runtime-error' };
+  }
+  if (event.kind === 'operation' && event.result === 'not-applicable') {
+    return { kind: 'not-evaluated', reason: 'not-a-rules-operation' };
+  }
+  if (event.result === 'deny') {
+    return { kind: 'evaluated', verdict: 'deny' };
+  }
+  if (event.kind === 'request') {
+    return { kind: 'evaluated', verdict: 'allow' };
+  }
+  if (event.rules) {
+    return { kind: 'evaluated', verdict: 'allow' };
+  }
+  return { kind: 'not-evaluated', reason: 'no-rules' };
+}
+
+function immutableAuthState(auth: AuthState): AuthState {
+  if (auth === null) return null;
+  return Object.freeze({
+    uid: auth.uid,
+    ...(auth.token === undefined
+      ? {}
+      : { token: immutableRecord(auth.token) }),
+  });
+}
+
+function immutableRecord(value: Record<string, unknown>): Record<string, unknown> {
+  const clone: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    clone[key] = immutableValue(entry);
+  }
+  return Object.freeze(clone);
+}
+
+function immutableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return Object.freeze(value.map(immutableValue));
+  if (value && typeof value === 'object') {
+    return immutableRecord(value as Record<string, unknown>);
+  }
+  return value;
+}
+
+/** Project either traffic event family into the canonical record. */
+export function toOperationRecord(event: SandboxEvent): OperationRecord | null {
+  if (!isOperationEvent(event)) return null;
+  return Object.freeze({
+    id: event.id,
+    at: event.at,
+    eventKind: event.kind,
+    service: event.kind === 'request' ? (event.service ?? 'firestore') : event.service,
+    method: event.method,
+    ...(event.path === undefined ? {} : { path: event.path }),
+    auth: immutableAuthState(event.auth),
+    result: event.result,
+    context: operationContextFor(event),
+    rules: Object.freeze({ ...rulesDispositionFor(event) }),
+  });
+}

--- a/packages/pyric/src/sandbox/sandbox-context.ts
+++ b/packages/pyric/src/sandbox/sandbox-context.ts
@@ -1,7 +1,7 @@
 /**
  * `SandboxContext` — identity-bearing handle on a {@link Sandbox}.
  *
- * Cheap, immutable `(sandbox, auth)` pair. Service factories
+ * Cheap, immutable `(sandbox, auth, operationContext)` handle. Service factories
  * (`getFirestore`, future `getDatabase`, etc.) accept a
  * `SandboxContext` and route operations through the captured auth.
  *
@@ -22,19 +22,52 @@
 
 import type { AuthState } from './types/auth-state.js';
 import type { SandboxContext } from './types/context.js';
+import type { AuthLens, OperationContext } from './types/events.js';
 import { SandboxError } from './types/errors.js';
 import type { Sandbox } from './types/service.js';
+import { immutableOperationContext } from './operation-record.js';
+
+function authLensFor(auth: AuthState): AuthLens {
+  if (auth === null) return { mode: 'anon' };
+  return auth.token === undefined
+    ? { mode: 'as', uid: auth.uid }
+    : { mode: 'as', uid: auth.uid, token: auth.token };
+}
 
 export class SandboxContextImpl implements SandboxContext {
   constructor(
     public readonly sandbox: Sandbox,
     public readonly auth: AuthState,
-  ) {}
+    operationContext?: OperationContext,
+  ) {
+    this.operationContext = immutableOperationContext(operationContext ?? {
+      source: { kind: 'unattributed' },
+      authLens: authLensFor(auth),
+    });
+  }
+
+  public readonly operationContext: OperationContext;
 
   withAuth(auth: AuthState): SandboxContext {
     validateAuthState(auth);
-    return new SandboxContextImpl(this.sandbox, auth);
+    return new SandboxContextImpl(this.sandbox, auth, {
+      source: this.operationContext.source,
+      authLens: authLensFor(auth),
+      ...(this.operationContext.planId === undefined
+        ? {}
+        : { planId: this.operationContext.planId }),
+    });
   }
+}
+
+/** Bind source, lens, and optional plan identity to a sandbox handle. Service
+ * adapters use this once when constructing a handle; individual operations
+ * cannot accidentally omit or contradict it. */
+export function bindOperationContext(
+  ctx: SandboxContext,
+  operationContext: OperationContext,
+): SandboxContext {
+  return new SandboxContextImpl(ctx.sandbox, ctx.auth, operationContext);
 }
 
 /**

--- a/packages/pyric/src/sandbox/types/context.ts
+++ b/packages/pyric/src/sandbox/types/context.ts
@@ -1,13 +1,15 @@
 /**
- * The identity-bearing handle on a sandbox — a `(sandbox, auth)` pair.
+ * The identity- and provenance-bearing handle on a sandbox.
  */
 
 import type { AuthState } from './auth-state.js';
+import type { OperationContext } from './events.js';
 import type { Sandbox } from './service.js';
 
 /**
- * Identity-bearing handle on a {@link Sandbox}. A `(sandbox, auth)`
- * pair — cheap to create, immutable, freely shareable. Service
+ * Identity-bearing handle on a {@link Sandbox}. A
+ * `(sandbox, auth, operationContext)`
+ * tuple — cheap to create, immutable, freely shareable. Service
  * factories require a `SandboxContext`; bare `Sandbox` is a type
  * error so every call site states identity explicitly.
  *
@@ -21,10 +23,12 @@ export interface SandboxContext {
   readonly sandbox: Sandbox;
   /** The identity rules evaluate under for operations through this context. */
   readonly auth: AuthState;
+  /** Immutable provenance bound to every operation issued through this handle. */
+  readonly operationContext: OperationContext;
   /**
    * Derive a sibling context on the same sandbox with different auth.
-   * Replaces, doesn't merge — the new context carries only the new
-   * auth, regardless of any prior context's auth.
+   * Replaces auth and its lens while preserving the operation source and
+   * optional plan identity.
    */
   withAuth(auth: AuthState): SandboxContext;
 }

--- a/packages/pyric/src/sandbox/types/events.ts
+++ b/packages/pyric/src/sandbox/types/events.ts
@@ -5,6 +5,20 @@
  */
 
 import type { AuthState } from './auth-state.js';
+import type {
+  EventProvenance,
+  EventService,
+  OperationContext,
+  RulesDisposition,
+} from './operation.js';
+export type {
+  AuthLens,
+  EventActor,
+  EventProvenance,
+  EventService,
+  OperationContext,
+  RulesDisposition,
+} from './operation.js';
 
 /**
  * Eval-time payload emitted to {@link Sandbox.onDenial} subscribers.
@@ -158,6 +172,9 @@ export interface RequestEvent {
    *  setup/admin operation so fixture tooling can exclude it from protected
    *  behavior while still preserving it as replay context. */
   detail?: { admin?: boolean } & Record<string, unknown>;
+  /** Canonical statement of whether Security Rules evaluated this request.
+   * Added by the sandbox event recorder when an older emitter omits it. */
+  rulesDisposition?: RulesDisposition;
 }
 
 /**
@@ -443,6 +460,10 @@ export interface SandboxOperationEvent {
   groupKind?: 'batch' | 'transaction';
   triggeredBy?: { method: string; path?: string };
   detail?: Record<string, unknown>;
+  /** Canonical statement of whether Security Rules evaluated this operation.
+   * Service emitters may provide it directly; the recorder normalizes legacy
+   * operation shapes at the unified stream seam. */
+  rulesDisposition?: RulesDisposition;
 }
 
 /**
@@ -516,54 +537,6 @@ export interface SandboxRuntimeErrorEvent {
     message: string;
   };
   detail?: Record<string, unknown>;
-}
-
-/**
- * Which sandbox service emitted an event. Today only Firestore emits (events
- * omit `service`, read as `'firestore'`); Pyric Studio's keystone track makes
- * Auth/Storage/RTDB emit into this same stream. See the design rationale.
- */
-export type EventService = 'firestore' | 'auth' | 'storage' | 'rtdb' | 'messaging' | 'ai';
-
-/** Who initiated the operation behind an event (Studio attributes activity to
- *  the human, the app, or a specific agent). Absent ⇒ the served app. */
-export type EventActor =
-  | { kind: 'app' }
-  | { kind: 'studio' }
-  | { kind: 'agent'; name: string }
-  | { kind: 'app-builder' };
-
-/**
- * The auth lens an operation ran under: `admin` bypasses rules, `as` evaluates
- * rules as a specific uid (impersonation — the rules-debugging primitive),
- * `app-session` is the app's own signed-in user, and `anon` is a genuinely
- * UNAUTHENTICATED context (`withAuth(null)` — `request.auth == null` in rules).
- * Mirrors the worker's per-op `actAs`. Absent ⇒ `app-session`.
- *
- * `anon` vs absent matters for RELAYED ops (the remote sandbox): an op with no
- * lens resolves to the browser tab's port session — whoever happens to be
- * signed in in the tab. Remote code that means "no auth" must pin
- * `{ mode: 'anon' }` explicitly, or it silently runs as the tab's user.
- */
-export type AuthLens =
-  | { mode: 'admin' }
-  | { mode: 'as'; uid: string; token?: Record<string, unknown> }
-  | { mode: 'app-session' }
-  | { mode: 'anon' };
-
-/**
- * Provenance carried by every {@link SandboxEvent}. All fields are OPTIONAL and
- * additive: pre-provenance emitters omit them (treated as
- * firestore / app / app-session), so nothing breaks. The Pyric Studio event
- * unification track stamps them at emit across all services, which is what
- * turns the log into "who did what" (Action Center, audit, agent attribution).
- */
-export interface EventProvenance {
-  service?: EventService;
-  actor?: EventActor;
-  authLens?: AuthLens;
-  /** Set when the op is part of an agent plan (Pyric Agent dry-run / accept). */
-  planId?: string;
 }
 
 /**

--- a/packages/pyric/src/sandbox/types/index.ts
+++ b/packages/pyric/src/sandbox/types/index.ts
@@ -26,11 +26,7 @@ export { SandboxError } from './errors.js';
 export type { PersistableService, SandboxSnapshot } from './persistence.js';
 
 export type {
-  AuthLens,
   DenialEvent,
-  EventActor,
-  EventProvenance,
-  EventService,
   ListenerLifecycleEvent,
   RequestEvent,
   SandboxCommitEvent,
@@ -45,6 +41,14 @@ export type {
   SnapshotSuppressedEvent,
   WriteSandboxEvent,
 } from './events.js';
+export type {
+  AuthLens,
+  EventActor,
+  EventProvenance,
+  EventService,
+  OperationContext,
+  RulesDisposition,
+} from './operation.js';
 
 export type {
   LocalSandbox,

--- a/packages/pyric/src/sandbox/types/operation.ts
+++ b/packages/pyric/src/sandbox/types/operation.ts
@@ -1,0 +1,50 @@
+/** Cross-service operation identity and Security Rules disposition. */
+
+/** Which sandbox service emitted an event. */
+export type EventService = 'firestore' | 'auth' | 'storage' | 'rtdb' | 'messaging' | 'ai';
+
+/** Who initiated the operation behind an event. Missing source is represented
+ * explicitly as `unattributed`; it is never silently promoted to app traffic. */
+export type EventActor =
+  | { kind: 'app' }
+  | { kind: 'studio' }
+  | { kind: 'agent'; name: string }
+  | { kind: 'app-builder' }
+  | { kind: 'unattributed' };
+
+/** The identity/rules lens an operation actually ran under. */
+export type AuthLens =
+  | { mode: 'admin' }
+  | { mode: 'as'; uid: string; token?: Record<string, unknown> }
+  | { mode: 'app-session' }
+  | { mode: 'anon' };
+
+/** Immutable operation provenance, bound where an operation is issued.
+ * Source and auth lens are deliberately orthogonal: Studio may evaluate rules
+ * as a user, while an app or agent may use an admin lens. */
+export interface OperationContext {
+  readonly source: EventActor;
+  readonly authLens: AuthLens;
+  readonly planId?: string;
+}
+
+/** What happened at the Security Rules seam. Admin is a lens; `bypassed` is
+ * the rules disposition. */
+export type RulesDisposition =
+  | { kind: 'evaluated'; verdict: 'allow' | 'deny' }
+  | { kind: 'bypassed'; reason: 'admin' }
+  | {
+      kind: 'not-evaluated';
+      reason: 'no-rules' | 'unsupported' | 'not-a-rules-operation' | 'runtime-error';
+    };
+
+/** Compatibility provenance carried by sandbox events while producers and
+ * consumers migrate to the canonical `operationContext`. */
+export interface EventProvenance {
+  service?: EventService;
+  actor?: EventActor;
+  authLens?: AuthLens;
+  operationContext?: OperationContext;
+  /** Set when the op is part of an agent plan. */
+  planId?: string;
+}

--- a/packages/pyric/src/storage/download.ts
+++ b/packages/pyric/src/storage/download.ts
@@ -16,7 +16,7 @@
  */
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
 import type { EventProvenance } from 'pyric/sandbox';
-import { getStorageService, targetOf } from './service.js';
+import { getStorageService, storageOperationProvenance, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored } from './rules.js';
 import { objectNotFound, quotaExceeded, invalidRootOperation } from './errors.js';
@@ -83,6 +83,7 @@ export async function deleteObject(
 ): Promise<void> {
   guardNonRoot(ref, 'deleteObject');
   const target = targetOf(ref.storage);
+  const operationProvenance = storageOperationProvenance(target, provenance);
   const service = await getStorageService(ref.storage);
   const existing = await service.backend.getMetadata(ref.fullPath);
   enforceRules(service, {
@@ -92,7 +93,7 @@ export async function deleteObject(
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
-  }, target, provenance);
+  }, target, operationProvenance);
   await service.backend.delete(ref.fullPath);
   try {
     emitSandboxEvent(
@@ -105,7 +106,7 @@ export async function deleteObject(
         before: existing ?? undefined,
         detail: { bucket: ref.bucket },
       }),
-      { ...provenance, service: 'storage' },
+      operationProvenance,
     );
   } catch {
     // Observational — never let event emission break a storage delete.
@@ -119,6 +120,7 @@ async function fetchBlob(
   maxDownloadSizeBytes: number | undefined,
 ): Promise<Blob> {
   const target = targetOf(ref.storage);
+  const operationProvenance = storageOperationProvenance(target);
   const service = await getStorageService(ref.storage);
   // Rule check uses the existing object's metadata (when present)
   // as `resource`. `unauthorized` supersedes `not-found`: the rule
@@ -134,7 +136,7 @@ async function fetchBlob(
       path: ref.fullPath,
     },
     resource: resourceFromStored(existing),
-  }, target);
+  }, target, operationProvenance);
   const blob = await service.backend.getBlob(ref.fullPath);
   if (!blob) {
     throw objectNotFound(ref.fullPath);

--- a/packages/pyric/src/storage/enforce.ts
+++ b/packages/pyric/src/storage/enforce.ts
@@ -42,7 +42,11 @@
  */
 import { emitSandboxEvent, makeSandboxOperationEvent } from 'pyric/sandbox/internal';
 import type { EventProvenance } from 'pyric/sandbox';
-import type { StorageService, Target } from './service.js';
+import {
+  storageOperationProvenance,
+  type StorageService,
+  type Target,
+} from './service.js';
 import { evaluateStorageRules, type EvaluationInput, type FirestoreLookup } from './rules.js';
 import { unauthorized } from './errors.js';
 
@@ -52,30 +56,33 @@ export function enforceRules(
   target?: Target,
   provenance?: EventProvenance,
 ): void {
+  const boundProvenance = target?.kind === 'sandbox'
+    ? storageOperationProvenance(target, provenance)
+    : provenance;
   // Admin plane (internal `getAdminStorageSandbox` handles): rules are
   // bypassed entirely — firebase-admin semantics. See `SandboxTarget.admin`.
   // Rules never ran; the event still lands so Studio can show the op, with
   // `result: 'not-applicable'` + `origin: 'admin'` — the same shape RTDB's
-  // admin plane (`adminSet`/`adminGet`/...) emits, which Studio's
-  // `verdict.ts` classifies as `'admin'` regardless of `result`.
+  // admin plane (`adminSet`/`adminGet`/...) emits, with an explicit
+  // bypass disposition independent of source or auth-lens presentation.
   if (target?.kind === 'sandbox' && target.admin === true) {
-    emitOperation(target, input, 'not-applicable', undefined, 'admin', false, provenance);
+    emitOperation(target, input, 'not-applicable', undefined, 'admin', false, boundProvenance);
     return;
   }
   if (!service.rules) {
     // Open-by-default: no rules configured, no evaluation happened.
     // Still emit `allow` for parity — an unrestricted op is legitimately
     // "allowed", just never evaluated.
-    emitOperation(target, input, 'allow', undefined, 'user', false, provenance);
+    emitOperation(target, input, 'allow', undefined, 'user', false, boundProvenance);
     return;
   }
   const result = evaluateStorageRules(service.rules, input, undefined, firestoreLookupFor(target));
   if (!result.allowed) {
-    emitOperation(target, input, 'deny', result.reasons, 'user', true, provenance);
+    emitOperation(target, input, 'deny', result.reasons, 'user', true, boundProvenance);
     const detail = result.reasons.length > 0 ? ` — ${result.reasons.join('; ')}` : '';
     throw unauthorized(input.request.method, input.request.path, detail);
   }
-  emitOperation(target, input, 'allow', result.reasons, 'user', true, provenance);
+  emitOperation(target, input, 'allow', result.reasons, 'user', true, boundProvenance);
 }
 
 /**
@@ -104,6 +111,11 @@ function emitOperation(
         result,
         origin,
         reasons,
+        rulesDisposition: origin === 'admin'
+          ? { kind: 'bypassed', reason: 'admin' }
+          : evaluated
+            ? { kind: 'evaluated', verdict: result === 'deny' ? 'deny' : 'allow' }
+            : { kind: 'not-evaluated', reason: 'no-rules' },
         rules: evaluated
           ? {
               engine: 'storage',

--- a/packages/pyric/src/storage/index.ts
+++ b/packages/pyric/src/storage/index.ts
@@ -25,6 +25,7 @@
 
 import { getStorageSandbox } from './service.js';
 import type { FirebaseStorage } from './service.js';
+import { bindOperationContext } from 'pyric/sandbox/internal';
 
 import type { PyricApp } from 'pyric/app';
 
@@ -36,7 +37,10 @@ export type { FirebaseStorage, StorageOptions, Target, SandboxTarget } from './s
 // Package resolution chooses Firebase or Pyric before this module loads.
 // Therefore a Pyric Storage entry accepts only a sandbox-backed PyricApp.
 export function getStorage(app: PyricApp, _bucketUrl?: string): FirebaseStorage {
-  return getStorageSandbox(app.sandbox);
+  return getStorageSandbox(bindOperationContext(app.sandbox.withAuth(app.sandbox.currentUser), {
+    source: { kind: 'app' },
+    authLens: { mode: 'app-session' },
+  }));
 }
 
 export { StorageError } from './errors.js';

--- a/packages/pyric/src/storage/internal.ts
+++ b/packages/pyric/src/storage/internal.ts
@@ -15,4 +15,7 @@
  * the sandbox's host-only seams.
  */
 
-export { getAdminStorageSandbox } from './service.js';
+export {
+  bindStorageOperationContext,
+  getAdminStorageSandbox,
+} from './service.js';

--- a/packages/pyric/src/storage/list.ts
+++ b/packages/pyric/src/storage/list.ts
@@ -24,7 +24,7 @@
  * that semantic exactly.
  */
 import { ref, type StorageReference } from './reference.js';
-import { getStorageService, targetOf } from './service.js';
+import { getStorageService, storageOperationProvenance, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 
 /**
@@ -45,6 +45,7 @@ export interface ListResult {
 export async function listAll(refIn: StorageReference): Promise<ListResult> {
   const storage = refIn.storage;
   const target = targetOf(storage);
+  const operationProvenance = storageOperationProvenance(target);
   const service = await getStorageService(storage);
   // ST-B2: enforce rules on the listed prefix. Firebase Storage's
   // `read` permission governs both download AND list, so a `listAll`
@@ -59,7 +60,7 @@ export async function listAll(refIn: StorageReference): Promise<ListResult> {
       path: refIn.fullPath,
     },
     resource: null,
-  }, target);
+  }, target, operationProvenance);
   const scanPrefix = refIn.fullPath === '' ? '' : `${refIn.fullPath}/`;
   const records = await service.backend.listByPrefix(scanPrefix);
 

--- a/packages/pyric/src/storage/metadata.ts
+++ b/packages/pyric/src/storage/metadata.ts
@@ -17,7 +17,7 @@
  */
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
 import type { EventProvenance } from 'pyric/sandbox';
-import { getStorageService, targetOf } from './service.js';
+import { getStorageService, storageOperationProvenance, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
 import { objectNotFound, invalidRootOperation } from './errors.js';
@@ -127,6 +127,7 @@ export function bump(value: string): string {
 export async function getMetadata(ref: StorageReference): Promise<FullMetadata> {
   guardNonRoot(ref, 'getMetadata');
   const target = targetOf(ref.storage);
+  const operationProvenance = storageOperationProvenance(target);
   const service = await getStorageService(ref.storage);
   const stored = await service.backend.getMetadata(ref.fullPath);
   enforceRules(service, {
@@ -136,7 +137,7 @@ export async function getMetadata(ref: StorageReference): Promise<FullMetadata> 
       path: ref.fullPath,
     },
     resource: resourceFromStored(stored),
-  }, target);
+  }, target, operationProvenance);
   if (!stored) {
     throw objectNotFound(ref.fullPath);
   }
@@ -166,6 +167,7 @@ export async function updateMetadata(
 ): Promise<FullMetadata> {
   guardNonRoot(ref, 'updateMetadata');
   const target = targetOf(ref.storage);
+  const operationProvenance = storageOperationProvenance(target, provenance);
   const service = await getStorageService(ref.storage);
   const existing = await service.backend.getMetadata(ref.fullPath);
   enforceRules(service, {
@@ -189,7 +191,7 @@ export async function updateMetadata(
         : undefined,
     },
     resource: resourceFromStored(existing),
-  }, target, provenance);
+  }, target, operationProvenance);
   if (!existing) {
     throw objectNotFound(ref.fullPath);
   }
@@ -207,7 +209,7 @@ export async function updateMetadata(
         after: next,
         detail: { bucket: ref.bucket },
       }),
-      { ...provenance, service: 'storage' },
+      operationProvenance,
     );
   } catch {
     // Observational — never let event emission break a metadata update.

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -19,7 +19,12 @@
  * `Promise<StorageService>` for sandbox handles.
  */
 import { SandboxContextImpl } from 'pyric/sandbox';
-import type { Sandbox, SandboxContext } from 'pyric/sandbox';
+import type { EventProvenance, Sandbox, SandboxContext } from 'pyric/sandbox';
+import {
+  bindOperationContext,
+  provenanceForOperationContext,
+  resolveOperationContext,
+} from 'pyric/sandbox/internal';
 import { openStorageBackend, type StorageBackend } from './persistence.js';
 import { parseStorageRules, type StorageRules } from './rules.js';
 
@@ -223,13 +228,15 @@ export function getStorageSandbox(
   return handle;
 }
 
-/** One rules-bypass admin handle per `Sandbox` (internal admin plane). */
-const ADMIN_SANDBOX_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
+/** Admin handles are cached by bound context so Studio, agent, and
+ * unattributed callers can share storage state without sharing provenance. */
+const ADMIN_CONTEXT_HANDLES = new WeakMap<SandboxContext, FirebaseStorage>();
+const BARE_ADMIN_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
 
 /**
  * INTERNAL (exported via `pyric/storage/internal` only) — construct
  * (or return cached) the rules-BYPASS admin `FirebaseStorage` handle
- * for a sandbox. Shares the SAME `StorageService` (one IDB store, one
+ * for a sandbox or bound context. Shares the SAME `StorageService` (one IDB store, one
  * ruleset) as every rules-honest handle on that sandbox; only rule
  * evaluation is skipped (see {@link SandboxTarget.admin}). Bucket /
  * dbName / rules options follow the same first-call-per-`Sandbox`
@@ -242,29 +249,83 @@ const ADMIN_SANDBOX_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
  * surface so the modular API stays rules-honest.
  */
 export function getAdminStorageSandbox(
-  sandbox: Sandbox,
+  target: Sandbox | SandboxContext,
   options: StorageOptions = {},
 ): FirebaseStorage {
+  const fromBareSandbox = !isContext(target);
+  const sandbox = isContext(target) ? target.sandbox : target;
   // Service first (late differing `rules` must throw, even on a cache hit).
   const servicePromise = ensureService(sandbox, options, 'getAdminStorageSandbox');
 
-  const cached = ADMIN_SANDBOX_HANDLES.get(sandbox);
+  if (fromBareSandbox) {
+    const cachedBare = BARE_ADMIN_HANDLES.get(sandbox);
+    if (cachedBare) return cachedBare;
+  }
+
+  const baseContext = isContext(target) ? target : sandbox.withAuth(null);
+  const context = baseContext.operationContext.authLens.mode === 'admin'
+    ? baseContext
+    : bindOperationContext(baseContext, {
+        source: baseContext.operationContext.source,
+        authLens: { mode: 'admin' },
+        ...(baseContext.operationContext.planId === undefined
+          ? {}
+          : { planId: baseContext.operationContext.planId }),
+      });
+  const cached = ADMIN_CONTEXT_HANDLES.get(baseContext);
   if (cached) return cached;
 
   const sandboxTarget: SandboxTarget = {
     kind: 'sandbox',
     sandbox,
-    // Anonymous context: the admin plane has no acting user. Rules are
-    // bypassed, so the context identity only feeds event provenance
-    // (`auth: null` — same as an anonymous caller).
-    context: sandbox.withAuth(null),
+    context,
     bucket: options.bucket ?? DEFAULT_BUCKET,
     servicePromise,
     admin: true,
   };
   const handle: FirebaseStorage = Object.freeze({ [TARGET_SYMBOL]: sandboxTarget });
-  ADMIN_SANDBOX_HANDLES.set(sandbox, handle);
+  ADMIN_CONTEXT_HANDLES.set(baseContext, handle);
+  if (fromBareSandbox) BARE_ADMIN_HANDLES.set(sandbox, handle);
   return handle;
+}
+
+/** Merge a host override with the immutable provenance bound to a Storage
+ * handle. The result is captured before awaits, so concurrent async
+ * operations cannot exchange source or auth-lens identity. */
+export function storageOperationProvenance(
+  target: SandboxTarget,
+  override?: EventProvenance,
+): EventProvenance {
+  const context = resolveOperationContext(
+    override,
+    provenanceForOperationContext(target.context.operationContext),
+  );
+  return {
+    ...override,
+    ...provenanceForOperationContext(context),
+    service: 'storage',
+  };
+}
+
+/** Return an operation-scoped view of a Storage handle. The backing service,
+ * bucket, and admin/rules mode are shared; only immutable operation identity is
+ * rebound. Worker hosts use this internal seam instead of extending Firebase's
+ * public function signatures with host-only provenance arguments. */
+export function bindStorageOperationContext(
+  storage: FirebaseStorage,
+  provenance: EventProvenance | undefined,
+): FirebaseStorage {
+  if (!provenance) return storage;
+  const target = targetOf(storage);
+  const context = resolveOperationContext(
+    provenance,
+    provenanceForOperationContext(target.context.operationContext),
+  );
+  const scopedTarget: SandboxTarget = {
+    ...target,
+    context: bindOperationContext(target.context, context),
+  };
+  return Object.freeze({ [TARGET_SYMBOL]: scopedTarget });
 }
 
 /**

--- a/packages/pyric/src/storage/upload.ts
+++ b/packages/pyric/src/storage/upload.ts
@@ -25,7 +25,7 @@
  */
 import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
 import type { EventProvenance } from 'pyric/sandbox';
-import { getStorageService, targetOf } from './service.js';
+import { getStorageService, storageOperationProvenance, targetOf } from './service.js';
 import { enforceRules } from './enforce.js';
 import { resourceFromStored, requestResourceFor } from './rules.js';
 import { toFullMetadata, type SettableMetadata, type UploadResult } from './metadata.js';
@@ -47,15 +47,11 @@ export type StringFormat = 'raw' | 'base64' | 'data_url';
  * uploads need a non-empty path, matching Firebase's
  * `invalid-root-operation` precondition.
  *
- * `provenance` (host-only) is the op's {@link EventProvenance} bound at
- * ISSUE time by the worker host — `actor`/`authLens` threaded EXPLICITLY
- * onto the emitted `service_mutation` event. Storage dispatch is async
- * (the awaits above), so it escapes the sandbox's synchronous
- * ambient-provenance window (`runWithProvenance`); the window has already
- * closed by the time this emit runs. Passing provenance through the call
- * binds it immutably to THIS op, so concurrent uploads from different
- * issuers can never swap actors. `service: 'storage'` always wins. Omitted
- * ⇒ the app-session default (a served-app write stays untagged).
+ * Provenance is captured from the reference's operation-scoped Storage
+ * handle before the first await. The optional `provenance` argument remains
+ * as a compatibility override for internal callers. Either way, concurrent
+ * uploads cannot exchange source or auth-lens identity, and
+ * `service: 'storage'` always wins.
  */
 export async function uploadBytes(
   ref: StorageReference,
@@ -65,6 +61,7 @@ export async function uploadBytes(
 ): Promise<UploadResult> {
   guardNonRoot(ref, 'uploadBytes');
   const target = targetOf(ref.storage);
+  const operationProvenance = storageOperationProvenance(target, provenance);
   const blob = toBlob(data, metadata?.contentType);
   const stored = buildStoredMetadata({ ref, blob, settable: metadata });
   const service = await getStorageService(ref.storage);
@@ -84,7 +81,7 @@ export async function uploadBytes(
       }),
     },
     resource: resourceFromStored(existing),
-  }, target, provenance);
+  }, target, operationProvenance);
   await service.backend.put(ref.fullPath, blob, stored);
   // Land the put on the unified Studio stream. Best-effort: a throw from
   // the emit path must not fail the upload the caller just completed.
@@ -105,7 +102,7 @@ export async function uploadBytes(
           overwrite: existing != null,
         },
       }),
-      { ...provenance, service: 'storage' },
+      operationProvenance,
     );
   } catch {
     // Observational — never let event emission break a storage write.

--- a/packages/pyric/test/sandbox/event-provenance.test.ts
+++ b/packages/pyric/test/sandbox/event-provenance.test.ts
@@ -35,7 +35,7 @@ function makeSandbox() {
 }
 
 describe('event provenance (Studio T1 keystone)', () => {
-  it('stamps firestore/app/app-session defaults on every Firestore event', () => {
+  it('stamps firestore/unattributed/app-session defaults on every Firestore event', () => {
     const { sandbox, env } = makeSandbox();
     const events: SandboxEvent[] = [];
     sandbox.onEvent((e) => events.push(e));
@@ -46,7 +46,7 @@ describe('event provenance (Studio T1 keystone)', () => {
     expect(events.length).toBeGreaterThan(0);
     for (const e of events) {
       expect(e.service).toBe('firestore');
-      expect(e.actor).toEqual({ kind: 'app' });
+      expect(e.actor).toEqual({ kind: 'unattributed' });
       expect(e.authLens).toEqual({ mode: 'app-session' });
       expect(e.planId).toBeUndefined();
     }
@@ -60,7 +60,7 @@ describe('event provenance (Studio T1 keystone)', () => {
     expect(history.length).toBeGreaterThan(0);
     for (const e of history) {
       expect(e.service).toBe('firestore');
-      expect(e.actor).toEqual({ kind: 'app' });
+      expect(e.actor).toEqual({ kind: 'unattributed' });
       expect(e.authLens).toEqual({ mode: 'app-session' });
     }
   });
@@ -75,7 +75,7 @@ describe('event provenance (Studio T1 keystone)', () => {
     const boundary = events.find((e) => e.kind === 'session_boundary');
     expect(boundary).toBeDefined();
     expect(boundary!.service).toBe('firestore');
-    expect(boundary!.actor).toEqual({ kind: 'app' });
+    expect(boundary!.actor).toEqual({ kind: 'unattributed' });
     expect(boundary!.authLens).toEqual({ mode: 'app-session' });
   });
 

--- a/packages/pyric/test/sandbox/operation-record.test.ts
+++ b/packages/pyric/test/sandbox/operation-record.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Canonical operation-record contract.
+ *
+ * The public sandbox event stream is the seam: callers issue real operations
+ * through public Firestore / Storage handles and observe the one normalized
+ * record consumed by Studio, metrics, and audit surfaces. The assertions do
+ * not reach into service emitters or the recorder implementation.
+ */
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'bun:test';
+import {
+  initializeSandbox,
+  toOperationRecord,
+  type EventProvenance,
+  type OperationContext,
+  type RulesDisposition,
+  type SandboxEvent,
+} from 'pyric/sandbox';
+import { bindOperationContext } from 'pyric/sandbox/internal';
+import { initializeApp } from 'pyric/app';
+import {
+  collection,
+  doc,
+  getAdminFirestore,
+  getFirestore,
+  getDocs,
+  runTransaction,
+} from 'pyric/firestore';
+import {
+  getStorageSandbox,
+  listAll,
+  ref,
+  uploadBytes,
+} from 'pyric/storage';
+import {
+  bindStorageOperationContext,
+  getAdminStorageSandbox,
+} from 'pyric/storage/internal';
+
+const STUDIO_ADMIN = {
+  source: { kind: 'studio' },
+  authLens: { mode: 'admin' },
+} satisfies OperationContext;
+
+let storageSeq = 0;
+function storageDb(label: string): string {
+  storageSeq += 1;
+  return `operation-record-${label}-${storageSeq}`;
+}
+
+describe('canonical operation records', () => {
+  it('records a Studio Firestore admin LIST as a rules bypass', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.admin.setDocument('posts/p1', { title: 'One' });
+    const context = bindOperationContext(sandbox.withAuth(null), STUDIO_ADMIN);
+    const db = getAdminFirestore(context);
+    const before = sandbox.history().length;
+
+    await getDocs(collection(db, 'posts'));
+
+    const event = sandbox.history().slice(before).find(
+      (candidate) => candidate.kind === 'request' && candidate.method === 'list',
+    );
+    expect(event).toBeDefined();
+    const record = toOperationRecord(event!);
+    expect(record).not.toBeNull();
+    expect(record!.context).toEqual(STUDIO_ADMIN);
+    expect(record!.rules).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
+  it('keeps app source orthogonal to an admin Firestore lens', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.admin.setDocument('posts/p1', { title: 'One' });
+    const app = initializeApp(
+      { sandbox },
+      `operation-record-app-admin-${Math.random().toString(36).slice(2)}`,
+    );
+    const db = getAdminFirestore(app);
+    const before = sandbox.history().length;
+
+    await getDocs(collection(db, 'posts'));
+
+    const event = sandbox.history().slice(before).find(
+      (candidate) => candidate.kind === 'request' && candidate.method === 'list',
+    );
+    const record = toOperationRecord(event!);
+    expect(record?.context).toEqual({
+      source: { kind: 'app' },
+      authLens: { mode: 'admin' },
+    });
+    expect(record?.rules).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
+  it('records an app-as-user Firestore operation without conflating source and lens', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.admin.setDocument('posts/p1', { title: 'One' });
+    const context = bindOperationContext(sandbox.withAuth({ uid: 'alice' }), {
+      source: { kind: 'app' },
+      authLens: { mode: 'as', uid: 'alice' },
+    });
+    const before = sandbox.history().length;
+
+    await getDocs(collection(getFirestore(context), 'posts'));
+
+    const event = sandbox.history().slice(before).find(
+      (candidate) => candidate.kind === 'request' && candidate.method === 'list',
+    );
+    expect(toOperationRecord(event!)?.context).toEqual({
+      source: { kind: 'app' },
+      authLens: { mode: 'as', uid: 'alice' },
+    });
+  });
+
+  it('preserves Studio/admin provenance after an async transaction callback yields', async () => {
+    const sandbox = initializeSandbox();
+    const context = bindOperationContext(sandbox.withAuth(null), STUDIO_ADMIN);
+    const db = getAdminFirestore(context);
+    const before = sandbox.history().length;
+
+    await runTransaction(db, async (tx) => {
+      await Promise.resolve();
+      tx.set(doc(db, 'posts/async-tx'), { title: 'Async' });
+    });
+
+    const event = sandbox.history().slice(before).find(
+      (candidate) => candidate.kind === 'request' && candidate.groupKind === 'transaction',
+    );
+    const record = toOperationRecord(event!);
+    expect(record?.context).toEqual(STUDIO_ADMIN);
+    expect(record?.rules).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
+  it('preserves Studio/admin provenance across an async Storage LIST', async () => {
+    const sandbox = initializeSandbox();
+    const context = bindOperationContext(sandbox.withAuth(null), STUDIO_ADMIN);
+    const storage = getAdminStorageSandbox(context, {
+      dbName: storageDb('admin-list'),
+    });
+    expect(getAdminStorageSandbox(context)).toBe(storage);
+    await uploadBytes(ref(storage, 'notes/a.txt'), new Uint8Array([1]));
+    const before = sandbox.history().length;
+
+    await listAll(ref(storage, 'notes'));
+
+    const event = sandbox.history().slice(before).find(
+      (candidate) => candidate.kind === 'operation' && candidate.service === 'storage',
+    );
+    expect(event).toBeDefined();
+    const record = toOperationRecord(event!);
+    expect(record).not.toBeNull();
+    expect(record!.context).toEqual(STUDIO_ADMIN);
+    expect(record!.rules).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
+  it('distinguishes open-by-default Storage from a Rules allow', async () => {
+    const sandbox = initializeSandbox();
+    const context = bindOperationContext(sandbox.withAuth(null), {
+      source: { kind: 'app' },
+      authLens: { mode: 'app-session' },
+    });
+    const storage = getStorageSandbox(context, { dbName: storageDb('open-list') });
+
+    await listAll(ref(storage, ''));
+
+    const event = sandbox.history().find(
+      (candidate) => candidate.kind === 'operation' && candidate.service === 'storage',
+    );
+    expect(event).toBeDefined();
+    const record = toOperationRecord(event!);
+    expect(record!.context.source).toEqual({ kind: 'app' });
+    expect(record!.rules).toEqual({ kind: 'not-evaluated', reason: 'no-rules' });
+  });
+
+  it('captures async provenance at issue time', async () => {
+    const sandbox = initializeSandbox();
+    const storage = getStorageSandbox(sandbox.withAuth(null), {
+      dbName: storageDb('issue-time'),
+    });
+    const provenance: EventProvenance = {
+      actor: { kind: 'studio' },
+      authLens: { mode: 'anon' },
+    };
+
+    const pending = listAll(ref(bindStorageOperationContext(storage, provenance), ''));
+    provenance.actor = { kind: 'app' };
+    provenance.authLens = { mode: 'app-session' };
+    await pending;
+
+    const event = sandbox.history().find(
+      (candidate) => candidate.kind === 'operation' && candidate.service === 'storage',
+    );
+    expect(toOperationRecord(event!)?.context).toEqual({
+      source: { kind: 'studio' },
+      authLens: { mode: 'anon' },
+    });
+  });
+
+  it('does not infer a rules bypass from the admin lens alone', () => {
+    const event: SandboxEvent = {
+      kind: 'operation',
+      id: 'admin-lens-without-bypass',
+      at: 1,
+      service: 'storage',
+      method: 'list',
+      path: 'notes',
+      auth: null,
+      result: 'allow',
+      origin: 'user',
+      operationContext: {
+        source: { kind: 'app' },
+        authLens: { mode: 'admin' },
+      },
+    };
+
+    expect(toOperationRecord(event)?.rules).toEqual({
+      kind: 'not-evaluated',
+      reason: 'no-rules',
+    });
+  });
+
+  it('deeply snapshots mutable auth and rules inputs', () => {
+    const token = { claims: { role: 'reader' } };
+    const rules: RulesDisposition = { kind: 'evaluated', verdict: 'allow' };
+    const event: SandboxEvent = {
+      kind: 'operation',
+      id: 'immutable-record',
+      at: 1,
+      service: 'firestore',
+      method: 'get',
+      path: 'notes/a',
+      auth: { uid: 'alice', token },
+      result: 'allow',
+      origin: 'user',
+      rulesDisposition: rules,
+    };
+    const record = toOperationRecord(event)!;
+
+    token.claims.role = 'admin';
+    rules.verdict = 'deny';
+
+    expect(record.auth).toEqual({
+      uid: 'alice',
+      token: { claims: { role: 'reader' } },
+    });
+    expect(record.rules).toEqual({ kind: 'evaluated', verdict: 'allow' });
+    expect(Object.isFrozen(record.auth)).toBe(true);
+    expect(Object.isFrozen(record.rules)).toBe(true);
+  });
+});

--- a/packages/pyric/test/sandbox/run-with-provenance.test.ts
+++ b/packages/pyric/test/sandbox/run-with-provenance.test.ts
@@ -85,7 +85,7 @@ describe('sandbox.runWithProvenance', () => {
 
     env.execute({ method: 'set', path: 'notes/n2', auth: null, data: { body: 'after' } });
     for (const e of events) {
-      expect(e.actor).toEqual({ kind: 'app' });
+      expect(e.actor).toEqual({ kind: 'unattributed' });
     }
   });
 
@@ -150,7 +150,7 @@ describe('sandbox.runWithProvenance', () => {
     expect(writeEvents.length).toBeGreaterThan(0);
     for (const e of writeEvents) expect(e.actor).toEqual({ kind: 'studio' });
     expect(deferred.length).toBeGreaterThan(0);
-    for (const e of deferred) expect(e.actor).toEqual({ kind: 'app' });
+    for (const e of deferred) expect(e.actor).toEqual({ kind: 'unattributed' });
     unsub();
   });
 });

--- a/packages/pyric/test/sandbox/service-events.test.ts
+++ b/packages/pyric/test/sandbox/service-events.test.ts
@@ -75,10 +75,13 @@ function listeners(events: SandboxEvent[]): SandboxListenerEvent[] {
   return events.filter((e): e is SandboxListenerEvent & typeof e => e.kind === 'listener');
 }
 
-function provenanceOK(e: ServiceMutationEvent): void {
+function provenanceOK(
+  e: ServiceMutationEvent,
+  authLens: NonNullable<ServiceMutationEvent['authLens']> = { mode: 'app-session' },
+): void {
   // Every emit funnels through stampProvenance, so the defaults are present.
-  expect(e.actor).toEqual({ kind: 'app' });
-  expect(e.authLens).toEqual({ mode: 'app-session' });
+  expect(e.actor).toEqual({ kind: 'unattributed' });
+  expect(e.authLens).toEqual(authLens);
 }
 
 describe('Studio T1 — Auth emits service_mutation events', () => {
@@ -177,7 +180,7 @@ describe('Studio T1 — Storage emits service_mutation events', () => {
     expect((put!.auth as { uid: string }).uid).toBe('alice');
     expect(put!.detail?.contentType).toBe('image/png');
     expect(put!.detail?.overwrite).toBe(false);
-    provenanceOK(put!);
+    provenanceOK(put!, { mode: 'as', uid: 'alice' });
   });
 
   it('deleteObject and updateMetadata emit object_delete / metadata_update', async () => {

--- a/packages/studio/src/dev/seed.ts
+++ b/packages/studio/src/dev/seed.ts
@@ -30,9 +30,11 @@ import {
   type Firestore,
 } from 'pyric/firestore';
 import { getAuth, sandbox as authSandbox, type Auth } from 'pyric/auth';
-import { getStorage, ref, uploadBytes, type FirebaseStorage } from 'pyric/storage';
+import { ref, uploadBytes, type FirebaseStorage } from 'pyric/storage';
+import { getAdminStorageSandbox } from 'pyric/storage/internal';
 import { initializeSandbox, type LocalSandbox } from 'pyric/sandbox';
 import { setRules } from 'pyric/sandbox/firestore';
+import { studioAdminContext } from '../shell/studio-operation-context.js';
 
 /** The resolved handles a seeded Studio sandbox exposes to surfaces. */
 export interface SeededHandles {
@@ -273,10 +275,11 @@ export async function createSeededSandbox(): Promise<SeededHandles> {
   // name throws app/duplicate-app), so each seeded sandbox gets its own.
   const app = initializeApp({ sandbox }, `pyric-seed-${seedAppSeq++}`);
 
-  const adminFirestore = getAdminFirestore(sandbox);
+  const studioContext = studioAdminContext(sandbox);
+  const adminFirestore = getAdminFirestore(studioContext);
   const firestore = getFirestore(sandbox);
   const auth = getAuth(sandbox);
-  const storage = getStorage(app);
+  const storage = getAdminStorageSandbox(studioContext);
 
   // Seed through the admin (rules-bypass) handle: this is fixture data.
   await applySeed({ adminFirestore, auth, storage });

--- a/packages/studio/src/features/action-center/reducer.test.ts
+++ b/packages/studio/src/features/action-center/reducer.test.ts
@@ -157,9 +157,9 @@ describe('multi-service folding', () => {
 // ─── Actor attribution + auth-lens ──────────────────────────────────────────
 
 describe('actor attribution', () => {
-  test('absent actor defaults to app (no attribution suffix)', () => {
+  test('absent actor remains unattributed', () => {
     const digest = digestFromEvents([write('users/a', 'create')]);
-    expect(digest[0].actor).toEqual({ kind: 'app' });
+    expect(digest[0].actor).toEqual({ kind: 'unattributed' });
     expect(attribution(digest[0])).toBe('');
   });
 

--- a/packages/studio/src/features/action-center/reducer.ts
+++ b/packages/studio/src/features/action-center/reducer.ts
@@ -64,7 +64,8 @@ export type DigestActor =
   | { kind: 'app' }
   | { kind: 'studio' }
   | { kind: 'agent'; name: string }
-  | { kind: 'app-builder' };
+  | { kind: 'app-builder' }
+  | { kind: 'unattributed' };
 
 /** A single aggregated activity line. */
 export interface DigestItem {
@@ -213,9 +214,9 @@ function bucketFor(service: string, path: string | undefined): string {
   return `/${segs.join('/')}`;
 }
 
-/** Provenance actor → digest actor (absent ⇒ the served app). */
+/** Provenance actor → digest actor (absent stays honestly unattributed). */
 function normaliseActor(actor: EventActor | undefined): DigestActor {
-  if (!actor) return { kind: 'app' };
+  if (!actor) return { kind: 'unattributed' };
   return actor;
 }
 
@@ -260,8 +261,8 @@ interface Mutation {
 
 /** Project a raw event onto a mutation, or `null` to skip it. */
 export function toMutation(event: SandboxEvent): Mutation | null {
-  const actor = normaliseActor(event.actor);
-  const lens = lensInfo(event.authLens);
+  const actor = normaliseActor(event.operationContext?.source ?? event.actor);
+  const lens = lensInfo(event.operationContext?.authLens ?? event.authLens);
 
   if (event.kind === 'write') {
     // Committed Firestore write: the real change (denied ops never reach here).

--- a/packages/studio/src/features/data/sandbox.ts
+++ b/packages/studio/src/features/data/sandbox.ts
@@ -34,9 +34,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { initializeApp, type PyricApp } from 'pyric/app';
 import { getAdminFirestore, getFirestore, type Firestore } from 'pyric/firestore';
 import { getAuth, type Auth } from 'pyric/auth';
-import { getStorage, type FirebaseStorage } from 'pyric/storage';
+import type { FirebaseStorage } from 'pyric/storage';
 import { initializeSandbox, type PersistenceBackend, type Sandbox } from 'pyric/sandbox';
 import { getInternalEnv } from 'pyric/sandbox/internal';
+import { getAdminStorageSandbox } from 'pyric/storage/internal';
+import { studioAdminContext } from '../../shell/studio-operation-context.js';
 import type { FirestoreApi } from '@pyric/ui/firestore';
 import type { AuthApi } from '@pyric/ui/auth';
 import type { StorageApi } from '@pyric/ui/storage';
@@ -131,13 +133,14 @@ let studioAppSeq = 0;
 function makeHandles(sandbox: Sandbox): StudioDataHandles {
   const app = initializeApp({ sandbox }, `pyric-studio-${studioAppSeq++}`);
   const env = getInternalEnv(sandbox);
+  const studioContext = studioAdminContext(sandbox);
   return {
     sandbox,
     app,
     firestore: getFirestore(sandbox),
-    adminFirestore: getAdminFirestore(sandbox),
+    adminFirestore: getAdminFirestore(studioContext),
     auth: getAuth(sandbox),
-    storage: getStorage(app),
+    storage: getAdminStorageSandbox(studioContext),
     listRootCollections: () => env.listRootCollections(),
     listSubcollections: (docPath: string) => env.listSubcollections(docPath),
     listDocuments: (collectionPath: string) => listDocumentsForBrowse(env, collectionPath),

--- a/packages/studio/src/features/home/activity.ts
+++ b/packages/studio/src/features/home/activity.ts
@@ -14,7 +14,13 @@
 import type { SandboxEvent } from 'pyric/sandbox';
 import type { CommandTarget } from './command.js';
 
-export type ActivityProvenance = 'app' | 'studio' | 'agent' | 'app-builder' | 'system';
+export type ActivityProvenance =
+  | 'app'
+  | 'studio'
+  | 'agent'
+  | 'app-builder'
+  | 'unattributed'
+  | 'system';
 
 export interface ActivityRow {
   id: string;
@@ -34,7 +40,7 @@ function provenanceOf(event: SandboxEvent): {
   provenance: ActivityProvenance;
   identity: string;
 } {
-  const actor = event.actor;
+  const actor = event.operationContext?.source ?? event.actor;
   if (actor?.kind === 'agent') return { provenance: 'agent', identity: `agent:${actor.name}` };
   if (actor?.kind === 'studio') return { provenance: 'studio', identity: 'studio' };
   if (actor?.kind === 'app-builder') return { provenance: 'app-builder', identity: 'builder' };
@@ -42,6 +48,9 @@ function provenanceOf(event: SandboxEvent): {
     'auth' in event && event.auth && typeof event.auth === 'object'
       ? (event.auth as { uid?: string }).uid
       : undefined;
+  if (!actor || actor.kind === 'unattributed') {
+    return { provenance: 'unattributed', identity: uid ?? 'unattributed' };
+  }
   return { provenance: 'app', identity: uid ?? 'app' };
 }
 

--- a/packages/studio/src/features/rules-debug/model.ts
+++ b/packages/studio/src/features/rules-debug/model.ts
@@ -18,6 +18,7 @@ import type {
   SandboxEvent,
   SandboxOperationEvent,
 } from 'pyric/sandbox';
+import { toOperationRecord } from 'pyric/sandbox';
 import type { EvaluatedRuleInfo, ExprTraceEntry } from 'pyric/rules/internal';
 
 type DeniedSandboxEvent = RequestEvent | SandboxOperationEvent;
@@ -93,10 +94,7 @@ function isDeniedRequest(e: SandboxEvent): e is DeniedSandboxEvent {
  *  unsupported. Excludes non-rule results (not-applicable, error) so the rules
  *  inspector only ever opens ops that actually went through a rules engine. */
 function isRulesEvaluatedRequest(e: SandboxEvent): e is DeniedSandboxEvent {
-  return (
-    (e.kind === 'request' || e.kind === 'operation') &&
-    (e.result === 'allow' || e.result === 'deny' || e.result === 'unsupported')
-  );
+  return toOperationRecord(e)?.rules.kind === 'evaluated';
 }
 
 function serviceOf(e: DeniedSandboxEvent): string {

--- a/packages/studio/src/features/rules-debug/rules-debug.test.ts
+++ b/packages/studio/src/features/rules-debug/rules-debug.test.ts
@@ -25,7 +25,11 @@ import {
   initializeSandbox,
   type SandboxEvent,
 } from 'pyric/sandbox';
-import { getFirestore as getAdminFirestore } from 'pyric/sandbox/admin-firestore';
+import { bindOperationContext } from 'pyric/sandbox/internal';
+import {
+  getAdminFirestore,
+  getFirestore as getRulesFirestore,
+} from 'pyric/sandbox/admin-firestore';
 import { getFirestore as getSandboxFirestore, doc, setDoc, collection, query, getDocs, SandboxError } from 'pyric/firestore';
 import { getDatabase, ref, set, sandbox as rtdbSandbox } from 'pyric/database';
 import {
@@ -84,11 +88,31 @@ const UNPARSEABLE_RULES = `this is not a ruleset {{{`;
  *  attempting auth so a re-run can reproduce it. */
 function denyingSandbox() {
   const sandbox = initializeSandbox();
-  getAdminFirestore(sandbox.withAuth(null)).setRules(OWNER_RULES);
+  getRulesFirestore(sandbox.withAuth(null)).setRules(OWNER_RULES);
   return sandbox;
 }
 
 describe('rules-debug model: Firestore denial → rule → context', () => {
+  it('does not present a Studio admin LIST as a Rules evaluation', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.admin.setDocument('posts/p1', { title: 'One' });
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((event) => events.push(event));
+    const context = bindOperationContext(sandbox.withAuth(null), {
+      source: { kind: 'studio' },
+      authLens: { mode: 'admin' },
+    });
+
+    await getAdminFirestore(context).collection('posts').get();
+
+    expect(selectRuleEvaluations(events)).toEqual([]);
+    const list = events.find(
+      (event) => event.kind === 'request' && event.method === 'list',
+    );
+    if (!list || list.kind !== 'request') throw new Error('Expected a Firestore LIST event');
+    expect(list.rulesDisposition).toEqual({ kind: 'bypassed', reason: 'admin' });
+  });
+
   it('projects a denied write into a Denial carrying rule, auth, and path/op', async () => {
     const sandbox = denyingSandbox();
     const events: SandboxEvent[] = [];
@@ -634,7 +658,7 @@ service cloud.firestore {
 
   async function listDenial() {
     const sandbox = initializeSandbox();
-    getAdminFirestore(sandbox.withAuth(null)).setRules(LIST_DENY_RULES);
+    getRulesFirestore(sandbox.withAuth(null)).setRules(LIST_DENY_RULES);
     const events: SandboxEvent[] = [];
     sandbox.onEvent((e) => events.push(e));
     const db = getSandboxFirestore(sandbox.withAuth({ uid: 'bob' }));

--- a/packages/studio/src/features/traffic/TrafficMetricsViews.tsx
+++ b/packages/studio/src/features/traffic/TrafficMetricsViews.tsx
@@ -2,17 +2,12 @@
  * Traffic tab strip, views 2 + 3: "Billable metrics" and "Subscriptions &
  * Rules" (Firebase Console "Usage" reference). Both metric charts reuse the
  * `@pyric/ui/traffic` bucketing hooks unchanged — this module is rendering
- * + the Studio-specific admin classifier only.
+ * + the Studio-specific Rules-bypass classifier only.
  *
- * ── Admin classification ──
- * `useBillableMetrics` / `useRulesMetrics` default to `origin === 'admin'`,
- * the one signal the base `TrafficEvent` type declares. Firestore's
- * admin-lens ops don't currently set that (RTDB's do — see the hook's
- * module doc in `@pyric/ui/traffic`); the richer signal is `authLens`,
- * which only `StudioTrafficEvent` carries. So Studio passes `verdictFor`
- * (the same admin check `verdict.ts` already uses for the row pill) as the
- * `isAdmin` override, closing that gap for every surface that reads
- * through this adapter.
+ * ── Rules-bypass classification ──
+ * The shared metric hooks retain their legacy `isAdmin` callback name, but
+ * Studio supplies the canonical Rules disposition. The metrics therefore do
+ * not infer rule behavior from the operation's source or auth lens.
  *
  * ── Subscriptions gap (documented, not faked) ──
  * The Console reference charts two subscription metrics: peak snapshot
@@ -41,11 +36,10 @@ import {
 } from '@pyric/ui/traffic';
 import { verdictFor, type StudioTrafficEvent } from './verdict.js';
 
-/** Shared admin classifier: reuse the row-pill logic so a Firestore
- *  admin-lens op (authLens-only, no `origin: 'admin'`) is still excluded
- *  from rules metrics and still counted as a billable op. */
-function isAdminOp(event: { origin?: string }): boolean {
-  return verdictFor(event as unknown as StudioTrafficEvent) === 'admin';
+/** Shared bypass classifier: rules metrics exclude operations whose canonical
+ * disposition says Rules were bypassed. */
+function isBypassedOp(event: { origin?: string }): boolean {
+  return verdictFor(event as unknown as StudioTrafficEvent) === 'bypassed';
 }
 
 function allZero(series: readonly MetricSeries[]): boolean {
@@ -108,7 +102,7 @@ export function BillableMetricsView({
   events: StudioTrafficEvent[];
   window: TimeWindow;
 }) {
-  const metrics = useBillableMetrics({ events, window, isAdmin: isAdminOp });
+  const metrics = useBillableMetrics({ events, window, isAdmin: isBypassedOp });
   return (
     <div className="traffic__metrics" data-pyric-ui="traffic-billable-view">
       <MetricPanel
@@ -134,7 +128,7 @@ export function SubscriptionsRulesView({
   events: StudioTrafficEvent[];
   window: TimeWindow;
 }) {
-  const rules = useRulesMetrics({ events, window, isAdmin: isAdminOp });
+  const rules = useRulesMetrics({ events, window, isAdmin: isBypassedOp });
   return (
     <div className="traffic__metrics" data-pyric-ui="traffic-subscriptions-rules-view">
       <section className="traffic__metric-panel" data-pyric-ui="traffic-subscriptions-gap">

--- a/packages/studio/src/features/traffic/TrafficSurface.tsx
+++ b/packages/studio/src/features/traffic/TrafficSurface.tsx
@@ -8,13 +8,13 @@
  *   2. A compact filter row (verdict), single row per the spec's filter
  *      contract.
  *   3. The request stream (grouped via `useTrafficGroups`), each row carrying a
- *      VERDICT pill — allow | deny | admin (rules bypassed) | blank for
+ *      VERDICT pill — allow | deny | bypassed | blank for
  *      non-rule ops — derived from fields the events already carry
  *      (`verdict.ts`). Clicking a RULES-EVALUATED row (allow or deny —
  *      `opensRulesInspector`) EXPANDS IN PLACE (disclosure, no modal) into the
  *      RULES INSPECTOR detail (features/rules-debug): the deciding rule per
  *      service, request.auth, the data the rule saw, and the capability-gated
- *      re-runs. Admin-bypass and blank-verdict rows (no rules decision to
+ *      re-runs. Bypassed and blank-verdict rows (no rules decision to
  *      inspect) navigate to the record the op touched (`subjectTarget` → the
  *      route codec) instead.
  *
@@ -364,7 +364,9 @@ export function TrafficSurface() {
                           const target = subjectTarget(ev);
                           if (target) pushPath(target);
                         }}
-                        renderClassification={verdictBadge}
+                        renderClassification={(event) =>
+                          verdictBadge(event as StudioTrafficEvent)
+                        }
                         formatTime={defaultFormatTime}
                       />
                     </li>
@@ -379,7 +381,9 @@ export function TrafficSurface() {
                         event={item.event}
                         selected={item.event.id === expandedId}
                         onSelect={(e) => onRowSelect(e as StudioTrafficEvent)}
-                        renderClassification={verdictBadge}
+                        renderClassification={(event) =>
+                          verdictBadge(event as StudioTrafficEvent)
+                        }
                         formatTime={defaultFormatTime}
                       />
                       {item.event.id === expandedId &&

--- a/packages/studio/src/features/traffic/traffic.css
+++ b/packages/studio/src/features/traffic/traffic.css
@@ -394,7 +394,7 @@
   color: var(--muted);
   font: inherit;
   font-size: var(--fs-caption);
-  /* Pills are uppercase everywhere (ALLOW / DENY / ADMIN verdicts, the
+  /* Pills are uppercase everywhere (ALLOW / DENY / BYPASSED verdicts, the
      service labels) — the filter pills match the standard. */
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -438,7 +438,7 @@
   background: var(--deny);
   color: var(--deny-ink);
 }
-.traffic__verdict[data-verdict='admin'] {
+.traffic__verdict[data-verdict='bypassed'] {
   background: var(--accent-tint);
   color: var(--accent);
 }

--- a/packages/studio/src/features/traffic/verdict.test.ts
+++ b/packages/studio/src/features/traffic/verdict.test.ts
@@ -1,5 +1,6 @@
 /** Traffic verdict derivation (specs/traffic.md MVP) — pure mapping tests. */
 import { describe, expect, it } from 'bun:test';
+import type { OperationContext } from 'pyric/sandbox';
 import {
   actingIdentity,
   denialReasons,
@@ -13,36 +14,32 @@ import {
 
 describe('verdictFor', () => {
   it('maps rule-evaluated results', () => {
-    expect(verdictFor({ result: 'allow', origin: 'user' })).toBe('allow');
-    expect(verdictFor({ result: 'deny', origin: 'user' })).toBe('deny');
+    expect(verdictFor({ rulesDisposition: { kind: 'evaluated', verdict: 'allow' } })).toBe('allow');
+    expect(verdictFor({ rulesDisposition: { kind: 'evaluated', verdict: 'deny' } })).toBe('deny');
   });
 
-  it('marks rules-bypassed ops as admin (lens or origin), beating allow', () => {
-    expect(
-      verdictFor({ result: 'allow', origin: 'user', authLens: { mode: 'admin' } }),
-    ).toBe('admin');
-    expect(verdictFor({ result: 'allow', origin: 'admin' })).toBe('admin');
+  it('labels a rules bypass without conflating it with the admin lens', () => {
+    expect(verdictFor({ rulesDisposition: { kind: 'bypassed', reason: 'admin' } })).toBe(
+      'bypassed',
+    );
   });
 
   it('is blank for non-rule ops', () => {
-    expect(verdictFor({ result: 'not-applicable', origin: 'user' })).toBeNull();
-    expect(verdictFor({ result: 'unsupported', origin: 'user' })).toBeNull();
-    expect(verdictFor({ result: 'error', origin: 'user' })).toBeNull();
+    expect(verdictFor({ rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' } })).toBeNull();
+    expect(verdictFor({ rulesDisposition: { kind: 'not-evaluated', reason: 'unsupported' } })).toBeNull();
   });
 
-  it('does not treat an impersonation lens as admin', () => {
-    expect(
-      verdictFor({ result: 'deny', origin: 'user', authLens: { mode: 'as', uid: 'alice' } }),
-    ).toBe('deny');
+  it('does not derive a rules verdict from the auth lens', () => {
+    expect(verdictFor({ rulesDisposition: { kind: 'evaluated', verdict: 'deny' } })).toBe('deny');
   });
 });
 
 describe('filterByVerdict', () => {
   const events = [
-    { id: 'a', result: 'allow', origin: 'user' },
-    { id: 'b', result: 'deny', origin: 'user' },
-    { id: 'c', result: 'allow', origin: 'admin' },
-    { id: 'd', result: 'not-applicable', origin: 'system' },
+    { id: 'a', rulesDisposition: { kind: 'evaluated', verdict: 'allow' } },
+    { id: 'b', rulesDisposition: { kind: 'evaluated', verdict: 'deny' } },
+    { id: 'c', rulesDisposition: { kind: 'bypassed', reason: 'admin' } },
+    { id: 'd', rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' } },
   ] as const;
 
   it('passes everything through on all (including blank-verdict ops)', () => {
@@ -52,29 +49,27 @@ describe('filterByVerdict', () => {
   it('filters to one verdict', () => {
     expect(filterByVerdict(events, 'allow').map((e) => e.id)).toEqual(['a']);
     expect(filterByVerdict(events, 'deny').map((e) => e.id)).toEqual(['b']);
-    expect(filterByVerdict(events, 'admin').map((e) => e.id)).toEqual(['c']);
+    expect(filterByVerdict(events, 'bypassed').map((e) => e.id)).toEqual(['c']);
   });
 });
 
 describe('actingIdentity', () => {
   it('prefers the pinned lens', () => {
-    expect(actingIdentity({ auth: { uid: 'tab-user' }, authLens: { mode: 'admin' } })).toBe(
+    expect(actingIdentity({ auth: { uid: 'tab-user' }, operationContext: { source: { kind: 'studio' }, authLens: { mode: 'admin' } } })).toBe(
       'admin (rules bypassed)',
     );
     expect(
-      actingIdentity({ auth: null, authLens: { mode: 'as', uid: 'alice' } }),
+      actingIdentity({ auth: null, operationContext: { source: { kind: 'studio' }, authLens: { mode: 'as', uid: 'alice' } } }),
     ).toBe('as alice');
-    expect(actingIdentity({ auth: { uid: 'tab-user' }, authLens: { mode: 'anon' } })).toBe(
+    expect(actingIdentity({ auth: { uid: 'tab-user' }, operationContext: { source: { kind: 'studio' }, authLens: { mode: 'anon' } } })).toBe(
       'anonymous',
     );
   });
 
-  it('falls back to the op auth state (app-session / absent lens)', () => {
+  it('falls back to the op auth state for an app-session lens', () => {
     expect(
-      actingIdentity({ auth: { uid: 'bob' }, authLens: { mode: 'app-session' } }),
+      actingIdentity({ auth: { uid: 'bob' }, operationContext: { source: { kind: 'app' }, authLens: { mode: 'app-session' } } }),
     ).toBe('bob');
-    expect(actingIdentity({ auth: { uid: 'bob' } })).toBe('bob');
-    expect(actingIdentity({ auth: null })).toBe('anonymous');
   });
 });
 
@@ -115,20 +110,16 @@ describe('subjectTarget', () => {
 
 describe('opensRulesInspector (row-click semantics)', () => {
   it('rules-evaluated rows open the inspector: allow AND deny', () => {
-    expect(opensRulesInspector({ result: 'allow', origin: 'user' })).toBe(true);
-    expect(opensRulesInspector({ result: 'deny', origin: 'user' })).toBe(true);
+    expect(opensRulesInspector({ rulesDisposition: { kind: 'evaluated', verdict: 'allow' } })).toBe(true);
+    expect(opensRulesInspector({ rulesDisposition: { kind: 'evaluated', verdict: 'deny' } })).toBe(true);
   });
 
   it('admin-bypass rows keep subject navigation (rules never ran)', () => {
-    expect(
-      opensRulesInspector({ result: 'allow', origin: 'user', authLens: { mode: 'admin' } }),
-    ).toBe(false);
-    expect(opensRulesInspector({ result: 'allow', origin: 'admin' })).toBe(false);
+    expect(opensRulesInspector({ rulesDisposition: { kind: 'bypassed', reason: 'admin' } })).toBe(false);
   });
 
   it('blank-verdict rows keep subject navigation (no rules decision)', () => {
-    expect(opensRulesInspector({ result: 'not-applicable' as never, origin: 'user' })).toBe(false);
-    expect(opensRulesInspector({ result: 'error' as never, origin: 'user' })).toBe(false);
+    expect(opensRulesInspector({ rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' } })).toBe(false);
   });
 });
 
@@ -142,25 +133,19 @@ describe('denialReasons', () => {
 });
 
 describe('filterStudioTraffic', () => {
-  type Ev = { id: string; actor?: { kind?: string; name?: string } };
-  const studio: Ev = { id: 's1', actor: { kind: 'studio' } };
-  const app: Ev = { id: 'a1' }; // absent actor = served app / pre-provenance
-  const appExplicit: Ev = { id: 'a2', actor: { kind: 'app' } };
-  const agent: Ev = { id: 'g1', actor: { kind: 'agent', name: 'claude' } };
+  type Ev = { id: string; operationContext: OperationContext };
+  const studio: Ev = { id: 's1', operationContext: { source: { kind: 'studio' }, authLens: { mode: 'admin' } } };
+  const studioAsUser: Ev = { id: 's2', operationContext: { source: { kind: 'studio' }, authLens: { mode: 'as', uid: 'alice' } } };
+  const app: Ev = { id: 'a1', operationContext: { source: { kind: 'app' }, authLens: { mode: 'app-session' } } };
+  const appAdmin: Ev = { id: 'a2', operationContext: { source: { kind: 'app' }, authLens: { mode: 'admin' } } };
+  const agent: Ev = { id: 'g1', operationContext: { source: { kind: 'agent', name: 'claude' }, authLens: { mode: 'admin' } } };
 
   it('drops only studio-issued events when hiding', () => {
-    expect(filterStudioTraffic([studio, app, appExplicit, agent], true)).toEqual([
+    expect(filterStudioTraffic([studio, studioAsUser, app, appAdmin, agent], true)).toEqual([
       app,
-      appExplicit,
+      appAdmin,
       agent,
     ]);
-  });
-
-  it('never hides untagged (pre-provenance / bridge-relayed) events', () => {
-    // Provenance is declared at the issuing call site; an absent actor must
-    // pass through — remote admin-SDK traffic is untagged by design.
-    expect(filterStudioTraffic([app], true)).toEqual([app]);
-    expect(isStudioTraffic(app)).toBe(false);
   });
 
   it('is a pass-through copy when not hiding', () => {
@@ -170,8 +155,8 @@ describe('filterStudioTraffic', () => {
     expect(out).not.toBe(input);
   });
 
-  it('classifies via actor.kind only, not the auth lens', () => {
-    expect(isStudioTraffic({ actor: { kind: 'studio' } })).toBe(true);
-    expect(isStudioTraffic({ actor: { kind: 'agent' } })).toBe(false);
+  it('classifies via source only, not the auth lens', () => {
+    expect(isStudioTraffic(studioAsUser)).toBe(true);
+    expect(isStudioTraffic(appAdmin)).toBe(false);
   });
 });

--- a/packages/studio/src/features/traffic/verdict.ts
+++ b/packages/studio/src/features/traffic/verdict.ts
@@ -5,70 +5,63 @@
  *
  *   allow  rules evaluated and allowed
  *   deny   rules evaluated and denied
- *   admin  rules BYPASSED (admin lens / admin origin)
- *   null   non-rule op (not-applicable / unsupported / error) — blank cell
+ *   bypassed  rules BYPASSED (currently by an admin lens)
+ *   null   Rules not evaluated (no rules / unsupported / runtime op) — blank cell
  *
  * PURE: mapping + filtering + identity formatting only; the surface renders.
  */
 
-import type { AuthLens } from 'pyric/sandbox';
+import type { OperationContext, RulesDisposition } from 'pyric/sandbox';
 import type { TrafficEvent } from '@pyric/ui/traffic';
 import type { CommandTarget } from '../home/command.js';
 
 /** A traffic event as Studio's adapter emits it: the library shape plus the
- *  provenance every `SandboxEvent` may carry (additive, optional). `actor`
- *  is stamped MECHANICALLY at the issuing call site (Studio's worker client
- *  declares `issuer: 'studio'`; the worker host maps it onto the event via
- *  the sandbox's ambient-provenance window) — never inferred from the op's
- *  shape, so a user's own admin-SDK traffic through the remote bridge is
- *  never classified as Studio's. */
+ * canonical context and Rules disposition normalized by the sandbox recorder.
+ * Studio source is stamped mechanically at the issuing call site, never
+ * inferred from the operation shape. */
 export type StudioTrafficEvent = TrafficEvent & {
-  authLens?: AuthLens;
-  actor?: { kind?: string; name?: string };
+  operationContext: OperationContext;
+  rulesDisposition: RulesDisposition;
 };
 
 /** Was this op issued by Pyric Studio itself (data viewers/editors, the
- *  typeahead index, seed actions)? Provenance-stamped events only — an
- *  absent `actor` means the served app (or a pre-provenance emitter) and is
- *  never hidden. */
-export function isStudioTraffic(event: { actor?: { kind?: string } }): boolean {
-  return event.actor?.kind === 'studio';
+ * typeahead index, seed actions)? Source is independent of the auth lens. */
+export function isStudioTraffic(event: Pick<StudioTrafficEvent, 'operationContext'>): boolean {
+  return event.operationContext.source.kind === 'studio';
 }
 
 /** Drop Studio-issued events when `hide` is on (pure; `hide: false` is a
  *  pass-through copy so callers can treat the result uniformly). */
-export function filterStudioTraffic<E extends { actor?: { kind?: string } }>(
+export function filterStudioTraffic<E extends Pick<StudioTrafficEvent, 'operationContext'>>(
   events: readonly E[],
   hide: boolean,
 ): E[] {
   return hide ? events.filter((e) => !isStudioTraffic(e)) : [...events];
 }
 
-export type TrafficVerdict = 'allow' | 'deny' | 'admin' | null;
+export type TrafficVerdict = 'allow' | 'deny' | 'bypassed' | null;
 
 /** The filter positions, `all` plus each real verdict. */
-export type VerdictFilter = 'all' | 'allow' | 'deny' | 'admin';
+export type VerdictFilter = 'all' | 'allow' | 'deny' | 'bypassed';
 
-export const VERDICT_FILTERS: readonly VerdictFilter[] = ['all', 'allow', 'deny', 'admin'];
+export const VERDICT_FILTERS: readonly VerdictFilter[] = ['all', 'allow', 'deny', 'bypassed'];
 
 /**
- * Derive the verdict. Admin wins first: an op under the admin lens (or with
- * `origin: 'admin'`) never evaluated rules, so its `allow` result is a bypass,
- * not a rules verdict.
+ * Derive the verdict from the recorder's Rules disposition. Source and auth
+ * lens are intentionally irrelevant here.
  */
 export function verdictFor(event: {
-  result: StudioTrafficEvent['result'];
-  origin?: StudioTrafficEvent['origin'];
-  authLens?: AuthLens;
+  rulesDisposition: RulesDisposition;
 }): TrafficVerdict {
-  if (event.authLens?.mode === 'admin' || event.origin === 'admin') return 'admin';
-  if (event.result === 'deny') return 'deny';
-  if (event.result === 'allow') return 'allow';
-  return null; // not-applicable / unsupported / error → not a rules op
+  if (event.rulesDisposition.kind === 'bypassed') return 'bypassed';
+  if (event.rulesDisposition.kind === 'evaluated') {
+    return event.rulesDisposition.verdict;
+  }
+  return null;
 }
 
 /** Apply the verdict filter (`all` passes everything, including blanks). */
-export function filterByVerdict<E extends { result: StudioTrafficEvent['result']; origin?: StudioTrafficEvent['origin']; authLens?: AuthLens }>(
+export function filterByVerdict<E extends { rulesDisposition: RulesDisposition }>(
   events: readonly E[],
   filter: VerdictFilter,
 ): E[] {
@@ -82,20 +75,18 @@ export function filterByVerdict<E extends { result: StudioTrafficEvent['result']
  */
 export function actingIdentity(event: {
   auth: StudioTrafficEvent['auth'];
-  authLens?: AuthLens;
+  operationContext: OperationContext;
 }): string {
-  const lens = event.authLens;
-  if (lens) {
-    switch (lens.mode) {
-      case 'admin':
-        return 'admin (rules bypassed)';
-      case 'as':
-        return `as ${lens.uid}`;
-      case 'anon':
-        return 'anonymous';
-      case 'app-session':
-        break; // fall through to the op's auth state
-    }
+  const lens = event.operationContext.authLens;
+  switch (lens.mode) {
+    case 'admin':
+      return 'admin (rules bypassed)';
+    case 'as':
+      return `as ${lens.uid}`;
+    case 'anon':
+      return 'anonymous';
+    case 'app-session':
+      break;
   }
   return event.auth?.uid ? event.auth.uid : 'anonymous';
 }
@@ -113,12 +104,9 @@ export function denialReasons(event: { reasons?: readonly string[] }): string[] 
  * rows (non-rule ops) keep their subject navigation instead.
  */
 export function opensRulesInspector(event: {
-  result: StudioTrafficEvent['result'];
-  origin?: StudioTrafficEvent['origin'];
-  authLens?: AuthLens;
+  rulesDisposition: RulesDisposition;
 }): boolean {
-  const v = verdictFor(event);
-  return v === 'allow' || v === 'deny';
+  return event.rulesDisposition.kind === 'evaluated';
 }
 
 /**

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -35,6 +35,7 @@ import type {
   SandboxOperationEvent,
   SandboxSnapshot,
 } from 'pyric/sandbox';
+import { toOperationRecord } from 'pyric/sandbox';
 import type { StudioTrafficEvent } from '../features/traffic/verdict.js';
 import { useDevSeed } from '../dev/DevSeedProvider.js';
 import { useEnvironment } from './environment.js';
@@ -264,10 +265,16 @@ function isTrafficEvent(
 function toTrafficEvent(
   e: (RequestEvent | SandboxOperationEvent) & EventProvenance,
 ): StudioTrafficEvent {
+  const record = toOperationRecord(e);
+  if (!record) {
+    throw new Error('Studio traffic adapter received a non-operation event');
+  }
   if (e.kind === 'request') {
-    // Structurally identical (plus provenance fields riding through) — the
-    // verdict layer reads `authLens` off the same object.
-    return e as unknown as StudioTrafficEvent;
+    return {
+      ...e,
+      operationContext: record.context,
+      rulesDisposition: record.rules,
+    } as StudioTrafficEvent;
   }
   return {
     kind: 'operation',
@@ -287,7 +294,8 @@ function toTrafficEvent(
     groupId: e.groupId,
     groupKind: e.groupKind,
     triggeredBy: e.triggeredBy,
-    authLens: e.authLens,
+    operationContext: record.context,
+    rulesDisposition: record.rules,
   };
 }
 

--- a/packages/studio/src/shell/studio-operation-context.ts
+++ b/packages/studio/src/shell/studio-operation-context.ts
@@ -1,0 +1,14 @@
+/** Studio-owned operation contexts shared by in-process service adapters. */
+
+import type { OperationContext, Sandbox, SandboxContext } from 'pyric/sandbox';
+import { bindOperationContext } from 'pyric/sandbox/internal';
+
+export const STUDIO_ADMIN_CONTEXT = Object.freeze({
+  source: Object.freeze({ kind: 'studio' }),
+  authLens: Object.freeze({ mode: 'admin' }),
+}) satisfies OperationContext;
+
+/** Bind Studio as the issuer and admin as the execution lens. */
+export function studioAdminContext(sandbox: Sandbox): SandboxContext {
+  return bindOperationContext(sandbox.withAuth(null), STUDIO_ADMIN_CONTEXT);
+}


### PR DESCRIPTION
Adds a canonical operation record so Studio can distinguish who issued an operation, which auth lens executed it, and whether Security Rules evaluated it.

```ts
import {
  initializeSandbox,
  toOperationRecord,
  type SandboxEvent,
} from 'pyric/sandbox';
import { bindOperationContext } from 'pyric/sandbox/internal';
import {
  collection,
  getAdminFirestore,
  getDocs,
} from 'pyric/firestore';

const sandbox = initializeSandbox();
const events: SandboxEvent[] = [];
sandbox.onEvent((event) => events.push(event));

// Studio's trusted producer adapter binds source and execution context once
// when it constructs the service handle. Application code does not call this.
const studioAdmin = bindOperationContext(sandbox.withAuth(null), {
  source: { kind: 'studio' },
  authLens: { mode: 'admin' },
});

await getDocs(collection(getAdminFirestore(studioAdmin), 'posts'));

const listEvent = events.find(
  (event) => event.kind === 'request' && event.method === 'list',
);
if (!listEvent) throw new Error('Expected a Firestore LIST event');

const record = toOperationRecord(listEvent);
if (!record) throw new Error('Expected an operation record');

console.log({ context: record.context, rules: record.rules });
// {
//   context: {
//     source: { kind: 'studio' },
//     authLens: { mode: 'admin' },
//   },
//   rules: { kind: 'bypassed', reason: 'admin' },
// }
```

## `bindOperationContext` is adapter plumbing, not an application identity API

The example shows the operation from Studio's producer seat, which is why it imports `pyric/sandbox/internal`. Applications consume the resulting events through public APIs such as `toOperationRecord`; they do not assign their own source attribution.

The unrestricted binder stays internal for two reasons. First, making it an application API would let ordinary app code label itself as Studio or an agent, weakening what Activity and Traffic attribution means. This is not a security boundary—code in the same process can still fabricate local data—but it keeps provenance forgery from becoming a supported, accidental workflow. Second, source/lens precedence and async propagation are adapter protocol details that need room to evolve as more services adopt the model.

If external runners or agent integrations need supported attribution, they should receive a narrower, purpose-specific public API rather than the raw binder. Observation remains public; arbitrary attribution does not.

## Source, auth lens, and Rules disposition no longer imply one another

| Operation | Source | Auth lens | Rules disposition | Hidden by “Hide Studio traffic” |
| --- | --- | --- | --- | --- |
| Studio data viewer using admin access | `studio` | `admin` | `bypassed` | yes |
| Attached app using an admin handle | `app` | `admin` | `bypassed` | no |
| Event with no source evidence | `unattributed` | independently recorded | never inferred from source | no |

Activity, Action Center, and Traffic now consume the same immutable operation record. Traffic filters only on `context.source`; its verdict and Rules Inspector use only `rules`. An admin Firestore LIST therefore reads as a bypass with no fabricated rule evaluation, while a rules-evaluated LIST retains its allow/deny inspection trace.

Firestore transaction commits and Storage operations capture provenance before asynchronous work begins. The Storage worker binds an internal operation-scoped handle instead of extending Firebase-shaped public read/list signatures, so concurrent Studio and app operations cannot exchange attribution.

## Risk

`OperationContext` and `RulesDisposition` are additive event fields, but the canonical source union now includes `{ kind: 'unattributed' }`. Exhaustive downstream source switches must handle that case. This PR deliberately chooses a total, serializable source value over preserving absence inside canonical records; that naming/shape decision is the main point for reviewer judgment.

The other sensitive seam is nested provenance: ordinary nested `runWithProvenance` calls remain inner-wins, while a complete service-handle context is treated as execution evidence. The outer issuer supplies source identity and the handle supplies the auth lens that actually reached the service.

<details>
<summary>Implementation notes and verification</summary>

- Added the transport-neutral `OperationContext`, `RulesDisposition`, and immutable `OperationRecord` normalization seam.
- Bound known app and Studio sources in Firestore and Storage producers; omitted source becomes `unattributed` rather than `app`.
- Preserved the current sandbox-only app, Firestore, and Storage architecture from `main` while resolving the cherry-pick.
- Kept the parallel RTDB transport refactor out of this branch; none of its owned files changed.
- Added contracts for app-as-user, app-as-admin, Studio-as-admin, async Firestore transactions, async Storage, deep immutability, and concurrent issuer isolation.
- Two independent code reviews found no remaining standards or spec blockers after revisions.
- `bun run build` — exit 0.
- Pyric, Pyric Tools, and Studio TypeScript checks — exit 0.
- `bun run test` — exit 0 across Pyric, Pyric Admin, Pyric Tools, UI, Studio, conformance, and tool-parity.

</details>

Closes #239.
