### PR TITLE
perf(ci): restore fast Build & Test feedback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,20 @@ jobs:
       - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
         run: bash scripts/build.sh
 
+      - name: Cache Playwright Chromium
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Chromium browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install chromium
+
+      - name: Install Chromium system dependencies
+        run: bunx playwright install-deps chromium
+
       - name: Documentation generation, drift, links, and site build
         # API markdown is generated from the declarations named by each
         # package export map. The site test re-ports authored sources, builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
     name: Build all packages + run tests
     runs-on: ubuntu-latest
     steps:
+      - name: Start job timer
+        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
@@ -34,7 +37,9 @@ jobs:
           bun-version: '1.3.11'
 
       - name: Install
-        run: bun install --frozen-lockfile
+        # Playground carries Firebase deployment tooling for local demos. None
+        # of this job's build, conformance, or test commands enter that workspace.
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
 
       - name: Compat terminology lint (registry prose + generated docs)
         # Fails on colloquialisms, GitHub issue-number references, and
@@ -65,22 +70,6 @@ jobs:
         # topological build. Same script `npm run build` runs locally;
         # CI and local can't drift.
         run: bash scripts/build.sh
-
-      - name: Install Chromium for browser gates
-        run: bunx playwright install --with-deps chromium
-
-      - name: Documentation generation, drift, links, and site build
-        # API markdown is generated from the declarations named by each
-        # package export map. The site test re-ports authored sources, builds
-        # every route and Markdown twin, verifies the output/link inventory,
-        # and runs the documentation-rhythm audit.
-        run: bun run docs:api:check && bun run --cwd packages/site-docs test
-
-      - name: Served app + SharedWorker conformance
-        # Runs the canonical firebase/* swap through pyric dev, including named
-        # apps, cross-tab Auth isolation, config locking, deletion teardown,
-        # and the worker-owned AI boundary. These are blocking oracle claims.
-        run: bun run --cwd packages/cli test:app-conformance
 
       - name: Oracle conformance gate (observations × probes)
         # Loads every observations/*.json (structural floor), asserts each
@@ -152,10 +141,105 @@ jobs:
         # and @pyric/ui.
         run: npm run test
 
+      - name: Report timing and enforce five-minute job budget
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
+          echo "### Build + unit/conformance tests: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 300 )); then
+            echo "Build + unit/conformance tests exceeded the 300s CI budget (${elapsed}s)." >&2
+            exit 1
+          fi
+
+  documentation:
+    name: Documentation generation + site verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start job timer
+        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
+
+      - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
+        run: bash scripts/build.sh
+
+      - name: Documentation generation, drift, links, and site build
+        # API markdown is generated from the declarations named by each
+        # package export map. The site test re-ports authored sources, builds
+        # every route and Markdown twin, verifies the output/link inventory,
+        # and runs the documentation-rhythm audit.
+        run: bun run docs:api:check && bun run --cwd packages/site-docs test
+
+      - name: Report timing and enforce five-minute job budget
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
+          echo "### Documentation verification: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 300 )); then
+            echo "Documentation verification exceeded the 300s CI budget (${elapsed}s)." >&2
+            exit 1
+          fi
+
+  browser-conformance:
+    name: Served app + SharedWorker conformance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start job timer
+        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
+
+      - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
+        run: bash scripts/build.sh
+
+      - name: Cache Playwright Chromium
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Chromium browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install chromium
+
+      - name: Install Chromium system dependencies
+        run: bunx playwright install-deps chromium
+
+      - name: Served app + SharedWorker conformance
+        # Runs the canonical firebase/* swap through pyric dev, including named
+        # apps, cross-tab Auth isolation, config locking, deletion teardown,
+        # and the worker-owned AI boundary. These are blocking oracle claims.
+        run: bun run --cwd packages/cli test:app-conformance
+
+      - name: Report timing and enforce five-minute job budget
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
+          echo "### Browser conformance: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 300 )); then
+            echo "Browser conformance exceeded the 300s CI budget (${elapsed}s)." >&2
+            exit 1
+          fi
+
   packaging:
     name: Packaging gate (pack + install + subpath resolution)
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, documentation, browser-conformance]
     # Cost: the publish-shape gate runs only when the PR carries the
     # `ci-packaging` label (apply it on release PRs or ones touching package
     # manifests / exports / dist layout). Most code PRs do not need it.
@@ -199,7 +283,7 @@ jobs:
   install-matrix:
     name: Install matrix (${{ matrix.pm }})
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, documentation, browser-conformance]
     # Cost: same as `packaging`, only runs under the `ci-packaging` label.
     if: contains(github.event.pull_request.labels.*.name, 'ci-packaging')
     # Package managers resolve exports / scoped names / local tarballs differently;

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -37,6 +37,8 @@
  */
 
 import { startServer } from '@pyric/cli/bridge';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { parseArgs, type ParsedArgs } from './parse-args.js';
 import { runInit, runVendor } from './init.js';
 import { runServe } from './serve.js';
@@ -354,24 +356,36 @@ async function main(): Promise<number> {
 // Re-export parseArgs so the bin script + tests can share the parser.
 export { parseArgs } from './parse-args.js';
 
-// Always run `main()` — this file IS the bin entry. Tests in
-// `cli.test.ts` import individual helpers (`./parse-args.js`,
-// `./init.js`, `./rules.js`, etc.) and never touch this module, so
-// there's nothing to gate against. The previous `isDirectRun` check
-// matched `process.argv[1]` against a `/cli/index.js` regex — on Linux,
-// npm bin symlinks leave `argv[1]` as `node_modules/.bin/pyric` (NOT
-// resolved through the symlink), the regex missed, main() never ran,
-// and `pyric --help` printed nothing in CI. Dropping the guard fixes
-// it. (Verified on Linux Node 20 in the packaging gate.)
-main().then(
-  (code) => exitAfterFlush(code),
-  (err) => {
-    process.stderr.write(
-      `pyric: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
-    );
-    exitAfterFlush(2);
-  },
-);
+/**
+ * True when this module is the executable entry rather than an import.
+ *
+ * Bun identifies source and compiled entry points with `import.meta.main`.
+ * Node does not, so compare real paths there: resolving both sides preserves
+ * npm's `node_modules/.bin/pyric` symlink behavior that a textual path check
+ * previously broke.
+ */
+export function isDirectRun(): boolean {
+  if (import.meta.main) return true;
+  const argvEntry = process.argv[1];
+  if (!argvEntry) return false;
+  try {
+    return realpathSync(argvEntry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  main().then(
+    (code) => exitAfterFlush(code),
+    (err) => {
+      process.stderr.write(
+        `pyric: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      );
+      exitAfterFlush(2);
+    },
+  );
+}
 
 /**
  * Drain stdout + stderr before exiting. `process.exit()` does NOT wait

--- a/packages/cli/test/cli/index.test.ts
+++ b/packages/cli/test/cli/index.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { FIREBASE_TESTED_AGAINST } from '../../src/version/compat-target.js';
+import { dispatch, parseArgs } from '../../src/cli/index.js';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'cli', 'index.ts');
@@ -39,6 +40,27 @@ function runCli(args: string[], input?: string): { code: number; stdout: string;
   };
 }
 
+async function runDispatch(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  let stdout = '';
+  let stderr = '';
+  const stdoutWrite = process.stdout.write;
+  const stderrWrite = process.stderr.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    return { code: await dispatch(parseArgs(args)), stdout, stderr };
+  } finally {
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+  }
+}
+
 describe('retained pyric command surface', () => {
   it('advertises every local-development workflow through the CLI entry', () => {
     const { code, stdout, stderr } = runCli(['--help']);
@@ -50,21 +72,21 @@ describe('retained pyric command surface', () => {
     }
   });
 
-  it('does not expose production deployment commands', () => {
-    const help = runCli(['--help']);
+  it('does not expose production deployment commands', async () => {
+    const help = await runDispatch(['--help']);
     expect(help.code).toBe(0);
     expect(help.stdout).not.toMatch(/\bpyric deploy\b/);
     expect(help.stdout).not.toContain('hosting:channel:deploy');
 
     for (const command of ['deploy', 'hosting:channel:deploy']) {
-      const removed = runCli([command]);
+      const removed = await runDispatch([command]);
       expect(removed.code).toBe(1);
       expect(removed.stderr).toContain(`unknown command '${command}'`);
     }
   });
 
-  it('does not advertise production project or credential commands', () => {
-    const help = runCli(['--help']);
+  it('does not advertise production project or credential commands', async () => {
+    const help = await runDispatch(['--help']);
     expect(help.code).toBe(0);
 
     for (const command of REMOVED_PROJECT_COMMANDS) {
@@ -73,16 +95,16 @@ describe('retained pyric command surface', () => {
   });
 
   for (const command of REMOVED_PROJECT_COMMANDS) {
-    it(`rejects removed command ${command}`, () => {
-      const removed = runCli([command]);
+    it(`rejects removed command ${command}`, async () => {
+      const removed = await runDispatch([command]);
       expect(removed.code).toBe(1);
       expect(removed.stderr).toContain(`unknown command '${command}'`);
     });
   }
 
   for (const [flag, value] of REMOVED_BRIDGE_FLAGS) {
-    it(`rejects removed bridge option ${flag}`, () => {
-      const result = runCli(['bridge', flag, ...(value === undefined ? [] : [value])]);
+    it(`rejects removed bridge option ${flag}`, async () => {
+      const result = await runDispatch(['bridge', flag, ...(value === undefined ? [] : [value])]);
       expect(result.code).toBe(1);
       expect(result.stderr).toContain(`unknown option '${flag}' for pyric bridge`);
     });
@@ -91,8 +113,8 @@ describe('retained pyric command surface', () => {
 });
 
 describe('service command hierarchy', () => {
-  it('advertises every service artifact operation with space-delimited names', () => {
-    const help = runCli(['--help']);
+  it('advertises every service artifact operation with space-delimited names', async () => {
+    const help = await runDispatch(['--help']);
 
     expect(help.code).toBe(0);
     for (const command of [
@@ -112,18 +134,18 @@ describe('service command hierarchy', () => {
     }
   });
 
-  it('routes Firestore rules lint through the namespaced command', () => {
+  it('routes Firestore rules lint through the namespaced command', async () => {
     const rulesPath = join(PACKAGE_ROOT, 'test', 'e2e', 'fixture', 'firestore.rules');
-    const result = runCli(['firestore', 'rules', 'lint', rulesPath]);
+    const result = await runDispatch(['firestore', 'rules', 'lint', rulesPath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
     expect(JSON.parse(result.stdout)).toHaveProperty('warnings');
   });
 
-  it('routes Firestore rules validate through the namespaced command', () => {
+  it('routes Firestore rules validate through the namespaced command', async () => {
     const rulesPath = join(PACKAGE_ROOT, 'test', 'e2e', 'fixture', 'firestore.rules');
-    const result = runCli(['firestore', 'rules', 'validate', rulesPath]);
+    const result = await runDispatch(['firestore', 'rules', 'validate', rulesPath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
@@ -152,9 +174,9 @@ describe('service command hierarchy', () => {
     expect(JSON.parse(result.stdout)).toHaveProperty('success', true);
   });
 
-  it('resolves Firestore rules modules through the namespaced command', () => {
+  it('resolves Firestore rules modules through the namespaced command', async () => {
     const sourcePath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'firestore.modules.rules');
-    const result = runCli(['firestore', 'rules', 'resolve', sourcePath]);
+    const result = await runDispatch(['firestore', 'rules', 'resolve', sourcePath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
@@ -162,13 +184,13 @@ describe('service command hierarchy', () => {
     expect(result.stdout).toContain('function isAuthenticated()');
   });
 
-  it('generates Firestore indexes through the namespaced command', () => {
+  it('generates Firestore indexes through the namespaced command', async () => {
     const outputDir = mkdtempSync(join(tmpdir(), 'pyric-firestore-indexes-'));
     const sourcePath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'firestore-queries.ts');
     const outputPath = join(outputDir, 'firestore.indexes.json');
 
     try {
-      const result = runCli([
+      const result = await runDispatch([
         'firestore',
         'indexes',
         'generate',
@@ -185,9 +207,9 @@ describe('service command hierarchy', () => {
     }
   });
 
-  it('routes Storage rules lint through the namespaced command', () => {
+  it('routes Storage rules lint through the namespaced command', async () => {
     const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'storage.rules');
-    const result = runCli(['storage', 'rules', 'lint', rulesPath]);
+    const result = await runDispatch(['storage', 'rules', 'lint', rulesPath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
@@ -214,18 +236,18 @@ describe('service command hierarchy', () => {
     expect(JSON.parse(result.stdout)).toHaveProperty('data.allowed', false);
   });
 
-  it('routes Database rules lint through the namespaced command', () => {
+  it('routes Database rules lint through the namespaced command', async () => {
     const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.json');
-    const result = runCli(['database', 'rules', 'lint', rulesPath]);
+    const result = await runDispatch(['database', 'rules', 'lint', rulesPath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
     expect(JSON.parse(result.stdout)).toHaveProperty('warnings');
   });
 
-  it('routes Database rules validate through the namespaced command', () => {
+  it('routes Database rules validate through the namespaced command', async () => {
     const rulesPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.json');
-    const result = runCli(['database', 'rules', 'validate', rulesPath]);
+    const result = await runDispatch(['database', 'rules', 'validate', rulesPath]);
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
@@ -249,13 +271,13 @@ describe('service command hierarchy', () => {
     expect(JSON.parse(result.stdout)).toHaveProperty('data.allowed', true);
   });
 
-  it('routes Database rules generate through the namespaced command', () => {
+  it('routes Database rules generate through the namespaced command', async () => {
     const outputDir = mkdtempSync(join(tmpdir(), 'pyric-database-rules-'));
     const configPath = join(PACKAGE_ROOT, 'test', 'cli', 'fixtures', 'database.rules.ts');
     const outputPath = join(outputDir, 'database.rules.json');
 
     try {
-      const result = runCli([
+      const result = await runDispatch([
         'database',
         'rules',
         'generate',
@@ -283,8 +305,8 @@ describe('service command hierarchy', () => {
       'database:rules:simulate',
       'database:rules:generate',
     ]) {
-      it(`rejects ${command} without an alias`, () => {
-        const result = runCli([command]);
+      it(`rejects ${command} without an alias`, async () => {
+        const result = await runDispatch([command]);
         expect(result.code).toBe(1);
         expect(result.stderr).toContain(`unknown command '${command}'`);
       });
@@ -293,12 +315,12 @@ describe('service command hierarchy', () => {
 });
 
 describe('pyric dev command surface', () => {
-  it('rejects the removed serve spelling instead of retaining an alias', () => {
-    expect(runCli(['serve']).code).toBe(1);
+  it('rejects the removed serve spelling instead of retaining an alias', async () => {
+    expect((await runDispatch(['serve'])).code).toBe(1);
   });
 
-  it('advertises dev and never serve', () => {
-    const { code, stdout } = runCli(['--help']);
+  it('advertises dev and never serve', async () => {
+    const { code, stdout } = await runDispatch(['--help']);
     expect(code).toBe(0);
     expect(stdout).toContain('pyric dev [flags]');
     expect(stdout).not.toContain('pyric serve');
@@ -311,8 +333,8 @@ const ownVersion = (
 
 describe('pyric version output', () => {
   for (const flag of ['--version', '-v']) {
-    it(`${flag} names the package and tested-against Firebase versions`, () => {
-      const { code, stdout } = runCli([flag]);
+    it(`${flag} names the package and tested-against Firebase versions`, async () => {
+      const { code, stdout } = await runDispatch([flag]);
       expect(code).toBe(0);
       expect(stdout).toContain(ownVersion);
       expect(stdout).toContain(FIREBASE_TESTED_AGAINST);

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -20,7 +20,9 @@ describe('served app conformance merge gate', () => {
   });
 
   test('required CI installs Chromium and runs the proof after building', () => {
-    expect(workflow).toContain('bunx playwright install --with-deps chromium');
+    expect(workflow).toContain('Cache Playwright Chromium');
+    expect(workflow).toContain('bunx playwright install chromium');
+    expect(workflow).toContain('bunx playwright install-deps chromium');
     expect(workflow).toContain('bun run --cwd packages/cli test:app-conformance');
     expect(workflow.indexOf('bash scripts/build.sh')).toBeLessThan(
       workflow.indexOf('bun run --cwd packages/cli test:app-conformance'),

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -7,6 +7,9 @@ const cliPackage = JSON.parse(
   readFileSync(resolve(root, 'packages/cli/package.json'), 'utf8'),
 ) as { scripts?: Record<string, string> };
 const workflow = readFileSync(resolve(root, '.github/workflows/build.yml'), 'utf8');
+const browserJobStart = workflow.indexOf('  browser-conformance:');
+const browserJobEnd = workflow.indexOf('\n  packaging:', browserJobStart);
+const browserJob = workflow.slice(browserJobStart, browserJobEnd);
 
 describe('served app conformance merge gate', () => {
   test('the CLI script runs every SharedWorker topology proof', () => {
@@ -20,12 +23,20 @@ describe('served app conformance merge gate', () => {
   });
 
   test('required CI installs Chromium and runs the proof after building', () => {
-    expect(workflow).toContain('Cache Playwright Chromium');
-    expect(workflow).toContain('bunx playwright install chromium');
-    expect(workflow).toContain('bunx playwright install-deps chromium');
-    expect(workflow).toContain('bun run --cwd packages/cli test:app-conformance');
-    expect(workflow.indexOf('bash scripts/build.sh')).toBeLessThan(
-      workflow.indexOf('bun run --cwd packages/cli test:app-conformance'),
-    );
+    expect(browserJobStart).toBeGreaterThanOrEqual(0);
+    expect(browserJobEnd).toBeGreaterThan(browserJobStart);
+    expect(browserJob).toContain('Cache Playwright Chromium');
+    expect(browserJob).toContain('bunx playwright install chromium');
+    expect(browserJob).toContain('bunx playwright install-deps chromium');
+    expect(browserJob).toContain('bun run --cwd packages/cli test:app-conformance');
+    const build = browserJob.indexOf('bash scripts/build.sh');
+    const cache = browserJob.indexOf('Cache Playwright Chromium');
+    const browser = browserJob.indexOf('bunx playwright install chromium');
+    const dependencies = browserJob.indexOf('bunx playwright install-deps chromium');
+    const proof = browserJob.indexOf('bun run --cwd packages/cli test:app-conformance');
+    expect(build).toBeLessThan(cache);
+    expect(cache).toBeLessThan(browser);
+    expect(browser).toBeLessThan(dependencies);
+    expect(dependencies).toBeLessThan(proof);
   });
 });

--- a/scripts/gen-api-docs.ts
+++ b/scripts/gen-api-docs.ts
@@ -12,7 +12,7 @@
  * plumbing follows the public package contract instead of a second list of
  * source paths.
  */
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -24,9 +24,12 @@ import {
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = join(HERE, '..');
+const execFileAsync = promisify(execFile);
+const DEFAULT_RENDER_CONCURRENCY = 4;
 
 export const GENERATED_HEADER =
   '<!-- Generated from the package export declaration via TypeDoc. Do not edit by hand; run bun run docs:api:generate. -->';
@@ -127,7 +130,7 @@ function publicName(descriptor: ApiDescriptor): string {
   return `${packageName}/${descriptor.subpath}`;
 }
 
-export function renderApiMarkdown(descriptor: ApiDescriptor): string {
+export async function renderApiMarkdown(descriptor: ApiDescriptor): Promise<string> {
   const entry = entryDtsPath(descriptor);
   if (!existsSync(entry)) {
     throw new Error(`missing declaration entry: ${entry}\n  Build first: bun run build`);
@@ -159,15 +162,33 @@ export function renderApiMarkdown(descriptor: ApiDescriptor): string {
     };
     const optionsPath = join(tmp, 'typedoc.json');
     writeFileSync(optionsPath, JSON.stringify(options, null, 2));
-    execFileSync('bunx', ['typedoc', '--options', optionsPath], {
+    await execFileAsync('bunx', ['typedoc', '--options', optionsPath], {
       cwd: REPO_ROOT,
-      stdio: ['ignore', 'ignore', 'inherit'],
     });
     const body = readFileSync(join(tmp, 'README.md'), 'utf8').replace(/\s+$/, '');
     return `${GENERATED_HEADER}\n\n${body}\n`;
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+}
+
+async function renderDescriptors(
+  descriptors: ApiDescriptor[],
+  concurrency = DEFAULT_RENDER_CONCURRENCY,
+): Promise<string[]> {
+  const rendered = new Array<string>(descriptors.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), descriptors.length) },
+    async () => {
+      while (next < descriptors.length) {
+        const index = next++;
+        rendered[index] = await renderApiMarkdown(descriptors[index]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return rendered;
 }
 
 function parseArgs(argv: string[]): { write: boolean; check: boolean; only: Set<string> | null } {
@@ -199,21 +220,23 @@ if (import.meta.main) {
     process.exit(1);
   }
 
+  const rendered = await renderDescriptors(descriptors);
+
   if (write) {
-    for (const descriptor of descriptors) {
+    for (const [index, descriptor] of descriptors.entries()) {
       const out = outputPath(descriptor);
       mkdirSync(dirname(out), { recursive: true });
-      writeFileSync(out, renderApiMarkdown(descriptor));
+      writeFileSync(out, rendered[index]);
       console.log(`Generated ${out.replace(`${REPO_ROOT}/`, '')}`);
     }
   }
 
   if (check) {
     const problems: string[] = [];
-    for (const descriptor of descriptors) {
+    for (const [index, descriptor] of descriptors.entries()) {
       const out = outputPath(descriptor);
       const rel = out.replace(`${REPO_ROOT}/`, '');
-      const generated = renderApiMarkdown(descriptor);
+      const generated = rendered[index];
       if (!existsSync(out)) problems.push(`${rel}: missing`);
       else if (readFileSync(out, 'utf8') !== generated) problems.push(`${rel}: drifted`);
     }

--- a/scripts/gen-api-docs.ts
+++ b/scripts/gen-api-docs.ts
@@ -12,7 +12,7 @@
  * plumbing follows the public package contract instead of a second list of
  * source paths.
  */
-import { execFile } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -24,12 +24,9 @@ import {
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = join(HERE, '..');
-const execFileAsync = promisify(execFile);
-const DEFAULT_RENDER_CONCURRENCY = 4;
 
 export const GENERATED_HEADER =
   '<!-- Generated from the package export declaration via TypeDoc. Do not edit by hand; run bun run docs:api:generate. -->';
@@ -130,7 +127,7 @@ function publicName(descriptor: ApiDescriptor): string {
   return `${packageName}/${descriptor.subpath}`;
 }
 
-export async function renderApiMarkdown(descriptor: ApiDescriptor): Promise<string> {
+export function renderApiMarkdown(descriptor: ApiDescriptor): string {
   const entry = entryDtsPath(descriptor);
   if (!existsSync(entry)) {
     throw new Error(`missing declaration entry: ${entry}\n  Build first: bun run build`);
@@ -162,33 +159,15 @@ export async function renderApiMarkdown(descriptor: ApiDescriptor): Promise<stri
     };
     const optionsPath = join(tmp, 'typedoc.json');
     writeFileSync(optionsPath, JSON.stringify(options, null, 2));
-    await execFileAsync('bunx', ['typedoc', '--options', optionsPath], {
+    execFileSync('bunx', ['typedoc', '--options', optionsPath], {
       cwd: REPO_ROOT,
+      stdio: ['ignore', 'ignore', 'inherit'],
     });
     const body = readFileSync(join(tmp, 'README.md'), 'utf8').replace(/\s+$/, '');
     return `${GENERATED_HEADER}\n\n${body}\n`;
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
-}
-
-async function renderDescriptors(
-  descriptors: ApiDescriptor[],
-  concurrency = DEFAULT_RENDER_CONCURRENCY,
-): Promise<string[]> {
-  const rendered = new Array<string>(descriptors.length);
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.min(Math.max(1, concurrency), descriptors.length) },
-    async () => {
-      while (next < descriptors.length) {
-        const index = next++;
-        rendered[index] = await renderApiMarkdown(descriptors[index]);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return rendered;
 }
 
 function parseArgs(argv: string[]): { write: boolean; check: boolean; only: Set<string> | null } {
@@ -220,23 +199,21 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const rendered = await renderDescriptors(descriptors);
-
   if (write) {
-    for (const [index, descriptor] of descriptors.entries()) {
+    for (const descriptor of descriptors) {
       const out = outputPath(descriptor);
       mkdirSync(dirname(out), { recursive: true });
-      writeFileSync(out, rendered[index]);
+      writeFileSync(out, renderApiMarkdown(descriptor));
       console.log(`Generated ${out.replace(`${REPO_ROOT}/`, '')}`);
     }
   }
 
   if (check) {
     const problems: string[] = [];
-    for (const [index, descriptor] of descriptors.entries()) {
+    for (const descriptor of descriptors) {
       const out = outputPath(descriptor);
       const rel = out.replace(`${REPO_ROOT}/`, '');
-      const generated = rendered[index];
+      const generated = renderApiMarkdown(descriptor);
       if (!existsSync(out)) problems.push(`${rel}: missing`);
       else if (readFileSync(out, 'utf8') !== generated) problems.push(`${rel}: drifted`);
     }


### PR DESCRIPTION
## What changed

- exclude the playground-only deployment toolchain from normal CI installs
- run unit/conformance, documentation, and browser gates as three parallel jobs
- cache the Playwright Chromium download while still installing required system dependencies in both browser-consuming jobs
- drive CLI parser/dispatcher assertions in-process while retaining four real process-boundary tests
- scope the browser-gate regression contract to its own workflow job and step order
- report and enforce a 300-second budget for every normal CI job

## Trust and correctness

No conformance, coverage, assurance, documentation, browser, packaging, or install-matrix assertion is removed or made conditional for speed. Packaging and install-matrix retain full installs and wait for all three normal jobs when the ci-packaging label is present.

## GitHub Actions evidence

Baseline: https://github.com/davideast/pyric/actions/runs/29386750440 — 7m56s workflow / 7m53s main job.

Final commit eef6e1f0:

- attempt 1: https://github.com/davideast/pyric/actions/runs/29389468984/attempts/1 — green in 4m16s; main 4m13s, docs 3m04s, browser 2m14s
- attempt 2: https://github.com/davideast/pyric/actions/runs/29389468984/attempts/2 — green in 4m25s; main 4m21s, docs 3m05s, browser 2m09s
- median: 4m20.5s
- improvement from 7m56s: 45.3%, recovering 3m35.5s from the critical path

Representative step changes across baseline and the two final attempts:

- install: 111s to 6–7s
- full tests: 164s to 147–155s
- build: 61s to 75–77s on the critical runner
- former serial Chromium + docs + browser tail: 112s removed from the main critical path and preserved in parallel jobs

## Local evidence

- fresh cold filtered install: 3.07s, 2,095 packages
- fresh full build: 26.96s
- CLI surface suite: 12.4s to 1.51s, 38 tests / 117 assertions preserved
- full unit chain and all conformance, coverage, assurance, entry-path, and registry gates: green
- documentation build, links, dist, and rhythm audit: green
- browser conformance: 7 passed
- packaging gate: all 5 packages pack, install, resolve, execute, and preserve npm-bin behavior

## Remaining bottlenecks / follow-ups

The 147–155s full test step is now the dominant critical-path cost, including repeated CLI Functions lifecycle setup. Each parallel job also performs a 72–81s clean build; a future immutable build-artifact fan-out could recover compute if its integrity and embedded-base variants are proven. Documentation verification remains 76–77s and TypeDoc receipt generation remains sequential because bounded concurrency did not improve Actions time. Chromium system dependency setup still costs 13–14s even when the browser cache hits.