### PR TITLE
feat(studio): foreground observed traffic metrics

### DIFF
--- a/packages/studio/src/features/traffic/TrafficMetricsViews.tsx
+++ b/packages/studio/src/features/traffic/TrafficMetricsViews.tsx
@@ -1,6 +1,6 @@
 /**
- * Traffic tab strip, views 2 + 3: "Billable metrics" and "Subscriptions &
- * Rules" (Firebase Console "Usage" reference). Both metric charts reuse the
+ * Traffic tab strip, views 2 + 3: "Billable metrics" and "Rules"
+ * (Firebase Console "Usage" reference). Both metric charts reuse the
  * `@pyric/ui/traffic` bucketing hooks unchanged — this module is rendering
  * + the Studio-specific Rules-bypass classifier only.
  *
@@ -9,32 +9,34 @@
  * Studio supplies the canonical Rules disposition. The metrics therefore do
  * not infer rule behavior from the operation's source or auth lens.
  *
- * ── Subscriptions gap (documented, not faked) ──
- * The Console reference charts two subscription metrics: peak snapshot
- * listeners and peak active connections. Neither is derivable honestly
- * today: `ListenerLifecycleEvent` (attach/detach/errored,
- * `pyric/sandbox`'s `types.ts`) exists at the sandbox layer, but
- * `studio-data.ts#isTrafficEvent` only admits `kind: 'request' | 'operation'`
- * — lifecycle events never reach `useStudioTraffic`, and `TrafficEvent`
- * itself has no lifecycle-kind variant to carry them if they did. Charting
- * a "peak listeners" number here would mean inventing data no observed
- * event supports, so this view names the gap instead: what's missing is
- * (1) widening `TrafficEvent`/`isTrafficEvent`/`toTrafficEvent` to carry
- * `ListenerLifecycleEvent`, and (2) a bucketing kernel that tracks
- * concurrent attach/detach state per bucket (a running count, not a
- * simple per-event tally like billable/rules metrics).
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import {
   TrafficLineChart,
   TrafficMetricCards,
   useBillableMetrics,
   useRulesMetrics,
+  type MetricPoint,
   type MetricSeries,
   type TimeWindow,
 } from '@pyric/ui/traffic';
 import { verdictFor, type StudioTrafficEvent } from './verdict.js';
+import { billableStory, rulesStory, type MetricStory } from './metric-story.js';
+
+const metricNumberFormatter = new Intl.NumberFormat();
+const metricTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+function formatMetricNumber(value: number): string {
+  return metricNumberFormatter.format(value);
+}
+
+function formatMetricTime(value: number): string {
+  return metricTimeFormatter.format(value);
+}
 
 /** Shared bypass classifier: rules metrics exclude operations whose canonical
  * disposition says Rules were bypassed. */
@@ -46,25 +48,35 @@ function allZero(series: readonly MetricSeries[]): boolean {
   return series.every((s) => s.total === 0);
 }
 
-/** One metric chart: the total-cards legend (checkbox toggles) above a
- *  line chart, sharing one visibility set between the two. */
-function MetricPanel({
-  title,
+/** Shared data-journal composition: observed story, direct totals, evidence,
+ *  and a visible source boundary with methodology on demand. */
+function JournalMetricPanel({
+  eyebrow,
+  story,
   series,
   points,
+  window,
   emptyLabel,
+  evidenceTitle,
+  source,
+  methodology,
 }: {
-  title: string;
+  eyebrow: string;
+  story: MetricStory;
   series: MetricSeries[];
-  points: { index: number; start: number; end: number }[];
+  points: MetricPoint[];
+  window: TimeWindow;
   emptyLabel: string;
+  evidenceTitle: string;
+  source: string;
+  methodology: ReactNode;
 }) {
   const [visible, setVisible] = useState<Set<string>>(
-    () => new Set(series.map((s) => s.key)),
+    () => new Set(series.map((item) => item.key)),
   );
   const toggle = useCallback((key: string) => {
-    setVisible((prev) => {
-      const next = new Set(prev);
+    setVisible((previous) => {
+      const next = new Set(previous);
       if (next.has(key)) next.delete(key);
       else next.add(key);
       return next;
@@ -72,24 +84,57 @@ function MetricPanel({
   }, []);
 
   return (
-    <section className="traffic__metric-panel" data-pyric-ui="traffic-metric-panel">
-      <h3 className="traffic__metric-title">{title}</h3>
+    <section
+      className="traffic__metric-panel traffic__metric-panel--journal"
+      data-pyric-ui="traffic-metric-panel"
+    >
+      <header className="traffic__metric-story">
+        <p className="traffic__metric-eyebrow">{eyebrow}</p>
+        <h3 className="traffic__metric-headline">{story.headline}</h3>
+        <p className="traffic__metric-finding">{story.finding}</p>
+      </header>
+
       <TrafficMetricCards
         series={series}
         visible={visible}
         onToggle={toggle}
-        className="traffic__metric-cards"
+        formatValue={formatMetricNumber}
+        className={`traffic__metric-cards traffic__metric-cards--journal traffic__metric-cards--${series.length}`}
       />
+
       {allZero(series) ? (
         <p className="traffic__empty">{emptyLabel}</p>
       ) : (
-        <TrafficLineChart
-          points={points}
-          series={series}
-          visible={visible}
-          className="traffic__chart"
-        />
+        <div className="traffic__metric-evidence">
+          <div className="traffic__metric-evidence-header">
+            <h4>{evidenceTitle}</h4>
+            <span>
+              {formatMetricTime(window.start)}–{formatMetricTime(window.end)}
+            </span>
+          </div>
+          <TrafficLineChart
+            points={points}
+            series={series}
+            visible={visible}
+            omitZeroSeries
+            formatValue={formatMetricNumber}
+            formatTime={formatMetricTime}
+            className="traffic__chart traffic__chart--journal"
+          />
+          <div className="traffic__metric-axis" aria-hidden="true">
+            <span>{formatMetricTime(window.start)}</span>
+            <span>{formatMetricTime(window.end)}</span>
+          </div>
+        </div>
       )}
+
+      <footer className="traffic__metric-footer">
+        <p className="traffic__metric-source">{source}</p>
+        <details className="traffic__metric-methodology">
+          <summary>How this is counted</summary>
+          <div>{methodology}</div>
+        </details>
+      </footer>
     </section>
   );
 }
@@ -102,51 +147,98 @@ export function BillableMetricsView({
   events: StudioTrafficEvent[];
   window: TimeWindow;
 }) {
-  const metrics = useBillableMetrics({ events, window, isAdmin: isBypassedOp });
+  // The billing semantics documented below are Firestore-specific. Storage and
+  // RTDB operations can share method names but not Firestore's billing unit.
+  const firestoreEvents = useMemo(
+    () => events.filter((event) => (event.service ?? 'firestore') === 'firestore'),
+    [events],
+  );
+  const metrics = useBillableMetrics({
+    events: firestoreEvents,
+    window,
+    isAdmin: isBypassedOp,
+  });
+  const story = useMemo(() => billableStory(metrics.series), [metrics.series]);
+
   return (
     <div className="traffic__metrics" data-pyric-ui="traffic-billable-view">
-      <MetricPanel
-        title="Billable metrics"
+      <JournalMetricPanel
+        eyebrow="Billable activity"
+        story={story}
         series={metrics.series}
         points={metrics.points}
+        window={window}
         emptyLabel="No reads, writes, or deletes in this session yet."
+        evidenceTitle="When the activity happened"
+        source="Source: Pyric Firestore sandbox events · Operation counts, not a Firebase invoice"
+        methodology={
+          <>
+            <p>
+              Counts successful Firestore sandbox <code>get</code>/<code>list</code>,{' '}
+              <code>create</code>/<code>update</code>/<code>set</code>, and{' '}
+              <code>delete</code>/<code>remove</code> operations in the displayed window.
+              Rules-bypassed admin operations are included because they still execute.
+            </p>
+            <p>
+              <strong>Read ops are a proxy, not billed document reads.</strong> Each{' '}
+              <code>list</code> is counted once because the event does not report how many
+              documents the query returned. This is observed sandbox activity, not a Firebase
+              invoice.
+            </p>
+          </>
+        }
       />
-      <p className="traffic__metric-note">
-        "Read ops" counts <code>get</code>/<code>list</code> operations, not documents returned —
-        a <code>list</code> event doesn't carry how many documents its query matched (see the
-        gap note below), so this is an operation count, not a byte-accurate bill.
-      </p>
     </div>
   );
 }
 
-/** Tab 3: rules allow/deny/error metrics + the honest subscriptions gap. */
-export function SubscriptionsRulesView({
+/** Tab 3: rules allow/deny/error metrics. */
+export function RulesMetricsView({
   events,
   window,
 }: {
   events: StudioTrafficEvent[];
   window: TimeWindow;
 }) {
-  const rules = useRulesMetrics({ events, window, isAdmin: isBypassedOp });
+  const evaluatedEvents = useMemo(
+    () => events.filter((event) => event.rulesDisposition.kind === 'evaluated'),
+    [events],
+  );
+  const rules = useRulesMetrics({ events: evaluatedEvents, window });
+  // `RulesDisposition` has only allow/deny verdicts. A runtime error is
+  // explicitly `not-evaluated`, so the shared hook's generic error series is
+  // not a Rules metric in Studio.
+  const decisionSeries = useMemo(
+    () => rules.series.filter((series) => series.key === 'allows' || series.key === 'denies'),
+    [rules.series],
+  );
+  const story = useMemo(() => rulesStory(decisionSeries), [decisionSeries]);
+
   return (
-    <div className="traffic__metrics" data-pyric-ui="traffic-subscriptions-rules-view">
-      <section className="traffic__metric-panel" data-pyric-ui="traffic-subscriptions-gap">
-        <h3 className="traffic__metric-title">Subscription metrics</h3>
-        <p className="traffic__empty">
-          Not available yet: the event stream doesn't carry snapshot-listener lifecycle
-          (attach/detach) or an active-connection count, so a "peak listeners" chart here would
-          be invented, not observed. Charting this needs the sandbox's{' '}
-          <code>ListenerLifecycleEvent</code> (attach/detach/errored) to reach the Traffic event
-          stream — it's tracked internally but currently stops before{' '}
-          <code>useStudioTraffic</code>.
-        </p>
-      </section>
-      <MetricPanel
-        title="Rules metrics"
-        series={rules.series}
+    <div className="traffic__metrics" data-pyric-ui="traffic-rules-view">
+      <JournalMetricPanel
+        eyebrow="Rules decisions"
+        story={story}
+        series={decisionSeries}
         points={rules.points}
-        emptyLabel="No rule evaluations in this session yet."
+        window={window}
+        emptyLabel="No allow or deny decisions in this session yet."
+        evidenceTitle="When Rules evaluated requests"
+        source="Source: Pyric sandbox events · Evaluated Rules dispositions only"
+        methodology={
+          <>
+            <p>
+              Counts only operations whose canonical Rules disposition is{' '}
+              <code>evaluated</code>, grouped by its <code>allow</code> or <code>deny</code>{' '}
+              verdict.
+            </p>
+            <p>
+              <strong>Bypasses and runtime failures are not Rules decisions.</strong> Admin
+              bypasses, services without Rules, unsupported operations, and runtime errors are
+              excluded because Rules did not produce a verdict.
+            </p>
+          </>
+        }
       />
     </div>
   );

--- a/packages/studio/src/features/traffic/TrafficSurface.tsx
+++ b/packages/studio/src/features/traffic/TrafficSurface.tsx
@@ -51,25 +51,20 @@ import {
 } from './verdict.js';
 import { queryWithInspect, selectedInspectId, toggleInspect } from './inspect-selection.js';
 import { TrafficRulesInspector } from './TrafficRulesInspector.js';
-import { BillableMetricsView, SubscriptionsRulesView } from './TrafficMetricsViews.js';
+import { BillableMetricsView, RulesMetricsView } from './TrafficMetricsViews.js';
+import { TRAFFIC_TABS, trafficTabForView, type TrafficTab } from './traffic-tabs.js';
 import './traffic.css';
 
+export type { TrafficTab } from './traffic-tabs.js';
+
 /** The Traffic tab strip's three views (Firebase Console "Usage" reference:
- *  Timeline / Billable metrics / Subscriptions & Rules), deep-linkable via
+ *  Timeline / Billable metrics / Rules), deep-linkable via
  *  `?view=` (omitted for the default `timeline`, matching the `inspect`
  *  param's drop-when-empty precedent in `shell/path.ts`). */
-export type TrafficTab = 'timeline' | 'billable' | 'subscriptions';
-const TRAFFIC_TABS: ReadonlyArray<{ id: TrafficTab; label: string }> = [
-  { id: 'timeline', label: 'Timeline' },
-  { id: 'billable', label: 'Billable metrics' },
-  { id: 'subscriptions', label: 'Subscriptions & Rules' },
-];
-
 function deriveTrafficTab(): TrafficTab {
   const { tab, query } = currentPath();
   if (tab !== 'traffic') return 'timeline';
-  const v = query.view;
-  return v === 'billable' || v === 'subscriptions' ? v : 'timeline';
+  return trafficTabForView(query.view);
 }
 
 /** Two-way bind the active Traffic tab to `?view=`, mirroring `useDataNav`'s
@@ -264,8 +259,8 @@ export function TrafficSurface() {
 
       {tab === 'billable' ? (
         <BillableMetricsView events={events} window={window} />
-      ) : tab === 'subscriptions' ? (
-        <SubscriptionsRulesView events={events} window={window} />
+      ) : tab === 'rules' ? (
+        <RulesMetricsView events={events} window={window} />
       ) : (
         <>
           <TrafficTimeline

--- a/packages/studio/src/features/traffic/metric-story.test.ts
+++ b/packages/studio/src/features/traffic/metric-story.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import type { MetricSeries } from '@pyric/ui/traffic';
+import { billableStory, rulesStory } from './metric-story.js';
+
+function series(reads: number, writes: number, deletes: number): MetricSeries[] {
+  return [
+    { key: 'reads', label: 'Read ops', values: [], total: reads },
+    { key: 'writes', label: 'Writes', values: [], total: writes },
+    { key: 'deletes', label: 'Deletes', values: [], total: deletes },
+  ];
+}
+
+describe('billableStory', () => {
+  it('leads with the observed total and largest share', () => {
+    expect(billableStory(series(8, 1, 1))).toEqual({
+      total: 10,
+      headline: '10 observed billable operations',
+      finding: 'Read operations accounted for 80% of activity in this window.',
+    });
+  });
+
+  it('describes a tie without choosing a false leader', () => {
+    expect(billableStory(series(2, 2, 1)).finding).toBe(
+      'Read operations and writes tied for the largest share of activity in this window.',
+    );
+  });
+
+  it('has an observed empty-state claim', () => {
+    expect(billableStory(series(0, 0, 0))).toEqual({
+      total: 0,
+      headline: 'No billable activity observed',
+      finding: 'Successful reads, writes, and deletes will appear here as they happen.',
+    });
+  });
+});
+
+describe('rulesStory', () => {
+  const rulesSeries = (allows: number, denies: number): MetricSeries[] => [
+    { key: 'allows', label: 'Allows', values: [], total: allows },
+    { key: 'denies', label: 'Denies', values: [], total: denies },
+  ];
+
+  it('leads with observed evaluations and their largest share', () => {
+    expect(rulesStory(rulesSeries(3, 1))).toEqual({
+      total: 4,
+      headline: '4 observed Rules evaluations',
+      finding: 'Allowed requests accounted for 75% of evaluations in this window.',
+    });
+  });
+
+  it('does not manufacture a leader for an even split', () => {
+    expect(rulesStory(rulesSeries(2, 2)).finding).toBe(
+      'Evaluations were split evenly between allowed requests and denied requests.',
+    );
+  });
+
+  it('describes the empty observed state', () => {
+    expect(rulesStory(rulesSeries(0, 0))).toEqual({
+      total: 0,
+      headline: 'No Rules evaluations observed',
+      finding: 'Allow and deny decisions will appear here as Rules evaluate requests.',
+    });
+  });
+});

--- a/packages/studio/src/features/traffic/metric-story.ts
+++ b/packages/studio/src/features/traffic/metric-story.ts
@@ -1,0 +1,103 @@
+import type { MetricSeries } from '@pyric/ui/traffic';
+
+const numberFormatter = new Intl.NumberFormat();
+
+const billableLabels: Record<string, string> = {
+  reads: 'read operations',
+  writes: 'writes',
+  deletes: 'deletes',
+};
+
+const rulesLabels: Record<string, string> = {
+  allows: 'allowed requests',
+  denies: 'denied requests',
+};
+
+function joinLabels(labels: readonly string[]): string {
+  if (labels.length <= 1) return labels[0] ?? '';
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
+}
+
+function sentenceCase(value: string): string {
+  return value ? `${value[0]!.toUpperCase()}${value.slice(1)}` : value;
+}
+
+export interface MetricStory {
+  total: number;
+  headline: string;
+  finding: string;
+}
+
+interface StoryOptions {
+  labels: Record<string, string>;
+  singular: string;
+  plural: string;
+  subject: string;
+  evenSplitPrefix: string;
+  emptyHeadline: string;
+  emptyFinding: string;
+}
+
+/** Turn metric totals into a factual summary without inventing a comparison. */
+function metricStory(series: readonly MetricSeries[], options: StoryOptions): MetricStory {
+  const total = series.reduce((sum, item) => sum + item.total, 0);
+  if (total === 0) {
+    return {
+      total,
+      headline: options.emptyHeadline,
+      finding: options.emptyFinding,
+    };
+  }
+
+  const largest = Math.max(...series.map((item) => item.total));
+  const leaders = series.filter((item) => item.total === largest);
+  const headline = `${numberFormatter.format(total)} observed ${
+    total === 1 ? options.singular : options.plural
+  }`;
+  const labelFor = (item: MetricSeries) => options.labels[item.key] ?? item.label.toLowerCase();
+
+  if (leaders.length > 1) {
+    const names = leaders.map(labelFor);
+    return {
+      total,
+      headline,
+      finding:
+        leaders.length === series.length
+          ? `${options.evenSplitPrefix} ${joinLabels(names)}.`
+          : `${sentenceCase(joinLabels(names))} tied for the largest share of ${options.subject} in this window.`,
+    };
+  }
+
+  const leader = leaders[0]!;
+  const share = Math.round((leader.total / total) * 100);
+  return {
+    total,
+    headline,
+    finding: `${sentenceCase(labelFor(leader))} accounted for ${share}% of ${options.subject} in this window.`,
+  };
+}
+
+export function billableStory(series: readonly MetricSeries[]): MetricStory {
+  return metricStory(series, {
+    labels: billableLabels,
+    singular: 'billable operation',
+    plural: 'billable operations',
+    subject: 'activity',
+    evenSplitPrefix: 'Activity was split evenly across',
+    emptyHeadline: 'No billable activity observed',
+    emptyFinding: 'Successful reads, writes, and deletes will appear here as they happen.',
+  });
+}
+
+export function rulesStory(series: readonly MetricSeries[]): MetricStory {
+  return metricStory(series, {
+    labels: rulesLabels,
+    singular: 'Rules evaluation',
+    plural: 'Rules evaluations',
+    subject: 'evaluations',
+    evenSplitPrefix: 'Evaluations were split evenly between',
+    emptyHeadline: 'No Rules evaluations observed',
+    emptyFinding: 'Allow and deny decisions will appear here as Rules evaluate requests.',
+  });
+}

--- a/packages/studio/src/features/traffic/traffic-tabs.test.ts
+++ b/packages/studio/src/features/traffic/traffic-tabs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { TRAFFIC_TABS, trafficTabForView } from './traffic-tabs.js';
+
+describe('Traffic metric tabs', () => {
+  it('offers only metrics backed by observed events', () => {
+    expect(TRAFFIC_TABS).toEqual([
+      { id: 'timeline', label: 'Timeline' },
+      { id: 'billable', label: 'Billable metrics' },
+      { id: 'rules', label: 'Rules' },
+    ]);
+  });
+
+  it('routes the observed metric views', () => {
+    expect(trafficTabForView('billable')).toBe('billable');
+    expect(trafficTabForView('rules')).toBe('rules');
+  });
+
+  it('redirects legacy subscription links to the remaining Rules view', () => {
+    expect(trafficTabForView('subscriptions')).toBe('rules');
+  });
+
+  it('defaults unknown views to the timeline', () => {
+    expect(trafficTabForView(undefined)).toBe('timeline');
+    expect(trafficTabForView('unknown')).toBe('timeline');
+  });
+});

--- a/packages/studio/src/features/traffic/traffic-tabs.ts
+++ b/packages/studio/src/features/traffic/traffic-tabs.ts
@@ -1,0 +1,14 @@
+export type TrafficTab = 'timeline' | 'billable' | 'rules';
+
+export const TRAFFIC_TABS: ReadonlyArray<{ id: TrafficTab; label: string }> = [
+  { id: 'timeline', label: 'Timeline' },
+  { id: 'billable', label: 'Billable metrics' },
+  { id: 'rules', label: 'Rules' },
+];
+
+/** Resolve a `?view=` value, preserving links to the removed subscriptions view. */
+export function trafficTabForView(view: string | undefined): TrafficTab {
+  if (view === 'billable') return 'billable';
+  if (view === 'rules' || view === 'subscriptions') return 'rules';
+  return 'timeline';
+}

--- a/packages/studio/src/features/traffic/traffic.css
+++ b/packages/studio/src/features/traffic/traffic.css
@@ -20,8 +20,7 @@
   margin: 0;
 }
 
-/* ── Tab strip (S-TRAFFIC: Timeline / Billable metrics / Subscriptions &
-   Rules) ────────────────────────────────────────────────────────────── */
+/* ── Tab strip (S-TRAFFIC: Timeline / Billable metrics / Rules) ─────── */
 .traffic__tabs {
   display: flex;
   align-items: center;
@@ -92,19 +91,39 @@
   flex-direction: column;
   gap: var(--space-3);
 }
-.traffic__metric-title {
-  margin: 0;
-  font-size: var(--fs-label);
-  font-weight: 600;
-  color: var(--ink);
+/* Metric views use a data-journal hierarchy: the finding and observed totals
+   lead; the chart is supporting evidence; methodology is disclosed on demand. */
+.traffic__metric-panel--journal {
+  gap: var(--space-5);
 }
-.traffic__metric-note {
+.traffic__metric-story {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: 720px;
+}
+.traffic__metric-eyebrow {
   margin: 0;
   color: var(--faint);
-  font-size: var(--fs-caption);
+  font-size: var(--fs-micro);
+  font-weight: 600;
+  letter-spacing: var(--tracking-micro);
+  text-transform: uppercase;
 }
-.traffic__metric-note code {
-  font-family: var(--font-mono);
+.traffic__metric-headline {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: var(--fs-display);
+  font-weight: 650;
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+}
+.traffic__metric-finding {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--fs-body);
+  line-height: 1.5;
 }
 
 .traffic__metric-cards {
@@ -146,22 +165,104 @@
   color: var(--ink);
 }
 
+.traffic__metric-cards--journal {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+}
+.traffic__metric-cards--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.traffic__metric-cards--journal [data-pyric-metric-card] {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  grid-template-areas:
+    'toggle swatch label'
+    'value value value';
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  border: none;
+  border-top: 3px solid var(--pyric-series-color, var(--line-2));
+  border-radius: 0;
+  padding: var(--space-3) var(--space-4) var(--space-4);
+  background: transparent;
+}
+.traffic__metric-cards--journal [data-pyric-metric-card] + [data-pyric-metric-card] {
+  border-left: 1px solid var(--line);
+}
+.traffic__metric-cards--journal [data-pyric-metric-checkbox] {
+  grid-area: toggle;
+  margin: 0;
+}
+.traffic__metric-cards--journal [data-pyric-metric-swatch] {
+  grid-area: swatch;
+}
+.traffic__metric-cards--journal [data-pyric-metric-label] {
+  grid-area: label;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--fs-micro);
+  font-weight: 600;
+  letter-spacing: var(--tracking-micro);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.traffic__metric-cards--journal [data-pyric-metric-value] {
+  grid-area: value;
+  margin-top: var(--space-1);
+  font-family: var(--font-display);
+  font-size: var(--fs-display);
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+  line-height: 1;
+}
+
 /* Series color channel: one index per metric key, shared by a card's
    swatch and the chart's matching line — token roles only. */
+.traffic__metric-cards [data-pyric-series-index='0'],
 .traffic__metric-cards [data-pyric-series-index='0'] [data-pyric-metric-swatch],
 .traffic__chart [data-pyric-series-index='0'] {
   --pyric-series-color: var(--accent);
 }
+.traffic__metric-cards [data-pyric-series-index='1'],
 .traffic__metric-cards [data-pyric-series-index='1'] [data-pyric-metric-swatch],
 .traffic__chart [data-pyric-series-index='1'] {
   --pyric-series-color: var(--diff-add);
 }
+.traffic__metric-cards [data-pyric-series-index='2'],
 .traffic__metric-cards [data-pyric-series-index='2'] [data-pyric-metric-swatch],
 .traffic__chart [data-pyric-series-index='2'] {
   --pyric-series-color: var(--diff-remove);
 }
 .traffic__metric-cards [data-pyric-metric-swatch] {
   background: var(--pyric-series-color, var(--muted));
+}
+
+/* Rules is a decision pair: calm green for allows, consequential red for
+   denies. Billable retains the neutral three-series palette above. */
+[data-pyric-ui='traffic-rules-view']
+  .traffic__metric-cards
+  [data-pyric-series-index='0'],
+[data-pyric-ui='traffic-rules-view']
+  .traffic__metric-cards
+  [data-pyric-series-index='0']
+  [data-pyric-metric-swatch],
+[data-pyric-ui='traffic-rules-view'] .traffic__chart [data-pyric-series-index='0'] {
+  --pyric-series-color: var(--diff-add);
+}
+[data-pyric-ui='traffic-rules-view']
+  .traffic__metric-cards
+  [data-pyric-series-index='1'],
+[data-pyric-ui='traffic-rules-view']
+  .traffic__metric-cards
+  [data-pyric-series-index='1']
+  [data-pyric-metric-swatch],
+[data-pyric-ui='traffic-rules-view'] .traffic__chart [data-pyric-series-index='1'] {
+  --pyric-series-color: var(--diff-remove);
 }
 
 .traffic__chart {
@@ -238,6 +339,117 @@
 .traffic__chart [data-pyric-tooltip-value] {
   font-family: var(--font-mono);
   color: var(--ink);
+}
+
+.traffic__metric-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.traffic__metric-evidence-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.traffic__metric-evidence-header h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: var(--fs-label);
+  font-weight: 600;
+}
+.traffic__metric-evidence-header span,
+.traffic__metric-axis {
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+}
+.traffic__chart--journal {
+  border: none;
+  border-radius: 0;
+  padding: var(--space-3) 0 0;
+  background: transparent;
+}
+.traffic__chart--journal [data-pyric-chart-svg] {
+  height: 220px;
+  border-bottom: 1px solid var(--line);
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent,
+    transparent calc(25% - 1px),
+    var(--line) 25%
+  );
+}
+.traffic__chart--journal [data-pyric-chart-line] {
+  stroke-width: 2;
+}
+.traffic__metric-axis {
+  display: flex;
+  justify-content: space-between;
+}
+.traffic__metric-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--line);
+  padding-top: var(--space-3);
+}
+.traffic__metric-source {
+  margin: 0;
+  color: var(--faint);
+  font-size: var(--fs-caption);
+}
+.traffic__metric-methodology {
+  color: var(--muted);
+  font-size: var(--fs-caption);
+}
+.traffic__metric-methodology summary {
+  width: max-content;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: var(--fs-caption);
+  font-weight: 600;
+}
+.traffic__metric-methodology > div {
+  max-width: 760px;
+  padding-top: var(--space-2);
+  line-height: 1.55;
+}
+.traffic__metric-methodology p {
+  margin: 0;
+}
+.traffic__metric-methodology p + p {
+  margin-top: var(--space-2);
+}
+.traffic__metric-methodology code {
+  font-family: var(--font-mono);
+}
+.traffic__metric-methodology strong {
+  color: var(--ink);
+}
+
+@media (max-width: 620px) {
+  .traffic__metric-cards--journal [data-pyric-metric-card] {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      'swatch label'
+      'value value';
+    padding-inline: var(--space-2);
+  }
+  .traffic__metric-cards--journal [data-pyric-metric-checkbox] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    opacity: 0;
+  }
+  .traffic__metric-cards--journal [data-pyric-metric-card]:has(input:focus-visible) {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+  .traffic__metric-evidence-header span {
+    display: none;
+  }
 }
 
 /* ── Volume timeline ────────────────────────────────────────────────── */

--- a/packages/studio/src/styles/tokens.css
+++ b/packages/studio/src/styles/tokens.css
@@ -33,9 +33,11 @@
     Consolas, monospace;
   --font-display: var(--font-ui);
 
-  /* One tight type scale. Title for surface heads, body for prose, label for
-     UI controls, data for mono identifiers/values, micro for uppercase
-     eyebrows + column heads, caption for the quietest meta. */
+  /* One tight type scale. Display is reserved for an editorial headline or
+     primary metric; title for surface heads, body for prose, label for UI
+     controls, data for mono identifiers/values, micro for uppercase eyebrows
+     + column heads, caption for the quietest meta. */
+  --fs-display: 28px;
   --fs-title: 17px;
   --fs-body: 13px;
   --fs-label: 12px;

--- a/packages/studio/test/features/traffic/TrafficMetricsViews.test.tsx
+++ b/packages/studio/test/features/traffic/TrafficMetricsViews.test.tsx
@@ -1,0 +1,219 @@
+// Install JSDOM globals before importing React or RTL.
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  pretendToBeVisual: true,
+});
+const g = globalThis as any;
+g.window = dom.window;
+g.document = dom.window.document;
+g.HTMLElement = dom.window.HTMLElement;
+g.SVGElement = dom.window.SVGElement;
+g.Element = dom.window.Element;
+g.Node = dom.window.Node;
+g.Event = dom.window.Event;
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import {
+  BillableMetricsView,
+  RulesMetricsView,
+} from '../../../src/features/traffic/TrafficMetricsViews.js';
+import type { StudioTrafficEvent } from '../../../src/features/traffic/verdict.js';
+
+afterEach(() => cleanup());
+
+function operation(
+  id: string,
+  method: StudioTrafficEvent['method'],
+  at: number,
+): StudioTrafficEvent {
+  return {
+    id,
+    kind: 'operation',
+    service: 'firestore',
+    at,
+    method,
+    path: 'notes/one',
+    auth: null,
+    result: 'allow',
+    reasons: [],
+    origin: 'user',
+    operationContext: {
+      source: { kind: 'app' },
+      authLens: { mode: 'app-session' },
+    },
+    rulesDisposition: { kind: 'evaluated', verdict: 'allow' },
+  } as StudioTrafficEvent;
+}
+
+function rulesDecision(
+  id: string,
+  verdict: 'allow' | 'deny',
+  at: number,
+): StudioTrafficEvent {
+  return {
+    ...operation(id, 'get', at),
+    result: verdict,
+    rulesDisposition: { kind: 'evaluated', verdict },
+  } as StudioTrafficEvent;
+}
+
+describe('<BillableMetricsView>', () => {
+  it('leads with the observed story and prominent series totals', () => {
+    const events = [
+      operation('r1', 'get', 1_000),
+      operation('r2', 'get', 2_000),
+      operation('r3', 'list', 3_000),
+      operation('w1', 'set', 4_000),
+      operation('d1', 'delete', 5_000),
+    ];
+    const { container, getByText } = render(
+      <BillableMetricsView events={events} window={{ start: 0, end: 10_000 }} />,
+    );
+
+    expect(getByText('5 observed billable operations')).toBeTruthy();
+    expect(getByText('Read operations accounted for 60% of activity in this window.')).toBeTruthy();
+    expect(
+      container.querySelector('[data-pyric-metric-key="reads"] [data-pyric-metric-value]')
+        ?.textContent,
+    ).toBe('3');
+    expect(
+      container.querySelector('[data-pyric-metric-key="writes"] [data-pyric-metric-value]')
+        ?.textContent,
+    ).toBe('1');
+    expect(
+      container.querySelector('[data-pyric-metric-key="deletes"] [data-pyric-metric-value]')
+        ?.textContent,
+    ).toBe('1');
+    expect(getByText('When the activity happened')).toBeTruthy();
+  });
+
+  it('keeps the measurement boundary available but collapsed by default', () => {
+    const { container, getByText } = render(
+      <BillableMetricsView
+        events={[operation('r1', 'list', 1_000)]}
+        window={{ start: 0, end: 10_000 }}
+      />,
+    );
+
+    const methodology = container.querySelector('.traffic__metric-methodology') as HTMLDetailsElement;
+    expect(methodology.open).toBe(false);
+    expect(getByText('How this is counted')).toBeTruthy();
+    expect(container.textContent).toContain(
+      'Source: Pyric Firestore sandbox events · Operation counts, not a Firebase invoice',
+    );
+    expect(container.textContent).toContain('Read ops are a proxy, not billed document reads.');
+    expect(container.textContent).toContain('not a Firebase invoice');
+  });
+
+  it('does not mix other services into Firestore billing semantics', () => {
+    const storageRead = {
+      ...operation('storage-read', 'get', 2_000),
+      service: 'storage',
+    } as StudioTrafficEvent;
+    const rtdbWrite = {
+      ...operation('rtdb-write', 'set', 3_000),
+      service: 'rtdb',
+    } as StudioTrafficEvent;
+
+    const { getByText } = render(
+      <BillableMetricsView
+        events={[operation('firestore-read', 'get', 1_000), storageRead, rtdbWrite]}
+        window={{ start: 0, end: 10_000 }}
+      />,
+    );
+
+    expect(getByText('1 observed billable operation')).toBeTruthy();
+    expect(getByText('Read operations accounted for 100% of activity in this window.')).toBeTruthy();
+  });
+
+  it('uses each prominent metric as its chart-series toggle', () => {
+    const { container } = render(
+      <BillableMetricsView
+        events={[operation('r1', 'get', 1_000), operation('w1', 'set', 2_000)]}
+        window={{ start: 0, end: 10_000 }}
+      />,
+    );
+
+    expect(container.querySelector('[data-pyric-chart-line][data-pyric-series-key="reads"]')).toBeTruthy();
+    const readsToggle = container.querySelector(
+      '[data-pyric-metric-key="reads"] input[type="checkbox"]',
+    )!;
+    fireEvent.click(readsToggle);
+    expect(container.querySelector('[data-pyric-chart-line][data-pyric-series-key="reads"]')).toBeNull();
+  });
+});
+
+describe('<RulesMetricsView>', () => {
+  it('uses the same editorial hierarchy for observed allow and deny decisions', () => {
+    const events = [
+      rulesDecision('a1', 'allow', 1_000),
+      rulesDecision('a2', 'allow', 2_000),
+      rulesDecision('a3', 'allow', 3_000),
+      rulesDecision('d1', 'deny', 4_000),
+    ];
+    const { container, getByText } = render(
+      <RulesMetricsView events={events} window={{ start: 0, end: 10_000 }} />,
+    );
+
+    expect(getByText('4 observed Rules evaluations')).toBeTruthy();
+    expect(getByText('Allowed requests accounted for 75% of evaluations in this window.')).toBeTruthy();
+    expect(
+      container.querySelector('[data-pyric-metric-key="allows"] [data-pyric-metric-value]')
+        ?.textContent,
+    ).toBe('3');
+    expect(
+      container.querySelector('[data-pyric-metric-key="denies"] [data-pyric-metric-value]')
+        ?.textContent,
+    ).toBe('1');
+    expect(container.querySelector('[data-pyric-metric-key="errors"]')).toBeNull();
+    expect(getByText('When Rules evaluated requests')).toBeTruthy();
+  });
+
+  it('counts only canonical evaluated dispositions', () => {
+    const bypassed = {
+      ...operation('bypass', 'get', 2_000),
+      rulesDisposition: { kind: 'bypassed', reason: 'admin' },
+    } as StudioTrafficEvent;
+    const noRules = {
+      ...operation('no-rules', 'get', 3_000),
+      rulesDisposition: { kind: 'not-evaluated', reason: 'no-rules' },
+    } as StudioTrafficEvent;
+    const runtimeError = {
+      ...operation('runtime', 'get', 4_000),
+      result: 'error',
+      rulesDisposition: { kind: 'not-evaluated', reason: 'runtime-error' },
+    } as StudioTrafficEvent;
+
+    const { container, getByText } = render(
+      <RulesMetricsView
+        events={[rulesDecision('denied', 'deny', 1_000), bypassed, noRules, runtimeError]}
+        window={{ start: 0, end: 10_000 }}
+      />,
+    );
+
+    expect(getByText('1 observed Rules evaluation')).toBeTruthy();
+    expect(getByText('Denied requests accounted for 100% of evaluations in this window.')).toBeTruthy();
+    expect(container.textContent).toContain(
+      'Source: Pyric sandbox events · Evaluated Rules dispositions only',
+    );
+    expect(container.textContent).toContain('runtime errors are excluded');
+  });
+
+  it('keeps the prominent decision totals wired to chart visibility', () => {
+    const { container } = render(
+      <RulesMetricsView
+        events={[rulesDecision('allowed', 'allow', 1_000), rulesDecision('denied', 'deny', 2_000)]}
+        window={{ start: 0, end: 10_000 }}
+      />,
+    );
+
+    expect(container.querySelector('[data-pyric-chart-line][data-pyric-series-key="denies"]')).toBeTruthy();
+    fireEvent.click(
+      container.querySelector('[data-pyric-metric-key="denies"] input[type="checkbox"]')!,
+    );
+    expect(container.querySelector('[data-pyric-chart-line][data-pyric-series-key="denies"]')).toBeNull();
+  });
+});

--- a/packages/ui/src/traffic/components/TrafficLineChart.tsx
+++ b/packages/ui/src/traffic/components/TrafficLineChart.tsx
@@ -8,6 +8,9 @@ export interface TrafficLineChartProps {
    *  {@link TrafficMetricCards}' `visible`/`onToggle` so the legend cards
    *  and the chart's lines toggle in lockstep. */
   visible?: ReadonlySet<string>;
+  /** Omit all-zero series from the plot and tooltip while retaining their
+   *  explicit total in the accompanying metric strip. */
+  omitZeroSeries?: boolean;
   formatValue?: (n: number) => string;
   formatTime?: (t: number) => string;
   emptyState?: React.ReactNode;
@@ -40,6 +43,7 @@ export function TrafficLineChart({
   points,
   series,
   visible,
+  omitZeroSeries = false,
   formatValue = defaultFormatValue,
   formatTime = defaultFormatTime,
   emptyState,
@@ -55,7 +59,9 @@ export function TrafficLineChart({
     );
   }
 
-  const visibleSeries = series.filter((s) => !visible || visible.has(s.key));
+  const visibleSeries = series.filter(
+    (s) => (!visible || visible.has(s.key)) && (!omitZeroSeries || s.total > 0),
+  );
   let maxValue = 0;
   for (const s of visibleSeries) for (const v of s.values) if (v > maxValue) maxValue = v;
   const scale = maxValue === 0 ? 1 : maxValue;
@@ -72,7 +78,8 @@ export function TrafficLineChart({
         <svg viewBox="0 0 100 100" preserveAspectRatio="none" role="img" aria-label="metrics over time">
           {series.map((s) => {
             const seriesIndex = series.indexOf(s);
-            const isVisible = !visible || visible.has(s.key);
+            const isVisible =
+              (!visible || visible.has(s.key)) && (!omitZeroSeries || s.total > 0);
             if (!isVisible) return null;
             const d = s.values.map((v, i) => `${i === 0 ? 'M' : 'L'}${xAt(i)},${yAt(v)}`).join(' ');
             return (

--- a/packages/ui/src/traffic/hooks/useTrafficMetrics.ts
+++ b/packages/ui/src/traffic/hooks/useTrafficMetrics.ts
@@ -4,7 +4,7 @@ import type { TrafficEvent } from '../types.js';
 
 /**
  * Billable-metrics + rules-metrics aggregation (Traffic tab: "Billable
- * metrics" and "Subscriptions & Rules"). Mirrors the Firebase Console
+ * metrics" and "Rules"). Mirrors the Firebase Console
  * Usage tab's shape (per-series totals + a bucketed time series), built
  * on top of the same half-open `[window.start, window.end)` bucketing
  * kernel {@link bucketTraffic} already uses.

--- a/packages/ui/test/traffic/components/TrafficLineChart.test.tsx
+++ b/packages/ui/test/traffic/components/TrafficLineChart.test.tsx
@@ -57,6 +57,17 @@ describe('<TrafficLineChart>', () => {
     expect(container.querySelector('[data-pyric-series-key="reads"]')).toBeNull();
   });
 
+  it('can omit zero-total series without hiding their metric card', () => {
+    const events = [evt({ at: 50, method: 'get', result: 'allow' })];
+    const { points, series } = bucketBillableMetrics(events, WINDOW, 10);
+    const { container } = render(
+      <TrafficLineChart points={points} series={series} omitZeroSeries />,
+    );
+    const lines = container.querySelectorAll('[data-pyric-chart-line]');
+    expect(lines.length).toBe(1);
+    expect(lines[0].getAttribute('data-pyric-series-key')).toBe('reads');
+  });
+
   it('shows a tooltip with per-series values on hover', () => {
     const events = [evt({ at: 50, method: 'get', result: 'allow' })];
     const { points, series } = bucketBillableMetrics(events, WINDOW, 10);


### PR DESCRIPTION
Reframes Studio’s Traffic metrics as an observed-data journal and removes the unsupported subscription placeholder.

```text
BILLABLE ACTIVITY
5 observed billable operations
Read operations accounted for 60% of activity in this window.

READ OPS  3        WRITES  1        DELETES  1
──────────────────────────────────────────────
When the activity happened

Source: Pyric Firestore sandbox events · Operation counts, not a Firebase invoice
```

## Rules totals exclude events where Rules produced no decision

The adjacent Rules view uses the same hierarchy: an observed-evaluation headline, a plain-language finding, prominent Allow and Deny totals, and the chart as supporting evidence. It counts only canonical `evaluated` dispositions. Admin bypasses, services without Rules, unsupported operations, and runtime errors are excluded because none produced a Rules verdict.

The main review judgment is that narrower boundary. The previous generic metrics series could present runtime failures as Rules “Errors”; this view removes that card instead of implying Rules evaluated those requests.

## Billable activity is explicitly Firestore operation activity

Billable metrics no longer mix Storage or Realtime Database events into Firestore billing semantics. The visible source line and collapsed methodology state that reads are operation counts—each `list` counts once—not returned-document counts or a Firebase invoice. Zero-total series remain visible as explicit totals but no longer draw meaningless flat chart lines.

## Legacy subscription links now land on Rules

The Traffic tabs are Timeline, Billable metrics, and Rules. Existing `?view=subscriptions` links resolve to Rules rather than breaking. Subscription listener and connection charts remain absent until both gauges can be observed exactly; #284 records the required lifecycle, baseline, and aggregation work.

The navigation rename and the interpretation of Rules totals are the user-visible risks. Focused tests cover the legacy redirect, Firestore-only billing scope, evaluated-disposition boundary, prominent totals, source text, and chart toggles.

<details>
<summary>Implementation notes and verification</summary>

- The journal composition is shared by Billable metrics and Rules; their metric stories remain separate pure functions.
- `TrafficLineChart` adds `omitZeroSeries`, leaving the metric strip responsible for showing explicit zero totals.
- Studio test suite: 322 passed, 0 failed across 39 files.
- UI test suite passed.
- Studio and UI typechecks passed.
- Studio and UI production builds passed.
- Desktop and mobile layouts were checked against live Studio traffic.
- `git diff --check` passed.

</details>
