### PR TITLE
feat(cli): adopt service command hierarchy

### DIFF
--- a/packages/pyric-tools/src/cli/cli.test.ts
+++ b/packages/pyric-tools/src/cli/cli.test.ts
@@ -50,6 +50,11 @@ function makeScope(projectId = 'test-project'): ProjectScope {
   };
 }
 
+function serviceArgs(argv: string[]) {
+  const parsed = parseArgs(argv);
+  return { ...parsed, positional: parsed.positional.slice(2) };
+}
+
 // ── parseArgs ─────────────────────────────────────────────────────────
 
 describe('parseArgs', () => {
@@ -61,12 +66,12 @@ describe('parseArgs', () => {
   });
 
   it('parses --flag=value syntax', () => {
-    const p = parseArgs(['rules:simulate', '--stdin=true']);
+    const p = parseArgs(['firestore', 'rules', 'simulate', '--stdin=true']);
     expect(p.flags.get('stdin')).toBe('true');
   });
 
   it('treats a flag without a value as boolean true', () => {
-    const p = parseArgs(['rules:simulate', '--stdin']);
+    const p = parseArgs(['firestore', 'rules', 'simulate', '--stdin']);
     expect(p.flags.get('stdin')).toBe(true);
   });
 
@@ -94,7 +99,7 @@ describe('parseArgs', () => {
 describe('runRulesLint', () => {
   it('errors out when no path given', async () => {
     const io = bufferIo();
-    const code = await runRulesLint(parseArgs(['rules:lint']), { ...io });
+    const code = await runRulesLint(serviceArgs(['firestore', 'rules', 'lint']), { ...io });
     expect(code).toBe(1);
     expect(io.getErr()).toContain('missing rules-file path');
   });
@@ -102,7 +107,7 @@ describe('runRulesLint', () => {
   it('passes the source to the linter and prints JSON', async () => {
     const io = bufferIo();
     const lintFn = mock(() => ({ warnings: [], metrics: { sourceSize: 5 } as never }));
-    const code = await runRulesLint(parseArgs(['rules:lint', 'firestore.rules']), {
+    const code = await runRulesLint(serviceArgs(['firestore', 'rules', 'lint', 'firestore.rules']), {
       ...io,
       cwd: '/tmp',
       readFile: (async () => 'source') as never,
@@ -119,13 +124,13 @@ describe('runRulesLint', () => {
 describe('runRulesValidate', () => {
   it('errors out when no path given', async () => {
     const io = bufferIo();
-    const code = await runRulesValidate(parseArgs(['rules:validate']), { ...io });
+    const code = await runRulesValidate(serviceArgs(['firestore', 'rules', 'validate']), { ...io });
     expect(code).toBe(1);
   });
 
   it('reports parse failure with exit 2 on invalid rules', async () => {
     const io = bufferIo();
-    const code = await runRulesValidate(parseArgs(['rules:validate', 'bad.rules']), {
+    const code = await runRulesValidate(serviceArgs(['firestore', 'rules', 'validate', 'bad.rules']), {
       ...io,
       cwd: '/tmp',
       readFile: (async () => 'not valid rules at all') as never,
@@ -142,7 +147,7 @@ describe('runRulesSimulate', () => {
       success: true,
       data: { results: [], passed: 0, failed: 0 },
     } as never));
-    const code = await runRulesSimulate(parseArgs(['rules:simulate']), {
+    const code = await runRulesSimulate(serviceArgs(['firestore', 'rules', 'simulate']), {
       ...io,
       cwd: '/tmp',
       readFirebaseJson: async () => ({ firestore: { rules: 'firestore.rules' } }),
@@ -159,7 +164,7 @@ describe('runRulesSimulate', () => {
   it('reads request from stdin when --stdin is set', async () => {
     const io = bufferIo();
     const simulateFn = mock(() => ({ success: true, data: { results: [], passed: 0, failed: 0 } } as never));
-    const code = await runRulesSimulate(parseArgs(['rules:simulate', '--stdin']), {
+    const code = await runRulesSimulate(serviceArgs(['firestore', 'rules', 'simulate', '--stdin']), {
       ...io,
       cwd: '/tmp',
       readStdin: async () =>
@@ -184,14 +189,14 @@ describe('runRulesSimulate', () => {
 describe('runDatabaseRulesLint', () => {
   it('errors out when no path given', async () => {
     const io = bufferIo();
-    const code = await runDatabaseRulesLint(parseArgs(['database:rules:lint']), { ...io });
+    const code = await runDatabaseRulesLint(serviceArgs(['database', 'rules', 'lint']), { ...io });
     expect(code).toBe(1);
     expect(io.getErr()).toContain('missing rules-file path');
   });
 
   it('prints RTDB expression lints as JSON', async () => {
     const io = bufferIo();
-    const code = await runDatabaseRulesLint(parseArgs(['database:rules:lint', 'database.rules.json']), {
+    const code = await runDatabaseRulesLint(serviceArgs(['database', 'rules', 'lint', 'database.rules.json']), {
       ...io,
       cwd: '/tmp',
       readFile: (async () => '{"rules":{".read":true,".write":false}}') as never,
@@ -208,7 +213,7 @@ describe('runDatabaseRulesLint', () => {
 describe('runDatabaseRulesValidate', () => {
   it('reports RTDB expression parse errors', async () => {
     const io = bufferIo();
-    const code = await runDatabaseRulesValidate(parseArgs(['database:rules:validate', 'database.rules.json']), {
+    const code = await runDatabaseRulesValidate(serviceArgs(['database', 'rules', 'validate', 'database.rules.json']), {
       ...io,
       cwd: '/tmp',
       readFile: (async () => '{"rules":{".read":"auth.uid =="}}') as never,
@@ -222,7 +227,7 @@ describe('runDatabaseRulesValidate', () => {
 describe('runDatabaseRulesSimulate', () => {
   it('simulates inline RTDB rules from stdin', async () => {
     const io = bufferIo();
-    const code = await runDatabaseRulesSimulate(parseArgs(['database:rules:simulate', '--stdin']), {
+    const code = await runDatabaseRulesSimulate(serviceArgs(['database', 'rules', 'simulate', '--stdin']), {
       ...io,
       readStdin: async () =>
         JSON.stringify({
@@ -249,7 +254,7 @@ describe('runDatabaseRulesGenerate', () => {
 
     const io = bufferIo();
     const writes: Array<{ path: unknown; contents: unknown }> = [];
-    const code = await runDatabaseRulesGenerate(parseArgs(['database:rules:generate']), {
+    const code = await runDatabaseRulesGenerate(serviceArgs(['database', 'rules', 'generate']), {
       ...io,
       cwd: '/project',
       loadRulesDocument: (async () => ({ ok: true, document: doc })) as never,
@@ -269,7 +274,7 @@ describe('runDatabaseRulesGenerate', () => {
 
   it('reports a clear error when no constraints module is found', async () => {
     const io = bufferIo();
-    const code = await runDatabaseRulesGenerate(parseArgs(['database:rules:generate']), {
+    const code = await runDatabaseRulesGenerate(serviceArgs(['database', 'rules', 'generate']), {
       ...io,
       cwd: '/project',
       loadRulesDocument: (async () => ({
@@ -290,7 +295,7 @@ describe('runDatabaseRulesGenerate', () => {
     let loadedPath: string | undefined;
     const writes: Array<{ path: unknown }> = [];
     const code = await runDatabaseRulesGenerate(
-      parseArgs(['database:rules:generate', '--config', 'rtdb.rules.ts', '--out', 'out/rules.json']),
+      serviceArgs(['database', 'rules', 'generate', '--config', 'rtdb.rules.ts', '--out', 'out/rules.json']),
       {
         ...io,
         cwd: '/project',

--- a/packages/pyric-tools/src/cli/database-rules.ts
+++ b/packages/pyric-tools/src/cli/database-rules.ts
@@ -1,5 +1,5 @@
 /**
- * `pyric database:rules:*` subcommands — local tooling for Realtime Database
+ * `pyric database rules *` subcommands — local tooling for Realtime Database
  * rules JSON.
  */
 
@@ -108,13 +108,13 @@ export async function runDatabaseRulesLint(
   const err = deps.stderr ?? process.stderr;
   const path = parsed.positional[0];
   if (!path) {
-    err.write('pyric database:rules:lint: missing rules-file path. Usage: pyric database:rules:lint <path>\n');
+    err.write('pyric database rules lint: missing rules-file path. Usage: pyric database rules lint <path>\n');
     return 1;
   }
 
   const file = await readRulesFile(path, deps);
   if (!file.ok) {
-    err.write(`pyric database:rules:lint: ${file.message}\n`);
+    err.write(`pyric database rules lint: ${file.message}\n`);
     return 1;
   }
 
@@ -137,13 +137,13 @@ export async function runDatabaseRulesValidate(
   const err = deps.stderr ?? process.stderr;
   const path = parsed.positional[0];
   if (!path) {
-    err.write('pyric database:rules:validate: missing rules-file path. Usage: pyric database:rules:validate <path>\n');
+    err.write('pyric database rules validate: missing rules-file path. Usage: pyric database rules validate <path>\n');
     return 1;
   }
 
   const file = await readRulesFile(path, deps);
   if (!file.ok) {
-    err.write(`pyric database:rules:validate: ${file.message}\n`);
+    err.write(`pyric database rules validate: ${file.message}\n`);
     return 1;
   }
 
@@ -209,11 +209,11 @@ export async function runDatabaseRulesSimulate(
     try {
       payload = JSON.parse(await readStdinFn()) as SimulatePayload;
     } catch (e) {
-      err.write(`pyric database:rules:simulate: failed to parse stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`);
+      err.write(`pyric database rules simulate: failed to parse stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`);
       return 1;
     }
     if (!payload.operation || !payload.path) {
-      err.write('pyric database:rules:simulate: stdin payload must include `operation` and `path`.\n');
+      err.write('pyric database rules simulate: stdin payload must include `operation` and `path`.\n');
       return 1;
     }
     databaseUrl = payload.databaseUrl ?? databaseUrl;
@@ -223,19 +223,19 @@ export async function runDatabaseRulesSimulate(
       try {
         rulesJson = JSON.parse(await readFileFn(resolvePath(deps.cwd ?? process.cwd(), payload.rulesPath), 'utf-8'));
       } catch (e) {
-        err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+        err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
         return 1;
       }
     } else {
       const file = await readFirebaseRules(deps);
       if (!file.ok) {
-        err.write(`pyric database:rules:simulate: ${file.message}\n`);
+        err.write(`pyric database rules simulate: ${file.message}\n`);
         return 1;
       }
       try {
         rulesJson = JSON.parse(file.raw);
       } catch (e) {
-        err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+        err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
         return 2;
       }
     }
@@ -249,13 +249,13 @@ export async function runDatabaseRulesSimulate(
   } else {
     const file = await readFirebaseRules(deps);
     if (!file.ok) {
-      err.write(`pyric database:rules:simulate: ${file.message}\n`);
+      err.write(`pyric database rules simulate: ${file.message}\n`);
       return 1;
     }
     try {
       rulesJson = JSON.parse(file.raw);
     } catch (e) {
-      err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+      err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
       return 2;
     }
     input = {
@@ -272,13 +272,13 @@ export async function runDatabaseRulesSimulate(
     out.write(`${JSON.stringify(result, null, 2)}\n`);
     return result.success ? 0 : 2;
   } catch (e) {
-    err.write(`pyric database:rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+    err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
     return 2;
   }
 }
 
 /**
- * `pyric database:rules:generate [--config <path>] [--out <path>]`
+ * `pyric database rules generate [--config <path>] [--out <path>]`
  *
  * Loads a user's RTDB constraints module (a file that calls
  * `defineRtdbRules(...)` from `pyric/rules`), compiles it via
@@ -306,7 +306,7 @@ export async function runDatabaseRulesGenerate(
 
   const loaded: LoadRtdbRulesDocumentResult = await loadRulesDocument(configPath, { cwd });
   if (!loaded.ok) {
-    err.write(`pyric database:rules:generate: ${loaded.message}\n`);
+    err.write(`pyric database rules generate: ${loaded.message}\n`);
     return 1;
   }
 
@@ -330,6 +330,6 @@ export async function runDatabaseRulesGenerate(
   await mkdirFn(dirname(resolvedOut), { recursive: true });
   await writeFileFn(resolvedOut, `${JSON.stringify(rulesJson, null, 2)}\n`, 'utf-8');
 
-  out.write(`pyric database:rules:generate: wrote ${resolvedOut}\n`);
+  out.write(`pyric database rules generate: wrote ${resolvedOut}\n`);
   return 0;
 }

--- a/packages/pyric-tools/src/cli/firestore-indexes.ts
+++ b/packages/pyric-tools/src/cli/firestore-indexes.ts
@@ -1,0 +1,70 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve as resolvePath } from 'node:path';
+import {
+  ExtractFirestoreIndexesHandler,
+  type ExtractIndexesOptions,
+} from 'pyric/rules/internal/extract';
+import type { ParsedArgs } from './parse-args.js';
+import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
+
+type ExtractResult = ReturnType<ExtractFirestoreIndexesHandler['execute']>;
+
+export interface FirestoreIndexesDeps {
+  extract?: (options: ExtractIndexesOptions) => ExtractResult;
+  readFirebaseJson?: (cwd: string) => Promise<FirebaseJson>;
+  writeFile?: typeof writeFile;
+  mkdir?: typeof mkdir;
+  cwd?: string;
+  stdout?: { write(s: string): void };
+  stderr?: { write(s: string): void };
+}
+
+export async function runFirestoreIndexesGenerate(
+  parsed: ParsedArgs,
+  deps: FirestoreIndexesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const cwd = deps.cwd ?? process.cwd();
+  if (parsed.positional.length === 0) {
+    err.write(
+      'pyric firestore indexes generate: missing source path. Usage: pyric firestore indexes generate <path...> [--out <path>]\n',
+    );
+    return 1;
+  }
+
+  const extract =
+    deps.extract ??
+    ((options: ExtractIndexesOptions) => new ExtractFirestoreIndexesHandler().execute(options));
+  const result = extract({ paths: parsed.positional.map((path) => resolvePath(cwd, path)) });
+  if (!result.success) {
+    err.write(`pyric firestore indexes generate: ${result.error.message}\n`);
+    return 2;
+  }
+
+  const outFlag = parsed.flags.get('out');
+  let configuredPath: string | undefined;
+  if (typeof outFlag !== 'string') {
+    try {
+      configuredPath = (await (deps.readFirebaseJson ?? readFirebaseJson)(cwd)).firestore?.indexes;
+    } catch {
+      configuredPath = undefined;
+    }
+  }
+  const outputPath = resolvePath(
+    cwd,
+    typeof outFlag === 'string' ? outFlag : configuredPath ?? 'firestore.indexes.json',
+  );
+  await (deps.mkdir ?? mkdir)(dirname(outputPath), { recursive: true });
+  await (deps.writeFile ?? writeFile)(
+    outputPath,
+    `${JSON.stringify(result.data.config, null, 2)}\n`,
+    'utf-8',
+  );
+
+  out.write(`pyric firestore indexes generate: wrote ${outputPath}\n`);
+  for (const warning of result.data.warnings) {
+    err.write(`pyric firestore indexes generate: warning: ${warning.file}: ${warning.message}\n`);
+  }
+  return 0;
+}

--- a/packages/pyric-tools/src/cli/index.ts
+++ b/packages/pyric-tools/src/cli/index.ts
@@ -9,13 +9,17 @@
  *   pyric vendor [dir] [--json]
  *   pyric snapshot [--out FILE] [--port N] [--force] [--json] [--include-passwords]
  *   pyric mcp
- *   pyric rules:lint <path>
- *   pyric rules:validate <path>
- *   pyric rules:simulate [--stdin]
- *   pyric database:rules:lint <path>
- *   pyric database:rules:validate <path>
- *   pyric database:rules:simulate [--stdin]
- *   pyric database:rules:generate [--config <path>] [--out <path>]
+ *   pyric firestore rules lint <path>
+ *   pyric firestore rules validate <path>
+ *   pyric firestore rules simulate [--stdin]
+ *   pyric firestore rules resolve <path> [--out <path>]
+ *   pyric firestore indexes generate <path...> [--out <path>]
+ *   pyric storage rules lint <path>
+ *   pyric storage rules simulate [--stdin]
+ *   pyric database rules lint <path>
+ *   pyric database rules validate <path>
+ *   pyric database rules simulate [--stdin]
+ *   pyric database rules generate [--config <path>] [--out <path>]
  *   pyric auth:configure-provider <provider> <true|false>
  *   pyric auth:manage-domains <add|remove|list> [domain]
  *   pyric firestore:discover [collection]
@@ -45,13 +49,6 @@
 import { startServer, type BridgeMode } from '@pyric/cli/bridge';
 import { parseArgs, type ParsedArgs } from './parse-args.js';
 import { runLoginCommand, runLogoutCommand, runWhoamiCommand } from './login.js';
-import { runRulesLint, runRulesValidate, runRulesSimulate } from './rules.js';
-import {
-  runDatabaseRulesLint,
-  runDatabaseRulesValidate,
-  runDatabaseRulesSimulate,
-  runDatabaseRulesGenerate,
-} from './database-rules.js';
 import { runAuthConfigureProvider, runAuthManageDomains } from './auth.js';
 import { runFirestoreDiscover } from './discover.js';
 import { runInit, runVendor } from './init.js';
@@ -62,6 +59,7 @@ import { runMcpProxy } from './mcp-proxy.js';
 import { pyricVersion } from '../serve/standalone-assets.js';
 import { cliVersion } from '../pkg-version.js';
 import { FIREBASE_TESTED_AGAINST } from '../version/compat-target.js';
+import { dispatchServiceCommand } from './service-commands.js';
 
 // The standalone binary bakes the real `pyric` version onto the embedded-assets
 // global; the npm bin has no such global and falls back to '0.0.0'.
@@ -79,13 +77,17 @@ USAGE
   pyric snapshot [--out=FILE]
   pyric verify [fixture|dir] [--engine sandbox|rules-test-api|both]
   pyric verify cases [fixture] [--service firestore] [--out FILE]
-  pyric rules:lint <path>
-  pyric rules:validate <path>
-  pyric rules:simulate [--stdin]
-  pyric database:rules:lint <path>
-  pyric database:rules:validate <path>
-  pyric database:rules:simulate [--stdin]
-  pyric database:rules:generate [--config <path>] [--out <path>]
+  pyric firestore rules lint <path>
+  pyric firestore rules validate <path>
+  pyric firestore rules simulate [--stdin]
+  pyric firestore rules resolve <path> [--out <path>]
+  pyric firestore indexes generate <path...> [--out <path>]
+  pyric storage rules lint <path>
+  pyric storage rules simulate [--stdin]
+  pyric database rules lint <path>
+  pyric database rules validate <path>
+  pyric database rules simulate [--stdin]
+  pyric database rules generate [--config <path>] [--out <path>]
   pyric auth:configure-provider <anonymous|email|phone|google> <true|false>
   pyric auth:manage-domains <add|remove|list> [domain]
   pyric firestore:discover [collection]
@@ -130,13 +132,17 @@ COMMANDS
                              (repeat for mixed captures). --json. Exit 1 on divergence.
   verify cases [fixture]     Derive Firestore Rules Test API cases from a captured
                              fixture and print JSON, or write with --out FILE.
-  rules:lint                 Run Firestore rules linter against a file.
-  rules:validate             Validate Firestore rules structure against a file.
-  rules:simulate             Local rules simulator (smoke-test or --stdin scripted).
-  database:rules:lint        Run Realtime Database rules JSON expression linter.
-  database:rules:validate    Validate Realtime Database rules JSON expressions.
-  database:rules:simulate    Local RTDB rules simulator (smoke-test or --stdin scripted).
-  database:rules:generate    Compile a constraints module to database.rules.json.
+  firestore rules lint       Run the Firestore rules linter against a file.
+  firestore rules validate   Validate Firestore rules structure against a file.
+  firestore rules simulate   Run the local Firestore rules simulator.
+  firestore rules resolve    Resolve Firestore 2+modules imports to one ruleset.
+  firestore indexes generate Generate firestore.indexes.json from application source.
+  storage rules lint         Check Storage rules syntax locally.
+  storage rules simulate     Run the local Storage rules evaluator.
+  database rules lint        Run the Realtime Database rules expression linter.
+  database rules validate    Validate Realtime Database rules expressions.
+  database rules simulate    Run the local Realtime Database rules simulator.
+  database rules generate    Compile a constraints module to database.rules.json.
   auth:configure-provider    Identity Toolkit: enable/disable an auth provider.
   auth:manage-domains        Identity Toolkit: add/remove/list authorized domains.
   firestore:discover         Crawl a Firestore to infer schema.
@@ -427,6 +433,9 @@ export async function dispatch(parsed: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  const serviceCommand = await dispatchServiceCommand(parsed);
+  if (serviceCommand !== null) return serviceCommand;
+
   switch (parsed.subcommand) {
     case null:
     case undefined:
@@ -452,20 +461,6 @@ export async function dispatch(parsed: ParsedArgs): Promise<number> {
       return await runLogoutCommand();
     case 'whoami':
       return await runWhoamiCommand();
-    case 'rules:lint':
-      return await runRulesLint(parsed);
-    case 'rules:validate':
-      return await runRulesValidate(parsed);
-    case 'rules:simulate':
-      return await runRulesSimulate(parsed);
-    case 'database:rules:lint':
-      return await runDatabaseRulesLint(parsed);
-    case 'database:rules:validate':
-      return await runDatabaseRulesValidate(parsed);
-    case 'database:rules:simulate':
-      return await runDatabaseRulesSimulate(parsed);
-    case 'database:rules:generate':
-      return await runDatabaseRulesGenerate(parsed);
     case 'auth:configure-provider':
       return await runAuthConfigureProvider(parsed);
     case 'auth:manage-domains':

--- a/packages/pyric-tools/src/cli/rules.ts
+++ b/packages/pyric-tools/src/cli/rules.ts
@@ -1,10 +1,10 @@
 /**
- * `pyric rules:*` subcommands — thin wrappers over `pyric/rules`.
+ * `pyric firestore rules *` subcommands — thin wrappers over `pyric/rules`.
  *
- *   - `rules:lint <path>` runs the AST linter, prints findings JSON.
- *   - `rules:validate <path>` runs the structural validator, prints
+ *   - `firestore rules lint <path>` runs the AST linter, prints findings JSON.
+ *   - `firestore rules validate <path>` runs the structural validator, prints
  *     findings JSON.
- *   - `rules:simulate` runs the local simulator. With no flags it
+ *   - `firestore rules simulate` runs the local simulator. With no flags it
  *     reads `firebase.json` for the rules path and runs a single
  *     allow-anonymous sanity test. With `--stdin` it reads a JSON
  *     request `{ source?, testCases }` from stdin instead — the way
@@ -14,8 +14,8 @@
  * library failure (parse error etc.).
  */
 
-import { readFile } from 'node:fs/promises';
-import { resolve as resolvePath } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve as resolvePath } from 'node:path';
 import {
   lintFirestoreRules,
   validateFirestoreRules,
@@ -26,6 +26,7 @@ import {
   type ValidationFinding,
   type TestFirestoreRulesResult,
 } from 'pyric/rules/internal';
+import { resolveModules } from 'pyric/rules/internal/node';
 import type { ParsedArgs } from './parse-args.js';
 import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
 
@@ -39,6 +40,16 @@ export interface RulesDeps {
   cwd?: string;
   /** Override stdin reader — used in tests. */
   readStdin?: () => Promise<string>;
+  stdout?: { write(s: string): void };
+  stderr?: { write(s: string): void };
+}
+
+export interface ResolveRulesDeps {
+  readFile?: typeof readFile;
+  writeFile?: typeof writeFile;
+  mkdir?: typeof mkdir;
+  resolveModules?: typeof resolveModules;
+  cwd?: string;
   stdout?: { write(s: string): void };
   stderr?: { write(s: string): void };
 }
@@ -64,20 +75,20 @@ export async function runRulesLint(parsed: ParsedArgs, deps: RulesDeps = {}): Pr
 
   const path = parsed.positional[0];
   if (!path) {
-    err.write('pyric rules:lint: missing rules-file path. Usage: pyric rules:lint <path>\n');
+    err.write('pyric firestore rules lint: missing rules-file path. Usage: pyric firestore rules lint <path>\n');
     return 1;
   }
   let source: string;
   try {
     source = await readFileFn(resolvePath(cwd, path), 'utf-8');
   } catch (e) {
-    err.write(`pyric rules:lint: ${e instanceof Error ? e.message : String(e)}\n`);
+    err.write(`pyric firestore rules lint: ${e instanceof Error ? e.message : String(e)}\n`);
     return 1;
   }
   const result: LintResult = lintFn(source);
   out.write(`${JSON.stringify(result, null, 2)}\n`);
   // Non-zero only when the linter signals a hard parse error. Warnings
-  // are informational — exit 0 keeps `pyric rules:lint` chainable in
+  // are informational — exit 0 keeps `pyric firestore rules lint` chainable in
   // build pipelines without `|| true`.
   return result.parseError ? 2 : 0;
 }
@@ -91,23 +102,74 @@ export async function runRulesValidate(parsed: ParsedArgs, deps: RulesDeps = {})
 
   const path = parsed.positional[0];
   if (!path) {
-    err.write('pyric rules:validate: missing rules-file path. Usage: pyric rules:validate <path>\n');
+    err.write('pyric firestore rules validate: missing rules-file path. Usage: pyric firestore rules validate <path>\n');
     return 1;
   }
   let source: string;
   try {
     source = await readFileFn(resolvePath(cwd, path), 'utf-8');
   } catch (e) {
-    err.write(`pyric rules:validate: ${e instanceof Error ? e.message : String(e)}\n`);
+    err.write(`pyric firestore rules validate: ${e instanceof Error ? e.message : String(e)}\n`);
     return 1;
   }
   const ast = parseToAST(source);
   if (!ast) {
-    err.write('pyric rules:validate: failed to parse rules source.\n');
+    err.write('pyric firestore rules validate: failed to parse rules source.\n');
     return 2;
   }
   const findings: ValidationFinding[] = validateFn(ast);
   out.write(`${JSON.stringify(findings, null, 2)}\n`);
+  return 0;
+}
+
+export async function runRulesResolve(
+  parsed: ParsedArgs,
+  deps: ResolveRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const cwd = deps.cwd ?? process.cwd();
+  const sourcePath = parsed.positional[0];
+  if (!sourcePath) {
+    err.write(
+      'pyric firestore rules resolve: missing rules-file path. Usage: pyric firestore rules resolve <path> [--out <path>]\n',
+    );
+    return 1;
+  }
+
+  const absoluteSourcePath = resolvePath(cwd, sourcePath);
+  let source: string;
+  try {
+    source = await (deps.readFile ?? readFile)(absoluteSourcePath, 'utf-8');
+  } catch (error) {
+    err.write(
+      `pyric firestore rules resolve: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 1;
+  }
+
+  const result = (deps.resolveModules ?? resolveModules)(source, {
+    basePath: dirname(absoluteSourcePath),
+  });
+  if (!result.success) {
+    err.write(`pyric firestore rules resolve: ${result.error.message}\n`);
+    return 2;
+  }
+
+  const outFlag = parsed.flags.get('out');
+  if (typeof outFlag !== 'string') {
+    out.write(result.data.resolved.endsWith('\n') ? result.data.resolved : `${result.data.resolved}\n`);
+    return 0;
+  }
+
+  const outputPath = resolvePath(cwd, outFlag);
+  await (deps.mkdir ?? mkdir)(dirname(outputPath), { recursive: true });
+  await (deps.writeFile ?? writeFile)(
+    outputPath,
+    result.data.resolved.endsWith('\n') ? result.data.resolved : `${result.data.resolved}\n`,
+    'utf-8',
+  );
+  out.write(`pyric firestore rules resolve: wrote ${outputPath}\n`);
   return 0;
 }
 
@@ -136,12 +198,12 @@ export async function runRulesSimulate(
       payload = JSON.parse(raw) as { source?: string; testCases?: TestCase[] };
     } catch (e) {
       err.write(
-        `pyric rules:simulate: failed to parse stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`,
+        `pyric firestore rules simulate: failed to parse stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`,
       );
       return 1;
     }
     if (!payload.testCases || !Array.isArray(payload.testCases)) {
-      err.write('pyric rules:simulate: stdin payload must include `testCases: TestCase[]`.\n');
+      err.write('pyric firestore rules simulate: stdin payload must include `testCases: TestCase[]`.\n');
       return 1;
     }
     testCases = payload.testCases;
@@ -152,7 +214,7 @@ export async function runRulesSimulate(
       const rulesPath = firebaseJson.firestore?.rules;
       if (!rulesPath) {
         err.write(
-          'pyric rules:simulate: stdin payload omitted `source` and firebase.json has no firestore.rules path.\n',
+          'pyric firestore rules simulate: stdin payload omitted `source` and firebase.json has no firestore.rules path.\n',
         );
         return 1;
       }
@@ -168,13 +230,13 @@ export async function runRulesSimulate(
     }
     const rulesPath = firebaseJson.firestore?.rules;
     if (!rulesPath) {
-      err.write('pyric rules:simulate: firebase.json has no `firestore.rules` path.\n');
+      err.write('pyric firestore rules simulate: firebase.json has no `firestore.rules` path.\n');
       return 1;
     }
     try {
       source = await readFileFn(resolvePath(cwd, rulesPath), 'utf-8');
     } catch (e) {
-      err.write(`pyric rules:simulate: ${e instanceof Error ? e.message : String(e)}\n`);
+      err.write(`pyric firestore rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
       return 1;
     }
     // Default sample test — anonymous read on /sample/x. Useful as a

--- a/packages/pyric-tools/src/cli/service-commands.ts
+++ b/packages/pyric-tools/src/cli/service-commands.ts
@@ -1,0 +1,73 @@
+import type { ParsedArgs } from './parse-args.js';
+import {
+  runDatabaseRulesGenerate,
+  runDatabaseRulesLint,
+  runDatabaseRulesSimulate,
+  runDatabaseRulesValidate,
+} from './database-rules.js';
+import { runFirestoreIndexesGenerate } from './firestore-indexes.js';
+import {
+  runRulesLint,
+  runRulesResolve,
+  runRulesSimulate,
+  runRulesValidate,
+} from './rules.js';
+import { runStorageRulesLint, runStorageRulesSimulate } from './storage-rules.js';
+
+const SERVICES = new Set(['firestore', 'storage', 'database']);
+
+function invocation(parsed: ParsedArgs): string {
+  return [parsed.subcommand, ...parsed.positional].filter(Boolean).join(' ');
+}
+
+function argumentsAfterPath(parsed: ParsedArgs, pathLength: number): ParsedArgs {
+  return { ...parsed, positional: parsed.positional.slice(pathLength - 1) };
+}
+
+/**
+ * Dispatch the `pyric <service> <artifact> <operation>` command family.
+ * Returns `null` when the first token is not a service command so the
+ * top-level dispatcher can continue with commands such as `dev` and `verify`.
+ */
+export async function dispatchServiceCommand(parsed: ParsedArgs): Promise<number | null> {
+  const service = parsed.subcommand;
+  if (!service || !SERVICES.has(service)) return null;
+
+  const [artifact, operation] = parsed.positional;
+  if (service === 'firestore' && artifact === 'rules' && operation === 'lint') {
+    return await runRulesLint(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'firestore' && artifact === 'rules' && operation === 'validate') {
+    return await runRulesValidate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'firestore' && artifact === 'rules' && operation === 'simulate') {
+    return await runRulesSimulate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'firestore' && artifact === 'rules' && operation === 'resolve') {
+    return await runRulesResolve(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'firestore' && artifact === 'indexes' && operation === 'generate') {
+    return await runFirestoreIndexesGenerate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'storage' && artifact === 'rules' && operation === 'lint') {
+    return await runStorageRulesLint(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'storage' && artifact === 'rules' && operation === 'simulate') {
+    return await runStorageRulesSimulate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'database' && artifact === 'rules' && operation === 'lint') {
+    return await runDatabaseRulesLint(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'database' && artifact === 'rules' && operation === 'validate') {
+    return await runDatabaseRulesValidate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'database' && artifact === 'rules' && operation === 'simulate') {
+    return await runDatabaseRulesSimulate(argumentsAfterPath(parsed, 3));
+  }
+  if (service === 'database' && artifact === 'rules' && operation === 'generate') {
+    return await runDatabaseRulesGenerate(argumentsAfterPath(parsed, 3));
+  }
+
+  process.stderr.write(`pyric: unknown command '${invocation(parsed)}'.\n`);
+  return 1;
+}

--- a/packages/pyric-tools/src/cli/storage-rules.ts
+++ b/packages/pyric-tools/src/cli/storage-rules.ts
@@ -1,0 +1,172 @@
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import {
+  evaluateStorageRules,
+  parseStorageRules,
+  type StorageRequest,
+  type StorageResource,
+} from 'pyric/storage';
+import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
+import type { ParsedArgs } from './parse-args.js';
+
+export interface StorageRulesDeps {
+  readFile?: typeof readFile;
+  parseStorageRules?: typeof parseStorageRules;
+  evaluateStorageRules?: typeof evaluateStorageRules;
+  readFirebaseJson?: (cwd: string) => Promise<FirebaseJson>;
+  readStdin?: () => Promise<string>;
+  cwd?: string;
+  stdout?: { write(s: string): void };
+  stderr?: { write(s: string): void };
+}
+
+interface StorageSimulationPayload {
+  source?: string;
+  request?: StorageRequest;
+  resource?: StorageResource | null;
+  now?: string;
+}
+
+function defaultReadStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function projectRulesSource(deps: StorageRulesDeps): Promise<string> {
+  const cwd = deps.cwd ?? process.cwd();
+  const firebaseJson = await (deps.readFirebaseJson ?? readFirebaseJson)(cwd);
+  const storageConfig = Array.isArray(firebaseJson.storage)
+    ? firebaseJson.storage.find((entry) => entry.rules)
+    : firebaseJson.storage;
+  const rulesPath = storageConfig?.rules;
+  if (!rulesPath) throw new Error('firebase.json has no `storage.rules` path.');
+  return await (deps.readFile ?? readFile)(resolvePath(cwd, rulesPath), 'utf-8');
+}
+
+export async function runStorageRulesLint(
+  parsed: ParsedArgs,
+  deps: StorageRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  const cwd = deps.cwd ?? process.cwd();
+  const path = parsed.positional[0];
+  if (!path) {
+    err.write(
+      'pyric storage rules lint: missing rules-file path. Usage: pyric storage rules lint <path>\n',
+    );
+    return 1;
+  }
+
+  let source: string;
+  try {
+    source = await (deps.readFile ?? readFile)(resolvePath(cwd, path), 'utf-8');
+  } catch (error) {
+    err.write(
+      `pyric storage rules lint: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 1;
+  }
+
+  try {
+    (deps.parseStorageRules ?? parseStorageRules)(source);
+    out.write(`${JSON.stringify({ warnings: [], metrics: { sourceSize: source.length } }, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    out.write(
+      `${JSON.stringify(
+        {
+          warnings: [],
+          parseError: { message: error instanceof Error ? error.message : String(error) },
+          metrics: { sourceSize: source.length },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return 2;
+  }
+}
+
+export async function runStorageRulesSimulate(
+  parsed: ParsedArgs,
+  deps: StorageRulesDeps = {},
+): Promise<number> {
+  const out = deps.stdout ?? process.stdout;
+  const err = deps.stderr ?? process.stderr;
+  let source: string;
+  let request: StorageRequest;
+  let resource: StorageResource | null;
+  let now = new Date();
+
+  if (parsed.flags.get('stdin') === true) {
+    let payload: StorageSimulationPayload;
+    try {
+      payload = JSON.parse(await (deps.readStdin ?? defaultReadStdin)()) as StorageSimulationPayload;
+    } catch (error) {
+      err.write(
+        `pyric storage rules simulate: failed to parse stdin JSON: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+    if (!payload.request) {
+      err.write('pyric storage rules simulate: stdin payload must include `request`.\n');
+      return 1;
+    }
+    try {
+      source = payload.source ?? (await projectRulesSource(deps));
+    } catch (error) {
+      err.write(
+        `pyric storage rules simulate: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+    request = payload.request;
+    resource = payload.resource ?? null;
+    if (payload.now !== undefined) {
+      now = new Date(payload.now);
+      if (Number.isNaN(now.getTime())) {
+        err.write('pyric storage rules simulate: `now` must be an ISO-8601 timestamp.\n');
+        return 1;
+      }
+    }
+  } else {
+    try {
+      source = await projectRulesSource(deps);
+    } catch (error) {
+      err.write(
+        `pyric storage rules simulate: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+    request = {
+      auth: null,
+      method: 'get',
+      path: 'b/pyric-default/o/sample/x',
+    };
+    resource = null;
+  }
+
+  try {
+    const rules = (deps.parseStorageRules ?? parseStorageRules)(source);
+    const result = (deps.evaluateStorageRules ?? evaluateStorageRules)(
+      rules,
+      { request, resource },
+      now,
+    );
+    out.write(`${JSON.stringify({ success: true, data: result }, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    err.write(
+      `pyric storage rules simulate: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 2;
+  }
+}

--- a/packages/pyric-tools/src/serve/standalone-assets.ts
+++ b/packages/pyric-tools/src/serve/standalone-assets.ts
@@ -14,7 +14,7 @@
  *
  * The npm build never sets the global. `isStandalone()` is false there and
  * `serve` keeps its runtime esbuild path untouched. The heavy base64 blobs are
- * exposed behind lazy loaders so non-`serve` commands (rules:lint, deploy, …)
+ * exposed behind lazy loaders so commands such as `firestore rules lint`
  * never pay to parse them.
  */
 import { mkdirSync, writeFileSync, existsSync } from 'node:fs';

--- a/packages/pyric-tools/test/cli/fixtures/database.rules.json
+++ b/packages/pyric-tools/test/cli/fixtures/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": true,
+    ".write": false
+  }
+}

--- a/packages/pyric-tools/test/cli/fixtures/database.rules.ts
+++ b/packages/pyric-tools/test/cli/fixtures/database.rules.ts
@@ -1,0 +1,7 @@
+import { allow, defineRtdbRules, deny } from 'pyric/rules';
+
+export default defineRtdbRules({
+  paths: {
+    '/': { read: allow(), write: deny() },
+  },
+});

--- a/packages/pyric-tools/test/cli/fixtures/firestore-queries.ts
+++ b/packages/pyric-tools/test/cli/fixtures/firestore-queries.ts
@@ -1,0 +1,10 @@
+import { collection, orderBy, query, where } from 'firebase/firestore';
+
+export function openOrders(db: unknown) {
+  const q = query(
+    collection(db as never, 'orders'),
+    where('status', '==', 'open'),
+    orderBy('createdAt', 'desc'),
+  );
+  return q;
+}

--- a/packages/pyric-tools/test/cli/fixtures/firestore.modules.rules
+++ b/packages/pyric-tools/test/cli/fixtures/firestore.modules.rules
@@ -1,0 +1,10 @@
+import { isAuthenticated } from 'auth';
+
+rules_version = '2+modules';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /notes/{noteId} {
+      allow read: if isAuthenticated();
+    }
+  }
+}

--- a/packages/pyric-tools/test/cli/fixtures/storage.rules
+++ b/packages/pyric-tools/test/cli/fixtures/storage.rules
@@ -1,0 +1,7 @@
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{object=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/packages/pyric-tools/test/cli/index.test.ts
+++ b/packages/pyric-tools/test/cli/index.test.ts
@@ -238,7 +238,7 @@ describe('service command hierarchy', () => {
     }
   });
 
-  it('rejects the retired colon-delimited spellings without aliases', () => {
+  describe('retired colon-delimited spellings', () => {
     for (const command of [
       'rules:lint',
       'rules:validate',
@@ -248,9 +248,11 @@ describe('service command hierarchy', () => {
       'database:rules:simulate',
       'database:rules:generate',
     ]) {
-      const result = runCli([command]);
-      expect(result.code).toBe(1);
-      expect(result.stderr).toContain(`unknown command '${command}'`);
+      it(`rejects ${command} without an alias`, () => {
+        const result = runCli([command]);
+        expect(result.code).toBe(1);
+        expect(result.stderr).toContain(`unknown command '${command}'`);
+      });
     }
   });
 });

--- a/packages/pyric-tools/test/cli/index.test.ts
+++ b/packages/pyric-tools/test/cli/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { FIREBASE_TESTED_AGAINST } from '../../src/version/compat-target.js';
@@ -8,10 +9,11 @@ import { FIREBASE_TESTED_AGAINST } from '../../src/version/compat-target.js';
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'cli', 'index.ts');
 
-function runCli(args: string[]): { code: number; stdout: string; stderr: string } {
+function runCli(args: string[], input?: string): { code: number; stdout: string; stderr: string } {
   const result = spawnSync('bun', [CLI_ENTRY, ...args], {
     cwd: PACKAGE_ROOT,
     encoding: 'utf8',
+    input,
     timeout: 30_000,
   });
   return {
@@ -50,6 +52,206 @@ describe('retained pyric command surface', () => {
       exports: Record<string, unknown>;
     };
     expect(Object.keys(manifest.exports)).not.toContain('./deploy');
+  });
+});
+
+describe('service command hierarchy', () => {
+  it('advertises every service artifact operation with space-delimited names', () => {
+    const help = runCli(['--help']);
+
+    expect(help.code).toBe(0);
+    for (const command of [
+      'firestore rules lint',
+      'firestore rules validate',
+      'firestore rules simulate',
+      'firestore rules resolve',
+      'firestore indexes generate',
+      'storage rules lint',
+      'storage rules simulate',
+      'database rules lint',
+      'database rules validate',
+      'database rules simulate',
+      'database rules generate',
+    ]) {
+      expect(help.stdout).toContain(`pyric ${command}`);
+    }
+  });
+
+  it('routes Firestore rules lint through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'e2e', 'fixture', 'firestore.rules');
+    const result = runCli(['firestore', 'rules', 'lint', rulesPath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('warnings');
+  });
+
+  it('routes Firestore rules validate through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'e2e', 'fixture', 'firestore.rules');
+    const result = runCli(['firestore', 'rules', 'validate', rulesPath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toBeArray();
+  });
+
+  it('routes Firestore rules simulate through the namespaced command', () => {
+    const result = runCli(
+      ['firestore', 'rules', 'simulate', '--stdin'],
+      JSON.stringify({
+        source: `rules_version = '2'; service cloud.firestore { match /databases/{database}/documents { match /{document=**} { allow read, write: if false; } } }`,
+        testCases: [
+          {
+            description: 'anonymous read stays denied',
+            expectation: 'DENY',
+            method: 'get',
+            path: 'notes/one',
+            auth: null,
+          },
+        ],
+      }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('success', true);
+  });
+
+  it('resolves Firestore rules modules through the namespaced command', () => {
+    const sourcePath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'firestore.modules.rules');
+    const result = runCli(['firestore', 'rules', 'resolve', sourcePath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain("rules_version = '2';");
+    expect(result.stdout).toContain('function isAuthenticated()');
+  });
+
+  it('generates Firestore indexes through the namespaced command', () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'pyric-firestore-indexes-'));
+    const sourcePath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'firestore-queries.ts');
+    const outputPath = join(outputDir, 'firestore.indexes.json');
+
+    try {
+      const result = runCli([
+        'firestore',
+        'indexes',
+        'generate',
+        sourcePath,
+        '--out',
+        outputPath,
+      ]);
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(readFileSync(outputPath, 'utf8'))).toHaveProperty('indexes');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('routes Storage rules lint through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'storage.rules');
+    const result = runCli(['storage', 'rules', 'lint', rulesPath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('warnings');
+  });
+
+  it('routes Storage rules simulate through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'storage.rules');
+    const result = runCli(
+      ['storage', 'rules', 'simulate', '--stdin'],
+      JSON.stringify({
+        source: readFileSync(rulesPath, 'utf8'),
+        request: {
+          auth: null,
+          method: 'get',
+          path: 'b/pyric-default/o/notes/one.txt',
+        },
+        resource: { size: 12 },
+      }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('data.allowed', false);
+  });
+
+  it('routes Database rules lint through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.json');
+    const result = runCli(['database', 'rules', 'lint', rulesPath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('warnings');
+  });
+
+  it('routes Database rules validate through the namespaced command', () => {
+    const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.json');
+    const result = runCli(['database', 'rules', 'validate', rulesPath]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('errors');
+  });
+
+  it('routes Database rules simulate through the namespaced command', () => {
+    const result = runCli(
+      ['database', 'rules', 'simulate', '--stdin'],
+      JSON.stringify({
+        rulesJson: { rules: { '.read': true } },
+        operation: 'read',
+        path: '/notes/one',
+        auth: null,
+        mockData: {},
+      }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toHaveProperty('data.allowed', true);
+  });
+
+  it('routes Database rules generate through the namespaced command', () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'pyric-database-rules-'));
+    const configPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.ts');
+    const outputPath = join(outputDir, 'database.rules.json');
+
+    try {
+      const result = runCli([
+        'database',
+        'rules',
+        'generate',
+        '--config',
+        configPath,
+        '--out',
+        outputPath,
+      ]);
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(readFileSync(outputPath, 'utf8'))).toHaveProperty('rules');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the retired colon-delimited spellings without aliases', () => {
+    for (const command of [
+      'rules:lint',
+      'rules:validate',
+      'rules:simulate',
+      'database:rules:lint',
+      'database:rules:validate',
+      'database:rules:simulate',
+      'database:rules:generate',
+    ]) {
+      const result = runCli([command]);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain(`unknown command '${command}'`);
+    }
   });
 });
 

--- a/scripts/packed-cli-smoke.mjs
+++ b/scripts/packed-cli-smoke.mjs
@@ -91,6 +91,25 @@ const help = run(['--help']);
 expect(help.code === 0, 'pyric --help must exit 0', help);
 expect(!help.stdout.includes('pyric deploy'), 'pyric --help must not advertise production deployment', help);
 expect(!help.stdout.includes('hosting:channel:deploy'), 'pyric --help must not advertise Hosting deployment', help);
+for (const command of [
+  'firestore rules lint',
+  'firestore rules validate',
+  'firestore rules simulate',
+  'firestore rules resolve',
+  'firestore indexes generate',
+  'storage rules lint',
+  'storage rules simulate',
+  'database rules lint',
+  'database rules validate',
+  'database rules simulate',
+  'database rules generate',
+]) {
+  expect(
+    help.stdout.includes(`pyric ${command}`),
+    `pyric --help must advertise ${command}`,
+    help,
+  );
+}
 const removedDeploy = run(['deploy', 'rules']);
 expect(removedDeploy.code === 1, 'pyric deploy must be rejected as an unknown command', removedDeploy);
 expect(removedDeploy.stderr.includes("unknown command 'deploy'"), 'pyric deploy must fail without a compatibility path', removedDeploy);
@@ -100,6 +119,17 @@ expect(
   removedHostingDeploy.stderr.includes("unknown command 'hosting:channel:deploy'"),
   'pyric hosting:channel:deploy must fail without a compatibility path',
   removedHostingDeploy,
+);
+const removedColonCommand = run(['rules:lint']);
+expect(
+  removedColonCommand.code === 1,
+  'pyric rules:lint must be rejected as an unknown command',
+  removedColonCommand,
+);
+expect(
+  removedColonCommand.stderr.includes("unknown command 'rules:lint'"),
+  'pyric rules:lint must fail without a compatibility alias',
+  removedColonCommand,
 );
 process.stdout.write('  ✓ packed pyric exposes no production deployment commands\n');
 
@@ -116,6 +146,88 @@ service cloud.firestore {
   }
 }`;
 writeFileSync(resolve(workDir, 'firestore.rules'), `${allowAnonymous}\n`);
+
+// Slice 2: service-namespaced local tooling executes from the installed
+// artifact. These commands are credential-free by contract.
+const firestoreLint = run(['firestore', 'rules', 'lint', 'firestore.rules']);
+expect(firestoreLint.code === 0, 'pyric firestore rules lint must exit 0', firestoreLint);
+expect(
+  Array.isArray(parseJson(firestoreLint, 'pyric firestore rules lint').warnings),
+  'pyric firestore rules lint must return warnings JSON',
+  firestoreLint,
+);
+
+const storageRules = `service firebase.storage {
+  match /b/{bucket}/o {
+    match /{object=**} { allow read, write: if false; }
+  }
+}`;
+writeFileSync(resolve(workDir, 'storage.rules'), `${storageRules}\n`);
+const storageLint = run(['storage', 'rules', 'lint', 'storage.rules']);
+expect(storageLint.code === 0, 'pyric storage rules lint must exit 0', storageLint);
+expect(
+  Array.isArray(parseJson(storageLint, 'pyric storage rules lint').warnings),
+  'pyric storage rules lint must return warnings JSON',
+  storageLint,
+);
+
+writeFileSync(
+  resolve(workDir, 'database.rules.json'),
+  `${JSON.stringify({ rules: { '.read': true, '.write': false } }, null, 2)}\n`,
+);
+const databaseLint = run(['database', 'rules', 'lint', 'database.rules.json']);
+expect(databaseLint.code === 0, 'pyric database rules lint must exit 0', databaseLint);
+expect(
+  Array.isArray(parseJson(databaseLint, 'pyric database rules lint').warnings),
+  'pyric database rules lint must return warnings JSON',
+  databaseLint,
+);
+
+const moduleRules = `import { isAuthenticated } from 'auth';
+rules_version = '2+modules';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /notes/{noteId} { allow read: if isAuthenticated(); }
+  }
+}`;
+writeFileSync(resolve(workDir, 'firestore.modules.rules'), `${moduleRules}\n`);
+const resolvedRules = run(['firestore', 'rules', 'resolve', 'firestore.modules.rules']);
+expect(resolvedRules.code === 0, 'pyric firestore rules resolve must exit 0', resolvedRules);
+expect(
+  resolvedRules.stdout.includes("rules_version = '2';") &&
+    resolvedRules.stdout.includes('function isAuthenticated()'),
+  'pyric firestore rules resolve must inline the referenced module',
+  resolvedRules,
+);
+
+const querySource = `import { collection, orderBy, query, where } from 'firebase/firestore';
+export function openOrders(db) {
+  const q = query(
+    collection(db, 'orders'),
+    where('status', '==', 'open'),
+    orderBy('createdAt', 'desc'),
+  );
+  return q;
+}`;
+writeFileSync(resolve(workDir, 'queries.js'), `${querySource}\n`);
+const indexes = run([
+  'firestore',
+  'indexes',
+  'generate',
+  'queries.js',
+  '--out',
+  'firestore.indexes.json',
+]);
+expect(indexes.code === 0, 'pyric firestore indexes generate must exit 0', indexes);
+expect(
+  Array.isArray(
+    JSON.parse(readFileSync(resolve(workDir, 'firestore.indexes.json'), 'utf8')).indexes,
+  ),
+  'pyric firestore indexes generate must write an indexes artifact',
+  indexes,
+);
+process.stdout.write('  ✓ packed pyric executes local tooling across all three services\n');
+
 const fixture = {
   schema: 'pyric.verify.fixture.v1',
   description: 'anonymous note creation from a packed CLI smoke',
@@ -157,7 +269,7 @@ const fixture = {
 };
 writeFileSync(resolve(workDir, 'session.json'), `${JSON.stringify(fixture, null, 2)}\n`);
 
-// Slice 2: the stable nested command generates a local Rules Test API artifact
+// Slice 3: the stable nested command generates a local Rules Test API artifact
 // through the packed binary, proving argument routing and output-file handling.
 const cases = run([
   'verify',
@@ -181,7 +293,7 @@ expect(
 );
 process.stdout.write('  ✓ packed pyric verify cases writes the expected local artifact\n');
 
-// Slice 3: replay the anonymous write through the local assurance engine. No
+// Slice 4: replay the anonymous write through the local assurance engine. No
 // credential source is available in this process. Re-running against deny-all
 // rules proves the command preserves its regression exit code rather than
 // merely loading the fixture.


### PR DESCRIPTION
Gives local artifact commands one consistent `pyric <service> <artifact> <operation>` grammar and removes the colon-delimited spellings.

```sh
pyric firestore rules lint firestore.rules
pyric firestore rules validate firestore.rules
pyric firestore rules simulate
pyric firestore rules resolve firestore.modules.rules --out firestore.rules
pyric firestore indexes generate src --out firestore.indexes.json

pyric storage rules lint storage.rules
pyric storage rules simulate

pyric database rules lint database.rules.json
pyric database rules validate database.rules.json
pyric database rules simulate
pyric database rules generate --config database.rules.ts --out database.rules.json
```

## Service, artifact, and operation now determine every local rules command

The dispatcher consumes the three command-path tokens before passing file arguments and flags to focused handlers. Existing Firestore and Database lint, validate, simulate, and generate behavior moves under that hierarchy without aliases. Firestore module resolution, Firestore index extraction, and Storage syntax checking/simulation become executable CLI operations using the same grammar.

Storage `lint` currently proves syntax by parsing the ruleset; the help text deliberately does not claim semantic lint findings that the Storage engine does not produce.

## Risk

The main compatibility risk is command routing: scripts using `rules:*` or `database:rules:*` now fail as unknown commands. That is intentional for the unpublished alpha; this PR adds no aliases or deprecation path.

Reviewer judgment is most useful on three seams:

- nested-token consumption in `service-commands.ts`;
- default output selection for `firestore indexes generate`;
- the distinction between Storage syntax checking and Firestore/Database semantic linting.

Documentation is intentionally excluded because the site rewrite is being handled separately.

<details>
<summary>Implementation notes and verification</summary>

- Added spawned-process coverage for every advertised service command and explicit rejection of the retired colon spellings.
- Each retired spelling has its own test budget. The initial CI run placed seven process launches in one test and exceeded Bun's five-second test timeout; no command was hanging or dispatching incorrectly.
- Extended the packed CLI smoke to execute credential-free local tooling across Firestore, Storage, and Realtime Database from the built package artifact.
- `bun run typecheck` in `packages/pyric-tools`: pass.
- `bun test src/cli/cli.test.ts test/cli/index.test.ts`: 59 pass, 0 fail.
- Retired-command regression under a stricter one-second per-test timeout: 7 pass, 0 fail.
- `bun run build` in `packages/pyric-tools`: pass.
- `bun run test:packaging`: pass; all packages packed, installed into a clean consumer, resolved their exports, and the packed CLI smoke passed.
- A broad local package-suite attempt reached 1,123 pass and 6 skip; 59 fixed-port server tests could not bind because ports 5179 and 5190–5198 were already occupied. The focused CLI and packed-artifact gates are clean.

</details>
