### PR TITLE
Remove three-minute CI job budget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,6 @@ jobs:
     name: Build all packages + run tests
     runs-on: ubuntu-latest
     steps:
-      - name: Start job timer
-        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
@@ -140,23 +137,10 @@ jobs:
         # The other workspace suites run concurrently in library-tests.
         run: bun run test:ci:cli
 
-      - name: Report timing and enforce three-minute job budget
-        if: always()
-        run: |
-          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Build + unit/conformance tests: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 180 )); then
-            echo "Build + unit/conformance tests exceeded the 180s CI budget (${elapsed}s)." >&2
-            exit 1
-          fi
-
   library-tests:
     name: Run library + UI tests
     runs-on: ubuntu-latest
     steps:
-      - name: Start job timer
-        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
@@ -172,23 +156,10 @@ jobs:
       - name: Run library, UI, Studio, and conformance tests
         run: bun run test:ci:libraries
 
-      - name: Report timing and enforce three-minute job budget
-        if: always()
-        run: |
-          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Library + UI tests: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 180 )); then
-            echo "Library + UI tests exceeded the 180s CI budget (${elapsed}s)." >&2
-            exit 1
-          fi
-
   browser-conformance:
     name: Served app + SharedWorker conformance
     runs-on: ubuntu-latest
     steps:
-      - name: Start job timer
-        run: echo "PYRIC_CI_JOB_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
@@ -220,16 +191,6 @@ jobs:
         # apps, cross-tab Auth isolation, config locking, deletion teardown,
         # and the worker-owned AI boundary. These are blocking oracle claims.
         run: bun run --cwd packages/cli test:app-conformance
-
-      - name: Report timing and enforce three-minute job budget
-        if: always()
-        run: |
-          elapsed=$(( $(date +%s) - PYRIC_CI_JOB_STARTED_AT ))
-          echo "### Browser conformance: ${elapsed}s / 180s" >> "$GITHUB_STEP_SUMMARY"
-          if (( elapsed > 180 )); then
-            echo "Browser conformance exceeded the 180s CI budget (${elapsed}s)." >&2
-            exit 1
-          fi
 
   packaging:
     name: Packaging gate (pack + install + subpath resolution)

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -33,9 +33,6 @@ describe('served app conformance merge gate', () => {
     expect(libraryJob).toContain('bash scripts/build.sh --packages-only');
     expect(libraryJob).toContain('bun run test:ci:libraries');
     expect(libraryJob).not.toContain('bun run test:ci:cli');
-    expect(mainJob).toContain('${elapsed}s / 180s');
-    expect(libraryJob).toContain('${elapsed}s / 180s');
-
     const complete = rootPackage.scripts?.test?.split(' && ') ?? [];
     const split = [
       ...(rootPackage.scripts?.['test:ci:cli']?.split(' && ') ?? []),
@@ -63,7 +60,6 @@ describe('served app conformance merge gate', () => {
     expect(browserJob).toContain('bunx playwright install-deps chromium');
     expect(browserJob).toContain('bun run --cwd packages/cli test:app-conformance');
     expect(browserJob).toContain('bash scripts/build.sh --skip-docs');
-    expect(browserJob).toContain('${elapsed}s / 180s');
     const build = browserJob.indexOf('bash scripts/build.sh --skip-docs');
     const cache = browserJob.indexOf('Cache Playwright Chromium');
     const browser = browserJob.indexOf('bunx playwright install chromium');


### PR DESCRIPTION
Removes the custom three-minute failure budget from all continuously run build jobs so successful checks are no longer failed solely for taking longer than 180 seconds.

```yaml
jobs:
  build-and-test:
    steps:
      - name: Run CLI tests
        run: bun run test:ci:cli

  library-tests:
    steps:
      - name: Run library, UI, Studio, and conformance tests
        run: bun run test:ci:libraries

  browser-conformance:
    steps:
      - name: Served app + SharedWorker conformance
        run: bun run --cwd packages/cli test:app-conformance
```

## Successful jobs are no longer turned red after 180 seconds

The workflow previously recorded each job's start time and ended with an `if: always()` step that failed when elapsed time exceeded three minutes. Those timer and enforcement steps are removed from `build-and-test`, `library-tests`, and `browser-conformance`. GitHub's normal job limits still apply.

The workflow-contract test no longer requires the retired timing output. It continues to enforce the job split, package-only builds, Playwright installation order, and the blocking SharedWorker proof.

## Risk

Slow or stuck jobs will consume runner time longer before GitHub's platform limit stops them. Reviewers should judge whether removing the budget entirely is preferable to raising it.

<details>
<summary>Implementation notes</summary>

- `bun test packages/cli/test/e2e/app-conformance-gate.test.ts` passes, 3 tests and 30 expectations.
- `git diff --check` passes.
- Confirmed no `180s`, `three-minute`, `PYRIC_CI_JOB_STARTED_AT`, or `timeout-minutes` enforcement remains in `.github/workflows/build.yml`.
- The initial CI run exposed three stale timing assertions in the existing workflow-contract test. Commit `9c857aba` removes only those assertions.

</details>
