### PR TITLE
Functions: build the RTDB create execution core

### DIFF
--- a/packages/cli/src/functions-rtdb/execution.ts
+++ b/packages/cli/src/functions-rtdb/execution.ts
@@ -1,0 +1,362 @@
+export interface RtdbSnapshotCommit {
+  /** Absolute RTDB path represented by before/after. */
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface CreatedValueProjection {
+  /** Normalized RTDB ref without a leading slash, matching Functions events. */
+  ref: string;
+  params: Record<string, string>;
+  value: unknown;
+}
+
+export type RtdbCreatedCallable = (
+  rawEvent: Record<string, unknown>,
+) => unknown | Promise<unknown>;
+
+export interface DiscoveredOnValueCreated {
+  exportName: string;
+  reference: string;
+  instance: string;
+  callable: RtdbCreatedCallable;
+}
+
+export interface CreatedEventOptions {
+  id: string;
+  time: string;
+  projectId: string;
+  instance: string;
+  location: string;
+  databaseHost: string;
+}
+
+export type CreatedExecutionResult =
+  | { status: 'fulfilled'; event: Record<string, unknown> }
+  | { status: 'rejected'; event: Record<string, unknown>; error: unknown };
+
+export interface RtdbTriggerDelivery {
+  subscribe(
+    path: string,
+    listener: (value: unknown) => void,
+    onError?: (error: unknown) => void,
+  ): () => void;
+}
+
+export interface OnValueCreatedExecutionOptions {
+  exported: Record<string, unknown>;
+  delivery: RtdbTriggerDelivery;
+  eventOptions(
+    projection: CreatedValueProjection,
+    sequence: number,
+    trigger: DiscoveredOnValueCreated,
+  ): CreatedEventOptions;
+  onExecution?(
+    result: CreatedExecutionResult,
+    trigger: DiscoveredOnValueCreated,
+    projection: CreatedValueProjection,
+  ): void;
+  onDeliveryError?(error: unknown, trigger: DiscoveredOnValueCreated): void;
+}
+
+export interface OnValueCreatedExecutionHost {
+  readonly triggerCount: number;
+  readonly ready: Promise<void>;
+  idle(): Promise<void>;
+  close(): void;
+}
+
+const CREATED_EVENT_TYPE = 'google.firebase.database.ref.v1.created';
+
+type EndpointFunction = RtdbCreatedCallable & {
+  __endpoint?: {
+    eventTrigger?: {
+      eventType?: unknown;
+      eventFilters?: Record<string, unknown>;
+      eventFilterPathPatterns?: Record<string, unknown>;
+    };
+  };
+};
+
+/** Discover unchanged v2 RTDB create functions through public endpoint metadata. */
+export function discoverOnValueCreated(
+  exported: Record<string, unknown>,
+): DiscoveredOnValueCreated[] {
+  const discovered: DiscoveredOnValueCreated[] = [];
+  for (const [exportName, value] of Object.entries(exported)) {
+    if (typeof value !== 'function') continue;
+    const callable = value as EndpointFunction;
+    const trigger = callable.__endpoint?.eventTrigger;
+    if (trigger?.eventType !== CREATED_EVENT_TYPE) continue;
+    const reference = trigger.eventFilterPathPatterns?.ref;
+    const instance =
+      trigger.eventFilters?.instance ?? trigger.eventFilterPathPatterns?.instance;
+    if (typeof reference !== 'string' || typeof instance !== 'string') continue;
+    discovered.push({ exportName, reference, instance, callable });
+  }
+  return discovered;
+}
+
+/** Invoke the real Firebase Functions wrapper and await the user's result. */
+export async function executeOnValueCreated(
+  trigger: DiscoveredOnValueCreated,
+  projection: CreatedValueProjection,
+  options: CreatedEventOptions,
+): Promise<CreatedExecutionResult> {
+  const event: Record<string, unknown> = {
+    specversion: '1.0',
+    id: options.id,
+    source:
+      `//firebase.googleapis.com/projects/${options.projectId}` +
+      `/locations/${options.location}/instances/${options.instance}`,
+    subject: `refs/${projection.ref}`,
+    type: CREATED_EVENT_TYPE,
+    time: options.time,
+    location: options.location,
+    instance: options.instance,
+    ref: projection.ref,
+    firebasedatabasehost: options.databaseHost,
+    authtype: 'unknown',
+    authid: null,
+    data: {
+      data: null,
+      delta: projection.value,
+    },
+  };
+
+  try {
+    await trigger.callable(event);
+    return { status: 'fulfilled', event };
+  } catch (error) {
+    return { status: 'rejected', event, error };
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.split('/').filter(Boolean).join('/');
+}
+
+function canonicalPath(path: string): string {
+  const normalized = normalizePath(path);
+  return normalized ? `/${normalized}` : '/';
+}
+
+/** Test adapter for the same snapshot-delivery seam the remote relay uses. */
+export class InMemoryRtdbTriggerDelivery implements RtdbTriggerDelivery {
+  readonly #values = new Map<string, unknown>();
+  readonly #listeners = new Map<string, Set<(value: unknown) => void>>();
+
+  seed(path: string, value: unknown): void {
+    this.#values.set(canonicalPath(path), structuredClone(value));
+  }
+
+  emit(path: string, value: unknown): void {
+    const key = canonicalPath(path);
+    const snapshot = structuredClone(value);
+    this.#values.set(key, snapshot);
+    for (const listener of this.#listeners.get(key) ?? []) {
+      listener(structuredClone(snapshot));
+    }
+  }
+
+  subscribe(path: string, listener: (value: unknown) => void): () => void {
+    const key = canonicalPath(path);
+    let listeners = this.#listeners.get(key);
+    if (!listeners) {
+      listeners = new Set();
+      this.#listeners.set(key, listeners);
+    }
+    listeners.add(listener);
+    listener(structuredClone(this.#values.get(key) ?? null));
+    return () => {
+      listeners?.delete(listener);
+      if (listeners?.size === 0) this.#listeners.delete(key);
+    };
+  }
+}
+
+function pathParts(path: string): string[] {
+  const normalized = normalizePath(path);
+  return normalized ? normalized.split('/') : [];
+}
+
+function exists(value: unknown): boolean {
+  return value !== null && value !== undefined;
+}
+
+function paramName(segment: string): string | null {
+  return /^\{([A-Za-z][A-Za-z0-9_]*)\}$/.exec(segment)?.[1] ?? null;
+}
+
+function child(value: unknown, key: string): unknown {
+  if (typeof value !== 'object' || value === null) return undefined;
+  return Object.prototype.hasOwnProperty.call(value, key)
+    ? (value as Record<string, unknown>)[key]
+    : undefined;
+}
+
+function childKeys(value: unknown): string[] {
+  if (typeof value !== 'object' || value === null) return [];
+  return Object.keys(value).filter((key) => exists(child(value, key))).sort();
+}
+
+function watchPath(reference: string): string {
+  const literal: string[] = [];
+  for (const segment of pathParts(reference)) {
+    if (paramName(segment)) break;
+    literal.push(segment);
+  }
+  return canonicalPath(literal.join('/'));
+}
+
+/** Project absent-to-present values for one v2 RTDB trigger reference. */
+export function projectValueCreates(
+  reference: string,
+  commit: RtdbSnapshotCommit,
+): CreatedValueProjection[] {
+  const pattern = pathParts(reference);
+  const committed = pathParts(commit.path);
+  if (committed.length > pattern.length) return [];
+
+  const params: Record<string, string> = {};
+  for (let index = 0; index < committed.length; index += 1) {
+    const capture = paramName(pattern[index]);
+    if (capture) params[capture] = committed[index];
+    else if (pattern[index] !== committed[index]) return [];
+  }
+
+  const projected: CreatedValueProjection[] = [];
+  const visit = (
+    depth: number,
+    before: unknown,
+    after: unknown,
+    concrete: string[],
+    captures: Record<string, string>,
+  ): void => {
+    if (depth === pattern.length) {
+      if (!exists(before) && exists(after)) {
+        projected.push({
+          ref: concrete.join('/'),
+          params: captures,
+          value: after,
+        });
+      }
+      return;
+    }
+
+    const segment = pattern[depth];
+    const capture = paramName(segment);
+    if (capture) {
+      for (const key of childKeys(after)) {
+        visit(
+          depth + 1,
+          child(before, key),
+          child(after, key),
+          [...concrete, key],
+          { ...captures, [capture]: key },
+        );
+      }
+      return;
+    }
+
+    visit(
+      depth + 1,
+      child(before, segment),
+      child(after, segment),
+      [...concrete, segment],
+      captures,
+    );
+  };
+
+  visit(
+    committed.length,
+    commit.before,
+    commit.after,
+    committed,
+    params,
+  );
+  return projected;
+}
+
+/**
+ * Connect discovered functions to an abstract snapshot-delivery source.
+ * The first snapshot on each subscription is a baseline, never a historical
+ * create. Later handler executions share one serialized queue.
+ */
+export function startOnValueCreatedExecution(
+  options: OnValueCreatedExecutionOptions,
+): OnValueCreatedExecutionHost {
+  const triggers = discoverOnValueCreated(options.exported);
+  const unsubscribe: Array<() => void> = [];
+  let closed = false;
+  let sequence = 0;
+  let tail = Promise.resolve();
+  let baselinesRemaining = triggers.length;
+  let readinessFailed = false;
+  let markReady!: () => void;
+  let failReady!: (error: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    markReady = resolve;
+    failReady = reject;
+  });
+  if (baselinesRemaining === 0) markReady();
+
+  for (const trigger of triggers) {
+    const path = watchPath(trigger.reference);
+    let hasBaseline = false;
+    let previous: unknown;
+    unsubscribe.push(
+      options.delivery.subscribe(
+        path,
+        (next) => {
+          if (closed) return;
+          if (!hasBaseline) {
+            previous = next;
+            hasBaseline = true;
+            baselinesRemaining -= 1;
+            if (baselinesRemaining === 0 && !readinessFailed) markReady();
+            return;
+          }
+
+          const before = previous;
+          previous = next;
+          const projections = projectValueCreates(trigger.reference, {
+            path,
+            before,
+            after: next,
+          });
+          for (const projection of projections) {
+            const deliverySequence = ++sequence;
+            tail = tail.then(async () => {
+              const result = await executeOnValueCreated(
+                trigger,
+                projection,
+                options.eventOptions(projection, deliverySequence, trigger),
+              );
+              options.onExecution?.(result, trigger, projection);
+            });
+          }
+        },
+        (error) => {
+          if (!hasBaseline && !readinessFailed) {
+            readinessFailed = true;
+            failReady(error);
+          }
+          options.onDeliveryError?.(error, trigger);
+        },
+      ),
+    );
+  }
+
+  return {
+    triggerCount: triggers.length,
+    ready,
+    idle: () => tail,
+    close() {
+      if (closed) return;
+      closed = true;
+      for (const stop of unsubscribe.splice(0)) stop();
+    },
+  };
+}

--- a/packages/cli/src/functions-rtdb/index.ts
+++ b/packages/cli/src/functions-rtdb/index.ts
@@ -1,0 +1,16 @@
+export {
+  discoverOnValueCreated,
+  executeOnValueCreated,
+  InMemoryRtdbTriggerDelivery,
+  projectValueCreates,
+  startOnValueCreatedExecution,
+  type CreatedEventOptions,
+  type CreatedExecutionResult,
+  type CreatedValueProjection,
+  type DiscoveredOnValueCreated,
+  type OnValueCreatedExecutionHost,
+  type OnValueCreatedExecutionOptions,
+  type RtdbCreatedCallable,
+  type RtdbSnapshotCommit,
+  type RtdbTriggerDelivery,
+} from './execution.js';

--- a/packages/cli/src/register/index.ts
+++ b/packages/cli/src/register/index.ts
@@ -58,11 +58,12 @@ const moduleApi = Module as unknown as {
  * CJS→ESM seam: a rewritten `require()` fails against the pyric mirrors'
  * `import`-condition-only exports (the CJS resolver ignores hook-supplied
  * condition overrides), even though `require(esm)` can load them fine.
- * Locate the package from the REQUIRING module and resolve the subpath under
- * import conditions ourselves. Returns the resolved file URL, or null to
- * rethrow the original error.
+ * Locate the package from this installed CLI and resolve the subpath under
+ * import conditions ourselves. The user's function package is not required
+ * to install Pyric's mapped targets. Returns the resolved file URL, or null
+ * to rethrow the original error.
  */
-function resolveEsmOnlyForRequire(mapped: string, parentURL: string | undefined): string | null {
+function resolveEsmOnlyForRequire(mapped: string): string | null {
   if (typeof moduleApi.findPackageJSON !== 'function') return null;
   const slash = mapped.indexOf('/');
   const pkgName = slash === -1 ? mapped : mapped.slice(0, slash);
@@ -71,7 +72,7 @@ function resolveEsmOnlyForRequire(mapped: string, parentURL: string | undefined)
   try {
     pkgJsonPath = moduleApi.findPackageJSON(
       pkgName,
-      parentURL ?? pathToFileURL(join(process.cwd(), 'noop.js')),
+      import.meta.url,
     );
   } catch {
     return null;
@@ -94,14 +95,15 @@ function activate(): void {
         const mapped = mapFirebaseSpecifier(specifier);
         if (mapped === null) return nextResolve(specifier, context);
         try {
-          return nextResolve(mapped, context);
+          return nextResolve(mapped, { ...context, parentURL: import.meta.url });
         } catch (err) {
           // CJS `require('firebase-admin/app')` resolves under the `require`
           // condition, but the pyric mirrors are ESM-only. Resolve the file
           // under import conditions ourselves — require(esm) (Node ≥ 22.12)
           // loads it fine once given the URL.
-          if ((err as { code?: string }).code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-            const url = resolveEsmOnlyForRequire(mapped, context.parentURL);
+          const code = (err as { code?: string }).code;
+          if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'MODULE_NOT_FOUND') {
+            const url = resolveEsmOnlyForRequire(mapped);
             if (url) return { url, shortCircuit: true };
           }
           throw err;

--- a/packages/cli/test/functions-rtdb/execution.test.ts
+++ b/packages/cli/test/functions-rtdb/execution.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import {
+  discoverOnValueCreated,
+  executeOnValueCreated,
+  InMemoryRtdbTriggerDelivery,
+  projectValueCreates,
+  startOnValueCreatedExecution,
+  type RtdbSnapshotCommit,
+} from '../../src/functions-rtdb/index.js';
+
+const requireFromConformance = createRequire(
+  join(import.meta.dir, '../../../conformance/package.json'),
+);
+process.env.GCLOUD_PROJECT ??= 'demo-project';
+process.env.FIREBASE_CONFIG ??= JSON.stringify({
+  projectId: 'demo-project',
+  databaseURL: 'https://demo-project-default-rtdb.firebaseio.com',
+});
+
+const adminApp = requireFromConformance('firebase-admin/app') as typeof import('firebase-admin/app');
+const functionsV2 = requireFromConformance('firebase-functions/v2') as typeof import('firebase-functions/v2');
+const databaseFunctions = requireFromConformance(
+  'firebase-functions/v2/database',
+) as typeof import('firebase-functions/v2/database');
+let testAdminApp: ReturnType<typeof adminApp.initializeApp>;
+
+beforeAll(() => {
+  testAdminApp = adminApp.initializeApp(
+    { projectId: 'demo-project' },
+    'functions-rtdb-execution-test',
+  );
+  functionsV2.app.setEmulatedAdminApp(testAdminApp);
+});
+
+afterAll(async () => {
+  await adminApp.deleteApp(testAdminApp);
+});
+
+describe('projectValueCreates', () => {
+  test('projects one exact absent-to-present transition at the matched ref', () => {
+    const commit: RtdbSnapshotCommit = {
+      path: '/messages/id/original',
+      before: null,
+      after: 'hello',
+    };
+
+    expect(projectValueCreates('/messages/id/original', commit)).toEqual([
+      {
+        ref: 'messages/id/original',
+        params: {},
+        value: 'hello',
+      },
+    ]);
+  });
+
+  test('expands named single-segment wildcards and captures their params', () => {
+    const commit: RtdbSnapshotCommit = {
+      path: '/cases/single/items',
+      before: null,
+      after: {
+        itemA: { marker: 'single' },
+      },
+    };
+
+    expect(projectValueCreates('/cases/{caseId}/items/{itemId}', commit)).toEqual([
+      {
+        ref: 'cases/single/items/itemA',
+        params: { caseId: 'single', itemId: 'itemA' },
+        value: { marker: 'single' },
+      },
+    ]);
+  });
+
+  test('projects every newly present matched descendant from ancestor and multi-path snapshots', () => {
+    expect(
+      projectValueCreates('/cases/{caseId}/items/{itemId}', {
+        path: '/cases',
+        before: {
+          multi: { items: { existing: { marker: 'keep' } } },
+        },
+        after: {
+          multi: {
+            items: {
+              existing: { marker: 'updated but not created' },
+              delta: { marker: 'multi-a' },
+              gamma: { marker: 'multi-b' },
+            },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        ref: 'cases/multi/items/delta',
+        params: { caseId: 'multi', itemId: 'delta' },
+        value: { marker: 'multi-a' },
+      },
+      {
+        ref: 'cases/multi/items/gamma',
+        params: { caseId: 'multi', itemId: 'gamma' },
+        value: { marker: 'multi-b' },
+      },
+    ]);
+  });
+
+  test('fans out an ancestor create and projects each snapshot to its matched descendant', () => {
+    expect(
+      projectValueCreates('/batches/{batchId}/items/{itemId}', {
+        path: '/batches',
+        before: null,
+        after: {
+          fanout: {
+            items: {
+              alpha: { marker: 'fanout-a' },
+              beta: { marker: 'fanout-b' },
+            },
+            sibling: { excluded: true },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        ref: 'batches/fanout/items/alpha',
+        params: { batchId: 'fanout', itemId: 'alpha' },
+        value: { marker: 'fanout-a' },
+      },
+      {
+        ref: 'batches/fanout/items/beta',
+        params: { batchId: 'fanout', itemId: 'beta' },
+        value: { marker: 'fanout-b' },
+      },
+    ]);
+  });
+});
+
+describe('discoverOnValueCreated', () => {
+  test('recognizes real v2 RTDB create callables by endpoint metadata', () => {
+    const { onValueCreated, onValueUpdated } = databaseFunctions;
+    const created = onValueCreated('/messages/{pushId}/original', () => undefined);
+    const updated = onValueUpdated('/messages/{pushId}/original', () => undefined);
+
+    expect(discoverOnValueCreated({ created, updated, helper: () => undefined })).toEqual([
+      {
+        exportName: 'created',
+        reference: 'messages/{pushId}/original',
+        instance: '*',
+        callable: created,
+      },
+    ]);
+  });
+});
+
+describe('executeOnValueCreated', () => {
+  test('awaits the real SDK callable and supplies a production-shaped create event', async () => {
+    const { onValueCreated } = databaseFunctions;
+
+    let received: Record<string, unknown> | undefined;
+    let finished = false;
+    const callable = onValueCreated(
+      '/messages/{pushId}/original',
+      async (event) => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        received = {
+          id: event.id,
+          type: event.type,
+          time: event.time,
+          instance: event.instance,
+          location: event.location,
+          ref: event.ref,
+          subject: event.subject,
+          params: event.params,
+          authType: event.authType,
+          authId: event.authId,
+          value: event.data.val(),
+        };
+        finished = true;
+      },
+    );
+    const [trigger] = discoverOnValueCreated({ makeUppercase: callable });
+
+    const result = await executeOnValueCreated(
+      trigger,
+      {
+        ref: 'messages/id/original',
+        params: { pushId: 'id' },
+        value: 'hello',
+      },
+      {
+        id: 'delivery-1',
+        time: '2026-07-13T20:00:00.000Z',
+        projectId: 'demo-project',
+        instance: 'demo-project-default-rtdb',
+        location: 'us-central1',
+        databaseHost: 'firebasedatabase.app',
+      },
+    );
+
+    expect(finished).toBe(true);
+    expect(result.status).toBe('fulfilled');
+    expect(received).toEqual({
+      id: 'delivery-1',
+      type: 'google.firebase.database.ref.v1.created',
+      time: '2026-07-13T20:00:00.000Z',
+      instance: 'demo-project-default-rtdb',
+      location: 'us-central1',
+      ref: 'messages/id/original',
+      subject: 'refs/messages/id/original',
+      params: { pushId: 'id' },
+      authType: 'unknown',
+      authId: null,
+      value: 'hello',
+    });
+  });
+
+  test('returns a rejected execution report for a thrown handler error', async () => {
+    const { onValueCreated } = databaseFunctions;
+    const marker = new Error('PYRIC_EXPECTED_ONVALUECREATED_FAILURE');
+    const [trigger] = discoverOnValueCreated({
+      failed: onValueCreated('/failures/{id}', async () => {
+        throw marker;
+      }),
+    });
+
+    const result = await executeOnValueCreated(
+      trigger,
+      { ref: 'failures/one', params: { id: 'one' }, value: true },
+      {
+        id: 'failed-delivery',
+        time: '2026-07-13T20:00:00.000Z',
+        projectId: 'demo-project',
+        instance: 'demo-project-default-rtdb',
+        location: 'us-central1',
+        databaseHost: 'firebasedatabase.app',
+      },
+    );
+
+    expect(result).toMatchObject({ status: 'rejected', error: marker });
+  });
+});
+
+describe('startOnValueCreatedExecution', () => {
+  test('rejects readiness when the snapshot source fails before its baseline', async () => {
+    const sourceError = new Error('snapshot relay unavailable');
+    const created = databaseFunctions.onValueCreated('/items/{itemId}', () => undefined);
+    const host = startOnValueCreatedExecution({
+      exported: { created },
+      delivery: {
+        subscribe(_path, _listener, onError) {
+          onError?.(sourceError);
+          return () => undefined;
+        },
+      },
+      eventOptions: () => {
+        throw new Error('no event should be built before readiness');
+      },
+    });
+
+    await expect(
+      Promise.race([
+        host.ready,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('ready remained pending')), 20),
+        ),
+      ]),
+    ).rejects.toBe(sourceError);
+    host.close();
+  });
+
+  test('treats the first snapshot as a baseline and delivers only a later absent-to-present value', async () => {
+    const { onValueCreated } = databaseFunctions;
+    const values: unknown[] = [];
+    const makeUppercase = onValueCreated(
+      '/messages/id/original',
+      (event) => {
+        values.push(event.data.val());
+      },
+    );
+    const delivery = new InMemoryRtdbTriggerDelivery();
+    delivery.seed('/messages/id/original', 'already here');
+    const host = startOnValueCreatedExecution({
+      exported: { makeUppercase },
+      delivery,
+      eventOptions: (_projection, sequence) => ({
+        id: `delivery-${sequence}`,
+        time: '2026-07-13T20:00:00.000Z',
+        projectId: 'demo-project',
+        instance: 'demo-project-default-rtdb',
+        location: 'us-central1',
+        databaseHost: 'firebasedatabase.app',
+      }),
+    });
+
+    expect(host.ready).toBeInstanceOf(Promise);
+    await host.ready;
+    expect(values).toEqual([]);
+
+    delivery.emit('/messages/id/original', 'updated');
+    delivery.emit('/messages/id/original', null);
+    delivery.emit('/messages/id/original', 'created again');
+    await host.idle();
+
+    expect(values).toEqual(['created again']);
+    host.close();
+  });
+
+  test('serializes handler execution across successive snapshot deliveries', async () => {
+    const { onValueCreated } = databaseFunctions;
+    const started: string[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const created = onValueCreated('/items/{itemId}', async (event) => {
+      started.push(event.params.itemId);
+      if (event.params.itemId === 'one') await firstBlocked;
+    });
+    const delivery = new InMemoryRtdbTriggerDelivery();
+    delivery.seed('/items', null);
+    const host = startOnValueCreatedExecution({
+      exported: { created },
+      delivery,
+      eventOptions: (_projection, sequence) => ({
+        id: `serial-${sequence}`,
+        time: '2026-07-13T20:00:00.000Z',
+        projectId: 'demo-project',
+        instance: 'demo-project-default-rtdb',
+        location: 'us-central1',
+        databaseHost: 'firebasedatabase.app',
+      }),
+    });
+    await host.ready;
+
+    delivery.emit('/items', { one: 1 });
+    delivery.emit('/items', { one: 1, two: 2 });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(started).toEqual(['one']);
+
+    releaseFirst();
+    await host.idle();
+    expect(started).toEqual(['one', 'two']);
+    host.close();
+  });
+});

--- a/packages/cli/test/register/register-child.test.ts
+++ b/packages/cli/test/register/register-child.test.ts
@@ -28,6 +28,7 @@ const hasRegisterHooks =
 
 let fixtureDir: string;
 let inactiveFixtureDir: string;
+let isolatedFixtureDir: string;
 
 function runNode(
   script: string,
@@ -69,6 +70,24 @@ beforeAll(() => {
   writeFileSync(
     join(inactiveFixtureDir, 'package.json'),
     JSON.stringify({ name: 'register-inactive-fixture', type: 'module' }),
+  );
+
+  // Installed-CLI fixture: the user package intentionally has neither
+  // firebase-admin nor pyric-admin in its own dependency tree. The register
+  // hook must resolve its mapped target from @pyric/cli's installation.
+  isolatedFixtureDir = mkdtempSync(join(tmpdir(), 'pyric-register-isolated-'));
+  mkdirSync(join(isolatedFixtureDir, 'node_modules'));
+  writeFileSync(
+    join(isolatedFixtureDir, 'package.json'),
+    JSON.stringify({ name: 'register-isolated-fixture', type: 'commonjs' }),
+  );
+  writeFileSync(
+    join(isolatedFixtureDir, 'database.cjs'),
+    `const assert = require('node:assert');
+const database = require('firebase-admin/database');
+assert.strictEqual(typeof database.getDatabaseWithUrl, 'function');
+console.log('ISOLATED_DATABASE_OK');
+`,
   );
 
   // ESM fixture: env is set, firebase-admin/app IS pyric-admin (its
@@ -174,6 +193,7 @@ console.log(JSON.stringify({
 afterAll(() => {
   if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
   if (inactiveFixtureDir) rmSync(inactiveFixtureDir, { recursive: true, force: true });
+  if (isolatedFixtureDir) rmSync(isolatedFixtureDir, { recursive: true, force: true });
 });
 
 describe('@pyric/cli/register (child process)', () => {
@@ -205,6 +225,20 @@ describe('@pyric/cli/register (child process)', () => {
     expect(res.stderr).toContain('@pyric/cli/register: active');
     expect(res.stdout).toContain('CJS_OK');
     expect(res.status).toBe(0);
+  });
+
+  it.skipIf(!hasRegisterHooks)('resolves mapped packages from the installed CLI rather than the requiring package', () => {
+    expect(existsSync(join(isolatedFixtureDir, 'node_modules/pyric-admin'))).toBe(false);
+    expect(existsSync(join(isolatedFixtureDir, 'node_modules/firebase-admin'))).toBe(false);
+    const res = runNode(
+      'database.cjs',
+      { PYRIC_SANDBOX: 'remote:http://127.0.0.1:5000' },
+      isolatedFixtureDir,
+    );
+    expect(res).toMatchObject({
+      status: 0,
+      stdout: expect.stringContaining('ISOLATED_DATABASE_OK'),
+    });
   });
 
   it('is inert without PYRIC_SANDBOX — real firebase-admin, no factory, no log', () => {

--- a/packages/pyric-admin/docs/database/reference/api.generated.md
+++ b/packages/pyric-admin/docs/database/reference/api.generated.md
@@ -436,17 +436,15 @@ Mirror-owned structural types for the implemented admin RTDB surface.
 
 Returns the AdminDatabase service for the supplied app.
 
-Signature mirrors `firebase-admin/database`'s `getDatabase(app?)` and
-`getDatabaseWithUrl(url, app)` collapsed into a single function:
+Signature mirrors `firebase-admin/database`'s `getDatabase(app?)`.
 
   - `getDatabase()` — default database for the DEFAULT app (resolved
     through `pyric-admin/app`'s registry, exactly like firebase-admin's
     no-arg `getDatabase()`; throws `app/no-app` when no default app has
     been initialized). Works for local and remote sandbox apps.
   - `getDatabase(app)` — default database for the app.
-  - `getDatabase(app, url)` — accepts the upstream-compatible URL
-    position, which the sandbox ignores because it has no notion of
-    multiple database instances per project.
+  - `getDatabase(app, url)` — legacy Pyric-only compatibility form. New
+    code should use the upstream-shaped [getDatabaseWithUrl](#getdatabasewithurl) export.
 
 The sandbox brand returns the local or remote `Database` backed by the
 per-`Sandbox` state described in the module-level docs.
@@ -460,6 +458,34 @@ per-`Sandbox` state described in the module-level docs.
 ##### \_url?
 
 `string`
+
+#### Returns
+
+[`Database`](#database)
+
+***
+
+### getDatabaseWithUrl()
+
+> **getDatabaseWithUrl**(`_url`, `app?`): [`Database`](#database)
+
+Returns the AdminDatabase service selected by an upstream-shaped
+database URL.
+
+This is the exact `firebase-admin/database` argument order used by the
+Firebase Functions SDK: `getDatabaseWithUrl(url, app?)`. The first Pyric
+Functions slice has one shared RTDB instance, so the URL selects that
+instance rather than creating a second sandbox database.
+
+#### Parameters
+
+##### \_url
+
+`string`
+
+##### app?
+
+`SandboxAdminApp`
 
 #### Returns
 

--- a/packages/pyric-admin/docs/database/reference/api.md
+++ b/packages/pyric-admin/docs/database/reference/api.md
@@ -14,19 +14,30 @@ absent.
 
 ## Initialization
 
-### `getDatabase(app?, url?)`
+### `getDatabase(app?, legacyUrl?)`
 
 ```ts
-function getDatabase(app?: PyricAdminApp, url?: string): Database;
+function getDatabase(app?: PyricAdminApp, legacyUrl?: string): Database;
 ```
 
-firebase-admin's `getDatabase(app?)` and `getDatabaseWithUrl(url, app)` collapsed into one function:
+Mirrors firebase-admin's `getDatabase(app?)`:
 
 - `getDatabase()`: default database for the `'[DEFAULT]'` sandbox app, resolved through `pyric-admin/app`'s registry. Throws `app/no-app` when nothing is initialized.
 - `getDatabase(app)`: default database for the app.
-- `getDatabase(app, url)`: accepts `url` for shape compatibility; the sandbox ignores it because it has no project-level database instances.
+- `getDatabase(app, legacyUrl)`: retained for compatibility with Pyric's former collapsed signature. New code should use `getDatabaseWithUrl`.
 
 Successive calls for the same sandbox return handles that share data, matching firebase-admin's singleton-per-app semantics. Throws `TypeError` for an unbranded value.
+
+### `getDatabaseWithUrl(url, app?)`
+
+```ts
+function getDatabaseWithUrl(url: string, app?: PyricAdminApp): Database;
+```
+
+Uses firebase-admin's exact URL-first argument order. The Functions SDK calls
+this export when materializing `event.data.ref`. Pyric's first Functions slice
+has one shared RTDB instance, so the URL selects that instance; it does not
+create a separate sandbox tree.
 
 ---
 

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -141,17 +141,15 @@ type AdminEventType = EventType;
 /**
  * Returns the {@link AdminDatabase} service for the supplied app.
  *
- * Signature mirrors `firebase-admin/database`'s `getDatabase(app?)` and
- * `getDatabaseWithUrl(url, app)` collapsed into a single function:
+ * Signature mirrors `firebase-admin/database`'s `getDatabase(app?)`.
  *
  *   - `getDatabase()` — default database for the DEFAULT app (resolved
  *     through `pyric-admin/app`'s registry, exactly like firebase-admin's
  *     no-arg `getDatabase()`; throws `app/no-app` when no default app has
  *     been initialized). Works for local and remote sandbox apps.
  *   - `getDatabase(app)` — default database for the app.
- *   - `getDatabase(app, url)` — accepts the upstream-compatible URL
- *     position, which the sandbox ignores because it has no notion of
- *     multiple database instances per project.
+ *   - `getDatabase(app, url)` — legacy Pyric-only compatibility form. New
+ *     code should use the upstream-shaped {@link getDatabaseWithUrl} export.
  *
  * The sandbox brand returns the local or remote `Database` backed by the
  * per-`Sandbox` state described in the module-level docs.
@@ -172,6 +170,22 @@ export function getDatabase(
     'pyric-admin/database: getDatabase expected a PyricAdminApp ' +
       '(initialize via `initializeApp` from pyric-admin/app).',
   );
+}
+
+/**
+ * Returns the {@link AdminDatabase} service selected by an upstream-shaped
+ * database URL.
+ *
+ * This is the exact `firebase-admin/database` argument order used by the
+ * Firebase Functions SDK: `getDatabaseWithUrl(url, app?)`. The first Pyric
+ * Functions slice has one shared RTDB instance, so the URL selects that
+ * instance rather than creating a second sandbox database.
+ */
+export function getDatabaseWithUrl(
+  _url: string,
+  app?: PyricAdminApp,
+): AdminDatabase {
+  return getDatabase(app);
 }
 
 // ─── Sandbox backend ─────────────────────────────────────────────────

--- a/packages/pyric-admin/test/database/get-database-with-url.test.ts
+++ b/packages/pyric-admin/test/database/get-database-with-url.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  deleteApp,
+  getApps,
+  initializeApp,
+} from '../../src/app/index.js';
+import {
+  getDatabase,
+  getDatabaseWithUrl,
+} from '../../src/database/index.js';
+
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+describe('getDatabaseWithUrl', () => {
+  test('accepts the upstream url-first signature and selects the supplied app database', async () => {
+    const app = initializeApp({ sandbox: initializeSandbox() });
+
+    const database = getDatabaseWithUrl(
+      'https://demo-project-default-rtdb.firebaseio.com',
+      app,
+    );
+    await database.ref('functions/created').set({ value: 42 });
+
+    expect((await getDatabase(app).ref('functions/created').get()).val()).toEqual({
+      value: 42,
+    });
+  });
+});

--- a/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
@@ -21,17 +21,26 @@ absent.
 
 ## Initialization
 
-### `getDatabase(app?, url?)`
+### `getDatabase(app?, legacyUrl?)`
 ```ts
-function getDatabase(app?: PyricAdminApp, url?: string): Database;
+function getDatabase(app?: PyricAdminApp, legacyUrl?: string): Database;
 ```
-firebase-admin's `getDatabase(app?)` and `getDatabaseWithUrl(url, app)` collapsed into one function:
+Mirrors firebase-admin's `getDatabase(app?)`:
 
 - `getDatabase()`: default database for the `'[DEFAULT]'` sandbox app, resolved through `pyric-admin/app`'s registry. Throws `app/no-app` when nothing is initialized.
 - `getDatabase(app)`: default database for the app.
-- `getDatabase(app, url)`: accepts `url` for shape compatibility; the sandbox ignores it because it has no project-level database instances.
+- `getDatabase(app, legacyUrl)`: retained for compatibility with Pyric's former collapsed signature. New code should use `getDatabaseWithUrl`.
 
 Successive calls for the same sandbox return handles that share data, matching firebase-admin's singleton-per-app semantics. Throws `TypeError` for an unbranded value.
+
+### `getDatabaseWithUrl(url, app?)`
+```ts
+function getDatabaseWithUrl(url: string, app?: PyricAdminApp): Database;
+```
+Uses firebase-admin's exact URL-first argument order. The Functions SDK calls
+this export when materializing `event.data.ref`. Pyric's first Functions slice
+has one shared RTDB instance, so the URL selects that instance; it does not
+create a separate sandbox tree.
 
 ---
 


### PR DESCRIPTION
Adds an inactive RTDB `onValueCreated` execution core that projects snapshot commits and invokes the real Firebase Functions callable.

~~~ts
import { onValueCreated } from "firebase-functions/v2/database";
import {
  InMemoryRtdbTriggerDelivery,
  startOnValueCreatedExecution,
} from "./src/functions-rtdb/index.js";

const createdValues: unknown[] = [];
const itemCreated = onValueCreated("/items/{itemId}", async (event) => {
  createdValues.push({ itemId: event.params.itemId, value: event.data.val() });
});

const delivery = new InMemoryRtdbTriggerDelivery();
delivery.seed("/items", null); // Baseline, not a historical create.
const host = startOnValueCreatedExecution({
  exported: { itemCreated },
  delivery,
  eventOptions: (_projection, sequence) => ({
    id: "delivery-" + sequence,
    time: "2026-07-13T20:00:00.000Z",
    projectId: "demo-project",
    instance: "demo-project-default-rtdb",
    location: "us-central1",
    databaseHost: "firebasedatabase.app",
  }),
});

await host.ready;
delivery.emit("/items", { alpha: { marker: "created" } });
await host.idle();
// createdValues is [{ itemId: "alpha", value: { marker: "created" } }]
host.close();
~~~

## Snapshot diffs become exact create deliveries

`projectValueCreates()` compares before/after snapshots at the longest static path prefix. It emits only absent-to-present matches, captures named single-segment wildcards, fans ancestor writes out to each matching descendant, projects each event snapshot to its matched value, and handles multiple new children from one multi-path update.

The host treats each subscription’s first snapshot as its baseline, exposes a readiness promise, rejects readiness when the source fails before that baseline, and serializes later handler execution within the session.

## Real SDK metadata and callables stay on the execution path

`discoverOnValueCreated()` recognizes exports through the real SDK’s endpoint metadata. `executeOnValueCreated()` builds the raw RTDB CloudEvent, invokes the exported wrapper rather than `.run`, awaits the user’s promise, and returns a structured fulfilled or rejected result.

No `firebase-functions` dependency is added to `@pyric/cli`; the user project owns the real SDK. This internal module is not imported by ordinary `pyric dev` yet.

## Risk

The core depends on metadata used by the Firebase emulator and on the raw event shape from Firebase Functions 7.2.5. PR4 must report unsupported trigger metadata rather than silently treating it as this exact/wildcard slice.

Serialization is an in-session property, not a production ordering, retry, concurrency, durability, or multiple-instance claim.

This PR moves no conformance status or published trust number. Functions remains 0/13 until transport and product wiring replay the frozen observations.

Stacked on #287; part of #280.

<details>
<summary>Implementation notes and verification</summary>

- Red-first slices covered the module, wildcard projection, real callable discovery, execution, readiness, and pre-baseline source failure.
- `bun test packages/cli/test/functions-rtdb/execution.test.ts` — 10 pass.
- Register and mapping suites — 19 pass.
- CLI typecheck and build — green.
- `bun run compat:check` — green; 799 rows, 256 observations, no regressions.
- `bun run compat:climb` — Functions remains 0/13 with no green-row regressions.
- The broad CLI suite reached 1,084 pass and 18 expected skips; two unrelated unreachable-network tests timed out at five seconds. Both reproduce alone and neither imports this module.

</details>
