### PR TITLE
test(cli): ratify and smoke-test MCP tool contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,13 @@ jobs:
         # Runs after the build: the derivation loads the built pyric/* packages.
         run: bun run compat:assurance:check
 
+      - name: Agent tool exposure contract
+        # Every tool visible through the default MCP bridge, Playground agent,
+        # or composed CLI registry must have an explicit exposure decision.
+        # Additions cannot silently appear on one surface, and removals make
+        # their annotations stale until the contract is updated deliberately.
+        run: bun run tool:parity:check
+
       - name: Compat coverage gate (surface + behavior %, regression-only)
         # Runs packages/conformance/src/coverage.ts, which combines surface-census.ts
         # (mirrored SDK exports / SDK exports) and the compat ledger

--- a/packages/pyric-tools/src/bridge/server/headless.ts
+++ b/packages/pyric-tools/src/bridge/server/headless.ts
@@ -29,7 +29,7 @@ import {
 import { getFirestore } from 'pyric/firestore';
 import { setRules } from 'pyric/sandbox/firestore';
 import { buildMcpServer } from './mcp.js';
-import { getSandboxToolMetadata, getRulesToolHandlers } from './tool-metadata.js';
+import { getDefaultMcpToolSurface } from './mcp-contract.js';
 import { createLocalBridge, type LocalBridgeOptions } from './local-bridge.js';
 
 /** Where the headless sandbox snapshot is persisted (relative to the project
@@ -44,10 +44,7 @@ export const HEADLESS_STATE_RELATIVE = join('.pyric', 'state', 'headless.json');
  */
 export function buildHeadlessMcpServer(sandbox: LocalSandbox, opts?: LocalBridgeOptions) {
   const bridge = createLocalBridge(sandbox, opts);
-  return buildMcpServer(bridge, {
-    forwarded: getSandboxToolMetadata(),
-    inProcess: getRulesToolHandlers(),
-  });
+  return buildMcpServer(bridge, getDefaultMcpToolSurface());
 }
 
 /**

--- a/packages/pyric-tools/src/bridge/server/mcp-contract.ts
+++ b/packages/pyric-tools/src/bridge/server/mcp-contract.ts
@@ -1,0 +1,102 @@
+import type { ToolHandler } from '@inbrowser/agent';
+import {
+  getRulesToolHandlers,
+  getSandboxToolMetadata,
+  type ToolMetadata,
+} from './tool-metadata.js';
+
+/**
+ * The exact tools a default local Pyric MCP server forwards to its sandbox.
+ * A tool addition or removal is a public contract change and must update this
+ * manifest deliberately.
+ */
+export const DEFAULT_MCP_FORWARDED_TOOL_NAMES = [
+  'firestore_simulator_create',
+  'firestore_simulator_execute',
+  'firestore_simulator_read',
+  'firestore_simulator_batch',
+  'firestore_create_with_auto_id',
+  'firestore_simulator_undo',
+  'firestore_simulator_redo',
+  'firestore_simulator_events',
+  'firestore_simulator_transaction',
+  'firestore_get_document',
+  'firestore_list_documents',
+  'firestore_create_document',
+  'firestore_add_document',
+  'firestore_update_document',
+  'firestore_delete_document',
+  'firestore_batch_write',
+  'firestore_query_where',
+  'sandbox_inspect',
+  'rtdb_simulate_access',
+  'rtdb_crawl_structure',
+  'firebase_assurance_attach',
+  'firebase_assurance_start',
+  'firebase_assurance_map',
+  'firebase_assurance_define',
+  'firebase_assurance_propose',
+  'firebase_assurance_run',
+  'firebase_assurance_inspect',
+  'firebase_assurance_minimize',
+  'firebase_assurance_verify',
+  'firebase_assurance_export',
+] as const;
+
+/** Local rules tools that run in the MCP process without a browser peer. */
+export const DEFAULT_MCP_IN_PROCESS_TOOL_NAMES = [
+  'firestore_simulate_rules',
+  'firestore_rules_stdlib_list',
+  'firestore_rules_stdlib_get',
+  'firestore_lint_rules',
+  'firestore_resolve_modules',
+] as const;
+
+export const DEFAULT_MCP_TOOL_NAMES = [
+  ...DEFAULT_MCP_FORWARDED_TOOL_NAMES,
+  ...DEFAULT_MCP_IN_PROCESS_TOOL_NAMES,
+] as const;
+
+export interface DefaultMcpToolSurface {
+  forwarded: ToolMetadata[];
+  inProcess: ToolHandler[];
+}
+
+function assertExactNames(
+  label: string,
+  actual: readonly string[],
+  expected: readonly string[],
+): void {
+  const actualSorted = [...actual].sort();
+  const expectedSorted = [...expected].sort();
+  if (
+    actualSorted.length !== expectedSorted.length ||
+    actualSorted.some((name, index) => name !== expectedSorted[index])
+  ) {
+    throw new Error(
+      `${label} drifted from the default MCP contract\n` +
+        `expected: ${expected.join(', ')}\n` +
+        `actual:   ${actual.join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Assemble the default MCP surface and fail closed if a factory changed
+ * without a corresponding public-contract decision.
+ */
+export function getDefaultMcpToolSurface(): DefaultMcpToolSurface {
+  const forwarded = getSandboxToolMetadata();
+  const inProcess = getRulesToolHandlers();
+  assertExactNames(
+    'forwarded sandbox tools',
+    forwarded.map((tool) => tool.name),
+    DEFAULT_MCP_FORWARDED_TOOL_NAMES,
+  );
+  assertExactNames(
+    'in-process rules tools',
+    inProcess.map((tool) => tool.name),
+    DEFAULT_MCP_IN_PROCESS_TOOL_NAMES,
+  );
+  return { forwarded, inProcess };
+}

--- a/packages/pyric-tools/src/bridge/server/standalone.ts
+++ b/packages/pyric-tools/src/bridge/server/standalone.ts
@@ -34,7 +34,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { ToolHandler } from '@inbrowser/agent';
 import { createBridge, type Bridge, type BridgeToolEvent } from './bridge.js';
 import { buildMcpServer } from './mcp.js';
-import { getSandboxToolMetadata, getRulesToolHandlers } from './tool-metadata.js';
+import { getDefaultMcpToolSurface } from './mcp-contract.js';
 import { createAuditWriter, type AuditWriter } from './audit.js';
 import {
   createConsoleLogger,
@@ -198,10 +198,10 @@ export async function startServer(
   // Build the MCP server. In sandbox mode, forward sandbox tools to
   // the bridge and run rules tools in-process. In prod mode, run all
   // tools in-process (caller supplies them via `prodTools`).
-  const forwarded = mode === 'sandbox' ? getSandboxToolMetadata() : [];
-  const rulesTools = mode === 'sandbox' ? getRulesToolHandlers() : [];
+  const sandboxSurface = mode === 'sandbox' ? getDefaultMcpToolSurface() : null;
+  const forwarded = sandboxSurface?.forwarded ?? [];
   const inProcess: ToolHandler[] = [
-    ...rulesTools,
+    ...(sandboxSurface?.inProcess ?? []),
     ...(opts.prodTools ?? []),
   ];
 

--- a/packages/pyric-tools/src/serve/bridge-mount.ts
+++ b/packages/pyric-tools/src/serve/bridge-mount.ts
@@ -22,7 +22,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { ToolHandler } from '@inbrowser/agent';
 import { createBridge, type BridgeToolEvent } from '../bridge/server/bridge.js';
 import { buildMcpServer } from '../bridge/server/mcp.js';
-import { getSandboxToolMetadata, getRulesToolHandlers } from '../bridge/server/tool-metadata.js';
+import { getDefaultMcpToolSurface } from '../bridge/server/mcp-contract.js';
 import { createAuditWriter } from '../bridge/server/audit.js';
 import { attachPeer } from '../bridge/server/peer.js';
 import { pyricVersion } from './standalone-assets.js';
@@ -119,9 +119,10 @@ export function createBridgeMount(opts: BridgeMountOptions = {}): BridgeMount {
     session.transport.onclose = () => {
       if (session.sessionId) sessions.delete(session.sessionId);
     };
+    const surface = getDefaultMcpToolSurface();
     const server = buildMcpServer(bridge, {
-      forwarded: getSandboxToolMetadata(),
-      inProcess: [...getRulesToolHandlers(), ...(opts.extraTools ?? [])],
+      forwarded: surface.forwarded,
+      inProcess: [...surface.inProcess, ...(opts.extraTools ?? [])],
     });
     session.close = async () => {
       if (session.idle) clearTimeout(session.idle);

--- a/packages/pyric-tools/test/bridge/e2e.test.ts
+++ b/packages/pyric-tools/test/bridge/e2e.test.ts
@@ -34,6 +34,7 @@ import {
   isBridgeMessage,
   NO_SANDBOX_ERROR_MESSAGE,
 } from '../../src/bridge/protocol.js';
+import { DEFAULT_MCP_TOOL_NAMES } from '../../src/bridge/server/mcp-contract.js';
 
 const PORT = 5179; // distinct from default 5174
 
@@ -195,13 +196,7 @@ describe('@pyric/cli/bridge end-to-end MCP bridge', () => {
     try {
       const result = await client.listTools();
       const names = result.tools.map((t) => t.name).sort();
-      // Sandbox-mode bridge exposes simulator tools (forwarded) +
-      // rules tools (in-process).
-      for (const sandboxName of SANDBOX_TOOL_NAMES) {
-        expect(names).toContain(sandboxName);
-      }
-      // Spot-check a rules tool that should also be present.
-      expect(names).toContain('firestore_lint_rules');
+      expect(names).toEqual([...DEFAULT_MCP_TOOL_NAMES].sort());
     } finally {
       await close();
       peer.disconnect();

--- a/packages/pyric-tools/test/bridge/mcp-contract.test.ts
+++ b/packages/pyric-tools/test/bridge/mcp-contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { SANDBOX_TOOL_NAMES } from '../../src/bridge/client/dispatch.js';
+import {
+  DEFAULT_MCP_FORWARDED_TOOL_NAMES,
+  DEFAULT_MCP_IN_PROCESS_TOOL_NAMES,
+  DEFAULT_MCP_TOOL_NAMES,
+  getDefaultMcpToolSurface,
+} from '../../src/bridge/server/mcp-contract.js';
+
+describe('default MCP tool contract', () => {
+  it('ratifies the exact public tools/list surface', () => {
+    expect(DEFAULT_MCP_TOOL_NAMES).toEqual([
+      'firestore_simulator_create',
+      'firestore_simulator_execute',
+      'firestore_simulator_read',
+      'firestore_simulator_batch',
+      'firestore_create_with_auto_id',
+      'firestore_simulator_undo',
+      'firestore_simulator_redo',
+      'firestore_simulator_events',
+      'firestore_simulator_transaction',
+      'firestore_get_document',
+      'firestore_list_documents',
+      'firestore_create_document',
+      'firestore_add_document',
+      'firestore_update_document',
+      'firestore_delete_document',
+      'firestore_batch_write',
+      'firestore_query_where',
+      'sandbox_inspect',
+      'rtdb_simulate_access',
+      'rtdb_crawl_structure',
+      'firebase_assurance_attach',
+      'firebase_assurance_start',
+      'firebase_assurance_map',
+      'firebase_assurance_define',
+      'firebase_assurance_propose',
+      'firebase_assurance_run',
+      'firebase_assurance_inspect',
+      'firebase_assurance_minimize',
+      'firebase_assurance_verify',
+      'firebase_assurance_export',
+      'firestore_simulate_rules',
+      'firestore_rules_stdlib_list',
+      'firestore_rules_stdlib_get',
+      'firestore_lint_rules',
+      'firestore_resolve_modules',
+    ]);
+  });
+
+  it('matches the browser dispatcher and live in-process handlers exactly', () => {
+    const surface = getDefaultMcpToolSurface();
+    expect(surface.forwarded.map((tool) => tool.name).sort()).toEqual(
+      [...DEFAULT_MCP_FORWARDED_TOOL_NAMES].sort(),
+    );
+    expect([...SANDBOX_TOOL_NAMES].sort()).toEqual(
+      [...DEFAULT_MCP_FORWARDED_TOOL_NAMES].sort(),
+    );
+    expect(surface.inProcess.map((tool) => tool.name).sort()).toEqual(
+      [...DEFAULT_MCP_IN_PROCESS_TOOL_NAMES].sort(),
+    );
+  });
+});

--- a/packages/pyric-tools/test/cli/mcp-stdio.test.ts
+++ b/packages/pyric-tools/test/cli/mcp-stdio.test.ts
@@ -1,0 +1,25 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_MCP_TOOL_NAMES } from '../../src/bridge/server/mcp-contract.js';
+import { runPackedMcpSmoke } from '../../../../scripts/packed-mcp-smoke.mjs';
+
+const workDir = mkdtempSync(join(tmpdir(), 'pyric-mcp-stdio-'));
+
+afterAll(() => rmSync(workDir, { recursive: true, force: true }));
+
+describe('pyric mcp stdio contract', () => {
+  it('initializes, lists the exact contract, and executes local and sandbox tools', async () => {
+    const result = await runPackedMcpSmoke({
+      bin: join(import.meta.dir, '..', '..', 'dist', 'cli', 'index.js'),
+      workDir,
+      expectedToolNames: [...DEFAULT_MCP_TOOL_NAMES],
+      quiet: true,
+    });
+
+    expect([...result.toolNames].sort()).toEqual([...DEFAULT_MCP_TOOL_NAMES].sort());
+    expect(result.localCall.ok).toBe(true);
+    expect(result.sandboxCall.ok).toBe(true);
+  }, 30_000);
+});

--- a/packages/pyric-tools/test/serve/bridge-mount.test.ts
+++ b/packages/pyric-tools/test/serve/bridge-mount.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { WebSocket } from 'ws';
 import { startServe, type ServeRuntime } from '../../src/cli/serve.js';
 import { silentServeLogger } from '../../src/serve/server.js';
+import { DEFAULT_MCP_TOOL_NAMES } from '../../src/bridge/server/mcp-contract.js';
 
 function fixtureProject(): string {
   const dir = mkdtempSync(join(tmpdir(), 'pyric-serve-bridge-'));
@@ -88,11 +89,10 @@ describe('pyric dev --bridge', () => {
 
     const list = await mcp(2, 'tools/list');
     expect(list.status).toBe(200); // was 500 with the shared transport
-    const names = ((list.json as { result: { tools: Array<{ name: string }> } }).result.tools).map((t) => t.name);
-    expect(names.length).toBeGreaterThan(0);
-    expect(names.some((n) => n.includes('inspect'))).toBe(true); // sandbox_inspect forwarded
-    expect(names).toContain('firebase_assurance_attach');
-    expect(names).toContain('firebase_assurance_run');
+    const names = ((list.json as { result: { tools: Array<{ name: string }> } }).result.tools)
+      .map((t) => t.name)
+      .sort();
+    expect(names).toEqual([...DEFAULT_MCP_TOOL_NAMES].sort());
   });
 
   it('accepts a WS sandbox peer on the serve origin', async () => {

--- a/packages/pyric-tools/test/serve/vite-plugin-bridge-e2e.test.ts
+++ b/packages/pyric-tools/test/serve/vite-plugin-bridge-e2e.test.ts
@@ -25,6 +25,7 @@ import path, { join } from 'node:path';
 import { homedir } from 'node:os';
 import { initializeSandbox } from 'pyric/sandbox';
 import { connectBridge, type ConnectedBridge } from '../../src/bridge/client/bridge.js';
+import { DEFAULT_MCP_TOOL_NAMES } from '../../src/bridge/server/mcp-contract.js';
 import { defaultSdkEntries, bundleWorker, workerSourceHash } from '../../src/serve/bundler.js';
 import { pyricSandbox } from '../../src/serve/vite-plugin.js';
 
@@ -133,17 +134,46 @@ describe.skipIf(GATED)('e2e — bridge through a real vite dev server (GATED: PY
   });
 
   const base = (): string => `http://localhost:${port}`;
-  // One stateless MCP-over-HTTP request (streamable HTTP replies as an SSE frame
-  // or bare JSON — handle both, exactly like the serve-side bridge test).
-  const mcp = async (id: number, method: string, params: Record<string, unknown> = {}) => {
-    const res = await fetchSafe(base() + '/__pyric/mcp', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
-      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
-    });
-    const text = await res.text();
-    const line = text.split('\n').find((l) => l.startsWith('data:')) ?? text;
-    return { status: res.status, json: JSON.parse(line.replace(/^data:\s*/, '')) as Record<string, any> };
+  const createMcpSession = () => {
+    let sessionId: string | null = null;
+    const request = async (
+      id: number | null,
+      method: string,
+      params: Record<string, unknown> = {},
+    ) => {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      };
+      if (sessionId) headers['mcp-session-id'] = sessionId;
+      const res = await fetchSafe(base() + '/__pyric/mcp', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(
+          id === null
+            ? { jsonrpc: '2.0', method, params }
+            : { jsonrpc: '2.0', id, method, params },
+        ),
+      });
+      sessionId = res.headers.get('mcp-session-id') ?? sessionId;
+      const text = await res.text();
+      if (!text) return { status: res.status, json: null as Record<string, any> | null };
+      const line = text.split('\n').find((entry) => entry.startsWith('data:')) ?? text;
+      return {
+        status: res.status,
+        json: JSON.parse(line.replace(/^data:\s*/, '')) as Record<string, any>,
+      };
+    };
+    const initialize = async () => {
+      const response = await request(1, 'initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'e2e', version: '0' },
+      });
+      await request(null, 'notifications/initialized');
+      return response;
+    };
+    return { initialize, request };
   };
 
   it('serves health + an absolute bridgeUrl carrying the bound port', async () => {
@@ -155,14 +185,15 @@ describe.skipIf(GATED)('e2e — bridge through a real vite dev server (GATED: PY
   }, 30_000);
 
   it('answers a real MCP handshake over HTTP: initialize THEN tools/list', async () => {
-    const init = await mcp(1, 'initialize', {
-      protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e', version: '0' },
-    });
+    const mcp = createMcpSession();
+    const init = await mcp.initialize();
     expect(init.status).toBe(200);
-    expect(init.json.result.serverInfo.name).toBe('pyric');
-    const list = await mcp(2, 'tools/list');
+    expect(init.json?.result.serverInfo.name).toBe('pyric');
+    const list = await mcp.request(2, 'tools/list');
     expect(list.status).toBe(200);
-    expect((list.json.result.tools as Array<{ name: string }>).length).toBeGreaterThan(0);
+    expect(
+      (list.json?.result.tools as Array<{ name: string }>).map((tool) => tool.name).sort(),
+    ).toEqual([...DEFAULT_MCP_TOOL_NAMES].sort());
   }, 30_000);
 
   it('round-trips a tool call MCP → bridge → real connectBridge sandbox peer → back', async () => {
@@ -181,13 +212,15 @@ describe.skipIf(GATED)('e2e — bridge through a real vite dev server (GATED: PY
     await withTimeout(connected, 9000, 'peer connect');
 
     // Pick a forwarded sandbox tool from the live list (name may be prefixed).
-    const list = await mcp(10, 'tools/list');
-    const inspect = (list.json.result.tools as Array<{ name: string }>).find((t) => t.name.includes('inspect'));
+    const mcp = createMcpSession();
+    await mcp.initialize();
+    const list = await mcp.request(10, 'tools/list');
+    const inspect = (list.json?.result.tools as Array<{ name: string }>).find((t) => t.name.includes('inspect'));
     expect(inspect).toBeTruthy();
 
-    const call = await mcp(11, 'tools/call', { name: inspect!.name, arguments: {} });
+    const call = await mcp.request(11, 'tools/call', { name: inspect!.name, arguments: {} });
     expect(call.status).toBe(200);
-    expect(call.json.error).toBeUndefined(); // forwarded + executed, not "not connected"
-    expect(call.json.result).toBeTruthy();
+    expect(call.json?.error).toBeUndefined(); // forwarded + executed, not "not connected"
+    expect(call.json?.result).toBeTruthy();
   }, 30_000);
 });

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -365,6 +365,10 @@ check_bin_executable() {
 check_bin_executable "pyric"
 PYRIC_BIN="$WORK/consumer/node_modules/.bin/pyric"
 node "$ROOT/scripts/packed-cli-smoke.mjs" "$PYRIC_BIN" "$WORK/cli-smoke"
+node "$ROOT/scripts/packed-mcp-smoke.mjs" \
+  "$PYRIC_BIN" \
+  "$WORK/mcp-smoke" \
+  "$ROOT/packages/pyric-tools/dist/bridge/server/mcp-contract.js"
 
 # ─── Phase 5.5: serve smoke (init + serve from the packed bin) ─────────
 # The subpath + bin checks above prove imports resolve, but they never boot

--- a/scripts/packed-mcp-smoke.mjs
+++ b/scripts/packed-mcp-smoke.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/**
+ * Drive an installed `pyric mcp` binary over its real stdio protocol.
+ * This deliberately speaks JSON-RPC directly so the packaging gate does not
+ * borrow the server's MCP SDK dependency as its client implementation.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const GOOD_RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} { allow read, write: if false; }
+  }
+}`;
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function resultPayload(response, name) {
+  if (response.error) {
+    throw new Error(`${name} returned JSON-RPC error: ${JSON.stringify(response.error)}`);
+  }
+  const text = response.result?.content?.find((entry) => entry.type === 'text')?.text;
+  if (typeof text !== 'string') {
+    throw new Error(`${name} returned no MCP text content: ${JSON.stringify(response)}`);
+  }
+  return JSON.parse(text);
+}
+
+export async function runPackedMcpSmoke({
+  bin,
+  workDir,
+  expectedToolNames,
+  quiet = false,
+}) {
+  const executable = isAbsolute(bin) ? bin : resolve(bin);
+  const cwd = isAbsolute(workDir) ? workDir : resolve(workDir);
+  mkdirSync(join(cwd, '.pyric'), { recursive: true });
+
+  // An identity-bearing stale pointer makes discovery deterministically choose
+  // headless mode without blindly scanning into an unrelated developer server.
+  writeFileSync(
+    join(cwd, '.pyric', 'serve.json'),
+    `${JSON.stringify({
+      port: 65_534,
+      instanceId: 'packed-mcp-smoke-intentionally-absent',
+    })}\n`,
+  );
+
+  const child = spawn(executable, ['mcp'], {
+    cwd,
+    env: { ...process.env, CI: '1', HOME: cwd, USERPROFILE: cwd },
+    shell: process.platform === 'win32',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdoutBuffer = '';
+  let stderr = '';
+  let nextId = 1;
+  const pending = new Map();
+
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdoutBuffer += chunk;
+    for (;;) {
+      const newline = stdoutBuffer.indexOf('\n');
+      if (newline < 0) break;
+      const line = stdoutBuffer.slice(0, newline).replace(/\r$/, '');
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        for (const waiter of pending.values()) waiter.reject(error);
+        pending.clear();
+        continue;
+      }
+      if (message.id == null) continue;
+      const waiter = pending.get(message.id);
+      if (!waiter) continue;
+      pending.delete(message.id);
+      waiter.resolve(message);
+    }
+  });
+
+  const exited = new Promise((resolveExit, rejectExit) => {
+    child.once('error', rejectExit);
+    child.once('exit', (code, signal) => {
+      const error = new Error(
+        `pyric mcp exited before completing (code=${code}, signal=${signal})\nstderr:\n${stderr}`,
+      );
+      for (const waiter of pending.values()) waiter.reject(error);
+      pending.clear();
+      resolveExit({ code, signal });
+    });
+  });
+
+  const send = (message) => {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  };
+  const request = async (method, params = {}) => {
+    const id = nextId++;
+    const response = new Promise((resolveResponse, rejectResponse) => {
+      pending.set(id, { resolve: resolveResponse, reject: rejectResponse });
+    });
+    send({ jsonrpc: '2.0', id, method, params });
+    return await withTimeout(response, 10_000, `MCP ${method}`);
+  };
+
+  try {
+    const initialized = await request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'pyric-packed-smoke', version: '1' },
+    });
+    if (initialized.error || initialized.result?.serverInfo?.name !== 'pyric') {
+      throw new Error(`pyric mcp initialize failed: ${JSON.stringify(initialized)}`);
+    }
+    send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
+
+    const listed = await request('tools/list');
+    const toolNames = listed.result?.tools?.map((tool) => tool.name);
+    const actualSorted = [...(toolNames ?? [])].sort();
+    const expectedSorted = [...expectedToolNames].sort();
+    if (JSON.stringify(actualSorted) !== JSON.stringify(expectedSorted)) {
+      throw new Error(
+        `packed pyric mcp tool contract drifted\n` +
+          `expected: ${expectedToolNames.join(', ')}\n` +
+          `actual:   ${(toolNames ?? []).join(', ')}`,
+      );
+    }
+
+    const localCall = resultPayload(
+      await request('tools/call', {
+        name: 'firestore_lint_rules',
+        arguments: { source: GOOD_RULES },
+      }),
+      'firestore_lint_rules',
+    );
+    if (!localCall.ok) throw new Error(`local MCP call failed: ${JSON.stringify(localCall)}`);
+
+    const sandboxCall = resultPayload(
+      await request('tools/call', { name: 'sandbox_inspect', arguments: {} }),
+      'sandbox_inspect',
+    );
+    if (!sandboxCall.ok) {
+      throw new Error(`sandbox MCP call failed: ${JSON.stringify(sandboxCall)}`);
+    }
+
+    child.stdin.end();
+    const exit = await withTimeout(exited, 5_000, 'pyric mcp shutdown');
+    if (exit.code !== 0) {
+      throw new Error(`pyric mcp exited ${exit.code}\nstderr:\n${stderr}`);
+    }
+
+    if (!quiet) {
+      process.stdout.write(
+        `  ✓ packed pyric mcp initialized, listed ${toolNames.length} tools, and executed local + sandbox calls\n`,
+      );
+    }
+    return { toolNames, localCall, sandboxCall };
+  } catch (error) {
+    child.kill('SIGTERM');
+    throw error;
+  }
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  const [bin, workDir, contractModule] = process.argv.slice(2);
+  if (!bin || !workDir || !contractModule) {
+    process.stderr.write(
+      'usage: node scripts/packed-mcp-smoke.mjs <pyric-bin> <work-dir> <mcp-contract-module>\n',
+    );
+    process.exit(2);
+  }
+  const contract = await import(pathToFileURL(resolve(contractModule)).href);
+  await runPackedMcpSmoke({
+    bin,
+    workDir,
+    expectedToolNames: [...contract.DEFAULT_MCP_TOOL_NAMES],
+  });
+}

--- a/scripts/tool-parity.annotations.json
+++ b/scripts/tool-parity.annotations.json
@@ -1,6 +1,210 @@
 {
   "_readme": "Exposure decisions for the tool parity audit (scripts/tool-parity.mjs). Every tool visible on any surface (MCP bridge / playground agent / @pyric/cli registry) must be recorded here as 'gap' (absence is a defect to fix) or 'deliberate' (absence is design, with the reason). Unannotated tools fail `bun run tool:parity --check`. Seeded from docs/design/TOOL-SYSTEM.md's exposure matrix.",
   "tools": {
+    "auth_configure_provider": {
+      "decision": "deliberate",
+      "reason": "legacy production-control registry tool; excluded from local MCP and Playground and scheduled for removal from @pyric/cli"
+    },
+    "auth_get_config": {
+      "decision": "deliberate",
+      "reason": "legacy production-control registry tool; excluded from local MCP and Playground and scheduled for removal from @pyric/cli"
+    },
+    "auth_manage_domains": {
+      "decision": "deliberate",
+      "reason": "legacy production-control registry tool; excluded from local MCP and Playground and scheduled for removal from @pyric/cli"
+    },
+    "build_game_rules": {
+      "decision": "deliberate",
+      "reason": "Playground skill-specific authoring workflow, activated only by its skill; not a general MCP primitive"
+    },
+    "debug_firestore_rules": {
+      "decision": "deliberate",
+      "reason": "Playground orchestration wrapper; external agents compose the MCP rules and inspection primitives directly"
+    },
+    "firestore_add_document": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_batch_write": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_create_document": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_create_with_auto_id": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_delete_document": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_discover_paths": {
+      "decision": "deliberate",
+      "reason": "production-project discovery is excluded from the local MCP contract and is scheduled for removal from @pyric/cli"
+    },
+    "firestore_extract_indexes": {
+      "decision": "deliberate",
+      "reason": "artifact generation is exposed through `pyric firestore indexes generate`; external agents can invoke the CLI without a duplicate MCP tool"
+    },
+    "firestore_find_collection_group": {
+      "decision": "deliberate",
+      "reason": "production-project discovery is excluded from the local MCP contract and is scheduled for removal from @pyric/cli"
+    },
+    "firestore_get_document": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_inspect_rules": {
+      "decision": "deliberate",
+      "reason": "production rules inspection is excluded from the local MCP contract; Playground exposure remains explicitly project-gated"
+    },
+    "firestore_lint_rules": {
+      "decision": "deliberate",
+      "reason": "local MCP rules primitive; the Playground reaches linting through its native authoring workflow rather than a duplicate top-level handler"
+    },
+    "firestore_list_documents": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_query_where": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "firestore_resolve_modules": {
+      "decision": "deliberate",
+      "reason": "local MCP rules primitive; the Playground resolves modules inside its native authoring and write workflow"
+    },
+    "firestore_rules_stdlib_get": {
+      "decision": "deliberate",
+      "reason": "intentionally shared rules-authoring reference across MCP, Playground, and the composed registry"
+    },
+    "firestore_rules_stdlib_list": {
+      "decision": "deliberate",
+      "reason": "intentionally shared rules-authoring reference across MCP, Playground, and the composed registry"
+    },
+    "firestore_simulate_rules": {
+      "decision": "deliberate",
+      "reason": "local MCP rules primitive; the Playground reaches simulation through its diagnostic workflow rather than a duplicate top-level handler"
+    },
+    "firestore_simulator_batch": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_create": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_events": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_execute": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_read": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_redo": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_transaction": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_simulator_undo": {
+      "decision": "deliberate",
+      "reason": "stateful simulator operation for external MCP sessions; the Playground owns its simulator through higher-level session workflows"
+    },
+    "firestore_test_rules": {
+      "decision": "gap",
+      "reason": "Rules Test API verification is allowed but is not in the default credential-free MCP contract; it needs an explicit credential-aware adapter"
+    },
+    "firestore_update_document": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox CRUD belongs in MCP; the Playground uses its native session workspace instead of duplicating the bridge data plane"
+    },
+    "inspect_auth_users": {
+      "decision": "deliberate",
+      "reason": "Playground session-inspection affordance; the default MCP contract currently exposes only ratified attached-sandbox tool families"
+    },
+    "pyric_derive_rules_test_cases": {
+      "decision": "deliberate",
+      "reason": "exposed as `pyric verify cases`; external agents can invoke the CLI without a duplicate MCP tool"
+    },
+    "pyric_verify_fixture": {
+      "decision": "deliberate",
+      "reason": "exposed as `pyric verify`; external agents can invoke the CLI without a duplicate MCP tool"
+    },
+    "rtdb_build_expression": {
+      "decision": "deliberate",
+      "reason": "legacy registry helper; public RTDB artifact generation is owned by `pyric database rules generate`"
+    },
+    "rtdb_crawl_structure": {
+      "decision": "deliberate",
+      "reason": "bounded attached-sandbox inspection belongs in MCP; the Playground reads its own session state directly"
+    },
+    "rtdb_delete": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_deploy_rules": {
+      "decision": "deliberate",
+      "reason": "legacy deployment registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_get": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_get_rules": {
+      "decision": "deliberate",
+      "reason": "production RTDB control-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_push": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_set": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_simulate_access": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox rules inspection belongs in MCP; the Playground uses its own session rules engine"
+    },
+    "rtdb_update": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "rtdb_validated_write": {
+      "decision": "deliberate",
+      "reason": "production RTDB data-plane registry tool; excluded from local MCP and scheduled for removal from @pyric/cli"
+    },
+    "run_workspace_tests": {
+      "decision": "deliberate",
+      "reason": "Playground virtual-workspace operation; external agents run project tests through their native shell"
+    },
+    "sandbox_discover_paths": {
+      "decision": "deliberate",
+      "reason": "Playground session-navigation affordance; MCP already exposes bounded list, query, and inspect primitives"
+    },
+    "sandbox_inspect": {
+      "decision": "deliberate",
+      "reason": "attached-sandbox diagnostic belongs in MCP; the Playground observes its session state directly"
+    },
+    "seed_auth_users": {
+      "decision": "deliberate",
+      "reason": "Playground fixture convenience; external MCP sessions operate on the attached application sandbox rather than a parallel seed API"
+    },
+    "seed_firestore_data_as_admin": {
+      "decision": "deliberate",
+      "reason": "Playground fixture convenience; MCP exposes explicit Firestore create and batch operations instead"
+    },
     "inspect_firestore_traffic": {
       "decision": "gap",
       "reason": "missing from MCP — an external agent debugging rules needs the same visibility the playground agent has"


### PR DESCRIPTION
Ratifies the default `pyric mcp` surface as an exact 35-tool set and proves the installed tarball over the real stdio protocol.

```sh
node scripts/packed-mcp-smoke.mjs \
  ./node_modules/.bin/pyric \
  /tmp/pyric-mcp-smoke \
  ./packages/pyric-tools/dist/bridge/server/mcp-contract.js

# ✓ packed pyric mcp initialized, listed 35 tools,
#   and executed local + sandbox calls
```

## Default MCP servers now fail closed on tool drift

`getDefaultMcpToolSurface()` assembles the same committed contract for the headless server, standalone sandbox bridge, and served/Vite bridge:

| Family | Count | Execution |
|---|---:|---|
| Firestore simulator, data, and inspection | 18 | attached sandbox |
| RTDB inspection | 2 | attached sandbox |
| Assurance | 10 | attached sandbox |
| Firestore rules | 5 | local CLI process |

The contract pins the exact set, not listing order. Adding or removing a factory tool without updating the manifest fails immediately. HTTP and real-Vite `tools/list` tests now assert the whole set instead of spot-checking a few names.

## Risk

Intentional MCP additions or removals—including the in-progress RTDB architecture work—must update the manifest explicitly. `extraTools` remains an extension of the served bridge and is not part of the default contract.

The Rules Test API tool is recorded as an explicit gap rather than silently included: it is allowed verification functionality, but the default MCP server remains credential-free until a credential-aware adapter is designed.

## Production registry tools are audited, not approved

The strict parity gate now requires an exposure decision for all 79 tools across MCP, Playground, and the composed registry. The surviving production/control-plane registry tools are classified as excluded from local MCP and scheduled for removal; this PR does not preserve or expand them.

<details>
<summary>Verification</summary>

- `bun run --cwd packages/pyric-tools typecheck`
- `bun test` in `packages/pyric-tools`: 1,199 passed, 6 gated/skipped
- `PYRIC_BRIDGE_E2E=1 bun test test/serve/vite-plugin-bridge-e2e.test.ts`: 3 passed
- `bun run tool:parity:check`: 79 classified, 0 unclassified
- `npm run test:packaging`: packed, installed, initialized MCP over stdio, listed 35 tools, executed local + sandbox calls

</details>
