### PR TITLE
test(packaging): assert public app registry contract

### DIFF
--- a/scripts/packed-resolution-smoke.mjs
+++ b/scripts/packed-resolution-smoke.mjs
@@ -47,8 +47,12 @@ const admin = await import('firebase-admin/database');
 const appModule = await import('firebase/app');
 const firestore = await import('firebase/firestore');
 assert.equal(typeof admin.getDatabase, 'function');
-const app = appModule.initializeApp({ projectId: 'packed-active-resolution' });
-assert.equal(app[Symbol.for('pyric.app.target')], 'sandbox');
+const options = { projectId: 'packed-active-resolution' };
+const app = appModule.initializeApp(options);
+assert.equal(app.name, '[DEFAULT]');
+assert.deepEqual(app.options, options);
+assert.equal(appModule.getApp(), app);
+assert.deepEqual(appModule.getApps(), [app]);
 assert.equal(typeof firestore.getFirestore(app), 'object');
 `,
 );


### PR DESCRIPTION
Updates the packed activated-Node smoke to verify Firebase's public app-registry contract after #300 removed the Pyric-only app target brand.

```js
const options = { projectId: 'packed-active-resolution' };
const app = initializeApp(options);

assert.equal(app.name, '[DEFAULT]');
assert.deepEqual(app.options, options);
assert.equal(getApp(), app);
assert.deepEqual(getApps(), [app]);
assert.equal(typeof getFirestore(app), 'object');
```

## Packed activation no longer depends on Pyric-only branding

The SDK-free packed consumer still proves that `@pyric/cli/register` resolves `firebase/app` and `firebase/firestore` to Pyric: those packages are absent from the consumer, then the activated imports initialize the default app, round-trip it through the Firebase registry, and construct its Firestore service.

The previous assertion read `Symbol.for('pyric.app.target')`, an internal marker intentionally removed when `pyric/app` adopted Firebase's public app shape in #300. That made the packaging gate reject the swappable API it was meant to protect.

## Risk

Only the packed-consumer assertion changes. It no longer identifies Pyric through a private property; activation remains proven by successful Firebase imports in an SDK-free consumer and by the public registry/service behavior.

<details>
<summary>Implementation notes</summary>

- Before: `bun run test:packaging` failed because the packed app's deleted private target symbol was `undefined`.
- After: `bun run test:packaging` passes all five package builds, tarball installs, advertised subpath checks, packed CLI smoke tests, and module-system checks.
- No runtime or published API code changes.

</details>
