### PR TITLE
fix(functions): support ESM and CommonJS sources

### DIFF
--- a/packages/cli/src/functions-rtdb/child.ts
+++ b/packages/cli/src/functions-rtdb/child.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { RemoteSandbox } from '../remote/index.js';
 import {
   startOnValueCreatedExecution,
@@ -203,6 +203,23 @@ function send(message: FunctionsRtdbChildMessage): void {
   process.send?.(message);
 }
 
+/** Load either module format with ESM semantics and recover exact CJS exports. */
+async function loadFunctionsExports(entry: string): Promise<Record<string, unknown>> {
+  const namespace = await import(pathToFileURL(entry).href) as Record<string, unknown>;
+  // Node >=22.12 exposes the exact CommonJS module.exports value under this
+  // marker. Using it avoids walking both synthetic named exports and `default`,
+  // which would discover every CJS trigger twice. ESM has no marker and its
+  // namespace is already the Firebase loader shape we need.
+  const commonJsExports = namespace['module.exports'];
+  if (
+    (typeof commonJsExports === 'object' && commonJsExports !== null) ||
+    typeof commonJsExports === 'function'
+  ) {
+    return commonJsExports as Record<string, unknown>;
+  }
+  return namespace;
+}
+
 async function runFunctionsRtdbChild(): Promise<void> {
   const entry = process.env.PYRIC_FUNCTIONS_ENTRY;
   const instance = process.env.PYRIC_FUNCTIONS_INSTANCE;
@@ -252,7 +269,7 @@ async function runFunctionsRtdbChild(): Promise<void> {
     // The real database provider asks firebase-admin/app for its default app
     // when it wraps a raw CloudEvent. Initializing that app before loading the
     // user's module avoids importing the broad firebase-functions/v2 barrel.
-    const exported = requireFromEntry(entry) as Record<string, unknown>;
+    const exported = await loadFunctionsExports(entry);
     const effectiveInstances = [...new Set(
       inspectOnValueCreated(exported).triggers.map((trigger) =>
         trigger.instance === '*' ? instance : trigger.instance,

--- a/packages/cli/src/functions-rtdb/child.ts
+++ b/packages/cli/src/functions-rtdb/child.ts
@@ -1,7 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, extname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { RemoteSandbox } from '../remote/index.js';
 import {
@@ -203,21 +204,32 @@ function send(message: FunctionsRtdbChildMessage): void {
   process.send?.(message);
 }
 
-/** Load either module format with ESM semantics and recover exact CJS exports. */
-async function loadFunctionsExports(entry: string): Promise<Record<string, unknown>> {
-  const namespace = await import(pathToFileURL(entry).href) as Record<string, unknown>;
-  // Node >=22.12 exposes the exact CommonJS module.exports value under this
-  // marker. Using it avoids walking both synthetic named exports and `default`,
-  // which would discover every CJS trigger twice. ESM has no marker and its
-  // namespace is already the Firebase loader shape we need.
-  const commonJsExports = namespace['module.exports'];
-  if (
-    (typeof commonJsExports === 'object' && commonJsExports !== null) ||
-    typeof commonJsExports === 'function'
-  ) {
-    return commonJsExports as Record<string, unknown>;
+function usesCommonJs(entry: string): boolean {
+  const extension = extname(entry);
+  if (extension === '.cjs') return true;
+  if (extension === '.mjs') return false;
+
+  let directory = dirname(entry);
+  while (true) {
+    const packageJsonPath = join(directory, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+        type?: unknown;
+      };
+      return packageJson.type !== 'module';
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return true;
+    directory = parent;
   }
-  return namespace;
+}
+
+/** Load the entry with the semantics selected by its extension and package scope. */
+async function loadFunctionsExports(entry: string): Promise<Record<string, unknown>> {
+  if (usesCommonJs(entry)) {
+    return createRequire(entry)(entry) as Record<string, unknown>;
+  }
+  return await import(pathToFileURL(entry).href) as Record<string, unknown>;
 }
 
 async function runFunctionsRtdbChild(): Promise<void> {

--- a/packages/cli/test/functions-rtdb/child.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/child.integration.test.ts
@@ -57,7 +57,7 @@ beforeAll(async () => {
     JSON.stringify({ name: 'unchanged-functions', private: true, type: 'commonjs' }),
   );
   writeFileSync(
-    join(fixtureDir, 'functions/index.cjs'),
+    join(fixtureDir, 'functions/index.js'),
     `const { onValueCreated, onValueUpdated } = require('firebase-functions/v2/database');
 exports.makeUppercase = onValueCreated(
   '/messages/{pushId}/original',
@@ -150,7 +150,7 @@ describe('isolated Functions RTDB child', () => {
     const events: FunctionsRtdbChildEvent[] = [];
     child = spawnFunctionsRtdbChild({
       cwd: join(fixtureDir, 'functions'),
-      entry: join(fixtureDir, 'functions/index.cjs'),
+      entry: join(fixtureDir, 'functions/index.js'),
       childModuleUrl: pathToFileURL(childModule),
       env: buildChildEnv(process.env, {
         serveUrl: runtime.handle.url,

--- a/packages/cli/test/functions-rtdb/child.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/child.integration.test.ts
@@ -93,6 +93,30 @@ exports.unsupportedInstance = onValueCreated(
     join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
     join(fixtureDir, 'functions/node_modules/firebase-functions'),
   );
+  mkdirSync(join(fixtureDir, 'functions-esm/node_modules'), { recursive: true });
+  writeFileSync(
+    join(fixtureDir, 'functions-esm/package.json'),
+    JSON.stringify({
+      name: 'unchanged-functions-esm',
+      private: true,
+      type: 'module',
+      main: 'index.js',
+    }),
+  );
+  writeFileSync(
+    join(fixtureDir, 'functions-esm/index.js'),
+    `import { onValueCreated } from 'firebase-functions/v2/database';
+await Promise.resolve();
+export const makeUppercase = onValueCreated(
+  '/esm-messages/{pushId}/original',
+  event => event.data.ref.parent.child('uppercase').set(event.data.val().toUpperCase()),
+);
+`,
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+    join(fixtureDir, 'functions-esm/node_modules/firebase-functions'),
+  );
 
   runtime = await startServe({
     cwd: fixtureDir,
@@ -171,6 +195,41 @@ describe('isolated Functions RTDB child', () => {
       params: { pushId: 'id' },
       status: 'fulfilled',
     });
+    expect(await child.stop()).toBe(0);
+  }, 15_000);
+
+  test('loads unchanged ESM source and writes back into the same remote sandbox', async () => {
+    const events: FunctionsRtdbChildEvent[] = [];
+    child = spawnFunctionsRtdbChild({
+      cwd: join(fixtureDir, 'functions-esm'),
+      entry: join(fixtureDir, 'functions-esm/index.js'),
+      childModuleUrl: pathToFileURL(childModule),
+      env: buildChildEnv(process.env, {
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+      instance: 'demo-project-default-rtdb',
+      location: 'us-central1',
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(await child.ready).toEqual({
+      triggerCount: 1,
+      unsupportedTriggers: [],
+    });
+    await observer.rtdb.set('esm-messages/id/original', 'hello');
+    const eventDeadline = Date.now() + 5_000;
+    while (events.length === 0 && Date.now() < eventDeadline) {
+      await new Promise((resolveSleep) => setTimeout(resolveSleep, 20));
+    }
+    expect(events).toContainEqual({
+      type: 'execution',
+      exportName: 'makeUppercase',
+      ref: 'esm-messages/id/original',
+      params: { pushId: 'id' },
+      status: 'fulfilled',
+    });
+    await waitForValue('esm-messages/id/uppercase', 'HELLO');
     expect(await child.stop()).toBe(0);
   }, 15_000);
 

--- a/packages/cli/test/functions-rtdb/dev.e2e.test.ts
+++ b/packages/cli/test/functions-rtdb/dev.e2e.test.ts
@@ -50,76 +50,103 @@ afterAll(async () => {
 });
 
 describe('pyric dev Functions RTDB integration', () => {
-  test('discovers unchanged source, executes it in one sandbox, and stops cleanly', async () => {
+  test('executes unchanged CommonJS and ESM sources in one sandbox and stops cleanly', async () => {
     if (!existsSync(cliEntry)) throw new Error(`build the CLI first: ${cliEntry}`);
-    const cwd = mkdtempSync(join(tmpdir(), 'pyric-functions-dev-'));
-    mkdirSync(join(cwd, 'public'));
-    mkdirSync(join(cwd, 'functions/node_modules'), { recursive: true });
-    writeFileSync(join(cwd, 'public/index.html'), '<!doctype html><body>fixture</body>');
-    writeFileSync(join(cwd, '.firebaserc'), JSON.stringify({ projects: { default: 'demo-project' } }));
-    writeFileSync(join(cwd, 'firebase.json'), JSON.stringify({
-      hosting: { public: 'public' },
-      functions: { source: 'functions' },
-    }));
-    writeFileSync(join(cwd, 'functions/package.json'), JSON.stringify({
-      name: 'unchanged-functions',
-      private: true,
-      type: 'commonjs',
-      main: 'index.cjs',
-    }));
-    writeFileSync(join(cwd, 'functions/index.cjs'), `
-const { onValueCreated } = require('firebase-functions/v2/database');
+    for (const format of ['commonjs', 'module'] as const) {
+      const esm = format === 'module';
+      const cwd = mkdtempSync(join(tmpdir(), `pyric-functions-dev-${format}-`));
+      const entry = esm ? 'index.js' : 'index.cjs';
+      mkdirSync(join(cwd, 'public'));
+      mkdirSync(join(cwd, 'functions/node_modules'), { recursive: true });
+      writeFileSync(join(cwd, 'public/index.html'), '<!doctype html><body>fixture</body>');
+      writeFileSync(join(cwd, '.firebaserc'), JSON.stringify({
+        projects: { default: 'demo-project' },
+      }));
+      writeFileSync(join(cwd, 'firebase.json'), JSON.stringify({
+        hosting: { public: 'public' },
+        functions: { source: 'functions' },
+      }));
+      writeFileSync(join(cwd, 'functions/package.json'), JSON.stringify({
+        name: `unchanged-functions-${format}`,
+        private: true,
+        type: format,
+        main: entry,
+      }));
+      writeFileSync(join(cwd, 'functions', entry), esm
+        ? `import { onValueCreated } from 'firebase-functions/v2/database';
+await Promise.resolve();
+export const makeUppercase = onValueCreated(
+  '/messages/{pushId}/original',
+  event => event.data.ref.parent.child('uppercase')
+    .set(event.data.val().toUpperCase()),
+);
+`
+        : `const { onValueCreated } = require('firebase-functions/v2/database');
 exports.makeUppercase = onValueCreated(
   '/messages/{pushId}/original',
   event => event.data.ref.parent.child('uppercase')
     .set(event.data.val().toUpperCase()),
 );
 `);
-    symlinkSync(
-      join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
-      join(cwd, 'functions/node_modules/firebase-functions'),
-    );
+      symlinkSync(
+        join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+        join(cwd, 'functions/node_modules/firebase-functions'),
+      );
 
-    let stdout = '';
-    let stderr = '';
-    command = spawn('node', [
-      cliEntry,
-      'dev',
-      '--port=0',
-      '--host=127.0.0.1',
-      '--no-open',
-      '--no-capture',
-    ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
-    command.stdout?.setEncoding('utf8');
-    command.stderr?.setEncoding('utf8');
-    command.stdout?.on('data', (chunk: string) => { stdout += chunk; });
-    command.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+      let stdout = '';
+      let stderr = '';
+      command = spawn('node', [
+        cliEntry,
+        'dev',
+        '--port=0',
+        '--host=127.0.0.1',
+        '--no-open',
+        '--no-capture',
+      ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+      command.stdout?.setEncoding('utf8');
+      command.stderr?.setEncoding('utf8');
+      command.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+      command.stderr?.on('data', (chunk: string) => { stderr += chunk; });
 
-    const pointer = await waitFor(() => {
-      const path = join(cwd, '.pyric/serve.json');
-      return existsSync(path)
-        ? JSON.parse(readFileSync(path, 'utf8')) as { url: string }
-        : null;
-    });
-    peer = await connectWorkerPeer(`${pointer.url.replace(/^http/, 'ws')}/__pyric/sandbox`);
-    observer = await connectRemoteSandbox({ url: pointer.url });
-    await waitFor(() => stdout.includes('✔ functions 1 onValueCreated trigger') ? true : null);
+      try {
+        const pointer = await waitFor(() => {
+          const path = join(cwd, '.pyric/serve.json');
+          return existsSync(path)
+            ? JSON.parse(readFileSync(path, 'utf8')) as { url: string }
+            : null;
+        });
+        peer = await connectWorkerPeer(
+          `${pointer.url.replace(/^http/, 'ws')}/__pyric/sandbox`,
+        );
+        observer = await connectRemoteSandbox({ url: pointer.url });
+        await waitFor(() =>
+          stdout.includes('✔ functions 1 onValueCreated trigger') ? true : null);
 
-    await observer.rtdb.set('messages/id/original', 'hello');
-    await waitFor(async () =>
-      (await observer!.rtdb.get('messages/id/uppercase')) === 'HELLO' ? true : null);
-    await waitFor(() =>
-      stdout.includes('✔ function  makeUppercase ← /messages/id/original') ? true : null);
+        await observer.rtdb.set('messages/id/original', 'hello');
+        await waitFor(async () =>
+          (await observer!.rtdb.get('messages/id/uppercase')) === 'HELLO' ? true : null);
+        await waitFor(() =>
+          stdout.includes('✔ function  makeUppercase ← /messages/id/original') ? true : null);
 
-    command.kill('SIGTERM');
-    const code = await Promise.race([
-      new Promise<number>((resolveExit) => command!.once('exit', (exit) => resolveExit(exit ?? 1))),
-      Bun.sleep(5_000).then(() => -1),
-    ]);
-    expect(code).toBe(0);
-    expect(stdout).toContain('Shutting down...');
-    expect(stderr).not.toContain('Functions child exited unexpectedly');
-  }, 20_000);
+        command.kill('SIGTERM');
+        const code = await Promise.race([
+          new Promise<number>((resolveExit) =>
+            command!.once('exit', (exit) => resolveExit(exit ?? 1))),
+          Bun.sleep(5_000).then(() => -1),
+        ]);
+        expect(code).toBe(0);
+        expect(stdout).toContain('Shutting down...');
+        expect(stderr).not.toContain('Functions child exited unexpectedly');
+      } finally {
+        observer?.close();
+        observer = undefined;
+        await peer?.close().catch(() => {});
+        peer = undefined;
+        if (command?.exitCode === null) command.kill('SIGKILL');
+        command = undefined;
+      }
+    }
+  }, 30_000);
 
   test('SIGTERM during Functions module evaluation stops the isolated child', async () => {
     if (!existsSync(cliEntry)) throw new Error(`build the CLI first: ${cliEntry}`);

--- a/packages/pyric-admin/src/app/index.ts
+++ b/packages/pyric-admin/src/app/index.ts
@@ -29,6 +29,20 @@ export interface SandboxAdminApp {
 export type PyricAdminApp = SandboxAdminApp;
 export type InitializeAdminAppConfig = { sandbox: Sandbox };
 
+/**
+ * Firebase Functions' ESM runtime statically imports this credential factory
+ * while linking its database provider. Pyric initializes the sandbox app
+ * before that provider executes, so the factory is not used by supported
+ * Functions flows. Keep the named export link-compatible, but fail clearly if
+ * application code asks the development sandbox for production credentials.
+ */
+export function applicationDefault(): never {
+  throw new Error(
+    'pyric-admin/app: applicationDefault() is unavailable in the sandbox. ' +
+      'Pyric development does not use production credentials.',
+  );
+}
+
 /** Local error with the observable firebase-admin app-error shape. */
 class FirebaseAppError extends Error {
   readonly code: string;
@@ -40,8 +54,20 @@ class FirebaseAppError extends Error {
   }
 }
 
-const appRegistry = new Map<string, PyricAdminApp>();
-const ambientApps = new WeakSet<PyricAdminApp>();
+// Node may evaluate this ESM-only mirror through distinct require(esm) and
+// import module records when the register hook rewrites both CJS and ESM
+// Firebase consumers. Firebase Admin's app registry is process-wide, so keep
+// the mirror registry behind Symbol.for as well: both module records must see
+// the same default app and sandbox handle.
+const APP_REGISTRY = Symbol.for('pyric.admin.app.registry');
+const AMBIENT_APPS = Symbol.for('pyric.admin.app.ambientApps');
+interface GlobalAppRegistry {
+  [APP_REGISTRY]?: Map<string, PyricAdminApp>;
+  [AMBIENT_APPS]?: WeakSet<PyricAdminApp>;
+}
+const globalRegistry = globalThis as GlobalAppRegistry;
+const appRegistry = globalRegistry[APP_REGISTRY] ??= new Map<string, PyricAdminApp>();
+const ambientApps = globalRegistry[AMBIENT_APPS] ??= new WeakSet<PyricAdminApp>();
 
 function validateAppName(name: unknown): asserts name is string {
   if (typeof name !== 'string' || name === '') {


### PR DESCRIPTION
`pyric dev` now runs RTDB Functions sources authored as either ESM or CommonJS, including ESM dependency graphs that use top-level await.

```json
// functions/package.json — ESM projects can use their existing Firebase layout
{
  "type": "module",
  "main": "index.js",
  "dependencies": {
    "firebase-admin": "^13.5.0",
    "firebase-functions": "^6.4.0"
  }
}
```

```js
// functions/index.js
import { onValueCreated } from "firebase-functions/v2/database";

await Promise.resolve(); // top-level await is supported

export const makeUppercase = onValueCreated("/messages/{id}", async (event) => {
  await event.data.ref.set(String(event.data.val()).toUpperCase());
});
```

```json
// A CommonJS project keeps the same behavior by changing only its package metadata.
{
  "type": "commonjs",
  "main": "index.cjs",
  "dependencies": {
    "firebase-admin": "^13.5.0",
    "firebase-functions": "^6.4.0"
  }
}
```

```js
// functions/index.cjs
const { onValueCreated } = require("firebase-functions/v2/database");

exports.makeUppercase = onValueCreated("/messages/{id}", async (event) => {
  await event.data.ref.set(String(event.data.val()).toUpperCase());
});
```

## Both module systems now reach the same Functions sandbox

The Functions child selects Node's loader from the entry extension and nearest package scope. ESM uses native `import` and therefore gets linking and top-level-await semantics; CommonJS uses `require` so trigger discovery receives the exact export object once, with its original names. This avoids relying on module-namespace markers that differ across supported Node releases.

Firebase Functions' ESM build statically imports `applicationDefault` from `firebase-admin/app`. `pyric-admin/app` now supplies that linker-visible compatibility export while continuing to reject production credential use inside the sandbox.

## Risk

The Admin app registry now lives on process-global symbols so the separate module records created by `require()` and `import()` observe the same default app and sandbox. That is intentional parity with Firebase Admin's process-wide app registry, but it broadens the lifetime of this internal state to the worker process.

Direct calls to `applicationDefault()` still throw: Pyric does not provide production credentials. This change makes the symbol linkable for the real `firebase-functions` ESM graph; it does not add credential support.

<details>
<summary>Implementation notes and verification</summary>

- Added real-SDK child integration coverage for CommonJS and ESM with top-level await.
- Added public `pyric dev` parity coverage that writes through a remote RTDB peer and observes both module formats execute the same trigger.
- `bun test --cwd packages/cli`: 1,148 pass, 18 environment-gated skips, 0 fail.
- `bun test --cwd packages/pyric-admin`: 645 pass, 0 fail.
- `bun run test:packaging`: all five packages built, packed, installed, resolved, and passed smoke tests.
- `bun run --cwd packages/cli typecheck`, `bun run build:cli`, and `git diff --check`: pass.

</details>
