### PR TITLE
Fix Storage LIST traffic navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -245,10 +245,13 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/react": "^16.1.0",
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "fake-indexeddb": "^6.2.5",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -44,11 +44,14 @@
     "@lezer/highlight": "^1.2.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/bun": "latest",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "fake-indexeddb": "^6.2.5",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"

--- a/packages/studio/src/features/data/DataFeature.tsx
+++ b/packages/studio/src/features/data/DataFeature.tsx
@@ -126,7 +126,7 @@ function DataViews({
       const pane = (
         <LiveStoragePane
           storage={handles.storage}
-          focusPath={target?.view === 'storage' ? target.objectPath : null}
+          focusTarget={target?.view === 'storage' ? target : { kind: 'root' }}
         />
       );
       // Served mode supplies the worker StorageApi bundle so the browser drives

--- a/packages/studio/src/features/data/StoragePane.tsx
+++ b/packages/studio/src/features/data/StoragePane.tsx
@@ -8,9 +8,8 @@
  * `useStorageRulesGate`) on the left — wrapped in an `UploadDropzone` so
  * files and folders drop straight into the browsed folder — and an
  * `ObjectInspector` (content-type preview + metadata table + custom
- * metadata) on the right. When a `gs://` / storage-path cross-reference is
- * clicked elsewhere in Studio, `focusPath` drives the browser to that
- * object's folder and selects it.
+ * metadata) on the right. The routed `focusTarget` keeps object inspection
+ * distinct from prefix browsing even when both occupy the same Storage path.
  *
  * CREATE FOLDER (VS Code style): the "New folder" affordance discloses an
  * inline input that accepts nested paths — `stuff/things/cool` creates the
@@ -36,7 +35,14 @@
  * (token-driven).
  */
 
-import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import type { FormEvent, ReactNode } from 'react';
 import {
   ObjectBrowser,
@@ -66,8 +72,8 @@ import './storage.css';
 
 export interface StoragePaneProps {
   storage: FirebaseStorage;
-  /** An object path to focus (from a `gs://` cross-reference jump). */
-  focusPath: string | null;
+  /** URL-derived Storage intent. Prefix and object paths are not interchangeable. */
+  focusTarget: { kind: 'root' } | { kind: 'prefix' | 'object'; path: string };
 }
 
 /** Parent folder of an object path (`a/b/c.png` → `a/b`; `c.png` → ``). */
@@ -200,16 +206,36 @@ function renderEntry(entry: StorageListEntry): ReactNode {
   );
 }
 
-export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
+export function LiveStoragePane({ storage, focusTarget }: StoragePaneProps) {
   const nav = useDataNav();
-  const pathState = usePathState();
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  // Selecting an object writes the hash (#storage/<path>) so it's deep-linkable
-  // + reload-persistent; folder navigation / back clears it. The `focusPath`
-  // seed below reads the hash (descend + select on a deep-link/cross-ref).
-  const selectObject = (objectPath: string | null) => {
-    setSelectedPath(objectPath);
-    nav.navigate({ view: 'storage', objectPath });
+  const selectedPath =
+    focusTarget.kind === 'object'
+      ? normalizeStoragePath(focusTarget.path)
+      : null;
+  const browsedPath =
+    focusTarget.kind === 'prefix'
+      ? normalizeStoragePath(focusTarget.path)
+      : selectedPath
+        ? parentFolder(selectedPath)
+        : '';
+  const browsePrefix = useCallback(
+    (path: string) => {
+      const norm = normalizeStoragePath(path);
+      nav.navigate(
+        norm
+          ? { view: 'storage', kind: 'prefix', path: norm }
+          : { view: 'storage', kind: 'root' },
+      );
+    },
+    [nav.navigate],
+  );
+  const pathState = usePathState({ path: browsedPath, onPathChange: browsePrefix });
+  const selectObject = (objectPath: string) => {
+    nav.navigate({
+      view: 'storage',
+      kind: 'object',
+      path: normalizeStoragePath(objectPath),
+    });
   };
   const list = useStorageList(storage, pathState.path);
   const selection = useStorageSelection();
@@ -298,22 +324,10 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
     dispatchPending({ type: 'create', path: full });
     // VS Code semantics: creating `stuff/things/cool` lands you inside it.
     pathState.setPath(full);
-    selectObject(null);
     setFolderName('');
     setFolderError(null);
     setCreating(false);
   };
-
-  // Honor a cross-ref jump: descend to the object's folder and select it.
-  useEffect(() => {
-    if (focusPath) {
-      const norm = normalizeStoragePath(focusPath);
-      pathState.setPath(parentFolder(norm));
-      setSelectedPath(norm);
-    }
-    // pathState.setPath is stable; focusPath is the trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusPath]);
 
   // Selection is scoped to the directory currently on screen. Navigating to
   // another prefix starts a fresh selection, matching the Firebase console.
@@ -333,10 +347,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
         <PathBreadcrumb
           path={pathState.path}
           rootLabel="files"
-          onNavigate={(p) => {
-            pathState.setPath(p);
-            selectObject(null);
-          }}
+          onNavigate={pathState.setPath}
         />
         <div className="storage__actions">
           {selection.size > 0 ? (
@@ -362,7 +373,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
                         : selectedPath.startsWith(`${entry.fullPath}/`),
                     )
                   ) {
-                    selectObject(null);
+                    pathState.setPath(pathState.path);
                   }
                   selection.clear();
                   list.refresh();
@@ -511,10 +522,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
                 />
               </label>
             )}
-            onNavigate={(p) => {
-              pathState.enter(p);
-              selectObject(null);
-            }}
+            onNavigate={pathState.enter}
             onSelect={(ref) => selectObject(ref.fullPath)}
             emptyState={
               <p className="storage__empty">
@@ -537,7 +545,7 @@ export function LiveStoragePane({ storage, focusPath }: StoragePaneProps) {
               <button
                 type="button"
                 className="storage__back"
-                onClick={() => selectObject(null)}
+                onClick={() => pathState.setPath(pathState.path)}
                 aria-label="Back to files"
               >
                 ‹ Files

--- a/packages/studio/src/features/data/navigation.test.ts
+++ b/packages/studio/src/features/data/navigation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { routeForTarget, targetForLocation } from './navigation.js';
+
+describe('Storage navigation intent', () => {
+  it('round-trips a prefix distinctly from an object at the same path', () => {
+    const prefix = { view: 'storage', kind: 'prefix', path: 'notes/note-01' } as const;
+    const object = { view: 'storage', kind: 'object', path: 'notes/note-01' } as const;
+
+    expect(routeForTarget(prefix)).toEqual({
+      tab: 'storage',
+      rest: ['notes', 'note-01'],
+      query: { kind: 'prefix' },
+    });
+    expect(routeForTarget(object)).toEqual({
+      tab: 'storage',
+      rest: ['notes', 'note-01'],
+    });
+    expect(targetForLocation('/storage/notes/note-01?kind=prefix')).toEqual(prefix);
+    expect(targetForLocation('/storage/notes/note-01')).toEqual(object);
+  });
+});

--- a/packages/studio/src/features/data/navigation.tsx
+++ b/packages/studio/src/features/data/navigation.tsx
@@ -27,6 +27,7 @@ import {
   subscribeToLocation,
 } from '../../shell/router.js';
 import { parsePath } from '../../shell/path.js';
+import type { CommandTarget } from '../home/command.js';
 import type { CrossRef } from './refs.js';
 
 /** The three service sub-views the Data feature spans. */
@@ -54,7 +55,8 @@ export function parseDocPath(docPath: string): NavigationPathSegment[] {
 export type DataTarget =
   | { view: 'firestore'; path: NavigationPathSegment[] }
   | { view: 'auth'; uid: string | null }
-  | { view: 'storage'; objectPath: string | null };
+  | { view: 'storage'; kind: 'root' }
+  | { view: 'storage'; kind: 'prefix' | 'object'; path: string };
 
 interface NavState {
   target: DataTarget | null;
@@ -68,20 +70,56 @@ interface NavState {
 // location is unchanged (else `useSyncExternalStore` re-renders forever), so we
 // memoize the derived state on the raw `pathname + search` key.
 
-function deriveNav(raw: string): NavState {
+function parsedLocation(raw: string) {
   const qIdx = raw.indexOf('?');
-  const { tab, rest, query } = parsePath(
+  return parsePath(
     qIdx === -1 ? raw : raw.slice(0, qIdx),
     qIdx === -1 ? '' : raw.slice(qIdx),
   );
-  let target: DataTarget | null = null;
-  if (tab === 'firestore') {
-    target = { view: 'firestore', path: parseDocPath(rest.join('/')) };
-  } else if (tab === 'auth') {
-    target = { view: 'auth', uid: rest[0] ?? null };
-  } else if (tab === 'storage') {
-    target = { view: 'storage', objectPath: rest.length ? rest.join('/') : null };
+}
+
+/** Decode the data target carried by a pathname + query location key. */
+export function targetForLocation(raw: string): DataTarget | null {
+  const { tab, rest, query } = parsedLocation(raw);
+  const path = rest.join('/');
+  if (tab === 'firestore') return { view: 'firestore', path: parseDocPath(path) };
+  if (tab === 'auth') return { view: 'auth', uid: rest[0] ?? null };
+  if (tab === 'storage') {
+    if (!path) return { view: 'storage', kind: 'root' };
+    return {
+      view: 'storage',
+      kind: query.kind === 'prefix' ? 'prefix' : 'object',
+      path,
+    };
   }
+  return null;
+}
+
+/** Encode a data target for the shell's single History-API router. */
+export function routeForTarget(target: DataTarget): CommandTarget {
+  switch (target.view) {
+    case 'firestore': {
+      const last = target.path[target.path.length - 1];
+      return {
+        tab: 'firestore',
+        rest: last ? last.path.split('/').filter(Boolean) : [],
+      };
+    }
+    case 'auth':
+      return { tab: 'auth', rest: target.uid ? [target.uid] : [] };
+    case 'storage':
+      if (target.kind === 'root') return { tab: 'storage' };
+      return {
+        tab: 'storage',
+        rest: target.path.split('/').filter(Boolean),
+        ...(target.kind === 'prefix' ? { query: { kind: 'prefix' } } : {}),
+      };
+  }
+}
+
+function deriveNav(raw: string): NavState {
+  const { tab, query } = parsedLocation(raw);
+  const target = targetForLocation(raw);
   const selectedInspectId = tab === 'traffic' ? query.inspect ?? null : null;
   return { target, selectedInspectId };
 }
@@ -102,26 +140,9 @@ function getServerSnapshot(): NavState {
   return cachedSnap;
 }
 
-/** The in-service `rest` segments for a target. */
-function restForTarget(target: DataTarget): string[] {
-  switch (target.view) {
-    case 'firestore': {
-      const last = target.path[target.path.length - 1];
-      return last ? last.path.split('/').filter(Boolean) : [];
-    }
-    case 'auth':
-      return target.uid ? [target.uid] : [];
-    case 'storage':
-      return target.objectPath ? target.objectPath.split('/').filter(Boolean) : [];
-  }
-}
-
 /** Switch sub-view (shell tab) + focus a target. */
 function navigateTo(target: DataTarget): void {
-  pushPath({
-    tab: target.view,
-    rest: restForTarget(target),
-  });
+  pushPath(routeForTarget(target));
 }
 
 function navigateInspectUrl(id: string): void {
@@ -154,7 +175,7 @@ export function useDataNav(): DataNavValue {
         navigateTo({ view: 'auth', uid: ref.uid });
         break;
       case 'storage':
-        navigateTo({ view: 'storage', objectPath: ref.objectPath });
+        navigateTo({ view: 'storage', kind: 'object', path: ref.objectPath });
         break;
       case 'document':
         navigateTo({ view: 'firestore', path: parseDocPath(ref.path) });

--- a/packages/studio/src/features/session/SessionSurface.tsx
+++ b/packages/studio/src/features/session/SessionSurface.tsx
@@ -127,7 +127,7 @@ export function SessionSurface() {
         nav.navigate({ view: 'auth', uid: row.target });
         break;
       case 'storage':
-        nav.navigate({ view: 'storage', objectPath: row.target });
+        nav.navigate({ view: 'storage', kind: 'object', path: row.target });
         break;
       // rtdb has no surface yet: no-op (the row stays inert).
     }

--- a/packages/studio/src/features/traffic/verdict.test.ts
+++ b/packages/studio/src/features/traffic/verdict.test.ts
@@ -75,36 +75,48 @@ describe('actingIdentity', () => {
 
 describe('subjectTarget', () => {
   it('routes a Firestore op (default service) to its path', () => {
-    expect(subjectTarget({ path: 'users/alice' })).toEqual({
+    expect(subjectTarget({ method: 'get', path: 'users/alice' })).toEqual({
       tab: 'firestore',
       rest: ['users', 'alice'],
     });
-    expect(subjectTarget({ service: 'firestore', path: 'notes' })).toEqual({
+    expect(subjectTarget({ service: 'firestore', method: 'list', path: 'notes' })).toEqual({
       tab: 'firestore',
       rest: ['notes'],
     });
   });
 
   it('routes an RTDB op to the viewer tab (path is component state — N4 gap)', () => {
-    expect(subjectTarget({ service: 'rtdb', path: '/rooms/r1' })).toEqual({ tab: 'rtdb' });
+    expect(subjectTarget({ service: 'rtdb', method: 'get', path: '/rooms/r1' })).toEqual({ tab: 'rtdb' });
   });
 
   it('routes storage to the object path and auth to the uid', () => {
-    expect(subjectTarget({ service: 'storage', path: 'uploads/logo.png' })).toEqual({
+    expect(subjectTarget({ service: 'storage', method: 'get', path: 'uploads/logo.png' })).toEqual({
       tab: 'storage',
       rest: ['uploads', 'logo.png'],
     });
-    expect(subjectTarget({ service: 'auth', path: 'u-1' })).toEqual({
+    expect(subjectTarget({ service: 'auth', method: 'get', path: 'u-1' })).toEqual({
       tab: 'auth',
       rest: ['u-1'],
     });
   });
 
+  it('routes a Storage list to its prefix without conflating it with an object', () => {
+    expect(subjectTarget({ service: 'storage', method: 'list', path: 'avatars' })).toEqual({
+      tab: 'storage',
+      rest: ['avatars'],
+      query: { kind: 'prefix' },
+    });
+    expect(subjectTarget({ service: 'storage', method: 'get', path: 'avatars' })).toEqual({
+      tab: 'storage',
+      rest: ['avatars'],
+    });
+  });
+
   it('yields nothing for non-addressable subjects', () => {
-    expect(subjectTarget({ service: 'auth', path: '*' })).toBeNull();
-    expect(subjectTarget({ service: 'rtdb', path: '(service)' })).toBeNull();
-    expect(subjectTarget({ path: '' })).toBeNull();
-    expect(subjectTarget({ service: 'firestore', path: '/' })).toBeNull();
+    expect(subjectTarget({ service: 'auth', method: 'delete', path: '*' })).toBeNull();
+    expect(subjectTarget({ service: 'rtdb', method: 'get', path: '(service)' })).toBeNull();
+    expect(subjectTarget({ method: 'get', path: '' })).toBeNull();
+    expect(subjectTarget({ service: 'firestore', method: 'list', path: '/' })).toBeNull();
   });
 });
 

--- a/packages/studio/src/features/traffic/verdict.test.ts
+++ b/packages/studio/src/features/traffic/verdict.test.ts
@@ -112,6 +112,15 @@ describe('subjectTarget', () => {
     });
   });
 
+  it('routes a Storage root list to the bucket root', () => {
+    expect(subjectTarget({ service: 'storage', method: 'list', path: '' })).toEqual({
+      tab: 'storage',
+    });
+    expect(subjectTarget({ service: 'storage', method: 'list', path: '/' })).toEqual({
+      tab: 'storage',
+    });
+  });
+
   it('yields nothing for non-addressable subjects', () => {
     expect(subjectTarget({ service: 'auth', method: 'delete', path: '*' })).toBeNull();
     expect(subjectTarget({ service: 'rtdb', method: 'get', path: '(service)' })).toBeNull();

--- a/packages/studio/src/features/traffic/verdict.ts
+++ b/packages/studio/src/features/traffic/verdict.ts
@@ -119,11 +119,13 @@ export function opensRulesInspector(event: {
  *   rtdb      → /rtdb                 (the viewer's path is component state —
  *                                      N4 gap: no path deep-link yet)
  *   storage   → /storage/<path>       (object path)
+ *             → /storage/<path>?kind=prefix (listed prefix)
  *   auth      → /auth/<uid>           (`path` carries the uid; `*` = clear-all,
  *                                      not addressable)
  */
 export function subjectTarget(event: {
   service?: StudioTrafficEvent['service'];
+  method: StudioTrafficEvent['method'];
   path: string;
 }): CommandTarget | null {
   const path = event.path;
@@ -135,7 +137,13 @@ export function subjectTarget(event: {
     case 'rtdb':
       return { tab: 'rtdb' };
     case 'storage':
-      return rest.length ? { tab: 'storage', rest } : null;
+      return rest.length
+        ? {
+            tab: 'storage',
+            rest,
+            ...(event.method === 'list' ? { query: { kind: 'prefix' } } : {}),
+          }
+        : null;
     case 'auth':
       return path !== '*' ? { tab: 'auth', rest: [path] } : null;
     default:

--- a/packages/studio/src/features/traffic/verdict.ts
+++ b/packages/studio/src/features/traffic/verdict.ts
@@ -129,6 +129,13 @@ export function subjectTarget(event: {
   path: string;
 }): CommandTarget | null {
   const path = event.path;
+  if (
+    event.service === 'storage' &&
+    event.method === 'list' &&
+    (path === '' || path === '/')
+  ) {
+    return { tab: 'storage' };
+  }
   if (!path || path === '(service)') return null;
   const rest = path.split('/').filter(Boolean);
   switch (event.service ?? 'firestore') {

--- a/packages/studio/test/features/data/storage-navigation.test.tsx
+++ b/packages/studio/test/features/data/storage-navigation.test.tsx
@@ -1,0 +1,197 @@
+// Install JSDOM globals before importing React or RTL.
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  pretendToBeVisual: true,
+  url: 'http://localhost/storage/avatars?kind=prefix',
+});
+const g = globalThis as any;
+g.window = dom.window;
+g.document = dom.window.document;
+g.HTMLElement = dom.window.HTMLElement;
+g.Element = dom.window.Element;
+g.Node = dom.window.Node;
+g.Event = dom.window.Event;
+g.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+
+import {
+  indexedDB as fakeIndexedDB,
+  IDBKeyRange as fakeIDBKeyRange,
+} from 'fake-indexeddb';
+g.indexedDB = fakeIndexedDB;
+g.IDBKeyRange = fakeIDBKeyRange;
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  getStorageSandbox,
+  ref,
+  uploadBytes,
+  type FirebaseStorage,
+} from 'pyric/storage';
+import { TrafficRow } from '@pyric/ui/traffic';
+import { LiveStoragePane } from '../../../src/features/data/StoragePane.js';
+import { useDataNav } from '../../../src/features/data/navigation.js';
+import { pushPath } from '../../../src/shell/router.js';
+import {
+  subjectTarget,
+  type StudioTrafficEvent,
+} from '../../../src/features/traffic/verdict.js';
+
+afterEach(() => cleanup());
+
+function makeStorage(): FirebaseStorage {
+  const sandbox = initializeSandbox({});
+  return getStorageSandbox(sandbox, {
+    dbName: `pyric-studio-storage-nav-${Math.random().toString(36).slice(2, 10)}`,
+  });
+}
+
+function RoutedStoragePane({ storage }: { storage: FirebaseStorage }) {
+  const { target } = useDataNav();
+  return (
+    <LiveStoragePane
+      storage={storage}
+      focusTarget={target?.view === 'storage' ? target : { kind: 'root' }}
+    />
+  );
+}
+
+const LIST_AVATARS = {
+  id: 'storage-list-avatars',
+  kind: 'operation',
+  service: 'storage',
+  method: 'list',
+  path: 'avatars',
+  at: 1,
+  durationMs: 1,
+  auth: null,
+  result: 'allow',
+  origin: 'client',
+  reasons: [],
+  operationContext: {
+    source: { kind: 'app' },
+    authLens: { mode: 'app-session' },
+  },
+  rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' },
+} as StudioTrafficEvent;
+
+function StorageListTrafficRow() {
+  return (
+    <TrafficRow
+      event={LIST_AVATARS}
+      onSelect={(event) => {
+        const target = subjectTarget(event as StudioTrafficEvent);
+        if (target) pushPath(target);
+      }}
+    />
+  );
+}
+
+describe('Storage route intent', () => {
+  it('opens a listed prefix when its Traffic row is clicked', async () => {
+    const storage = makeStorage();
+    await uploadBytes(ref(storage, 'avatars/alice.png'), new Uint8Array([1]));
+    window.history.replaceState(null, '', '/traffic');
+
+    const view = render(
+      <>
+        <StorageListTrafficRow />
+        <RoutedStoragePane storage={storage} />
+      </>,
+    );
+    fireEvent.click(view.container.querySelector('[data-pyric-traffic-row]')!);
+
+    expect(window.location.pathname + window.location.search).toBe(
+      '/storage/avatars?kind=prefix',
+    );
+    await waitFor(() =>
+      expect(
+        view.container.querySelector('[data-pyric-entry-path="avatars/alice.png"]'),
+      ).not.toBeNull(),
+    );
+    expect(
+      view.container.querySelector('[data-pyric-ui="object-inspector"][data-pyric-error]'),
+    ).toBeNull();
+  });
+
+  it('browses a prefix and inspects an object at the identical path', async () => {
+    const storage = makeStorage();
+    await uploadBytes(ref(storage, 'avatars'), new Blob(['object-at-the-prefix-path']));
+    await uploadBytes(ref(storage, 'avatars/alice.png'), new Uint8Array([1]), {
+      contentType: 'application/octet-stream',
+    });
+
+    const view = render(
+      <LiveStoragePane
+        storage={storage}
+        focusTarget={{ kind: 'prefix', path: 'avatars' }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        view.container.querySelector('[data-pyric-entry-path="avatars/alice.png"]'),
+      ).not.toBeNull(),
+    );
+    expect(view.container.querySelector('[data-pyric-object-metadata]')).toBeNull();
+
+    view.rerender(
+      <LiveStoragePane
+        storage={storage}
+        focusTarget={{ kind: 'object', path: 'avatars' }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        view.container.querySelector('[data-pyric-metadata-field="fullPath"] dd')
+          ?.textContent,
+      ).toContain('/avatars'),
+    );
+  });
+
+  it('restores prefix browsing through browser back navigation', async () => {
+    const storage = makeStorage();
+    await uploadBytes(ref(storage, 'avatars/alice.png'), new Uint8Array([1]), {
+      contentType: 'application/octet-stream',
+    });
+    window.history.replaceState(null, '', '/storage/avatars?kind=prefix');
+
+    const view = render(<RoutedStoragePane storage={storage} />);
+    const aliceRow = await waitFor(() => {
+      const row = view.container.querySelector(
+        '[data-pyric-entry-path="avatars/alice.png"]',
+      );
+      expect(row).not.toBeNull();
+      return row!;
+    });
+
+    fireEvent.click(aliceRow.querySelector('[data-pyric-entry-select]')!);
+    expect(window.location.pathname + window.location.search).toBe(
+      '/storage/avatars/alice.png',
+    );
+    await waitFor(() =>
+      expect(view.container.querySelector('[data-pyric-object-metadata]')).not.toBeNull(),
+    );
+
+    window.history.back();
+    await waitFor(() =>
+      expect(window.location.pathname + window.location.search).toBe(
+        '/storage/avatars?kind=prefix',
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        view.container.querySelector('[data-pyric-entry-path="avatars/alice.png"]'),
+      ).not.toBeNull(),
+    );
+    expect(view.container.querySelector('[data-pyric-object-metadata]')).toBeNull();
+  });
+});

--- a/packages/studio/test/features/data/storage-navigation.test.tsx
+++ b/packages/studio/test/features/data/storage-navigation.test.tsx
@@ -82,10 +82,20 @@ const LIST_AVATARS = {
   rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' },
 } as StudioTrafficEvent;
 
-function StorageListTrafficRow() {
+const LIST_ROOT = {
+  ...LIST_AVATARS,
+  id: 'storage-list-root',
+  path: '',
+} as StudioTrafficEvent;
+
+function StorageListTrafficRow({
+  event = LIST_AVATARS,
+}: {
+  event?: StudioTrafficEvent;
+}) {
   return (
     <TrafficRow
-      event={LIST_AVATARS}
+      event={event}
       onSelect={(event) => {
         const target = subjectTarget(event as StudioTrafficEvent);
         if (target) pushPath(target);
@@ -119,6 +129,31 @@ describe('Storage route intent', () => {
     expect(
       view.container.querySelector('[data-pyric-ui="object-inspector"][data-pyric-error]'),
     ).toBeNull();
+  });
+
+  it('labels a Storage root list as slash and opens the bucket root', async () => {
+    const storage = makeStorage();
+    await uploadBytes(ref(storage, 'avatars/alice.png'), new Uint8Array([1]));
+    window.history.replaceState(null, '', '/traffic');
+
+    const view = render(
+      <>
+        <StorageListTrafficRow event={LIST_ROOT} />
+        <RoutedStoragePane storage={storage} />
+      </>,
+    );
+    const row = view.container.querySelector('[data-pyric-traffic-row]')!;
+    expect(row.querySelector('[data-pyric-traffic-path]')!.textContent).toBe('/');
+
+    fireEvent.click(row);
+    expect(window.location.pathname + window.location.search).toBe('/storage');
+    await waitFor(() =>
+      expect(
+        view.container.querySelector(
+          '[data-pyric-entry-kind="folder"][data-pyric-entry-path="avatars"]',
+        ),
+      ).not.toBeNull(),
+    );
   });
 
   it('browses a prefix and inspects an object at the identical path', async () => {

--- a/packages/ui/src/traffic/components/TrafficRow.tsx
+++ b/packages/ui/src/traffic/components/TrafficRow.tsx
@@ -62,7 +62,7 @@ export function TrafficRow({
       <span data-pyric-traffic-time="">{formatTime(event.at)}</span>
       <span data-pyric-traffic-service={event.service ?? ''}>{event.service ?? ''}</span>
       <Badge kind={event.method}>{event.method}</Badge>
-      <span data-pyric-traffic-path="">{event.path}</span>
+      <span data-pyric-traffic-path="">{event.path || '/'}</span>
       {renderClassification ? renderClassification(event) : null}
     </button>
   );


### PR DESCRIPTION
Storage `LIST` traffic rows now carry prefix intent through Studio routing, including bucket-root reads, and open the listed folder instead of object metadata.

```ts
import { subjectTarget } from "./verdict.js";

subjectTarget({ service: "storage", method: "list", path: "avatars" });
// => { tab: "storage", rest: ["avatars"], query: { kind: "prefix" } }

subjectTarget({ service: "storage", method: "list", path: "" });
// => { tab: "storage" }

subjectTarget({ service: "storage", method: "get", path: "avatars" });
// => { tab: "storage", rest: ["avatars"] }
```

## Storage paths now encode prefix intent without probing metadata

`/storage/avatars?kind=prefix` browses the prefix and displays `avatars/alice.png`; `/storage/avatars` retains object-inspection semantics. The distinction round-trips through the route codec even when an object named `avatars` and the `avatars/` prefix both exist.

A Storage root `list` now renders its empty canonical path as `/` in Traffic and navigates to `/storage`. Folder navigation writes prefix targets to browser history, so reload and Back restore the browsed prefix while object selection writes an object target. Both normal Traffic rows and grouped members continue through the same method-aware target helper.

## Risk

The main risk is the Storage pane state transition from local selection state to URL-derived state. Folder creation, breadcrumbs, deletion fallback, object selection, reload, and Back navigation now all depend on the route target. Existing Storage object URLs remain backward compatible because a missing `kind=prefix` query still decodes as an object.

<details>
<summary>Implementation notes</summary>

- Added pure coverage for Storage `list` versus object-operation targeting, including empty and slash root paths.
- Added route serialization coverage proving prefix and object targets remain distinct.
- Added rendered Storage integration tests that click `LIST avatars` and root `LIST` Traffic rows, verify the expected browser contents, and reject object-inspector errors.
- Added coexistence and browser Back regressions using the real in-process Storage sandbox.
- Studio test suite: 305 passed.
- UI and Studio typechecks passed; the Studio production build passed.
- Chromium verification covered prefix LIST navigation, root LIST navigation, reload, object inspection, and Back.

Closes #281

</details>