### PR TITLE
Functions: add Admin RTDB resolver prerequisites

### DIFF
--- a/packages/cli/src/register/index.ts
+++ b/packages/cli/src/register/index.ts
@@ -58,11 +58,12 @@ const moduleApi = Module as unknown as {
  * CJS→ESM seam: a rewritten `require()` fails against the pyric mirrors'
  * `import`-condition-only exports (the CJS resolver ignores hook-supplied
  * condition overrides), even though `require(esm)` can load them fine.
- * Locate the package from the REQUIRING module and resolve the subpath under
- * import conditions ourselves. Returns the resolved file URL, or null to
- * rethrow the original error.
+ * Locate the package from this installed CLI and resolve the subpath under
+ * import conditions ourselves. The user's function package is not required
+ * to install Pyric's mapped targets. Returns the resolved file URL, or null
+ * to rethrow the original error.
  */
-function resolveEsmOnlyForRequire(mapped: string, parentURL: string | undefined): string | null {
+function resolveEsmOnlyForRequire(mapped: string): string | null {
   if (typeof moduleApi.findPackageJSON !== 'function') return null;
   const slash = mapped.indexOf('/');
   const pkgName = slash === -1 ? mapped : mapped.slice(0, slash);
@@ -71,7 +72,7 @@ function resolveEsmOnlyForRequire(mapped: string, parentURL: string | undefined)
   try {
     pkgJsonPath = moduleApi.findPackageJSON(
       pkgName,
-      parentURL ?? pathToFileURL(join(process.cwd(), 'noop.js')),
+      import.meta.url,
     );
   } catch {
     return null;
@@ -94,14 +95,15 @@ function activate(): void {
         const mapped = mapFirebaseSpecifier(specifier);
         if (mapped === null) return nextResolve(specifier, context);
         try {
-          return nextResolve(mapped, context);
+          return nextResolve(mapped, { ...context, parentURL: import.meta.url });
         } catch (err) {
           // CJS `require('firebase-admin/app')` resolves under the `require`
           // condition, but the pyric mirrors are ESM-only. Resolve the file
           // under import conditions ourselves — require(esm) (Node ≥ 22.12)
           // loads it fine once given the URL.
-          if ((err as { code?: string }).code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-            const url = resolveEsmOnlyForRequire(mapped, context.parentURL);
+          const code = (err as { code?: string }).code;
+          if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'MODULE_NOT_FOUND') {
+            const url = resolveEsmOnlyForRequire(mapped);
             if (url) return { url, shortCircuit: true };
           }
           throw err;

--- a/packages/cli/test/register/register-child.test.ts
+++ b/packages/cli/test/register/register-child.test.ts
@@ -28,6 +28,7 @@ const hasRegisterHooks =
 
 let fixtureDir: string;
 let inactiveFixtureDir: string;
+let isolatedFixtureDir: string;
 
 function runNode(
   script: string,
@@ -69,6 +70,24 @@ beforeAll(() => {
   writeFileSync(
     join(inactiveFixtureDir, 'package.json'),
     JSON.stringify({ name: 'register-inactive-fixture', type: 'module' }),
+  );
+
+  // Installed-CLI fixture: the user package intentionally has neither
+  // firebase-admin nor pyric-admin in its own dependency tree. The register
+  // hook must resolve its mapped target from @pyric/cli's installation.
+  isolatedFixtureDir = mkdtempSync(join(tmpdir(), 'pyric-register-isolated-'));
+  mkdirSync(join(isolatedFixtureDir, 'node_modules'));
+  writeFileSync(
+    join(isolatedFixtureDir, 'package.json'),
+    JSON.stringify({ name: 'register-isolated-fixture', type: 'commonjs' }),
+  );
+  writeFileSync(
+    join(isolatedFixtureDir, 'database.cjs'),
+    `const assert = require('node:assert');
+const database = require('firebase-admin/database');
+assert.strictEqual(typeof database.getDatabaseWithUrl, 'function');
+console.log('ISOLATED_DATABASE_OK');
+`,
   );
 
   // ESM fixture: env is set, firebase-admin/app IS pyric-admin (its
@@ -174,6 +193,7 @@ console.log(JSON.stringify({
 afterAll(() => {
   if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
   if (inactiveFixtureDir) rmSync(inactiveFixtureDir, { recursive: true, force: true });
+  if (isolatedFixtureDir) rmSync(isolatedFixtureDir, { recursive: true, force: true });
 });
 
 describe('@pyric/cli/register (child process)', () => {
@@ -205,6 +225,20 @@ describe('@pyric/cli/register (child process)', () => {
     expect(res.stderr).toContain('@pyric/cli/register: active');
     expect(res.stdout).toContain('CJS_OK');
     expect(res.status).toBe(0);
+  });
+
+  it.skipIf(!hasRegisterHooks)('resolves mapped packages from the installed CLI rather than the requiring package', () => {
+    expect(existsSync(join(isolatedFixtureDir, 'node_modules/pyric-admin'))).toBe(false);
+    expect(existsSync(join(isolatedFixtureDir, 'node_modules/firebase-admin'))).toBe(false);
+    const res = runNode(
+      'database.cjs',
+      { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' },
+      isolatedFixtureDir,
+    );
+    expect(res).toMatchObject({
+      status: 0,
+      stdout: expect.stringContaining('ISOLATED_DATABASE_OK'),
+    });
   });
 
   it('is inert without PYRIC_SANDBOX — real firebase-admin, no factory, no log', () => {

--- a/packages/pyric-admin/docs/database/reference/api.generated.md
+++ b/packages/pyric-admin/docs/database/reference/api.generated.md
@@ -436,17 +436,15 @@ Mirror-owned structural types for the implemented admin RTDB surface.
 
 Returns the AdminDatabase service for the supplied app.
 
-Signature mirrors `firebase-admin/database`'s `getDatabase(app?)` and
-`getDatabaseWithUrl(url, app)` collapsed into a single function:
+Signature mirrors `firebase-admin/database`'s `getDatabase(app?)`.
 
   - `getDatabase()` — default database for the DEFAULT app (resolved
     through `pyric-admin/app`'s registry, exactly like firebase-admin's
     no-arg `getDatabase()`; throws `app/no-app` when no default app has
     been initialized). Works for local and remote sandbox apps.
   - `getDatabase(app)` — default database for the app.
-  - `getDatabase(app, url)` — accepts the upstream-compatible URL
-    position, which the sandbox ignores because it has no notion of
-    multiple database instances per project.
+  - `getDatabase(app, url)` — legacy Pyric-only compatibility form. New
+    code should use the upstream-shaped [getDatabaseWithUrl](#getdatabasewithurl) export.
 
 The sandbox brand returns the local or remote `Database` backed by the
 per-`Sandbox` state described in the module-level docs.
@@ -460,6 +458,34 @@ per-`Sandbox` state described in the module-level docs.
 ##### \_url?
 
 `string`
+
+#### Returns
+
+[`Database`](#database)
+
+***
+
+### getDatabaseWithUrl()
+
+> **getDatabaseWithUrl**(`_url`, `app?`): [`Database`](#database)
+
+Returns the AdminDatabase service selected by an upstream-shaped
+database URL.
+
+This is the exact `firebase-admin/database` argument order used by the
+Firebase Functions SDK: `getDatabaseWithUrl(url, app?)`. The first Pyric
+Functions slice has one shared RTDB instance, so the URL selects that
+instance rather than creating a second sandbox database.
+
+#### Parameters
+
+##### \_url
+
+`string`
+
+##### app?
+
+`SandboxAdminApp`
 
 #### Returns
 

--- a/packages/pyric-admin/docs/database/reference/api.md
+++ b/packages/pyric-admin/docs/database/reference/api.md
@@ -14,19 +14,30 @@ absent.
 
 ## Initialization
 
-### `getDatabase(app?, url?)`
+### `getDatabase(app?, legacyUrl?)`
 
 ```ts
-function getDatabase(app?: PyricAdminApp, url?: string): Database;
+function getDatabase(app?: PyricAdminApp, legacyUrl?: string): Database;
 ```
 
-firebase-admin's `getDatabase(app?)` and `getDatabaseWithUrl(url, app)` collapsed into one function:
+Mirrors firebase-admin's `getDatabase(app?)`:
 
 - `getDatabase()`: default database for the `'[DEFAULT]'` sandbox app, resolved through `pyric-admin/app`'s registry. Throws `app/no-app` when nothing is initialized.
 - `getDatabase(app)`: default database for the app.
-- `getDatabase(app, url)`: accepts `url` for shape compatibility; the sandbox ignores it because it has no project-level database instances.
+- `getDatabase(app, legacyUrl)`: retained for compatibility with Pyric's former collapsed signature. New code should use `getDatabaseWithUrl`.
 
 Successive calls for the same sandbox return handles that share data, matching firebase-admin's singleton-per-app semantics. Throws `TypeError` for an unbranded value.
+
+### `getDatabaseWithUrl(url, app?)`
+
+```ts
+function getDatabaseWithUrl(url: string, app?: PyricAdminApp): Database;
+```
+
+Uses firebase-admin's exact URL-first argument order. The Functions SDK calls
+this export when materializing `event.data.ref`. Pyric's first Functions slice
+has one shared RTDB instance, so the URL selects that instance; it does not
+create a separate sandbox tree.
 
 ---
 

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -141,17 +141,15 @@ type AdminEventType = EventType;
 /**
  * Returns the {@link AdminDatabase} service for the supplied app.
  *
- * Signature mirrors `firebase-admin/database`'s `getDatabase(app?)` and
- * `getDatabaseWithUrl(url, app)` collapsed into a single function:
+ * Signature mirrors `firebase-admin/database`'s `getDatabase(app?)`.
  *
  *   - `getDatabase()` — default database for the DEFAULT app (resolved
  *     through `pyric-admin/app`'s registry, exactly like firebase-admin's
  *     no-arg `getDatabase()`; throws `app/no-app` when no default app has
  *     been initialized). Works for local and remote sandbox apps.
  *   - `getDatabase(app)` — default database for the app.
- *   - `getDatabase(app, url)` — accepts the upstream-compatible URL
- *     position, which the sandbox ignores because it has no notion of
- *     multiple database instances per project.
+ *   - `getDatabase(app, url)` — legacy Pyric-only compatibility form. New
+ *     code should use the upstream-shaped {@link getDatabaseWithUrl} export.
  *
  * The sandbox brand returns the local or remote `Database` backed by the
  * per-`Sandbox` state described in the module-level docs.
@@ -172,6 +170,22 @@ export function getDatabase(
     'pyric-admin/database: getDatabase expected a PyricAdminApp ' +
       '(initialize via `initializeApp` from pyric-admin/app).',
   );
+}
+
+/**
+ * Returns the {@link AdminDatabase} service selected by an upstream-shaped
+ * database URL.
+ *
+ * This is the exact `firebase-admin/database` argument order used by the
+ * Firebase Functions SDK: `getDatabaseWithUrl(url, app?)`. The first Pyric
+ * Functions slice has one shared RTDB instance, so the URL selects that
+ * instance rather than creating a second sandbox database.
+ */
+export function getDatabaseWithUrl(
+  _url: string,
+  app?: PyricAdminApp,
+): AdminDatabase {
+  return getDatabase(app);
 }
 
 // ─── Sandbox backend ─────────────────────────────────────────────────

--- a/packages/pyric-admin/test/database/get-database-with-url.test.ts
+++ b/packages/pyric-admin/test/database/get-database-with-url.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  deleteApp,
+  getApps,
+  initializeApp,
+} from '../../src/app/index.js';
+import {
+  getDatabase,
+  getDatabaseWithUrl,
+} from '../../src/database/index.js';
+
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+describe('getDatabaseWithUrl', () => {
+  test('accepts the upstream url-first signature and selects the supplied app database', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+
+    const database = getDatabaseWithUrl(
+      'https://demo-project-default-rtdb.firebaseio.com',
+      app,
+    );
+    await database.ref('functions/created').set({ value: 42 });
+
+    expect((await getDatabase(app).ref('functions/created').get()).val()).toEqual({
+      value: 42,
+    });
+  });
+});

--- a/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
@@ -21,17 +21,26 @@ absent.
 
 ## Initialization
 
-### `getDatabase(app?, url?)`
+### `getDatabase(app?, legacyUrl?)`
 ```ts
-function getDatabase(app?: PyricAdminApp, url?: string): Database;
+function getDatabase(app?: PyricAdminApp, legacyUrl?: string): Database;
 ```
-firebase-admin's `getDatabase(app?)` and `getDatabaseWithUrl(url, app)` collapsed into one function:
+Mirrors firebase-admin's `getDatabase(app?)`:
 
 - `getDatabase()`: default database for the `'[DEFAULT]'` sandbox app, resolved through `pyric-admin/app`'s registry. Throws `app/no-app` when nothing is initialized.
 - `getDatabase(app)`: default database for the app.
-- `getDatabase(app, url)`: accepts `url` for shape compatibility; the sandbox ignores it because it has no project-level database instances.
+- `getDatabase(app, legacyUrl)`: retained for compatibility with Pyric's former collapsed signature. New code should use `getDatabaseWithUrl`.
 
 Successive calls for the same sandbox return handles that share data, matching firebase-admin's singleton-per-app semantics. Throws `TypeError` for an unbranded value.
+
+### `getDatabaseWithUrl(url, app?)`
+```ts
+function getDatabaseWithUrl(url: string, app?: PyricAdminApp): Database;
+```
+Uses firebase-admin's exact URL-first argument order. The Functions SDK calls
+this export when materializing `event.data.ref`. Pyric's first Functions slice
+has one shared RTDB instance, so the URL selects that instance; it does not
+create a separate sandbox tree.
 
 ---
 


### PR DESCRIPTION
Adds the Admin RTDB URL export and makes activated Firebase rewrites resolve from the installed CLI instead of the user function’s dependency tree.

```js
// Run with:
// PYRIC_SANDBOX=remote:http://127.0.0.1:5000 node --import @pyric/cli/register database.cjs
const assert = require("node:assert");
const { getDatabaseWithUrl } = require("firebase-admin/database");

assert.equal(typeof getDatabaseWithUrl, "function");
```

The user package above does not install `firebase-admin` or `pyric-admin`. Activation rewrites the unchanged Firebase specifier, and the registration hook finds its compatible `pyric-admin/database` dependency beside `@pyric/cli`.

## `getDatabaseWithUrl(url, app?)` now has Firebase Admin’s argument order

```ts
import { initializeSandbox } from "pyric/sandbox";
import { initializeApp } from "pyric-admin/app";
import {
  getDatabase,
  getDatabaseWithUrl,
} from "pyric-admin/database";

const app = initializeApp({ sandbox: initializeSandbox() });
const selected = getDatabaseWithUrl(
  "https://demo-project-default-rtdb.firebaseio.com",
  app,
);

await selected.ref("functions/created").set({ value: 42 });
console.log((await getDatabase(app).ref("functions/created").get()).val());
// { value: 42 } — both accessors select the one shared sandbox RTDB instance.
```

Firebase Functions 7.2.5 calls this URL-first export when it materializes `event.data.ref`. The existing Pyric-only `getDatabase(app, legacyUrl)` form remains accepted, so this prerequisite is additive for current callers.

## Risk

When registration is active, mapped packages now deliberately resolve from `@pyric/cli`’s dependency closure. A user-installed, different `pyric-admin` version no longer wins resolution from the requiring function file; this keeps the registration hook and its mirrors version-compatible.

The database URL does not create or select a second tree. The approved first Functions slice has one RTDB instance and one shared sandbox, so every accepted URL selects that instance.

This PR changes no conformance row status, denominator, or published trust number. It is stacked on #286 and is part of #280.

<details>
<summary>Implementation notes and verification</summary>

- The Admin test was red first because `getDatabaseWithUrl` was not exported.
- The child-process resolver test was red first with `MODULE_NOT_FOUND: pyric-admin/database` from a fixture that installs neither Firebase Admin nor Pyric Admin.
- `bun test --cwd packages/pyric-admin` — 643 pass.
- Register and mapping suites — 19 pass.
- `bun run --cwd packages/pyric-admin typecheck` — green.
- `bun run --cwd packages/cli typecheck` — green.
- `bun run docs:api:check` — generated API receipts current.
- `bun run --cwd packages/site-docs test` — build, route/link verification, and rhythm audit green.
- `bun run test:packaging` — all five packages packed, installed into a consumer, resolved advertised subpaths, and passed runtime smoke; `pyric-admin/database` exposes two functions.

</details>
