### PR TITLE
feat(database): add sandbox-owned RTDB inspection

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -44,6 +44,15 @@ read, batch, transact, undo/redo, inspect the event log.
 `firestore_simulator_redo` · `firestore_simulator_events` ·
 `firestore_create_with_auto_id`
 
+## Realtime Database sandbox inspection — `@pyric/cli` bridge
+
+Local inspection of the RTDB state owned by the connected sandbox. Simulation
+reads the currently installed rules and data on every call; crawling returns a
+bounded structural view without leaf values. Neither tool contacts a production
+database or requires a rules-loading tool call first.
+
+`rtdb_simulate_access` · `rtdb_crawl_structure`
+
 ## Index extraction — `pyric/rules/indexes`
 
 `firestore_extract_indexes` — derive composite-index definitions from query

--- a/packages/pyric-tools/README.md
+++ b/packages/pyric-tools/README.md
@@ -82,18 +82,22 @@ rulesHash}`.
 
 ## MCP tool surface (`pyric bridge`)
 
-The bridge registers two toolsets, sourced directly from `pyric`'s own tool
-registries (`pyric/firestore` + `pyric/rules`) so the surface can't drift from
-the library — the canonical, always-current list is the
+The bridge composes its toolsets from the same factories used by its browser
+dispatcher so advertised and executable tools cannot drift. The canonical,
+always-current list is the
 [agent tool inventory](../../docs/agent-tools.md).
 
 **Sandbox-routed** — dispatched against the connected browser sandbox
 (`createFirestoreDataTools` + `createFirestoreSimulatorTools` +
-`createFirestoreInspectTools`):
+`createFirestoreInspectTools` + local RTDB inspection):
 
 - data: `firestore_get_document` / `_list_documents` / `_create_document` / `_update_document` / `_delete_document` / `_query_where` / `firestore_create_with_auto_id`
 - stateful simulator session: `firestore_simulator_create` / `_execute` / `_read` / `_batch` / `_undo` / `_redo` / `_events` / `_transaction`
 - diagnostics: `sandbox_inspect` — single-call sandbox state/rules snapshot
+- RTDB authorization: `rtdb_simulate_access` — evaluates one operation against
+  the rules and data currently installed in the connected sandbox
+- RTDB structure: `rtdb_crawl_structure` — returns a bounded structural view of
+  current sandbox data without leaf values
 
 **In-process** — run on the bridge process itself (`createFirestoreRulesTools`):
 

--- a/packages/pyric-tools/src/bridge/client/dispatch.ts
+++ b/packages/pyric-tools/src/bridge/client/dispatch.ts
@@ -10,7 +10,7 @@
  * therefore LISTED `firestore_create_document` / `sandbox_inspect`
  * etc., but a `callTool` failed at dispatch with "tool 'X' is not
  * registered with the connected sandbox peer" — succeed-at-list,
- * fail-at-dispatch. Registering all three families here (and deriving
+ * fail-at-dispatch. Registering every family here (and deriving
  * `SANDBOX_TOOL_NAMES` from the same set) closes the gap. The parity is
  * pinned by `test/bridge/tool-parity.test.ts`.
  */
@@ -98,7 +98,7 @@ function buildSandboxHandlers(sandbox: LocalSandbox) {
 
 /**
  * Build a dispatcher for the supplied `Sandbox`. The returned function
- * looks up tools by name across all three factories and invokes the
+ * looks up tools by name across every factory and invokes the
  * canonical handler. Throws `UnknownToolError` on unknown names.
  */
 export function buildSandboxDispatcher(

--- a/packages/pyric-tools/src/bridge/client/dispatch.ts
+++ b/packages/pyric-tools/src/bridge/client/dispatch.ts
@@ -26,6 +26,7 @@ import {
 import { getInternalEnv } from 'pyric/sandbox/internal';
 import type { LocalSandbox } from 'pyric/sandbox';
 import { ASSURANCE_TOOL_NAMES } from '../../assurance/tool-names.js';
+import { createRtdbInspectionTools } from '../../rtdb/inspection.js';
 
 export interface DispatchResult {
   ok: boolean;
@@ -90,6 +91,7 @@ function buildSandboxHandlers(sandbox: LocalSandbox) {
     ...createFirestoreSimulatorTools({ resolveSandbox: () => env }),
     ...createFirestoreDataTools({ resolveDb }),
     ...createFirestoreInspectTools({ resolveSandbox: () => sandbox }),
+    ...createRtdbInspectionTools({ resolveSandbox: () => sandbox }),
     ...createLazyAssuranceHandlers(sandbox),
   ];
 }
@@ -159,6 +161,7 @@ export const SANDBOX_TOOL_NAMES: string[] = (() => {
     ...createFirestoreSimulatorTools({ resolveSandbox: stub as never }),
     ...createFirestoreDataTools({ resolveDb: stub as never }),
     ...createFirestoreInspectTools({ resolveSandbox: stub as never }),
+    ...createRtdbInspectionTools({ resolveSandbox: stub as never }),
     ...ASSURANCE_TOOL_NAMES.map((name) => ({ name })),
   ].map((h) => h.name);
 })();

--- a/packages/pyric-tools/src/bridge/server/tool-metadata.ts
+++ b/packages/pyric-tools/src/bridge/server/tool-metadata.ts
@@ -20,6 +20,7 @@ import {
 } from 'pyric/rules/internal/node';
 import { createFirestoreDataTools, createFirestoreInspectTools } from 'pyric/firestore';
 import { createAssuranceTools } from '../../assurance/index.js';
+import { createRtdbInspectionTools } from '../../rtdb/inspection.js';
 
 export interface ToolMetadata {
   name: string;
@@ -69,6 +70,9 @@ export function getSandboxToolMetadata(): ToolMetadata[] {
     // that rules weren't loaded). Routes to the browser sandbox like
     // the other forwarded tools.
     ...createFirestoreInspectTools({
+      resolveSandbox: stubResolver as never,
+    }),
+    ...createRtdbInspectionTools({
       resolveSandbox: stubResolver as never,
     }),
     // Local authorization campaigns execute in the connected SharedWorker.

--- a/packages/pyric-tools/src/rtdb/crawl-snapshot.ts
+++ b/packages/pyric-tools/src/rtdb/crawl-snapshot.ts
@@ -1,0 +1,118 @@
+/** Structural RTDB traversal over an already-local sandbox snapshot. */
+export interface RtdbStructureNode {
+  path: string;
+  childCount: number;
+  truncated: boolean;
+  children: RtdbStructureNode[];
+  schema: Record<string, string>;
+  valueType?: string;
+}
+
+export interface CrawlSnapshotOptions {
+  path?: string;
+  maxDepth?: number;
+  maxChildren?: number;
+}
+
+function childPath(parent: string, key: string): string {
+  return parent === '/' ? `/${key}` : `${parent}/${key}`;
+}
+
+function valueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function normalizePath(path: string | undefined): string {
+  const segments = (path ?? '/').split('/').filter(Boolean);
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+function valueAtPath(value: unknown, path: string): unknown {
+  let current = value;
+  for (const segment of path.split('/').filter(Boolean)) {
+    if (current === null || typeof current !== 'object' || Array.isArray(current)) {
+      return null;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current ?? null;
+}
+
+function crawlNode(
+  value: unknown,
+  path: string,
+  depth: number,
+  maxDepth: number,
+  maxChildren: number,
+): RtdbStructureNode {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {
+      path,
+      childCount: 0,
+      truncated: false,
+      children: [],
+      schema: {},
+      valueType: valueType(value),
+    };
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const schema: Record<string, string> = {};
+  const objectEntries: Array<[string, Record<string, unknown>]> = [];
+
+  for (const [key, child] of entries) {
+    if (child !== null && typeof child === 'object' && !Array.isArray(child)) {
+      objectEntries.push([key, child as Record<string, unknown>]);
+    } else {
+      schema[key] = valueType(child);
+    }
+  }
+
+  const depthTruncated = depth >= maxDepth && objectEntries.length > 0;
+  const childLimitTruncated = entries.length > maxChildren;
+  const children = depth >= maxDepth
+    ? []
+    : objectEntries
+        .slice(0, maxChildren)
+        .map(([key, child]) => crawlNode(
+          child,
+          childPath(path, key),
+          depth + 1,
+          maxDepth,
+          maxChildren,
+        ));
+
+  return {
+    path,
+    childCount: entries.length,
+    truncated: depthTruncated || childLimitTruncated,
+    children,
+    schema,
+  };
+}
+
+export function crawlSnapshot(
+  snapshot: unknown,
+  options: CrawlSnapshotOptions = {},
+): RtdbStructureNode {
+  const path = normalizePath(options.path);
+  const maxDepth = options.maxDepth ?? 10;
+  const maxChildren = options.maxChildren ?? 100;
+  return crawlNode(
+    valueAtPath(snapshot, path),
+    path,
+    0,
+    maxDepth,
+    maxChildren,
+  );
+}
+
+export function countDescendantObjects(node: RtdbStructureNode): number {
+  return node.children.reduce(
+    (total, child) => total + 1 + countDescendantObjects(child),
+    0,
+  );
+}

--- a/packages/pyric-tools/src/rtdb/inspection.ts
+++ b/packages/pyric-tools/src/rtdb/inspection.ts
@@ -3,6 +3,7 @@ import type { ToolHandler } from '@inbrowser/agent';
 import { rtdbRules, type RtdbCase } from 'pyric/rules';
 import type { LocalSandbox } from 'pyric/sandbox';
 import { getActiveRules, snapshotState } from 'pyric/sandbox/database';
+import { countDescendantObjects, crawlSnapshot } from './crawl-snapshot.js';
 
 export interface RtdbInspectionToolDeps {
   resolveSandbox(): LocalSandbox | Promise<LocalSandbox>;
@@ -13,6 +14,12 @@ interface SimulateAccessArgs {
   path: string;
   auth?: { uid: string; claims?: Record<string, unknown> } | null;
   newData?: unknown;
+}
+
+interface CrawlStructureArgs {
+  path?: string;
+  maxDepth?: number;
+  maxChildren?: number;
 }
 
 export function createRtdbInspectionTools(
@@ -89,6 +96,40 @@ export function createRtdbInspectionTools(
             matchedRule: result.matchedRule,
             reason: result.reason,
           },
+        };
+      },
+    },
+    {
+      name: 'rtdb_crawl_structure',
+      description:
+        'Describe the structure of the RTDB data currently loaded in the local sandbox without returning leaf values or contacting a production database.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Root-relative path to inspect. Defaults to /.',
+          },
+          maxDepth: {
+            type: 'number',
+            minimum: 0,
+            description: 'Maximum object depth to return. Defaults to 10.',
+          },
+          maxChildren: {
+            type: 'number',
+            minimum: 1,
+            description: 'Maximum object children to return per node. Defaults to 100.',
+          },
+        },
+      },
+      async execute(rawArgs) {
+        const args = rawArgs as CrawlStructureArgs;
+        const sandbox = await deps.resolveSandbox();
+        const root = crawlSnapshot(snapshotState(sandbox), args);
+        return {
+          ok: true,
+          summary: `Crawled ${countDescendantObjects(root)} object paths from ${root.path}`,
+          data: root,
         };
       },
     },

--- a/packages/pyric-tools/src/rtdb/inspection.ts
+++ b/packages/pyric-tools/src/rtdb/inspection.ts
@@ -1,0 +1,96 @@
+/** Local RTDB inspection tools bound to one authoritative sandbox. */
+import type { ToolHandler } from '@inbrowser/agent';
+import { rtdbRules, type RtdbCase } from 'pyric/rules';
+import type { LocalSandbox } from 'pyric/sandbox';
+import { getActiveRules, snapshotState } from 'pyric/sandbox/database';
+
+export interface RtdbInspectionToolDeps {
+  resolveSandbox(): LocalSandbox | Promise<LocalSandbox>;
+}
+
+interface SimulateAccessArgs {
+  operation: 'read' | 'write' | 'validate';
+  path: string;
+  auth?: { uid: string; claims?: Record<string, unknown> } | null;
+  newData?: unknown;
+}
+
+export function createRtdbInspectionTools(
+  deps: RtdbInspectionToolDeps,
+): ToolHandler[] {
+  return [
+    {
+      name: 'rtdb_simulate_access',
+      description:
+        'Simulate one read, write, or validate operation against the RTDB rules and data currently loaded in the local sandbox. No production database is contacted and no prior rules-loading tool call is required.',
+      parameters: {
+        type: 'object',
+        properties: {
+          operation: {
+            type: 'string',
+            enum: ['read', 'write', 'validate'],
+          },
+          path: { type: 'string' },
+          auth: {
+            anyOf: [
+              { type: 'null' },
+              {
+                type: 'object',
+                properties: {
+                  uid: { type: 'string' },
+                  claims: { type: 'object' },
+                },
+                required: ['uid'],
+              },
+            ],
+          },
+          newData: {},
+        },
+        required: ['operation', 'path'],
+      },
+      async execute(rawArgs) {
+        const args = rawArgs as SimulateAccessArgs;
+        const sandbox = await deps.resolveSandbox();
+        const rules = getActiveRules(sandbox);
+        if (!rules) {
+          return {
+            ok: false,
+            summary: 'No RTDB rules are loaded in the local sandbox.',
+            data: { code: 'NO_ACTIVE_RULES' },
+          };
+        }
+
+        const state = snapshotState(sandbox);
+        const data = state !== null && typeof state === 'object' && !Array.isArray(state)
+          ? state as Record<string, unknown>
+          : {};
+        const oneCase: RtdbCase = {
+          expectation: 'ALLOW',
+          operation: args.operation,
+          path: args.path,
+          auth: args.auth
+            ? { uid: args.auth.uid, token: args.auth.claims ?? {} }
+            : null,
+          data,
+          ...(args.newData !== undefined ? { newData: args.newData } : {}),
+        };
+        const result = rtdbRules(rules).simulate([oneCase]).cases[0];
+
+        return {
+          ok: !result.unsupported,
+          summary: result.unsupported
+            ? `Simulation unsupported: ${result.reason}`
+            : `Simulation: ${result.decision.toLowerCase()}`,
+          data: {
+            decision: result.decision,
+            allowed: result.decision === 'ALLOW',
+            unsupported: result.unsupported,
+            matchedPath: result.matchedPath,
+            matchedRule: result.matchedRule,
+            reason: result.reason,
+          },
+        };
+      },
+    },
+  ];
+}

--- a/packages/pyric-tools/test/bridge/premortem-fixes.test.ts
+++ b/packages/pyric-tools/test/bridge/premortem-fixes.test.ts
@@ -322,7 +322,7 @@ describe('Premortem fixes — A2 (session leak)', () => {
 });
 
 describe('Premortem fixes — A1 (dispatcher drift eliminated)', () => {
-  test('SANDBOX_TOOL_NAMES covers the simulator + data-plane + inspect factories (no advertise/execute drift)', () => {
+  test('SANDBOX_TOOL_NAMES covers every sandbox tool factory (no advertise/execute drift)', () => {
     expect(SANDBOX_TOOL_NAMES).toEqual([
       // simulator family
       'firestore_simulator_create',
@@ -345,6 +345,9 @@ describe('Premortem fixes — A1 (dispatcher drift eliminated)', () => {
       'firestore_query_where',
       // inspect
       'sandbox_inspect',
+      // local RTDB inspection
+      'rtdb_simulate_access',
+      'rtdb_crawl_structure',
       // local-only authorization assurance
       ...ASSURANCE_TOOL_NAMES,
     ]);

--- a/packages/pyric-tools/test/rtdb/crawl-structure.test.ts
+++ b/packages/pyric-tools/test/rtdb/crawl-structure.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { setData } from 'pyric/sandbox/database';
+
+import { buildSandboxDispatcher } from '../../src/bridge/client/dispatch.js';
+
+describe('rtdb_crawl_structure', () => {
+  test('describes the current local tree without returning leaf values', async () => {
+    const sandbox = initializeSandbox();
+    const dispatch = buildSandboxDispatcher(sandbox);
+    setData(sandbox, {
+      '/users/alice': { active: true, name: 'Alice' },
+      '/users/bob': { active: false, name: 'Bob' },
+      '/version': 3,
+    });
+
+    const result = await dispatch('rtdb_crawl_structure', {});
+
+    expect(result).toEqual({
+      ok: true,
+      summary: 'Crawled 3 object paths from /',
+      data: {
+        path: '/',
+        childCount: 2,
+        truncated: false,
+        schema: { version: 'number' },
+        children: [
+          {
+            path: '/users',
+            childCount: 2,
+            truncated: false,
+            schema: {},
+            children: [
+              {
+                path: '/users/alice',
+                childCount: 2,
+                truncated: false,
+                schema: { active: 'boolean', name: 'string' },
+                children: [],
+              },
+              {
+                path: '/users/bob',
+                childCount: 2,
+                truncated: false,
+                schema: { active: 'boolean', name: 'string' },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test('selects a subtree and reports depth and child truncation', async () => {
+    const sandbox = initializeSandbox();
+    const dispatch = buildSandboxDispatcher(sandbox);
+    setData(sandbox, {
+      '/groups/beta': { owner: 'bob', users: { bob: true } },
+      '/groups/alpha': { owner: 'alice', users: { alice: true } },
+    });
+
+    const result = await dispatch('rtdb_crawl_structure', {
+      path: '/groups',
+      maxDepth: 1,
+      maxChildren: 1,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      summary: 'Crawled 1 object paths from /groups',
+      data: {
+        path: '/groups',
+        childCount: 2,
+        truncated: true,
+        schema: {},
+        children: [
+          {
+            path: '/groups/alpha',
+            childCount: 2,
+            truncated: true,
+            schema: { owner: 'string' },
+            children: [],
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/pyric-tools/test/rtdb/simulate-access.test.ts
+++ b/packages/pyric-tools/test/rtdb/simulate-access.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { setData, setRules } from 'pyric/sandbox/database';
+
+import { buildSandboxDispatcher } from '../../src/bridge/client/dispatch.js';
+
+describe('rtdb_simulate_access', () => {
+  test('uses the sandbox current rules and data on every call', async () => {
+    const sandbox = initializeSandbox();
+    const dispatch = buildSandboxDispatcher(sandbox);
+    setData(sandbox, {
+      '/members/alice': true,
+      '/notes/n1': { title: 'Before', owner: 'alice' },
+    });
+
+    setRules(sandbox, {
+      rules: {
+        notes: {
+          '$noteId': {
+            '.write': "root.child('members').child(auth.uid).val() == true",
+            '.validate': "newData.hasChildren(['title', 'owner'])",
+          },
+        },
+      },
+    });
+
+    const denied = await dispatch('rtdb_simulate_access', {
+      operation: 'write',
+      path: '/notes/n1',
+      auth: { uid: 'alice' },
+      newData: { title: 'Missing owner' },
+    });
+    expect(denied).toMatchObject({
+      ok: true,
+      data: { decision: 'DENY' },
+    });
+
+    setRules(sandbox, {
+      rules: {
+        notes: {
+          '$noteId': {
+            '.write': "root.child('members').child(auth.uid).val() == true",
+            '.validate': "newData.hasChild('title')",
+          },
+        },
+      },
+    });
+
+    const allowed = await dispatch('rtdb_simulate_access', {
+      operation: 'write',
+      path: '/notes/n1',
+      auth: { uid: 'alice' },
+      newData: { title: 'Still a simulation' },
+    });
+    expect(allowed).toMatchObject({
+      ok: true,
+      data: { decision: 'ALLOW' },
+    });
+  });
+});

--- a/packages/pyric/CHANGELOG.md
+++ b/packages/pyric/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added: local Realtime Database inspection
+
+- `rtdbRules({ rules: ... }).simulate(cases)` now evaluates compiled RTDB
+  rules JSON directly. It does not fetch rules or depend on a prior tool call.
+- `pyric/sandbox/database` exposes owner controls for installing RTDB rules,
+  seeding data, and reading detached snapshots from a `LocalSandbox`. These
+  controls share the same backend used by the `pyric/database` mirror.
+
 ### Breaking: `pyric/rules` public API replaced
 
 `pyric/rules` shipped an accidental public surface of roughly 135 exports

--- a/packages/pyric/README.md
+++ b/packages/pyric/README.md
@@ -24,6 +24,7 @@ backend, plus Pyric's rules tooling and sandbox runtime.
 | `pyric/rules/rtdb` | Realtime Database rules facade: mapper, parser/linter, simulator, deploy/read rule tool factory |
 | `pyric/rules/rtdb-constraints` | Realtime Database rules constraint helpers |
 | `pyric/sandbox` | In-process Firebase sandbox runtime |
+| `pyric/sandbox/database` | Owner controls for local RTDB rules, seed data, and state snapshots |
 | `pyric/sandbox/internal` | Adapter-only internal protocol surface |
 | `pyric/sandbox/admin-compat` | Chainable admin-compat Firestore wrapper over the sandbox |
 

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -98,6 +98,10 @@
       "types": "./dist/firestore/sandbox-controls.d.ts",
       "import": "./dist/firestore/sandbox-controls.js"
     },
+    "./sandbox/database": {
+      "types": "./dist/database/sandbox-controls.d.ts",
+      "import": "./dist/database/sandbox-controls.js"
+    },
     "./sandbox/internal": {
       "types": "./dist/sandbox/internal/index.d.ts",
       "import": "./dist/sandbox/internal/index.js"

--- a/packages/pyric/src/database/modular.ts
+++ b/packages/pyric/src/database/modular.ts
@@ -47,6 +47,7 @@ import { SandboxContextImpl } from 'pyric/sandbox';
 import { APP_TARGET, type PyricApp } from 'pyric/app';
 
 import { RtdbBackend } from './sandbox/backend.js';
+import { getOrCreateBackend } from './sandbox/backend-for.js';
 import { generatePushId } from './sandbox/push-id.js';
 import {
   serverTimestampSentinel,
@@ -92,51 +93,6 @@ function isSandboxKind(t: Target): t is SandboxTarget | SandboxLiveTarget {
 function authFor(t: SandboxTarget | SandboxLiveTarget): AuthState {
   if (t.admin) return null;
   return t.kind === 'sandbox' ? t.auth : t.sandbox.currentUser;
-}
-
-/**
- * One backend per `Sandbox`. The modular surface tracks the binding
- * here so successive `getDatabase(sandbox)` calls return handles that
- * share data (matches `firebase/database`'s singleton-per-`FirebaseApp`).
- */
-const backendBySandbox = new WeakMap<Sandbox, RtdbBackend>();
-
-function getOrCreateBackend(sandbox: Sandbox): RtdbBackend {
-  let backend = backendBySandbox.get(sandbox);
-  if (!backend) {
-    // Pass the owning sandbox so the backend can land RTDB write activity
-    // on the unified Studio `onEvent`/`history()` stream (keystone T1).
-    backend = new RtdbBackend(sandbox);
-    backendBySandbox.set(sandbox, backend);
-    // Register the RTDB tree as a persistable service on the sandbox — the
-    // same durability mechanism auth uses (see auth/index.ts:backendFor).
-    // This makes `enablePersistence` include the tree in the serialized blob
-    // and restore it on reload (worker death / browser restart), instead of
-    // the old memory-only behavior where RTDB data was lost while Firestore
-    // docs + auth users came back.
-    //
-    // Guarded by the WeakMap memoization above: we only reach this branch
-    // ONCE per sandbox, so double-registration is impossible in practice
-    // (registerPersistableService throws on duplicates anyway).
-    //
-    //   - snapshot: serialize the tree as a plain JSON value.
-    //   - restore : REPLACE the tree AND fire listeners so a live RTDB view
-    //               (Studio's RTDB tab) converges on the restored data.
-    //   - subscribe: notify the controller on ANY write so a mutation
-    //               schedules a debounced flush. RTDB writes emit
-    //               `service_mutation` events, which the controller's
-    //               `isPersistableEvent` does NOT cover — so this hook is the
-    //               sole flush trigger, exactly as auth does it.
-    const capturedBackend = backend;
-    sandbox.registerPersistableService('rtdb', {
-      snapshot: () => capturedBackend.exportTree(),
-      restore: (data: unknown) => {
-        capturedBackend.restoreTree(data as JsonValue);
-      },
-      subscribe: (onChange: () => void) => capturedBackend.subscribeWrites(onChange),
-    });
-  }
-  return backend;
 }
 
 const refToTarget = new WeakMap<object, Target>();

--- a/packages/pyric/src/database/sandbox-controls.ts
+++ b/packages/pyric/src/database/sandbox-controls.ts
@@ -1,0 +1,33 @@
+/** RTDB-specific owner controls for the public `pyric/sandbox/database` seam. */
+import type { LocalSandbox } from 'pyric/sandbox';
+
+import { getOrCreateBackend } from './sandbox/backend-for.js';
+import type { JsonValue } from './sandbox/data-tree.js';
+
+export type RtdbRulesJson = { rules: Record<string, unknown> };
+
+/** Replace the active RTDB rules. Pass `null` to restore default allow. */
+export function setRules(
+  sandbox: LocalSandbox,
+  rules: RtdbRulesJson | null,
+): void {
+  getOrCreateBackend(sandbox).setRules(rules);
+}
+
+/** Read the currently active rules as detached JSON. */
+export function getActiveRules(sandbox: LocalSandbox): RtdbRulesJson | null {
+  return getOrCreateBackend(sandbox).getActiveRules();
+}
+
+/** Replace RTDB data in bulk without applying security rules. */
+export function setData(
+  sandbox: LocalSandbox,
+  data: Record<string, unknown>,
+): void {
+  getOrCreateBackend(sandbox).setData(data as Record<string, JsonValue>);
+}
+
+/** Snapshot the complete RTDB tree without applying security rules. */
+export function snapshotState(sandbox: LocalSandbox): JsonValue {
+  return getOrCreateBackend(sandbox).snapshotState();
+}

--- a/packages/pyric/src/database/sandbox/backend-for.ts
+++ b/packages/pyric/src/database/sandbox/backend-for.ts
@@ -1,0 +1,31 @@
+/**
+ * One RTDB backend per local sandbox.
+ *
+ * The database mirror and the owner controls both cross this internal seam so
+ * they cannot accidentally create parallel trees for the same Sandbox.
+ */
+import type { Sandbox } from 'pyric/sandbox';
+
+import { RtdbBackend } from './backend.js';
+import type { JsonValue } from './data-tree.js';
+
+const backendBySandbox = new WeakMap<Sandbox, RtdbBackend>();
+
+export function getOrCreateBackend(sandbox: Sandbox): RtdbBackend {
+  let backend = backendBySandbox.get(sandbox);
+  if (backend) return backend;
+
+  backend = new RtdbBackend(sandbox);
+  backendBySandbox.set(sandbox, backend);
+
+  const capturedBackend = backend;
+  sandbox.registerPersistableService('rtdb', {
+    snapshot: () => capturedBackend.exportTree(),
+    restore: (data: unknown) => {
+      capturedBackend.restoreTree(data as JsonValue);
+    },
+    subscribe: (onChange: () => void) => capturedBackend.subscribeWrites(onChange),
+  });
+
+  return backend;
+}

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -160,6 +160,7 @@ export interface ChildListener {
 export class RtdbBackend {
   private readonly tree = new DataTree();
   private readonly rules = new RulesEvaluator();
+  private activeRules: { rules: Record<string, unknown> } | null = null;
   private readonly valueListeners = new Set<ValueListener>();
   private readonly childListeners = new Set<ChildListener>();
   private nextId = 0;
@@ -396,6 +397,11 @@ export class RtdbBackend {
 
   setRules(rulesJson: { rules: Record<string, unknown> } | null): void {
     this.rules.setRules(rulesJson);
+    this.activeRules = rulesJson === null ? null : structuredClone(rulesJson);
+  }
+
+  getActiveRules(): { rules: Record<string, unknown> } | null {
+    return this.activeRules === null ? null : structuredClone(this.activeRules);
   }
 
   snapshotState(): JsonValue {

--- a/packages/pyric/src/rules/api/rtdb.ts
+++ b/packages/pyric/src/rules/api/rtdb.ts
@@ -6,11 +6,9 @@
  *   - the value {@link defineRtdbRules} returns (an {@link RtdbRulesDocument})
  *   - compiled `{ rules }` JSON
  *
- * The definition and document inputs support the full surface. A compiled
- * `{ rules }` JSON input can only round-trip through `toJSON` — there is no
- * IR to lint or simulate against — so `lint` returns nothing and `simulate`
- * reports every case as unsupported. `toJSON` always returns compiled
- * `rules.json`.
+ * Every input supports the full surface. Compiled `{ rules }` JSON is mapped
+ * directly into the RTDB IR, so callers do not need a prior fetch/generate
+ * step before simulation. `toJSON` always returns compiled `rules.json`.
  */
 
 import { defineRtdbRules } from '../../database/constraints/document.js';
@@ -19,7 +17,12 @@ import type {
   RtdbRulesDocument,
   RtdbRulesDocumentInternal,
   RtdbRulesJson,
+  RtdbRulesSimulationAuth,
+  RtdbRulesSimulationInput,
 } from '../../database/constraints/document.js';
+import { RtdbMapper } from '../../database/mapper.js';
+import { SimulateHandler } from '../../database/simulation/handler.js';
+import type { SimulationInput, SimulateResult } from '../../database/simulation/spec.js';
 import type { RuleIssue } from './issue.js';
 import { rtdbFindingToIssue } from './issue.js';
 import type {
@@ -151,39 +154,44 @@ class DocumentRtdbRuleset implements RtdbRuleset {
   }
 }
 
-/** A handle over already-compiled `{ rules }` JSON — round-trip only. */
-class CompiledRtdbRuleset implements RtdbRuleset {
+function normalizeAuth(auth: RtdbRulesSimulationAuth | undefined): SimulationInput['auth'] {
+  if (auth === undefined || auth === null) return null;
+  if (typeof auth === 'string') return { uid: auth, token: {} };
+  return { uid: auth.uid, token: auth.token ?? {} };
+}
+
+/** Internal document adapter for already-compiled Firebase rules JSON. */
+class CompiledRtdbRulesDocument implements RtdbRulesDocumentInternal {
   constructor(private readonly json: RtdbRulesJson) {}
-  lint(): RuleIssue[] {
-    return [];
-  }
-  simulate(cases: RtdbCase[]): RtdbSimulationSummary {
-    const caseResults: RtdbCaseResult[] = cases.map((c) => ({
-      case: c,
-      ...(c.description !== undefined ? { description: c.description } : {}),
-      expectation: c.expectation,
-      decision: 'UNSUPPORTED' as const,
-      passed: false,
-      unsupported: true,
-      matchedPath: c.path,
-      matchedRule: c.operation,
-      reason: 'Cannot simulate: constructed from compiled rules.json (no IR).',
-    }));
-    return { passed: 0, failed: 0, unsupported: caseResults.length, cases: caseResults };
-  }
-  explain(oneCase: RtdbCase): RtdbExplanation {
-    return {
-      decision: 'UNSUPPORTED',
-      expectation: oneCase.expectation,
-      passed: false,
-      unsupported: true,
-      matchedPath: oneCase.path,
-      matchedRule: oneCase.operation,
-      reason: 'Cannot simulate: constructed from compiled rules.json (no IR).',
-    };
-  }
+
   toJSON(): RtdbRulesJson {
     return this.json;
+  }
+
+  toIR(databaseUrl = 'sandbox://rtdb') {
+    return RtdbMapper.mapToIR(this.json, null, databaseUrl);
+  }
+
+  check(databaseUrl?: string) {
+    return {
+      ok: true,
+      errors: [],
+      warnings: [],
+      ir: this.toIR(databaseUrl),
+    };
+  }
+
+  simulate(
+    input: RtdbRulesSimulationInput,
+    opts: { databaseUrl?: string } = {},
+  ): SimulateResult {
+    return new SimulateHandler().execute(this.toIR(opts.databaseUrl), {
+      operation: input.operation,
+      path: input.path,
+      auth: normalizeAuth(input.auth),
+      mockData: input.mockData ?? input.data ?? {},
+      ...(input.newData !== undefined ? { newData: input.newData } : {}),
+    });
   }
 }
 
@@ -193,7 +201,9 @@ class CompiledRtdbRuleset implements RtdbRuleset {
  */
 export function rtdbRules(input: RtdbRulesInput): RtdbRuleset {
   if (isDocument(input)) return new DocumentRtdbRuleset(input);
-  if (isCompiledJson(input)) return new CompiledRtdbRuleset(input);
+  if (isCompiledJson(input)) {
+    return new DocumentRtdbRuleset(new CompiledRtdbRulesDocument(input));
+  }
   return new DocumentRtdbRuleset(
     defineRtdbRules(input as RtdbRulesDefinition) as RtdbRulesDocumentInternal,
   );

--- a/packages/pyric/test/database/sandbox-controls.test.ts
+++ b/packages/pyric/test/database/sandbox-controls.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { get, getDatabase, ref } from 'pyric/database';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  getActiveRules,
+  setData,
+  setRules,
+  snapshotState,
+} from 'pyric/sandbox/database';
+
+describe('pyric/sandbox/database', () => {
+  test('owner controls and the database mirror share one sandbox state', async () => {
+    const sandbox = initializeSandbox();
+
+    setData(sandbox, {
+      '/notes/n1': { title: 'Local only' },
+    });
+
+    expect(snapshotState(sandbox)).toEqual({
+      notes: { n1: { title: 'Local only' } },
+    });
+
+    const note = await get(ref(getDatabase(sandbox), '/notes/n1'));
+    expect(note.val()).toEqual({ title: 'Local only' });
+  });
+
+  test('replacing active rules changes the next mirrored operation', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));
+    const rules = { rules: { '.read': false } };
+
+    setRules(sandbox, rules);
+    expect(getActiveRules(sandbox)).toEqual(rules);
+    await expect(get(ref(db, '/notes/n1'))).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+
+    setRules(sandbox, { rules: { '.read': true } });
+    await expect(get(ref(db, '/notes/n1'))).resolves.toBeDefined();
+  });
+});

--- a/packages/pyric/test/rules/public-api.test.ts
+++ b/packages/pyric/test/rules/public-api.test.ts
@@ -316,11 +316,26 @@ describe('rtdbRules constructor', () => {
     expect(ruleset.toJSON().rules).toBeDefined();
   });
 
-  test('accepts compiled { rules } JSON (round-trip only)', () => {
-    const compiled = { rules: { '.read': true, '.write': false } };
+  test('simulates compiled { rules } JSON directly', () => {
+    const compiled = { rules: { '.read': 'auth != null', '.write': false } };
     const ruleset = rtdbRules(compiled);
     expect(ruleset.toJSON()).toEqual(compiled);
-    expect(ruleset.lint()).toEqual([]);
+    expect(ruleset.simulate([
+      {
+        description: 'signed-in user reads',
+        expectation: 'ALLOW',
+        operation: 'read',
+        path: '/notes/n1',
+        auth: { uid: 'alice' },
+      },
+      {
+        description: 'anonymous user cannot read',
+        expectation: 'DENY',
+        operation: 'read',
+        path: '/notes/n1',
+        auth: null,
+      },
+    ]).cases.map((result) => result.decision)).toEqual(['ALLOW', 'DENY']);
   });
 
   test('lint() surfaces check findings as unified issues', () => {

--- a/scripts/tool-parity.mjs
+++ b/scripts/tool-parity.mjs
@@ -115,6 +115,7 @@ const MCP_CONTRIBUTIONS = [
   { file: `${PYRIC}/rules/simulator-tools-impl.ts`, factory: 'createFirestoreSimulatorTools', gate: 'forwarded' },
   { file: `${PYRIC}/firestore/tools.ts`, factory: 'createFirestoreDataTools', gate: 'forwarded' },
   { file: `${PYRIC}/firestore/tools.ts`, factory: 'createFirestoreInspectTools', gate: 'forwarded' },
+  { file: `${TOOLS}/rtdb/inspection.ts`, factory: 'createRtdbInspectionTools', gate: 'forwarded' },
   { file: `${TOOLS}/assurance/tools.ts`, factory: 'createAssuranceTools', gate: 'forwarded, local-only' },
   // getRulesToolHandlers → createFirestoreRulesTools, which spreads the
   // stdlib factory and adds firestore_test_rules only when a scope is

--- a/scripts/tool-parity.test.mjs
+++ b/scripts/tool-parity.test.mjs
@@ -40,6 +40,8 @@ describe('tool-parity extraction against the real codebase', () => {
       'firestore_get_document',
       'firestore_batch_write',
       'sandbox_inspect',
+      'rtdb_simulate_access',
+      'rtdb_crawl_structure',
       'firestore_simulate_rules',
       'firestore_lint_rules',
       'firestore_rules_stdlib_list',


### PR DESCRIPTION
Adds sandbox-owned RTDB inspection: compiled rules simulate directly, owner controls share mirror state, and the bridge exposes local simulation and structural crawling.

```ts
import { get, getDatabase, ref } from 'pyric/database';
import { rtdbRules } from 'pyric/rules';
import { initializeSandbox } from 'pyric/sandbox';
import {
  getActiveRules,
  setData,
  setRules,
  snapshotState,
} from 'pyric/sandbox/database';

const sandbox = initializeSandbox();
const rules = {
  rules: {
    notes: {
      '$noteId': { '.read': 'auth != null' },
    },
  },
};

setData(sandbox, { notes: { n1: { title: 'Local only' } } });
setRules(sandbox, rules);

// The Firebase-shaped mirror reads the same backend the owner controls seeded.
const note = await get(
  ref(getDatabase(sandbox.withAuth({ uid: 'alice' })), '/notes/n1'),
);
note.val(); // { title: 'Local only' }

// Compiled rules JSON simulates directly; there is no fetch/generate/cache step.
const data = snapshotState(sandbox);
if (data === null || typeof data !== 'object' || Array.isArray(data)) {
  throw new Error('Expected an object-shaped RTDB root');
}
const result = rtdbRules(getActiveRules(sandbox)!).simulate([
  {
    operation: 'read',
    path: '/notes/n1',
    auth: null,
    data,
    expectation: 'DENY',
  },
]);
result.cases[0].decision; // 'DENY'
```

## The connected sandbox is the RTDB rules and data authority

The sandbox bridge now forwards two calls to the connected browser sandbox:

```json
{"name":"rtdb_simulate_access","arguments":{"operation":"write","path":"/notes/n1","auth":{"uid":"alice"},"newData":{"title":"After"}}}
{"name":"rtdb_crawl_structure","arguments":{"path":"/notes","maxDepth":2,"maxChildren":50}}
```

`rtdb_simulate_access` reads the active rules and data on every execution, then delegates to `rtdbRules(...).simulate(...)`. Replacing rules after a dispatcher is created changes the next result, so simulation cannot depend on call order or stale IR. `rtdb_crawl_structure` walks a detached local snapshot in stable key order, reports primitive types instead of values, and bounds descended object nodes by depth and child count.

The sandbox metadata and executable dispatcher both derive these handlers from the same factory. The exact inventory and advertised/executable parity are pinned by tests.

## Risk

`pyric/sandbox/database` is a new experimental owner surface. Calling it first creates the same per-sandbox backend used by `pyric/database` and registers that backend with sandbox persistence; the shared-backend and package-resolution tests cover that ownership change.

This is the additive half of the repair. The legacy production-oriented RTDB tool exports and their stateful IR cache remain present but are not used by these sandbox handlers. Removing those exports and making `pyric/database` a strict `firebase/database` mirror is intentionally held for the dependent follow-up PR, after this replacement lands.

<details>
<summary>Implementation notes and verification</summary>

The change was developed in test-first slices for compiled-rule simulation, shared sandbox ownership, current-state authorization simulation, bounded crawling, and bridge inventory parity.

- `npm run test`: complete CI test sequence, including the repository-wide tool exposure audit
- `bun test` in `packages/pyric`: 4,935 passed, 28 skipped, 0 failed
- `bun test` in `packages/pyric-tools`: 1,458 passed, 6 skipped, 0 failed
- `bun run build:pyric`
- `bun run build:pyric-tools`
- `bun run lint:manifest`
- `bun run test:packaging`: all four packages packed, installed, and resolved; `pyric/sandbox/database` imported with four exports from the installed tarball
- `bun run compat:check`

No compatibility registry row, frozen observation, denylist entry, or coverage baseline changes in this PR. The published trust numbers remain unchanged: overall surface 64.1% (75.6% intended) and behavior 86.8% (89.8% intended), with zero orphan observations.

</details>
