### PR TITLE
feat(studio): show pages connected to the shared sandbox worker

### DIFF
--- a/packages/cli/src/remote/index.ts
+++ b/packages/cli/src/remote/index.ts
@@ -401,9 +401,10 @@ export function createRemoteSandboxCore(
             message = noTabError(serveUrl).message;
           } else if (/^Unknown method:/.test(message)) {
             // Version skew: a live tab whose SharedWorker predates this op.
+            // Other open pages of this origin keep the old worker alive.
             message +=
               ' — the running sandbox may predate this feature; restart pyric dev ' +
-              'and reload the browser tab.';
+              'and close other open pages of this origin, then reload.';
           }
           call.reject(remoteError(code, message, msg.error?.denialContext));
         }

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -32,6 +32,8 @@ import {
   getAuth as workerGetAuth,
   onAuthStateChanged as workerOnAuthStateChanged,
   restorePortSession as workerRestorePortSession,
+  startPresence,
+  subscribePresence,
   type ClientDb,
 } from '../worker/client.js';
 import { SessionStore } from './session-store.js';
@@ -95,6 +97,10 @@ export const sandbox = initializeSandbox();
  */
 export const workerDb: ClientDb | null = useWorker ? workerGetFirestore(WORKER_URL, WORKER_NAME) : null;
 
+/** This page's presence session (#227) — registers as `app` with the shared worker. */
+export const presenceSession =
+  useWorker && workerDb ? startPresence({ db: workerDb, kind: 'app' }) : null;
+
 // Staleness guard: warn (don't split) if the running worker is older than what
 // serve is now serving. serve stamps the served bundle hash into
 // `<meta name="pyric-worker-v">`; the worker reports its OWN baked hash. A
@@ -105,13 +111,33 @@ if (useWorker && typeof document !== 'undefined') {
     .querySelector('meta[name="pyric-worker-v"]')
     ?.getAttribute('content');
   void getWorkerVersion(workerDb!)
-    .then((runningV) => {
+    .then(async (runningV) => {
       if (servedV && runningV && runningV !== 'dev' && servedV !== runningV) {
+        const otherPages = await new Promise<number>((resolve) => {
+          const unsub = subscribePresence(workerDb!, (snap) => {
+            unsub();
+            const others = snap.clients.filter(
+              (c) => c.clientId !== presenceSession?.clientId,
+            ).length;
+            resolve(others);
+          });
+          // Don't hang the warn forever if the sub never fires.
+          setTimeout(() => {
+            unsub();
+            resolve(-1);
+          }, 2_000);
+        });
+        const othersHint =
+          otherPages > 0
+            ? ` ${otherPages} other page${otherPages === 1 ? '' : 's'} must disconnect before the worker can restart.`
+            : otherPages === 0
+              ? ' This is the only connected page — reload it to pick up the new worker.'
+              : '';
         console.warn(
           `[pyric dev] the SharedWorker is running OLDER code (build ${runningV}) than what is now ` +
             `served (build ${servedV}). A SharedWorker can't hot-update — CLOSE ALL TABS of this origin ` +
             'and reopen to load the new worker. (All tabs share one worker, so a partial reload leaves ' +
-            'the old code running for everyone.)',
+            `the old code running for everyone.)${othersHint}`,
         );
       }
     })

--- a/packages/cli/src/serve/worker/client.ts
+++ b/packages/cli/src/serve/worker/client.ts
@@ -50,6 +50,7 @@ export * from './client/rules.js';
 export * from './client/admin-firestore.js';
 export * from './client/rtdb.js';
 export * from './client/studio.js';
+export * from './client/presence.js';
 export * from './client/auth.js';
 export * from './client/storage.js';
 export * from './client/ai.js';

--- a/packages/cli/src/serve/worker/client/presence.ts
+++ b/packages/cli/src/serve/worker/client/presence.ts
@@ -1,0 +1,175 @@
+/**
+ * Worker-client connected-page presence (#227).
+ *
+ * Each served page (app or Studio) identifies itself with a stable-per-page
+ * `clientId`, registers with the SharedWorker, heartbeats on a bounded
+ * interval, updates route/visibility, and best-effort disconnects on
+ * `pagehide`. Studio also subscribes for live snapshots.
+ *
+ * Presence is independent of auth sessions and Firestore subscriptions.
+ */
+
+import type {
+  InboundMessage,
+  PresenceClientKind,
+  PresenceSnapshot,
+  PresenceVisibility,
+} from '../protocol.js';
+import {
+  PRESENCE_HEARTBEAT_INTERVAL_MS,
+  PRESENCE_STALE_MS,
+} from '../presence-timing.js';
+import { nextId, nextSubId, rpc, _snapSubs } from './core.js';
+import type { ClientDb, Unsubscribe } from './handles.js';
+
+export type { PresenceClientKind, PresenceSnapshot, PresenceVisibility };
+export { PRESENCE_HEARTBEAT_INTERVAL_MS, PRESENCE_STALE_MS };
+
+/** Mint a random client id (page-lifetime). */
+export function mintPresenceClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `page-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function currentRoute(): string {
+  if (typeof location === 'undefined') return '/';
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+function currentVisibility(): PresenceVisibility {
+  if (typeof document === 'undefined') return 'visible';
+  return document.visibilityState === 'hidden' ? 'hidden' : 'visible';
+}
+
+export interface PresenceSession {
+  /** Logical page id — Studio uses this to label "This page". */
+  readonly clientId: string;
+  readonly kind: PresenceClientKind;
+  /** Stop heartbeats, listeners, and send a best-effort disconnect. */
+  stop(): void;
+}
+
+export interface StartPresenceOptions {
+  db: ClientDb;
+  kind: PresenceClientKind;
+  /** Override client id (tests / reconnect). Default: mint a new one. */
+  clientId?: string;
+  /** Heartbeat interval. Default: {@link PRESENCE_HEARTBEAT_INTERVAL_MS}. */
+  heartbeatIntervalMs?: number;
+}
+
+/**
+ * Register this page with the worker and keep the lease alive until
+ * {@link PresenceSession.stop} or `pagehide`.
+ */
+export function startPresence(opts: StartPresenceOptions): PresenceSession {
+  const { db, kind } = opts;
+  const clientId = opts.clientId ?? mintPresenceClientId();
+  const intervalMs = opts.heartbeatIntervalMs ?? PRESENCE_HEARTBEAT_INTERVAL_MS;
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const register = (): void => {
+    void rpc(db.port, {
+      t: 'op',
+      id: nextId(),
+      method: 'presence.register',
+      clientId,
+      kind,
+      route: currentRoute(),
+      visibility: currentVisibility(),
+    }).catch(() => {});
+  };
+
+  const heartbeat = (): void => {
+    void rpc(db.port, {
+      t: 'op',
+      id: nextId(),
+      method: 'presence.heartbeat',
+      clientId,
+    }).catch(() => {});
+  };
+
+  const update = (): void => {
+    void rpc(db.port, {
+      t: 'op',
+      id: nextId(),
+      method: 'presence.update',
+      clientId,
+      route: currentRoute(),
+      visibility: currentVisibility(),
+    }).catch(() => {});
+  };
+
+  const disconnect = (): void => {
+    void rpc(db.port, {
+      t: 'op',
+      id: nextId(),
+      method: 'presence.disconnect',
+      clientId,
+    }).catch(() => {});
+  };
+
+  register();
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', update);
+  }
+  if (typeof window !== 'undefined') {
+    window.addEventListener('popstate', update);
+    window.addEventListener('hashchange', update);
+    // Best-effort clean disconnect; lease expiry covers unclean shutdown.
+    window.addEventListener('pagehide', onPageHide);
+    // Heartbeats only in a real page — unit shims have no document lifecycle.
+    timer = setInterval(() => {
+      if (!stopped) heartbeat();
+    }, intervalMs);
+  }
+
+  function onPageHide(): void {
+    stop();
+  }
+
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', update);
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('popstate', update);
+      window.removeEventListener('hashchange', update);
+      window.removeEventListener('pagehide', onPageHide);
+    }
+    disconnect();
+  }
+
+  return { clientId, kind, stop };
+}
+
+/**
+ * Subscribe to the worker's authoritative presence snapshot. The callback
+ * fires immediately with the current snapshot, then on every change.
+ */
+export function subscribePresence(
+  db: ClientDb,
+  callback: (snapshot: PresenceSnapshot) => void,
+): Unsubscribe {
+  const subId = nextSubId();
+  _snapSubs.set(subId, {
+    next: (value) => {
+      callback(value as PresenceSnapshot);
+    },
+  });
+  db.port.postMessage({ t: 'sub', subId, target: 'presence' } satisfies InboundMessage);
+  return () => {
+    _snapSubs.delete(subId);
+    db.port.postMessage({ t: 'unsub', subId } satisfies InboundMessage);
+  };
+}

--- a/packages/cli/src/serve/worker/host/dispatch.ts
+++ b/packages/cli/src/serve/worker/host/dispatch.ts
@@ -22,6 +22,7 @@ import {
   isRtdbSub,
   isAiSub,
   isMessagingSub,
+  isPresenceSub,
 } from '../protocol.js';
 // The canonical agent tool dispatcher — reused on the worker so a bridged agent
 // executes against THIS sandbox (one backend for app + Studio + agent), instead
@@ -63,6 +64,13 @@ import { isRtdbOp, handleRtdbOp } from './rtdb.js';
 import { isStorageOp, handleStorageOp } from './storage.js';
 import { isConnectionOp, handleConnectionOp } from './connection.js';
 import { isStudioOp, handleStudioOp } from './studio.js';
+import {
+  isPresenceOp,
+  handlePresenceOp,
+  handlePresenceSub,
+  handlePresenceUnsub,
+  cleanupPortPresence,
+} from './presence.js';
 import { handleSub, handleRtdbSub, handleUnsub, dropPortSessionSubs } from './subscriptions.js';
 
 // ─── Op orchestrator ────────────────────────────────────────────────────────
@@ -89,6 +97,7 @@ async function handleOp(ctx: HostCtx, port: PortLike, msg: OpMessage): Promise<v
   if (isStorageOp(msg.method)) return handleStorageOp(ctx, port, msg);
   if (isConnectionOp(msg.method)) return handleConnectionOp(ctx, port, msg);
   if (isStudioOp(msg.method)) return handleStudioOp(ctx, port, msg);
+  if (isPresenceOp(msg.method)) return handlePresenceOp(ctx, port, msg);
 
   // Auth (`auth.*`), AI (`ai.*`), and messaging (`messaging.*`) ops are routed
   // to their handlers by dispatchMessage BEFORE reaching handleOp, so any
@@ -178,16 +187,19 @@ async function dispatchMessage(
       handleAiSub(ctx, port, msg);
     } else if (isMessagingSub(msg)) {
       handleMessagingSub(ctx, port, msg);
+    } else if (isPresenceSub(msg)) {
+      handlePresenceSub(ctx, port, msg);
     } else {
       handleSub(ctx, port, msg);
     }
   } else if (msg.t === 'unsub') {
-    // An unsub may target an auth sub, an event-stream sub, or a Firestore
-    // listener — try the cheap routing registries first, then fall through to
-    // the Firestore listener teardown.
+    // An unsub may target an auth sub, an event-stream sub, a presence sub, or
+    // a Firestore listener — try the cheap routing registries first, then fall
+    // through to the Firestore listener teardown.
     if (
       !handleAuthUnsub(ctx, port, msg.subId) &&
-      !handleEventUnsub(ctx, port, msg.subId)
+      !handleEventUnsub(ctx, port, msg.subId) &&
+      !handlePresenceUnsub(ctx, port, msg.subId)
     ) {
       handleUnsub(ctx, port, msg);
     }
@@ -220,6 +232,10 @@ export function cleanupPort(ctx: HostCtx, port: PortLike): void {
   // visibility stops feeding the routing rule. Its delivery-handler unsubs
   // live in `ctx.subs` and are torn down with the loop below.
   cleanupPortMessaging(ctx, port);
+
+  // Presence: best-effort remove this port's logical client when it was the
+  // last association (lease expiry remains the correctness path).
+  cleanupPortPresence(ctx, port);
 
   const portSubs = ctx.subs.get(port);
   if (!portSubs) return;

--- a/packages/cli/src/serve/worker/host/presence.ts
+++ b/packages/cli/src/serve/worker/host/presence.ts
@@ -1,0 +1,312 @@
+/**
+ * SharedWorker host — connected-page presence (#227).
+ *
+ * Ephemeral, worker-lifetime registry of logical pages attached to this
+ * sandbox worker. Distinct from per-port subscription / auth-session /
+ * messaging maps: the user-facing count is keyed by `clientId`, so one page
+ * with multiple MessagePorts still counts as one client.
+ *
+ * Correctness rests on heartbeats + lease expiry (MessagePort `close` is
+ * best-effort and unreliable in Chrome). `cleanupPort` is an optimization
+ * that removes a client when its last associated port disappears.
+ */
+
+import type { OpMessage, PresenceClientRecord, PresenceSnapshot, PresenceSubMessage } from '../protocol.js';
+import { type HostCtx, type PortLike, ok, fail, post } from '../host-context.js';
+import { PRESENCE_HEARTBEAT_INTERVAL_MS, PRESENCE_STALE_MS } from '../presence-timing.js';
+
+export { PRESENCE_HEARTBEAT_INTERVAL_MS, PRESENCE_STALE_MS };
+
+/** Controllable clock for deterministic lease tests. */
+let _now: () => number = () => Date.now();
+
+export function setPresenceNow(fn: () => number): void {
+  _now = fn;
+}
+
+export function resetPresenceNow(): void {
+  _now = () => Date.now();
+}
+
+export function presenceNow(): number {
+  return _now();
+}
+
+interface PresenceEntry extends PresenceClientRecord {
+  /** Ports currently associated with this logical client. */
+  ports: Set<PortLike>;
+}
+
+interface PresenceState {
+  clients: Map<string, PresenceEntry>;
+  /** Reverse index: port → clientId (for cleanupPort optimization). */
+  portToClient: Map<PortLike, string>;
+  /** Presence subscribers: Map<port, Set<subId>>. */
+  subs: Map<PortLike, Set<string>>;
+  /** Periodic expiry timer (worker-global; tests drive expiry via {@link expireStalePresence}). */
+  timer: ReturnType<typeof setInterval> | null;
+}
+
+const _state = new WeakMap<HostCtx, PresenceState>();
+
+function stateFor(ctx: HostCtx): PresenceState {
+  let s = _state.get(ctx);
+  if (!s) {
+    s = {
+      clients: new Map(),
+      portToClient: new Map(),
+      subs: new Map(),
+      timer: null,
+    };
+    _state.set(ctx, s);
+  }
+  return s;
+}
+
+function ensureExpiryTimer(ctx: HostCtx): void {
+  const s = stateFor(ctx);
+  if (s.timer != null) return;
+  // Sweep at half the stale window so expiry is prompt without busy-polling.
+  s.timer = setInterval(() => {
+    expireStalePresence(ctx);
+  }, Math.max(5_000, Math.floor(PRESENCE_STALE_MS / 2)));
+  // Workers may not have unref; guard for Node/test hosts that do.
+  const t = s.timer as { unref?: () => void };
+  if (typeof t.unref === 'function') t.unref();
+}
+
+function stopExpiryTimerIfIdle(ctx: HostCtx): void {
+  const s = stateFor(ctx);
+  if (s.clients.size > 0 || s.subs.size > 0) return;
+  if (s.timer != null) {
+    clearInterval(s.timer);
+    s.timer = null;
+  }
+}
+
+function toSnapshot(s: PresenceState): PresenceSnapshot {
+  const clients: PresenceClientRecord[] = [];
+  for (const e of s.clients.values()) {
+    clients.push({
+      clientId: e.clientId,
+      kind: e.kind,
+      route: e.route,
+      visibility: e.visibility,
+      connectedAt: e.connectedAt,
+      lastSeen: e.lastSeen,
+    });
+  }
+  clients.sort((a, b) => a.connectedAt - b.connectedAt || a.clientId.localeCompare(b.clientId));
+  return { clients };
+}
+
+function broadcast(ctx: HostCtx): void {
+  const s = stateFor(ctx);
+  const snap = toSnapshot(s);
+  for (const [port, subIds] of s.subs) {
+    for (const subId of subIds) {
+      post(port, { t: 'snap', subId, value: snap });
+    }
+  }
+}
+
+/**
+ * Drop clients whose lease is older than {@link PRESENCE_STALE_MS}.
+ * Returns true when any client was removed (and subscribers were notified).
+ * Tests call this with a controllable {@link setPresenceNow}.
+ */
+export function expireStalePresence(ctx: HostCtx, now: number = presenceNow()): boolean {
+  const s = stateFor(ctx);
+  let removed = false;
+  for (const [id, entry] of s.clients) {
+    if (now - entry.lastSeen > PRESENCE_STALE_MS) {
+      for (const port of entry.ports) {
+        if (s.portToClient.get(port) === id) s.portToClient.delete(port);
+      }
+      s.clients.delete(id);
+      removed = true;
+    }
+  }
+  if (removed) {
+    broadcast(ctx);
+    stopExpiryTimerIfIdle(ctx);
+  }
+  return removed;
+}
+
+/** Authoritative presence snapshot for diagnostics / tests. */
+export function getPresenceSnapshot(ctx: HostCtx): PresenceSnapshot {
+  expireStalePresence(ctx);
+  return toSnapshot(stateFor(ctx));
+}
+
+const PRESENCE_METHODS = new Set<string>([
+  'presence.register',
+  'presence.heartbeat',
+  'presence.update',
+  'presence.disconnect',
+]);
+
+export function isPresenceOp(method: OpMessage['method']): boolean {
+  return PRESENCE_METHODS.has(method);
+}
+
+export async function handlePresenceOp(
+  ctx: HostCtx,
+  port: PortLike,
+  msg: OpMessage,
+): Promise<void> {
+  const s = stateFor(ctx);
+  expireStalePresence(ctx);
+
+  switch (msg.method) {
+    case 'presence.register': {
+      const { clientId, kind, route, visibility } = msg;
+      if (!clientId || (kind !== 'app' && kind !== 'studio')) {
+        fail(port, msg.id, new Error('presence.register: invalid clientId/kind'));
+        return;
+      }
+      const now = presenceNow();
+      const existing = s.clients.get(clientId);
+      if (existing) {
+        // Re-register (reload / reconnect): one logical entry, refresh metadata,
+        // associate this port, drop stale port associations for this clientId.
+        for (const p of existing.ports) {
+          if (s.portToClient.get(p) === clientId) s.portToClient.delete(p);
+        }
+        existing.ports.clear();
+        existing.ports.add(port);
+        existing.kind = kind;
+        existing.route = route;
+        existing.visibility = visibility;
+        existing.lastSeen = now;
+        // Keep original connectedAt across reconnects within the worker lifetime
+        // so the UI does not flicker "just connected" on a soft reload — but a
+        // full reconnect after disconnect/expiry starts fresh (new entry below).
+      } else {
+        s.clients.set(clientId, {
+          clientId,
+          kind,
+          route,
+          visibility,
+          connectedAt: now,
+          lastSeen: now,
+          ports: new Set([port]),
+        });
+      }
+      s.portToClient.set(port, clientId);
+      ensureExpiryTimer(ctx);
+      ok(port, msg.id, { ok: true });
+      broadcast(ctx);
+      break;
+    }
+
+    case 'presence.heartbeat': {
+      const entry = s.clients.get(msg.clientId);
+      if (!entry) {
+        // Unknown / already expired — client should re-register.
+        ok(port, msg.id, { ok: false, reason: 'unknown' });
+        return;
+      }
+      entry.lastSeen = presenceNow();
+      entry.ports.add(port);
+      s.portToClient.set(port, msg.clientId);
+      ok(port, msg.id, { ok: true });
+      // Heartbeats renew the lease without broadcasting — lastSeen freshness
+      // is only needed for expiry; subscribers care about connect/disconnect/
+      // route/visibility. Still broadcast so Studio can show freshness if it
+      // wants; cheap for small N.
+      broadcast(ctx);
+      break;
+    }
+
+    case 'presence.update': {
+      const entry = s.clients.get(msg.clientId);
+      if (!entry) {
+        ok(port, msg.id, { ok: false, reason: 'unknown' });
+        return;
+      }
+      if (msg.route !== undefined) entry.route = msg.route;
+      if (msg.visibility !== undefined) entry.visibility = msg.visibility;
+      entry.lastSeen = presenceNow();
+      entry.ports.add(port);
+      s.portToClient.set(port, msg.clientId);
+      ok(port, msg.id, { ok: true });
+      broadcast(ctx);
+      break;
+    }
+
+    case 'presence.disconnect': {
+      const entry = s.clients.get(msg.clientId);
+      if (entry) {
+        for (const p of entry.ports) {
+          if (s.portToClient.get(p) === msg.clientId) s.portToClient.delete(p);
+        }
+        s.clients.delete(msg.clientId);
+        ok(port, msg.id, { ok: true });
+        broadcast(ctx);
+        stopExpiryTimerIfIdle(ctx);
+      } else {
+        ok(port, msg.id, { ok: true });
+      }
+      break;
+    }
+
+    default: {
+      fail(port, msg.id, new Error(`Unknown method: ${String((msg as { method: unknown }).method)}`));
+    }
+  }
+}
+
+export function handlePresenceSub(ctx: HostCtx, port: PortLike, msg: PresenceSubMessage): void {
+  expireStalePresence(ctx);
+  const s = stateFor(ctx);
+  let subIds = s.subs.get(port);
+  if (!subIds) {
+    subIds = new Set();
+    s.subs.set(port, subIds);
+  }
+  if (subIds.has(msg.subId)) return;
+  subIds.add(msg.subId);
+  ensureExpiryTimer(ctx);
+  post(port, { t: 'snap', subId: msg.subId, value: toSnapshot(s) });
+}
+
+export function handlePresenceUnsub(ctx: HostCtx, port: PortLike, subId: string): boolean {
+  const s = stateFor(ctx);
+  const subIds = s.subs.get(port);
+  if (!subIds || !subIds.has(subId)) return false;
+  subIds.delete(subId);
+  if (subIds.size === 0) s.subs.delete(port);
+  stopExpiryTimerIfIdle(ctx);
+  return true;
+}
+
+/**
+ * Port-close optimization: if this port was the last association for a
+ * logical client, remove that client. Lease expiry remains the correctness
+ * path when close events are missing.
+ */
+export function cleanupPortPresence(ctx: HostCtx, port: PortLike): void {
+  const s = stateFor(ctx);
+  // Drop presence subscriptions on this port.
+  s.subs.delete(port);
+
+  const clientId = s.portToClient.get(port);
+  s.portToClient.delete(port);
+  if (!clientId) {
+    stopExpiryTimerIfIdle(ctx);
+    return;
+  }
+  const entry = s.clients.get(clientId);
+  if (!entry) {
+    stopExpiryTimerIfIdle(ctx);
+    return;
+  }
+  entry.ports.delete(port);
+  if (entry.ports.size === 0) {
+    s.clients.delete(clientId);
+    broadcast(ctx);
+  }
+  stopExpiryTimerIfIdle(ctx);
+}

--- a/packages/cli/src/serve/worker/index.ts
+++ b/packages/cli/src/serve/worker/index.ts
@@ -148,6 +148,16 @@ export {
   // Event stream (Pyric Studio keystone — onEvent/history over the port)
   subscribeEvents,
   eventHistory,
+  // Connected-page presence (#227)
+  startPresence,
+  subscribePresence,
+  mintPresenceClientId,
+  PRESENCE_HEARTBEAT_INTERVAL_MS,
+  PRESENCE_STALE_MS,
+  type PresenceSession,
+  type PresenceSnapshot,
+  type PresenceClientKind,
+  type PresenceVisibility,
   // Sandbox snapshot export (Pyric Studio rules re-run: fork + test edited rules)
   getSnapshot,
   // RTDB shared-worker preview bridge. Aliased to avoid colliding with Storage

--- a/packages/cli/src/serve/worker/presence-timing.ts
+++ b/packages/cli/src/serve/worker/presence-timing.ts
@@ -1,0 +1,15 @@
+/**
+ * Connected-page presence lease timing (#227).
+ *
+ * Leaf module — safe for both the SharedWorker host and the browser client
+ * bundle. Do not import host or sandbox code here.
+ */
+
+/** Suggested client heartbeat interval. */
+export const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Lease TTL. Sized to tolerate one delayed background-tab heartbeat under
+ * typical timer throttling (~1/min) without falsely evicting a live page.
+ */
+export const PRESENCE_STALE_MS = 90_000;

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -519,6 +519,30 @@ export type OpMessage = (
   // state)`); a hidden tab's port marks its client not-visible, and routing is
   // foreground iff ANY visible client. Pages send this on `visibilitychange`.
   | { t: 'op'; id: string; method: 'messaging.setVisibility'; state: ClientVisibilityState }
+  // ── Connected-page presence (#227) ──────────────────────────────────────
+  // Ephemeral, worker-lifetime logical-page registry — NOT port/subscription/
+  // auth-session counts. Pages register with a clientId, renew a short lease
+  // via heartbeat, and disconnect on pagehide. Studio subscribes (target:
+  // 'presence') for the authoritative snapshot. See host/presence.ts.
+  | {
+      t: 'op';
+      id: string;
+      method: 'presence.register';
+      clientId: string;
+      kind: PresenceClientKind;
+      route: string;
+      visibility: PresenceVisibility;
+    }
+  | { t: 'op'; id: string; method: 'presence.heartbeat'; clientId: string }
+  | {
+      t: 'op';
+      id: string;
+      method: 'presence.update';
+      clientId: string;
+      route?: string;
+      visibility?: PresenceVisibility;
+    }
+  | { t: 'op'; id: string; method: 'presence.disconnect'; clientId: string }
 ) & {
   /**
    * Per-op auth lens (Pyric Studio): `admin` bypasses rules, `{ as: uid }`
@@ -683,13 +707,50 @@ export interface MessagingSubMessage {
   target: 'messaging.foreground' | 'messaging.background';
 }
 
+/**
+ * Subscribe to connected-page presence (#227). On subscribe the host delivers
+ * the current {@link PresenceSnapshot} as `{ t:'snap', subId, value }`, then
+ * re-snaps on every registry change (register / heartbeat / update /
+ * disconnect / lease expiry). Studio renders the worker's snapshot — it does
+ * not implement a second client-side expiry policy.
+ */
+export interface PresenceSubMessage {
+  t: 'sub';
+  subId: string;
+  target: 'presence';
+}
+
+/** Logical page kind for presence (#227). */
+export type PresenceClientKind = 'app' | 'studio';
+
+/** Page Visibility API state carried on presence records. */
+export type PresenceVisibility = 'visible' | 'hidden';
+
+/** One logical connected page in a presence snapshot. */
+export interface PresenceClientRecord {
+  clientId: string;
+  kind: PresenceClientKind;
+  route: string;
+  visibility: PresenceVisibility;
+  /** Epoch ms when this clientId first registered in this worker lifetime. */
+  connectedAt: number;
+  /** Epoch ms of the most recent register / heartbeat / update. */
+  lastSeen: number;
+}
+
+/** Authoritative presence snapshot owned by the SharedWorker host. */
+export interface PresenceSnapshot {
+  clients: PresenceClientRecord[];
+}
+
 export type SubMessage =
   | FirestoreSubMessage
   | AuthSubMessage
   | EventSubMessage
   | RtdbValueSubMessage
   | AiStreamSubMessage
-  | MessagingSubMessage;
+  | MessagingSubMessage
+  | PresenceSubMessage;
 
 /** Type guard: is this an auth subscription (vs a Firestore / event one)? */
 export function isAuthSub(msg: SubMessage): msg is AuthSubMessage {
@@ -704,6 +765,11 @@ export function isEventSub(msg: SubMessage): msg is EventSubMessage {
 /** Type guard: is this a messaging delivery subscription? */
 export function isMessagingSub(msg: SubMessage): msg is MessagingSubMessage {
   return msg.target === 'messaging.foreground' || msg.target === 'messaging.background';
+}
+
+/** Type guard: is this a connected-page presence subscription? */
+export function isPresenceSub(msg: SubMessage): msg is PresenceSubMessage {
+  return msg.target === 'presence';
 }
 
 export function isRtdbSub(msg: SubMessage): msg is RtdbValueSubMessage {

--- a/packages/cli/test/e2e/site-static/static-site.pw.ts
+++ b/packages/cli/test/e2e/site-static/static-site.pw.ts
@@ -235,3 +235,45 @@ test('DIAGNOSTIC: full request log for /__pyric/* on first load (not an assertio
   // worker's hot-reload EventSource opens a /__pyric/events connection even
   // with no `pyric dev` behind the site).
 });
+
+test('Studio presence chip reports two logical clients then converges to one (#227)', async ({
+  browser,
+}) => {
+  // Two real Studio pages against one SharedWorker: the shell chip must show
+  // "2 pages connected", then converge to one after the second page closes.
+  // Asserts externally visible behavior only (count label), not protocol internals.
+  const context = await browser.newContext();
+  const pageA = await context.newPage();
+  const pageB = await context.newPage();
+
+  await pageA.goto('/');
+  await pageB.goto('/');
+
+  const chipA = pageA.getByRole('button', { name: /page(?:s)? connected/i });
+  const chipB = pageB.getByRole('button', { name: /page(?:s)? connected/i });
+
+  await expect(chipA).toBeVisible({ timeout: 10_000 });
+  await expect(chipB).toBeVisible({ timeout: 10_000 });
+
+  // Wait until both pages see each other (count may start at 1 while the peer
+  // registers).
+  await expect
+    .poll(async () => (await chipA.textContent())?.trim(), { timeout: 10_000 })
+    .toBe('2 pages connected');
+  await expect
+    .poll(async () => (await chipB.textContent())?.trim(), { timeout: 10_000 })
+    .toBe('2 pages connected');
+
+  await pageB.close();
+
+  await expect
+    .poll(async () => (await chipA.textContent())?.trim(), { timeout: 10_000 })
+    .toBe('1 page connected');
+
+  // Expand details: This page + honest visibility boundary.
+  await chipA.click();
+  await expect(pageA.getByText('This page', { exact: true })).toBeVisible();
+  await expect(pageA.getByText(/browser profile/i)).toBeVisible();
+
+  await context.close();
+});

--- a/packages/cli/test/remote/loop-hold.test.ts
+++ b/packages/cli/test/remote/loop-hold.test.ts
@@ -319,7 +319,7 @@ describe('remote core — version-skew guidance on Unknown method', () => {
       expect(message).toContain('Unknown method: storage.notShippedYet');
       expect(message).toContain('the running sandbox may predate this feature');
       expect(message).toContain('restart pyric dev');
-      expect(message).toContain('reload the browser tab');
+      expect(message).toContain('close other open pages');
     }
   });
 

--- a/packages/cli/test/serve/worker/client-surface.test.ts
+++ b/packages/cli/test/serve/worker/client-surface.test.ts
@@ -13,8 +13,9 @@
 import { describe, expect, test } from 'bun:test';
 import * as client from '../../../src/serve/worker/client.js';
 
-/** The 120 value (runtime) exports of the worker client, sorted. Frozen. */
+/** The 125 value (runtime) exports of the worker client, sorted. Frozen. */
 const EXPECTED_VALUE_EXPORTS: readonly string[] = [
+  'PRESENCE_HEARTBEAT_INTERVAL_MS', 'PRESENCE_STALE_MS',
   'acceptProviderCredential', 'addDoc', 'adminClearUsers', 'adminCreateUser',
   'adminDeleteDocument', 'adminDeleteRtdbValue', 'adminDeleteUser', 'adminGetDocument',
   'adminListDocuments', 'adminReadRtdbState', 'adminReadState', 'adminSetDocument',
@@ -33,6 +34,7 @@ const EXPECTED_VALUE_EXPORTS: readonly string[] = [
   'getStorage', 'getWorkerInstanceId', 'getWorkerVersion', 'importWorkerState',
   'increment', 'inMemoryPersistence', 'limit', 'limitToLast', 'listAll',
   'listRootCollections', 'listSubcollections', 'listUsers', 'listWorkerBranches',
+  'mintPresenceClientId',
   'onAuthStateChanged', 'onIdTokenChanged', 'onSnapshot', 'or', 'orderBy', 'query',
   'ref', 'relayWorkerOp', 'relayWorkerSub', 'restorePortSession', 'rtdbChild',
   'rtdbConnectDatabaseEmulator', 'rtdbGet', 'rtdbGetDatabase', 'rtdbOff', 'rtdbOnValue',
@@ -40,7 +42,8 @@ const EXPECTED_VALUE_EXPORTS: readonly string[] = [
   'runTransaction', 'saveWorkerBranch', 'serverTimestamp', 'setDatabaseRules', 'setDoc',
   'setFirestoreRules', 'setLens', 'setOpIssuer', 'setPersistence',
   'setProviderConfig', 'setRules', 'signInAnonymously', 'signInWithCredential',
-  'signInWithEmailAndPassword', 'signOut', 'startAfter', 'startAt', 'subscribeEvents',
+  'signInWithEmailAndPassword', 'signOut', 'startAfter', 'startAt', 'startPresence',
+  'subscribeEvents', 'subscribePresence',
   'sum', 'switchWorkerBranch', 'updateDoc', 'updateProfile', 'uploadBytes', 'where',
   'writeBatch',
 ];

--- a/packages/cli/test/serve/worker/dispatch-table.test.ts
+++ b/packages/cli/test/serve/worker/dispatch-table.test.ts
@@ -96,6 +96,12 @@ const ROUTABLE_METHODS = {
   rtdb: ['rtdb.get', 'rtdb.set', 'rtdb.update', 'rtdb.remove', 'rtdb.push', 'rtdb.adminSnapshot'],
   connection: ['getVersion', 'exportState', 'importState', 'saveBranch', 'listBranches', 'switchBranch', 'deleteBranch'],
   studio: ['getSnapshot'],
+  presence: [
+    'presence.register',
+    'presence.heartbeat',
+    'presence.update',
+    'presence.disconnect',
+  ],
   storage: [
     'storage.listAll',
     'storage.getMetadata',
@@ -144,10 +150,10 @@ describe('host dispatch table (frozen)', () => {
     ctx = await makeCtx();
   });
 
-  it('routes exactly 69 op methods across all families', () => {
-    expect(ALL_METHODS.length).toBe(69);
+  it('routes exactly 73 op methods across all families', () => {
+    expect(ALL_METHODS.length).toBe(73);
     // No duplicates in the frozen list.
-    expect(new Set(ALL_METHODS).size).toBe(69);
+    expect(new Set(ALL_METHODS).size).toBe(73);
   });
 
   for (const [family, methods] of Object.entries(ROUTABLE_METHODS)) {

--- a/packages/cli/test/serve/worker/presence.test.ts
+++ b/packages/cli/test/serve/worker/presence.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Connected-page presence (#227) — worker host registry tests.
+ *
+ * Fake ports + controllable clock: registration, heartbeat renewal, clean
+ * disconnect, stale lease expiry, duplicate logical-client registration,
+ * multi-subscriber fan-out, and background-throttling survival (one delayed
+ * heartbeat must not evict a live hidden page).
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  handleMessage,
+  cleanupPort,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import {
+  setPresenceNow,
+  resetPresenceNow,
+  expireStalePresence,
+  getPresenceSnapshot,
+  PRESENCE_STALE_MS,
+} from '../../../src/serve/worker/host/presence.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  PresenceSnapshot,
+  ResMessage,
+  SnapMessage,
+} from '../../../src/serve/worker/protocol.js';
+import { initializeSandbox, createMemoryBackend } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+
+function fakePort(): PortLike & { messages: OutboundMessage[]; snapMessages: SnapMessage[] } {
+  const messages: OutboundMessage[] = [];
+  const snapMessages: SnapMessage[] = [];
+  return {
+    messages,
+    snapMessages,
+    postMessage(msg: OutboundMessage) {
+      messages.push(msg);
+      if (msg.t === 'snap') snapMessages.push(msg);
+    },
+  };
+}
+
+type FakePort = ReturnType<typeof fakePort>;
+
+async function makeCtx(): Promise<HostCtx> {
+  const sandbox = initializeSandbox();
+  const { getFirestore: getAdminFirestore } = await import('pyric/sandbox/admin-firestore');
+  getAdminFirestore(sandbox.withAuth(null)).setRules(`
+    rules_version = '2';
+    service cloud.firestore {
+      match /databases/{database}/documents {
+        match /{document=**} { allow read, write: if true; }
+      }
+    }
+  `);
+  await sandbox.enablePersistence({
+    key: `presence-${Math.random()}`,
+    injectedBackend: createMemoryBackend(),
+  });
+  return { db: getFirestore(sandbox), sandbox, instanceId: 'test', subs: new Map() };
+}
+
+async function sendOp(ctx: HostCtx, port: FakePort, msg: InboundMessage): Promise<ResMessage> {
+  await handleMessage(ctx, port, msg);
+  const id = (msg as { id: string }).id;
+  const res = port.messages.find((m): m is ResMessage => m.t === 'res' && m.id === id);
+  if (!res) throw new Error(`No res for ${id}`);
+  return res;
+}
+
+function lastPresenceSnap(port: FakePort, subId: string): PresenceSnapshot | undefined {
+  for (let i = port.snapMessages.length - 1; i >= 0; i--) {
+    const m = port.snapMessages[i]!;
+    if (m.subId === subId) return m.value as PresenceSnapshot;
+  }
+  return undefined;
+}
+
+describe('presence registry', () => {
+  let ctx: HostCtx;
+  let clock: number;
+
+  beforeEach(async () => {
+    ctx = await makeCtx();
+    clock = 1_000_000;
+    setPresenceNow(() => clock);
+  });
+
+  afterEach(() => {
+    resetPresenceNow();
+  });
+
+  it('registers two logical clients and fans the snapshot to a subscriber', async () => {
+    const app = fakePort();
+    const studio = fakePort();
+    const sub = fakePort();
+
+    await handleMessage(ctx, sub, { t: 'sub', subId: 'p1', target: 'presence' });
+    expect(lastPresenceSnap(sub, 'p1')?.clients).toEqual([]);
+
+    await sendOp(ctx, app, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'app-1',
+      kind: 'app',
+      route: '/shop',
+      visibility: 'visible',
+    });
+    await sendOp(ctx, studio, {
+      t: 'op',
+      id: 'r2',
+      method: 'presence.register',
+      clientId: 'studio-1',
+      kind: 'studio',
+      route: '/__pyric/studio/',
+      visibility: 'visible',
+    });
+
+    const snap = lastPresenceSnap(sub, 'p1');
+    expect(snap?.clients).toHaveLength(2);
+    expect(snap?.clients.map((c) => c.clientId).sort()).toEqual(['app-1', 'studio-1']);
+    expect(snap?.clients.find((c) => c.clientId === 'app-1')?.kind).toBe('app');
+    expect(snap?.clients.find((c) => c.clientId === 'studio-1')?.kind).toBe('studio');
+  });
+
+  it('re-registering the same clientId does not duplicate the entry', async () => {
+    const portA = fakePort();
+    const portB = fakePort();
+    await sendOp(ctx, portA, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'page-1',
+      kind: 'app',
+      route: '/a',
+      visibility: 'visible',
+    });
+    clock += 5_000;
+    await sendOp(ctx, portB, {
+      t: 'op',
+      id: 'r2',
+      method: 'presence.register',
+      clientId: 'page-1',
+      kind: 'app',
+      route: '/b',
+      visibility: 'hidden',
+    });
+    const snap = getPresenceSnapshot(ctx);
+    expect(snap.clients).toHaveLength(1);
+    expect(snap.clients[0]?.route).toBe('/b');
+    expect(snap.clients[0]?.visibility).toBe('hidden');
+  });
+
+  it('clean disconnect removes the client promptly', async () => {
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'page-1',
+      kind: 'app',
+      route: '/',
+      visibility: 'visible',
+    });
+    expect(getPresenceSnapshot(ctx).clients).toHaveLength(1);
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'd1',
+      method: 'presence.disconnect',
+      clientId: 'page-1',
+    });
+    expect(getPresenceSnapshot(ctx).clients).toHaveLength(0);
+  });
+
+  it('stale lease expiry removes a client that never heartbeats', async () => {
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'gone',
+      kind: 'app',
+      route: '/',
+      visibility: 'visible',
+    });
+    clock += PRESENCE_STALE_MS + 1;
+    expect(expireStalePresence(ctx)).toBe(true);
+    expect(getPresenceSnapshot(ctx).clients).toHaveLength(0);
+  });
+
+  it('one delayed heartbeat under background throttling does not evict a live page', async () => {
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'bg',
+      kind: 'app',
+      route: '/',
+      visibility: 'hidden',
+    });
+    // Advance just under the stale threshold (one delayed heartbeat survives).
+    clock += PRESENCE_STALE_MS - 1_000;
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'h1',
+      method: 'presence.heartbeat',
+      clientId: 'bg',
+    });
+    clock += PRESENCE_STALE_MS - 1_000;
+    expect(expireStalePresence(ctx)).toBe(false);
+    expect(getPresenceSnapshot(ctx).clients).toHaveLength(1);
+  });
+
+  it('cleanupPort removes a client when it was the last associated port', async () => {
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'page-1',
+      kind: 'studio',
+      route: '/',
+      visibility: 'visible',
+    });
+    cleanupPort(ctx, port);
+    expect(getPresenceSnapshot(ctx).clients).toHaveLength(0);
+  });
+
+  it('fans presence updates to multiple subscribers', async () => {
+    const a = fakePort();
+    const b = fakePort();
+    await handleMessage(ctx, a, { t: 'sub', subId: 'sa', target: 'presence' });
+    await handleMessage(ctx, b, { t: 'sub', subId: 'sb', target: 'presence' });
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'x',
+      kind: 'app',
+      route: '/x',
+      visibility: 'visible',
+    });
+    expect(lastPresenceSnap(a, 'sa')?.clients).toHaveLength(1);
+    expect(lastPresenceSnap(b, 'sb')?.clients).toHaveLength(1);
+  });
+
+  it('presence.update refreshes route and visibility', async () => {
+    const port = fakePort();
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'r1',
+      method: 'presence.register',
+      clientId: 'p',
+      kind: 'app',
+      route: '/old',
+      visibility: 'visible',
+    });
+    await sendOp(ctx, port, {
+      t: 'op',
+      id: 'u1',
+      method: 'presence.update',
+      clientId: 'p',
+      route: '/new',
+      visibility: 'hidden',
+    });
+    const c = getPresenceSnapshot(ctx).clients[0];
+    expect(c?.route).toBe('/new');
+    expect(c?.visibility).toBe('hidden');
+  });
+});

--- a/packages/studio/src/clients/worker-live.test.ts
+++ b/packages/studio/src/clients/worker-live.test.ts
@@ -290,3 +290,85 @@ describe("createStudioEnvironment('local') live-plane gating", () => {
     expect(typeof env.live!.feed.subscribe).toBe('function');
   });
 });
+
+describe('presence live-plane contract (#227)', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+    resetWorkerLens(undefined);
+  });
+
+  it('registers presence and delivers snapshots to subscribePresence', () => {
+    const sw = controllableSharedWorker();
+    restore = sw.restore;
+    const plane = connectWorkerLive('worker://test')!;
+
+    expect(typeof plane.presenceClientId).toBe('string');
+    expect(plane.presenceClientId.length).toBeGreaterThan(0);
+
+    // startPresence posts a presence.register op.
+    const register = sw.port.sent.find(
+      (m): m is { t: 'op'; method: string; clientId: string; kind: string } =>
+        (m as { method?: string }).method === 'presence.register',
+    );
+    expect(register).toBeDefined();
+    expect(register!.kind).toBe('studio');
+    expect(register!.clientId).toBe(plane.presenceClientId);
+
+    const seen: number[] = [];
+    const unsub = plane.subscribePresence((snap) => seen.push(snap.clients.length));
+
+    const subMsg = sw.port.sent.find(
+      (m): m is { t: 'sub'; subId: string; target: string } =>
+        (m as { t?: string }).t === 'sub' &&
+        (m as { target?: string }).target === 'presence',
+    );
+    expect(subMsg).toBeDefined();
+
+    sw.deliver({
+      t: 'snap',
+      subId: subMsg!.subId,
+      value: {
+        clients: [
+          {
+            clientId: plane.presenceClientId,
+            kind: 'studio',
+            route: '/',
+            visibility: 'visible',
+            connectedAt: 1,
+            lastSeen: 1,
+          },
+        ],
+      },
+    });
+    expect(seen).toEqual([1]);
+
+    sw.deliver({
+      t: 'snap',
+      subId: subMsg!.subId,
+      value: {
+        clients: [
+          {
+            clientId: plane.presenceClientId,
+            kind: 'studio',
+            route: '/',
+            visibility: 'visible',
+            connectedAt: 1,
+            lastSeen: 2,
+          },
+          {
+            clientId: 'app-other',
+            kind: 'app',
+            route: '/shop',
+            visibility: 'hidden',
+            connectedAt: 2,
+            lastSeen: 2,
+          },
+        ],
+      },
+    });
+    expect(seen).toEqual([1, 2]);
+    unsub();
+  });
+});

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -52,6 +52,8 @@ import {
   subscribeEvents,
   setLens as workerSetLens,
   getLens as workerGetLens,
+  startPresence,
+  subscribePresence as workerSubscribePresence,
   listRootCollections as workerListRootCollections,
   listSubcollections as workerListSubcollections,
   adminListDocuments as workerAdminListDocuments,
@@ -79,7 +81,11 @@ import {
   limit as workerLimit,
   startAfter as workerStartAfter,
   type ClientDb,
+  type PresenceSnapshot,
+  type PresenceSession,
 } from '@pyric/cli/serve/worker';
+
+export type { PresenceSnapshot };
 
 /**
  * The per-op auth lens Studio drives. Mirrors `pyric/sandbox`'s `AuthLens` /
@@ -179,6 +185,13 @@ export interface WorkerLivePlane {
   switchBranch(name: string): Promise<void>;
   /** Phase 3: delete a named branch. */
   deleteBranch(name: string): Promise<void>;
+  /**
+   * Connected-page presence (#227): this Studio tab's logical client id, so
+   * the shell can label the matching registry entry "This page".
+   */
+  presenceClientId: string;
+  /** Live presence snapshots from the SharedWorker (authoritative). */
+  subscribePresence(cb: (snapshot: PresenceSnapshot) => void): () => void;
 }
 
 /**
@@ -291,6 +304,9 @@ export function connectWorkerLive(
   // the first collection/document listeners frozen to the app session.
   workerSetLens({ mode: 'admin' });
 
+  // Register this Studio page in the shared presence registry (#227).
+  const presence: PresenceSession = startPresence({ db, kind: 'studio' });
+
   // One feed shared by F1 and the auth `subscribeUsers` re-list signal. One auth
   // handle reusing the same port (the single-backend invariant).
   const feed = workerEventFeed(db);
@@ -298,6 +314,8 @@ export function connectWorkerLive(
 
   return {
     db,
+    presenceClientId: presence.clientId,
+    subscribePresence: (cb) => workerSubscribePresence(db, cb),
     instanceId: () => getWorkerInstanceId(db),
     exportState: () => exportWorkerState(db),
     importState: (bundle) => importWorkerState(db, bundle),

--- a/packages/studio/src/shell/StatusCluster.tsx
+++ b/packages/studio/src/shell/StatusCluster.tsx
@@ -1,7 +1,7 @@
 /**
  * Shell status cluster (specs/shell.md): the bar's right region.
  *
- * Two chips, both global truths, both by exception or by presence:
+ * Chips, all global truths:
  *
  *  - SANDBOX HEALTH — rendered ONLY when degraded (status by exception;
  *    a healthy sandbox earns no pixels). Degraded means: the environment
@@ -9,6 +9,10 @@
  *    the live SharedWorker plane is unreachable — the surfaces are then
  *    mirrors, not the live sandbox. Links to Settings (diagnostics), the
  *    surface that resolves it.
+ *  - CONNECTED PAGES (#227) — how many logical pages share this sandbox
+ *    worker. Quiet for one page; prominent when multiple. An accessible
+ *    popover lists each client (app/Studio, route, visibility, freshness)
+ *    and states the visibility boundary honestly.
  *  - MCP PRESENCE — rendered while the bridge is AVAILABLE: the bridge
  *    endpoint answers `/__pyric/health` and a sandbox peer (ANY tab) is
  *    connected. Deliberately NOT Studio's own peer registration — the peer
@@ -22,15 +26,20 @@
  * geometry.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { useEnvironment } from './environment.js';
 import { useServeInit } from './serve-init.js';
 import { useBridgeAvailability } from './bridge-availability.js';
+import { usePresenceView } from './presence.js';
 import { hrefFor, pushPath } from './router.js';
 
 export function StatusCluster() {
   const env = useEnvironment();
   const serve = useServeInit();
   const bridgeAvailability = useBridgeAvailability();
+  const presence = usePresenceView();
+  const [presenceOpen, setPresenceOpen] = useState(false);
+  const presenceTriggerRef = useRef<HTMLButtonElement>(null);
 
   const served = serve.status === 'ready';
   const workerDown = served && env.status === 'ready' && !env.env.live;
@@ -42,6 +51,18 @@ export function StatusCluster() {
       : null;
 
   const connected = bridgeAvailability === 'available';
+
+  useEffect(() => {
+    if (!presenceOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setPresenceOpen(false);
+        presenceTriggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [presenceOpen]);
 
   return (
     <div className="studio__status" aria-label="Studio status">
@@ -62,6 +83,70 @@ export function StatusCluster() {
           <span className="studio-chip__dot" aria-hidden="true" />
           {degraded}
         </a>
+      ) : null}
+      {presence && presence.count > 0 ? (
+        <span className="studio-presence">
+          <button
+            ref={presenceTriggerRef}
+            type="button"
+            className={
+              presence.prominent
+                ? 'studio-chip studio-chip--live studio-presence__trigger'
+                : 'studio-chip studio-presence__trigger'
+            }
+            aria-haspopup="dialog"
+            aria-expanded={presenceOpen}
+            aria-controls="studio-presence-panel"
+            title={
+              presence.otherCount > 0
+                ? `${presence.chipLabel}. ${presence.otherCount} other page${presence.otherCount === 1 ? '' : 's'} can keep the worker alive.`
+                : `${presence.chipLabel}. Expand for details.`
+            }
+            onClick={() => setPresenceOpen((o) => !o)}
+          >
+            <span className="studio-chip__dot" aria-hidden="true" />
+            {presence.chipLabel}
+          </button>
+          {presenceOpen ? (
+            <>
+              <div
+                className="studio-presence__backdrop"
+                onMouseDown={() => setPresenceOpen(false)}
+              />
+              <div
+                id="studio-presence-panel"
+                className="studio-presence__panel"
+                role="dialog"
+                aria-label="Connected pages"
+              >
+                <p className="studio-presence__lead">
+                  {presence.count === 1
+                    ? 'This page is the only connection to the shared sandbox worker.'
+                    : `${presence.count} pages share this sandbox worker. Closing this page alone will not restart it.`}
+                </p>
+                <ul className="studio-presence__list">
+                  {presence.clients.map((c) => (
+                    <li key={c.clientId} className="studio-presence__item">
+                      <div className="studio-presence__item-head">
+                        <span className="studio-presence__kind">{c.kindLabel}</span>
+                        {c.isThisPage ? (
+                          <span className="studio-presence__this">This page</span>
+                        ) : null}
+                      </div>
+                      <div className="studio-presence__route" title={c.route}>
+                        {c.route}
+                      </div>
+                      <div className="studio-presence__meta">
+                        {c.visibilityLabel} · {c.freshnessLabel}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+                <p className="studio-presence__boundary">{presence.boundaryCopy}</p>
+              </div>
+            </>
+          ) : null}
+        </span>
       ) : null}
       {connected ? (
         <span

--- a/packages/studio/src/shell/presence.test.ts
+++ b/packages/studio/src/shell/presence.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure presence view-model mapping for the Studio shell (#227).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  presenceViewModel,
+  PRESENCE_BOUNDARY_COPY,
+} from './presence.js';
+import type { PresenceSnapshot } from '../clients/worker-live.js';
+
+const NOW = 1_000_000;
+
+function snap(clients: PresenceSnapshot['clients']): PresenceSnapshot {
+  return { clients };
+}
+
+describe('presenceViewModel', () => {
+  it('renders a quiet single-page state and marks This page', () => {
+    const view = presenceViewModel(
+      snap([
+        {
+          clientId: 'me',
+          kind: 'studio',
+          route: '/__pyric/studio/',
+          visibility: 'visible',
+          connectedAt: NOW - 10_000,
+          lastSeen: NOW - 100,
+        },
+      ]),
+      'me',
+      NOW,
+    );
+    expect(view.count).toBe(1);
+    expect(view.prominent).toBe(false);
+    expect(view.chipLabel).toBe('1 page connected');
+    expect(view.otherCount).toBe(0);
+    expect(view.clients[0]?.isThisPage).toBe(true);
+    expect(view.clients[0]?.kindLabel).toBe('Studio');
+    expect(view.boundaryCopy).toBe(PRESENCE_BOUNDARY_COPY);
+  });
+
+  it('renders a prominent multi-page state with app/Studio distinction', () => {
+    const view = presenceViewModel(
+      snap([
+        {
+          clientId: 'app-1',
+          kind: 'app',
+          route: '/cart',
+          visibility: 'hidden',
+          connectedAt: NOW - 30_000,
+          lastSeen: NOW - 2_000,
+        },
+        {
+          clientId: 'me',
+          kind: 'studio',
+          route: '/__pyric/studio/',
+          visibility: 'visible',
+          connectedAt: NOW - 20_000,
+          lastSeen: NOW,
+        },
+        {
+          clientId: 'studio-2',
+          kind: 'studio',
+          route: '/__pyric/studio/?tab=data',
+          visibility: 'visible',
+          connectedAt: NOW - 5_000,
+          lastSeen: NOW - 500,
+        },
+      ]),
+      'me',
+      NOW,
+    );
+    expect(view.count).toBe(3);
+    expect(view.prominent).toBe(true);
+    expect(view.chipLabel).toBe('3 pages connected');
+    expect(view.otherCount).toBe(2);
+    expect(view.clients[0]?.isThisPage).toBe(true);
+    expect(view.clients.map((c) => c.kindLabel)).toContain('App');
+    expect(view.clients.find((c) => c.clientId === 'app-1')?.visibilityLabel).toBe('Hidden');
+    expect(view.boundaryCopy).toContain('browser profile');
+  });
+});

--- a/packages/studio/src/shell/presence.ts
+++ b/packages/studio/src/shell/presence.ts
@@ -1,0 +1,110 @@
+/**
+ * Connected-page presence for the Studio shell (#227).
+ *
+ * Pure view-model mapping (unit-tested) + a React hook that subscribes to the
+ * live SharedWorker presence plane. The shell shows a quiet single-page chip
+ * or a prominent multi-page chip; an accessible popover lists each client.
+ */
+
+import { useEffect, useState } from 'react';
+import type { PresenceSnapshot } from '../clients/worker-live.js';
+import { useEnvironment } from './environment.js';
+
+/** Honest visibility boundary — presence only sees this SharedWorker. */
+export const PRESENCE_BOUNDARY_COPY =
+  'Only pages in this browser profile, on this origin, connected to this shared sandbox worker. Other profiles, incognito windows, origins, or worker names are not visible.';
+
+export interface PresenceClientView {
+  clientId: string;
+  kindLabel: 'App' | 'Studio';
+  route: string;
+  visibilityLabel: 'Visible' | 'Hidden';
+  /** True when this entry is the current Studio page. */
+  isThisPage: boolean;
+  /** Relative freshness hint from lastSeen vs `now`. */
+  freshnessLabel: string;
+}
+
+export interface PresenceViewModel {
+  /** Total logical pages attached to the worker. */
+  count: number;
+  /** Quiet single-page vs prominent multi-page chip label. */
+  chipLabel: string;
+  /** Whether the multi-page (prominent) chip style should be used. */
+  prominent: boolean;
+  clients: PresenceClientView[];
+  boundaryCopy: string;
+  /** How many OTHER pages must disconnect for a worker restart. */
+  otherCount: number;
+}
+
+function freshnessLabel(lastSeen: number, now: number): string {
+  const ageMs = Math.max(0, now - lastSeen);
+  if (ageMs < 5_000) return 'just now';
+  if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
+  if (ageMs < 3_600_000) return `${Math.floor(ageMs / 60_000)}m ago`;
+  return `${Math.floor(ageMs / 3_600_000)}h ago`;
+}
+
+function kindLabel(kind: 'app' | 'studio'): 'App' | 'Studio' {
+  return kind === 'studio' ? 'Studio' : 'App';
+}
+
+/**
+ * Pure snapshot → shell view-model. `thisClientId` identifies the current
+ * Studio page so its row can be labeled "This page".
+ */
+export function presenceViewModel(
+  snapshot: PresenceSnapshot,
+  thisClientId: string,
+  now: number = Date.now(),
+): PresenceViewModel {
+  const count = snapshot.clients.length;
+  const clients: PresenceClientView[] = snapshot.clients.map((c) => ({
+    clientId: c.clientId,
+    kindLabel: kindLabel(c.kind),
+    route: c.route || '/',
+    visibilityLabel: c.visibility === 'hidden' ? 'Hidden' : 'Visible',
+    isThisPage: c.clientId === thisClientId,
+    freshnessLabel: freshnessLabel(c.lastSeen, now),
+  }));
+  // This page first, then Studio before app, then route.
+  clients.sort((a, b) => {
+    if (a.isThisPage !== b.isThisPage) return a.isThisPage ? -1 : 1;
+    if (a.kindLabel !== b.kindLabel) return a.kindLabel === 'Studio' ? -1 : 1;
+    return a.route.localeCompare(b.route);
+  });
+  const otherCount = clients.filter((c) => !c.isThisPage).length;
+  return {
+    count,
+    chipLabel: count === 1 ? '1 page connected' : `${count} pages connected`,
+    prominent: count > 1,
+    clients,
+    boundaryCopy: PRESENCE_BOUNDARY_COPY,
+    otherCount,
+  };
+}
+
+/**
+ * Subscribe to worker presence while the live plane is available. Returns
+ * `null` until the first snapshot (or when there is no live plane).
+ */
+export function usePresenceView(): PresenceViewModel | null {
+  const env = useEnvironment();
+  const live =
+    env.status === 'ready' && env.env.live ? env.env.live : null;
+  const [view, setView] = useState<PresenceViewModel | null>(null);
+
+  useEffect(() => {
+    if (!live) {
+      setView(null);
+      return;
+    }
+    const thisId = live.presenceClientId;
+    return live.subscribePresence((snap) => {
+      setView(presenceViewModel(snap, thisId));
+    });
+  }, [live]);
+
+  return view;
+}

--- a/packages/studio/src/styles/index.css
+++ b/packages/studio/src/styles/index.css
@@ -317,6 +317,95 @@ a.studio-chip:hover {
   background: var(--diff-remove);
 }
 
+/* Connected-page presence popover (#227) */
+.studio-presence {
+  position: relative;
+  display: inline-flex;
+}
+.studio-presence__trigger {
+  appearance: none;
+  font: inherit;
+  cursor: pointer;
+}
+.studio-presence__trigger:hover {
+  border-color: var(--line-2);
+  color: var(--ink);
+}
+.studio-presence__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+.studio-presence__panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 50;
+  width: min(320px, calc(100vw - 24px));
+  padding: 12px 12px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--elevated);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--ink) 12%, transparent);
+  color: var(--ink);
+}
+.studio-presence__lead {
+  margin: 0 0 10px;
+  font-size: var(--fs-caption);
+  color: var(--muted);
+  line-height: 1.45;
+}
+.studio-presence__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+.studio-presence__item {
+  padding: 8px 9px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+.studio-presence__item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+.studio-presence__kind {
+  font-size: var(--fs-caption);
+  font-weight: 600;
+  color: var(--ink);
+}
+.studio-presence__this {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.studio-presence__route {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.studio-presence__meta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--faint);
+}
+.studio-presence__boundary {
+  margin: 10px 0 0;
+  font-size: 11px;
+  color: var(--faint);
+  line-height: 1.45;
+}
+
 .studio-surface {
   container-type: inline-size;
 }


### PR DESCRIPTION
## Summary
- Add ephemeral SharedWorker page-presence (register / heartbeat / disconnect + lease expiry) keyed by logical client id, not ports or subscriptions.
- Surface connected-page count in Studio’s status cluster with progressive disclosure (quiet single-page vs prominent multi-page, This page labeling, visibility boundary).
- Point stale-worker / version-skew guidance at remaining connected pages so remediation is concrete (#227).

## Test plan
- [x] `bun test` host presence suite + dispatch-table (73 ops) in `packages/cli`
- [x] Studio presence view-model + worker-live presence contract tests
- [x] Playwright site-static: two Studio pages → `2 pages connected` → close one → `1 page connected`
- [ ] Manual: open app + Studio against `pyric dev`, confirm chip and details; crash/force-close a tab and wait for lease expiry