### PR TITLE
perf(ci): remove docs gate and parallelize test lanes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,13 +140,13 @@ jobs:
         # The other workspace suites run concurrently in library-tests.
         run: bun run test:ci:cli
 
-      - name: Report timing and enforce five-minute job budget
+      - name: Report timing and enforce three-minute job budget
         if: always()
         run: |
           elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Build + unit/conformance tests: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 300 )); then
-            echo "Build + unit/conformance tests exceeded the 300s CI budget (${elapsed}s)." >&2
+          echo "### Build + unit/conformance tests: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 180 )); then
+            echo "Build + unit/conformance tests exceeded the 180s CI budget (${elapsed}s)." >&2
             exit 1
           fi
 
@@ -172,13 +172,13 @@ jobs:
       - name: Run library, UI, Studio, and conformance tests
         run: bun run test:ci:libraries
 
-      - name: Report timing and enforce five-minute job budget
+      - name: Report timing and enforce three-minute job budget
         if: always()
         run: |
           elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Library + UI tests: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 300 )); then
-            echo "Library + UI tests exceeded the 300s CI budget (${elapsed}s)." >&2
+          echo "### Library + UI tests: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 180 )); then
+            echo "Library + UI tests exceeded the 180s CI budget (${elapsed}s)." >&2
             exit 1
           fi
 
@@ -221,13 +221,13 @@ jobs:
         # and the worker-owned AI boundary. These are blocking oracle claims.
         run: bun run --cwd packages/cli test:app-conformance
 
-      - name: Report timing and enforce five-minute job budget
+      - name: Report timing and enforce three-minute job budget
         if: always()
         run: |
           elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Browser conformance: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 300 )); then
-            echo "Browser conformance exceeded the 300s CI budget (${elapsed}s)." >&2
+          echo "### Browser conformance: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 180 )); then
+            echo "Browser conformance exceeded the 180s CI budget (${elapsed}s)." >&2
             exit 1
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,12 @@ jobs:
         # the COMPAT matrices cite (INF-3/INF-4). Cheap, deterministic.
         run: bun run packages/conformance/src/check-observation-versions.ts
 
-      - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
+      - name: Build packages + embedded Studio (documentation omitted)
         # scripts/build.sh handles the cycle-tolerant bootstrap pass
         # (declaration stubs for every package) then the strict
         # topological build. Same script `npm run build` runs locally;
         # CI and local can't drift.
-        run: bash scripts/build.sh
+        run: bash scripts/build.sh --skip-docs
 
       - name: Oracle conformance gate (observations × probes)
         # Loads every observations/*.json (structural floor), asserts each
@@ -136,10 +136,9 @@ jobs:
         # packages, so dist must exist first.
         run: set -o pipefail; bun run compat:coverage | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Run tests
-        # `npm run test` cycles through pyric, pyric-admin, @pyric/cli,
-        # and @pyric/ui.
-        run: npm run test
+      - name: Run CLI tests
+        # The other workspace suites run concurrently in library-tests.
+        run: bun run test:ci:cli
 
       - name: Report timing and enforce five-minute job budget
         if: always()
@@ -151,8 +150,8 @@ jobs:
             exit 1
           fi
 
-  documentation:
-    name: Documentation generation + site verification
+  library-tests:
+    name: Run library + UI tests
     runs-on: ubuntu-latest
     steps:
       - name: Start job timer
@@ -167,37 +166,19 @@ jobs:
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
 
-      - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
-        run: bash scripts/build.sh
+      - name: Build workspace packages (embedded apps omitted)
+        run: bash scripts/build.sh --packages-only
 
-      - name: Cache Playwright Chromium
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-
-      - name: Install Chromium browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install chromium
-
-      - name: Install Chromium system dependencies
-        run: bunx playwright install-deps chromium
-
-      - name: Documentation generation, drift, links, and site build
-        # API markdown is generated from the declarations named by each
-        # package export map. The site test re-ports authored sources, builds
-        # every route and Markdown twin, verifies the output/link inventory,
-        # and runs the documentation-rhythm audit.
-        run: bun run docs:api:check && bun run --cwd packages/site-docs test
+      - name: Run library, UI, Studio, and conformance tests
+        run: bun run test:ci:libraries
 
       - name: Report timing and enforce five-minute job budget
         if: always()
         run: |
           elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Documentation verification: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Library + UI tests: ${elapsed}s / 300s" >> "$GITHUB_STEP_SUMMARY"
           if (( elapsed > 300 )); then
-            echo "Documentation verification exceeded the 300s CI budget (${elapsed}s)." >&2
+            echo "Library + UI tests exceeded the 300s CI budget (${elapsed}s)." >&2
             exit 1
           fi
 
@@ -217,8 +198,8 @@ jobs:
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
 
-      - name: Build all packages (scripts/build.sh — two-pass stubs then strict)
-        run: bash scripts/build.sh
+      - name: Build packages + embedded Studio (documentation omitted)
+        run: bash scripts/build.sh --skip-docs
 
       - name: Cache Playwright Chromium
         id: playwright-cache
@@ -253,7 +234,7 @@ jobs:
   packaging:
     name: Packaging gate (pack + install + subpath resolution)
     runs-on: ubuntu-latest
-    needs: [build-and-test, documentation, browser-conformance]
+    needs: [build-and-test, library-tests, browser-conformance]
     # Cost: the publish-shape gate runs only when the PR carries the
     # `ci-packaging` label (apply it on release PRs or ones touching package
     # manifests / exports / dist layout). Most code PRs do not need it.
@@ -297,7 +278,7 @@ jobs:
   install-matrix:
     name: Install matrix (${{ matrix.pm }})
     runs-on: ubuntu-latest
-    needs: [build-and-test, documentation, browser-conformance]
+    needs: [build-and-test, library-tests, browser-conformance]
     # Cost: same as `packaging`, only runs under the `ci-packaging` label.
     if: contains(github.event.pull_request.labels.*.name, 'ci-packaging')
     # Package managers resolve exports / scoped names / local tarballs differently;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:cli": "bun run --cwd packages/cli build",
     "build:ui": "bun run --cwd packages/ui build",
     "test": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun test --cwd packages/cli && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs",
+    "test:ci:cli": "bun test --cwd packages/cli",
+    "test:ci:libraries": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs",
     "tool:parity": "bun run scripts/tool-parity.mjs",
     "tool:parity:check": "bun run scripts/tool-parity.mjs --check",
     "test:soak": "bun run --cwd packages/cli test:soak",

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -33,6 +33,8 @@ describe('served app conformance merge gate', () => {
     expect(libraryJob).toContain('bash scripts/build.sh --packages-only');
     expect(libraryJob).toContain('bun run test:ci:libraries');
     expect(libraryJob).not.toContain('bun run test:ci:cli');
+    expect(mainJob).toContain('${elapsed}s / 180s');
+    expect(libraryJob).toContain('${elapsed}s / 180s');
 
     const complete = rootPackage.scripts?.test?.split(' && ') ?? [];
     const split = [
@@ -61,6 +63,7 @@ describe('served app conformance merge gate', () => {
     expect(browserJob).toContain('bunx playwright install-deps chromium');
     expect(browserJob).toContain('bun run --cwd packages/cli test:app-conformance');
     expect(browserJob).toContain('bash scripts/build.sh --skip-docs');
+    expect(browserJob).toContain('${elapsed}s / 180s');
     const build = browserJob.indexOf('bash scripts/build.sh --skip-docs');
     const cache = browserJob.indexOf('Cache Playwright Chromium');
     const browser = browserJob.indexOf('bunx playwright install chromium');

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -3,15 +3,46 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dir, '../../../..');
+const rootPackage = JSON.parse(
+  readFileSync(resolve(root, 'package.json'), 'utf8'),
+) as { scripts?: Record<string, string> };
 const cliPackage = JSON.parse(
   readFileSync(resolve(root, 'packages/cli/package.json'), 'utf8'),
 ) as { scripts?: Record<string, string> };
 const workflow = readFileSync(resolve(root, '.github/workflows/build.yml'), 'utf8');
+const mainJobStart = workflow.indexOf('  build-and-test:');
+const mainJobEnd = workflow.indexOf('\n  library-tests:', mainJobStart);
+const mainJob = workflow.slice(mainJobStart, mainJobEnd);
+const libraryJobStart = mainJobEnd;
+const libraryJobEnd = workflow.indexOf('\n  browser-conformance:', libraryJobStart);
+const libraryJob = workflow.slice(libraryJobStart, libraryJobEnd);
 const browserJobStart = workflow.indexOf('  browser-conformance:');
 const browserJobEnd = workflow.indexOf('\n  packaging:', browserJobStart);
 const browserJob = workflow.slice(browserJobStart, browserJobEnd);
 
 describe('served app conformance merge gate', () => {
+  test('required CI splits CLI and library tests without building documentation', () => {
+    expect(workflow).not.toContain('\n  documentation:');
+    expect(mainJobStart).toBeGreaterThanOrEqual(0);
+    expect(mainJobEnd).toBeGreaterThan(mainJobStart);
+    expect(mainJob).toContain('bash scripts/build.sh --skip-docs');
+    expect(mainJob).toContain('bun run test:ci:cli');
+    expect(mainJob).not.toContain('bun run test:ci:libraries');
+    expect(libraryJobStart).toBeGreaterThanOrEqual(0);
+    expect(libraryJobEnd).toBeGreaterThan(libraryJobStart);
+    expect(libraryJob).toContain('bash scripts/build.sh --packages-only');
+    expect(libraryJob).toContain('bun run test:ci:libraries');
+    expect(libraryJob).not.toContain('bun run test:ci:cli');
+
+    const complete = rootPackage.scripts?.test?.split(' && ') ?? [];
+    const split = [
+      ...(rootPackage.scripts?.['test:ci:cli']?.split(' && ') ?? []),
+      ...(rootPackage.scripts?.['test:ci:libraries']?.split(' && ') ?? []),
+    ];
+    expect(split).toHaveLength(complete.length);
+    expect([...split].sort()).toEqual([...complete].sort());
+  });
+
   test('the CLI script runs every SharedWorker topology proof', () => {
     const command = cliPackage.scripts?.['test:app-conformance'];
     expect(command).toBeDefined();
@@ -29,7 +60,8 @@ describe('served app conformance merge gate', () => {
     expect(browserJob).toContain('bunx playwright install chromium');
     expect(browserJob).toContain('bunx playwright install-deps chromium');
     expect(browserJob).toContain('bun run --cwd packages/cli test:app-conformance');
-    const build = browserJob.indexOf('bash scripts/build.sh');
+    expect(browserJob).toContain('bash scripts/build.sh --skip-docs');
+    const build = browserJob.indexOf('bash scripts/build.sh --skip-docs');
     const cache = browserJob.indexOf('Cache Playwright Chromium');
     const browser = browserJob.indexOf('bunx playwright install chromium');
     const dependencies = browserJob.indexOf('bunx playwright install-deps chromium');

--- a/packages/pyric/test/storage/metadata.test.ts
+++ b/packages/pyric/test/storage/metadata.test.ts
@@ -71,10 +71,6 @@ describe('updateMetadata', () => {
       customMetadata: { tag: 'first' },
     });
 
-    // Pause one millisecond so the new `updated` timestamp is
-    // guaranteed-distinct on systems with sub-ms wallclock resolution.
-    await new Promise((resolve) => setTimeout(resolve, 1));
-
     const next = await updateMetadata(r, {
       contentType: 'application/json',
       customMetadata: { tag: 'second' },
@@ -83,7 +79,13 @@ describe('updateMetadata', () => {
     expect(next.contentType).toBe('application/json');
     expect(next.customMetadata).toEqual({ tag: 'second' });
     expect(next.metageneration).toBe('2');
-    expect(next.updated).not.toBe(upload.metadata.updated);
+    // ISO timestamps have millisecond precision, so two real updates may
+    // legitimately receive the same string on a fast runner. The server-set
+    // timestamp must never move backwards; metageneration above proves the
+    // metadata update itself was committed.
+    expect(Date.parse(next.updated)).toBeGreaterThanOrEqual(
+      Date.parse(upload.metadata.updated),
+    );
     // Server-set fields preserved.
     expect(next.generation).toBe(upload.metadata.generation);
     expect(next.timeCreated).toBe(upload.metadata.timeCreated);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,6 +15,24 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+BUILD_STUDIO=true
+BUILD_DOCS=true
+for arg in "$@"; do
+  case "$arg" in
+    --skip-docs)
+      BUILD_DOCS=false
+      ;;
+    --packages-only)
+      BUILD_STUDIO=false
+      BUILD_DOCS=false
+      ;;
+    *)
+      echo "Unknown build option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
 # ── Helpers ─────────────────────────────────────────────────────────────
 
 build_pkg() {
@@ -69,13 +87,17 @@ build_pkg "ui"
 # target lives inside the already-built @pyric/cli dist.
 echo ""
 echo "━━━ Phase 3: Studio app ━━━"
-echo "▸ Building packages/studio (base /__pyric/ui/)"
-rm -rf packages/studio/dist
-STUDIO_BASE=/__pyric/ui/ bun run --cwd packages/studio build
-echo "▸ Embedding studio app → packages/cli/dist/serve/studio-ui/"
-rm -rf packages/cli/dist/serve/studio-ui
-mkdir -p packages/cli/dist/serve/studio-ui
-cp -R packages/studio/dist/app/. packages/cli/dist/serve/studio-ui/
+if $BUILD_STUDIO; then
+  echo "▸ Building packages/studio (base /__pyric/ui/)"
+  rm -rf packages/studio/dist
+  STUDIO_BASE=/__pyric/ui/ bun run --cwd packages/studio build
+  echo "▸ Embedding studio app → packages/cli/dist/serve/studio-ui/"
+  rm -rf packages/cli/dist/serve/studio-ui
+  mkdir -p packages/cli/dist/serve/studio-ui
+  cp -R packages/studio/dist/app/. packages/cli/dist/serve/studio-ui/
+else
+  echo "▸ Skipped for packages-only build"
+fi
 
 echo ""
 echo "━━━ Phase 4: Docs site ━━━"
@@ -84,13 +106,17 @@ echo "━━━ Phase 4: Docs site ━━━"
 # /__pyric/ui/docs/<slug>/, assets at /__pyric/ui/_astro/*, the search index at
 # /__pyric/ui/docs/index.json, and tabs back at /__pyric/ui/<tab>. The default
 # (no DOCS_BASE) build the hosted site uses is unaffected — base stays `/`.
-echo "▸ Building packages/site-docs (base /__pyric/ui/)"
-rm -rf packages/site-docs/dist
-DOCS_BASE=/__pyric/ui/ bun run --cwd packages/site-docs build
-echo "▸ Embedding docs site → packages/cli/dist/serve/docs-ui/"
-rm -rf packages/cli/dist/serve/docs-ui
-mkdir -p packages/cli/dist/serve/docs-ui
-cp -R packages/site-docs/dist/. packages/cli/dist/serve/docs-ui/
+if $BUILD_DOCS; then
+  echo "▸ Building packages/site-docs (base /__pyric/ui/)"
+  rm -rf packages/site-docs/dist
+  DOCS_BASE=/__pyric/ui/ bun run --cwd packages/site-docs build
+  echo "▸ Embedding docs site → packages/cli/dist/serve/docs-ui/"
+  rm -rf packages/cli/dist/serve/docs-ui
+  mkdir -p packages/cli/dist/serve/docs-ui
+  cp -R packages/site-docs/dist/. packages/cli/dist/serve/docs-ui/
+else
+  echo "▸ Skipped for CI build profile"
+fi
 
 echo ""
 echo "✅ All packages built successfully"


### PR DESCRIPTION
Shortens required Build & Test feedback by omitting the WIP documentation gate and running the complete test workload in concurrent CLI, library, and browser lanes.

```sh
# Required CLI lane: packages and the served Studio, without documentation.
bash scripts/build.sh --skip-docs
bun run test:ci:cli

# Required library lane: packages only, without either embedded app.
bash scripts/build.sh --packages-only
bun run test:ci:libraries

# Required browser lane: the real served-app and SharedWorker proof remains blocking.
bash scripts/build.sh --skip-docs
bun run --cwd packages/cli test:app-conformance
```

## Required PR feedback now has a three-minute ceiling

| Measurement | Before | Final SHA |
| --- | ---: | ---: |
| Hosted median | 4m20.5s | 2m43.5s |
| Final attempt 1 | — | 2m46s |
| Final attempt 2 | — | 2m41s |

Each required lane measures elapsed wall time and fails above 180 seconds. The final median is 37.2% lower; browser conformance and the existing oracle, coverage, and conformance gates still block merges.

## Risk

Documentation changes receive no build, drift, link, or browser verification in normal PR CI. That omission is deliberate while the documentation is a WIP; the full build continues to include documentation for packaging and release checks.

Splitting the original test chain could silently omit a workspace suite. The workflow contract compares the commands in `test:ci:cli` plus `test:ci:libraries` with the original `test` command and requires the exact same command count and set.

The 180-second ceiling could expose GitHub-hosted runner variance. The two final-SHA critical-path measurements were 166 and 161 seconds, leaving 14–19 seconds of observed headroom.

## The default build still produces both embedded applications

```sh
# Packaging and release callers retain the original behavior.
bash scripts/build.sh

test -f packages/cli/dist/serve/studio-ui/index.html
test -f packages/cli/dist/serve/docs-ui/index.html
```

`--skip-docs` retains the embedded Studio needed by CLI and browser tests. `--packages-only` skips both embedded applications for suites that only consume workspace packages. Calling the script without an option remains the complete release build.

<details>
<summary>Implementation notes</summary>

- Hosted final-SHA attempt 1 passed: main 2m46s, libraries 1m59s, browser 1m45s.
- Hosted final-SHA attempt 2 passed: main 2m41s, libraries 2m18s, browser 1m51s.
- The packaging gate passed for all five packages: build, pack, consumer install, advertised subpath resolution, runtime smoke, and CLI smoke.
- CLI, library/UI, and browser-conformance lanes passed with their respective build profiles.
- The default build produced both `studio-ui/index.html` and `docs-ui/index.html`.
- The new library lane exposed a pre-existing assertion that required two ISO timestamps to differ after a 1ms delay. ISO timestamps have millisecond precision, so the assertion now requires the update time not to move backwards while `metageneration === "2"` proves that the update committed. The test passed 100 repetitions: 800 assertions, 0 failures.
- A dependency-aware build rewrite was declined. The lower-risk lane split already meets the sub-three-minute target while preserving the trust-critical proofs.

</details>