### PR TITLE
Functions: relay RTDB creates to an isolated child

### DIFF
--- a/packages/cli/src/functions-rtdb/child.ts
+++ b/packages/cli/src/functions-rtdb/child.ts
@@ -1,0 +1,300 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RemoteSandbox } from '../remote/index.js';
+import {
+  startOnValueCreatedExecution,
+  type CreatedExecutionResult,
+  type OnValueCreatedExecutionHost,
+} from './execution.js';
+import { RemoteRtdbTriggerDelivery } from './remote-delivery.js';
+
+export interface SerializedFunctionsRtdbError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+export type FunctionsRtdbChildEvent =
+  | {
+      type: 'execution';
+      exportName: string;
+      ref: string;
+      status: 'fulfilled';
+    }
+  | {
+      type: 'execution';
+      exportName: string;
+      ref: string;
+      status: 'rejected';
+      error: SerializedFunctionsRtdbError;
+    }
+  | {
+      type: 'delivery-error';
+      exportName: string;
+      error: SerializedFunctionsRtdbError;
+    };
+
+export interface FunctionsRtdbChildReady {
+  triggerCount: number;
+}
+
+export interface SpawnFunctionsRtdbChildOptions {
+  cwd: string;
+  entry: string;
+  env: NodeJS.ProcessEnv;
+  projectId: string;
+  instance: string;
+  location: string;
+  databaseHost?: string;
+  childModuleUrl?: string | URL;
+  nodeExecutable?: string;
+  onEvent?(event: FunctionsRtdbChildEvent): void;
+}
+
+export interface FunctionsRtdbChildHandle {
+  child: ChildProcess;
+  ready: Promise<FunctionsRtdbChildReady>;
+  exited: Promise<number>;
+  stop(): Promise<number>;
+}
+
+type FunctionsRtdbChildMessage =
+  | ({ type: 'ready' } & FunctionsRtdbChildReady)
+  | FunctionsRtdbChildEvent
+  | { type: 'fatal'; error: SerializedFunctionsRtdbError }
+  | { type: 'stopped' };
+
+const FORCE_KILL_AFTER_MS = 2_000;
+
+function serializeError(error: unknown): SerializedFunctionsRtdbError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(error.stack === undefined ? {} : { stack: error.stack }),
+    };
+  }
+  return { name: 'Error', message: String(error) };
+}
+
+function isChildMessage(value: unknown): value is FunctionsRtdbChildMessage {
+  return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+/** Spawn the real Firebase Functions SDK in an isolated Node process. */
+export function spawnFunctionsRtdbChild(
+  options: SpawnFunctionsRtdbChildOptions,
+): FunctionsRtdbChildHandle {
+  const childModuleUrl = options.childModuleUrl ?? new URL('./child.js', import.meta.url);
+  const childModulePath = typeof childModuleUrl === 'string' && !childModuleUrl.startsWith('file:')
+    ? resolve(childModuleUrl)
+    : fileURLToPath(childModuleUrl);
+  const child = spawn(options.nodeExecutable ?? 'node', [childModulePath], {
+    cwd: options.cwd,
+    env: {
+      ...options.env,
+      PYRIC_FUNCTIONS_RTDB_CHILD: '1',
+      PYRIC_FUNCTIONS_ENTRY: resolve(options.entry),
+      PYRIC_FUNCTIONS_PROJECT_ID: options.projectId,
+      PYRIC_FUNCTIONS_INSTANCE: options.instance,
+      PYRIC_FUNCTIONS_LOCATION: options.location,
+      PYRIC_FUNCTIONS_DATABASE_HOST: options.databaseHost ?? 'firebasedatabase.app',
+    },
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  });
+
+  let readySettled = false;
+  let stopping = false;
+  let stderr = '';
+  child.stderr?.setEncoding('utf8');
+  child.stderr?.on('data', (chunk: string) => {
+    stderr = `${stderr}${chunk}`.slice(-8_192);
+  });
+
+  let resolveReady!: (ready: FunctionsRtdbChildReady) => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<FunctionsRtdbChildReady>((resolvePromise, rejectPromise) => {
+    resolveReady = resolvePromise;
+    rejectReady = rejectPromise;
+  });
+
+  child.on('message', (raw: unknown) => {
+    if (!isChildMessage(raw)) return;
+    if (raw.type === 'ready') {
+      readySettled = true;
+      resolveReady({ triggerCount: raw.triggerCount });
+    } else if (raw.type === 'fatal') {
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(new Error(
+          `Functions RTDB child failed: ${raw.error.stack ?? raw.error.message}`,
+        ));
+      }
+    } else if (raw.type === 'execution' || raw.type === 'delivery-error') {
+      options.onEvent?.(raw);
+    }
+  });
+
+  let forceTimer: ReturnType<typeof setTimeout> | undefined;
+  const exited = new Promise<number>((resolveExited) => {
+    child.once('error', (error) => {
+      if (!readySettled) {
+        readySettled = true;
+        rejectReady(error);
+      }
+    });
+    child.once('close', (code, signal) => {
+      if (forceTimer !== undefined) clearTimeout(forceTimer);
+      const exitCode = typeof code === 'number' ? code : signal ? 1 : 0;
+      if (!readySettled) {
+        readySettled = true;
+        const diagnostic = stderr.trim();
+        rejectReady(new Error(
+          `Functions RTDB child exited before ready (code ${exitCode})` +
+            (diagnostic ? `\n${diagnostic}` : ''),
+        ));
+      }
+      resolveExited(exitCode);
+    });
+  });
+
+  return {
+    child,
+    ready,
+    exited,
+    async stop(): Promise<number> {
+      if (child.exitCode !== null || child.signalCode !== null) return exited;
+      if (!stopping) {
+        stopping = true;
+        if (child.connected) child.send({ type: 'stop' });
+        else child.kill('SIGTERM');
+        forceTimer = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+        }, FORCE_KILL_AFTER_MS);
+        forceTimer.unref();
+      }
+      return exited;
+    },
+  };
+}
+
+interface AdminAppModule {
+  initializeApp(): { sandbox: RemoteSandbox };
+  deleteApp(app: unknown): Promise<void>;
+}
+
+function send(message: FunctionsRtdbChildMessage): void {
+  process.send?.(message);
+}
+
+async function runFunctionsRtdbChild(): Promise<void> {
+  const entry = process.env.PYRIC_FUNCTIONS_ENTRY;
+  const projectId = process.env.PYRIC_FUNCTIONS_PROJECT_ID;
+  const instance = process.env.PYRIC_FUNCTIONS_INSTANCE;
+  const location = process.env.PYRIC_FUNCTIONS_LOCATION;
+  const databaseHost = process.env.PYRIC_FUNCTIONS_DATABASE_HOST;
+  if (!entry || !projectId || !instance || !location || !databaseHost) {
+    throw new Error('Functions RTDB child is missing its required environment');
+  }
+
+  const requireFromEntry = createRequire(entry);
+  const adminApp = requireFromEntry('firebase-admin/app') as AdminAppModule;
+  const app = adminApp.initializeApp();
+  let host: OnValueCreatedExecutionHost | undefined;
+  let closing: Promise<void> | undefined;
+
+  const close = (): Promise<void> => {
+    if (closing) return closing;
+    closing = (async () => {
+      host?.close();
+      await host?.idle();
+      app.sandbox.close();
+      await adminApp.deleteApp(app);
+    })();
+    return closing;
+  };
+
+  const shutdown = async (): Promise<void> => {
+    await close();
+    send({ type: 'stopped' });
+    process.disconnect?.();
+  };
+
+  process.once('message', (raw: unknown) => {
+    if (isChildMessage(raw) && raw.type === 'stopped') return;
+    if (typeof raw === 'object' && raw !== null && 'type' in raw && raw.type === 'stop') {
+      void shutdown().catch((error) => {
+        send({ type: 'fatal', error: serializeError(error) });
+        process.exitCode = 1;
+        process.disconnect?.();
+      });
+    }
+  });
+  process.once('SIGINT', () => void shutdown());
+  process.once('SIGTERM', () => void shutdown());
+
+  try {
+    // The real database provider asks firebase-admin/app for its default app
+    // when it wraps a raw CloudEvent. Initializing that app before loading the
+    // user's module avoids importing the broad firebase-functions/v2 barrel.
+    const exported = requireFromEntry(entry) as Record<string, unknown>;
+    host = startOnValueCreatedExecution({
+      exported,
+      delivery: new RemoteRtdbTriggerDelivery(app.sandbox.rtdb),
+      eventOptions: (_projection, sequence) => ({
+        id: `${randomUUID()}-${sequence}`,
+        time: new Date().toISOString(),
+        projectId,
+        instance,
+        location,
+        databaseHost,
+      }),
+      onExecution(result, trigger, projection) {
+        sendExecution(result, trigger.exportName, projection.ref);
+      },
+      onDeliveryError(error, trigger) {
+        send({
+          type: 'delivery-error',
+          exportName: trigger.exportName,
+          error: serializeError(error),
+        });
+      },
+    });
+    await host.ready;
+    send({ type: 'ready', triggerCount: host.triggerCount });
+  } catch (error) {
+    await close();
+    throw error;
+  }
+}
+
+function sendExecution(
+  result: CreatedExecutionResult,
+  exportName: string,
+  ref: string,
+): void {
+  if (result.status === 'fulfilled') {
+    send({ type: 'execution', exportName, ref, status: 'fulfilled' });
+  } else {
+    send({
+      type: 'execution',
+      exportName,
+      ref,
+      status: 'rejected',
+      error: serializeError(result.error),
+    });
+  }
+}
+
+if (process.env.PYRIC_FUNCTIONS_RTDB_CHILD === '1') {
+  void runFunctionsRtdbChild().catch((error) => {
+    const serialized = serializeError(error);
+    send({ type: 'fatal', error: serialized });
+    process.stderr.write(`${serialized.stack ?? `${serialized.name}: ${serialized.message}`}\n`);
+    process.exitCode = 1;
+    process.disconnect?.();
+  });
+}

--- a/packages/cli/src/functions-rtdb/index.ts
+++ b/packages/cli/src/functions-rtdb/index.ts
@@ -14,3 +14,14 @@ export {
   type RtdbSnapshotCommit,
   type RtdbTriggerDelivery,
 } from './execution.js';
+
+export { RemoteRtdbTriggerDelivery } from './remote-delivery.js';
+
+export {
+  spawnFunctionsRtdbChild,
+  type FunctionsRtdbChildEvent,
+  type FunctionsRtdbChildHandle,
+  type FunctionsRtdbChildReady,
+  type SerializedFunctionsRtdbError,
+  type SpawnFunctionsRtdbChildOptions,
+} from './child.js';

--- a/packages/cli/src/functions-rtdb/remote-delivery.ts
+++ b/packages/cli/src/functions-rtdb/remote-delivery.ts
@@ -1,0 +1,23 @@
+import type { RemoteRtdb } from '../remote/index.js';
+import type { RtdbTriggerDelivery } from './execution.js';
+
+/** Existing remote RTDB value subscriptions adapted to the execution seam. */
+export class RemoteRtdbTriggerDelivery implements RtdbTriggerDelivery {
+  readonly #rtdb: Pick<RemoteRtdb, 'onValue'>;
+
+  constructor(rtdb: Pick<RemoteRtdb, 'onValue'>) {
+    this.#rtdb = rtdb;
+  }
+
+  subscribe(
+    path: string,
+    listener: (value: unknown) => void,
+    onError?: (error: unknown) => void,
+  ): () => void {
+    return this.#rtdb.onValue(
+      path,
+      (snapshot) => listener(snapshot.value),
+      onError,
+    );
+  }
+}

--- a/packages/cli/test/functions-rtdb/child.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/child.integration.test.ts
@@ -1,0 +1,240 @@
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import WebSocket from 'ws';
+import { createMemoryBackend, initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import {
+  spawnFunctionsRtdbChild,
+  type FunctionsRtdbChildEvent,
+  type FunctionsRtdbChildHandle,
+} from '../../src/functions-rtdb/child.js';
+import {
+  buildChildEnv,
+  registerModuleUrl,
+} from '../../src/cli/dev-runner.js';
+import { startServe, type ServeRuntime } from '../../src/cli/serve.js';
+import {
+  isBridgeMessage,
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../src/bridge/protocol.js';
+import { connectRemoteSandbox, type RemoteSandbox } from '../../src/remote/index.js';
+import { silentServeLogger } from '../../src/serve/server.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../src/serve/worker/protocol.js';
+
+const cliRoot = resolve(import.meta.dir, '../..');
+const repoRoot = resolve(cliRoot, '../..');
+const childModule = join(cliRoot, 'dist/functions-rtdb/child.js');
+
+let fixtureDir: string;
+let runtime: ServeRuntime;
+let peer: { close(): Promise<void> };
+let observer: RemoteSandbox;
+let child: FunctionsRtdbChildHandle | undefined;
+
+async function makeWorkerCtx(): Promise<HostCtx> {
+  const sandbox = initializeSandbox();
+  await sandbox.enablePersistence({
+    key: `functions-child-${Math.random()}`,
+    injectedBackend: createMemoryBackend(),
+  });
+  return {
+    db: getFirestore(sandbox),
+    sandbox,
+    instanceId: 'functions-child-test',
+    subs: new Map(),
+  };
+}
+
+async function connectWorkerPeer(
+  url: string,
+  ctx: HostCtx,
+): Promise<{ close(): Promise<void> }> {
+  const ws = new WebSocket(url);
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      const message = raw as OutboundMessage;
+      if (message.t === 'res') {
+        const response: BridgeMessage = message.ok
+          ? { type: 'worker-res', id: message.id, ok: true, value: message.value }
+          : { type: 'worker-res', id: message.id, ok: false, error: message.error };
+        ws.send(JSON.stringify(response));
+      } else if (message.t === 'snap') {
+        ws.send(JSON.stringify({
+          type: 'worker-snap',
+          subId: message.subId,
+          value: message.value,
+        } satisfies BridgeMessage));
+      }
+    },
+  };
+
+  await new Promise<void>((resolveConnected, rejectConnected) => {
+    ws.once('open', () => {
+      ws.send(JSON.stringify({
+        type: 'hello',
+        protocol: 1,
+        tools: [],
+        sandboxId: 'functions-child-peer',
+        capabilities: [WORKER_RELAY_CAPABILITY],
+      } satisfies BridgeMessage));
+    });
+    ws.on('message', (raw) => {
+      let message: unknown;
+      try {
+        message = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      if (!isBridgeMessage(message)) return;
+      if (message.type === 'hello-ack') {
+        resolveConnected();
+      } else if (message.type === 'worker-op') {
+        void handleMessage(ctx, port, {
+          ...message.op,
+          t: 'op',
+          id: message.id,
+        } as InboundMessage);
+      } else if (message.type === 'worker-sub') {
+        void handleMessage(ctx, port, {
+          ...message.sub,
+          t: 'sub',
+          subId: message.subId,
+        } as InboundMessage);
+      } else if (message.type === 'worker-unsub') {
+        void handleMessage(ctx, port, {
+          t: 'unsub',
+          subId: message.subId,
+        } satisfies InboundMessage);
+      }
+    });
+    ws.once('error', rejectConnected);
+    ws.once('close', () => rejectConnected(new Error('worker peer closed before ready')));
+  });
+
+  return {
+    close: () => new Promise<void>((resolveClosed) => {
+      if (ws.readyState === WebSocket.CLOSED) return resolveClosed();
+      ws.once('close', () => resolveClosed());
+      ws.close();
+    }),
+  };
+}
+
+async function waitForValue(path: string, expected: unknown): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if ((await observer.rtdb.get(path)) === expected) return;
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 20));
+  }
+  throw new Error(`timed out waiting for ${path}=${JSON.stringify(expected)}`);
+}
+
+beforeAll(async () => {
+  if (!existsSync(childModule)) {
+    throw new Error(`Functions child is not built — run bun run --cwd packages/cli build (${childModule})`);
+  }
+  fixtureDir = mkdtempSync(join(tmpdir(), 'pyric-functions-child-'));
+  mkdirSync(join(fixtureDir, 'public'));
+  mkdirSync(join(fixtureDir, 'functions/node_modules'), { recursive: true });
+  writeFileSync(join(fixtureDir, 'public/index.html'), '<!doctype html><body>fixture</body>');
+  writeFileSync(
+    join(fixtureDir, 'firebase.json'),
+    JSON.stringify({ hosting: { public: 'public' } }),
+  );
+  writeFileSync(
+    join(fixtureDir, 'functions/package.json'),
+    JSON.stringify({ name: 'unchanged-functions', private: true, type: 'commonjs' }),
+  );
+  writeFileSync(
+    join(fixtureDir, 'functions/index.cjs'),
+    `const { onValueCreated } = require('firebase-functions/v2/database');
+exports.makeUppercase = onValueCreated(
+  '/messages/{pushId}/original',
+  event => event.data.ref.parent.child('uppercase').set(event.data.val().toUpperCase()),
+);
+exports.markProcessed = onValueCreated(
+  '/messages/{pushId}/uppercase',
+  event => event.data.ref.parent.child('processed').set(
+    event.params.pushId + ':' + event.data.val()
+  ),
+);
+`,
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+    join(fixtureDir, 'functions/node_modules/firebase-functions'),
+  );
+
+  runtime = await startServe({
+    cwd: fixtureDir,
+    port: 0,
+    cacheRoot: join(fixtureDir, '.cache'),
+    logger: silentServeLogger(),
+    bridge: true,
+    disableAuditLog: true,
+  });
+  peer = await connectWorkerPeer(
+    `ws://127.0.0.1:${runtime.handle.port}/__pyric/sandbox`,
+    await makeWorkerCtx(),
+  );
+  observer = await connectRemoteSandbox({ url: runtime.handle.url });
+});
+
+afterAll(async () => {
+  if (child) await child.stop();
+  observer?.close();
+  if (peer) await peer.close();
+  if (runtime) await runtime.handle.stop();
+});
+
+describe('isolated Functions RTDB child', () => {
+  test('loads unchanged CommonJS source and writes back into the same remote sandbox', async () => {
+    const events: FunctionsRtdbChildEvent[] = [];
+    child = spawnFunctionsRtdbChild({
+      cwd: join(fixtureDir, 'functions'),
+      entry: join(fixtureDir, 'functions/index.cjs'),
+      childModuleUrl: pathToFileURL(childModule),
+      env: buildChildEnv(process.env, {
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+      projectId: 'demo-project',
+      instance: 'demo-project-default-rtdb',
+      location: 'us-central1',
+      onEvent: (event) => events.push(event),
+    });
+
+    expect((await child.ready).triggerCount).toBe(2);
+    await observer.rtdb.set('messages/id/original', 'hello');
+    await waitForValue('messages/id/uppercase', 'HELLO');
+    await waitForValue('messages/id/processed', 'id:HELLO');
+
+    expect(events).toContainEqual({
+      type: 'execution',
+      exportName: 'makeUppercase',
+      ref: 'messages/id/original',
+      status: 'fulfilled',
+    });
+    expect(events).toContainEqual({
+      type: 'execution',
+      exportName: 'markProcessed',
+      ref: 'messages/id/uppercase',
+      status: 'fulfilled',
+    });
+    expect(await child.stop()).toBe(0);
+  }, 15_000);
+});

--- a/packages/cli/test/functions-rtdb/remote-delivery.test.ts
+++ b/packages/cli/test/functions-rtdb/remote-delivery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { RemoteRtdbTriggerDelivery } from '../../src/functions-rtdb/remote-delivery.js';
+import type {
+  RemoteRtdb,
+  RemoteRtdbSnapshot,
+} from '../../src/remote/index.js';
+
+describe('RemoteRtdbTriggerDelivery', () => {
+  test('adapts the existing RTDB value subscription to snapshot values', () => {
+    let subscribedPath: string | undefined;
+    let deliver!: (snapshot: RemoteRtdbSnapshot) => void;
+    let unsubscribed = false;
+    const rtdb = {
+      onValue(path, callback) {
+        subscribedPath = path;
+        deliver = callback;
+        return () => {
+          unsubscribed = true;
+        };
+      },
+    } as Pick<RemoteRtdb, 'onValue'>;
+    const adapter = new RemoteRtdbTriggerDelivery(rtdb);
+    const values: unknown[] = [];
+
+    const unsubscribe = adapter.subscribe('/items', (value) => values.push(value));
+    deliver({ key: 'items', exists: true, value: { alpha: 1 }, size: 1 });
+
+    expect(subscribedPath).toBe('/items');
+    expect(values).toEqual([{ alpha: 1 }]);
+    unsubscribe();
+    expect(unsubscribed).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds the internal snapshot adapter and isolated Node child that execute real `firebase-functions/v2/database` `onValueCreated` exports against the shared Pyric sandbox.

```js
const { onValueCreated } = require('firebase-functions/v2/database');

exports.makeUppercase = onValueCreated(
  '/messages/{pushId}/original',
  event => event.data.ref.parent
    .child('uppercase')
    .set(event.data.val().toUpperCase()),
);

// A sandbox write to messages/id/original = "hello" executes this unchanged
// CommonJS export in Node and writes messages/id/uppercase = "HELLO" back to
// the same browser-hosted RTDB seen by the app, Studio, and agent.
```

## Risk

The reviewer judgment is the transport seam: this uses the existing `RemoteRtdb.onValue()` snapshot relay instead of adding a Functions-specific worker protocol or delivery-ID stream. The relay already owns subscription cleanup, peer replacement, reconnect re-registration, and suppression of byte-identical reconnect snapshots. The execution core then derives only absent-to-present transitions from successive snapshots. This satisfies sequential current-session delivery without changing MCP; durable delivery of values created and deleted entirely during an outage remains explicitly outside the first slice.

The child is internal and inactive under ordinary `pyric dev` in this PR. PR4 still owns project discovery, command lifecycle wiring, user-facing reporting, conformance flips, and documentation.

## Function writes return through the same relay and produce later commits

```js
exports.markProcessed = onValueCreated(
  '/messages/{pushId}/uppercase',
  event => event.data.ref.parent
    .child('processed')
    .set(event.params.pushId + ':' + event.data.val()),
);

// makeUppercase's Admin write becomes the next RTDB snapshot transition.
// The isolated integration observes messages/id/processed = "id:HELLO".
```

The child initializes the mapped default Admin app before loading the user's module. The real Firebase Functions database provider finds that default app when it constructs `event.data`, so the child does not import the broad `firebase-functions/v2` barrel and accidentally require unrelated Admin services outside this slice.

Part of #280.

<details>
<summary>Implementation notes</summary>

- `RemoteRtdbTriggerDelivery` is a narrow adapter over the existing RTDB value subscription.
- `spawnFunctionsRtdbChild()` launches `node` explicitly, injects only private lifecycle configuration, reports readiness/execution/delivery failures over IPC, drains executions on shutdown, and force-kills after a bounded grace period.
- The integration uses a real bridge server, real worker-host RTDB backend, real `firebase-functions` 7.2.5 package, unchanged CommonJS registration, mapped `firebase-admin`, and a second trigger to prove function-generated commits re-enter delivery.
- The default MCP tool contract and worker protocol are unchanged.
- Conformance remains honestly at 0/13 in this inactive infrastructure PR; no registry row or published trust number moves.

Verification after rebasing directly onto `origin/main` (`aee9a3aa`):

```text
bun run --cwd packages/cli typecheck
bun run --cwd packages/cli build
bun test packages/cli/test/functions-rtdb packages/cli/test/bridge/worker-relay.test.ts packages/cli/test/register

51 pass, 13 expected climb skips, 0 fail
```

The isolated child integration also passed five consecutive reruns before the final rebase.

</details>
