### PR TITLE
fix(studio): dedupe search and focus timeline traffic

### DIFF
--- a/packages/studio/src/features/home/CommandTypeahead.tsx
+++ b/packages/studio/src/features/home/CommandTypeahead.tsx
@@ -181,10 +181,7 @@ export function CommandTypeahead({
                   {group.results.map((r, i) => {
                     const flatIndex = start + i;
                     return (
-                      // Keyed with the flat index too: two entries can share a
-                      // kind+label id (e.g. two users with no email whose uids
-                      // render identically after truncation upstream).
-                      <li key={`${r.id}:${flatIndex}`}>
+                      <li key={r.id}>
                         <button
                           type="button"
                           role="option"

--- a/packages/studio/src/features/home/resource-index-state.test.ts
+++ b/packages/studio/src/features/home/resource-index-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { createIndexBatchPublisher, foldIndexBatch, type ResourceIndexUpdate } from './resource-index-state.js';
+import { documentEntry, objectEntry, userEntry } from './typeahead.js';
+
+describe('createIndexBatchPublisher', () => {
+  it('replaces the previous build when React applies progressive updates later', () => {
+    const updates: ResourceIndexUpdate[] = [];
+    const publish = createIndexBatchPublisher((update) => updates.push(update));
+
+    publish([documentEntry('users/alice')]);
+    publish([userEntry({ uid: 'alice', email: 'alice@gmail.com' })]);
+    publish([objectEntry('avatars/alice.png')]);
+
+    let entries = [
+      documentEntry('users/bob'),
+      userEntry({ uid: 'bob', email: 'bob@gmail.com' }),
+      objectEntry('avatars/bob.png'),
+    ];
+    for (const update of updates) entries = update(entries);
+
+    expect(entries.map((entry) => `${entry.kind}:${entry.label}`)).toEqual([
+      'document:users/alice',
+      'user:alice@gmail.com',
+      'object:avatars/alice.png',
+    ]);
+  });
+});
+
+describe('foldIndexBatch', () => {
+  it('keeps one entry per stable resource target', () => {
+    const alice = documentEntry('users/alice');
+
+    expect(foldIndexBatch(null, [alice, alice], true)).toEqual([alice]);
+  });
+
+  it('lets the latest representation of a resource replace the old one', () => {
+    const previous = userEntry({ uid: 'alice', email: 'old-alice@gmail.com' });
+    const current = userEntry({ uid: 'alice', email: 'alice@gmail.com' });
+
+    expect(foldIndexBatch([previous], [current], false)).toEqual([current]);
+  });
+});

--- a/packages/studio/src/features/home/resource-index-state.ts
+++ b/packages/studio/src/features/home/resource-index-state.ts
@@ -19,12 +19,38 @@
  * how many builds/ticks precede it.
  */
 
-import type { ResourceEntry } from './typeahead.js';
+import { resourceEntryIdentity, type ResourceEntry } from './typeahead.js';
+
+export type ResourceIndexUpdate = (previous: ResourceEntry[] | null) => ResourceEntry[];
+
+/**
+ * Turn progressive build batches into state updates. Keeping the
+ * first-batch replacement rule here lets tests exercise the same deferred
+ * updater scheduling React uses in the hook.
+ */
+export function createIndexBatchPublisher(
+  schedule: (update: ResourceIndexUpdate) => void,
+): (batch: readonly ResourceEntry[]) => void {
+  let firstOfBuild = true;
+  return (batch) => {
+    // React may apply this updater after the progressive callback returns.
+    // Snapshot the decision now instead of closing over the mutable flag.
+    const replacePreviousBuild = firstOfBuild;
+    firstOfBuild = false;
+    schedule((previous) => foldIndexBatch(previous, batch, replacePreviousBuild));
+  };
+}
+
+function uniqueResources(entries: readonly ResourceEntry[]): ResourceEntry[] {
+  const byIdentity = new Map<string, ResourceEntry>();
+  for (const entry of entries) byIdentity.set(resourceEntryIdentity(entry), entry);
+  return [...byIdentity.values()];
+}
 
 export function foldIndexBatch(
   prev: ResourceEntry[] | null,
   batch: readonly ResourceEntry[],
   firstOfBuild: boolean,
 ): ResourceEntry[] {
-  return firstOfBuild ? [...batch] : [...(prev ?? []), ...batch];
+  return uniqueResources(firstOfBuild ? batch : [...(prev ?? []), ...batch]);
 }

--- a/packages/studio/src/features/home/typeahead.test.ts
+++ b/packages/studio/src/features/home/typeahead.test.ts
@@ -81,6 +81,33 @@ describe('matchTypeahead', () => {
     expect(groups.find((g) => g.kind === 'user')!.results[0].label).toBe('alice@example.com');
   });
 
+  it('returns one row when the same indexed resource is repeated', () => {
+    const aliceDoc = documentEntry('users/alice');
+    const aliceUser = userEntry({
+      uid: 'uid-alice-1',
+      email: 'alice@example.com',
+    });
+    const aliceObject = objectEntry('uploads/avatars/alice.png');
+    const repeated = [aliceDoc, aliceDoc, aliceUser, aliceUser, aliceObject, aliceObject];
+
+    const groups = matchTypeahead('alice', ROUTES, repeated);
+
+    expect(groups.find((group) => group.kind === 'document')!.results).toHaveLength(1);
+    expect(groups.find((group) => group.kind === 'user')!.results).toHaveLength(1);
+    expect(groups.find((group) => group.kind === 'object')!.results).toHaveLength(1);
+  });
+
+  it('keeps distinct Auth users that happen to share an email label', () => {
+    const groups = matchTypeahead('shared@example.com', ROUTES, [
+      userEntry({ uid: 'first', email: 'shared@example.com' }),
+      userEntry({ uid: 'second', email: 'shared@example.com' }),
+    ]);
+    const users = groups.find((group) => group.kind === 'user')!.results;
+
+    expect(users).toHaveLength(2);
+    expect(users.map((user) => user.target.rest?.[0]).sort()).toEqual(['first', 'second']);
+  });
+
   it('matches auth users by uid as well as email', () => {
     const groups = matchTypeahead('uid-bob', ROUTES, INDEX);
     const users = groups.find((g) => g.kind === 'user');

--- a/packages/studio/src/features/home/typeahead.ts
+++ b/packages/studio/src/features/home/typeahead.ts
@@ -45,6 +45,12 @@ export interface SuggestionGroup {
   results: CommandResult[];
 }
 
+/** Stable resource identity: labels can change (an Auth user's email), while
+ * the routed target remains the same resource. */
+export function resourceEntryIdentity(entry: ResourceEntry): string {
+  return `${entry.kind}:${entry.target.tab}:${(entry.target.rest ?? []).join('/')}`;
+}
+
 /** Build-time caps (the index is a suggestion source, not a mirror). The caps
  *  bound the FETCHES, not just the kept entries: doc queries carry a limit(),
  *  only the first `collectionsScanned` collections get a doc query at all, and
@@ -313,8 +319,11 @@ export function matchTypeahead(
     // to recover.
     const pathAware = kind === 'document' || kind === 'subcollection';
     const groupable = kind === 'collection' || kind === 'subcollection';
-    const scored = entries
-      .filter((e) => e.kind === kind)
+    const uniqueEntries = new Map<string, ResourceEntry>();
+    for (const entry of entries) {
+      if (entry.kind === kind) uniqueEntries.set(resourceEntryIdentity(entry), entry);
+    }
+    const scored = [...uniqueEntries.values()]
       .map((e) => ({
         entry: e,
         score: Math.max(
@@ -332,7 +341,7 @@ export function matchTypeahead(
         kind,
         title: GROUP_TITLES[kind],
         results: scored.map(({ entry }) => ({
-          id: `${entry.kind}:${entry.label}`,
+          id: resourceEntryIdentity(entry),
           label: entry.label,
           hint: hintFor(entry),
           target: entry.target,

--- a/packages/studio/src/features/home/useResourceIndex.ts
+++ b/packages/studio/src/features/home/useResourceIndex.ts
@@ -43,7 +43,7 @@ import { sandbox as authSandbox } from 'pyric/auth';
 import { ref as inProcessRef, listAll as inProcessListAll } from 'pyric/storage';
 import { useEnvironment } from '../../shell/environment.js';
 import { useStudioDataSource } from '../../shell/studio-data.js';
-import { foldIndexBatch } from './resource-index-state.js';
+import { createIndexBatchPublisher } from './resource-index-state.js';
 import {
   bfsStorageObjectPaths,
   buildResourceIndex,
@@ -188,11 +188,12 @@ export function useResourceIndex(): ResourceIndexState {
       // what stops a chained rebuild (every worker tick re-fires `ensure`) from
       // stacking a fresh inventory on top of the previous one — the "counts
       // count up rapidly" bug.
-      let firstOfBuild = true;
+      const publishBatch = createIndexBatchPublisher((update) =>
+        setEntries(update),
+      );
       void buildResourceIndex(sources, INDEX_CAPS, (batch) => {
         if (token !== buildToken.current) return; // superseded by a newer build
-        setEntries((cur) => foldIndexBatch(cur, batch, firstOfBuild));
-        firstOfBuild = false;
+        publishBatch(batch);
       })
         .catch(() => {
           // Best-effort: keep whatever landed via onBatch (possibly nothing).

--- a/packages/studio/src/features/traffic/TrafficSurface.tsx
+++ b/packages/studio/src/features/traffic/TrafficSurface.tsx
@@ -53,6 +53,7 @@ import { queryWithInspect, selectedInspectId, toggleInspect } from './inspect-se
 import { TrafficRulesInspector } from './TrafficRulesInspector.js';
 import { BillableMetricsView, RulesMetricsView } from './TrafficMetricsViews.js';
 import { TRAFFIC_TABS, trafficTabForView, type TrafficTab } from './traffic-tabs.js';
+import { trafficTimeFocus, toggleTimeFocus } from './timeline-focus.js';
 import './traffic.css';
 
 export type { TrafficTab } from './traffic-tabs.js';
@@ -113,6 +114,10 @@ function relAgo(at: number, now: number): string {
   return `${Math.round(m / 60)}h ago`;
 }
 
+function timelineRangeLabel(window: TimeWindow): string {
+  return `${defaultFormatTime(window.start)}–${defaultFormatTime(window.end)}`;
+}
+
 /** The per-row verdict cell (blank for non-rule ops). */
 function VerdictCell({ event }: { event: StudioTrafficEvent }) {
   const v = verdictFor(event);
@@ -154,6 +159,7 @@ export function TrafficSurface() {
   );
   const hiddenStudioCount = allEvents.length - events.length;
   const [verdictFilter, setVerdictFilter] = useState<VerdictFilter>('all');
+  const [timeFocus, setTimeFocus] = useState<TimeWindow | null>(null);
   const expandedId = useInspectParam();
   const [visibleRows, setVisibleRows] = useState(PAGE_SIZE);
 
@@ -193,11 +199,17 @@ export function TrafficSurface() {
   }, [events]);
   const now = window.end;
 
+  const focusedTraffic = useMemo(
+    () => (timeFocus ? trafficTimeFocus(events, timeFocus) : null),
+    [events, timeFocus],
+  );
+  const tableEvents = focusedTraffic?.events ?? events;
+
   // Newest-first stream; verdict filter first, then grouping (the volume
   // reducer: storms → one row).
   const ordered = useMemo(
-    () => filterByVerdict(events, verdictFilter).sort((a, b) => b.at - a.at),
-    [events, verdictFilter],
+    () => filterByVerdict(tableEvents, verdictFilter).sort((a, b) => b.at - a.at),
+    [tableEvents, verdictFilter],
   );
   const { items } = useTrafficGroups({ events: ordered });
   const visibleItems = items.slice(0, visibleRows);
@@ -266,6 +278,11 @@ export function TrafficSurface() {
           <TrafficTimeline
             events={events}
             window={window}
+            brush={timeFocus ?? undefined}
+            onBrush={(nextWindow) => {
+              setTimeFocus((current) => toggleTimeFocus(current, nextWindow));
+              if (expandedId) closeInspect();
+            }}
             liveAt={window.end}
             bucketCount={36}
             className="traffic__timeline"
@@ -297,10 +314,36 @@ export function TrafficSurface() {
                 <span>now</span>
               </div>
             )}
+            renderBucketSummary={(bucket) => (
+              <div className="traffic__bucket-summary">
+                <span>{timelineRangeLabel(bucket)}</span>
+                <strong>
+                  {bucket.count} {bucket.count === 1 ? 'request' : 'requests'}
+                </strong>
+                <span>{bucket.denies} denied</span>
+              </div>
+            )}
             emptyState={
               <p className="traffic__empty">No requests in this window yet.</p>
             }
           />
+
+          {focusedTraffic ? (
+            <section
+              className="traffic__time-focus"
+              aria-label="Selected traffic interval"
+              aria-live="polite"
+            >
+              <div className="traffic__time-focus-story">
+                <p className="traffic__time-focus-eyebrow">Selected interval</p>
+                <h3>{timelineRangeLabel(focusedTraffic.window)}</h3>
+                <p>{focusedTraffic.finding}</p>
+              </div>
+              <button type="button" onClick={() => setTimeFocus(null)}>
+                Show all traffic
+              </button>
+            </section>
+          ) : null}
 
           <div className="traffic__filters" role="group" aria-label="Traffic filters">
             <span className="traffic__filters-label" aria-hidden="true">
@@ -332,12 +375,21 @@ export function TrafficSurface() {
 
           {items.length === 0 ? (
             <p className="traffic__empty">
-              {verdictFilter === 'all'
-                ? 'No requests yet. Reads, writes, and listeners against the sandbox stream in live.'
-                : `No ${verdictFilter} traffic in this session.`}
+              {focusedTraffic
+                ? verdictFilter === 'all'
+                  ? 'No requests occurred in the selected interval.'
+                  : `No ${verdictFilter} traffic occurred in the selected interval.`
+                : verdictFilter === 'all'
+                  ? 'No requests yet. Reads, writes, and listeners against the sandbox stream in live.'
+                  : `No ${verdictFilter} traffic in this session.`}
             </p>
           ) : (
-            <div className="traffic__log" data-pyric-ui="traffic-log" data-pyric-grouped="">
+            <div
+              className="traffic__log"
+              data-pyric-ui="traffic-log"
+              data-pyric-grouped=""
+              data-pyric-time-focused={focusedTraffic ? '' : undefined}
+            >
               <ul data-pyric-traffic-log-items="">
                 {visibleItems.map((item) =>
                   item.type === 'group' ? (

--- a/packages/studio/src/features/traffic/timeline-focus.test.ts
+++ b/packages/studio/src/features/traffic/timeline-focus.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import type { TrafficEvent } from '@pyric/ui/traffic';
+import { trafficTimeFocus, toggleTimeFocus } from './timeline-focus.js';
+
+const event = (id: string, at: number, result: TrafficEvent['result'] = 'allow') =>
+  ({ id, at, result }) as TrafficEvent;
+
+describe('trafficTimeFocus', () => {
+  it("selects the bucket's half-open interval", () => {
+    const focus = trafficTimeFocus(
+      [event('before', 99), event('start', 100), event('inside', 199, 'deny'), event('end', 200)],
+      { start: 100, end: 200 },
+    );
+
+    expect(focus.events.map(({ id }) => id)).toEqual(['start', 'inside']);
+    expect(focus.total).toBe(2);
+    expect(focus.denies).toBe(1);
+    expect(focus.finding).toBe('2 requests occurred in this interval; 1 was denied.');
+  });
+
+  it('describes empty, clear, and all-denied intervals honestly', () => {
+    expect(trafficTimeFocus([], { start: 0, end: 100 }).finding).toBe('No requests occurred in this interval.');
+    expect(trafficTimeFocus([event('one', 10)], { start: 0, end: 100 }).finding).toBe(
+      'One request occurred in this interval; it was not denied.',
+    );
+    expect(
+      trafficTimeFocus([event('one', 10, 'deny'), event('two', 20, 'deny')], {
+        start: 0,
+        end: 100,
+      }).finding,
+    ).toBe('All 2 requests in this interval were denied.');
+  });
+});
+
+describe('toggleTimeFocus', () => {
+  it('pins a new interval and clears an already-pinned interval', () => {
+    const interval = { start: 100, end: 200 };
+
+    expect(toggleTimeFocus(null, interval)).toEqual(interval);
+    expect(toggleTimeFocus(interval, { ...interval })).toBeNull();
+    expect(toggleTimeFocus(interval, { start: 200, end: 300 })).toEqual({
+      start: 200,
+      end: 300,
+    });
+  });
+});

--- a/packages/studio/src/features/traffic/timeline-focus.ts
+++ b/packages/studio/src/features/traffic/timeline-focus.ts
@@ -1,0 +1,42 @@
+import type { TimeWindow, TrafficEvent } from '@pyric/ui/traffic';
+
+export interface TrafficTimeFocus<Event extends TrafficEvent = TrafficEvent> {
+  window: TimeWindow;
+  events: Event[];
+  total: number;
+  denies: number;
+  finding: string;
+}
+
+function focusFinding(total: number, denies: number): string {
+  if (total === 0) return 'No requests occurred in this interval.';
+  if (total === 1) {
+    return denies === 1
+      ? 'The request in this interval was denied.'
+      : 'One request occurred in this interval; it was not denied.';
+  }
+  if (denies === 0) return `${total} requests occurred in this interval; none were denied.`;
+  if (denies === total) return `All ${total} requests in this interval were denied.`;
+  return `${total} requests occurred in this interval; ${denies} ${denies === 1 ? 'was' : 'were'} denied.`;
+}
+
+/** Derive the records and observed finding for one half-open timeline bucket. */
+export function trafficTimeFocus<Event extends TrafficEvent>(
+  events: readonly Event[],
+  window: TimeWindow,
+): TrafficTimeFocus<Event> {
+  const focused = events.filter((event) => event.at >= window.start && event.at < window.end);
+  const denies = focused.reduce((count, event) => count + (event.result === 'deny' ? 1 : 0), 0);
+  return {
+    window,
+    events: focused,
+    total: focused.length,
+    denies,
+    finding: focusFinding(focused.length, denies),
+  };
+}
+
+/** Clicking the pinned bucket again clears it; any other bucket replaces it. */
+export function toggleTimeFocus(current: TimeWindow | null, next: TimeWindow): TimeWindow | null {
+  return current?.start === next.start && current.end === next.end ? null : next;
+}

--- a/packages/studio/src/features/traffic/traffic.css
+++ b/packages/studio/src/features/traffic/traffic.css
@@ -510,6 +510,37 @@
   position: relative;
 }
 
+.traffic__timeline [data-pyric-bucket-summary] {
+  position: absolute;
+  z-index: 4;
+  top: 4px;
+  left: clamp(
+    92px,
+    calc(var(--pyric-bucket-summary-x, 0.5) * 100%),
+    calc(100% - 92px)
+  );
+  transform: translateX(-50%);
+  max-width: calc(100% - 12px);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 5px 8px;
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+  pointer-events: none;
+}
+.traffic__bucket-summary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  white-space: nowrap;
+}
+.traffic__bucket-summary strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
 .traffic__timeline [data-pyric-timeline-bars] {
   display: flex;
   align-items: flex-end;
@@ -531,6 +562,21 @@
   justify-content: flex-end;
   cursor: default;
   min-width: 2px;
+}
+.traffic__timeline [data-pyric-bucket]:not(:disabled) {
+  cursor: pointer;
+}
+.traffic__timeline [data-pyric-bucket]:not(:disabled):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.traffic__timeline
+  [data-pyric-bucket]:not(:disabled):hover
+  [data-pyric-bucket-allow],
+.traffic__timeline
+  [data-pyric-bucket]:not(:disabled):focus-visible
+  [data-pyric-bucket-allow] {
+  background: color-mix(in srgb, var(--accent) 42%, var(--line-2));
 }
 
 .traffic__timeline [data-pyric-bucket-allow] {
@@ -557,6 +603,22 @@
   border-radius: 2px;
 }
 
+/* A pinned bucket stays legible as the rest of the live timeline continues
+   to provide context. */
+.traffic__timeline [data-pyric-brush] {
+  position: absolute;
+  z-index: 1;
+  inset-block: 0;
+  left: calc(var(--pyric-brush-left, 0) * 100%);
+  right: calc(var(--pyric-brush-right, 0) * 100%);
+  border: 1px solid color-mix(in srgb, var(--accent) 70%, transparent);
+  background: color-mix(in srgb, var(--accent-tint) 55%, transparent);
+  pointer-events: none;
+}
+.traffic__timeline [data-pyric-bucket-selected] {
+  filter: saturate(1.2);
+}
+
 /* Live edge marker. */
 .traffic__timeline [data-pyric-live] {
   position: absolute;
@@ -574,6 +636,80 @@
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--faint);
+}
+
+/* Pinned interval: the chart states the finding, then the request stream
+   becomes the supporting evidence for that exact half-open range. */
+.traffic__time-focus {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  border-left: 3px solid var(--accent);
+  padding: var(--space-2) var(--space-3);
+  background: var(--panel);
+}
+.traffic__time-focus-story {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: var(--space-1) var(--space-3);
+  min-width: 0;
+}
+.traffic__time-focus-eyebrow {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--faint);
+  font-size: var(--fs-micro);
+  font-weight: 600;
+  letter-spacing: var(--tracking-micro);
+  text-transform: uppercase;
+}
+.traffic__time-focus h3,
+.traffic__time-focus p {
+  margin: 0;
+}
+.traffic__time-focus h3 {
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: var(--fs-label);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.traffic__time-focus-story > p:last-child {
+  color: var(--muted);
+  font-size: var(--fs-caption);
+}
+.traffic__time-focus > button {
+  flex-shrink: 0;
+  margin-left: auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 10px;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: var(--fs-caption);
+  cursor: pointer;
+}
+.traffic__time-focus > button:hover {
+  border-color: var(--line-2);
+  color: var(--ink);
+}
+
+@media (max-width: 620px) {
+  .traffic__bucket-summary span:last-child {
+    display: none;
+  }
+  .traffic__time-focus {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .traffic__time-focus-story {
+    grid-template-columns: 1fr;
+  }
+  .traffic__time-focus > button {
+    margin-left: 0;
+  }
 }
 
 /* ── Filter row (single compact row — no stacked toolbars) ──────────── */

--- a/packages/ui/src/traffic/components/TrafficTimeline.tsx
+++ b/packages/ui/src/traffic/components/TrafficTimeline.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 import { useTrafficBuckets } from '../hooks/useTrafficBuckets.js';
 import type {
   TimeWindow,
@@ -39,6 +39,12 @@ export interface TrafficTimelineProps {
    * window so a bare consumer still gets a working selection.
    */
   onBrush?: (window: TimeWindow) => void;
+  /**
+   * Direct annotation shown while a bucket is hovered or keyboard-focused.
+   * The timeline owns preview state and positioning; the consumer owns the
+   * words and number formatting.
+   */
+  renderBucketSummary?: (bucket: TrafficBucket) => ReactNode;
   /**
    * Where the live edge marker sits, in epoch-ms. Defaults to
    * `window.end` (the right edge = "now"). Omit / pass `null` to hide
@@ -95,8 +101,9 @@ function fraction(t: number, window: TimeWindow): number {
  * Styling hooks: `[data-pyric-ui="traffic-timeline"]`,
  * `[data-pyric-timeline-header]`, `[data-pyric-timeline-bars]`,
  * `[data-pyric-bucket]` (with `data-pyric-bucket-index`,
- * `data-pyric-has-denies`), `[data-pyric-brush]`,
- * `[data-pyric-live]`, `[data-pyric-timeline-axis]`.
+ * `data-pyric-has-denies`, `data-pyric-bucket-selected`),
+ * `[data-pyric-bucket-summary]`, `[data-pyric-brush]`, `[data-pyric-live]`,
+ * `[data-pyric-timeline-axis]`.
  */
 export function TrafficTimeline({
   events,
@@ -105,12 +112,16 @@ export function TrafficTimeline({
   bucketCount = 30,
   brush,
   onBrush,
+  renderBucketSummary,
   liveAt,
   header,
   axis,
   emptyState,
   className,
 }: TrafficTimelineProps) {
+  const summaryId = useId();
+  const [hoveredBucket, setHoveredBucket] = useState<number | null>(null);
+  const [focusedBucket, setFocusedBucket] = useState<number | null>(null);
   // Hook is always called (rules of hooks); its result is discarded
   // when the caller pre-bucketed.
   const computed = useTrafficBuckets({
@@ -120,6 +131,11 @@ export function TrafficTimeline({
   });
   const result = prebucketed ?? computed;
   const { buckets, total } = result;
+  const activeBucketIndex = hoveredBucket ?? focusedBucket;
+  const activeBucket =
+    activeBucketIndex === null ? null : (buckets.find((bucket) => bucket.index === activeBucketIndex) ?? null);
+  const activeBucketSelected =
+    activeBucket !== null && brush?.start === activeBucket.start && brush.end === activeBucket.end;
 
   if (buckets.length === 0) {
     return (
@@ -150,11 +166,43 @@ export function TrafficTimeline({
       )}
 
       <div data-pyric-timeline-chart="">
-        <div data-pyric-timeline-bars="" role="img" aria-label="request volume over time">
+        <div
+          data-pyric-timeline-bars=""
+          role={onBrush ? 'group' : 'img'}
+          aria-label="request volume over time"
+        >
           {buckets.map((bucket) => (
-            <Bar key={bucket.index} bucket={bucket} window={window} onBrush={onBrush} />
+            <Bar
+              key={bucket.index}
+              bucket={bucket}
+              window={window}
+              onBrush={onBrush}
+              onHover={renderBucketSummary ? setHoveredBucket : undefined}
+              onFocus={renderBucketSummary ? setFocusedBucket : undefined}
+              summaryId={
+                renderBucketSummary && !activeBucketSelected && activeBucket?.index === bucket.index
+                  ? summaryId
+                  : undefined
+              }
+              selected={brush?.start === bucket.start && brush.end === bucket.end}
+            />
           ))}
         </div>
+
+        {activeBucket && renderBucketSummary && !activeBucketSelected ? (
+          <div
+            id={summaryId}
+            role="tooltip"
+            data-pyric-bucket-summary=""
+            style={
+              {
+                '--pyric-bucket-summary-x': (activeBucket.index + 0.5) / Math.max(buckets.length, 1),
+              } as React.CSSProperties
+            }
+          >
+            {renderBucketSummary(activeBucket)}
+          </div>
+        ) : null}
 
         {brush && (
           <div
@@ -189,12 +237,22 @@ function Bar({
   bucket,
   window,
   onBrush,
+  onHover,
+  onFocus,
+  summaryId,
+  selected,
 }: {
   bucket: TrafficBucket;
   window: TimeWindow;
   onBrush?: (window: TimeWindow) => void;
+  onHover?: (index: number | null) => void;
+  onFocus?: (index: number | null) => void;
+  summaryId?: string;
+  selected: boolean;
 }) {
   const interactive = onBrush !== undefined;
+  const requestLabel = `${bucket.count} ${bucket.count === 1 ? 'request' : 'requests'}`;
+  const denyLabel = `${bucket.denies} denied`;
   return (
     <button
       type="button"
@@ -203,7 +261,15 @@ function Bar({
       data-pyric-bucket-count={bucket.count}
       data-pyric-bucket-denies={bucket.denies}
       data-pyric-has-denies={bucket.denies > 0 ? '' : undefined}
+      data-pyric-bucket-selected={selected ? '' : undefined}
       disabled={!interactive}
+      aria-label={`${requestLabel}, ${denyLabel}`}
+      aria-describedby={summaryId}
+      aria-pressed={interactive ? selected : undefined}
+      onPointerEnter={onHover ? () => onHover(bucket.index) : undefined}
+      onPointerLeave={onHover ? () => onHover(null) : undefined}
+      onFocus={onFocus ? () => onFocus(bucket.index) : undefined}
+      onBlur={onFocus ? () => onFocus(null) : undefined}
       onClick={
         interactive
           ? () => onBrush?.({ start: bucket.start, end: bucket.end })

--- a/packages/ui/test/traffic/components/TrafficTimeline.test.tsx
+++ b/packages/ui/test/traffic/components/TrafficTimeline.test.tsx
@@ -82,15 +82,33 @@ describe('<TrafficTimeline>', () => {
   it('fires onBrush with the clicked bucket window', () => {
     let picked: TimeWindow | null = null;
     const { container } = render(
-      <TrafficTimeline
-        events={[evt({ at: 150 })]}
-        window={WINDOW}
-        bucketCount={10}
-        onBrush={(w) => (picked = w)}
-      />,
+      <TrafficTimeline events={[evt({ at: 150 })]} window={WINDOW} bucketCount={10} onBrush={(w) => (picked = w)} />,
     );
     fireEvent.click(container.querySelectorAll('[data-pyric-bucket]')[1]);
     expect(picked).toEqual({ start: 100, end: 200 });
+  });
+
+  it('shows a direct bucket summary on pointer hover and keyboard focus', () => {
+    const { container, getByText, queryByText } = render(
+      <TrafficTimeline
+        events={[evt({ at: 150 }), evt({ at: 160, result: 'deny' })]}
+        window={WINDOW}
+        bucketCount={10}
+        onBrush={() => {}}
+        renderBucketSummary={(bucket) => <span>{`${bucket.count} requests · ${bucket.denies} denied`}</span>}
+      />,
+    );
+    const bucket = container.querySelectorAll('[data-pyric-bucket]')[1];
+
+    expect(queryByText('2 requests · 1 denied')).toBeNull();
+    fireEvent.pointerEnter(bucket);
+    expect(getByText('2 requests · 1 denied')).toBeTruthy();
+    fireEvent.pointerLeave(bucket);
+    expect(queryByText('2 requests · 1 denied')).toBeNull();
+    fireEvent.focus(bucket);
+    expect(getByText('2 requests · 1 denied')).toBeTruthy();
+    fireEvent.blur(bucket);
+    expect(queryByText('2 requests · 1 denied')).toBeNull();
   });
 
   it('does not make bars interactive without onBrush', () => {


### PR DESCRIPTION
Makes Studio's command palette return one row per resource and turns timeline buckets into inspectable traffic filters.

```text
⌘K  alice

Firestore documents  users/alice
Auth users            alice@gmail.com
Storage objects       avatars/alice.png

Traffic timeline
hover  23:06–23:07  →  26 requests · 3 denied
click  23:06–23:07  →  the request log shows those 26 records
click the bucket again → the full request log returns
```

## One stable target produces one command result

Progressive index batches could append a new inventory to the previous build because the deferred React state updater read a mutable first-batch flag after it had changed. The publisher now snapshots whether a batch replaces or appends before scheduling the update.

Resources are also deduplicated by their routed identity—resource kind, destination tab, and path—both while folding index batches and before ranking suggestions. An Auth user's changing email therefore updates one result, while two users sharing an email remain distinct because their routed UIDs differ.

## Timeline buckets now explain and filter their evidence

Hovering or keyboard-focusing a bucket directly annotates its interval, request count, and denied count. Clicking pins the half-open interval, adds an observed finding below the chart, and limits the traffic table to the records supporting that finding. The existing verdict and Hide Studio filters intersect with the selected interval; clicking the pinned bucket again restores the full table.

## Risk

The identity boundary is the routed target: multiple representations intentionally collapse when they navigate to the same resource. The timeline's click behavior now filters the table rather than only drawing a brush, so the selected-interval narrative and Show all traffic control need UI judgment. No traffic events or metrics are changed.

<details>
<summary>Implementation notes</summary>

- 54 focused Studio tests pass, including deferred index updates, duplicate targets, shared Auth email labels, interval membership, and selection toggling.
- 117 UI traffic tests pass, including pointer hover and keyboard focus behavior.
- Studio and UI typechecks pass.
- Studio production build passes.
- Browser verification returned exactly one alice result per Firestore, Auth, and Storage service, and a pinned bucket's table row count matched its annotation on desktop and mobile.

</details>
