### PR TITLE
fix(studio): correct auth user list semantics

### DIFF
--- a/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
+++ b/packages/pyric-tools/test/e2e/site-static/static-site.pw.ts
@@ -195,6 +195,30 @@ test('the curated demo seed (__pyric/init.json) is applied on first worker boot'
   expect(seeded?.title).toBe('Welcome to Pyric Studio');
 });
 
+test('Auth rows align selection controls and distinguish never-signed-in users', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Auth', exact: true }).click();
+
+  const table = page.getByRole('table', { name: 'Authentication users' });
+  await expect(table).toBeVisible();
+  const signal = await table.evaluate((root) => {
+    const rows = Array.from(root.querySelectorAll('[role="row"]'));
+    const checkboxCenters = rows.map((row) => {
+      const checkbox = row.querySelector('input[type="checkbox"]');
+      if (!(checkbox instanceof HTMLInputElement)) throw new Error('selection checkbox missing');
+      const rect = checkbox.getBoundingClientRect();
+      return rect.left + rect.width / 2;
+    });
+    const signedIn = rows.slice(1).map(
+      (row) => row.querySelector('[data-pyric-user-cell="signed-in"]')?.textContent?.trim(),
+    );
+    return { checkboxCenters, signedIn };
+  });
+
+  expect(new Set(signal.checkboxCenters).size).toBe(1);
+  expect(signal.signedIn).toEqual(['never', 'never']);
+});
+
 test('DIAGNOSTIC: full request log for /__pyric/* on first load (not an assertion — informational)', async ({
   page,
 }) => {

--- a/packages/site-docs/src/content/docs/ui-auth-authusers.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authusers.md
@@ -108,7 +108,8 @@ non-React drivers.
 | `filter` | `string` | Picks the zero state: "No users for this project yet" vs "No results" (`data-pyric-no-results`). |
 | `onSelect` | `(user) => void` | Identifier cell becomes a button. |
 | `renderIdentifier` / `renderProviders` / `renderActions` | render props | Cell overrides; actions add a trailing column. |
-| `formatDate` | `(iso \| null) => ReactNode` | Default: locale date, em dash for null. |
+| `formatCreatedAt` | `(iso \| null) => ReactNode` | Created-time formatter. Default: locale date, em dash for null. |
+| `formatLastLoginAt` | `(iso \| null) => ReactNode` | Last-sign-in formatter. Kept separate so consumers can render a null login as "never". |
 | `emptyState` / `noResultsState` | `ReactNode` | Copy overrides. |
 | `virtualizeThreshold` / `rowHeight` / `virtualizedHeight` | | Virtualizes >100 rows via `<VirtualList>`. |
 

--- a/packages/studio/src/dev/seed.test.ts
+++ b/packages/studio/src/dev/seed.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
+import { initializeSandbox } from 'pyric/sandbox';
+import { seedAuth } from './seed.js';
+
+describe('Studio Auth dev seed', () => {
+  it('seeds provider provenance as Auth data rather than custom claims', async () => {
+    const auth = getAuth(initializeSandbox());
+    await seedAuth(auth);
+    const users = authSandbox.listUsers(auth);
+
+    const alice = users.find((user) => user.uid === 'alice');
+    expect(alice?.providerUserInfo).toEqual([{ providerId: 'google.com' }]);
+    expect(alice?.customClaims).toEqual({ plan: 'pro' });
+
+    const anonymous = users.find((user) => user.isAnonymous);
+    expect(anonymous).toBeDefined();
+    expect(anonymous?.providerUserInfo).toEqual([]);
+  });
+});

--- a/packages/studio/src/dev/seed.ts
+++ b/packages/studio/src/dev/seed.ts
@@ -8,8 +8,8 @@
  *     geopoint / timestamp / reference fields), plus `users` and `posts`.
  *     Writes go through the ADMIN handle (`getAdminFirestore`) so the seed
  *     bypasses rules; it's a fixture, not an app action.
- *   - Auth: a handful of users incl. a Google-style verified user and an
- *     anonymous user, via the `sandbox.createUser` admin seam.
+ *   - Auth: admin-created users via `sandbox.createUser`, plus an anonymous
+ *     account created through the client sign-in flow.
  *   - Storage: a couple of objects (an avatar PNG + a text note attachment).
  *
  * Everything here is import-gated behind `import.meta.env.DEV` at the call site
@@ -29,7 +29,13 @@ import {
   updateDoc,
   type Firestore,
 } from 'pyric/firestore';
-import { getAuth, sandbox as authSandbox, type Auth } from 'pyric/auth';
+import {
+  getAuth,
+  sandbox as authSandbox,
+  signInAnonymously,
+  signOut,
+  type Auth,
+} from 'pyric/auth';
 import { ref, uploadBytes, type FirebaseStorage } from 'pyric/storage';
 import { getAdminStorageSandbox } from 'pyric/storage/internal';
 import { initializeSandbox, type LocalSandbox } from 'pyric/sandbox';
@@ -48,21 +54,22 @@ export interface SeededHandles {
   storage: FirebaseStorage;
 }
 
-/** Three sandbox users: a Google-style verified user, a password user, and an
- *  anonymous one, created through the admin user seam. */
-function seedAuth(auth: Auth): void {
+/** Three admin-created users plus one real anonymous sign-in. Provider
+ * provenance lives in Auth's provider fields, never in custom claims. */
+export async function seedAuth(auth: Auth): Promise<void> {
   authSandbox.createUser(auth, {
     uid: 'alice',
     email: 'alice@gmail.com',
     displayName: 'Alice Nguyen',
     emailVerified: true,
     photoUrl: 'https://lh3.googleusercontent.com/a/alice',
-    // Google-style sign-in is reflected by a verified Google email + photo.
-    customClaims: { provider: 'google.com', plan: 'pro' },
+    providerUserInfo: [{ providerId: 'google.com' }],
+    customClaims: { plan: 'pro' },
   });
   authSandbox.createUser(auth, {
     uid: 'bob',
     email: 'bob@example.com',
+    password: 'pyric-demo',
     displayName: 'Bob Carter',
     emailVerified: true,
     customClaims: { role: 'editor' },
@@ -73,10 +80,10 @@ function seedAuth(auth: Auth): void {
     displayName: 'Carol Diaz',
     emailVerified: false,
   });
-  // An anonymous user: no email, no display name (Firebase's anon shape).
-  authSandbox.createUser(auth, {
-    uid: 'anon-7Hk2',
-  });
+  // Anonymous accounts are born through sign-in. Admin createUser with no
+  // email is still a non-anonymous account and must not be presented as one.
+  await signInAnonymously(auth);
+  await signOut(auth);
 }
 
 /** A geopoint near SF, reused across the geo-tagged notes. */
@@ -263,7 +270,7 @@ export async function applySeed(
   handles: Pick<SeededHandles, 'adminFirestore' | 'auth' | 'storage'>,
 ): Promise<void> {
   await seedFirestore(handles.adminFirestore);
-  seedAuth(handles.auth);
+  await seedAuth(handles.auth);
   await seedStorage(handles.storage);
 }
 

--- a/packages/studio/src/features/auth/AuthSurface.tsx
+++ b/packages/studio/src/features/auth/AuthSurface.tsx
@@ -218,7 +218,8 @@ function AuthSurfaceBody({ auth }: { auth: Auth }) {
               selectUser(u.uid);
             }}
             renderIdentifier={renderIdentifier}
-            formatDate={clockTime}
+            formatCreatedAt={clockTime}
+            formatLastLoginAt={relativeTime}
             renderSelectionHeader={
               <label className="auth-select" title="Select all shown users">
                 <input

--- a/packages/studio/src/features/auth/auth.css
+++ b/packages/studio/src/features/auth/auth.css
@@ -286,7 +286,6 @@
 
 [data-pyric-ui='auth-user-list'] [data-pyric-user-entry] {
   border-bottom: 1px solid var(--line);
-  border-left: 2px solid transparent;
   cursor: default;
 }
 [data-pyric-ui='auth-user-list'] [data-pyric-user-entry]:hover {

--- a/packages/ui/docs/auth/AuthUsers.md
+++ b/packages/ui/docs/auth/AuthUsers.md
@@ -105,7 +105,8 @@ non-React drivers.
 | `filter` | `string` | Picks the zero state: "No users for this project yet" vs "No results" (`data-pyric-no-results`). |
 | `onSelect` | `(user) => void` | Identifier cell becomes a button. |
 | `renderIdentifier` / `renderProviders` / `renderActions` | render props | Cell overrides; actions add a trailing column. |
-| `formatDate` | `(iso \| null) => ReactNode` | Default: locale date, em dash for null. |
+| `formatCreatedAt` | `(iso \| null) => ReactNode` | Created-time formatter. Default: locale date, em dash for null. |
+| `formatLastLoginAt` | `(iso \| null) => ReactNode` | Last-sign-in formatter. Kept separate so consumers can render a null login as "never". |
 | `emptyState` / `noResultsState` | `ReactNode` | Copy overrides. |
 | `virtualizeThreshold` / `rowHeight` / `virtualizedHeight` | | Virtualizes >100 rows via `<VirtualList>`. |
 

--- a/packages/ui/src/auth/components/AuthUserList.tsx
+++ b/packages/ui/src/auth/components/AuthUserList.tsx
@@ -33,9 +33,11 @@ export interface AuthUserListProps {
   /** Optional content for the trailing actions column header (for example,
    *  a select-all checkbox). Only rendered with `renderActions`. */
   renderActionsHeader?: ReactNode;
-  /** Timestamp formatter for Created / Signed In. Default: locale date,
-   *  em dash for null. */
-  formatDate?: (iso: string | null) => ReactNode;
+  /** Timestamp formatter for Created. Default: locale date, em dash for null. */
+  formatCreatedAt?: (iso: string | null) => ReactNode;
+  /** Timestamp formatter for Signed In. Kept separate because a missing login
+   *  means "never", while a missing/invalid creation time is malformed data. */
+  formatLastLoginAt?: (iso: string | null) => ReactNode;
   /** Zero state when the project has no users at all. */
   emptyState?: ReactNode;
   /** Zero state when the filter matches nothing. */
@@ -93,7 +95,8 @@ export function AuthUserList({
   renderSelectionHeader,
   renderActions,
   renderActionsHeader,
-  formatDate = defaultFormatDate,
+  formatCreatedAt = defaultFormatDate,
+  formatLastLoginAt = defaultFormatDate,
   emptyState,
   noResultsState,
   className,
@@ -155,10 +158,10 @@ export function AuthUserList({
         {(renderProviders ?? defaultProviders)(user)}
       </span>
       <span role="cell" data-pyric-user-cell="created">
-        {formatDate(user.createdAt)}
+        {formatCreatedAt(user.createdAt)}
       </span>
       <span role="cell" data-pyric-user-cell="signed-in">
-        {formatDate(user.lastLoginAt)}
+        {formatLastLoginAt(user.lastLoginAt)}
       </span>
       <span role="cell" data-pyric-user-cell="uid">
         {user.uid}

--- a/packages/ui/test/auth/components/AuthUserList.test.tsx
+++ b/packages/ui/test/auth/components/AuthUserList.test.tsx
@@ -114,15 +114,16 @@ describe('<AuthUserList>', () => {
     ).toBe('Anonymous');
   });
 
-  it('formats created/signed-in; em dash for never-signed-in; uid cell', () => {
+  it('formats created and signed-in timestamps independently', () => {
     const { container } = render(
       <AuthUserList
         users={[user({ uid: 'u1', lastLoginAt: null })]}
-        formatDate={(iso) => (iso ? 'formatted' : 'never')}
+        formatCreatedAt={() => 'created-at'}
+        formatLastLoginAt={(iso) => (iso ? 'signed-in-at' : 'never')}
       />,
     );
     const entry = container.querySelector('[data-pyric-user-entry]')!;
-    expect(entry.querySelector('[data-pyric-user-cell="created"]')!.textContent).toBe('formatted');
+    expect(entry.querySelector('[data-pyric-user-cell="created"]')!.textContent).toBe('created-at');
     expect(entry.querySelector('[data-pyric-user-cell="signed-in"]')!.textContent).toBe('never');
     expect(entry.querySelector('[data-pyric-user-cell="uid"]')!.textContent).toBe('u1');
   });


### PR DESCRIPTION
Corrects Studio's Auth user list so provider provenance, last-sign-in state, and selection alignment reflect the underlying user records.

```tsx
import { AuthUserList } from '@pyric/ui/auth';
import { getAuth, sandbox as authSandbox } from 'pyric/auth';
import { initializeSandbox } from 'pyric/sandbox';
import { seedAuth } from './dev/seed.js';

const auth = getAuth(initializeSandbox());
await seedAuth(auth);
const users = authSandbox.listUsers(auth);

<AuthUserList
  users={users}
  formatCreatedAt={(iso) => (iso ? new Date(iso).toLocaleTimeString() : 'unknown')}
  formatLastLoginAt={(iso) => (iso ? new Date(iso).toLocaleTimeString() : 'never')}
/>;

// alice       Provider: Google          Signed In: never
// anonymous-1 Provider: Anonymous       Signed In: just now
```

## Provider and sign-in columns now describe Auth state

The Studio seed records Google's provider ID in `providerUserInfo` instead of an unrelated custom claim. Its anonymous fixture is now created through `signInAnonymously`; an admin-created user without an email is not an anonymous Firebase identity.

Created time and last-sign-in time now have separate formatter contracts. A missing creation timestamp remains malformed/unknown data, while a missing `lastLoginAt` means the user has never signed in. Removing the data-row-only two-pixel border puts every selection checkbox on the same horizontal center as the header control.

## Risk

`AuthUserList` replaces the single `formatDate` prop with `formatCreatedAt` and `formatLastLoginAt`. This intentionally changes the alpha UI API instead of preserving an ambiguous compatibility alias. The dev seed's anonymous UID is now generated by the sign-in flow, and that record correctly has a recent last-login timestamp.

<details>
<summary>Implementation notes and verification</summary>

- Added seed coverage proving Google provider provenance is not stored in custom claims and the anonymous fixture has the Auth anonymous shape.
- Added component coverage for independent Created and Signed In formatting.
- Added a static-site Playwright regression that checks checkbox center coordinates and `never` rendering.
- Full monorepo test suite: passed.
- Studio: 306 tests passed.
- UI: 285 tests passed.
- Full production build and generated documentation build: passed.
- Standards review and spec review: no remaining findings.

</details>
