### PR TITLE
refactor(cli): isolate credential-free discovery

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,10 @@
       "types": "./dist/discover/index.d.ts",
       "import": "./dist/discover/index.js"
     },
+    "./discover/production": {
+      "types": "./dist/discover/production.d.ts",
+      "import": "./dist/discover/production.js"
+    },
     "./vite": {
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"

--- a/packages/cli/src/discover/crawler-adapter.ts
+++ b/packages/cli/src/discover/crawler-adapter.ts
@@ -34,13 +34,11 @@ import type {
   CrawlerCollectionRef,
   CrawlerDocumentRef,
   CrawlerFirestore,
-} from '@pyric/cli/discover';
-import type {
   CollectionGroupCapableFirestore,
   CollectionGroupQuery,
   CollectionGroupSnapshot,
-} from '@pyric/cli/discover';
-import type { WireDocumentSnapshot } from '@pyric/cli/discover';
+  WireDocumentSnapshot,
+} from './firestore-source.js';
 import { encodeFieldsProto } from 'pyric/sandbox/internal';
 
 /**

--- a/packages/cli/src/discover/crawler.ts
+++ b/packages/cli/src/discover/crawler.ts
@@ -26,57 +26,18 @@
 import { runWithLimit } from './concurrency.js';
 import { emptySchema, mergeDoc } from './merge.js';
 import { SessionStore, type SessionError } from './session.js';
-import { snapshotToObservations, type WireDocumentSnapshot } from './wire.js';
+import { snapshotToObservations } from './wire.js';
+import type {
+  CrawlerCollectionRef,
+  CrawlerDocumentRef,
+  CrawlerFirestore,
+} from './firestore-source.js';
 import type {
   CollectionSchema,
   DiscoverEvent,
   FieldSchema,
   SamplingComplete,
 } from './types.js';
-
-// ─── Structural Firestore contract ────────────────────────────────────────
-
-/**
- * Minimal collection-reference contract the crawler depends on. Structurally
- * compatible with `firebase-admin/firestore`'s `CollectionReference` so the
- * crawler can be passed a real `Firestore` *and* mocked in unit tests with
- * no firebase-admin import.
- */
-export interface CrawlerCollectionRef {
-  readonly id: string;
-  readonly path: string;
-  listDocuments(): Promise<CrawlerDocumentRef[]>;
-}
-
-/** Minimal document-reference contract — structural twin of admin SDK. */
-export interface CrawlerDocumentRef {
-  readonly id: string;
-  readonly path: string;
-  listCollections(): Promise<CrawlerCollectionRef[]>;
-  /**
-   * Fetch the document snapshot. Item 2.3+ uses this to feed wire values
-   * into the merge layer. Returns a `WireDocumentSnapshot` (the structural
-   * shape `wire.ts` expects) — admin SDK's `DocumentSnapshot` satisfies it
-   * by virtue of exposing `_fieldsProto` and `ref.path`.
-   */
-  get(): Promise<WireDocumentSnapshot>;
-}
-
-/**
- * Minimal Firestore root contract.
- *
- * `listCollections` is required for any crawl. `collection(path)` and
- * `doc(path)` are only required when continuations are in play (Item 4.2):
- * resuming a paused crawl reconstructs frontier/sample refs from
- * persisted paths via these factories. firebase-admin's `Firestore`
- * provides both natively; the `CrawlOptions.continuation` code path
- * fails loud if they're absent.
- */
-export interface CrawlerFirestore {
-  listCollections(): Promise<CrawlerCollectionRef[]>;
-  collection?(path: string): CrawlerCollectionRef;
-  doc?(path: string): CrawlerDocumentRef;
-}
 
 // ─── Crawl options ────────────────────────────────────────────────────────
 

--- a/packages/cli/src/discover/credential-free.ts
+++ b/packages/cli/src/discover/credential-free.ts
@@ -1,0 +1,28 @@
+/**
+ * Credential-free discovery implementation.
+ *
+ * This is the internal composition seam for traversal, grouping, schema
+ * inference, convergence, tool handlers, and sandbox adapters. It must remain
+ * importable without production REST, auth/token modules, or Firebase SDKs.
+ * The public `@pyric/cli/discover` entry exposes only this retained module;
+ * the production adapter lives at a separate temporary entry for issue #265.
+ */
+
+export type {
+  WireDocumentSnapshot,
+  CrawlerCollectionRef,
+  CrawlerDocumentRef,
+  CrawlerFirestore,
+  CollectionGroupQuery,
+  CollectionGroupSnapshot,
+  CollectionGroupCapableFirestore,
+} from './firestore-source.js';
+export * from './crawler.js';
+export * from './findCollectionGroup.js';
+export * from './wire.js';
+export * from './types.js';
+export * from './session.js';
+export * from './concurrency.js';
+export * from './merge.js';
+export * from './crawler-adapter.js';
+export * from './tools.js';

--- a/packages/cli/src/discover/findCollectionGroup.ts
+++ b/packages/cli/src/discover/findCollectionGroup.ts
@@ -29,41 +29,8 @@
  */
 'use strict';
 
-import { toTemplatePath, type CrawlerCollectionRef } from './crawler.js';
-import type { WireDocumentSnapshot } from './wire.js';
-
-// ─── Structural Firestore contract for collection-group queries ─────────
-
-/**
- * Minimal collection-group query contract — structurally satisfied by
- * `firebase-admin/firestore` `Query` (returned by `db.collectionGroup`).
- * Defined here (not in `crawler.ts`) so consumers can pass a richer
- * mock for `findCollectionGroup` tests without touching the crawler's
- * existing `CrawlerFirestore` interface.
- */
-export interface CollectionGroupQuery {
-  select(...fields: string[]): CollectionGroupQuery;
-  limit(n: number): CollectionGroupQuery;
-  get(): Promise<{ docs: CollectionGroupSnapshot[] }>;
-}
-
-/**
- * Subset of `firebase-admin/firestore` `QueryDocumentSnapshot` we use:
- * just the parent collection ref. Field data is intentionally ignored
- * — `.select()` with no args returns refs only.
- */
-export interface CollectionGroupSnapshot {
-  ref: { parent: { path: string } };
-}
-
-/**
- * Firestore root contract extension — adds `collectionGroup(id)`. Kept
- * separate from `CrawlerFirestore` so the crawler doesn't pick up an
- * unused method. firebase-admin's `Firestore` satisfies both natively.
- */
-export interface CollectionGroupCapableFirestore {
-  collectionGroup(collectionId: string): CollectionGroupQuery;
-}
+import { toTemplatePath } from './crawler.js';
+import type { CollectionGroupCapableFirestore } from './firestore-source.js';
 
 // ─── Tool surface ────────────────────────────────────────────────────────
 
@@ -162,7 +129,3 @@ export async function findCollectionGroup(
     limitWasReached: docs.length === limit,
   };
 }
-
-// Re-export the snapshot type alias for tests that need to construct
-// fixtures without importing the underlying wire type.
-export type { CrawlerCollectionRef, WireDocumentSnapshot };

--- a/packages/cli/src/discover/firestore-source.ts
+++ b/packages/cli/src/discover/firestore-source.ts
@@ -1,0 +1,59 @@
+/**
+ * Credential-neutral Firestore seam for discovery.
+ *
+ * The crawler depends only on these structural shapes. Sandbox snapshots,
+ * LocalEnvironment, production REST, and test fixtures each provide an
+ * adapter without teaching the discovery implementation how that data was
+ * obtained. Keep credentials, tokens, SDK initialization, and network policy
+ * out of this module.
+ */
+
+/** Minimal document snapshot shape needed for wire-type inference. */
+export interface WireDocumentSnapshot {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _fieldsProto?: Record<string, any>;
+  ref?: { path?: string };
+}
+
+/** Minimal collection-reference shape needed for traversal. */
+export interface CrawlerCollectionRef {
+  readonly id: string;
+  readonly path: string;
+  listDocuments(): Promise<CrawlerDocumentRef[]>;
+}
+
+/** Minimal document-reference shape needed for traversal and sampling. */
+export interface CrawlerDocumentRef {
+  readonly id: string;
+  readonly path: string;
+  listCollections(): Promise<CrawlerCollectionRef[]>;
+  get(): Promise<WireDocumentSnapshot>;
+}
+
+/**
+ * Firestore-shaped source consumed by the crawler.
+ *
+ * `collection` and `doc` are needed only when resuming a continuation.
+ */
+export interface CrawlerFirestore {
+  listCollections(): Promise<CrawlerCollectionRef[]>;
+  collection?(path: string): CrawlerCollectionRef;
+  doc?(path: string): CrawlerDocumentRef;
+}
+
+/** Minimal collection-group query shape used by host discovery. */
+export interface CollectionGroupQuery {
+  select(...fields: string[]): CollectionGroupQuery;
+  limit(n: number): CollectionGroupQuery;
+  get(): Promise<{ docs: CollectionGroupSnapshot[] }>;
+}
+
+/** Parent-path projection used by collection-group discovery. */
+export interface CollectionGroupSnapshot {
+  ref: { parent: { path: string } };
+}
+
+/** Optional source capability used by `findCollectionGroup`. */
+export interface CollectionGroupCapableFirestore {
+  collectionGroup(collectionId: string): CollectionGroupQuery;
+}

--- a/packages/cli/src/discover/index.ts
+++ b/packages/cli/src/discover/index.ts
@@ -1,24 +1,5 @@
-/**
- * Barrel for the discover crawler — see ../discover.ts for the
- * subpath entry and rationale.
- */
+/** Credential-free public discovery entry. */
 
-export * from './crawler.js';
-export * from './findCollectionGroup.js';
-export * from './wire.js';
-export * from './types.js';
-export * from './session.js';
-export * from './concurrency.js';
-export * from './merge.js';
-// Crawler adapter — wraps LocalEnvironment as a CrawlerFirestore so
-// the discover tools can run hermetically against the sandbox.
-export * from './crawler-adapter.js';
-// ToolHandler factory — `firestore_discover_paths` +
-// `firestore_find_collection_group`. Browser-safe.
-export * from './tools.js';
-// REST-backed CrawlerFirestore — required because the modular Web SDK
-// has no `listCollections()` API (admin-only). Any non-admin environment
-// with an OAuth access token (browser, edge runtime, plain Node script
-// without firebase-admin) uses this to satisfy the crawler's structural
-// `CrawlerFirestore` contract.
-export * from './rest-crawler-firestore.js';
+// Retained traversal, inference, grouping, convergence, tools, and sandbox
+// adapters. This module has no credential or production-network dependency.
+export * from './credential-free.js';

--- a/packages/cli/src/discover/production.ts
+++ b/packages/cli/src/discover/production.ts
@@ -1,0 +1,9 @@
+/**
+ * Production-project discovery adapter.
+ *
+ * Kept as an explicit, isolated entry for issue #264 so credential-free
+ * discovery does not load token-bearing REST behavior. Issue #265 removes
+ * this adapter and its consumers.
+ */
+
+export * from './rest-crawler-firestore.js';

--- a/packages/cli/src/discover/rest-crawler-firestore.ts
+++ b/packages/cli/src/discover/rest-crawler-firestore.ts
@@ -30,8 +30,8 @@ import type {
   CrawlerCollectionRef,
   CrawlerDocumentRef,
   CrawlerFirestore,
-} from './crawler.js';
-import type { WireDocumentSnapshot } from './wire.js';
+  WireDocumentSnapshot,
+} from './firestore-source.js';
 
 const FIRESTORE_REST = 'https://firestore.googleapis.com/v1';
 

--- a/packages/cli/src/discover/tools.ts
+++ b/packages/cli/src/discover/tools.ts
@@ -30,9 +30,12 @@ import type { ToolHandler } from '@inbrowser/agent';
 import { crawl, type FullCrawlResult } from './crawler.js';
 import { findCollectionGroup } from './findCollectionGroup.js';
 import { SessionStore } from './session.js';
-import type { CrawlerFirestore, PersistedCrawlState } from './crawler.js';
+import type { PersistedCrawlState } from './crawler.js';
 import type { CollectionSchema, DiscoverEvent } from './types.js';
-import type { CollectionGroupCapableFirestore } from './findCollectionGroup.js';
+import type {
+  CollectionGroupCapableFirestore,
+  CrawlerFirestore,
+} from './firestore-source.js';
 
 export interface FirestoreDiscoverToolDeps {
   /**

--- a/packages/cli/src/discover/wire.ts
+++ b/packages/cli/src/discover/wire.ts
@@ -18,6 +18,7 @@
 
 import type { FieldObservation } from './merge.js';
 import { fieldTypeKey } from './merge.js';
+import type { WireDocumentSnapshot } from './firestore-source.js';
 import type {
   ExampleValue,
   FieldType,
@@ -247,18 +248,6 @@ function parseRefTargetCollectionPath(refPath: string): string {
 }
 
 // ─── Document snapshot → observations ─────────────────────────────────────
-
-/**
- * Minimal shape of the firebase-admin DocumentSnapshot needed by this
- * module. Defined here to avoid pulling firebase-admin types into a pure
- * data file — the crawler/handler layer is responsible for handing us
- * objects that satisfy this shape.
- */
-export interface WireDocumentSnapshot {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _fieldsProto?: Record<string, any>;
-  ref?: { path?: string };
-}
 
 /**
  * Convert a Firestore document snapshot into a FieldObservation map.

--- a/packages/cli/test/discover/crawler.test.ts
+++ b/packages/cli/test/discover/crawler.test.ts
@@ -22,11 +22,13 @@ import {
   crawlStructure,
   inferTemplateVariable,
   toTemplatePath,
-  type CrawlerCollectionRef,
-  type CrawlerDocumentRef,
-  type CrawlerFirestore,
 } from '../../src/discover/crawler.js';
-import type { WireDocumentSnapshot } from '../../src/discover/wire.js';
+import type {
+  CrawlerCollectionRef,
+  CrawlerDocumentRef,
+  CrawlerFirestore,
+  WireDocumentSnapshot,
+} from '../../src/discover/firestore-source.js';
 import { buildMockFirestore, type TreeSpec } from './helpers/mock-firestore.js';
 
 // ─── inferTemplateVariable ────────────────────────────────────────────────

--- a/packages/cli/test/discover/credential-free-contract.test.ts
+++ b/packages/cli/test/discover/credential-free-contract.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import * as credentialFreeDiscovery from '../../src/discover/index.js';
+import {
+  LocalEnvironmentCrawlerAdapter,
+  crawl,
+  findCollectionGroup,
+} from '../../src/discover/index.js';
+import { createRestCrawlerFirestore } from '../../src/discover/production.js';
+
+const ALLOW_ALL_RULES =
+  "rules_version = '2'; service cloud.firestore { match /databases/{database}/documents { match /{document=**} { allow read, write: if true; }}}";
+
+describe('credential-free discovery contract', () => {
+  test('public discovery traverses, groups, infers, and converges without network access', async () => {
+    const env = new LocalEnvironment();
+    const documents: Record<string, Record<string, unknown>> = {
+      'users/alice': { displayName: 'Alice' },
+      'users/bob': { displayName: 'Bob' },
+    };
+    for (const user of ['alice', 'bob']) {
+      for (let i = 0; i < 3; i++) {
+        documents[`users/${user}/posts/${user}-${i}`] = {
+          status: 'published',
+          score: 1,
+        };
+      }
+    }
+    env.seed({ rules: ALLOW_ALL_RULES, documents });
+
+    const originalFetch = globalThis.fetch;
+    let networkCalls = 0;
+    globalThis.fetch = (async () => {
+      networkCalls += 1;
+      throw new Error('credential-free discovery attempted network access');
+    }) as typeof fetch;
+
+    try {
+      const source = new LocalEnvironmentCrawlerAdapter(env);
+      const result = await crawl(source, { stopOnStable: 2, maxSamples: 10 });
+
+      expect([...result.finalizedSchemas.keys()].sort()).toEqual([
+        'users',
+        'users/{userId}/posts',
+      ]);
+
+      const posts = result.finalizedSchemas.get('users/{userId}/posts');
+      expect(posts).toMatchObject({
+        templatePath: 'users/{userId}/posts',
+        samplingComplete: 'converged_via_stable',
+        declaredAt: 2,
+      });
+      expect(posts?.schema.fields.status?.types).toContainEqual({
+        kind: 'scalar',
+        type: 'string',
+      });
+      expect(posts?.schema.fields.score?.types).toContainEqual({
+        kind: 'scalar',
+        type: 'integer',
+      });
+
+      const grouped = await findCollectionGroup(source, 'posts');
+      expect(grouped).toEqual({
+        hosts: [
+          {
+            templatePath: 'users/{userId}/posts',
+            sampleDocCount: 6,
+          },
+        ],
+        reads: 6,
+        limitWasReached: false,
+      });
+      expect(networkCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('production discovery remains available as an isolated adapter for issue #265', () => {
+    expect(typeof createRestCrawlerFirestore).toBe('function');
+    expect('createRestCrawlerFirestore' in credentialFreeDiscovery).toBe(false);
+    expect('RestCrawlerFirestoreError' in credentialFreeDiscovery).toBe(false);
+  });
+
+  test('credential-free module graph has no production, credential, or Firebase SDK edge', () => {
+    const entry = fileURLToPath(
+      new URL('../../src/discover/index.ts', import.meta.url),
+    );
+    const visited = new Set<string>();
+    const externalSpecifiers = new Set<string>();
+
+    function visit(file: string): void {
+      if (visited.has(file)) return;
+      visited.add(file);
+      const source = readFileSync(file, 'utf8');
+      const imports = source.matchAll(
+        /(?:from\s+|import\s*\()(['"])([^'"]+)\1/g,
+      );
+      const sideEffectImports = source.matchAll(
+        /\bimport\s+(['"])([^'"]+)\1/g,
+      );
+      for (const match of [...imports, ...sideEffectImports]) {
+        const specifier = match[2]!;
+        if (!specifier.startsWith('.')) {
+          externalSpecifiers.add(specifier);
+          continue;
+        }
+        const target = resolve(
+          dirname(file),
+          specifier.replace(/\.js$/, '.ts'),
+        );
+        visit(target);
+      }
+    }
+
+    visit(entry);
+
+    expect(
+      [...visited].some(
+        (file) =>
+          file.endsWith('production.ts') ||
+          file.endsWith('rest-crawler-firestore.ts'),
+      ),
+    ).toBe(false);
+    expect(
+      [...visited].some((file) => file.includes('/credentials/')),
+    ).toBe(false);
+    expect([...externalSpecifiers]).not.toContain('@pyric/cli/discover');
+    expect(
+      [...externalSpecifiers].filter(
+        (specifier) =>
+          specifier === 'firebase' ||
+          specifier.startsWith('firebase/') ||
+          specifier === 'firebase-admin' ||
+          specifier.startsWith('firebase-admin/'),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/test/discover/find-collection-group.test.ts
+++ b/packages/cli/test/discover/find-collection-group.test.ts
@@ -21,12 +21,12 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import {
-  findCollectionGroup,
-  type CollectionGroupCapableFirestore,
-  type CollectionGroupQuery,
-  type CollectionGroupSnapshot,
-} from '../../src/discover/findCollectionGroup.js';
+import { findCollectionGroup } from '../../src/discover/findCollectionGroup.js';
+import type {
+  CollectionGroupCapableFirestore,
+  CollectionGroupQuery,
+  CollectionGroupSnapshot,
+} from '../../src/discover/firestore-source.js';
 
 // ─── Mock collection-group query ──────────────────────────────────────────
 

--- a/packages/cli/test/discover/helpers/mock-firestore.ts
+++ b/packages/cli/test/discover/helpers/mock-firestore.ts
@@ -1,8 +1,8 @@
 /**
  * Shared mock-Firestore builder for `firestore/discover/*` tests.
  *
- * Implements the structural `CrawlerFirestore` contract from
- * `crawler.ts` so tests don't need a real `firebase-admin` import. The
+ * Implements the credential-neutral `CrawlerFirestore` seam so tests don't
+ * need a real `firebase-admin` import. The
  * mock records call counts and peak in-flight RPCs into a `metrics`
  * object so concurrency caps and read-cost claims can be asserted
  * directly.
@@ -20,7 +20,7 @@ import type {
   CrawlerCollectionRef,
   CrawlerDocumentRef,
   CrawlerFirestore,
-} from '../../../../src/firestore/firestore/discover/crawler.js';
+} from '../../../src/discover/firestore-source.js';
 
 export type TreeSpec = Record<string, DocSpec[]>;
 export type DocSpec = {

--- a/packages/cli/test/discover/sampling.test.ts
+++ b/packages/cli/test/discover/sampling.test.ts
@@ -20,13 +20,13 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import {
-  crawl,
-  type CrawlerCollectionRef,
-  type CrawlerDocumentRef,
-  type CrawlerFirestore,
-} from '../../src/discover/crawler.js';
-import type { WireDocumentSnapshot } from '../../src/discover/wire.js';
+import { crawl } from '../../src/discover/crawler.js';
+import type {
+  CrawlerCollectionRef,
+  CrawlerDocumentRef,
+  CrawlerFirestore,
+  WireDocumentSnapshot,
+} from '../../src/discover/firestore-source.js';
 import { buildMockFirestore, type DocSpec } from './helpers/mock-firestore.js';
 
 // ─── Stream factories ─────────────────────────────────────────────────────

--- a/packages/cli/test/package-manifest.test.ts
+++ b/packages/cli/test/package-manifest.test.ts
@@ -12,4 +12,9 @@ describe('@pyric/cli package manifest', () => {
     expect(Object.keys(manifest.exports)).not.toContain('./auth');
     expect(Object.keys(manifest.exports)).not.toContain('./registry');
   });
+
+  it('isolates production discovery from the credential-free entry', () => {
+    expect(Object.keys(manifest.exports)).toContain('./discover');
+    expect(Object.keys(manifest.exports)).toContain('./discover/production');
+  });
 });

--- a/packages/playground/scripts/probe-discover.ts
+++ b/packages/playground/scripts/probe-discover.ts
@@ -41,7 +41,8 @@
 import { readFileSync } from 'node:fs';
 import { createSign } from 'node:crypto';
 import { resolve } from 'node:path';
-import { createRestCrawlerFirestore, crawl } from '@pyric/cli/discover';
+import { crawl } from '@pyric/cli/discover';
+import { createRestCrawlerFirestore } from '@pyric/cli/discover/production';
 
 /**
  * Mint a short-lived Firestore-scoped access token from a service-

--- a/packages/playground/src/lib/tools/diagnostics/firestore-discover.ts
+++ b/packages/playground/src/lib/tools/diagnostics/firestore-discover.ts
@@ -18,10 +18,10 @@
  * agent never sees their declarations.
  */
 import {
-  createRestCrawlerFirestore,
   createFirestoreDiscoverTools,
   type DiscoverPathsToolResult,
 } from '@pyric/cli/discover';
+import { createRestCrawlerFirestore } from '@pyric/cli/discover/production';
 import type { ToolContext, ToolHandler, ToolResult } from '@inbrowser/agent';
 
 /**
@@ -250,4 +250,3 @@ function thinFieldType(
   // scalar / reference / vector — already small, pass through.
   return t;
 }
-

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -348,6 +348,22 @@ for (const sym of [
   else bad('@pyric/cli/bridge STILL exports retired ' + sym);
 }
 
+// Credential-free discovery is the retained contract. The production REST
+// adapter remains reachable only through its explicit temporary entry until
+// issue #265 removes it.
+const discover = await import('@pyric/cli/discover');
+const productionDiscover = await import('@pyric/cli/discover/production');
+if (!('createRestCrawlerFirestore' in discover)) {
+  ok('@pyric/cli/discover does NOT export production REST discovery');
+} else {
+  bad('@pyric/cli/discover STILL exports production REST discovery');
+}
+if (typeof productionDiscover.createRestCrawlerFirestore === 'function') {
+  ok('@pyric/cli/discover/production exports the isolated REST adapter');
+} else {
+  bad('@pyric/cli/discover/production is MISSING the isolated REST adapter');
+}
+
 // Production deployment is owned by firebase-tools. The old programmatic
 // subpath must fail resolution instead of lingering as a compatibility shim.
 await assertNotExported('@pyric/cli/deploy');


### PR DESCRIPTION
`@pyric/cli/discover` now loads only credential-free traversal, grouping, inference, convergence, and sandbox adapters.

```ts
import { LocalEnvironment } from 'pyric/sandbox/internal';
import {
  LocalEnvironmentCrawlerAdapter,
  crawl,
} from '@pyric/cli/discover';

const environment = new LocalEnvironment();
environment.seed({
  rules: "rules_version = '2'; service cloud.firestore { match /databases/{database}/documents { match /{document=**} { allow read: if true; }}}",
  documents: { 'users/alice': { displayName: 'Alice' } },
});

const result = await crawl(
  new LocalEnvironmentCrawlerAdapter(environment),
);
console.log([...result.finalizedSchemas.keys()]);
// ['users'] — no token, credential, production REST, or SDK initialization.
```

## Production discovery is one removable leaf

The crawler's structural Firestore shapes now live at one credential-neutral seam shared by sandbox, REST, and test adapters. The retained public discovery entry composes only the credential-free implementation.

The existing REST crawler remains intact for this characterization PR, but its two exports move mechanically to the explicit temporary `@pyric/cli/discover/production` entry. Playground production consumers use that entry; sandbox consumers continue using `@pyric/cli/discover`. This gives #265 a single leaf to remove without rewriting crawler behavior.

## Risk

The intentional breaking change is the import location for `createRestCrawlerFirestore` and `RestCrawlerFirestoreError`. Their behavior is unchanged. Review should focus on whether the credential-free module graph is truly closed over local/pure dependencies and whether the temporary production entry contains the complete production adapter surface.

<details>
<summary>Verification</summary>

- Closes #264.
- Focused discovery, manifest, and Playground sandbox tests: 229 passed, 0 failed.
- `bun run build`: passed.
- `bun run test:packaging`: passed.
- Packed assertions prove `@pyric/cli/discover` excludes production REST discovery and `@pyric/cli/discover/production` exposes the isolated adapter.
- `git diff --check`: passed.

</details>
