### PR TITLE
Docs: organize the local-to-production workflow

### DIFF
--- a/docs/site-rewrite/HIERARCHY.md
+++ b/docs/site-rewrite/HIERARCHY.md
@@ -1,234 +1,80 @@
-# HIERARCHY (v3 proposal, for step-3 iteration)
+# Local-to-Production Workflow
 
-Canonical draft. Supersedes v2. Still ours to argue with.
+This is the final navigation hierarchy for issue #312. It replaces the earlier package, feature, and rules-wing taxonomies.
 
-## What changed from v2
+Pyric has one job in the learning path: let Firebase application code run against a local sandbox during development, then let the same code resolve to Firebase in production. The navigation follows that lifecycle.
 
-Your four calls, plus the novelty research, reshaped it:
+```text
+Overview
 
-- **A narrative overview page opens the docs.** Not titled "What is Pyric." The page IS the narrative, a concise read that explains what this is and what you get. It leads with "build your thing and get it right," and lets the deeper why reveal itself.
-- **Rules became a wing, not a doorway.** It now holds the engine, the standard library, the patterns, the limits that actually bite, verdict-stream debugging, and the auditing skills. The standard library lives inside the wing for now; we reconsider after the first pass.
-- **The gallery is a layer, not the front.** Most people do not know rules are brutally hard for games, and they do not care. They want their thing done well. So "What's possible" sits deep in the rules wing, where the Firebase-literate find it and are impressed, and where it never blocks the person just trying to ship.
-- **`PATTERNS.md` becomes first-class content**, ported from firebase-agent-sdk and written up, because the standard library already leans on it.
-- **The knowledge assets finally have a home** (in the rules wing), so the best material Pyric has stops living only in source.
-
-The governing frame did not change. Outcomes first, service-shaped where people search by service, the agent as the ambient second reader, nouns only in Reference at the bottom.
-
----
-
-## The left nav, top to bottom
-
-```
-Overview                              (the narrative page)
-
-GET STARTED
-  Start building
-
-BUILD
-  Sign in and manage users            Auth            v1
-  Store and query data                Firestore       v1
-  Sync realtime data                  Realtime DB     experimental
-  Store files                         Storage         experimental
-  Which data service should I use?
-
-SECURE & DEBUG  (the rules wing)
-  Secure it with rules                overview
-  Simulate and lint before you deploy
-  Write a rules test suite
-  Read a denial and understand it
-  The rules standard library
-  Rules patterns
-  The limits that actually bite
-  Audit your rules and data
-  What's possible                     (the gallery)
-
-OBSERVE & SHAPE
-  See what's happening
-  Shape your data
-
-SHIP & TEST
-  Ship to production
+RUN LOCALLY
+  Quickstart
+  How the swap works
+  Set up an agent
   Test in Node
 
-WORK WITH AN AGENT
-  Set up your agent                   MCP, Claude Code, Cursor, Codex
-  What your agent can do
-  Skills
-  Watch and review
+DEVELOP WITH FIREBASE APIS
+  Sign in and manage users
+  Store and query data
+  Sync realtime data
+  Store files
+  Receive messages
+  Run AI Logic locally
+  Run an RTDB function locally
+  Which data service?
 
-TRUST
-  How we know it matches Firebase
+INSPECT AND CORRECT
+  Inspect the sandbox
+    Traffic and rule verdicts
+    Read a denial
+    Seed, snapshot, and replay
+    Review agent activity
+  Correct Security Rules
+    Security Rules
+    Simulate and lint
+    Rules patterns
+    Rules standard library
+    RTDB rules in TypeScript
+    Rules limits
+    Case studies
+  Work with an agent
+    What an agent can do
+    Skills
+
+VERIFY THE BOUNDARY
+  Verify a captured session
+  Write a rules test suite
+  Audit rules and data
+
+SHIP UNCHANGED
+  Ship to production
+  Set up the Firebase project
+
+CONFORMANCE
+  How Pyric knows it works like Firebase
   What's experimental
+  Conformance scores
+  App, Firestore, Auth, Realtime Database, Storage, Rules,
+  Messaging, AI Logic, and Functions with RTDB evidence
 
 REFERENCE
-  pyric  ·  pyric-admin  ·  @pyric/cli
+  Generated and package-owned reference, collapsed from the primary path
 ```
 
----
+## Why products sit under development
 
-## Overview  (the narrative page)
+Auth, Firestore, Realtime Database, Storage, Messaging, AI Logic, and Functions are not separate Pyric workflows. They are the Firebase APIs used while developing. Their guide pages appear when application code is being written. Product-specific local behavior remains linked from those pages and searchable in reference.
 
-Not a table of contents. A short, well-written read that a person finishes knowing what this is and why they want it. The shape, in beats:
+## Why inspection and correction share a phase
 
-1. **What it is, in a breath.** Firebase that runs in your browser. Your `firebase/*` code runs against a local backend in dev and real Firebase in prod, unchanged.
-2. **The hook.** One command, no account, no project, no emulator. A full Firebase stack in the first ten seconds.
-3. **What you build with it.** Real auth, real data, real rules, seen working locally, then shipped.
-4. **The quiet why, for whoever keeps reading.** It focuses on the hard parts. It knows the things about Firebase that are not written down, and it hands them to you and your agent as tools, so the hard thing starts on the far side of the hard part. Forward-deployed expertise, in your own words, never a brag.
+Development moves between writing code, observing an operation, and correcting data or rules. Those actions form one loop. Studio, denial inspection, state controls, agent activity, and Security Rules therefore live together instead of becoming separate product or tool sections.
 
-Leads reader-first. The person who just wants to ship gets everything they need in the first two beats. The person who keeps reading discovers the depth. `[new; draws from NOVELTY.md, kept concise and humble]`
+## Why verification is not conformance
 
-**Title options to pick from:** "Overview," "The short version," "What you get," "Start here." Not "What is Pyric."
+Verification asks whether the application crosses the local-to-production boundary safely. It uses captured sessions, rules tests, and audits against the application's own behavior.
 
----
+Conformance asks whether Pyric itself matches Firebase. It is a separate evidence system with its own method, scores, limitations, and product matrices. A reader can complete the workflow without studying it, then inspect the evidence before deciding how much to trust the mirror.
 
-## GET STARTED
+## Route policy
 
-### Start building
-**Promise:** a working Firebase backend in one command. No account, no project, no emulator.
-- Your backend in one command `[reuse: @pyric/cli/tutorials/getting-started]`
-- Scaffold a new app `[reuse: init template docs]`
-- Add Pyric to an app you already have `[reuse: how-to/use-the-vite-plugin, tutorials/server-adoption]`
-- What just happened (the swap, one page) `[new, short]`
-- *And from an agent:* one flag and it can drive this too `[new, short]`
-
----
-
-## BUILD
-
-Service-shaped, so a person searching for auth or storage lands on sight. Each is written as outcomes. Detail carried from v2; unchanged except the agent notes now name the specific tool or skill.
-
-- **Sign in and manage users** (Auth, v1). Sign users in; manage users in the sandbox; design an identity model `[skill: firebase-auth-model]`; how identity reaches your rules. Auth finally earns real how-to and explanation pages.
-- **Store and query data** (Firestore, v1). Read and write; query; live snapshots; transactions; design queries and the indexes they need `[skill: firestore-query-indexes]`.
-- **Sync realtime data** (RTDB, experimental). Store and read; model the tree `[skill: rtdb-data-model]`; validated writes. Labeled experimental.
-- **Store files** (Storage, experimental). Upload and download; list and delete; metadata; enforce storage rules. Labeled experimental.
-- **Which data service should I use?** The one-page Firestore-vs-RTDB answer.
-
----
-
-## SECURE & DEBUG  (the rules wing)
-
-This is the wing the novelty research demanded. It is the strongest thing Pyric does, and it gets the room. It is not a lecture on rules. It is "get your rules right, prove it, and debug them with precision," with the depth waiting for whoever needs it.
-
-### Secure it with rules  (wing overview)
-**Promise:** prove a user can touch only their own data, before you deploy.
-The landing that orients the wing and shows the core loop: write, simulate, see the verdict, deploy. `[reuse: pyric/rules overview]`
-
-### Simulate and lint before you deploy
-**Promise:** catch the error before Firebase gives you an opaque 400 or 403.
-- Simulate a request's verdict `[reuse: rules/how-to/simulate-locally]`
-- Lint your rules `[reuse: rules/how-to/lint-source]`
-- The linter catches JS-in-rules mistakes and the real limits (short, points to "the limits that actually bite") `[new from linter, hallucination detector]`
-
-### Write a rules test suite
-**Promise:** rules you can trust because they are tested, in-process and in CI.
-- `[reuse: rules/tutorials/write-a-test-suite, how-to/test-against-firebase-rules-test-api]`
-
-### Read a denial and understand it
-**Promise:** never debug a bare permission-denied again.
-- The verdict on every operation, with the rule and data that decided it `[reuse: sandbox denial explanation + event stream]`
-- Compare two rulesets for weakening `[reuse: rules/how-to/compare-for-weakening]`
-
-### The rules standard library
-**Promise:** reusable, tested rule building blocks, and an import the rules language does not have.
-- What the standard library is, and `import { isMyTurn } from 'turns'` `[reuse: STDLIB.md, stdlib-modules.ts]`
-- The modules that break the "you can't do that in rules" assumptions: rate-limiting (`timing`), cross-document batch integrity (`atomic`), state machines (`transitions`), membership and spaces `[new from stdlib]`
-- Inside the wing for now; revisit whether it earns top-level presence after the first pass.
-
-### Rules patterns
-**Promise:** the techniques the hard rules are built from.
-- Config document, path blocking, piece-type-agnostic lookup, unique gates, and the rest `[new: port PATTERNS.md from firebase-agent-sdk, write up as first-class content]`
-
-### The limits that actually bite
-**Promise:** the Firestore rules limits Google does not document, so your rules compile the first time.
-- Source size, chain depth, let bindings, get() count, and the non-deterministic runtime budget with its flaky zone `[new from linter thresholds, LINTER_SPEC]`
-- Why the emulator does not save you here `[new from retrospective]`
-
-### Audit your rules and data
-**Promise:** find the holes before someone else does.
-- Audit Firestore rules `[skill: firestore-rules-audit]`
-- Author and audit RTDB rules `[skill: rtdb-security-rules]`
-- Audit the whole project's posture `[skill: firebase-audit]`
-- *And from an agent:* all three, on demand.
-
-### What's possible  (the gallery)
-**Promise:** proof, for the reader who thinks the claims are too big.
-- Chess, checkers, connect four, US tax code, and a live tic-tac-toe, all in pure rules `[new: firebase-agent-sdk/examples]`
-- Framed as what the tools make an agent capable of, not as the hero. Deep in the wing on purpose. The person shipping a CRUD app never has to see it; the Firebase nerd finds it and is impressed.
-
----
-
-## OBSERVE & SHAPE
-
-### See what's happening
-**Promise:** watch every read, write, and denial live, no log lines.
-- Watch traffic live in Studio; read the event stream yourself; inspect a denial; build your own monitor `[reuse: sandbox observe/traffic]`
-
-### Shape your data
-**Promise:** seed, snapshot, reset, and replay the backend like source.
-- Seed a scenario; snapshot and serve it back; reset between tests; replay a captured session; switch users `[reuse: sandbox state how-tos, pyric snapshot]`
-- *And from an agent:* seed and reset as tools.
-
----
-
-## SHIP & TEST
-
-### Ship to production
-**Promise:** the same code goes live, and you learn what changes before prod does.
-- The dev-to-prod build; deploy rules; deploy indexes from your query shapes; verify what flips before prod does; deploy hosting and functions; sign in for deploys `[reuse: deploy tree, verify]`
-- Set up the project itself: enable auth providers, authorize OAuth domains, provision database and storage `[new from control-plane research]`
-
-### Test in Node
-**Promise:** the same backend in tests and scripts, no browser, admin shape when needed.
-- Test against the sandbox in Node; use the admin shape (one line); share one backend across app, Node, and agent; a nod to verify `[reuse: sandbox test harness, pyric-admin]`
-
----
-
-## WORK WITH AN AGENT
-
-The agent is the ambient second reader everywhere, and this is its home. Every "and from an agent" note across the docs points here.
-
-- **Set up your agent.** What MCP gives you; Claude Code (the plugin and `pyric-start`); Cursor; Codex; any MCP client `[reuse: bridge, wire-claude-code, pyric-plugin]`
-- **What your agent can do.** The backend as a tool surface, by capability: read/write/query, simulate rules, run a stateful session, inspect, and discover `[reuse: agent-tools.md]`
-- **Skills.** What a skill is, how to install it, and the catalog: auth models, query and index design, rules audits, RTDB data models, RTDB rules, whole-project audits `[reuse: .agents/skills, pyric-plugin/skills]`
-- **Watch and review.** The Prototype console and the event stream `[reuse: studio Prototype, events]`
-
----
-
-## TRUST
-
-- **How we know it matches Firebase.** The claim and how it is proven: oracle observations, CI replay, the rules parity harness against the live Rules Test API. What a divergence means `[reuse: conformance docs, corrected to include rules parity]`
-- **What's experimental.** One honest page: Realtime Database, Storage, what experimental costs you, and when it graduates `[reuse: COMPAT headers]`
-
----
-
-## REFERENCE  (the one noun section)
-Per package, for the reader who already knows what they want.
-- **pyric** — Web SDK, sandbox runtime, rules engine, COMPAT matrices.
-- **pyric-admin** — admin-shaped sandbox surface and activation seam.
-- **@pyric/cli** — sandbox CLI, artifact and verification APIs, MCP tool catalog.
-
-`@pyric/ui` keeps its own component docs, out of scope here.
-
----
-
-## The writing debt, now that the wing is real
-
-Re-shelving existing prose covers a lot, but the rules wing and the overview carry most of the new writing. Bounded and specific:
-
-- The **Overview** narrative page.
-- The rules wing's new pages: the standard library writeup, **the ported and written-up PATTERNS.md**, "the limits that actually bite," and the linter/denial connective tissue.
-- The **gallery** page (mostly curation of existing examples).
-- **Auth** how-to and explanation pages (v1 but thin today).
-- The **Storage and RTDB** outcome pages.
-- The per-client **agent setup** recipes and the **skills catalog**.
-- The **project-setup** (enablement) pages under Ship.
-- The short **"and from an agent"** notes, each naming a specific tool. Six domain skills are first drafts of six of these.
-
----
-
-## Still open (small now)
-
-- After the first pass: does the standard library graduate out of the rules wing to its own top-level presence?
-- Overview page title (options listed above).
-- Grouping-header labels: GET STARTED / BUILD / SECURE & DEBUG / OBSERVE & SHAPE / SHIP & TEST / WORK WITH AN AGENT / TRUST / REFERENCE. Right words?
-- Does "Set up the project itself" (enablement) belong under Ship, or does it want its own small doorway given how much the control plane can do?
+The hierarchy changes navigation ownership, not URLs. Existing authored and package-documentation routes remain stable. Package reference, generated TypeDoc pages, and detailed conformance matrices stay built, searchable, and available to agents without occupying the primary learning path.

--- a/docs/site-rewrite/INVENTORY.md
+++ b/docs/site-rewrite/INVENTORY.md
@@ -1,212 +1,56 @@
-# INVENTORY
+# Workflow documentation inventory
 
-The factual capability surface of Pyric, grounded in the code at latest `main`. This is raw material for the docs rewrite: what the system can actually do, what is mature, what is experimental, and what the current docs already cover. Verified against the packages `pyric`, `pyric-admin`, and `@pyric/cli` (not `@pyric/ui`). Every claim traces to a file; a writer can open it and confirm.
+This inventory records the disposition of every authored guide page for issue #312. Package documentation remains authoritative for API depth. The porter proves that every package source is either published, promoted into the workflow, or explicitly superseded.
 
-This document names nouns on purpose. It is the parts bin. OUTCOMES.md turns it into verbs.
+## Authored guide pages
 
----
-
-## 0. One system, three packages
-
-Pyric is one system. The packages are how it ships, not how it is taught.
-
-| Package | Runs where | Is the mirror of | Carries |
-|---|---|---|---|
-| `pyric` | the app process (browser page or Node) | `firebase` (Web SDK) | the SDK mirror, the sandbox runtime, the rules engine |
-| `pyric-admin` | Node development | `firebase-admin` | the admin-shape sandbox mirror selected by activated package resolution |
-| `@pyric/cli` | Node CLI + Vite + editors | development tooling | the `pyric` CLI, the Vite plugin, the MCP surface, artifact generation, verification, Studio |
-
-The whole point of the mirror: application code keeps its `firebase/*` imports and calls unchanged. During development they resolve to a local sandbox. In production they resolve to real Firebase. The seam is one setup line (or zero, in ambient Node mode).
-
-Versions: all three at `0.1.0-alpha.8`. ESM-only, Node 22+.
-
----
-
-## 1. Maturity tiers (this shapes everything)
-
-The single most important fact for the hierarchy. The services are not equal.
-
-**Conformance-held, v1-supported: Auth, Firestore, Rules.** These are proven against recorded production behavior and are the surfaces a user should trust today.
-
-**Experimental, explicitly not v1: Realtime Database, Storage.** They work, they are documented, but most of their behavior is not yet pinned to a production observation. Their COMPAT headers say so out loud (`packages/pyric/docs/database/COMPAT.md:6-13`, `packages/pyric/docs/storage/COMPAT.md:6-11`).
-
-**Not present: Messaging.** The README says "soon"; there is no Messaging service in the code.
-
-Conformance numbers today (rows / conforming):
-
-| Service | Rows | Conforming | Tier |
-|---|---|---|---|
-| Firestore | 139 | 131 | v1 |
-| Auth | 74 | 63 | v1 |
-| Realtime Database | 170 | 144 | experimental |
-| Storage | 111 | 92 | experimental |
-
-Sandbox has no COMPAT matrix (it is the harness). Rules is NOT unverified, though. Correction to an earlier draft of this doc: the rules simulator has its own conformance, just not centralized in a COMPAT.md. It runs a parity harness (`packages/pyric/test/rules/parity/`) and a corpus (`packages/pyric/test/rules/corpus/`, with `valid`/`invalid`/`edge-cases`) against the live Firebase Rules Test API in CI (`.github/workflows/simulator-parity.yml`, the `parity-stress` job, gated on a service-account secret). The corpus and the game-rules fixtures (`test/fixtures/firestore-game-rules`) double as both a conformance gate and a driver of new rules knowledge. See NOVELTY.md.
-
----
-
-## 2. The Web SDK mirror (`pyric`)
-
-Runs inside the app process. In the browser, the process is the page: the whole backend executes in the tab. In Node, it is the Node process, so tests and scripts get the same backend with no browser.
-
-Every service handle is branded (`TARGET_SYMBOL`) and routes to a sandbox backend or a real Firebase backend. Same call sites either way.
-
-### Firestore (`pyric/firestore`, v1)
-`firestore/index.ts` (2270 lines) mirrors the `firebase/firestore` modular SDK.
-- Init: `getFirestore`, `actingAs(sandbox, identity)`, `getAdminFirestore` (rule-bypass).
-- Reads: `doc`, `collection`, `collectionGroup`, `getDoc`, `getDocs`.
-- Writes: `setDoc` (with merge), `updateDoc`, `deleteDoc`, `addDoc`.
-- Queries: `query`, `where`, `or`, `and`, `orderBy`, `limit`, `limitToLast`, cursors `startAt`/`startAfter`/`endAt`/`endBefore`.
-- Aggregations: `count`, `sum`, `average`, `getCountFromServer`, `getAggregateFromServer`.
-- Realtime: `onSnapshot` (doc + query).
-- Transactions/batches: `runTransaction`, `writeBatch`.
-- Field values: `serverTimestamp`, `increment`, `arrayUnion`, `arrayRemove`, `deleteField`; `FieldValue`, `Timestamp`.
-- Converters/equality: `withConverter`, `refEqual`, `queryEqual`, `snapshotEqual`.
-- Sandbox-only: `getFirestore(...).setRules()`, `.seed()`, `.snapshot()`; `sandbox` namespace; `SandboxInspect`.
-- Deny-listed (`docs/firestore/reference/feature-matrix.md`): all IndexedDB persistence/cache APIs, `getDocFromCache`/`getDocFromServer`, `loadBundle`/`namedQuery`, `findNearest` vector search, `disableNetwork`/`enableNetwork`, `waitForPendingWrites`, `initializeFirestore`, `terminate`, `connectFirestoreEmulator`.
-
-### Auth (`pyric/auth`, v1)
-Mirrors `firebase/auth` modular SDK.
-- Sign-in: `signInAnonymously`, `signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, `signInWithPopup`, `signInWithRedirect`, `getRedirectResult`, `signInWithCredential`, `signOut`.
-- Session/token/profile: `setPersistence`, `onAuthStateChanged`, `onIdTokenChanged`, `getIdToken`, `getIdTokenResult`, `updateProfile`.
-- Providers: `EmailAuthProvider`, `Google/Facebook/Github/OAuthProvider`.
-- Sandbox-only driver: `sandbox.setUser`, `seedUsers`, `setAuthFlowResolver`, `listIdentities`, `createSignInCredential`, `mockSignInResult`, `exportUsers`, `restoreSession`, per-connection session minting.
-- Deny-listed: `signInWithCustomToken`, `signInWithPhoneNumber`, `signInWithEmailLink`, MFA, `SAML/PhoneAuthProvider`, `sendPasswordResetEmail`, `linkWithCredential`, `reauthenticateWithCredential`, `user.delete()`.
-
-### Realtime Database (`pyric/database`, experimental)
-Two surfaces in one package.
-- Modular SDK (`database/modular.ts`): `getDatabase`, `ref`, `child`, `get`, `set`, `update`, `remove`, `push`, `onValue`, `onChildAdded/Changed/Removed/Moved`, `off`, `runTransaction`, `serverTimestamp`, `increment`; query builder `orderByChild/Key/Value`, `startAt`, `equalTo`, `limitToFirst/Last`.
-- Agent-tool + rules toolkit: `getRtdbTools`, factories for the 11 RTDB agent tools, IR generator, simulator, validated write, structure crawl.
-- Rules constraint DSL (`rules/rtdb/constraints`): `expr`, `all`, `any`, `not`, `deny`, `allow`, `turnGuard`, `schemaRules`, `defineRtdbRules`.
-
-### Storage (`pyric/storage`, experimental)
-Mirrors `firebase/storage` plus a control plane.
-- Object API: `ref`, `uploadBytes`, `uploadString`, `getBytes`, `getBlob`, `deleteObject`, `getMetadata`, `updateMetadata`, `listAll`.
-- Rules (in-process): `parseStorageRules`, `evaluateStorageRules`.
-- Admin/control plane (`storage/admin/`): `provisionStorage`, `enableStorageService`, `deployStorageRules`, bucket CORS, `createStorageAdminTools`.
-- Out of scope for v1: `getDownloadURL`, paginated `list`, `uploadBytesResumable`, Storage emulator parity, image transforms, Functions triggers.
-
-### The sandbox runtime (`pyric/sandbox`)
-The engine under every service. `initializeSandbox(config?)` returns a `Sandbox`.
-- Identity: `withAuth(auth)` binds an identity to a `SandboxContext`; `null` is anonymous.
-- Observability: `onEvent(cb)` is one typed event stream. Members (`sandbox/types.ts`): `request` (per-op rules verdict allow/deny), `write` (committed, with sentinel info), `snapshot_delivery`/`snapshot_suppressed`, `listener_attach/detach/errored`, `session_boundary` (reset/dispose), `service_mutation` (before/after), `operation`, `commit`. Every event carries provenance.
-- Replay: `history()` returns the full event array; `replay(events, rules?)` re-issues captured writes against a fresh sandbox and reports divergence.
-- State: `reset()`, `snapshot()`, `loadSnapshot()`, `admin` (rule-bypass reads), `currentUser` + `onCurrentUserChanged`.
-- Branches (`sandbox/branches/`): `fork`, `apply`, `diff`, `promote`, `discard` from a snapshot.
-- Persistence backends: `createMemoryBackend`, `createIndexedDBBackend`, `attachPersistence`; serialization + rehydration.
-- Cross-tab: `attachTabSync` (BroadcastChannel).
-- Remote: `REMOTE_SANDBOX`, `isRemoteSandbox` — a Node handle onto a browser-hosted worker sandbox.
-
-### The rules engine (`pyric/rules`)
-Firestore and RTDB rules as a library. Browser-safe core; Node-only disk pieces split to `pyric/rules/node`, TS-compiler-heavy extractor to `pyric/rules/extract`.
-- Parse/AST: `parseToAST`, `parseFunctions`, `assembleRules`, `validateFirestoreRules`.
-- Lint: `lintFirestoreRules` → warnings + metrics.
-- Modules stdlib (a 2+ modules extension): browser + Node resolvers, `STDLIB_MODULES`.
-- Simulate (local, no network): `SimulateFirestoreRulesHandler`, `evaluate`, trace recorder, value wrappers (Timestamp, Path, Reference, Bytes, Duration, LatLng), sentinel-expression engine used by the sandbox for `$expr` resolution.
-- Test (hosted): `TestFirestoreRulesHandler` against the Firebase Rules Test API (needs a `ProjectScope`).
-- Deploy/inspect over REST: `WriteFirestoreRulesHandler`, `InspectFirestoreRulesHandler`.
-- Index extraction: `extractIndexes` — static analysis of `query(collection, where, orderBy)` in source.
-- RTDB rules: `pyric/rules/rtdb` + the constraint DSL.
-
----
-
-## 3. The admin mirror (`pyric-admin`)
-
-Mirrors the useful `firebase-admin` shape against a sandbox. Canonical imports
-select it only during activated development; inactive production resolution
-loads Firebase Admin directly.
-
-`initializeApp` binds the sandbox explicitly with `{ sandbox }` or obtains the
-remote sandbox from activated `@pyric/cli/register` on a bare call. A guard
-refuses sandbox routing when `NODE_ENV=production` unless forced.
-
-Services (`pyric-admin/{firestore,auth,database,storage}`) use a local sandbox
-backend and, where implemented, a remote backend relaying to the browser
-SharedWorker.
-
-Remote is the interesting one. A remote-branded sandbox carries a worker-relay channel; each service relays ops over the bridge to the browser-hosted sandbox, pinned to `actAs:{mode:'admin'}` for the admin rules-bypass. That is how a Node script, the browser app, and an agent all see one shared pool of data and users.
-
-Sandbox-backend gaps: local auth has no tenancy/MFA/bulk-ops/updateUser; local database has no listeners/transactions/queries; storage has no streaming/resumable, and remote storage is single-bucket with an 8 MiB per-op cap. Everything unimplemented throws an explicit remediation error, never bad data.
-
----
-
-## 4. The toolchain (`@pyric/cli`)
-
-The `pyric` CLI plus everything around it. Dispatcher `src/cli/index.ts:440`.
-
-### CLI commands
-- **`pyric dev`** — serve the app against the in-process sandbox. Unmodified `firebase/*` imports resolve through a served import map to a SharedWorker sandbox (one backend shared across tabs, durable in IndexedDB; falls back to per-tab). `firestore.rules` deployed at load and hot-reloaded over SSE. Runs your own dev command too (`-- <cmd>` or the package's `dev` script) with `PYRIC_SANDBOX` set. Flags: `--ui` (Studio at `/__pyric/ui/`), `--bridge` (MCP at `/__pyric/mcp`), `--persist`, `--fresh`, `--seed <file>`, `--no-capture`, `--no-watch`, `--port`, `--host`, `--allowed-host`, `--no-run`, `--json`.
-- **`pyric init [dir]`** — scaffold a project. `--template web|node`, `--name`, `--force`.
-- **`pyric vendor [dir]`** — retrofit pyric into an existing project (standalone binary).
-- **`pyric snapshot`** — promote lived sandbox state to a committable fixture that `dev --seed` re-serves. `--out`, `--force`, `--include-passwords`.
-- **`pyric verify [fixture]`** — replay a captured session against a candidate ruleset for Firestore/RTDB. Engines `--engine sandbox|rules-test-api|both`. `--service`, `--rules service=path`. Exit 1 on divergence. Also `pyric verify cases`.
-- **`pyric bridge`** — standalone sandbox HTTP+WS MCP bridge that relays tool calls to the connected browser.
-- **`pyric mcp`** — stdio MCP server for editors; attaches to a running `dev --bridge` or hosts a headless sandbox.
-- **Service CLI**: `firestore rules lint|validate|simulate|resolve`; `firestore indexes generate`; `database rules lint|validate|simulate|generate`; `storage rules lint|simulate`.
-- **Production shipping**: use `firebase-tools` / Console (`firebase deploy --only …`), not pyric.
-
-### The Vite plugin `pyricSandbox()`
-The same `firebase/*` → sandbox swap for a source-driven Vite app, at module-resolution time, inside the normal `vite dev` loop (HMR, source maps). Options: `rules`, `root`, `persist`, `fresh`, `seed`, `capture`, `bridge`, `swapInBuild`.
-- `vite dev` always swaps.
-- `vite build` (production) ships real firebase with the same config — no graduation step.
-- `vite build --mode development` (or `swapInBuild:true`) makes a sandbox build (marked in `index.html`); `pyric dev` serves it. Production hosting deploys should use an unmarked production build via `firebase-tools`.
-
-### The MCP tool surface
-The sandbox and its services exposed as agent-callable tools over MCP. The default bridge pins **25** tool names in `mcp-contract.ts` (Firestore data + inspect, rules lint/simulate/stdlib, simulator session, and RTDB inspection). Library-only factories (not on the default bridge) include assurance, index extraction, RTDB generate, Storage admin, and `@pyric/cli/discover`. Unique differentiators: `firestore_simulate_rules`, the stateful `firestore_simulator_*` session, `sandbox_inspect`, `rtdb_simulate_access`, `rtdb_crawl_structure`. Production shipping is `firebase-tools` / Console.
-
-### Credentials for verify
-`@pyric/cli/credentials/node` — `fromServiceAccount` / `fromAdc` → `ProjectScope` for `pyric verify --engine rules-test-api|both` and the Rules Test API handler. CLI env: `FIREBASE_SA_BASE64` → `GOOGLE_APPLICATION_CREDENTIALS` → ADC.
-
-### Studio (`@pyric/studio`, behind `pyric dev --ui`)
-Local console at `/__pyric/ui/`. Eight tabs (`packages/studio/src/shell/routes.ts`): Home, Firestore, Auth, RTDB, Storage, Traffic, Prototype, Settings. No in-app Docs tab (the composed static site mounts `/docs`; a spec-named Rules tab is intentionally not mounted yet). Prototype is the embedded playground (an agent working against the shared sandbox).
-
----
-
-## 5. What proves it matches Firebase
-
-The claim "it behaves like Firebase" is tested, not asserted. Probes run against a real Firebase project and record its behavior as observations (`packages/conformance/`). CI replays every observation against the sandbox on every change. The public contract is the COMPAT matrix per service (section 1). Firestore and Auth distinguish three targets: sandbox (frozen context), sandbox-live (per-op identity, what the playground uses), and prod. A documented divergence is a row; an undocumented one is a bug.
-
----
-
-## 6. The existing docs (what we are replacing)
-
-184 generated pages. Everything except one hand-written QA page is generated by `packages/site-docs/scripts/port-content.ts` from the per-package `docs/` trees. The rewrite target is those source trees plus the nav plan in `port-content.ts`, not the generated collection.
-
-Current shape: **package-and-noun first**. Slug = `<pkg>-<service>-<diataxis>-<topic>` (for example `pyric-firestore-how-to-build-queries`). Nav is one disclosure per package subtree, Diataxis (Tutorials / How-to / Reference / Explanation) as the inner axis.
-
-Coverage by group:
-
-| Group | Pages | Notes |
+| Source | Classification | Navigation disposition |
 |---|---|---|
-| `pyric/firestore` | 19 | full Diataxis + COMPAT |
-| `pyric/rules` | 28 | deep; no COMPAT (tooling) |
-| `pyric/sandbox` | 26 | deep; no COMPAT (harness) |
-| `pyric/storage` | 15 | experimental |
-| `pyric/auth` | 5 | reference + compat only, no how-to/explanation |
-| `pyric/database` | 5 | experimental |
-| `pyric-admin/firestore` | 14 | only admin service documented |
-| `@pyric/cli` (root) | 14 | dev, init, verify, Vite, adoption |
-| `@pyric/ui` | 30 | not Diátaxis; out of scope for this rewrite |
+| `content/overview.md` | Pyric-specific workflow help | Overview |
+| `content/get-started/start-building.md` | Pyric-specific workflow help | Run locally |
+| `content/get-started/how-the-swap-works.md` | Pyric-specific workflow help | Run locally |
+| `content/agent/set-up-your-agent.md` | Pyric-specific workflow help | Run locally |
+| `content/ship/test-in-node.md` | Pyric-specific workflow help | Run locally |
+| `content/build/sign-in-and-manage-users.md` | Firebase API task with Pyric-specific local behavior | Develop with Firebase APIs |
+| `content/build/store-and-query-data.md` | Firebase API task with Pyric-specific local behavior | Develop with Firebase APIs |
+| `content/build/sync-realtime-data.md` | Firebase API task with Pyric-specific local behavior | Develop with Firebase APIs |
+| `content/build/store-files.md` | Firebase API task with Pyric-specific local behavior | Develop with Firebase APIs |
+| `content/build/receive-messages.md` | Firebase API task with Pyric-specific local delivery behavior | Develop with Firebase APIs |
+| `content/build/run-ai-logic-locally.md` | Firebase API task with Pyric-specific local answer engines | Develop with Firebase APIs |
+| `packages/cli/docs/how-to/run-rtdb-onvaluecreated.md` | Pyric-specific local Functions workflow | Promoted in place to Develop with Firebase APIs; existing route and source retained |
+| `content/build/which-data-service.md` | Ordinary Firebase product choice | Develop with Firebase APIs, retained as a short decision page that points to Firebase product documentation |
+| `content/observe/see-whats-happening.md` | Pyric-specific inspection workflow | Inspect and correct, Inspect the sandbox |
+| `content/secure/read-a-denial.md` | Pyric-specific inspection workflow | Inspect and correct, Inspect the sandbox |
+| `content/observe/shape-your-data.md` | Pyric-specific correction workflow | Inspect and correct, Inspect the sandbox |
+| `content/agent/watch-and-review.md` | Pyric-specific inspection workflow | Inspect and correct, Inspect the sandbox |
+| `content/secure/secure-it-with-rules.md` | Firebase task with Pyric-specific local behavior | Inspect and correct, Correct Security Rules |
+| `content/secure/simulate-and-lint.md` | Pyric-specific correction workflow | Inspect and correct, Correct Security Rules |
+| `content/secure/rules-patterns.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
+| `content/secure/rules-standard-library.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
+| `content/secure/rtdb-rules-in-typescript.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
+| `content/secure/limits-that-bite.md` | Production-measured rules guidance | Inspect and correct, Correct Security Rules; route retained pending the final heading pass |
+| `content/secure/whats-possible.md` | Rules case studies | Inspect and correct, Correct Security Rules |
+| `content/agent/what-your-agent-can-do.md` | Pyric-specific workflow help | Inspect and correct, Work with an agent |
+| `content/agent/skills.md` | Pyric-specific workflow help | Inspect and correct, Work with an agent |
+| `packages/cli/docs/how-to/verify-against-a-captured-session.md` | Pyric-specific boundary verification | Promoted in place to Verify the boundary; existing route and source retained |
+| `content/secure/write-a-rules-test-suite.md` | Boundary verification | Verify the boundary |
+| `content/secure/audit-your-rules.md` | Boundary verification | Verify the boundary |
+| `content/ship/ship-to-production.md` | Pyric-specific production handoff | Ship unchanged |
+| `content/ship/set-up-the-project.md` | Ordinary Firebase production setup | Ship unchanged, reduced to the Pyric boundary and links to official Firebase guidance |
+| `content/trust/how-we-know-it-matches-firebase.md` | Conformance explanation | Conformance |
+| `content/trust/whats-experimental.md` | Conformance limitation | Conformance |
 
-Examples (`examples/`): `vite-sandbox-app` (the flagship, the shape `pyric init --template web` scaffolds) and `admin-playground` (a `@pyric/ui` showcase).
+## Generated and package-owned documentation
 
-### Staleness and imbalance to fix
-- **Coverage is inverted from importance.** Auth is v1 and load-bearing but has 5 pages and no how-to or explanation. RTDB and Storage are experimental yet carry equal nav weight to v1 surfaces.
-- **The hierarchy is nouns.** Package → service → Diataxis. A reader who wants to "let a signed-in user save a document safely" has nowhere to land; they must already know it spans auth + firestore + rules.
-- **Emulator-connector rows persist** (`connectFirestoreEmulator`, `connectStorageEmulator`) despite the firm no-emulator position. Retire candidates.
-- **The tool count is grep-derived** and the README itself flags consolidation is ongoing. Do not hard-code "51".
-- **`@pyric/ui` is not Diataxis** and is out of scope here; it becomes the only package-named section (API reference), per the nav philosophy.
+| Material | Classification | Disposition |
+|---|---|---|
+| Product `COMPAT.md` files and `conformance/SCORES.md` | Conformance evidence | Remain generated, itemized under Conformance, and linked from the authored explanation |
+| TypeDoc API pages | Generated reference | Remain generated and searchable; never enter the primary workflow navigation |
+| Package tutorials, how-to pages, explanations, and hand-authored references | Product-specific depth | Remain built and searchable beneath Reference unless promoted or superseded explicitly |
+| `@pyric/ui` component pages | Generated implementation reference for component consumers | Remain beneath Reference; not used to teach the Pyric workflow |
 
----
+## Obsolete navigation concepts
 
-## 7. The seams that make good outcomes possible
+The following groupings are superseded: Get started, Build, Secure & debug, Observe & shape, Ship & test, Work with an agent, and Trust. Their pages remain useful, but their former taxonomy does not describe the local-to-production lifecycle.
 
-A short list of the load-bearing behaviors, because these are what the outcomes will be built from.
-
-1. **The same code runs against a sandbox in dev and real Firebase in prod.** No rewrite, no graduation. One import map or one Vite plugin.
-2. **The backend is local state.** Seed it, snapshot it, reset it, fork it, replay it, the way you edit a file.
-3. **Every operation is an observable event** with its rules verdict, including denials with the rule and data that produced them.
-4. **Rules are a library**, not a deploy target. Lint, simulate, and test them in-process, in CI, and from an agent.
-5. **The whole thing is an agent tool surface.** One MCP bridge exposes the sandbox so an agent drives the same backend the app and Studio see.
-6. **Work carries to production.** Rules exercised against real behavior, indexes extracted from query shapes, and a replay that tells you which operations change verdict before prod finds out.
-7. **One identity model across web and Node.** `withAuth` in the sandbox, the admin lens for privileged reads, the same shared pool over the remote bridge.
+No route changes are required for this reclassification. The final heading pass in #313 may rename a route only when the benefit justifies complete inbound-link handling.

--- a/docs/site-rewrite/content/README.md
+++ b/docs/site-rewrite/content/README.md
@@ -1,55 +1,17 @@
-# Docs rewrite content (step 4 drafts)
+# Authored workflow content
 
-Every page of the new docs, written to WRITING-BRIEF.md against HIERARCHY.md v3. All pages carry `status: draft` frontmatter. This tree is for review; wiring it into the site generator (`packages/site-docs/scripts/port-content.ts`) is the step after the red pen.
+These pages form the primary learning path. They teach Pyric as one local-to-production system, with Firebase products introduced only when application code reaches them.
 
-## The map
+## Workflow map
 
-| Nav | File | New or re-hung |
+| Phase | Pages | Role |
 |---|---|---|
-| Overview | `overview.md` | new (voice anchor) |
-| **GET STARTED** | | |
-| Start building | `get-started/start-building.md` | new landing over reused tutorials |
-| How the swap works | `get-started/how-the-swap-works.md` | new |
-| **BUILD** | | |
-| Sign in and manage users | `build/sign-in-and-manage-users.md` | new (Auth finally gets its guide) |
-| Store and query data | `build/store-and-query-data.md` | new landing over reused how-tos |
-| Sync realtime data | `build/sync-realtime-data.md` | new, experimental-labeled |
-| Store files | `build/store-files.md` | new, experimental-labeled |
-| Which data service? | `build/which-data-service.md` | new |
-| **SECURE & DEBUG** (the rules wing) | | |
-| Secure it with rules | `secure/secure-it-with-rules.md` | new wing landing |
-| Simulate and lint | `secure/simulate-and-lint.md` | new over reused how-tos |
-| Write a rules test suite | `secure/write-a-rules-test-suite.md` | new over reused tutorial |
-| Read a denial | `secure/read-a-denial.md` | new |
-| The rules standard library | `secure/rules-standard-library.md` | new (from STDLIB.md) |
-| Rules patterns | `secure/rules-patterns.md` | new (ported from firebase-agent-sdk skills) |
-| RTDB rules in TypeScript | `secure/rtdb-rules-in-typescript.md` | new (constraints DSL) |
-| The limits that actually bite | `secure/limits-that-bite.md` | new (from LINTER_SPEC + linter thresholds) |
-| Audit your rules and data | `secure/audit-your-rules.md` | new (from the audit skills) |
-| What's possible | `secure/whats-possible.md` | new (the gallery) |
-| **OBSERVE & SHAPE** | | |
-| See what's happening | `observe/see-whats-happening.md` | new landing over reused how-tos |
-| Shape your data | `observe/shape-your-data.md` | new landing over reused how-tos |
-| **SHIP & TEST** | | |
-| Ship to production | `ship/ship-to-production.md` | new landing over reused deploy tree |
-| Set up the project | `ship/set-up-the-project.md` | new (control-plane enablement) |
-| Test in Node | `ship/test-in-node.md` | new over reused harness tutorial |
-| **WORK WITH AN AGENT** | | |
-| Set up your agent | `agent/set-up-your-agent.md` | new (per-client recipes) |
-| What your agent can do | `agent/what-your-agent-can-do.md` | new (capability-taught) |
-| Skills | `agent/skills.md` | new (catalog) |
-| Watch and review | `agent/watch-and-review.md` | new |
-| **TRUST** | | |
-| How we know it matches Firebase | `trust/how-we-know-it-matches-firebase.md` | new over conformance docs |
-| What's experimental | `trust/whats-experimental.md` | new |
-| **REFERENCE** | (unchanged: existing per-package reference + COMPAT) | re-hung as-is |
+| Overview | `overview.md` | State the local-development contract and production handoff. |
+| Run locally | `get-started/*`, `agent/set-up-your-agent.md`, `ship/test-in-node.md` | Start the sandbox and connect browser, Node, or agent work to it. |
+| Develop with Firebase APIs | `build/*`, plus the existing RTDB Functions guide | Use ordinary Firebase APIs against the sandbox, then reach local behavior that differs by product. |
+| Inspect and correct | `observe/*`, most of `secure/*`, remaining `agent/*` | Read operations and denials, correct state and rules, and inspect agent work. |
+| Verify the boundary | `secure/write-a-rules-test-suite.md`, `secure/audit-your-rules.md`, plus the existing CLI verification guide | Check captured application behavior and rules before production. |
+| Ship unchanged | `ship/ship-to-production.md`, `ship/set-up-the-project.md` | Build with real Firebase and deploy through Firebase tooling. |
+| Conformance | `trust/*`, generated scores, and product matrices | Explain and expose the evidence that Pyric itself matches Firebase. |
 
-## What re-hanging means
-
-The package how-tos, explanations, and reference trees provide the depth behind
-these guide pages. The site porter shelves both sets beneath one outcome-first
-navigation model and rewrites links from authored sources.
-
-## Review guide
-
-Read `overview.md` first; it is the voice contract in action. Then read one page per section to check the voice holds. The knowledge pages (`secure/rules-standard-library.md`, `secure/limits-that-bite.md`, `secure/rules-patterns.md`, `secure/whats-possible.md`) carry the most new claims; their facts trace to STDLIB.md, LINTER_SPEC.md, the chess log, and the firebase-agent-sdk skill references.
+Detailed package documentation remains the source for API reference and product-specific depth. The site porter keeps those routes searchable while collapsing them beneath Reference.

--- a/docs/site-rewrite/content/build/receive-messages.md
+++ b/docs/site-rewrite/content/build/receive-messages.md
@@ -1,0 +1,49 @@
+---
+title: Receive Firebase Cloud Messaging locally
+navLabel: Receive messages
+outcome: Keep Firebase Cloud Messaging receive code unchanged while tokens and deliveries stay in the local sandbox.
+status: draft
+---
+
+# Receive Firebase Cloud Messaging locally
+
+Keep using the Firebase Cloud Messaging Web API:
+
+```ts
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+
+const messaging = getMessaging(app);
+const token = await getToken(messaging);
+
+onMessage(messaging, payload => {
+  console.log(payload.data);
+});
+```
+
+During development, the token and message broker belong to the local sandbox. No registration reaches Firebase Cloud Messaging. A production build runs the same application code through Firebase. Use the [Firebase Cloud Messaging Web documentation](https://firebase.google.com/docs/cloud-messaging/web/get-started) for normal registration and the [message handling guide](https://firebase.google.com/docs/cloud-messaging/web/receive-messages) for foreground and background behavior.
+
+## Deliver a message during local development
+
+Tests and development harnesses can inject a message through Pyric's sandbox-only driver:
+
+```ts
+import { getMessaging, onMessage, sandbox as messagingSandbox } from 'pyric/messaging';
+
+const messaging = getMessaging(app);
+onMessage(messaging, payload => {
+  console.log(payload.data);
+});
+
+await messagingSandbox.deliver(messaging, {
+  visibilityState: 'visible',
+  data: { event: 'report-ready' },
+});
+```
+
+Keep this driver outside application code that ships. A visible client routes the delivery to `onMessage`. A hidden client routes it to the service-worker `onBackgroundMessage` path. The local broker also models token stability and deletion, but it does not request browser notification permission or contact the FCM transport.
+
+## Check the supported boundary
+
+Read the generated [Messaging conformance matrix](../../../../packages/pyric/docs/messaging/COMPAT.md) for the current client, service-worker, and Admin send surfaces, including verified behavior and tracked limitations.
+
+Continue with [Inspect and correct](../observe/see-whats-happening.md) or [verify the production boundary](../../../../packages/cli/docs/how-to/verify-against-a-captured-session.md).

--- a/docs/site-rewrite/content/build/run-ai-logic-locally.md
+++ b/docs/site-rewrite/content/build/run-ai-logic-locally.md
@@ -1,0 +1,49 @@
+---
+title: Run Firebase AI Logic locally
+navLabel: Run AI Logic locally
+outcome: Keep Firebase AI Logic application code unchanged while model responses stay deterministic or come from a local model.
+status: draft
+---
+
+# Run Firebase AI Logic locally
+
+Keep using the Firebase AI Logic Web API:
+
+```ts
+import { getAI, getGenerativeModel } from 'firebase/ai';
+
+const ai = getAI(app);
+const model = getGenerativeModel(ai, {
+  model: 'gemini-flash-lite-latest',
+});
+const result = await model.generateContent('Summarize this report.');
+```
+
+During development, Pyric answers through a local engine instead of a Google AI endpoint. A production build runs the same application code through Firebase. Use the [Firebase AI Logic Web guide](https://firebase.google.com/docs/ai-logic/get-started?platform=web) for normal model, prompt, chat, streaming, schema, and function-calling APIs.
+
+## Choose how the sandbox answers
+
+The default scripted engine is deterministic and makes no network requests. Test setup can queue an exact response through the sandbox-only scripting entry point:
+
+```ts
+import { getAI } from 'pyric/ai';
+import { script } from 'pyric/ai/scripting';
+
+const ai = getAI(app);
+script(ai, [
+  {
+    match: 'Summarize this report.',
+    respond: { text: 'The report is ready for review.' },
+  },
+]);
+```
+
+Keep scripted setup outside application code that ships. Pyric also supports an OpenAI-compatible local engine through the `engine` option and the `pyric dev` AI proxy. This can connect the same Firebase AI Logic calls to Ollama or another local server. The [AI chat example](https://github.com/davideast/pyric/tree/main/examples/ai-chat) shows both engines with streaming, chat history, and function calling.
+
+Local engines do not reproduce model quality, safety policy, latency, quotas, billing, or service availability. Verify model-dependent behavior against the production backend before release.
+
+## Check the supported boundary
+
+Read the generated [AI Logic conformance matrix](../../../../packages/pyric/docs/ai/COMPAT.md) for the mirrored API, verified wire behavior, documented differences, unsupported APIs, and unverified rows.
+
+Continue with [Inspect and correct](../observe/see-whats-happening.md) or [ship unchanged](../ship/ship-to-production.md).

--- a/docs/site-rewrite/content/build/sign-in-and-manage-users.md
+++ b/docs/site-rewrite/content/build/sign-in-and-manage-users.md
@@ -1,119 +1,56 @@
 ---
-title: Sign users in and manage them
+title: Run Firebase Authentication locally
 navLabel: Sign in and manage users
-outcome: Run real auth flows against a local user database, seed test users with claims, and design an identity model your rules can trust.
+outcome: Keep Firebase Authentication code unchanged while identities, sessions, and provider flows stay in the local sandbox.
 status: draft
 ---
 
-# Sign users in
+# Run Firebase Authentication locally
 
-The auth code you would write against Firebase works as-is under `pyric dev`, and the users it creates live in your sandbox. Auth is v1 in Pyric: the surface is tested against recorded production behavior, so what signs in here signs in there.
+Keep using the Firebase Authentication Web API:
 
 ```ts
-import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
+import { getAuth, signInAnonymously } from 'firebase/auth';
 
 const auth = getAuth(app);
-
-onAuthStateChanged(auth, (user) => {
-  render(user ? `Signed in as ${user.uid}` : 'Signed out');
-});
-
 await signInAnonymously(auth);
 ```
 
-Email and password work the way you expect, creation and sign-in as separate flows:
+During development, this creates and signs into a local identity. A production build runs the same call through Firebase. Use the [Firebase Authentication documentation](https://firebase.google.com/docs/auth/web/start) for normal sign-in, account, provider, and observer APIs.
 
-```ts
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
+## What changes locally
 
-await createUserWithEmailAndPassword(auth, 'alice@example.com', 'correct-horse');
-await signInWithEmailAndPassword(auth, 'alice@example.com', 'correct-horse');
-```
+The sandbox owns the user database and active sessions. No identity is created in a Firebase project. Auth state remains available to Firestore, Realtime Database, and Storage Security Rules through the same Firebase-shaped user and token fields used by the application.
 
-And the Google flow:
+Popup and redirect providers do not contact Google, GitHub, or another identity provider. Pyric presents a local identity picker so provider-dependent application paths can run without OAuth configuration or external accounts.
 
-```ts
-import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+Pyric Studio shows the local users and current authentication state. It can create, edit, select, and remove test identities without adding those controls to application code.
 
-await signInWithPopup(auth, new GoogleAuthProvider());
-```
+## Seed identities for tests
 
-Under `pyric dev`, that call opens an account picker instead of a Google window. Pick an existing sandbox identity or create one on the spot, with a display name and custom claims if you want them.
-
-No OAuth app, no consent screen, and the identity flows into your rules like any other. `signInWithRedirect` and `getRedirectResult` follow the same path.
-
-## Manage users in the sandbox
-
-The user database is local state, so you can load it. In a test harness or seed script, `seedUsers` bulk-loads identities, claims included:
+Sandbox-only identity controls belong in test or setup code, never in the application path that ships:
 
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
-import { getAuth, signInWithEmailAndPassword, sandbox as authSandbox } from 'pyric/auth';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 
 const sandbox = initializeSandbox();
 const auth = getAuth(sandbox);
 
 authSandbox.seedUsers(auth, [
-  { uid: 'alice', email: 'alice@example.com', password: 'pw' },
-  { uid: 'admin', email: 'admin@example.com', password: 'pw', customClaims: { role: 'admin' } },
+  {
+    uid: 'alice',
+    email: 'alice@example.com',
+    password: 'local-only',
+    customClaims: { role: 'editor' },
+  },
 ]);
-
-await signInWithEmailAndPassword(auth, 'admin@example.com', 'pw');
 ```
 
-To flip between identities without a sign-in flow, `setUser` forces the current user directly (it takes a full user object) and notifies `onAuthStateChanged` subscribers like a real sign-in. Pass `null` to sign out:
+Those claims reach `request.auth.token` when local Security Rules evaluate an operation.
 
-```ts
-authSandbox.setUser(auth, aliceUser);
-authSandbox.setUser(auth, null);
-```
+## Check the supported boundary
 
-Keep the `sandbox` namespace out of app source. The real `firebase/auth` has no equivalent, so it belongs in your harness and seed code, where switching users mid-test is the point. In the running app, the account picker and `pyric snapshot` cover the same ground: lived users can be promoted to a committable fixture and re-seeded on boot.
+Authentication is not a complete reimplementation of every Firebase Auth feature. Read the generated [Auth conformance matrix](../../../../packages/pyric/docs/auth/COMPAT.md) for the current public surface, verified behavior, documented differences, unsupported APIs, and unverified rows.
 
-## Design an identity model
-
-Authentication answers who the user is. Rules answer what that identity may do. Connecting the two is a design task, and it has three moves.
-
-**Name your identities.** Anonymous visitor, signed-in user, owner, member, admin. Every access boundary in your app should map to one of these names before any rule mentions it.
-
-**Make the UID the bridge.** The `uid` is the stable key that connects Authentication to your data. Put profile documents at `users/{uid}`, use the UID as the document ID wherever a record belongs to one person, and decide early which profile fields are public and which are private.
-
-**Split claims from roles data.** Custom claims carry coarse, global, slow-changing roles (`admin`, `moderator`), and rules read them as `request.auth.token.role`. Membership, ownership, and anything resource-specific belongs in document data, where a rule can `get()` it.
-
-One caution that pays for itself: users must never be able to grant themselves a role through a writable profile field. Your rules have to protect the shape of profile creates and updates, not only who performs them.
-
-## How identity reaches your rules
-
-Every operation in the sandbox carries `request.auth`, exactly as production rules see it:
-
-```rules
-match /posts/{postId} {
-  allow update, delete: if request.auth != null
-    && (request.auth.uid == resource.data.ownerId
-        || request.auth.token.role == 'admin');
-}
-```
-
-- `request.auth` is `null` when nobody is signed in.
-- `request.auth.uid` is the owner check.
-- `request.auth.token.*` carries the custom claims, and the claims you pass to `seedUsers` flow through end to end, so a rules test with an admin claim exercises the same path production will.
-
-When a rule denies, the verdict names the rule and the data it saw. [Prove your rules protect the app](../secure/secure-it-with-rules.md) picks up from here.
-
-## The boundaries, plainly
-
-Not in v1, and loud about it:
-
-- Phone auth and email-link sign-in.
-- Multi-factor auth and account linking.
-- Password-reset emails.
-
-Code that reaches for these fails with a remediation message instead of returning bad data. The full deny list lives in the reference.
-
-## And from an agent
-
-The `firebase-auth-model` skill designs or audits an identity model end to end: it names the actors, maps UIDs to data shapes, weighs claims against document roles, and then verifies each rule branch by simulating the identities it defined. Point it at an existing app and it reports where the model and the rules disagree. Install it from the [skills catalog](../agent/skills.md).
-
-## Where to go next
-
-Your users exist and your rules can see them. [Store and query data](./store-and-query-data.md) puts them to work, and [secure it with rules](../secure/secure-it-with-rules.md) proves what they can touch.
+Continue with [Store and query data](./store-and-query-data.md) or [inspect a local operation](../observe/see-whats-happening.md).

--- a/docs/site-rewrite/content/build/store-and-query-data.md
+++ b/docs/site-rewrite/content/build/store-and-query-data.md
@@ -1,109 +1,39 @@
 ---
-title: Store and query data
+title: Run Cloud Firestore locally
 navLabel: Store and query data
-outcome: Read, write, query, and stream Firestore documents locally, and derive the composite indexes your queries need from your source.
+outcome: Keep Cloud Firestore application code unchanged while data, listeners, transactions, and Security Rules stay local.
 status: draft
 ---
 
-# Store and query your data
+# Run Cloud Firestore locally
 
-Firestore in Pyric is v1. The modular SDK surface, reads and writes, queries, snapshots, transactions, and aggregations, runs locally with your rules enforced, and it is tested against recorded production behavior. Your imports stay `firebase/firestore`.
-
-## Write and read documents
+Keep using the modular Cloud Firestore Web API:
 
 ```ts
-import {
-  getFirestore, collection, doc,
-  addDoc, setDoc, getDoc, serverTimestamp,
-} from 'firebase/firestore';
+import { collection, getDocs, getFirestore } from 'firebase/firestore';
 
 const db = getFirestore(app);
-
-const noteRef = await addDoc(collection(db, 'notes'), {
-  title: 'First note',
-  ownerId: uid,
-  createdAt: serverTimestamp(),
-});
-
-const snap = await getDoc(noteRef);
-console.log(snap.data());
+const notes = await getDocs(collection(db, 'notes'));
 ```
 
-`setDoc` writes to a known path (pass `{ merge: true }` to update in place), `updateDoc` patches fields, `deleteDoc` removes. Field sentinels work: `serverTimestamp`, `increment`, `arrayUnion`, `arrayRemove`, `deleteField`.
+During development, the call reads the local sandbox. A production build runs it through Firebase. Use the [Cloud Firestore Web documentation](https://firebase.google.com/docs/firestore/quickstart) for ordinary reads, writes, queries, listeners, transactions, batches, and data types.
 
-## Query with where, orderBy, limit
+## What changes locally
 
-```ts
-import { query, where, orderBy, limit, getDocs } from 'firebase/firestore';
+Documents stay in the browser-local backend. Tabs on the same development origin share that backend through one SharedWorker, so Firestore listeners observe writes across tabs. Pyric Studio reads the same documents and requests.
 
-const recent = query(
-  collection(db, 'notes'),
-  where('ownerId', '==', uid),
-  where('archived', '==', false),
-  orderBy('createdAt', 'desc'),
-  limit(20),
-);
+Every application operation is evaluated against the active local Firestore Security Rules. A denial stays local and appears in Studio with the request path and verdict. Saving the configured rules file replaces the active local ruleset without deploying it.
 
-const page = await getDocs(recent);
+The sandbox does not reproduce Firebase billing, network latency, regional behavior, or production indexes. A query that succeeds locally can still require a composite index in Firebase. Generate the index file from application query shapes before deployment:
+
+```bash
+npx pyric firestore indexes generate src
 ```
 
-Multiple `where` clauses AND together; the `or` and `and` combinators handle the rest. Cursors (`startAfter`, `endAt`) paginate, and collection groups query across every subcollection with a given name. Aggregations run without fetching the documents:
+Deploy the resulting Firebase index configuration with `firebase-tools`.
 
-```ts
-import { getCountFromServer } from 'firebase/firestore';
+## Check the supported boundary
 
-const count = await getCountFromServer(query(collection(db, 'notes'), where('archived', '==', false)));
-console.log(count.data().count);
-```
+Read the generated [Firestore conformance matrix](../../../../packages/pyric/docs/firestore/COMPAT.md) before depending on a less common API or production edge. It separates public surface coverage from verified behavior and lists every documented difference, bug, unsupported behavior, and unverified row.
 
-`sum` and `average` follow the same shape through `getAggregateFromServer`.
-
-## Keep the UI live
-
-```ts
-import { onSnapshot } from 'firebase/firestore';
-
-const unsubscribe = onSnapshot(recent, (snap) => {
-  for (const change of snap.docChanges()) {
-    console.log(change.type, change.doc.id);
-  }
-});
-```
-
-Listeners fire on every matching change, across tabs, because every tab shares one backend. If your rules deny a listener, the error callback fires with a verdict that names the rule, not a bare `permission-denied`.
-
-## Read, then write, atomically
-
-When a write depends on the current value, use a transaction:
-
-```ts
-import { runTransaction } from 'firebase/firestore';
-
-await runTransaction(db, async (tx) => {
-  const counter = await tx.get(doc(db, 'counters', 'main'));
-  const current = counter.exists() ? counter.data().count : 0;
-  tx.set(doc(db, 'counters', 'main'), { count: current + 1 });
-});
-```
-
-All reads must come before any writes inside the callback. Production enforces that because the engine retries on conflict, and the sandbox enforces it for parity, so the mistake surfaces on your machine instead of in a retry storm. For multiple writes with no read dependency, `writeBatch` is the cheaper shape.
-
-## Design queries and the indexes they need
-
-A query with combined filters and ordering needs a composite index in production, and the missing-index error arrives at the worst time. Pyric derives the index file from your code instead: `firestore_extract_indexes` statically reads your `query(collection(...), where(...), orderBy(...))` call sites and returns the `firestore.indexes.json` they require, with warnings where it suspects overshoot.
-
-When branchy code enumerates more shapes than your app will ever run, guide the extractor with JSDoc annotations on the function:
-
-- `@firestore-mutex { fieldA, fieldB }` drops combinations where those filters would coexist.
-- `@firestore-required fieldA` drops combinations missing a filter that is always present.
-- `@firestore-budget N` is a soft cap that warns when exceeded.
-
-The index file stops being a hand-kept artifact. It becomes derived output, and [ship to production](../ship/ship-to-production.md) deploys it.
-
-## And from an agent
-
-The `firestore-query-indexes` skill designs read shapes the way a review would: it inventories every query the product performs, proves each list query is constrained the way the rules demand, then runs `firestore_extract_indexes` after every change so the index file tracks the code. Install it from the [skills catalog](../agent/skills.md).
-
-## Where to go next
-
-Data without protection is a liability, so [secure it with rules](../secure/secure-it-with-rules.md). And when you need scenarios instead of hand-typed documents, [shape your data](../observe/shape-your-data.md) covers seeding, snapshots, and resets.
+Continue with [Inspect and correct](../observe/see-whats-happening.md) or [secure the data with local Security Rules](../secure/secure-it-with-rules.md).

--- a/docs/site-rewrite/content/build/store-files.md
+++ b/docs/site-rewrite/content/build/store-files.md
@@ -1,108 +1,31 @@
 ---
-title: Store files
+title: Run Cloud Storage locally
 navLabel: Store files
-outcome: Upload, list, download, and delete files locally, with storage rules enforced in-process.
+outcome: Keep Cloud Storage application code unchanged while objects, metadata, and Security Rules stay local.
 status: draft
 ---
 
-# Store files
+# Run Cloud Storage locally
 
-> **Experimental.** Storage works and is documented, but most of its behavior is not yet pinned to a recorded production observation the way Auth and Firestore are. Read [what's experimental](../trust/whats-experimental.md) before you rely on it.
-
-Files land in your sandbox the way documents do: locally, with rules deciding what gets in.
-
-## Upload and download
+Keep using the Cloud Storage for Firebase Web API:
 
 ```ts
-import { initializeSandbox } from 'pyric/sandbox';
-import { getStorageSandbox, ref, uploadBytes, getBlob } from 'pyric/storage';
+import { getStorage, ref, uploadBytes } from 'firebase/storage';
 
-const sandbox = initializeSandbox();
-const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }));
-
-const bytes = new TextEncoder().encode(JSON.stringify({ task: 'build a notes app' }));
-await uploadBytes(ref(storage, 'sessions/s1'), bytes, { contentType: 'application/json' });
-
-const blob = await getBlob(ref(storage, 'sessions/s1'));
-console.log(JSON.parse(await blob.text()));
+const storage = getStorage(app);
+await uploadBytes(ref(storage, 'attachments/report.txt'), file);
 ```
 
-`uploadString` covers text without the encoder, and `getBytes` returns an `ArrayBuffer` when you want raw bytes instead of a `Blob`. Under `pyric dev`, a served page's `firebase/storage` imports resolve to the sandbox's shared object store, so uploads show up across tabs like every other write. `pyric dev` enforces `storage.rules` the same as `firestore.rules` and `database.rules.json` — but unlike those two, storage rules load at server boot and don't hot-reload. Edit `storage.rules` and you need to restart the dev server to pick up the change.
+During development, the object is written to the local sandbox. A production build runs the same call through Firebase. Use the [Cloud Storage Web documentation](https://firebase.google.com/docs/storage/web/start) for ordinary uploads, downloads, metadata, references, and listing behavior.
 
-## List and delete
+## What changes locally
 
-```ts
-import { listAll, deleteObject } from 'pyric/storage';
+Objects and metadata remain in the browser-local backend. Pyric Studio browses the same object tree used by the application. Local Storage Security Rules evaluate application requests without deploying rules or contacting a Firebase bucket.
 
-const listing = await listAll(ref(storage, 'sessions'));
-console.log(listing.items.map((item) => item.name)); // ['s1']
+The sandbox does not reproduce bucket provisioning, CORS configuration, transfer latency, quotas, billing, or every resumable and streaming behavior. Those remain production concerns.
 
-await deleteObject(ref(storage, 'sessions/s1'));
-```
+## Check the supported boundary
 
-## Metadata rides along
+Read the generated [Storage conformance matrix](../../../../packages/pyric/docs/storage/COMPAT.md) for the current public API surface, verified operations, documented differences, unsupported behavior, and unverified rows.
 
-Set it at upload, read it back, patch it later:
-
-```ts
-import { getMetadata, updateMetadata } from 'pyric/storage';
-
-await uploadBytes(ref(storage, 'sessions/s1'), bytes, {
-  contentType: 'application/json',
-  customMetadata: { sessionId: 's1', version: '1.0' },
-});
-
-const meta = await getMetadata(ref(storage, 'sessions/s1'));
-console.log(meta.size, meta.customMetadata?.sessionId);
-
-await updateMetadata(ref(storage, 'sessions/s1'), {
-  customMetadata: { ...meta.customMetadata, version: '1.1' },
-});
-```
-
-Two contracts worth knowing, both matching the upstream SDK:
-
-- `updateMetadata` replaces the settable fields rather than merging. Fetch first and spread, as above.
-- `customMetadata` is string-to-string, so numbers and objects need serializing.
-
-## Enforce storage rules in-process
-
-Pass rules when you configure the handle, and every operation evaluates against them, no deploy anywhere:
-
-```ts
-const RULES = `service firebase.storage {
-  match /b/{bucket}/o {
-    match /sessions/{id} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null
-                   && (request.resource == null
-                       || (request.resource.size < 10 * 1024 * 1024
-                           && request.resource.contentType == 'application/json'));
-    }
-  }
-}`;
-
-const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { rules: RULES });
-```
-
-An anonymous upload now throws `FirebaseError` with `storage/unauthenticated`. An 11 MiB payload throws `storage/unauthorized`, the signed-in-but-not-allowed code.
-
-Notice the `request.resource == null` carve-out. `deleteObject` carries no payload, so without it every delete would fail the size check. The pattern is standard in production Storage rules, and it is enforced identically here.
-
-One rule-shape gotcha carried over faithfully from production: `listAll` requires `read` on the listed folder itself. A rule scoped to `match /sessions/{id}` grants nothing on `/sessions`, so give the folder its own read rule.
-
-## The boundaries, plainly
-
-The v1 scope is deliberate. What is not in it:
-
-- **No `getDownloadURL`.** For a renderable URL in dev, use `getBlob` and `URL.createObjectURL`. In production the upstream `firebase/storage` has the real one.
-- **No resumable uploads.** `uploadBytesResumable`, with its pause and progress machinery, is deferred. `uploadBytes` and `uploadString` are the write path.
-- **No paginated `list`.** `listAll` only.
-- **`resource.timeCreated` / `resource.updated` aren't exposed on `resource`.** Everything else on `resource` and `request` — including `request.time`, `matches()`, rule functions, and the granular verbs (`get`, `list`, `create`, `update`, `delete`) — works.
-- **One implicit bucket.** The `bucket` option round-trips through metadata but does not partition data.
-
-Each of these fails loudly at the call site instead of drifting quietly.
-
-## Where to go next
-
-If the data is structured rather than binary, [which data service should I use?](./which-data-service.md) sorts it out. And [what's experimental](../trust/whats-experimental.md) says exactly what experimental costs you.
+Continue with [Inspect and correct](../observe/see-whats-happening.md) or [enforce Storage rules](../../../../packages/pyric/docs/storage/how-to/enforce-rules.md).

--- a/docs/site-rewrite/content/build/sync-realtime-data.md
+++ b/docs/site-rewrite/content/build/sync-realtime-data.md
@@ -1,83 +1,33 @@
 ---
-title: Sync realtime data
+title: Run Realtime Database locally
 navLabel: Sync realtime data
-outcome: Store and watch a Realtime Database tree locally, model it around your reads, and guard writes with schema and rules checks.
+outcome: Keep Realtime Database application code unchanged while the data tree, listeners, and Security Rules stay local.
 status: draft
 ---
 
-# Sync realtime data
+# Run Realtime Database locally
 
-> **Experimental.** Realtime Database works and is documented, but most of its behavior is not yet pinned to a recorded production observation the way Auth and Firestore are. Read [what's experimental](../trust/whats-experimental.md) before you rely on it.
-
-Realtime Database is one JSON tree that many clients watch at once. In Pyric it runs locally, rules enforced, with the modular calls you already know.
-
-## Store and read
-
-Under `pyric dev`, your `firebase/database` imports resolve to the sandbox:
+Keep using the Firebase Realtime Database Web API:
 
 ```ts
-import { getDatabase, ref, set, get, onValue } from 'firebase/database';
+import { getDatabase, onValue, ref } from 'firebase/database';
 
-const db = getDatabase();
-
-await set(ref(db, 'status/alice'), { state: 'online', changedAt: Date.now() });
-
-const snap = await get(ref(db, 'status/alice'));
-console.log(snap.val()); // { state: 'online', changedAt: ... }
-
-onValue(ref(db, 'status'), (snap) => {
-  renderPresence(snap.val());
+const db = getDatabase(app);
+onValue(ref(db, 'rooms/main'), (snapshot) => {
+  renderRoom(snapshot.val());
 });
 ```
 
-`push` appends with chronologically sortable IDs, `update` patches, `remove` deletes. One boundary to know: the Vite plugin does not swap `firebase/database` yet, so this path runs under `pyric dev`. In Node, import the same functions from `pyric/database` and hand `getDatabase` a sandbox:
+During development, the listener reads the sandbox tree. A production build runs it through Firebase. Use the [Realtime Database Web documentation](https://firebase.google.com/docs/database/web/start) for normal data modeling, reads, writes, queries, listeners, and transactions.
 
-```ts
-import { initializeSandbox } from 'pyric/sandbox';
-import { getDatabase, ref, set } from 'pyric/database';
+## What changes locally
 
-const sandbox = initializeSandbox();
-const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));
-```
+The database tree and listener state remain in the local backend. Pyric Studio can browse and edit the same tree used by the application. Local Realtime Database Security Rules evaluate application operations without deploying a ruleset or contacting a Firebase database.
 
-## Model the tree around your reads
+Production concerns such as region, connection latency, billing, and deployed database configuration are outside the sandbox. Validate those in a Firebase environment before release.
 
-Every RTDB path is an endpoint, and reading a path downloads everything below it. So structure follows the reads, not the entities. The defaults that hold up:
+## Check the supported boundary
 
-- **Flat, top-level collections.** `/users`, `/posts`, `/postSummaries`. Never nest one entity type inside another, or one read drags the whole subtree.
-- **Index tables for reverse lookups.** `/userGroups/$uid/$groupId: true` answers "which groups is this user in" with one cheap read, and lets membership gate access in rules.
-- **Summary nodes sized for list screens.** The list reads `/postSummaries`, the detail screen fetches one `/posts/$id`.
-- **Push IDs for anything append-only.** Sequential numeric keys collide under concurrent writers; push IDs never do.
+Read the generated [Realtime Database conformance matrix](../../../../packages/pyric/docs/database/COMPAT.md) for the current modular API surface, verified behavior, rules evidence, documented differences, unsupported behavior, and unverified rows.
 
-Duplicated data stays consistent through fan-out: one `update` at the root with full paths as keys commits atomically.
-
-```ts
-import { update } from 'firebase/database';
-
-await update(ref(db), {
-  'posts/p1/title': 'New title',
-  'postSummaries/p1/title': 'New title',
-});
-```
-
-Either both paths change or neither does. Queries take one `orderBy`, so multi-field filters want a precomputed composite key (`"lang_level": "en_5"`) rather than a clever query.
-
-## Inspect and simulate locally
-
-Pyric keeps RTDB inspection and rules checks inside the sandbox. Studio and the
-CLI can crawl the current sandbox snapshot, while `rtdbRules(...).simulate()`
-evaluates reads and writes without contacting a production database. Production
-access happens only when the canonical Firebase package is selected outside the
-sandbox swap.
-
-## And from an agent
-
-The `rtdb-data-model` skill designs the tree the way this page describes,
-starting from an inventory of reads. In a Pyric session, local inspection tools
-map the sandbox snapshot without reaching production. Install the skill from the
-[catalog](../agent/skills.md), and see [set up your agent](../agent/set-up-your-agent.md)
-for the wiring.
-
-## Where to go next
-
-Not sure the tree is the right home for this data? [Which data service should I use?](./which-data-service.md) is the one-page answer. When the paths are settled, write the rules that hold them in TypeScript: [RTDB rules in TypeScript](../secure/rtdb-rules-in-typescript.md).
+For Pyric-specific rules authoring, see [RTDB rules in TypeScript](../secure/rtdb-rules-in-typescript.md). Continue with [Inspect and correct](../observe/see-whats-happening.md) to observe local writes and denials.

--- a/docs/site-rewrite/content/build/which-data-service.md
+++ b/docs/site-rewrite/content/build/which-data-service.md
@@ -1,29 +1,17 @@
 ---
-title: Which data service should I use?
+title: Choose a Firebase database
 navLabel: Which data service?
-outcome: Pick between Firestore and Realtime Database in one short read.
+outcome: Make the Firestore or Realtime Database decision from Firebase's production model, then check the corresponding Pyric boundary.
 status: draft
 ---
 
-# Which data service should I use?
+# Choose a Firebase database
 
-The short answer: Firestore, unless your data is a small shared tree that many clients watch at once.
+Choosing between Cloud Firestore and Realtime Database is a Firebase architecture decision, not a Pyric decision. Compare their production data models, query capabilities, scaling behavior, availability, locations, and pricing in the official [Firebase database comparison](https://firebase.google.com/docs/database/rtdb-vs-firestore).
 
-| | Firestore | Realtime Database |
-|---|---|---|
-| Model | documents and subcollections | one JSON tree |
-| Queries | combined filters, ordering, aggregations, cursors | path reads, one `orderBy` |
-| Built for | structured app data, almost every CRUD app | presence, live cursors, game state, counters |
-| Maturity in Pyric | v1, tested against recorded production behavior | [experimental](../trust/whats-experimental.md) |
+After choosing the production service, use the matching local path:
 
-**Choose Firestore for query power and structured documents.** Documents and subcollections grow with your app's shape, and access rules attach naturally to paths and document data. Most apps land here.
+- [Run Cloud Firestore locally](./store-and-query-data.md), then inspect the [Firestore conformance matrix](../../../../packages/pyric/docs/firestore/COMPAT.md).
+- [Run Realtime Database locally](./sync-realtime-data.md), then inspect the [Realtime Database conformance matrix](../../../../packages/pyric/docs/database/COMPAT.md).
 
-**Choose Realtime Database for low-latency tree sync.** The model is deliberately simpler, and that simplicity is the feature. It stops being a fit the moment you want multi-field queries, so [model the tree around your reads](./sync-realtime-data.md) before committing.
-
-Maturity belongs in the decision too. If either service would fit, pick Firestore.
-
-They also combine. A common shape is Firestore for the documents your app is made of and RTDB for the ephemeral layer on top, presence and typing indicators, where a two-field tree beats a document write per keystroke.
-
-## Where to go next
-
-[Store and query data](./store-and-query-data.md) for the Firestore path, or [sync realtime data](./sync-realtime-data.md) for the tree.
+The conformance matrices describe Pyric's current local boundary. They should not replace Firebase's production architecture guidance.

--- a/docs/site-rewrite/content/get-started/start-building.md
+++ b/docs/site-rewrite/content/get-started/start-building.md
@@ -1,45 +1,38 @@
 ---
-title: Your backend in one command
+title: Run Firebase locally
 navLabel: Quickstart
-outcome: Run a working Firebase backend locally, in a new app or the one you already have.
+outcome: Start a new Firebase application or add Pyric to an existing Vite application without connecting development to production.
 status: draft
 ---
 
-# Your backend in one command
+# Run Firebase locally
+
+Pyric adds a development-only resolution layer to a Firebase application. During Vite development, supported `firebase/*` imports resolve to a browser-local backend. A normal production build resolves those imports to Firebase again.
+
+## Start a new application
+
+Create a Vite application with canonical Firebase imports, Firestore rules, and the Pyric plugin already configured:
 
 ```bash
-npm install -D @pyric/cli
-npx pyric dev
-```
-
-That is a full Firebase backend, running inside the browser tab you are about to open. No account. No cloud project. No emulator, no Java, no port to babysit.
-
-`pyric dev` works in any directory with a `firebase.json`. It serves your app, resolves its ordinary `firebase/*` imports to a local sandbox, and enforces your `firestore.rules` from the first request.
-
-No app yet? Scaffold one.
-
-## Scaffold a new app
-
-```bash
-mkdir hello-pyric && cd hello-pyric
-pyric init --template web
+npx create-pyric my-app
+cd my-app
 npm install
-pyric dev
+npm run dev
 ```
 
-Open <http://localhost:3473>. The scaffold is a small posts app with canonical `firebase/app`, `firebase/auth`, and `firebase/firestore` imports, owner-based rules, and a seed file with two posts already in it. Sign in and create a post. It appears.
+`npm create pyric my-app` runs the same scaffold.
 
-Now prove the rules are real. Open `firestore.rules`, change the posts rule to `allow read: if false;`, and save. The rules hot-reload and the post list becomes a permission error.
+Open the local URL printed by Vite. The application and Pyric Studio use the same local backend. Studio is mounted at `/__pyric/ui/` on that origin.
 
-Put the rule back and the posts return. That loop, edit rules and watch real enforcement respond, is the loop everything else builds on.
+## Add Pyric to an existing Vite application
 
-Building a script or a test suite instead of a page? `pyric init --template node` scaffolds the Node shape.
+Install the development plugin:
 
-## Add Pyric to an app you already have
+```bash
+npm install --save-dev @pyric/cli
+```
 
-Pick by how your app is built.
-
-**You build with Vite.** Add one plugin and keep your own dev loop, HMR and all:
+Add it to the Vite configuration:
 
 ```ts
 // vite.config.ts
@@ -51,30 +44,27 @@ export default defineConfig({
 });
 ```
 
-`vite dev` now swaps `firebase/app`, `firebase/auth`, and `firebase/firestore` to the sandbox at module resolution, deploys your `firestore.rules` at page load, and hot-reloads them on save. A plain `vite build` still ships the real `firebase` package. Nothing in your source changes.
-
-**Your app is static or already built.** Run `pyric dev` in the directory. It serves the files and injects an import map that resolves the page's bare `firebase/*` imports to the sandbox at load time. Same swap, different layer.
-
-It can run your own dev command too: `pyric dev -- npm run dev`.
-
-## Your data survives
-
-The sandbox runs in a SharedWorker, so every tab shares one backend and a write in one tab shows up live in the others. The data lives in IndexedDB and survives a refresh. Three flags control it:
-
-- `--persist` keeps a committable on-disk copy at `.pyric/state/state.json`.
-- `--seed <file>` loads a fixture on boot.
-- `--fresh` starts over.
-
-## And from an agent
-
-One flag gives your agent the same backend:
+Start the normal development server:
 
 ```bash
-pyric dev --bridge
+npm run dev
 ```
 
-`--bridge` mounts an MCP endpoint on the dev server, and any MCP client (Claude Code, Cursor, Codex) can seed data, run queries, and check rules verdicts against the exact sandbox your tabs are using. [Set up your agent](../agent/set-up-your-agent.md) walks through each client.
+No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. The plugin discovers Firestore rules from `firebase.json`, or uses `firestore.rules` when no path is configured.
 
-## Where to go next
+## Use a static application or Node process
 
-You have a backend. [How the swap works](./how-the-swap-works.md) explains the swap in one page, or go straight to [signing users in](../build/sign-in-and-manage-users.md).
+`pyric dev` provides the same development-only package swap outside the Vite plugin:
+
+```bash
+npm install --save-dev @pyric/cli
+npx pyric dev
+```
+
+It can serve static files or start an existing development command. [The CLI guide](../../../../packages/cli/docs/README.md) covers those paths. [Test in Node](../ship/test-in-node.md) covers an in-process sandbox for tests and scripts.
+
+## What remains local
+
+The mirrored services do not connect to a production Firebase project. Local data changes stay in the sandbox. Local Security Rules changes are enforced there and are not deployed. Firebase configuration passed to `initializeApp(config)` is accepted so the application code stays unchanged, but it does not select a cloud backend during development.
+
+Continue with [How the swap works](./how-the-swap-works.md), then [develop with the Firebase APIs](../build/sign-in-and-manage-users.md).

--- a/docs/site-rewrite/content/overview.md
+++ b/docs/site-rewrite/content/overview.md
@@ -7,22 +7,29 @@ status: draft
 
 # Firebase that runs in your browser
 
-Pyric is Firestore, Auth, Realtime Database, Storage, and the Security Rules engine, implemented in TypeScript and running inside your app. In the browser, that means the page itself. The whole backend executes in the tab. In Node, it is the process your tests run in. Your code keeps its ordinary `firebase/*` imports. During development they resolve to Pyric. In production they resolve to Firebase. Nothing in your source changes.
+Pyric runs supported Firebase application code against a local backend during development. The application keeps its ordinary `firebase/*` imports and Firebase configuration. A normal production build resolves those imports to Firebase again. The source does not branch between local development and production.
 
-That is the whole trick, and it starts with one command.
+Start a new application with one command:
 
 ```bash
-npm install -D @pyric/cli
-npx pyric dev
+npx create-pyric my-app
 ```
 
-No account. No cloud project. No emulator, no Java, no port to babysit. You have a full Firebase stack before your coffee is warm, and it behaves like the real one because that claim is tested, not assumed. Pyric runs probes against production Firebase, records what actually happens, and replays every recorded behavior against itself in CI. When it diverges from Firebase, that is a documented row or a bug, never a surprise.
+Local development needs no Firebase account, cloud project, emulator, or Java runtime. The mirrored services do not connect to production. Local writes cannot delete production data or create Firebase usage charges, and local rules changes do not deploy.
 
-## Build the app, prove the rules, ship the same code
+## Follow the application from local development to production
 
-You build your app. Sign users in with the auth calls you already know. Write documents, run queries, keep the UI live with snapshots. Write security rules and find out, before you deploy, exactly what they allow and deny, because every operation in Pyric produces a verdict you can read, and a denial tells you which rule said no and what data it saw.
+The documentation follows one workflow:
 
-Then you ship. With the development resolver inactive, the same canonical imports load real Firebase. Your rules leave development already exercised against your app's real behaviour. Your composite indexes come from your actual queries instead of a hand-kept file. Before anything goes live, you can replay a captured session against the new rules and learn which operations would change verdict. Pyric produces and verifies those artifacts; `firebase-tools` or the Firebase Console deploys them.
+1. **Run locally.** Start the sandbox and connect the application, tests, or coding agent.
+2. **Develop with Firebase APIs.** Keep writing normal Auth, Firestore, Realtime Database, Storage, Messaging, and AI Logic code.
+3. **Inspect and correct.** Read local operations and rules verdicts, then adjust application code, data, or Security Rules.
+4. **Verify the boundary.** Replay captured behavior and test candidate rules before production.
+5. **Ship unchanged.** Build with real Firebase and deploy through `firebase-tools` or the Firebase Console.
+
+Development moves back and forth between writing Firebase code and inspecting what happened. The boundary check comes after that loop, before the production build.
+
+Conformance sits underneath the workflow as separate evidence. It records which Pyric behaviors have been compared with production Firebase, which differ, and which remain unsupported or unverified.
 
 ## Your agent works the same backend
 
@@ -36,4 +43,4 @@ Pyric was built by working those parts until they gave, and what was learned is 
 
 ## Where to go next
 
-Start with [the quickstart](./get-started/start-building.md). If you came here for rules, go straight to [prove your rules protect the app](./secure/secure-it-with-rules.md).
+Start with [Run Firebase locally](./get-started/start-building.md). The [conformance explanation](./trust/how-we-know-it-matches-firebase.md) documents the evidence and its limits.

--- a/docs/site-rewrite/content/ship/set-up-the-project.md
+++ b/docs/site-rewrite/content/ship/set-up-the-project.md
@@ -1,70 +1,25 @@
 ---
-title: Stand up the real Firebase project without leaving the terminal
-navLabel: Set up the project
-outcome: Enable providers, authorize domains, and provision databases, Storage, and hosting sites from the Console or firebase-tools.
+title: Prepare the Firebase project
+navLabel: Set up the Firebase project
+outcome: Configure the real Firebase services that production will use, without confusing project setup with local development.
 status: draft
 ---
 
-# Stand up the real Firebase project
+# Prepare the Firebase project
 
-Between "the app works in the sandbox" and "the app works in production" sits project configuration: sign-in providers to enable, domains to authorize, a database and a bucket to provision. Pyric does not replace that control plane — use the [Firebase Console](https://console.firebase.google.com/) and [`firebase-tools`](https://firebase.google.com/docs/cli) for production project administration.
+Pyric does not create, configure, or administer production Firebase projects. Local development needs no Firebase account or project. Production does.
 
-These steps change a real project. There is no dry run. Confirm which project is selected (`firebase use` / Console project picker) before mutating.
+Before shipping, create or select the real project and complete only the Firebase setup the application requires:
 
-## Enable the sign-in providers your app uses
+- [Register the web app and copy its Firebase configuration](https://firebase.google.com/docs/web/setup).
+- [Enable the Authentication providers used by the app](https://firebase.google.com/docs/auth/web/start).
+- [Create the Firestore database](https://firebase.google.com/docs/firestore/quickstart), if the app uses Firestore.
+- [Create the Realtime Database](https://firebase.google.com/docs/database/web/start), if the app uses Realtime Database.
+- [Create the default Storage bucket](https://firebase.google.com/docs/storage/web/start), if the app uses Storage.
+- [Install and select a project with the Firebase CLI](https://firebase.google.com/docs/cli) before deploying rules, indexes, Hosting, or Functions.
 
-In the Console: **Authentication → Sign-in method**. Enable `Anonymous`, `Email/Password`, `Phone`, and `Google` as your app needs.
+These steps affect a real project. Confirm the selected project before running a Firebase CLI command.
 
-Honest edges:
+The resulting Firebase configuration stays in the application code. During local development, Pyric accepts that configuration while resolving `firebase/*` to the sandbox. A production build resolves the same imports to Firebase and uses the configuration for the real project.
 
-- Enabling phone succeeds in the Console, but SMS delivery needs a billing account.
-- Google sign-in needs an OAuth client; the first enable happens in the Console (Authentication → Sign-in method → Google).
-
-## Authorize the domains you sign in from
-
-Firebase Auth keeps an allowlist of domains for OAuth redirects. Deploy to a new hosting domain without adding it, and Google sign-in fails on the new site. In the Console: **Authentication → Settings → Authorized domains**. Add the production (and preview) hosts; keep `localhost` for local development.
-
-## Create a hosting site
-
-A project's default site exists from the start; additional named sites are created in the Console (**Hosting**) or with `firebase hosting:sites:create`. Deploying to a site that doesn't exist fails — create the site first, then:
-
-```bash
-firebase deploy --only hosting
-```
-
-## Provision a Firestore database
-
-Create the database in the Console (**Firestore Database → Create database**) or with the Firebase CLI / gcloud flow your org already uses. A newly created database can take a short while for its data plane to come online; wait before issuing writes that must land.
-
-## Provision Storage, end to end
-
-Storage enablement is a multi-step sequence. For a scripted path inside pyric (sandbox / playground-style hosts), `provisionStorage` from `pyric/storage` still covers the sequence:
-
-```ts
-import { provisionStorage, defaultPlaygroundCors } from 'pyric/storage';
-
-const result = await provisionStorage(accessToken, 'my-app', {
-  rules: storageRulesSource,
-  cors: defaultPlaygroundCors('https://my-app.web.app'),
-});
-```
-
-Five steps, each skipped when already done:
-
-1. **Enable the Storage service**, then wait a few seconds for propagation, because immediate calls still return `SERVICE_DISABLED`.
-2. **Finalize the project's default location.** This one is irreversible: once set, the location cannot be changed. Skip when a location already exists; pick the location on purpose the first time.
-3. **Create and link the default bucket** (`my-app.firebasestorage.app`) if it isn't linked yet.
-4. **Deploy rules to the bucket's own release.** Storage rules apply through per-bucket release names. The project-wide `firebase.storage` release still exists as a legacy alias, but it is not bound to modern buckets, so deploying there quietly leaves the bucket's default deny-all in place. Target the per-bucket release.
-5. **Set browser-ready CORS.** A bucket without CORS configuration blocks the Storage Web SDK from any non-Firebase origin, surfacing as `No 'Access-Control-Allow-Origin' header` on the first request. Pass the origins your app serves from.
-
-For ordinary production projects, prefer the Console / `firebase-tools` Storage setup unless you specifically need this scripted helper.
-
-The result reports which steps ran, so a second invocation returns with everything marked already done.
-
-## APIs enable themselves (firebase-tools)
-
-Firebase CLI deploys typically enable required Google APIs as part of the deploy preflight. When your credential lacks permission to enable an API, that surfaces as an actionable error instead of a mysterious downstream failure.
-
-## Where to go next
-
-With the project stood up, [Ship to production](./ship-to-production.md) covers rules, indexes, verification, and the deploy itself.
+Continue with [Ship to production](./ship-to-production.md) for the unchanged build and deployment path.

--- a/packages/site-docs/scripts/port-content.ts
+++ b/packages/site-docs/scripts/port-content.ts
@@ -12,7 +12,7 @@
  * For each markdown file this writes src/content/docs/<slug>.md:
  * generated front matter (title from the doc's h1, nav group = package /
  * subtree, section = the tree's existing subdir, an order scoped to the
- * doc's nav group — see GROUP_ORDER below) plus the source body VERBATIM
+ * doc's nav group — see groupRank below) plus the source body VERBATIM
  * except intra-doc links:
  *
  *   - a relative link that resolves to another ported file is rewritten
@@ -160,70 +160,91 @@ const supersededByAbs = new Map<string, string>(
 interface GuideGroupSpec {
   /** Nav group label (disclosure summary). */
   label: string;
-  /** Dir relative to guideRoot ('' = the root itself). */
-  dir: string;
-  /** Files in nav order — explicit, never readdir order. */
-  files: string[];
+  /** Pages in nav order. Most live in the authored guide tree. A page
+   *  may instead name an existing package-doc source so useful depth can
+   *  move into the workflow without creating a second copy. */
+  pages: Array<{
+    dir?: string;
+    file?: string;
+    source?: string;
+    section?: string;
+    slug?: string;
+    navLabel?: string;
+  }>;
 }
 
 const GUIDE_GROUPS: GuideGroupSpec[] = [
-  { label: 'Overview', dir: '', files: ['overview.md'] },
+  { label: 'Overview', pages: [{ file: 'overview.md' }] },
   {
-    label: 'Get started',
-    dir: 'get-started',
-    files: ['start-building.md', 'how-the-swap-works.md'],
-  },
-  {
-    label: 'Build',
-    dir: 'build',
-    files: [
-      'sign-in-and-manage-users.md',
-      'store-and-query-data.md',
-      'sync-realtime-data.md',
-      'store-files.md',
-      'which-data-service.md',
+    label: 'Run locally',
+    pages: [
+      { dir: 'get-started', file: 'start-building.md' },
+      { dir: 'get-started', file: 'how-the-swap-works.md' },
+      { dir: 'agent', file: 'set-up-your-agent.md' },
+      { dir: 'ship', file: 'test-in-node.md' },
     ],
   },
   {
-    label: 'Secure & debug',
-    dir: 'secure',
-    files: [
-      'secure-it-with-rules.md',
-      'simulate-and-lint.md',
-      'write-a-rules-test-suite.md',
-      'read-a-denial.md',
-      'rules-standard-library.md',
-      'rules-patterns.md',
-      'rtdb-rules-in-typescript.md',
-      'limits-that-bite.md',
-      'audit-your-rules.md',
-      'whats-possible.md',
+    label: 'Develop with Firebase APIs',
+    pages: [
+      { dir: 'build', file: 'sign-in-and-manage-users.md' },
+      { dir: 'build', file: 'store-and-query-data.md' },
+      { dir: 'build', file: 'sync-realtime-data.md' },
+      { dir: 'build', file: 'store-files.md' },
+      { dir: 'build', file: 'receive-messages.md' },
+      { dir: 'build', file: 'run-ai-logic-locally.md' },
+      {
+        source: 'packages/cli/docs/how-to/run-rtdb-onvaluecreated.md',
+        slug: 'pyric-cli-how-to-run-rtdb-onvaluecreated',
+        navLabel: 'Run an RTDB function locally',
+      },
+      { dir: 'build', file: 'which-data-service.md' },
     ],
   },
   {
-    label: 'Observe & shape',
-    dir: 'observe',
-    files: ['see-whats-happening.md', 'shape-your-data.md'],
-  },
-  {
-    label: 'Ship & test',
-    dir: 'ship',
-    files: ['ship-to-production.md', 'set-up-the-project.md', 'test-in-node.md'],
-  },
-  {
-    label: 'Work with an agent',
-    dir: 'agent',
-    files: [
-      'set-up-your-agent.md',
-      'what-your-agent-can-do.md',
-      'skills.md',
-      'watch-and-review.md',
+    label: 'Inspect and correct',
+    pages: [
+      { dir: 'observe', file: 'see-whats-happening.md', section: 'Inspect the sandbox' },
+      { dir: 'secure', file: 'read-a-denial.md', section: 'Inspect the sandbox' },
+      { dir: 'observe', file: 'shape-your-data.md', section: 'Inspect the sandbox' },
+      { dir: 'agent', file: 'watch-and-review.md', section: 'Inspect the sandbox' },
+      { dir: 'secure', file: 'secure-it-with-rules.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'simulate-and-lint.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'rules-patterns.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'rules-standard-library.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'rtdb-rules-in-typescript.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'limits-that-bite.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'whats-possible.md', section: 'Correct Security Rules' },
+      { dir: 'agent', file: 'what-your-agent-can-do.md', section: 'Work with an agent' },
+      { dir: 'agent', file: 'skills.md', section: 'Work with an agent' },
     ],
   },
   {
-    label: 'Trust',
-    dir: 'trust',
-    files: ['how-we-know-it-matches-firebase.md', 'whats-experimental.md'],
+    label: 'Verify the boundary',
+    pages: [
+      {
+        source: 'packages/cli/docs/how-to/verify-against-a-captured-session.md',
+        section: '',
+        slug: 'pyric-cli-how-to-verify-against-a-captured-session',
+        navLabel: 'Verify a captured session',
+      },
+      { dir: 'secure', file: 'write-a-rules-test-suite.md' },
+      { dir: 'secure', file: 'audit-your-rules.md' },
+    ],
+  },
+  {
+    label: 'Ship unchanged',
+    pages: [
+      { dir: 'ship', file: 'ship-to-production.md' },
+      { dir: 'ship', file: 'set-up-the-project.md' },
+    ],
+  },
+  {
+    label: 'Conformance',
+    pages: [
+      { dir: 'trust', file: 'how-we-know-it-matches-firebase.md' },
+      { dir: 'trust', file: 'whats-experimental.md' },
+    ],
   },
 ];
 
@@ -398,28 +419,29 @@ const bySlug = new Map<string, Page>();
 
 /**
  * Order is scoped per nav group instead of one counter across the whole
- * tree: each group gets a rank (its index among GROUP_ORDER, spaced by
- * 1000 — comfortably above the largest group's page count) and each
- * page an offset from 1 within its group, assigned in the same
- * traversal order the old global counter used. `order = groupRank +
- * offset`. Adding a doc then renumbers at most the trailing pages of
- * its own group; adding a group renumbers nothing before it. GROUP_ORDER
- * must list every group label the port ever assigns (GUIDE_GROUPS, the
- * synthetic 'Conformance' group, then GROUPS) in the exact order the
- * nav renders them — that order is what the rendered sidebar sequence
- * depends on, not the numeric order values.
+ * tree: each group gets a rank spaced by 1000, comfortably above the
+ * largest group's page count, and each page an offset from 1 within its
+ * group. `order = groupRank + offset`. Adding a doc then renumbers at
+ * most the trailing pages of its own group. Workflow groups follow
+ * GUIDE_GROUPS order. Reference group ranks stay fixed below them.
  */
-const GROUP_ORDER: string[] = [
-  ...GUIDE_GROUPS.map((g) => g.label),
-  'Conformance',
-  ...GROUPS.map((g) => g.label),
-];
 const GROUP_RANK_SPACING = 1000;
-const groupRank = new Map(GROUP_ORDER.map((label, i) => [label, i * GROUP_RANK_SPACING]));
+// Reference groups began at rank 9 in the previous hierarchy. Keep that
+// stable so changing the primary workflow does not rewrite front matter for
+// every generated reference page. Guide ranks may change with the workflow;
+// reference ranks are a durable shelf below it.
+const REFERENCE_GROUP_START_RANK = 9;
+const groupRank = new Map([
+  ...GUIDE_GROUPS.map((group, i) => [group.label, i * GROUP_RANK_SPACING] as const),
+  ...GROUPS.map((group, i) => [
+    group.label,
+    (REFERENCE_GROUP_START_RANK + i) * GROUP_RANK_SPACING,
+  ] as const),
+]);
 const groupPosition = new Map<string, number>();
 function nextOrder(group: string): number {
   const rank = groupRank.get(group);
-  if (rank === undefined) throw new Error(`group not in GROUP_ORDER: ${group}`);
+  if (rank === undefined) throw new Error(`group has no rank: ${group}`);
   const position = (groupPosition.get(group) ?? 0) + 1;
   groupPosition.set(group, position);
   if (position >= GROUP_RANK_SPACING) {
@@ -429,7 +451,7 @@ function nextOrder(group: string): number {
 }
 
 function addPage(src: string, group: GroupSpec, section: string) {
-  if (supersededByAbs.has(src)) return; // replaced by a guide page
+  if (supersededByAbs.has(src) || bySrc.has(src)) return; // replaced or promoted into the guide
   const slug = slugFor(group.pkg, src, group.slugPrefix);
   const title = titleOf(src);
   const clash = bySlug.get(slug);
@@ -450,21 +472,26 @@ function addPage(src: string, group: GroupSpec, section: string) {
 
 /** Add one guide page: slug from the bare file name, title/navLabel/
  *  description from its own front matter (title falls back to the h1). */
-function addGuidePage(src: string, groupLabel: string) {
+function addGuidePage(
+  src: string,
+  groupLabel: string,
+  section = '',
+  options: { slug?: string; navLabel?: string } = {},
+) {
   const { fm } = parseFrontmatter(readFileSync(src, 'utf8'));
-  const slug = posix.basename(src, '.md').toLowerCase();
+  const slug = options.slug ?? posix.basename(src, '.md').toLowerCase();
   const clash = bySlug.get(slug);
   if (clash) throw new Error(`slug clash: ${slug} (${clash.src} vs ${src})`);
   const page: Page = {
     src,
     slug,
     group: groupLabel,
-    section: '',
+    section,
     order: nextOrder(groupLabel),
     title: fm.title ?? titleOf(src),
-    navLabel: fm.navLabel,
+    navLabel: options.navLabel ?? fm.navLabel,
     description: fm.outcome,
-    stripFm: true,
+    stripFm: Object.keys(fm).length > 0,
   };
   pages.push(page);
   bySrc.set(src, page);
@@ -474,10 +501,15 @@ function addGuidePage(src: string, groupLabel: string) {
 // Guide first: the nav renders groups in `order` order, so the
 // outcome-first sections sit above the package reference groups.
 for (const group of GUIDE_GROUPS) {
-  for (const file of group.files) {
-    const p = resolve(guideRoot, group.dir, file);
+  for (const page of group.pages) {
+    const p = page.source
+      ? resolve(repoRoot, page.source)
+      : resolve(guideRoot, page.dir ?? '', page.file ?? '');
     if (!existsSync(p)) throw new Error(`guide page missing: ${p}`);
-    addGuidePage(p, group.label);
+    addGuidePage(p, group.label, page.section ?? '', {
+      slug: page.slug,
+      navLabel: page.navLabel,
+    });
   }
 }
 
@@ -736,7 +768,7 @@ function rewriteLinks(page: Page, body: string): string {
         },
       );
     })
-    .join('');
+    .join('\n');
 }
 
 /* ── Conformance row lists ─────────────────────────────────────────── */
@@ -926,7 +958,7 @@ function transformCompatTables(body: string): string {
       }
       return out.join('\n');
     })
-    .join('');
+    .join('\n');
 }
 
 /* ── Emit ──────────────────────────────────────────────────────────── */

--- a/packages/site-docs/scripts/verify-dist.ts
+++ b/packages/site-docs/scripts/verify-dist.ts
@@ -49,6 +49,9 @@ interface SourcePage {
   file: string;
   slug: string;
   internal: boolean;
+  group: string;
+  section: string;
+  order: number;
   body: string;
 }
 
@@ -66,13 +69,78 @@ const sources: SourcePage[] = readdirSync(contentDir)
     const { fm, body } = splitFrontmatter(raw);
     const slug = fm.match(/^slug:\s*(\S+)/m)?.[1] ?? file.replace(/\.md$/, '');
     const internal = /^internal:\s*true/m.test(fm);
-    return { file, slug, internal, body };
+    const group = fm.match(/^group:\s*"?([^"\n]+)"?/m)?.[1] ?? '';
+    const section = fm.match(/^section:\s*"?([^"\n]*)"?/m)?.[1] ?? '';
+    const order = Number(fm.match(/^order:\s*(\d+)/m)?.[1] ?? Number.MAX_SAFE_INTEGER);
+    return { file, slug, internal, group, section, order, body };
   });
 
 const publicPages = sources.filter((s) => !s.internal);
 const internalPages = sources.filter((s) => s.internal);
 check(publicPages.length >= 150, `content: ${publicPages.length} public pages`);
 check(internalPages.length >= 1, 'content: has an internal rhythm page');
+const fusedFencePages = sources.filter((page) =>
+  page.body.split('\n').some(
+    (line) => line.includes('```') && !/^\s*```[A-Za-z0-9_-]*\s*$/.test(line),
+  ),
+);
+check(
+  fusedFencePages.length === 0,
+  'content: porter keeps fenced blocks on their own lines',
+  fusedFencePages.map((page) => page.slug).join(', '),
+);
+
+const expectedWorkflowGroups = [
+  'Overview',
+  'Run locally',
+  'Develop with Firebase APIs',
+  'Inspect and correct',
+  'Verify the boundary',
+  'Ship unchanged',
+  'Conformance',
+];
+const orderedGroups = [...new Set(
+  [...publicPages]
+    .sort((a, b) => a.order - b.order)
+    .map((page) => page.group),
+)];
+check(
+  JSON.stringify(orderedGroups.slice(0, expectedWorkflowGroups.length)) ===
+    JSON.stringify(expectedWorkflowGroups),
+  'content: primary navigation follows the local-to-production workflow',
+  `found ${orderedGroups.slice(0, expectedWorkflowGroups.length).join(' -> ')}`,
+);
+const promotedVerify = publicPages.find(
+  (page) => page.slug === 'pyric-cli-how-to-verify-against-a-captured-session',
+);
+check(
+  promotedVerify?.group === 'Verify the boundary',
+  'content: existing captured-session guide is promoted without changing route',
+  `group ${promotedVerify?.group ?? 'missing'}`,
+);
+const promotedFunction = publicPages.find(
+  (page) => page.slug === 'pyric-cli-how-to-run-rtdb-onvaluecreated',
+);
+check(
+  promotedFunction?.group === 'Develop with Firebase APIs',
+  'content: existing Functions guide is promoted without changing route',
+  `group ${promotedFunction?.group ?? 'missing'}`,
+);
+for (const slug of [
+  'sign-in-and-manage-users',
+  'store-and-query-data',
+  'sync-realtime-data',
+  'store-files',
+  'receive-messages',
+  'run-ai-logic-locally',
+]) {
+  const page = publicPages.find((candidate) => candidate.slug === slug);
+  check(
+    page?.group === 'Develop with Firebase APIs',
+    `content: ${slug} is discoverable while developing`,
+    `group ${page?.group ?? 'missing'}`,
+  );
+}
 
 // ── 0. Multi-package coverage: every packages/<pkg>/docs markdown file
 //       is ported (same slug mapping as scripts/port-content.ts) and

--- a/packages/site-docs/src/content/docs/audit-your-rules.md
+++ b/packages/site-docs/src/content/docs/audit-your-rules.md
@@ -1,9 +1,9 @@
 ---
 title: "Find the holes before someone else does"
 navLabel: "Audit your rules and data"
-group: "Secure & debug"
+group: "Verify the boundary"
 section: ""
-order: 3009
+order: 4003
 description: "Get an evidence-backed answer to who can access what, with every serious finding proven by a simulation."
 ---
 

--- a/packages/site-docs/src/content/docs/how-the-swap-works.md
+++ b/packages/site-docs/src/content/docs/how-the-swap-works.md
@@ -1,6 +1,6 @@
 ---
 title: "How the swap works"
-group: "Get started"
+group: "Run locally"
 section: ""
 order: 1002
 description: "Understand how your firebase imports reached a local backend, and why production is untouched."

--- a/packages/site-docs/src/content/docs/how-we-know-it-matches-firebase.md
+++ b/packages/site-docs/src/content/docs/how-we-know-it-matches-firebase.md
@@ -1,9 +1,9 @@
 ---
 title: "How does Pyric know it works like Firebase?"
 navLabel: "Conformance"
-group: "Trust"
+group: "Conformance"
 section: ""
-order: 7001
+order: 6001
 description: "See the production evidence behind Pyric's conformance claims, the gaps those claims leave open, and the checks to make before shipping."
 ---
 
@@ -14,9 +14,11 @@ If Pyric is a mirror of Firebase, how does it know it actually behaves like Fire
 Documentation describes intent. TypeScript declarations describe shape. Neither records what a deployed Firebase project actually did. The strongest available evidence is Firebase itself, so Pyric captures production behavior, compares the local result, and publishes where the two agree and where they do not. That is what it means to conform.
 
 The application call stays the same:
+
 ```ts
 import { signInWithEmailAndPassword } from 'firebase/auth';
 ```
+
 During Vite development, supported `firebase/*` imports resolve to Pyric. A production build resolves them to Firebase. Conformance asks whether the two implementations return the same value, error, state transition, or Rules verdict for a defined behavior.
 
 ## The conformance system
@@ -40,6 +42,7 @@ The observation records what Firebase did. The registry states the claim Pyric m
 ## Follow one behavior from Firebase to the matrix
 
 Consider a failed password sign-in. A probe signs into a real Firebase project with the wrong password and records the result, including the Firebase SDK version and project used for the capture:
+
 ```json
 {
   "name": "auth-wrong-password-error-code",
@@ -55,7 +58,9 @@ Consider a failed password sign-in. A probe signs into a real Firebase project w
   }
 }
 ```
+
 That committed [observation](https://github.com/davideast/pyric/blob/main/packages/conformance/observations/auth/auth-wrong-password-error-code.json) is a captured fact, not a summary of Firebase documentation. It is then attached to a specific registry row:
+
 ```ts
 {
   id: 'auth#15',
@@ -67,9 +72,11 @@ That committed [observation](https://github.com/davideast/pyric/blob/main/packag
   automation: 'oracle-backed',
 }
 ```
+
 The [registry row](https://github.com/davideast/pyric/blob/main/packages/conformance/registry/auth.ts) is the published claim. It names the production evidence, the broader local behavior test, the current status, and the strength of the automation behind it.
 
 Separately, an [oracle conformance test](https://github.com/davideast/pyric/blob/main/packages/pyric/test/auth/oracle-conformance.test.ts) reads the observation and requires Pyric to return the recorded error code:
+
 ```ts
 const observation = load('auth-wrong-password-error-code.json');
 
@@ -78,6 +85,7 @@ await expectCode(
   observation.code,
 );
 ```
+
 CI checks this chain in layers. Registry validation rejects missing or inconsistent evidence references. The library tests exercise local behavior, including observation-backed comparisons like this one. Selected production observations also have dedicated replay checks. The generated matrices are rebuilt from the registry and current public-surface census, then checked for drift.
 
 This distinction matters. `compat:check` validates the conformance model and generated results, but it does not replay every production observation by itself. The full CI suite combines those gates with the tests that exercise Pyric.
@@ -87,6 +95,7 @@ This distinction matters. `compat:check` validates the conformance model and gen
 A single API result can be captured as one observation. Security Rules need a broader method because a ruleset is a program. The relevant question is whether Firebase allows or denies a request under a particular ruleset, data state, identity, and operation.
 
 The [Rules corpus](https://github.com/davideast/pyric/tree/main/packages/conformance/rules-corpus) stores those inputs as scenarios. For example, Firestore treats direct access to a missing map field as a runtime error. Comparing that field with `null` denies the request, while the `in` operator performs an actual absence check:
+
 ```rules
 rules_version = '2';
 service cloud.firestore {
@@ -101,6 +110,7 @@ service cloud.firestore {
   }
 }
 ```
+
 The corpus expects the first request to be denied and the second to be allowed. Firebase supplies the authoritative verdict. Pyric's simulator must reach the same result.
 
 Firestore and Storage expose hosted Rules Test APIs, so their capture runners can ask Firebase for each verdict directly. Realtime Database has no equivalent API. Its runner deploys each scenario's rules to a dedicated oracle database, executes the live operations in an isolated namespace, records the results, restores the previous rules, and verifies cleanup. The acquisition paths differ, but the contract is the same: production decides the expected verdict.
@@ -149,13 +159,17 @@ No published result is typed into this page. Registry state and the live public-
 ## Verify the boundary before shipping
 
 Pyric is designed for local development, where operations have no production consequences. Before deployment, replay the captured development session against the candidate Rules:
+
 ```bash
 npx pyric verify
 ```
+
 The default engine runs locally and requires no cloud credentials. For Firestore, the hosted Rules Test API can provide a second verdict from Google in a controlled project:
+
 ```bash
 npx pyric verify --engine both --project staging-project
 ```
+
 Hosted verification evaluates derived cases. It does not deploy Rules or modify production data. It does require Firebase credentials and a project configured for that check.
 
 This is the final boundary of the conformance claim. Pyric supplies evidence that local behavior matches the cases it tracks. A staging or hosted verification step checks the application-specific configuration that a general conformance suite cannot know. Then the same `firebase/*` application code can proceed through the normal Firebase deployment path described in [Ship to production](../ship-to-production/).

--- a/packages/site-docs/src/content/docs/limits-that-bite.md
+++ b/packages/site-docs/src/content/docs/limits-that-bite.md
@@ -1,9 +1,9 @@
 ---
 title: "Firestore rules limits, measured"
 navLabel: "Rules limits"
-group: "Secure & debug"
-section: ""
-order: 3008
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3010
 description: "Know the measured limits of the production rules compiler and evaluator, with exact numbers, so your rules compile the first time."
 ---
 

--- a/packages/site-docs/src/content/docs/overview.md
+++ b/packages/site-docs/src/content/docs/overview.md
@@ -9,20 +9,29 @@ description: "Understand what Pyric is and what you get, in one short read."
 
 # Firebase that runs in your browser
 
-Pyric is Firestore, Auth, Realtime Database, Storage, and the Security Rules engine, implemented in TypeScript and running inside your app. In the browser, that means the page itself. The whole backend executes in the tab. In Node, it is the process your tests run in. Your code keeps its ordinary `firebase/*` imports. During development they resolve to Pyric. In production they resolve to Firebase. Nothing in your source changes.
+Pyric runs supported Firebase application code against a local backend during development. The application keeps its ordinary `firebase/*` imports and Firebase configuration. A normal production build resolves those imports to Firebase again. The source does not branch between local development and production.
 
-That is the whole trick, and it starts with one command.
+Start a new application with one command:
+
 ```bash
-npm install -D @pyric/cli
-npx pyric dev
+npx create-pyric my-app
 ```
-No account. No cloud project. No emulator, no Java, no port to babysit. You have a full Firebase stack before your coffee is warm, and it behaves like the real one because that claim is tested, not assumed. Pyric runs probes against production Firebase, records what actually happens, and replays every recorded behavior against itself in CI. When it diverges from Firebase, that is a documented row or a bug, never a surprise.
 
-## Build the app, prove the rules, ship the same code
+Local development needs no Firebase account, cloud project, emulator, or Java runtime. The mirrored services do not connect to production. Local writes cannot delete production data or create Firebase usage charges, and local rules changes do not deploy.
 
-You build your app. Sign users in with the auth calls you already know. Write documents, run queries, keep the UI live with snapshots. Write security rules and find out, before you deploy, exactly what they allow and deny, because every operation in Pyric produces a verdict you can read, and a denial tells you which rule said no and what data it saw.
+## Follow the application from local development to production
 
-Then you ship. With the development resolver inactive, the same canonical imports load real Firebase. Your rules leave development already exercised against your app's real behaviour. Your composite indexes come from your actual queries instead of a hand-kept file. Before anything goes live, you can replay a captured session against the new rules and learn which operations would change verdict. Pyric produces and verifies those artifacts; `firebase-tools` or the Firebase Console deploys them.
+The documentation follows one workflow:
+
+1. **Run locally.** Start the sandbox and connect the application, tests, or coding agent.
+2. **Develop with Firebase APIs.** Keep writing normal Auth, Firestore, Realtime Database, Storage, Messaging, and AI Logic code.
+3. **Inspect and correct.** Read local operations and rules verdicts, then adjust application code, data, or Security Rules.
+4. **Verify the boundary.** Replay captured behavior and test candidate rules before production.
+5. **Ship unchanged.** Build with real Firebase and deploy through `firebase-tools` or the Firebase Console.
+
+Development moves back and forth between writing Firebase code and inspecting what happened. The boundary check comes after that loop, before the production build.
+
+Conformance sits underneath the workflow as separate evidence. It records which Pyric behaviors have been compared with production Firebase, which differ, and which remain unsupported or unverified.
 
 ## Your agent works the same backend
 
@@ -36,4 +45,4 @@ Pyric was built by working those parts until they gave, and what was learned is 
 
 ## Where to go next
 
-Start with [the quickstart](../start-building/). If you came here for rules, go straight to [prove your rules protect the app](../secure-it-with-rules/).
+Start with [Run Firebase locally](../start-building/). The [conformance explanation](../how-we-know-it-matches-firebase/) documents the evidence and its limits.

--- a/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app-reference-api.md
@@ -10,12 +10,14 @@ order: 18002
 Exact public surface of the sandbox-only admin app registry.
 
 ## `initializeApp(config?, name?)`
+
 ```ts
 function initializeApp(
   config?: { sandbox: Sandbox },
   name?: string,
 ): PyricAdminApp;
 ```
+
 The default name is `'[DEFAULT]'`.
 
 - `initializeApp({ sandbox })` binds an in-process or remote sandbox.
@@ -34,33 +36,42 @@ the same binding: bare after bare, or the same `Sandbox` reference. A different
 binding throws a Firebase-shaped duplicate/options error.
 
 ## `getApp(name?)`
+
 ```ts
 function getApp(name?: string): PyricAdminApp;
 ```
+
 Return the registered app. The default name is `'[DEFAULT]'`. A missing app
 throws `app/no-app`; an empty or non-string name throws
 `app/invalid-app-name`.
 
 ## `getApps()`
+
 ```ts
 function getApps(): PyricAdminApp[];
 ```
+
 Return a copy of the registered app list.
 
 ## `deleteApp(app)`
+
 ```ts
 function deleteApp(app: PyricAdminApp): Promise<void>;
 ```
+
 Remove the app from the registry. The sandbox lifetime remains owned by its
 creator. An invalid value throws `app/invalid-argument`.
 
 ## `isSandboxAdminApp(app)`
+
 ```ts
 function isSandboxAdminApp(app: PyricAdminApp): app is SandboxAdminApp;
 ```
+
 Test the package brand without inspecting the object structurally.
 
 ## Types and constants
+
 ```ts
 const ADMIN_APP_TARGET: unique symbol;
 const DEFAULT_APP_NAME = '[DEFAULT]';
@@ -75,6 +86,7 @@ interface SandboxAdminApp {
   readonly name: string;
 }
 ```
+
 `ADMIN_APP_TARGET` uses `Symbol.for('pyric.admin.app.target')` so the brand is
 stable across module instances.
 

--- a/packages/site-docs/src/content/docs/pyric-admin-app.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-app.md
@@ -12,12 +12,14 @@ branded `PyricAdminApp`, and every other `pyric-admin/*` subpath uses that app's
 sandbox.
 
 Use an explicit sandbox in tests and scripts:
+
 ```ts
 import { initializeApp } from 'pyric-admin/app';
 import { initializeSandbox } from 'pyric/sandbox';
 
 const app = initializeApp({ sandbox: initializeSandbox() });
 ```
+
 Or use a bare `initializeApp()` in canonical server code running under `pyric
 dev`. The activated `@pyric/cli/register` resolver supplies the remote sandbox
 factory. Outside activated development, canonical `firebase-admin/app` imports

--- a/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth-reference-api.md
@@ -22,9 +22,11 @@ absent.
 ## Initialization
 
 ### `getAuth(app?)`
+
 ```ts
 function getAuth(app?: PyricAdminApp): Auth;
 ```
+
 Return an `Auth` handle for the given app, or for the `'[DEFAULT]'` sandbox app when called with no argument (throws `app/no-app` when nothing is initialized). Dispatch reads the brand symbol on the handle:
 
 - sandbox app with a remote-branded sandbox: returns the remote relay handle.
@@ -41,21 +43,27 @@ Token handling is stateless string transformation, shared byte for byte by both 
 **Sandbox tokens are not real JWTs.** They are deterministic strings with no signature. They round-trip through this same sandbox backend and are rejected by every other token verifier. Never send one to a real Firebase service.
 
 ### `Auth.createCustomToken(uid, developerClaims?)`
+
 ```ts
 createCustomToken(uid: string, developerClaims?: object): Promise<string>;
 ```
+
 Arms: local, remote. Mints `` `${SANDBOX_TOKEN_PREFIX}:${uid}:${JSON.stringify(claims ?? {})}` ``. No signing, no expiry.
 
 ### `Auth.verifyIdToken(idToken, checkRevoked?)`
+
 ```ts
 verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
 ```
+
 Arms: local, remote. Parses tokens minted by `createCustomToken` and rejects anything else, including real JWTs. Returns a `DecodedIdToken`-shaped object: `aud` and `iss` are `'pyric-sandbox'`, `sub` and `uid` are the token's uid, time fields are now (`exp` is now plus 3600 seconds), `firebase.sign_in_provider` is `'custom'`, and the developer claims are spread onto the result so `decoded.role` reads the same way it does in production. `checkRevoked` is accepted and ignored (sandbox tokens have no revocation state).
 
 ### `SANDBOX_TOKEN_PREFIX`
+
 ```ts
 const SANDBOX_TOKEN_PREFIX = 'pyric-sandbox-custom';
 ```
+
 The token format's prefix, exported so tests can lock the shape. Layout: `pyric-sandbox-custom:${uid}:${jsonClaims}`. `verifyIdToken` splits on the first two colons only, so JSON claims containing colons round-trip losslessly.
 
 ---
@@ -63,48 +71,60 @@ The token format's prefix, exported so tests can lock the shape. Layout: `pyric-
 ## User management
 
 ### `Auth.createUser(properties)`
+
 ```ts
 createUser(properties: CreateRequest): Promise<UserRecord>;
 ```
+
 Arms: local, remote.
 
 - Local: stores a `UserRecord` in the in-memory map. Auto-generates a uid of the form `pyric-sandbox-<20-digit counter>` when none is supplied. A supplied uid that already exists rejects. Defaults match upstream: `emailVerified: false`, `disabled: false`, empty `providerData`, `tenantId: null`, metadata with sandbox-current timestamps.
 - Remote: relays the worker's `auth.adminCreateUser` op. Uid conflicts, invalid emails, and weak passwords reject with the worker backend's `auth/*` error. `multiFactor` is not modeled; upstream `null` ("clear") fields are treated as unset, since a fresh user has nothing to clear.
 
 ### `Auth.getUser(uid)` / `Auth.getUserByEmail(email)`
+
 ```ts
 getUser(uid: string): Promise<UserRecord>;
 getUserByEmail(email: string): Promise<UserRecord>;
 ```
+
 Arms: local, remote. Rejects with a user-not-found message on a miss.
 
 - Local: map lookup by uid; linear scan for email. Sandbox-scale data only.
 - Remote: both go through `auth.listUsers` plus a client-side filter. The worker protocol has no dedicated single-lookup op; O(n) over the wire is fine at sandbox scale.
 
 ### `Auth.deleteUser(uid)`
+
 ```ts
 deleteUser(uid: string): Promise<void>;
 ```
+
 Arms: local, remote. Rejects on a missing uid, matching upstream's strict delete contract. Remote relays `auth.adminDeleteUser`.
 
 ### `Auth.setCustomUserClaims(uid, customUserClaims)`
+
 ```ts
 setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
 ```
+
 Arms: local, remote. Replaces the stored `customClaims`; `null` clears them (upstream contract). Remote relays `auth.adminUpdateUser` with a whole-map `customClaims` replacement.
 
 ### `Auth.updateUser(uid, properties)`
+
 ```ts
 updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord>;
 ```
+
 Arms: **remote only**. The local arm throws the not-implemented error.
 
 Remote relays `auth.adminUpdateUser` for the fields the worker models: `displayName`, `email`, `password`, `disabled`, `emailVerified`. Fields it cannot express throw rather than silently dropping a requested change: `photoURL`, `phoneNumber`, `multiFactor`, `providerToLink`, `providersToUnlink`.
 
 ### `Auth.listUsers(maxResults?, pageToken?)`
+
 ```ts
 listUsers(maxResults?: number, pageToken?: string): Promise<ListUsersResult>;
 ```
+
 Arms: **remote only**. The local arm throws the not-implemented error.
 
 Remote relays `auth.listUsers`. `maxResults` is honored by slicing; `pageToken` is accepted and ignored, and the result never sets one, because the whole pool fits one page at sandbox scale.
@@ -114,10 +134,12 @@ Remote relays `auth.listUsers`. `maxResults` is honored by slicing; `pageToken` 
 ## Everything else throws (local and remote)
 
 Every other method on the `Auth` surface throws an `Error` whose message names the method and the arm:
+
 ```
 pyric-admin/auth: <method> is not implemented in pyric-admin/auth sandbox backend
 pyric-admin/auth: <method> is not implemented in pyric-admin/auth remote sandbox backend
 ```
+
 The full list, by area:
 
 | Area | Methods |

--- a/packages/site-docs/src/content/docs/pyric-admin-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-auth.md
@@ -14,6 +14,7 @@ Admin-shape Auth with swappable backends. `getAuth(app)` mirrors `firebase-admin
 - **Remote sandbox app**: user CRUD relays over the worker channel to the browser-hosted sandbox, so server-created users land in the one user pool the browser app, Studio, and agents share. Adds `updateUser` and `listUsers` on top of the local subset.
 
 Everything the sandbox arms don't model throws an explicit "not implemented" error with the method name, never bad data.
+
 ```ts
 import { initializeApp } from 'pyric-admin/app';
 import { getAuth } from 'pyric-admin/auth';
@@ -27,6 +28,7 @@ const token = await auth.createCustomToken(user.uid, { role: 'admin' });
 const decoded = await auth.verifyIdToken(token);
 console.log(decoded.uid, decoded.role); // 'alice' 'admin'
 ```
+
 One honest note up front: sandbox tokens are deterministic strings, not real JWTs. They round-trip through the same sandbox backend and nothing else. The [API reference](../pyric-admin-auth-reference-api/) documents the exact format.
 
 ## Where to go next

--- a/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database-reference-api.md
@@ -22,9 +22,11 @@ absent.
 ## Initialization
 
 ### `getDatabase(app?, legacyUrl?)`
+
 ```ts
 function getDatabase(app?: PyricAdminApp, legacyUrl?: string): Database;
 ```
+
 Mirrors firebase-admin's `getDatabase(app?)`:
 
 - `getDatabase()`: default database for the `'[DEFAULT]'` sandbox app, resolved through `pyric-admin/app`'s registry. Throws `app/no-app` when nothing is initialized.
@@ -34,9 +36,11 @@ Mirrors firebase-admin's `getDatabase(app?)`:
 Successive calls for the same sandbox return handles that share data, matching firebase-admin's singleton-per-app semantics. Throws `TypeError` for an unbranded value.
 
 ### `getDatabaseWithUrl(url, app?)`
+
 ```ts
 function getDatabaseWithUrl(url: string, app?: PyricAdminApp): Database;
 ```
+
 Uses firebase-admin's exact URL-first argument order. The Functions SDK calls
 this export when materializing `event.data.ref`. Pyric's first Functions slice
 has one shared RTDB instance, so the URL selects that instance; it does not
@@ -62,51 +66,65 @@ create a separate sandbox tree.
 Every implemented method is `async` and shapes its results like firebase-admin. Properties on every ref: `key` (last segment, `null` at root), `parent` (`null` at root), `root`, `path` (canonical, `/`-prefixed), `ref` (itself), `database`, `toString()` (returns `sandbox://rtdb<path>`), `isEqual(other)` (path comparison), `toJSON()`.
 
 ### `ref.set(value)`
+
 ```ts
 set(value: unknown): Promise<void>;
 ```
+
 Arms: local, remote. Writes `value` at the ref's path; `null` deletes. A root-level `set` must be an object (or `null` to clear). Deleting trims now-empty ancestor objects, preserving the RTDB invariant that empty nodes don't exist. Remote relays `rtdb.set`.
 
 ### `ref.get()`
+
 ```ts
 get(): Promise<DataSnapshot>;
 ```
+
 Arms: local, remote. Reads the path and resolves to a `DataSnapshot`. Absent paths resolve to a snapshot with `exists() === false` and `val() === null`. Remote relays `rtdb.get`.
 
 ### `ref.once(eventType)`
+
 ```ts
 once(eventType: EventType): Promise<DataSnapshot>;
 ```
+
 Arms: local, remote. Only `'value'` is supported; any other event type throws. Local reads the tree directly. Remote establishes a value subscription, resolves with the initial snapshot, then detaches.
 
 ### `ref.update(values)`
+
 ```ts
 update(values: object): Promise<void>;
 ```
+
 Arms: local, remote, with a real semantic difference:
 
 - **Local: shallow merge.** Each key in `values` replaces the corresponding child at the ref's path (a key may itself be a relative path like `'a/b'`). A `null` value deletes that child. There is no multi-path atomicity guarantee beyond the synchronous loop.
 - **Remote: full multi-path update.** Relays `rtdb.update`, and the worker applies `pyric/database`'s modular multi-path semantics.
 
 ### `ref.remove()`
+
 ```ts
 remove(): Promise<void>;
 ```
+
 Arms: local, remote. Deletes the subtree; equivalent to `set(null)`. Remote relays `rtdb.remove`.
 
 ### `ref.push(value?, onComplete?)`
+
 ```ts
 push(value?: unknown, onComplete?: (err: Error | null) => void): ThenableReference;
 ```
+
 Arms: local, remote. Mints a 20-character push id with the same algorithm as firebase-js-sdk's published `nextPushId`, so sandbox keys are shape-compatible with production keys and sort chronologically. The returned `ThenableReference` exposes `.key` synchronously on both arms.
 
 - Local: the write is synchronous; `.then()` resolves immediately.
 - Remote: the client mints the id and relays `rtdb.push` carrying it; `.then()` settles when the relayed write commits, and a failure rejects the thenable and reaches `onComplete`. A bare `push()` performs no write, matching upstream.
 
 ### `ref.child(path)`
+
 ```ts
 child(path: string): Reference;
 ```
+
 Arms: local, remote. Pure path manipulation; returns a ref at `<this>/path`.
 
 ---
@@ -145,6 +163,7 @@ Use Firebase Admin directly when production needs these methods.
 ## `DataSnapshot`
 
 One snapshot implementation serves both sandbox arms (the remote arm feeds it wire values). Implemented surface:
+
 ```ts
 key: string | null;
 ref: Reference;
@@ -159,6 +178,7 @@ toJSON(): unknown;
 getPriority(): string | number | null; // always null
 exportVal(): unknown; // equals val(): no priorities are modeled
 ```
+
 ---
 
 ## Path safety (sandbox-only constraint)

--- a/packages/site-docs/src/content/docs/pyric-admin-database.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-database.md
@@ -16,6 +16,7 @@ Admin-shape Realtime Database with swappable backends. `getDatabase(app)` mirror
 Realtime Database support is experimental, on this surface and on `pyric/database`. The data plane works and is tested; most behavior is not yet pinned to a recorded production observation.
 
 Anything the sandbox arms don't model (listeners on the local arm, transactions, queries, priorities, `onDisconnect`, rules metadata) throws a clear "not implemented" error, never bad data.
+
 ```ts
 import { initializeApp } from 'pyric-admin/app';
 import { getDatabase } from 'pyric-admin/database';
@@ -31,6 +32,7 @@ console.log(snap.val()); // 'launch'
 const msg = db.ref('rooms/lobby/messages').push({ text: 'hi' });
 console.log(msg.key); // a real 20-char push id, available synchronously
 ```
+
 ## Where to go next
 
 - [API reference](../pyric-admin-database-reference-api/) for the full `Reference` and `DataSnapshot` surface, per arm.

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-error-translation.md
@@ -10,12 +10,15 @@ order: 19012
 Every operation through a `SandboxFirestore` handle that fails throws a `SandboxError`. The underlying simulator throws `FirestoreSimError`; the admin handle wraps every method, catches those, and re-throws as `SandboxError` with structured `denialContext`. This page explains the layer.
 
 ## What the wrapping does
+
 ```ts
 import { wrapWithErrorTranslation } from './error-translation.js';
 
 const fresh = wrapWithErrorTranslation(buildFirestoreHandle(ctx), ctx);
 ```
+
 The wrapper covers every method on the handle plus every object returned from it: `DocumentReference`, `Query`, `WriteBatch`, `Transaction`. Inside, the simulator might throw a `FirestoreSimError('permission-denied', ..., { request, resource, debugMessages })`. The wrapper translates that to:
+
 ```ts
 new SandboxError({
   code: 'permission-denied',
@@ -28,6 +31,7 @@ new SandboxError({
   },
 });
 ```
+
 Same shape every consumer sees. Catch with `instanceof SandboxError`, switch on `code`.
 
 ## Why translate
@@ -54,9 +58,11 @@ The `DenialContext` shape is also what `Sandbox.onDenial` and `Sandbox.onSnapsho
 The wrapper attaches the original `SandboxContext` to every wrapped value via a `CONTEXT_SYMBOL` property. This isn't for application code: it's so `onSnapshot` can recover the context from a `DocumentReference` passed to it.
 
 When you call:
+
 ```ts
 onSnapshot(db.doc('notes/n1'), callback);
 ```
+
 The `db.doc('notes/n1')` is a `DocumentReference`. `onSnapshot` doesn't get the context handed to it directly. It gets the ref. Without the stash, `onSnapshot` couldn't tell which auth identity to register the listener under.
 
 `CONTEXT_SYMBOL` is non-enumerable and uses a unique symbol, so it doesn't show up in `Object.keys`, doesn't serialise, doesn't appear in `console.log` output. Application code never sees it.
@@ -72,6 +78,7 @@ The reason for this dance is that the standalone function can be called against 
 ## What this means for tests
 
 Tests catching denials don't need to know about `FirestoreSimError`, `LocalEnvironment`, or any simulator internals. They write:
+
 ```ts
 try {
   await bobDb.collection('notes').doc('n1').update({ title: 'tamper' });
@@ -81,6 +88,7 @@ try {
   }
 }
 ```
+
 Same shape as catching denials from `Sandbox.onDenial`. Same shape as catching denials from a production runtime (with `'permission-denied'` from `firebase-admin/firestore`'s error class). The translation layer hides the simulator's existence.
 
 ## When translation doesn't happen

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-per-call-delegate.md
@@ -12,6 +12,7 @@ Every production-shaped method on `SandboxFirestore` constructs a fresh
 explains why and what it costs.
 
 ## The pattern
+
 ```ts
 function buildFirestoreHandle(ctx: SandboxContext): SandboxFirestore {
   const delegate = (): Firestore =>
@@ -26,11 +27,13 @@ function buildFirestoreHandle(ctx: SandboxContext): SandboxFirestore {
   };
 }
 ```
+
 Each method calls `delegate()` to get a fresh `Firestore` instance, then invokes the production-shaped method on it. The instance is constructed per call.
 
 ## Why not cache one delegate
 
 The obvious alternative caches the delegate at handle-construction time:
+
 ```ts
 // Naive version — broken.
 function buildFirestoreHandle(ctx: SandboxContext): SandboxFirestore {
@@ -41,6 +44,7 @@ function buildFirestoreHandle(ctx: SandboxContext): SandboxFirestore {
   };
 }
 ```
+
 This is faster (one allocation instead of many) and broken in one specific case: `sandbox.reset()`.
 
 `Sandbox.reset()` swaps the underlying `LocalEnvironment` for a fresh one. Existing `SandboxContext`s continue to work. Their next operation resolves through `getEnv()` and finds the new environment. But a cached delegate would still be bound to the *old* environment. Operations through the cached delegate would land in a discarded environment that nobody else can see.
@@ -65,6 +69,7 @@ In practice this means:
 - A `DocumentReference` obtained before `sandbox.reset()` will, after the reset, operate against a discarded environment.
 
 The latter is a real edge case. Test code that holds refs across resets is unusual but happens. The fix is to re-acquire refs after reset:
+
 ```ts
 beforeEach(() => {
   sandbox.reset();
@@ -72,6 +77,7 @@ beforeEach(() => {
   notesRef = adminDb.collection('notes');  // refresh
 });
 ```
+
 The README and the `getFirestore` JSDoc both call this out: refs are bound to whichever environment was live when they were obtained.
 
 ## Why this isn't a leak
@@ -81,9 +87,11 @@ A naive reader might worry: "If every method constructs a delegate, are old dele
 The only thing that lives across operations is the `SandboxFirestore` handle itself, which is cached per-context in a `WeakMap`. When the context is garbage-collected, the handle goes with it.
 
 ## The idempotency cache
+
 ```ts
 const handleCache = new WeakMap<SandboxContext, SandboxFirestore>();
 ```
+
 This is at the handle level, not the delegate level. The handle is cheap to keep (it's a small object with method references), and idempotency means `getFirestore(ctx)` returns the same object every time. Cached results from the first call (like the error-translation wrapping) don't get re-applied.
 
 The cache is a `WeakMap`, so a context that goes out of scope drops its handle automatically. No manual cleanup needed.

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-explanation-why-mirror-admin-shape.md
@@ -16,6 +16,7 @@ This page explains why we mirrored an existing API instead of designing a new on
 Test code should look like production code. Anything else is friction.
 
 A team writes a Cloud Function in `firebase-admin/firestore`:
+
 ```ts
 async function archiveOld(): Promise<void> {
   const snapshot = await db
@@ -28,7 +29,9 @@ async function archiveOld(): Promise<void> {
   await batch.commit();
 }
 ```
+
 The test for that function should look identical except for how `db` is obtained:
+
 ```ts
 // Production
 const db = getFirestoreAdmin();
@@ -36,6 +39,7 @@ const db = getFirestoreAdmin();
 // Test
 const db = getFirestore(sandbox.withAuth({ uid: 'admin', token: { admin: true } }));
 ```
+
 That's the shape we picked. Anything beyond the `db =` line is the same code in both contexts. Test code that imports from `pyric-admin` works against the sandbox today and against `firebase-admin/firestore` tomorrow if you swap the import.
 
 ## What we considered
@@ -43,11 +47,13 @@ That's the shape we picked. Anything beyond the `db =` line is the same code in 
 ### A simpler API for tests only
 
 We could have designed a small, opinionated test-only API:
+
 ```ts
 // Hypothetical, not the actual API.
 await sandbox.write('notes/n1', { ownerId: 'alice' });
 const data = await sandbox.read('notes/n1', { as: 'alice' });
 ```
+
 Shorter. Easier to learn. Fundamentally different from production code.
 
 The problem is that "test the shape of your production code" has a different goal from "express a test scenario concisely". Production code has methods (`add`, `update`, `set`, `delete`), arguments (`where`, `orderBy`, `limit`), return types (`QuerySnapshot.docChanges()`). The test API that elides those forces test authors to mentally translate. The translation is where bugs hide.

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-run-a-transaction.md
@@ -10,6 +10,7 @@ order: 19003
 This guide shows you how to use `runTransaction` on a sandbox Firestore handle.
 
 ## The shape
+
 ```ts
 import { getFirestore } from 'pyric-admin';
 
@@ -22,6 +23,7 @@ const result = await db.runTransaction(async (tx) => {
   return current + 1;
 });
 ```
+
 The callback receives a `Transaction` object with `.get`, `.getAll`, `.set`, `.update`, `.delete`, `.create`. All reads must happen before any writes: read-after-write inside a tx throws `'failed-precondition'`.
 
 ## Read tracking
@@ -37,6 +39,7 @@ The recorded reads are available on the event log via `getInternalEnv(sandbox).g
 ## Aborted transactions
 
 If the callback throws, the transaction is aborted: no writes are applied, the event log records the abort with the thrown error, and the original error re-throws to the caller:
+
 ```ts
 try {
   await db.runTransaction(async (tx) => {
@@ -48,6 +51,7 @@ try {
   console.error('Transaction aborted:', e.message);
 }
 ```
+
 Aborted transactions are **not undoable**. Popping one as an undo step would skip a real prior write, so the sandbox refuses to treat them as undoable events.
 
 ## Denied operations inside a transaction
@@ -57,10 +61,12 @@ If a `tx.set` would deny under the current rules, the transaction aborts with `S
 ## Cross-context transactions are not allowed
 
 A transaction's auth is the registering context's auth, captured at `runTransaction` call time. You cannot pass per-call auth or switch identity mid-transaction. To act as a different user, derive a different context:
+
 ```ts
 const adminDb = getFirestore(sandbox.withAuth({ uid: 'admin', token: { admin: true } }));
 await adminDb.runTransaction(async (tx) => { /* runs as admin */ });
 ```
+
 ## When `runTransaction` is overkill
 
 For single-doc operations with no read dependency, plain `set` / `update` / `delete` is fine. Reach for `runTransaction` when:

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-seed-and-set-rules.md
@@ -10,6 +10,7 @@ order: 19004
 This guide shows you how to use the sandbox-only `setRules` and `seed` methods on the Firestore handle.
 
 ## Deploy rules
+
 ```ts
 import { getFirestore } from 'pyric-admin';
 
@@ -29,9 +30,11 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
   throw new Error('rules failed to lint');
 }
 ```
+
 `setRules` returns the `LintResult` from `pyric/rules`. Check warnings before treating the deploy as successful. If the source has parse errors, the rules are *not* swapped (`setRules` is consistent with `LocalEnvironment.deployRules` on that point).
 
 ## Seed initial data
+
 ```ts
 const lint = adminDb.seed({
   documents: {
@@ -42,6 +45,7 @@ const lint = adminDb.seed({
   },
 });
 ```
+
 `seed` replaces the document store wholesale and **preserves the active ruleset**. Pass an empty `documents` map (or omit it) to clear data without touching rules.
 
 The return value is the lint of the preserved ruleset, for shape consistency with `setRules`. Callers that care about lint warnings can check them the same way after either call.
@@ -55,10 +59,12 @@ For tests where you want the seed itself to evaluate under rules (for example, t
 ## Order matters
 
 Rules first, then documents:
+
 ```ts
 adminDb.setRules(RULES);
 adminDb.seed({ documents: FIXTURES });
 ```
+
 If you seed before setting rules, the documents land under default-deny (the sandbox starts with no rules). Subsequent operations that need to read those documents will deny.
 
 In practice the order rarely matters because `seed` bypasses rules anyway, but it does matter for any operation you run between the two calls.
@@ -66,6 +72,7 @@ In practice the order rarely matters because `seed` bypasses rules anyway, but i
 ## Reset, then seed
 
 The most common pattern in tests:
+
 ```ts
 import { beforeEach } from 'bun:test';
 
@@ -75,16 +82,19 @@ beforeEach(() => {
   adminDb.seed({ documents: FIXTURES });
 });
 ```
+
 `reset` wipes everything (data, rules, listeners). The two follow-up calls restore the rules and fixtures. Subsequent tests start from the same known state.
 
 ## Snapshot for round-tripping
 
 The `snapshot()` method on the handle is a pair with `seed`: capture, restore.
+
 ```ts
 const before = adminDb.snapshot();
 // ... destructive operation
 adminDb.seed({ documents: before });
 ```
+
 `snapshot()` reads from the live state independent of rules. Use it for forensic dumps when a test fails or for round-tripping a known state across tests.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-translate-denials.md
@@ -10,6 +10,7 @@ order: 19005
 This guide shows you how to read the structured denial frame attached to every `permission-denied` error from `pyric-admin` operations.
 
 ## Catch with `instanceof`
+
 ```ts
 import { SandboxError } from 'pyric-admin';
 
@@ -30,9 +31,11 @@ try {
   }
 }
 ```
+
 `SandboxError` is re-exported from `pyric/sandbox`, so you can import it directly from `pyric-admin`. The `instanceof` check is what TypeScript narrows on: `e.code` is then typed.
 
 ## What `denialContext` carries
+
 ```ts
 interface DenialContext {
   auth?: AuthState;
@@ -50,6 +53,7 @@ interface DenialContext {
   failedFields?: string[];                       // deferred
 }
 ```
+
 For a denied write:
 
 - `request.method` = `create` / `update` / `delete`.
@@ -66,6 +70,7 @@ For a denied read:
 - `resource.data` / `resource.exists` reflect the doc being read (for `get`; absent for `list`).
 
 ## Render a "why did this deny" UI
+
 ```tsx
 function DenialBanner({ error }: { error: SandboxError }) {
   if (error.code !== 'permission-denied') return null;
@@ -85,6 +90,7 @@ function DenialBanner({ error }: { error: SandboxError }) {
   );
 }
 ```
+
 Real Firebase strips this context server-side for security. The sandbox can expose it because it's a development tool: every field is useful for debugging without leaking anything sensitive about the rules engine.
 
 ## Cross-listener denials

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-use-onsnapshot.md
@@ -10,6 +10,7 @@ order: 19006
 This guide shows you how to register a snapshot listener and react to changes.
 
 ## Watch a single document
+
 ```ts
 import { onSnapshot, type DocumentSnapshot } from 'pyric-admin';
 
@@ -24,9 +25,11 @@ const unsubscribe = onSnapshot(db.doc('notes/n1'), (snap: DocumentSnapshot) => {
 // ... later
 unsubscribe();
 ```
+
 The callback fires immediately with the initial snapshot, then again every time the document changes (write, delete, or rule re-evaluation after `setRules`).
 
 ## Watch a query
+
 ```ts
 import { onSnapshot, type QuerySnapshot } from 'pyric-admin';
 
@@ -37,11 +40,13 @@ const unsubscribe = onSnapshot(q, (snap: QuerySnapshot) => {
   }
 });
 ```
+
 `docChanges()` returns `added` / `modified` / `removed` events. On the initial fire, every matching document is reported as `added`.
 
 ## Use the observer form
 
 The Web-SDK-shaped observer is convenient when you want all three handlers:
+
 ```ts
 const unsubscribe = onSnapshot(db.doc('notes/n1'), {
   next: (snap) => console.log(snap.data()),
@@ -49,20 +54,24 @@ const unsubscribe = onSnapshot(db.doc('notes/n1'), {
   // complete is accepted but never fires — local stream has no terminal state.
 });
 ```
+
 ## Handle stream errors
 
 When a listener is silently terminated by a rule denial (most commonly during re-evaluation after a `setRules`), the `error` handler fires once and the listener stops:
+
 ```ts
 onSnapshot(db.doc('locked-by-rules/x'), {
   next: (snap) => render(snap.data()),
   error: (err) => render(`Error: ${err.message}`),
 });
 ```
+
 Once-per-stream: after `error` fires, no further `next` or `error` callbacks happen on this listener. To resume watching, register a new listener.
 
 For host-level error handling without each listener registering its own callback, subscribe to `sandbox.onSnapshotError(...)`. See Observe denials and stream errors in `pyric/sandbox`.
 
 ## Clean up in React `useEffect`
+
 ```ts
 useEffect(() => {
   const unsubscribe = onSnapshot(db.doc('notes/n1'), (snap) => {
@@ -71,6 +80,7 @@ useEffect(() => {
   return unsubscribe;
 }, []);
 ```
+
 Returning `unsubscribe` from the effect tells React to call it when the component unmounts or the effect re-runs. Without the cleanup, a re-render registers a fresh listener and the old one stays alive until the sandbox is reset.
 
 ## Why `metadata.fromCache` is always `false`

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-how-to-write-a-batch.md
@@ -10,6 +10,7 @@ order: 19007
 This guide shows you how to use `WriteBatch` for atomic multi-document writes.
 
 ## The shape
+
 ```ts
 const batch = db.batch();
 batch.set(db.doc('notes/n1'), { ownerId: 'alice', title: 'first' });
@@ -17,6 +18,7 @@ batch.set(db.doc('notes/n2'), { ownerId: 'alice', title: 'second' });
 batch.update(db.doc('users/alice'), { noteCount: FieldValue.increment(2) });
 await batch.commit();
 ```
+
 All three operations either succeed together or fail together. If the rule denies any one of them, the whole batch is rejected: no partial writes.
 
 ## What batches can do
@@ -38,6 +40,7 @@ If your write doesn't depend on the doc's current data, use a batch. It's cheape
 ## Denied operations
 
 If any operation in the batch would deny under the current rules, `commit` throws `SandboxError('permission-denied')` with the `denialContext` for the first denying operation. The event log records the batch attempt as denied; no operations land.
+
 ```ts
 try {
   await batch.commit();
@@ -47,9 +50,11 @@ try {
   }
 }
 ```
+
 ## Field-value sentinels in batches
 
 `FieldValue.serverTimestamp()`, `FieldValue.increment(n)`, `FieldValue.arrayUnion(...)`, `FieldValue.arrayRemove(...)`, and `FieldValue.delete()` all work in batches. The sandbox resolves them against the pre-batch state when computing the post-state:
+
 ```ts
 const batch = db.batch();
 batch.update(db.doc('counters/main'), {
@@ -58,6 +63,7 @@ batch.update(db.doc('counters/main'), {
 });
 await batch.commit();
 ```
+
 `request.resource.data.count` in the rule's view is the resolved post-batch value, not the sentinel itself.
 
 ## Order matters within the batch

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-api.md
@@ -17,9 +17,11 @@ loads `firebase-admin/firestore` directly with Pyric activation absent.
 ## Entry points
 
 ### `getFirestore(target?)`
+
 ```ts
 function getFirestore(target?: SandboxContext | PyricAdminApp): SandboxFirestore;
 ```
+
 Resolve the rules-applied Firestore handle. Three input shapes:
 
 - **`getFirestore(ctx)`** with a `SandboxContext`: the load-bearing form. Operations run under the context's captured identity. Anonymous is `sandbox.withAuth(null)`, written explicitly, so every call site states identity. Idempotent: repeat calls with the same context return the same handle (cached in a `WeakMap`).
@@ -33,10 +35,12 @@ Resolve the rules-applied Firestore handle. Three input shapes:
 **Errors.** Operations, and every object they return, re-throw failures as `SandboxError` with structured `denialContext` on permission denials. See [error translation](../pyric-admin-firestore-explanation-error-translation/).
 
 ### `getAdminFirestore(target)`
+
 ```ts
 function getAdminFirestore(ctx: SandboxContext): SandboxFirestore;
 function getAdminFirestore(sandbox: Sandbox): SandboxFirestore;
 ```
+
 Resolve a **rules-bypassing** handle: same chainable `SandboxFirestore` surface, but every operation it issues (reads, writes, queries, batches, transactions) skips security-rule evaluation and is treated as allow. A bare `Sandbox` is accepted because the bypass is identity-agnostic; no rule reads `request.auth` on this path.
 
 Storage preconditions still apply (a `create` on an existing doc still fails `already-exists`, matching real Firestore admin behavior), and the same `request`/`write` events fire and listeners wake, so bypass writes show up live and on the traffic log stamped as admin-bypass.
@@ -46,11 +50,13 @@ On a remote sandbox, the bypass rides the worker's `{ mode: 'admin' }` lens, the
 Use it for "edit anything as admin" surfaces. For rules-applied impersonation, use `getFirestore(sandbox.withAuth({ uid }))` instead.
 
 ### `onSnapshot(refOrQuery, ...)`
+
 ```ts
 function onSnapshot(reference: DocumentReference, observer: SnapshotObserver<DocumentSnapshot>): Unsubscribe;
 function onSnapshot(reference: Query | CollectionReference, observer: SnapshotObserver<QuerySnapshot>): Unsubscribe;
 // plus (options, observer), (onNext, onError?), and (options, onNext, onError?) forms of each
 ```
+
 Web-SDK-shaped streaming reads. Four overload groups per target kind mirror `firebase/firestore`'s `onSnapshot`, so call sites copied from production typecheck unchanged. Full overload list and rationale: [`onSnapshot` overloads](../pyric-admin-firestore-reference-onsnapshot/).
 
 Behavior notes verified against source:
@@ -65,10 +71,12 @@ Behavior notes verified against source:
 ## The chainable surface
 
 `SandboxFirestore` extends the production-shaped `Firestore`, so admin-style code chains the way it does against `firebase-admin/firestore`:
+
 ```ts
 await db.collection('notes').doc('n1').set({ title: 'hello' });
 const snap = await db.collection('notes').where('done', '==', false).get();
 ```
+
 The shapes, as implemented by the compat layer:
 
 - `db.collection(path)`, `db.doc(path)`, `db.collectionGroup(collectionId)`, `db.batch()`, `db.runTransaction(fn, opts?)`.
@@ -83,11 +91,13 @@ Detailed per-method behavior: [`SandboxFirestore` surface](../pyric-admin-firest
 ### Sandbox-only methods on the handle
 
 `SandboxFirestore` adds three methods with no production analog, named in sandbox vocabulary so they cannot be confused with deployment:
+
 ```ts
 setRules(rules: string): LintResult;
 seed(options?: { documents?: Record<string, DocumentData> }): LintResult;
 snapshot(): Record<string, DocumentData>;
 ```
+
 `setRules` swaps the active ruleset (parse errors leave the old rules in place), `seed` replaces stored documents while preserving rules, `snapshot` captures every document as a path-keyed map. Full contract: [`SandboxFirestore` surface](../pyric-admin-firestore-reference-sandbox-firestore/).
 
 ---
@@ -95,6 +105,7 @@ snapshot(): Record<string, DocumentData>;
 ## Values
 
 ### `FieldValue`
+
 ```ts
 class FieldValue {
   static serverTimestamp(): FieldValueSentinel;
@@ -104,9 +115,11 @@ class FieldValue {
   static delete(): FieldValueSentinel;
 }
 ```
+
 The admin-SDK static-method shape. Each call returns a `FieldValueSentinel` marker the write path resolves.
 
 ### `Timestamp`
+
 ```ts
 class Timestamp {
   constructor(seconds: number, nanoseconds: number);
@@ -118,9 +131,11 @@ class Timestamp {
   isEqual(other: Timestamp): boolean;
 }
 ```
+
 Admin-SDK shape (`seconds` plus `nanoseconds`).
 
 ### `SandboxError`
+
 ```ts
 class SandboxError extends Error {
   readonly code: SandboxErrorCode;
@@ -128,6 +143,7 @@ class SandboxError extends Error {
   readonly remediation?: string;
 }
 ```
+
 The typed error family from `pyric/sandbox`, re-exported so consumers can `catch (e) { if (e instanceof SandboxError) ... }` with one import path. `denialContext` is populated on `permission-denied` and carries the rule, the request, and the resource state that produced the verdict. See [Translate denials](../pyric-admin-firestore-how-to-translate-denials/).
 
 ---

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-onsnapshot.md
@@ -20,6 +20,7 @@ The Firebase Admin SDK's `onSnapshot` lives on the reference (`db.doc('x').onSna
 The reference-method form (`ref.onSnapshot(...)`) is also available because the underlying Firestore reference still carries that method.
 
 ## Document overloads
+
 ```ts
 // (observer)
 onSnapshot(ref: DocumentReference, observer: SnapshotObserver<DocumentSnapshot>): Unsubscribe;
@@ -29,21 +30,26 @@ onSnapshot(ref: DocumentReference, options: SnapshotListenOptions, observer: Sna
 onSnapshot(ref: DocumentReference, onNext: (snap: DocumentSnapshot) => void, onError?: (error: unknown) => void): Unsubscribe;
 onSnapshot(ref: DocumentReference, options: SnapshotListenOptions, onNext: (snap: DocumentSnapshot) => void, onError?: (error: unknown) => void): Unsubscribe;
 ```
+
 ## Query overloads
 
 Same four shapes against `Query`:
+
 ```ts
 onSnapshot(query: Query, observer: SnapshotObserver<QuerySnapshot>): Unsubscribe;
 onSnapshot(query: Query, options: SnapshotListenOptions, observer: SnapshotObserver<QuerySnapshot>): Unsubscribe;
 onSnapshot(query: Query, onNext: (snap: QuerySnapshot) => void, onError?: (error: unknown) => void): Unsubscribe;
 onSnapshot(query: Query, options: SnapshotListenOptions, onNext: (snap: QuerySnapshot) => void, onError?: (error: unknown) => void): Unsubscribe;
 ```
+
 ## `SnapshotListenOptions`
+
 ```ts
 interface SnapshotListenOptions {
   includeMetadataChanges?: boolean;
 }
 ```
+
 Accepted for shape parity. `includeMetadataChanges` has no observable effect in the sandbox (there's no offline cache and no pending-writes window), so `metadata.fromCache` and `metadata.hasPendingWrites` are always `false`.
 
 ## What `Unsubscribe` does

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-re-exported-types.md
@@ -23,6 +23,7 @@ Foundation types you'll always need alongside the data plane:
 Anyone needing more reaches into `pyric/sandbox` directly.
 
 ## Production-shaped types
+
 ```ts
 export type {
   AggregateField, AggregateQuerySnapshot, AggregateSpec, Filter,
@@ -36,6 +37,7 @@ export type {
   RulesMetrics, SetOptions, Transaction, WhereFilterOp, WriteBatch,
 } from 'pyric/sandbox/admin-firestore';
 ```
+
 These mirror `firebase-admin/firestore`. The shapes match production exactly; the implementations are sandbox-aware.
 
 ### Why the `Admin*` prefixes
@@ -49,6 +51,7 @@ The three snapshot types appear with `Admin*` prefixes:
 This is because the Web SDK has differently-shaped snapshot types with the same canonical names, and `onSnapshot` callbacks consume the Web shape. Aliasing the admin variants with the `Admin*` prefix keeps the canonical names available for the Web shape (see next section), so call sites copied from a `firebase/firestore` codebase typecheck without renaming.
 
 ## Web-SDK-shaped snapshot types
+
 ```ts
 export type {
   LiveDocumentSnapshot as DocumentSnapshot,
@@ -60,7 +63,9 @@ export type {
   SnapshotMetadata,
 } from 'pyric/sandbox/admin-firestore';
 ```
+
 Spelled with the conventional Web SDK names. Use these when typing `onSnapshot` callbacks:
+
 ```ts
 import { onSnapshot, type DocumentSnapshot } from 'pyric-admin/firestore';
 
@@ -68,6 +73,7 @@ onSnapshot(db.doc('games/g1'), (snap: DocumentSnapshot) => {
   console.log(snap.exists, snap.data(), snap.metadata.fromCache);
 });
 ```
+
 ## Values
 
 Two runtime values re-exported from the simulator:
@@ -80,6 +86,7 @@ Both behave the same way as in `firebase-admin/firestore`. The implementations r
 ## Why all this lives at the top of `pyric-admin`
 
 A user writing a test wants:
+
 ```ts
 import {
   getFirestore,
@@ -90,6 +97,7 @@ import {
   type DocumentSnapshot,
 } from 'pyric-admin';
 ```
+
 Mostly one import. Reaching for `pyric/sandbox` separately to get
 `SandboxError`, or for `pyric/sandbox/admin-firestore` separately for
 `FieldValue`, would create friction for the common case. The aliases and

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-reference-sandbox-firestore.md
@@ -47,6 +47,7 @@ After a successful `setRules`, every active snapshot listener is re-evaluated un
 ### `seed(options?): LintResult`
 
 Replace stored documents with a new seed map. Active rules are preserved.
+
 ```ts
 db.seed({
   documents: {
@@ -55,6 +56,7 @@ db.seed({
   },
 });
 ```
+
 Pass an empty `documents` map (or omit it) to clear data without touching rules.
 
 Returns the lint of the preserved ruleset for consistency with `setRules`: the same `LintResult` shape across both methods means the caller can check warnings the same way after either call.
@@ -62,10 +64,12 @@ Returns the lint of the preserved ruleset for consistency with `setRules`: the s
 ### `snapshot(): Record<string, DocumentData>`
 
 Capture every stored document as a `{ [path]: data }` map. Reads from the live state and is independent of rules (same idea as `sandbox.admin.getDocument(...)` but for the whole database in one call).
+
 ```ts
 const state = db.snapshot();
 console.log(state['notes/n1']);  // { ownerId: 'alice', title: 'first' }
 ```
+
 The returned object is a structural clone. Mutating it does not affect the sandbox.
 
 ## What this handle ignores

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore-tutorials-01-first-admin-session.md
@@ -10,14 +10,17 @@ order: 19002
 In this tutorial you will use `pyric-admin` to write, read, batch, transact, and watch documents in a sandbox. By the end you will have seen every piece of the surface in action.
 
 ## Before you start
+
 ```bash
 mkdir admin-tutorial && cd admin-tutorial
 bun init -y
 bun add pyric/sandbox pyric-admin
 ```
+
 ## Step 1: Boot the sandbox and deploy rules
 
 Create `session.ts`:
+
 ```ts
 import { initializeSandbox, SandboxError } from 'pyric/sandbox';
 import { getFirestore, FieldValue, onSnapshot } from 'pyric-admin';
@@ -47,9 +50,11 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 }
 console.log('Rules deployed.');
 ```
+
 Run with `bun run session.ts`. You should see `Rules deployed.` and no warnings.
 
 ## Step 2: Write as one user
+
 ```ts
 const aliceCtx = sandbox.withAuth({ uid: 'alice' });
 const aliceDb = getFirestore(aliceCtx);
@@ -62,11 +67,15 @@ await aliceDb.collection('notes').doc('n1').set({
 const snap = await aliceDb.collection('notes').doc('n1').get();
 console.log('Alice reads back:', snap.data());
 ```
+
 Output:
+
 ```
 Alice reads back: { ownerId: "alice", title: "My first note" }
 ```
+
 ## Step 3: Try a denied write
+
 ```ts
 const bobDb = getFirestore(sandbox.withAuth({ uid: 'bob' }));
 
@@ -78,9 +87,11 @@ try {
   }
 }
 ```
+
 Bob is not Alice; the update rule requires `request.auth.uid == resource.data.ownerId`. The denial fires with full context.
 
 ## Step 4: Run a transaction
+
 ```ts
 const result = await adminDb.runTransaction(async (tx) => {
   const counterRef = adminDb.doc('counters/main');
@@ -92,9 +103,11 @@ const result = await adminDb.runTransaction(async (tx) => {
 
 console.log('Counter is now:', result);
 ```
+
 Output: `Counter is now: 1`. Run the file again and it becomes 2 (the sandbox isn't reset between runs of the script).
 
 ## Step 5: Write a batch
+
 ```ts
 const batch = adminDb.batch();
 batch.set(adminDb.doc('notes/n2'), { ownerId: 'alice', title: 'batched A' });
@@ -104,9 +117,11 @@ await batch.commit();
 
 console.log('After batch:', adminDb.snapshot());
 ```
+
 The three operations either all succeed or all fail. `FieldValue.increment(2)` resolves against the pre-batch state.
 
 ## Step 6: Watch with `onSnapshot`
+
 ```ts
 const changes: any[] = [];
 const unsubscribe = onSnapshot(aliceDb.collection('notes'), (snap) => {
@@ -121,7 +136,9 @@ await aliceDb.collection('notes').doc('n1').update({ title: 'updated' });
 console.log('Saw changes:', changes);
 unsubscribe();
 ```
+
 Output:
+
 ```
 Saw changes: [
   'added n1', 'added n2', 'added n3',  // initial fire
@@ -129,13 +146,16 @@ Saw changes: [
   'modified n1',                        // update
 ]
 ```
+
 The listener fires once for the initial state, then again per write. Don't forget to `unsubscribe`: without it, a script holding the listener forever keeps the sandbox alive in memory.
 
 ## Step 7: Snapshot the world
+
 ```ts
 console.log('Full state:');
 console.log(adminDb.snapshot());
 ```
+
 Every document, every path. Use this for forensic dumps when a test fails.
 
 ## What you have learned

--- a/packages/site-docs/src/content/docs/pyric-admin-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-firestore.md
@@ -12,12 +12,15 @@ Admin-SDK-shaped Firestore adapter for the Pyric sandbox. Mirrors `firebase-admi
 Use this package when your production code uses `firebase-admin/firestore` (Node services, Cloud Functions). For the modular Web SDK shape, use [`pyric/firestore`](../pyric-admin-firestore/) instead.
 
 ## Install
+
 ```bash
 bun add pyric-admin pyric/sandbox
 # or
 npm install pyric-admin pyric/sandbox
 ```
+
 ## A 30-second example
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -38,6 +41,7 @@ await db.collection('notes').doc('n1').set({ title: 'hello' });
 const snap = await db.collection('notes').doc('n1').get();
 console.log(snap.exists, snap.data());
 ```
+
 Alongside the production-shaped surface, the `db` handle carries three sandbox-only methods: `setRules(src)`, `seed({ documents })`, and `snapshot()`. The package also re-exports the foundation and production-shaped types (`SandboxError`, `FieldValue`, `Timestamp`, the snapshot types) so consumers can import everything from `pyric-admin`.
 
 ## Where to go next

--- a/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage-reference-api.md
@@ -22,9 +22,11 @@ absent.
 ## Initialization
 
 ### `getStorage(app?)`
+
 ```ts
 function getStorage(app?: StorageApp): Storage;
 ```
+
 Get the `Storage` service for the given sandbox app, or for the `'[DEFAULT]'` app when called with no argument (throws `app/no-app` when nothing is initialized). A remote-branded sandbox gets the relay backend; a local sandbox gets the in-memory backend. Throws `TypeError` for an unbranded value.
 
 ---
@@ -32,16 +34,20 @@ Get the `Storage` service for the given sandbox app, or for the `'[DEFAULT]'` ap
 ## `Storage` and `Bucket`
 
 ### `storage.bucket(name?)`
+
 ```ts
 bucket(name?: string): Bucket;
 ```
+
 - Local: returns a handle for `name`, creating the bucket map on first use. Omitted `name` resolves to the default bucket `'pyric-default'` (the same default `pyric/storage` uses). Buckets are genuinely isolated from each other.
 - Remote: the worker's object store is single-bucket. `bucket()` and `bucket('pyric-default')` work; any other name throws immediately rather than silently merging buckets. This is the sharpest local/remote divergence, and it is loud on purpose.
 
 ### `bucket.file(path)`
+
 ```ts
 file(path: string): File;
 ```
+
 Returns a `File` handle; the file may or may not exist.
 
 ---
@@ -49,40 +55,52 @@ Returns a `File` handle; the file may or may not exist.
 ## `File`: the object data plane
 
 ### `file.save(data, options?)`
+
 ```ts
 save(data: Buffer | string | Uint8Array, options?: SaveOptions): Promise<void>;
 ```
+
 Arms: local, remote. Persists `data` at the file's path, replacing any existing content (no append semantics). Strings are UTF-8 encoded; buffers are copied on ingest so callers can reuse their input. `options.metadata` and `options.contentType` are stored alongside the bytes and round-trip.
 
 - `options.resumable: true` throws on both sandbox backends because resumable uploads are deferred.
 - Remote: relays `storage.putBytes` (base64 over the wire). Payloads over 8 MiB reject with the payload-too-large error below, before anything is sent.
 
 ### `file.download(options?)`
+
 ```ts
 download(options?: DownloadOptions): Promise<[Buffer]>;
 ```
+
 Arms: local, remote. Returns a `[Buffer]` tuple, mirroring `@google-cloud/storage`. A missing file throws `Error('No such object: <bucket>/<path>')` on both arms, the same message shape as production, so catch blocks that string-match keep working. `options.validation` is accepted and ignored on the sandbox arms. Remote relays `storage.getBytes`.
 
 ### `file.delete()`
+
 ```ts
 delete(): Promise<void>;
 ```
+
 Arms: local, remote. Idempotent: deleting a missing file is a no-op (the `ignoreNotFound: true` mode is the only one the sandbox models). Remote relays `storage.deleteObject`.
 
 ### `file.exists()`
+
 ```ts
 exists(): Promise<[boolean]>;
 ```
+
 Arms: local, remote. `[true]` if the file exists. Remote probes `storage.getMetadata` and maps object-not-found to `[false]`.
 
 ### `file.getSignedUrl(options)`
+
 ```ts
 getSignedUrl(options: GetSignedUrlOptions): Promise<[string]>;
 ```
+
 Arms: local, remote (byte-identical output; the remote arm never relays this call). Returns a deterministic stub:
+
 ```
 pyric-sandbox-storage://<bucket>/<path>?expires=<ms>&action=<action>
 ```
+
 The sandbox does NOT serve this URL. It is a stable placeholder so code that round-trips signed URLs through logs, fixtures, or replay sees a consistent shape. `expires` accepts ms-since-epoch, an ISO date string, or a `Date`, normalized to ms; expiration is not enforced.
 
 ---
@@ -113,6 +131,7 @@ Use Firebase Admin directly when production needs these methods.
 ## Types
 
 ### `Storage`, `Bucket`, `File`
+
 ```ts
 interface Storage {
   bucket(name?: string): Bucket;
@@ -133,9 +152,11 @@ interface File {
   getSignedUrl(options: GetSignedUrlOptions): Promise<[string]>;
 }
 ```
+
 These interfaces document the subset the sandbox backends implement.
 
 ### `SaveOptions`
+
 ```ts
 interface SaveOptions {
   metadata?: Record<string, unknown>;
@@ -143,23 +164,30 @@ interface SaveOptions {
   resumable?: boolean;  // true throws on sandbox backends
 }
 ```
+
 ### `DownloadOptions`
+
 ```ts
 interface DownloadOptions {
   validation?: 'md5' | 'crc32c' | boolean; // sandbox backends ignore
 }
 ```
+
 ### `GetSignedUrlOptions`
+
 ```ts
 interface GetSignedUrlOptions {
   action: 'read' | 'write' | 'delete' | 'resumable';
   expires: number | string | Date;
 }
 ```
+
 ### `StorageApp`
+
 ```ts
 type StorageApp = PyricAdminApp;
 ```
+
 The input `getStorage` accepts; an alias of the branded handle from `pyric-admin/app`.
 
 ---

--- a/packages/site-docs/src/content/docs/pyric-admin-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-admin-storage.md
@@ -15,6 +15,7 @@ Admin-shaped Cloud Storage for a sandbox. `getStorage(app)` reads the sandbox ha
 Storage support is experimental, on this surface and on `pyric/storage`. The object API works and is tested; most behavior is not yet pinned to a recorded production observation.
 
 Deferred surfaces (streams, resumable uploads, IAM, ACLs, copy/move) throw a clear "not implemented" error, never bad data. Production code loads `firebase-admin/storage` directly with Pyric activation absent.
+
 ```ts
 import { initializeApp } from 'pyric-admin/app';
 import { getStorage } from 'pyric-admin/storage';
@@ -30,6 +31,7 @@ const [exists] = await file.exists(); // [true]
 const [bytes] = await file.download();
 console.log(bytes.toString());
 ```
+
 ## Where to go next
 
 - [API reference](../pyric-admin-storage-reference-api/) for the full `Bucket` and `File` surface, including the byte cap and deferred list.

--- a/packages/site-docs/src/content/docs/pyric-ai-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-ai-compat.md
@@ -3,7 +3,7 @@ title: "pyric/ai compatibility matrix"
 navLabel: "AI Logic"
 group: "Conformance"
 section: ""
-order: 8009
+order: 6011
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-app-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-app-compat.md
@@ -3,7 +3,7 @@ title: "pyric/app compatibility matrix"
 navLabel: "App"
 group: "Conformance"
 section: ""
-order: 8002
+order: 6004
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-auth-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-compat.md
@@ -3,7 +3,7 @@ title: "pyric/auth compatibility matrix"
 navLabel: "Auth"
 group: "Conformance"
 section: ""
-order: 8004
+order: 6006
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-api.md
@@ -16,11 +16,13 @@ For coverage against `firebase/auth`'s full surface, see [feature-matrix.md](../
 ## Initialization
 
 ### `getAuth(target)`
+
 ```ts
 function getAuth(): Auth;
 function getAuth(sandbox: Sandbox): Auth;
 function getAuth(app: FirebaseApp): Auth;
 ```
+
 Construct an `Auth` handle. Idempotent on all three inputs: repeat calls for the same input return the same handle (matches `firebase/auth.getAuth(app)`).
 
 On a bare sandbox target, the handle and session are memoized per sandbox.
@@ -31,6 +33,7 @@ The `FirebaseApp` association is private; consumer-visible branding or
 `app.sandbox` fields are not required.
 
 ### `connectAuthEmulator(auth, url, options?)`
+
 ```ts
 function connectAuthEmulator(
   auth: Auth,
@@ -38,6 +41,7 @@ function connectAuthEmulator(
   options?: { disableWarnings?: boolean },
 ): void;
 ```
+
 No-op: the `pyric/auth` mirror is already the sandbox. Production code keeps
 the unswapped `firebase/auth` package, whose `connectAuthEmulator` behavior is
 owned by Firebase rather than this mirror.
@@ -47,12 +51,15 @@ owned by Firebase rather than this mirror.
 ## Sign-in / sign-out
 
 ### `signInAnonymously(auth)`
+
 ```ts
 function signInAnonymously(auth: Auth): Promise<UserCredential>;
 ```
+
 Sandbox: mints a `User` with an auto-generated uid prefixed `anonymous-`, `isAnonymous: true`, `email: null`. Writes through to `sandbox.currentUser` and fires `onAuthStateChanged`. Reuses the already-signed-in anonymous user instead of minting a new one if one is already current (avoids duplicate identities under double-mount patterns like React StrictMode). Throws `auth/operation-not-allowed` if the `anonymous` provider is disabled (`sandbox.setAuthProviderConfig`).
 
 ### `signInWithEmailAndPassword(auth, email, password)`
+
 ```ts
 function signInWithEmailAndPassword(
   auth: Auth,
@@ -60,9 +67,11 @@ function signInWithEmailAndPassword(
   password: string,
 ): Promise<UserCredential>;
 ```
+
 Sandbox: looks up the user in the in-memory DB seeded via `sandbox.seedUsers`. Email lookup is case-insensitive. Throws `auth/user-not-found` if absent, `auth/wrong-password` on mismatch, `auth/user-disabled` for a disabled account, `auth/operation-not-allowed` if the `password` provider is disabled.
 
 ### `createUserWithEmailAndPassword(auth, email, password)`
+
 ```ts
 function createUserWithEmailAndPassword(
   auth: Auth,
@@ -70,17 +79,21 @@ function createUserWithEmailAndPassword(
   password: string,
 ): Promise<UserCredential>;
 ```
+
 Sandbox: appends to the in-memory DB and signs in. Throws `auth/email-already-in-use` if the email is already registered, `auth/operation-not-allowed` if the `password` provider is disabled.
 
 ### `signOut(auth)`
+
 ```ts
 function signOut(auth: Auth): Promise<void>;
 ```
+
 Sets `currentUser` to `null` and fires listeners. It is a no-op if already
 signed out. `Auth` also exposes this as a method, `auth.signOut()`, delegating
 to the same mirror implementation.
 
 ### `signInWithPopup(auth, provider, resolver?)`
+
 ```ts
 function signInWithPopup(
   auth: Auth,
@@ -88,9 +101,11 @@ function signInWithPopup(
   resolver?: AuthFlowResolver,
 ): Promise<UserCredential>;
 ```
+
 Sandbox: resolves through a precedence chain: a per-call `resolver` argument, then one injected via `sandbox.setAuthFlowResolver`, then a one-shot mock staged with `sandbox.mockSignInResult`. With nothing configured it throws `auth/argument-error`, naming the API that was called (matches upstream's no-resolver default). Throws `auth/operation-not-allowed` first if the provider is disabled, and `auth/user-disabled` if the resolved identity is a disabled account. The `resolver` argument is sandbox-only; production package resolution leaves the canonical import on `firebase/auth`, which uses its own platform resolver.
 
 ### `signInWithRedirect(auth, provider, resolver?)`
+
 ```ts
 function signInWithRedirect(
   auth: Auth,
@@ -98,32 +113,41 @@ function signInWithRedirect(
   resolver?: AuthFlowResolver,
 ): Promise<void>;
 ```
+
 Sandbox: there's no navigation to redirect through, so this resolves the same resolver precedence as `signInWithPopup` inline, signs the user in immediately, and stashes the resulting credential for the next `getRedirectResult` call. Same error conditions as `signInWithPopup`. Production remains on `firebase/auth` (real navigation away and back).
 
 ### `getRedirectResult(auth)`
+
 ```ts
 function getRedirectResult(auth: Auth): Promise<UserCredential | null>;
 ```
+
 Sandbox: returns and clears the credential stashed by `signInWithRedirect` (one-shot); `null` if no redirect is pending. Production remains on `firebase/auth`.
 
 ### `signInWithCredential(auth, credential)`
+
 ```ts
 function signInWithCredential(auth: Auth, credential: AuthCredential): Promise<UserCredential>;
 ```
+
 Sandbox: looks up the pre-staged mock by `credential.providerId` (set via `sandbox.mockSignInResult`). One-shot: each mock is consumed by one sign-in call. Throws `auth/operation-not-allowed` if the provider is disabled, `auth/no-mock-configured` if no mock is staged, `auth/user-disabled` if the resolved identity is disabled.
 
 ### `setPersistence(auth, persistence)`
+
 ```ts
 function setPersistence(auth: Auth, persistence: Persistence): Promise<void>;
 ```
+
 Sandbox: records the mode on the backend, which migrates any already-stored session uid to the newly selected web-storage slot. No-op if the sandbox has no persistence controller attached. Prod: maps `inMemoryPersistence` / `browserSessionPersistence` / `browserLocalPersistence` to upstream's singletons.
 
 #### Persistence markers
+
 ```ts
 const inMemoryPersistence: Persistence;      // { type: 'NONE' }
 const browserSessionPersistence: Persistence; // { type: 'SESSION' }
 const browserLocalPersistence: Persistence;   // { type: 'LOCAL' }
 ```
+
 Opaque markers passed to `setPersistence`. Sandbox treats them as pure data (their `.type` string selects the web-storage slot); prod hands them straight to `firebase/auth.setPersistence`, which switches on the same singletons.
 
 ---
@@ -131,6 +155,7 @@ Opaque markers passed to `setPersistence`. Sandbox treats them as pure data (the
 ## Observers
 
 ### `onAuthStateChanged(auth, observer)`
+
 ```ts
 function onAuthStateChanged(
   auth: Auth,
@@ -139,6 +164,7 @@ function onAuthStateChanged(
     | { next?: (user: User | null) => void; error?: (e: Error) => void; complete?: () => void },
 ): Unsubscribe;
 ```
+
 Fires immediately on subscribe with current state (via microtask). Subsequent fires on every sign-in / sign-out. Multiple subscribers all fire. Unsubscribing during emission does not skip remaining subscribers. Same-identity `setUser` calls do NOT re-fire.
 
 ### `onIdTokenChanged(auth, observer)`
@@ -148,6 +174,7 @@ Same shape as `onAuthStateChanged`.
 Sandbox fires on identity change and on `getIdToken(true)` forced refresh, matching prod (oracle `auth-onidtokenchanged-force-refresh.json`). It does not fire spontaneously, because sandbox tokens don't expire.
 
 ### `beforeAuthStateChanged(auth, callback, onAbort?)`
+
 ```ts
 function beforeAuthStateChanged(
   auth: Auth,
@@ -155,6 +182,7 @@ function beforeAuthStateChanged(
   onAbort?: () => void,
 ): Unsubscribe;
 ```
+
 Registers a BLOCKING gate that runs before a real sign-in/sign-out transition commits — the pattern for gating sign-in with a client-side check (e.g. reject users who fail an allowlist). Callbacks run in registration order and may be async. If a callback throws (or its returned promise rejects), the transition is ABORTED: the pending `signInWith…` / `signOut` call rejects with `auth/login-blocked`, `currentUser` is left unchanged, and `onAuthStateChanged` / `onIdTokenChanged` do NOT fire. Every `onAbort` registered by a callback that already succeeded in the same pass runs, in reverse registration order, so side effects can be undone.
 
 Fires for both directions — a real sign-in (`nextUser` non-null) and a real sign-out (`nextUser === null`). Covers every sign-in path `pyric/auth` has: `signInAnonymously`, `signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, `signInWithPopup`, `signInWithRedirect`, `signInWithCredential`, and `signOut`.
@@ -166,24 +194,30 @@ Does NOT gate the `sandbox.setUser` test driver — that bypass has no productio
 ## Token accessors
 
 ### `getIdToken(user, forceRefresh?)`
+
 ```ts
 function getIdToken(user: User, forceRefresh?: boolean): Promise<string>;
 ```
+
 Top-level mirror of `firebase/auth`'s modular `getIdToken(user)`. Delegates to the `user.getIdToken(forceRefresh)` method, so behavior (and forced-refresh side effects on `onIdTokenChanged`) is identical whichever form calling code uses. Added because generated app code that imports the modular free function otherwise has no matching export.
 
 ### `getIdTokenResult(user, forceRefresh?)`
+
 ```ts
 function getIdTokenResult(user: User, forceRefresh?: boolean): Promise<IdTokenResult>;
 ```
+
 Top-level mirror of `user.getIdTokenResult(forceRefresh)`.
 
 ### `updateProfile(user, profile)`
+
 ```ts
 function updateProfile(
   user: User,
   profile: { displayName?: string | null; photoURL?: string | null },
 ): Promise<void>;
 ```
+
 Updates the signed-in user's `displayName` / `photoURL`. Pass `null` to clear a field, omit it to leave it untouched. Mutates the user object in place, so every held reference, including `auth.currentUser`, reflects the change. Does NOT fire `onAuthStateChanged` / `onIdTokenChanged` (matches upstream). Works without an `auth` handle in scope, matching upstream's user-only signature: it dispatches through a hidden brand every `User` carries back to whichever backend produced it. Throws `auth/invalid-user-token` if `user` wasn't produced by a `pyric/auth` sign-in.
 
 This is the client-facing, signed-in-user form. `sandbox.updateProfile(auth, uid, profile)` (below) is the sandbox-only by-uid admin variant, used when there's no live `User` handle to call this on.
@@ -205,6 +239,7 @@ Every provider is a marker class: no real OAuth flow runs on sandbox. `addScope`
 `EmailAuthProvider` doesn't run a popup/redirect flow, so it has no `addScope`, `setCustomParameters`, `credentialFromResult`, or `credentialFromError`, only the two credential constructors. `credentialFromError` returns `null` on every provider (sandbox has no error path that synthesizes a credential).
 
 ### `FEDERATED_PROVIDER_IDS` / `FederatedProviderId`
+
 ```ts
 const FEDERATED_PROVIDER_IDS: readonly [
   'google.com', 'apple.com', 'facebook.com', 'github.com',
@@ -212,6 +247,7 @@ const FEDERATED_PROVIDER_IDS: readonly [
 ];
 type FederatedProviderId = (typeof FEDERATED_PROVIDER_IDS)[number];
 ```
+
 The federated (OAuth) provider ids the sandbox treats as first-class: the dedicated provider classes' ids plus the rest of the standard Firebase IdP set, reached through the generic `OAuthProvider`. Not an allowlist. The backend accepts any provider id, including a custom `new OAuthProvider('oidc.acme')`. Exists so admin surfaces (a provider-toggle UI) can enumerate the supported set mechanically instead of hardcoding a copy. `password` and `anonymous` are deliberately absent: they're credential-derived sign-in methods, not federated links.
 
 ---
@@ -252,6 +288,7 @@ These back the `sandbox.*` methods below; see [sandbox-test-driver.md](../pyric-
 `import { sandbox as authSandbox } from 'pyric/auth'`. The name collides with the common `const sandbox = initializeSandbox()` local, so alias on import. Every method requires an `Auth` handle produced by this mirror. Signatures only here; see [sandbox-test-driver.md](../pyric-auth-reference-sandbox-test-driver/) for worked examples.
 
 ### Session and identity
+
 ```ts
 setUser(auth: Auth, user: User | null): void;
 listIdentities(auth: Auth): Array<{
@@ -271,22 +308,28 @@ mockSignInResult(auth: Auth, result: UserCredential): void;
 restoreSession(auth: Auth, uid: string): User;
 mintSession(auth: Auth, request: MintSessionRequest): MintedSession;
 ```
+
 `setUser` forces the current user directly (`null` signs out), bypassing lookup and mock staging entirely; it does not count as a real sign-in (no `lastLoginAt` bump). `listIdentities` snapshots every seeded/created identity for an account-picker UI; `providerId` is the primary label (first linked provider, or `'anonymous'`). `createSignInCredential` mints a credential for a host-driven pick-existing or add-account flow but does not sign anyone in on its own. Hand the result to a pending `AuthFlowResolver` promise. `mockSignInResult` one-shot-stages the result the next matching `signInWithPopup` / `signInWithCredential` call returns. `restoreSession` re-establishes a signed-in session for an existing identity (fires listeners like a real restore); throws `auth/user-not-found` / `auth/user-disabled`. `mintSession` mints a per-connection identity without touching the shared `auth.currentUser`, the substrate for one sandbox serving multiple authenticated connections.
 
 ### Flow wiring
+
 ```ts
 setAuthFlowResolver(auth: Auth, resolver: AuthFlowResolver | null): void;
 ```
+
 Installs (or, passed `null`, clears) the popup/redirect resolver that `signInWithPopup` / `signInWithRedirect` delegate to when no per-call resolver is given. The analog of a browser `getAuth` wiring `browserPopupRedirectResolver`.
 
 ### Seed and export
+
 ```ts
 seedUsers(auth: Auth, users: ReadonlyArray<SeedUser>): void;
 exportUsers(auth: Auth): SeedUser[];
 ```
+
 `seedUsers` bulk-loads test users for email/password lookup; re-seeding an existing uid overwrites. `exportUsers` returns the user DB in the exact shape `seedUsers` accepts, so the two round-trip losslessly. Provider-flow identities that never had a password export with a documented sentinel; anonymous users are not exported (ephemeral by design).
 
 ### User admin (emulator-REST-shaped)
+
 ```ts
 listUsers(auth: Auth): AuthUserRecord[];
 createUser(auth: Auth, request: CreateUserRequest): AuthUserRecord;
@@ -300,9 +343,11 @@ deleteUser(auth: Auth, uid: string): void;
 clearUsers(auth: Auth): void;
 subscribeUsers(auth: Auth, callback: () => void): Unsubscribe;
 ```
+
 `createUser` creates without signing in (admin semantics; `createUserWithEmailAndPassword` is the signs-you-in client variant). `updateUser` throws nothing for untouched fields (`undefined` = leave alone), replaces `customClaims` wholesale, and setting `disabled: true` blocks future sign-ins (`auth/user-disabled`) without terminating an active session. `updateProfile` (by uid) is the admin counterpart to the top-level `updateProfile(user, profile)` free function above, same field semantics, no live `User` handle required. `deleteUser` / `clearUsers` don't terminate active sessions (prod parity). `subscribeUsers` has a coarse contract: no payload, no initial fire; re-read with `listUsers` inside the callback.
 
 ### Sign-in provider config
+
 ```ts
 getAuthProviderConfig(auth: Auth): Array<{ providerId: string; enabled: boolean }>;
 setAuthProviderConfig(auth: Auth, providerId: string, enabled: boolean): void;
@@ -310,6 +355,7 @@ assertAuthProviderEnabled(auth: Auth, providerId: string): void;
 delegateProviderEnforcement(auth: Auth, delegated: boolean): void;
 subscribeAuthProviderConfig(auth: Auth, callback: () => void): Unsubscribe;
 ```
+
 Mirrors the Authentication → Sign-in method toggles. `password` and `anonymous` default to enabled; every other provider id is disabled until explicitly enabled. `setAuthProviderConfig` gates every sign-in entry point that provider serves; the matching call throws `auth/operation-not-allowed` when disabled, exactly like flipping the console toggle off. Config survives `enablePersistence` round-trips. `assertAuthProviderEnabled` is the same gate, exposed directly for hosts (like a served worker) that enforce it on behalf of an identity resolved elsewhere. `delegateProviderEnforcement` hands this handle's gating to a remote authority (serve-layer wiring); don't set it on a backend that is itself the authority. `subscribeAuthProviderConfig` has the same coarse no-payload contract as `subscribeUsers`.
 
 ---

--- a/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
+++ b/packages/site-docs/src/content/docs/pyric-auth-reference-sandbox-test-driver.md
@@ -8,9 +8,11 @@ order: 15004
 # Sandbox test driver: `pyric/auth/sandbox.*`
 
 The `sandbox` export is `pyric/auth`'s test-driver namespace. It mirrors `pyric/firestore`'s `sandbox.setRules` / `sandbox.seedDocuments` pattern: methods exist only for sandbox-backed `Auth` handles and throw `failed-precondition` against a prod handle.
+
 ```ts
 import { sandbox as authSandbox } from 'pyric/auth';
 ```
+
 The import alias avoids the name collision with the local `const sandbox = initializeSandbox()` you'll typically have in scope.
 
 ---
@@ -18,6 +20,7 @@ The import alias avoids the name collision with the local `const sandbox = initi
 ## `sandbox.setUser(auth, user | null)`
 
 Force the current user. Bypasses email/password lookup, mock-result registry, and seeded DB. Pass `null` to sign out.
+
 ```ts
 authSandbox.setUser(auth, {
   uid: 'forced-uid',
@@ -34,6 +37,7 @@ authSandbox.setUser(auth, {
   }),
 });
 ```
+
 Emits to `onAuthStateChanged` / `onIdTokenChanged` subscribers and writes through to `sandbox.currentUser`.
 
 ---
@@ -41,6 +45,7 @@ Emits to `onAuthStateChanged` / `onIdTokenChanged` subscribers and writes throug
 ## `sandbox.mockSignInResult(auth, result)`
 
 Pre-stage the result that the next matching `signInWithPopup` / `signInWithCredential` call returns. The mock is **one-shot**, consumed by the next call with the matching `providerId`. Stage again for repeat tests.
+
 ```ts
 authSandbox.mockSignInResult(auth, {
   user: makeGoogleUser('uid-1', 'a@example.com'),
@@ -54,6 +59,7 @@ await signInWithPopup(auth, new GoogleAuthProvider());
 await signInWithPopup(auth, new GoogleAuthProvider());
 // → throws auth/no-mock-configured
 ```
+
 The provider passed to `signInWithPopup` must have a `providerId` that matches `result.providerId`.
 
 ---
@@ -61,6 +67,7 @@ The provider passed to `signInWithPopup` must have a `providerId` that matches `
 ## `sandbox.seedUsers(auth, users)`
 
 Bulk-load test users for email/password lookup. Each record:
+
 ```ts
 interface SeedUser {
   uid: string;
@@ -69,7 +76,9 @@ interface SeedUser {
   displayName?: string;
   customClaims?: Record<string, unknown>;
 }
-``````ts
+```
+
+```ts
 authSandbox.seedUsers(auth, [
   { uid: 'alice', email: 'alice@example.com', password: 'pw1' },
   {
@@ -85,6 +94,7 @@ await signInWithEmailAndPassword(auth, 'admin@example.com', 'pw2');
 // auth.currentUser.uid === 'admin'
 // (await auth.currentUser.getIdTokenResult()).claims.role === 'admin'
 ```
+
 `customClaims` flow through into `sandbox.currentUser.token`, which is what the Firestore rules engine reads as `request.auth.token.*`. This is the seam that makes rules tests with custom claims work end-to-end on sandbox.
 
 Email lookup is case-insensitive. Re-seeding the same uid overwrites.

--- a/packages/site-docs/src/content/docs/pyric-auth.md
+++ b/packages/site-docs/src/content/docs/pyric-auth.md
@@ -12,14 +12,17 @@ Sandbox-only modular Web SDK Auth mirror. It implements `firebase/auth`'s tree-s
 Application code keeps canonical `firebase/auth` imports. Pyric's Vite/import-map or Node register boundary swaps those imports to this mirror in sandbox mode; production installs no swap and continues loading Firebase itself. Direct `pyric/auth` imports always select sandbox behavior.
 
 ## Install
+
 ```bash
 bun add pyric firebase
 ```
+
 `firebase` supplies the canonical production package. It is not a runtime dependency of the `pyric/auth` mirror.
 
 ## A 30-second example
 
 Sandbox backend:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getAuth, signInWithEmailAndPassword, onAuthStateChanged, sandbox as authSandbox } from 'pyric/auth';
@@ -38,7 +41,9 @@ onAuthStateChanged(auth, (user) => {
 await signInWithEmailAndPassword(auth, 'alice@example.com', 'pw');
 console.log(auth.currentUser?.uid); // 'alice'
 ```
+
 Production uses the canonical package without a Pyric swap:
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { getAuth, signInWithEmailAndPassword } from 'firebase/auth';
@@ -48,6 +53,7 @@ const auth = getAuth(app);
 
 await signInWithEmailAndPassword(auth, 'alice@example.com', 'pw');
 ```
+
 ## What's in v0
 
 The deliberately-minimal surface covers everything an `appSource` likely needs:

--- a/packages/site-docs/src/content/docs/pyric-cli-bridge.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-bridge.md
@@ -2,7 +2,7 @@
 title: "@pyric/cli/bridge"
 group: "@pyric/cli"
 section: "Bridge"
-order: 9013
+order: 9011
 ---
 # `@pyric/cli/bridge`
 
@@ -14,9 +14,11 @@ or `pyric dev --bridge`). This module is the implementation underneath.
 ## What this does
 
 Pyric's headline value is that an AI agent can see and act on the **same browser context** the developer sees: the in-page sandbox, its state, its rules, its event log. External MCP clients (Claude Code, Cursor) run in a terminal, not a browser tab. This bridge connects the two:
+
 ```
 external MCP client ──HTTP MCP──► pyric bridge (Node) ◄──WebSocket── browser tab (sandbox)
 ```
+
 The bridge process exposes:
 
 - `POST /mcp`: MCP-over-HTTP using `@modelcontextprotocol/sdk`.
@@ -30,6 +32,7 @@ operations are not registered.
 ## Two entry points, one package
 
 Conditional exports route to the right bundle based on runtime:
+
 ```jsonc
 {
   "exports": {
@@ -40,18 +43,22 @@ Conditional exports route to the right bundle based on runtime:
   }
 }
 ```
+
 - **Node** (`import { startServer } from '@pyric/cli/bridge'`): gets `createBridge`, `startServer`. (The Vite integration is `pyricSandbox({ bridge })` in `@pyric/cli/vite`.)
 - **Browser**: gets `connectBridge`.
 
 The wire format (shared types) lives in `protocol.ts` and is referenced from both bundles.
 
 ## CLI
+
 ```bash
 pyric bridge                          # sandbox bridge on 127.0.0.1:5174
 pyric bridge --port 6000 --project demo
 pyric dev --bridge                    # mount MCP on the dev-server origin
 ```
+
 ## Programmatic use
+
 ```ts
 import { startServer } from '@pyric/cli/bridge';
 
@@ -59,8 +66,10 @@ const handle = await startServer({ mode: 'sandbox', port: 5174 });
 // later
 await handle.stop();
 ```
+
 For Vite users, the bridge is folded into the `pyricSandbox` plugin: one plugin
 does the `firebase/*` → sandbox swap **and** the bridge:
+
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
@@ -68,6 +77,7 @@ import { pyricSandbox } from '@pyric/cli/vite';
 
 export default defineConfig({ plugins: [pyricSandbox({ bridge: true })] });
 ```
+
 The plugin mounts the bridge on Vite's own dev server at `/__pyric/mcp`,
 `/__pyric/health`, and `/__pyric/sandbox` (WS), so the bridge shares Vite's port
 instead of running as a sidecar. The agent's tool-calls route through the
@@ -75,6 +85,7 @@ SharedWorker, so the app, Pyric Studio, and the agent all share one sandbox. See
 [Use the Vite plugin](../pyric-cli-how-to-use-the-vite-plugin/#drive-the-sandbox-from-an-agent-bridge).
 
 ## Browser side
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { connectBridge } from '@pyric/cli/bridge';
@@ -87,6 +98,7 @@ if (import.meta.env.DEV) {
   connectBridge(sandbox);
 }
 ```
+
 ## See also
 
 - Agent tool inventory

--- a/packages/site-docs/src/content/docs/pyric-cli-functions-rtdb-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-functions-rtdb-compat.md
@@ -3,7 +3,7 @@ title: "Firebase Functions RTDB integration compatibility"
 navLabel: "Functions · RTDB"
 group: "Conformance"
 section: ""
-order: 8010
+order: 6012
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-build-a-standalone-binary.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-build-a-standalone-binary.md
@@ -13,14 +13,18 @@ Ship `pyric` as a single self-contained executable: no Node, no npm, no
 ## Build
 
 From the repo root:
+
 ```bash
 bun run compile:standalone        # clean build + all four cross-targets
 ```
+
 or, iterating inside the package (assumes `bun run build` already ran):
+
 ```bash
 bun run --cwd packages/cli compile        # all four targets
 bun run --cwd packages/cli compile host   # just this machine (fast)
 ```
+
 Binaries land in `packages/cli/dist-bin/`:
 
 | File | Platform |
@@ -35,9 +39,11 @@ Binaries land in `packages/cli/dist-bin/`:
 ~100 MB binaries are release artifacts, never published to npm or committed.
 
 Verify a build:
+
 ```bash
 bun run --cwd packages/cli smoke:standalone
 ```
+
 ## How `dev` works in the binary
 
 Every command runs from the binary, including `dev` (the headline one).
@@ -62,10 +68,12 @@ available to a scaffold by **vendoring**: the
 compile step also `npm pack`s both packages and embeds the tarballs, and
 `pyric init` (in the standalone binary) writes them into `vendor/` and points the
 project's deps at them:
+
 ```jsonc
 "devDependencies": { "@pyric/cli": "file:vendor/pyric-cli.tgz", "pyric": "file:vendor/pyric.tgz", … },
 "overrides": { "pyric": "file:vendor/pyric.tgz" }
 ```
+
 `bun install` then resolves `pyric`/`@pyric/cli` from `vendor/` and everything
 else (`firebase`, `vite`, `@inbrowser/agent`, `esbuild`) from npm. The
 `overrides` pin is load-bearing: a **placeholder `pyric` is published to npm at a
@@ -79,18 +87,22 @@ a clone installs offline too.
 
 Once the packages are published (or against a private registry), scaffold with
 registry deps instead:
+
 ```bash
 pyric init --template web --deps npm                 # ^<binary version>
 pyric init --template web --deps npm --pyric-version 0.1.0
 ```
+
 Default is `vendor` in the standalone binary, `npm` otherwise (e.g. `npx pyric`
 from the monorepo). `PYRIC_INIT_DEPS=npm` sets the default; `--deps` overrides it.
 
 Smoke the whole chain (`init → bun install → vite build`, offline for
 `pyric`/`@pyric/cli`) against a compiled binary:
+
 ```bash
 bun run --cwd packages/cli smoke:vendor
 ```
+
 ## Contract
 
 - **ESM-only**, like the npm package. The binary embeds its own runtime.

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-promote-sandbox-state-to-a-fixture.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-promote-sandbox-state-to-a-fixture.md
@@ -23,31 +23,39 @@ reference](../pyric-cli-reference-cli/).
 
 Run a persisted dev server and use the app: sign in, write documents, whatever you
 want the fixture to capture:
+
 ```sh
 pyric dev --persist
 ```
+
 `--persist` writes runtime state to `.pyric/state/state.json` as you go, so
 your data survives between sessions while you build it up.
 
 ## Promote it to a fixture
 
 With that dev server still running, snapshot it:
+
 ```sh
 pyric snapshot
 ```
+
 This reads the live dev server and writes a re-servable fixture to
 `pyric-state.json` (both docs and auth users). Choose a different path with
 `--out`:
+
 ```sh
 pyric snapshot --out fixtures/onboarding.json
 ```
+
 `pyric snapshot` refuses to clobber an existing file. Pass `--force` to
 overwrite it.
 
 If the live dev server is on a non-default port, point at it with `--port`:
+
 ```sh
 pyric snapshot --port 5002
 ```
+
 If no dev server is running, `pyric snapshot` falls back to the on-disk
 `.pyric/state/state.json`, so you can still promote state from a dev server you have
 since stopped.
@@ -55,10 +63,12 @@ since stopped.
 ## Commit the fixture
 
 The fixture is a plain JSON file meant to live in your repository:
+
 ```sh
 git add fixtures/onboarding.json
 git commit -m "Add onboarding fixture"
 ```
+
 User passwords are **redacted by default**: `.pyric/` is gitignored, but a
 promoted fixture is not, so committing raw passwords would leak them. The
 redaction sentinel round-trips through seeding, so re-serving still works
@@ -66,18 +76,22 @@ redaction sentinel round-trips through seeding, so re-serving still works
 
 To keep passwords for a local-only fixture you do not intend to commit, opt in
 explicitly:
+
 ```sh
 pyric snapshot --out local-fixture.json --include-passwords
 ```
+
 Only do this for trusted, local fixtures. Never commit a fixture produced this
 way.
 
 ## Re-seed from the fixture
 
 Anyone with the committed file can start from exactly the same state:
+
 ```sh
 pyric dev --seed fixtures/onboarding.json
 ```
+
 See [serve persistence and multi-tab](../pyric-cli-how-to-serve-persistence-and-multi-tab/) for
 more on `--seed` and how seeded state interacts with `--persist`.
 
@@ -85,6 +99,7 @@ more on `--seed` and how seeded state interacts with `--persist`.
 
 For scripts and CI, `--json` emits the result (output path, doc and user
 counts, source, redacted-password count) to stdout:
+
 ```sh
 pyric snapshot --out fixtures/onboarding.json --json
 ```

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-run-rtdb-onvaluecreated.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-run-rtdb-onvaluecreated.md
@@ -1,8 +1,9 @@
 ---
 title: "Run an RTDB onValueCreated function locally"
-group: "@pyric/cli"
-section: "How-to"
-order: 9006
+navLabel: "Run an RTDB function locally"
+group: "Develop with Firebase APIs"
+section: ""
+order: 2007
 ---
 # Run an RTDB `onValueCreated` function locally
 
@@ -12,16 +13,19 @@ Realtime Database as your app and Pyric Studio. The function source keeps its
 production imports and needs no credentials or deployment.
 
 Your `firebase.json` must declare one Functions source:
+
 ```json
 {
   "hosting": { "public": "public" },
   "functions": { "source": "functions" }
 }
 ```
+
 The source package's `main` field selects the built CommonJS JavaScript entry.
 It defaults to `index.js`. Native ESM Functions entries are not supported in
 this first slice; compile an ESM or TypeScript source package to CommonJS and
 point `main` at that output:
+
 ```json
 {
   "name": "my-functions",
@@ -32,7 +36,9 @@ point `main` at that output:
   }
 }
 ```
+
 Keep the production function unchanged:
+
 ```js
 const { onValueCreated } = require('firebase-functions/v2/database');
 
@@ -43,27 +49,36 @@ exports.makeUppercase = onValueCreated(
     .set(event.data.val().toUpperCase()),
 );
 ```
+
 Build the Functions package if its `main` points at generated JavaScript, then
 start the project:
+
 ```bash
 npx pyric dev
 ```
+
 Keep the browser tab that opens running. Pyric discovers the Functions entry,
 starts it in an isolated Node child, and reports its supported exports:
+
 ```text
 • functions waiting for the browser tab to connect the sandbox…
 ✔ functions 1 onValueCreated trigger from functions/lib/index.js
 ```
+
 Create the matching value through your ordinary client code:
+
 ```js
 import { getDatabase, ref, set } from 'firebase/database';
 
 await set(ref(getDatabase(), 'messages/id/original'), 'hello');
 ```
+
 The terminal reports the execution:
+
 ```text
 ✔ function  makeUppercase ← /messages/id/original (pushId=id)
 ```
+
 The app and Studio now read `messages/id/uppercase` as `"HELLO"` from that
 same sandbox. Press Ctrl-C to stop both `pyric dev` and the Functions child.
 

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-serve-persistence-and-multi-tab.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-serve-persistence-and-multi-tab.md
@@ -3,7 +3,7 @@ title: "Persistence and multi-tab with pyric dev"
 navLabel: "Persistence & multi-tab"
 group: "@pyric/cli"
 section: "How-to"
-order: 9007
+order: 9006
 ---
 # Persistence and multi-tab with `pyric dev`
 
@@ -65,9 +65,11 @@ Notes, honestly stated:
   port, profile, or incognito window is a fresh sandbox.
 
 ## Persist to a committable file: `--persist`
+
 ```bash
 pyric dev --persist
 ```
+
 `--persist` adds a durable, **git-trackable** state file at
 `.pyric/state/state.json`. The sandbox restores from it on start and mirrors
 writes back to it. Reach for it when you want sandbox state that:
@@ -114,9 +116,11 @@ private window) whenever you pass `--fresh`. (A real reset handshake that makes
 `--fresh` clear the browser store too is future work.)
 
 ## Seed data on boot: `--seed`
+
 ```bash
 pyric dev --seed seed.json
 ```
+
 Loads a fixture document set admin-style before your app runs. Accepts either a
 `"collection/doc" → fields` map or a `pyric snapshot` state file.
 

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-use-the-vite-plugin.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-use-the-vite-plugin.md
@@ -3,7 +3,7 @@ title: "Use the Vite plugin (@pyric/cli/vite)"
 navLabel: "Use the Vite plugin"
 group: "@pyric/cli"
 section: "How-to"
-order: 9008
+order: 9007
 ---
 # Use the Vite plugin (`@pyric/cli/vite`)
 
@@ -48,14 +48,17 @@ a pre-built or no-build app, reach for [`pyric dev`](../pyric-cli-how-to-serve-p
 ## Install
 
 Add `@pyric/cli` as a development dependency:
+
 ```bash
 npm install --save-dev @pyric/cli
 ```
+
 (`vite` is a peer dependency you already have.)
 
 ## Add it to `vite.config.ts`
 
 Import `pyricSandbox` from `@pyric/cli/vite` and add it to your `plugins`:
+
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
@@ -65,6 +68,7 @@ export default defineConfig({
   plugins: [pyricSandbox()],
 });
 ```
+
 With no options, the plugin discovers your rules from `firebase.json`'s
 `firestore.rules`, falling back to `firestore.rules` in your project root.
 
@@ -82,6 +86,7 @@ With no options, the plugin discovers your rules from `firebase.json`'s
 | `capture` | `boolean` | `true` | Write the live session to `.pyric/last-session.json` for `pyric verify`. Pass `false` to suppress. |
 | `bridge` | `boolean \| { project?, disableAuditLog? }` | `false` | Mount the **MCP bridge** so an external agent can drive the sandbox. `true` ⇒ defaults; the object form sets the audit project / disables the audit log. The agent shares the **same SharedWorker sandbox** as your app (and Studio). See [Drive the sandbox from an agent](#drive-the-sandbox-from-an-agent-bridge). |
 | `swapInBuild` | `boolean` | mode-based | Force whether `vite build` runs the swap, overriding the mode default. Unset: swap for any non-`production` mode. `true` = always a sandbox build; `false` = always real firebase in builds. `vite dev` is unaffected. See [Two build flavors](#two-build-flavors-production-vs-sandbox). |
+
 ```ts
 // Point at a non-default rules file, and persist + seed the sandbox
 pyricSandbox({
@@ -90,12 +95,15 @@ pyricSandbox({
   seed: 'seed.json',
 });
 ```
+
 ## Run your app on the sandbox
 
 Start your normal dev server:
+
 ```bash
 npm run dev   # i.e. vite dev
 ```
+
 Now `vite dev` serves your app against the in-process pyric sandbox:
 
 - Your app's `firebase/*` imports are **unchanged**: the plugin swaps
@@ -114,14 +122,18 @@ Now `vite dev` serves your app against the in-process pyric sandbox:
 Edit your `firestore.rules` and save. The plugin watches the file (through
 Vite's own watcher, no second file watcher) and **re-deploys the rules in
 place**, with no page reload. You'll see a line like:
+
 ```
   ↻ [pyric] rules reloaded (a1b2c3d4e5f6)
 ```
+
 If a save leaves the rules un-parseable, the plugin keeps the **last good**
 ruleset live and warns instead of breaking your session:
+
 ```
   ⚠ [pyric] rules NOT reloaded (last-good stays live): <reason>
 ```
+
 Fix the file and save again to deploy the corrected rules.
 
 ### Multi-tab sync and persistence
@@ -134,16 +146,20 @@ data is held in IndexedDB (it survives a refresh). If the browser lacks
 That IndexedDB data is still **browser-local**: it doesn't land in your repo. To
 make data + test users durable across restarts (and committable), turn on
 `persist`:
+
 ```ts
 pyricSandbox({ persist: true });          // writes .pyric/state/state.json
 pyricSandbox({ persist: true, fresh: true }); // wipe + re-seed this run
 ```
+
 To preload data, point `seed` at a `"collection/doc" → fields` map or a file from
 `pyric snapshot`. With `persist`, the seed applies only on the first run. After
 that, **lived state wins**:
+
 ```ts
 pyricSandbox({ seed: 'seed.json' });
 ```
+
 The persistence model (the `.pyric/state` file, `persist` vs `fresh`, and how
 seed precedence works) is identical to `pyric dev` and documented in depth in
 [Persistence and multi-tab](../pyric-cli-how-to-serve-persistence-and-multi-tab/).
@@ -153,11 +169,13 @@ seed precedence works) is identical to `pyric dev` and documented in depth in
 Turn on `bridge` and the plugin mounts the **MCP bridge** on Vite's own dev
 origin, so an external agent (Claude Code, Cursor, any MCP client) can read and
 write the *same* sandbox your app is using, live, while you keep `vite dev`:
+
 ```ts
 pyricSandbox({ bridge: true });
 // or tune the audit log:
 pyricSandbox({ bridge: { project: 'my-app', disableAuditLog: false } });
 ```
+
 This adds three routes on your dev server's port (no sidecar process):
 
 | Route | What it is |
@@ -210,10 +228,12 @@ sandbox init chunk (the runtime bootstrap and the sign-in helper) that shares
 one runtime with your app, nothing to intercept or inject at load time, so you
 can preview a bundled build under `pyric dev` (which sees the marker and skips
 its own runtime injection for these pages):
+
 ```bash
 vite build --mode development   # or the scaffolded `build:sandbox` script
 pyric dev                       # serves dist/ against the sandbox
 ```
+
 The output carries a **sandbox-build marker** in `index.html`
 (`<meta name="pyric-sandbox-build">`). The marker makes the flavor unmistakable:
 

--- a/packages/site-docs/src/content/docs/pyric-cli-how-to-verify-against-a-captured-session.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-how-to-verify-against-a-captured-session.md
@@ -1,9 +1,9 @@
 ---
 title: "How to verify your rules against a captured session"
-navLabel: "Verify rules"
-group: "@pyric/cli"
-section: "How-to"
-order: 9009
+navLabel: "Verify a captured session"
+group: "Verify the boundary"
+section: ""
+order: 4001
 ---
 # How to verify your rules against a captured session
 
@@ -18,57 +18,72 @@ Capture is on by default in `pyric dev`, so the loop has three steps.
 
 1. Start the sandbox. The session is written to `.pyric/last-session.json` as
    you go:
+
    ```sh
    pyric dev
    ```
+
    (Pass `--no-capture` to disable the recording.)
 
 2. Exercise your app against the running sandbox: sign in, create documents,
    run the journeys you care about. Every write is recorded.
 
 3. Replay the latest capture against the rules you intend to deploy:
+
    ```sh
    pyric verify
    ```
+
    With no positional argument, `verify` reads `.pyric/last-session.json`.
    It verifies the Firestore and RTDB services present in that capture.
    Candidate rules are resolved from `firebase.json`:
+
    ```json
    {
      "firestore": { "rules": "firestore.rules" },
      "database": { "rules": "database.rules.json" }
    }
    ```
+
 ## Verify against edited rules
 
 If you've tightened or rewritten your rules and want to check them before
 deploying, pass service-qualified rules overrides:
+
 ```sh
 pyric verify --rules firestore=path/to/firestore.rules
 pyric verify --rules rtdb=path/to/database.rules.json
 ```
+
 The capture stays fixed; only the ruleset changes. The diff between what the
 sandbox allowed and what these rules allow is exactly what surfaces.
 
 For a mixed capture, repeat `--rules`:
+
 ```sh
 pyric verify \
   --rules firestore=firestore.rules \
   --rules rtdb=database.rules.json
 ```
+
 To check only one service in a mixed capture, use `--service`:
+
 ```sh
 pyric verify --service rtdb --rules rtdb=database.rules.json
 ```
+
 ## Choose a verification engine
 
 The default engine is `sandbox`: Firestore uses local replay and RTDB uses the
 local RTDB replay primitive. This is the fast loop for development and CI:
+
 ```sh
 pyric verify journeys/checkout.json --engine sandbox
 ```
+
 For Firestore, you can also derive Rules Test API cases from the same fixture
 and send them to Firebase's hosted Rules Test API:
+
 ```sh
 pyric verify journeys/checkout.json \
   --service firestore \
@@ -76,8 +91,10 @@ pyric verify journeys/checkout.json \
   --project demo-app \
   --rules firestore=firestore.rules
 ```
+
 Use `both` when you want the local sandbox replay and hosted Firestore result in
 one run:
+
 ```sh
 pyric verify journeys/checkout.json \
   --service firestore \
@@ -85,6 +102,7 @@ pyric verify journeys/checkout.json \
   --project demo-app \
   --rules firestore=firestore.rules
 ```
+
 RTDB verification is sandbox-only. RTDB constraints still feed verification as
 RTDB rules JSON or an in-process `RtdbRulesDocument`; they are not a separate
 verification service.
@@ -93,11 +111,13 @@ verification service.
 
 When you want to see exactly what will be sent to the Rules Test API, derive the
 cases without running verification:
+
 ```sh
 pyric verify cases journeys/checkout.json \
   --service firestore \
   --out journeys/checkout.cases.json
 ```
+
 The output contains `testCases`, warnings, and unsupported events. Admin/setup
 traffic and listener re-evaluations are excluded so the cases describe user
 behavior protected by rules.
@@ -105,48 +125,59 @@ behavior protected by rules.
 ## Verify a specific fixture
 
 To replay a saved fixture instead of the latest capture, pass its path:
+
 ```sh
 pyric verify journeys/checkout.json
 ```
+
 ## Interpreting the result
 
 A session **fails** (exit code `1`) when replay finds a failing divergence:
 a write that succeeded in the sandbox would now be denied, an operation is not
 replayable, or the replayed state differs from the captured state. Each failure
 is labelled by service:
+
 ```
 ✗ chat - rtdb: 1 failure(s)
     [rtdb] now-denied: set /rooms/r1/messages/m1 (PERMISSION_DENIED)
 ```
+
 Firestore auto-id aliases, time drift, and sentinel drift are informational.
 They are expected artefacts of replaying generated values, so they do not fail
 the run. A clean run exits `0`:
+
 ```
 ✓ chat - firestore: ok (0 informational), rtdb: ok (0 informational)
 
 ✓ all selected services replay cleanly.
 ```
+
 ## Run a suite in CI
 
 To verify many captured journeys at once, point `verify` at a directory. Every
 `*.json` fixture in it is replayed and the command exits non-zero if any one
 diverges:
+
 ```sh
 pyric verify journeys/ --rules firestore=firestore.rules
 ```
+
 Add `--json` for machine-readable output to feed into a dashboard or gate.
 
 A minimal CI step: fail the build if any captured journey would break under
 the rules being shipped:
+
 ```yaml
 - name: Verify rules against captured journeys
   run: pyric verify journeys/ --rules firestore=firestore.rules
 ```
+
 The non-zero exit on a real divergence is what blocks the merge.
 
 ## Verify from code
 
 Use `@pyric/cli/verify` when your RTDB rules are authored in memory:
+
 ```ts
 import { verifyFixture } from '@pyric/cli/verify';
 import { rules } from './database.rules.js';
@@ -160,10 +191,12 @@ const result = await verifyFixture(fixture, {
 
 if (!result.ok) process.exit(1);
 ```
+
 `rules` can be an RTDB rules JSON object or an `RtdbRulesDocument` from
 `defineRtdbRules()`.
 
 Firestore can use the hosted engine from code:
+
 ```ts
 import { verifyFixture } from '@pyric/cli/verify';
 
@@ -177,4 +210,5 @@ const result = await verifyFixture(fixture, {
   },
 });
 ```
+
 For the full flag list, see the [`pyric verify` reference](../pyric-cli-reference-cli/).

--- a/packages/site-docs/src/content/docs/pyric-cli-reference-cli.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-reference-cli.md
@@ -2,7 +2,7 @@
 title: "pyric CLI reference"
 group: "@pyric/cli"
 section: "Reference"
-order: 9010
+order: 9008
 ---
 # `pyric` CLI reference
 
@@ -148,6 +148,7 @@ missing candidate rules exits `2`. Firestore auto-id aliases, time drift, and
 sentinel drift are informational and do not fail.
 
 Examples:
+
 ```sh
 pyric verify
 pyric verify journeys/ --rules firestore=firestore.rules
@@ -156,6 +157,7 @@ pyric verify journeys/checkout.json --engine both --project demo-app
 pyric verify --service rtdb --rules rtdb=database.rules.json
 pyric verify --rules firestore=firestore.rules --rules rtdb=database.rules.json
 ```
+
 See [verify against a captured session](../pyric-cli-how-to-verify-against-a-captured-session/).
 
 ### `pyric verify cases [fixture] [flags]`
@@ -167,9 +169,11 @@ verification.
 |---|---|---|
 | `--service firestore` | `firestore` | The service to derive cases for. Only Firestore is supported. |
 | `--out <path>` | stdout | Write the derived case JSON to a file. |
+
 ```sh
 pyric verify cases journeys/checkout.json --service firestore --out journeys/checkout.cases.json
 ```
+
 ### `pyric mcp`
 
 Start a stdio MCP server for editors. It attaches to a running `pyric dev

--- a/packages/site-docs/src/content/docs/pyric-cli-reference-package-and-resolution.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-reference-package-and-resolution.md
@@ -2,17 +2,19 @@
 title: "Package exports and resolution"
 group: "@pyric/cli"
 section: "Reference"
-order: 9011
+order: 9009
 ---
 # Package exports and resolution
 
 Install `@pyric/cli` as a development dependency. It provides the `pyric`
 binary and a small set of explicit programmatic subpaths; the package root is
 not an import target.
+
 ```bash
 npm install -D @pyric/cli
 npx pyric --help
 ```
+
 ## Public subpaths
 
 | Import | Purpose |

--- a/packages/site-docs/src/content/docs/pyric-cli-reference-verify.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-reference-verify.md
@@ -2,7 +2,7 @@
 title: "Verify API"
 group: "@pyric/cli"
 section: "Reference"
-order: 9012
+order: 9010
 ---
 # Verify API
 
@@ -10,6 +10,7 @@ order: 9012
 same fixture format and replay behavior as `pyric verify`.
 
 ## `verifyFixture(fixture, options)`
+
 ```ts
 import { verifyFixture } from '@pyric/cli/verify';
 
@@ -26,8 +27,10 @@ const result = await verifyFixture(fixture, {
   },
 });
 ```
+
 `fixture` must use schema `pyric.verify.fixture.v1`. The fixture has one
 ordered `events` timeline and per-service blocks under `services`.
+
 ```ts
 type VerifyRulesInput = {
   firestore?: string | { source: string };
@@ -35,7 +38,9 @@ type VerifyRulesInput = {
   storage?: string | { source: string };
 };
 ```
+
 `RtdbRulesDocument` values are compiled to rules JSON before replay.
+
 ```ts
 type VerifyEngine = 'sandbox' | 'rulesTestApi';
 
@@ -54,10 +59,12 @@ type VerifyFixtureOptions = {
   };
 };
 ```
+
 `engines` defaults to `['sandbox']`. `rulesTestApi` is Firestore-only in this
 release. Selecting it for RTDB returns an input error.
 
 ## Result shape
+
 ```ts
 type VerifyResult = {
   ok: boolean;
@@ -75,10 +82,12 @@ type VerifyServiceResult = {
   engines?: Partial<Record<VerifyEngine, VerifyEngineResult>>;
 };
 ```
+
 Failing divergence kinds are `now-denied`, `now-allowed`, `state-drift`,
 `unsupported`, and `engine-drift`. `expected-drift` is informational.
 
 ## `deriveRulesTestCases(fixture, options)`
+
 ```ts
 import { deriveRulesTestCases } from '@pyric/cli/verify';
 
@@ -87,18 +96,21 @@ const cases = deriveRulesTestCases(fixture, {
   mockReads: 'strict',
 });
 ```
+
 This compiles captured Firestore request events into Firebase Rules Test API
 `TestCase[]` values. Listener re-evaluations and admin/setup requests are
 excluded. Unsupported derivation entries fail verification when the
 `rulesTestApi` engine is selected.
 
 ## Fixture helpers
+
 ```ts
 import {
   buildVerifyFixture,
   parseVerifyFixture,
 } from '@pyric/cli/verify';
 ```
+
 `buildVerifyFixture()` is used by `pyric dev` capture. Most users read the
 captured JSON from `.pyric/last-session.json`; custom harnesses can use the
 builder to emit the same schema.

--- a/packages/site-docs/src/content/docs/pyric-cli-tutorials-server-adoption.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-tutorials-server-adoption.md
@@ -24,16 +24,20 @@ Takes about five minutes.
   the current directory.
 
 ## Step 1: Install
+
 ```bash
 npm i -D @pyric/cli
 ```
+
 `@pyric/cli` provides the CLI and Node resolver; its sandbox mirror
 dependencies are installed with it. None of them appear in your app code.
 
 ## Step 2: Run it
+
 ```bash
 npx pyric dev
 ```
+
 `pyric dev` starts the sandbox host and then runs **your own `dev`
 script** with the environment activated (or run an explicit command:
 `npx pyric dev -- node server.mjs`). Whenever it runs your server,
@@ -41,6 +45,7 @@ script** with the environment activated (or run an explicit command:
 calls travel through, no extra flag needed.
 
 Your server needs nothing pyric-shaped. This works as-is:
+
 ```js
 // server.mjs — zero pyric identifiers
 import { createServer } from 'node:http';
@@ -65,8 +70,10 @@ createServer(async (req, res) => {
   res.end('ok');
 }).listen(8080, () => console.log('api listening on http://localhost:8080'));
 ```
+
 The terminal shows the host banner, then your dev command's output
 prefixed with `[dev]`:
+
 ```
 === Serving from '/Users/you/code/your-app'...
 
@@ -90,15 +97,18 @@ prefixed with `[dev]`:
 [dev] pyric: firebase-admin routed to sandbox at http://localhost:3473
 [dev] api listening on http://localhost:8080
 ```
+
 (The `register: active` line appears once per Node process; `npm run
 dev` is itself a Node process, so seeing it twice is normal.)
 
 A browser tab on <http://localhost:3473> auto-opens: **it is the
 backend**, so keep it open. Now:
+
 ```bash
 curl http://localhost:8080/signup
 # {"uid":"user-1"}
 ```
+
 That user, the RTDB profile, and the stored avatar all landed in the
 sandbox your browser tab hosts. Run with `--ui` instead and Pyric Studio
 (`http://localhost:3473/__pyric/ui/`) shows the data live as your server
@@ -174,11 +184,13 @@ instead; nothing silently no-ops.
 second terminal): skip the child runner and set the two env vars
 yourself, with `pyric dev --bridge --no-run` (or any `pyric dev --bridge`)
 running elsewhere:
+
 ```bash
 PYRIC_SANDBOX=remote \
 NODE_OPTIONS="--import @pyric/cli/register" \
 node server.mjs
 ```
+
 `PYRIC_SANDBOX=remote` auto-discovers the running dev server via
 `.pyric/serve.json` in your project (written when `--bridge` is on);
 `PYRIC_SANDBOX=remote:http://localhost:3473` pins the URL explicitly.
@@ -188,6 +200,7 @@ start your dev server with the bridge enabled and retry.``
 
 **Explicit wiring for tests**: when you want pyric identifiers on
 purpose instead of env-var routing:
+
 ```ts
 import { connectRemoteSandbox } from '@pyric/cli/remote';
 import { initializeApp } from 'pyric-admin/app';
@@ -199,6 +212,7 @@ const db = getDatabase(app);
 // ...assertions...
 sandbox.close();
 ```
+
 An explicit config always bypasses the environment, so pyric-aware test
 code keeps full control even under `pyric dev`.
 

--- a/packages/site-docs/src/content/docs/pyric-cli-tutorials-wire-claude-code.md
+++ b/packages/site-docs/src/content/docs/pyric-cli-tutorials-wire-claude-code.md
@@ -33,15 +33,19 @@ Should take ~10 minutes.
 ## Step 1: Install pyric
 
 In your app's repo:
+
 ```bash
 npm install --save-dev pyric
 ```
+
 This pulls in the bridge implementation (`@pyric/cli/bridge`) as part of `@pyric/cli`.
 
 Verify:
+
 ```bash
 npx pyric --version
 ```
+
 Expected output: a version string (e.g. `0.0.0`).
 
 ## Step 2: Connect your app to the bridge
@@ -49,6 +53,7 @@ Expected output: a version string (e.g. `0.0.0`).
 The bridge waits for a browser tab to register a sandbox over WebSocket. Your app needs to call `connectBridge()` from `@pyric/cli/bridge` (browser entry) in dev mode.
 
 **Vite users**: the simplest path. Use the `pyricSandbox` plugin with `bridge: true`. One plugin does the `firebase/*` → sandbox swap **and** the bridge, so you don't even add the `connectBridge` snippet below:
+
 ```ts
 import { defineConfig } from 'vite';
 import { pyricSandbox } from '@pyric/cli/vite';
@@ -57,9 +62,11 @@ export default defineConfig({
   plugins: [pyricSandbox({ bridge: true })],
 });
 ```
+
 The plugin attaches the bridge to Vite's own dev server (so it shares Vite's port instead of running as a sidecar) AND wires the browser side automatically via the served init payload. You can skip Step 3 and 4: your app is already wired. `bridge: true` routes the agent's tool-calls through the **SharedWorker**, so the agent, your app, and Pyric Studio all share one sandbox (keep a tab open while the agent works); see [Use the Vite plugin](../pyric-cli-how-to-use-the-vite-plugin/#drive-the-sandbox-from-an-agent-bridge).
 
 **Non-Vite users**: add a small dev-mode snippet wherever your app initializes the sandbox:
+
 ```ts
 // e.g. src/main.ts or wherever you call initializeSandbox()
 import { initializeSandbox } from 'pyric/sandbox';
@@ -71,15 +78,19 @@ if (import.meta.env.DEV /* or NODE_ENV === 'development' */) {
   connectBridge(sandbox);
 }
 ```
+
 The conditional gate is important: `connectBridge` opens a WebSocket to `127.0.0.1:5174`, which doesn't exist in production. Without the gate, your production build would attempt a failed WebSocket handshake on page load.
 
 ## Step 3: Start the bridge (non-Vite users only)
 
 Open a new terminal in your app's directory and run:
+
 ```bash
 npx pyric bridge
 ```
+
 Expected output:
+
 ```
 pyric bridge 0.0.0 — mode: sandbox, project: sandbox
   listening on http://127.0.0.1:5174
@@ -90,6 +101,7 @@ pyric bridge 0.0.0 — mode: sandbox, project: sandbox
 
 Waiting for browser tab to connect. Ctrl-C to stop.
 ```
+
 Leave this terminal running.
 
 > Vite users: skip this step, the bridge already runs as part of `npm run dev`.
@@ -97,10 +109,13 @@ Leave this terminal running.
 ## Step 4: Verify the bridge is reachable
 
 In a third terminal:
+
 ```bash
 curl http://127.0.0.1:5174/health
 ```
+
 Expected:
+
 ```json
 {
   "status": "ok",
@@ -111,6 +126,7 @@ Expected:
   "startedAt": "2026-05-24T..."
 }
 ```
+
 The `sandboxConnected: false` is correct: no browser tab has registered yet. Vite users with the plugin: the URL is your Vite dev server's, with `/__pyric/health` as the path (e.g. `http://localhost:5173/__pyric/health`).
 
 ## Step 5: Open your app in a browser
@@ -118,36 +134,44 @@ The `sandboxConnected: false` is correct: no browser tab has registered yet. Vit
 Run your usual dev command (`npm run dev`, `bun run dev`, …) and open the app in a browser. Your `connectBridge(sandbox)` call (Step 2) will run and open the WebSocket.
 
 Verify with another curl:
+
 ```bash
 curl http://127.0.0.1:5174/health
 ```
+
 Expected: `"sandboxConnected": true`.
 
 If it's still `false`, check the browser devtools console for WebSocket errors. The most common cause is the dev-mode gate (Step 2 conditional) being false. Add a `console.log('pyric: connecting')` line above `connectBridge(...)` to confirm it runs.
 
 ## Step 6: Register the bridge with Claude Code
+
 ```bash
 claude mcp add pyric --transport http \
   --url http://127.0.0.1:5174/mcp \
   --scope project
 ```
+
 `--scope project` writes the MCP config to `.mcp.json` in the current directory (checked into git, shared with your team). Other scopes:
 
 - `--scope user`: `~/.claude.json`, personal only.
 - `--scope local`: this machine, this project, not checked in.
 
 Verify the registration:
+
 ```bash
 claude mcp list
 ```
+
 Expected: `pyric` shows in the list with `transport: http` and the URL.
 
 ## Step 7: Confirm Claude Code sees the bridge
 
 Inside Claude Code (in your terminal or IDE), run:
+
 ```
 /mcp
 ```
+
 Expected: `pyric` appears as a configured MCP server, status `connected`. If status shows `disconnected`, check the bridge process is still running (Step 3 terminal) and the URL matches.
 
 If Claude Code was already running when you ran `claude mcp add`, you may need to restart it to pick up new project-scoped MCP config.
@@ -169,9 +193,11 @@ Expected behavior:
 Open the browser devtools and check the sandbox's state: `users/u1` should be present.
 
 You can also verify via the audit log (sandbox events flow through the bridge's `onToolEvent` hook):
+
 ```bash
 tail -n 5 ~/.pyric/projects/sandbox/events.ndjson
 ```
+
 Each line is a JSON object with `tool`, `args`, `result`, `mode`, `timestamp`.
 
 ## Step 9: Try a sandbox-management tool

--- a/packages/site-docs/src/content/docs/pyric-conformance-scores.md
+++ b/packages/site-docs/src/content/docs/pyric-conformance-scores.md
@@ -2,7 +2,7 @@
 title: "Conformance scores"
 group: "Conformance"
 section: ""
-order: 8001
+order: 6003
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-database-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-database-compat.md
@@ -3,7 +3,7 @@ title: "pyric/database compatibility matrix"
 navLabel: "Realtime Database"
 group: "Conformance"
 section: ""
-order: 8005
+order: 6007
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 
@@ -1096,7 +1096,9 @@ The sandbox implementation has landed (`packages/pyric/src/database/modular.ts` 
 
 `packages/conformance/src/run.ts` now deploys an RTDB rules namespace
 analogous to `ensureOracleRules` / `ensureOracleStorageRules`. The
-JSON shape:```json
+JSON shape:
+
+```json
 {
   "rules": {
     ".read": false,
@@ -1108,7 +1110,9 @@ JSON shape:```json
     }
   }
 }
-```The harness mints a separate OAuth token scoped to
+```
+
+The harness mints a separate OAuth token scoped to
 `https://www.googleapis.com/auth/firebase.database` (the broader
 `firebase` scope used by Firestore + Storage + Management APIs is
 NOT accepted by the per-database rules endpoint) and `PUT`s to

--- a/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-database-explanation-rules-authoring-and-deploy-are-separate.md
@@ -21,8 +21,10 @@ That split keeps the in-memory workflow usable in tests, code generation, agent
 planning, and browser-like hosts. A caller can inspect `rtdbRules(rules).toJSON()`
 without holding credentials, write `database.rules.json` (or run
 `pyric database rules generate`), then ship later:
+
 ```bash
 firebase deploy --only database
 ```
+
 Agent tools keep the same boundary. Local simulation and generate tools return
 JSON-shaped artifacts; production release is outside pyric's CLI surface.

--- a/packages/site-docs/src/content/docs/pyric-database-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-api.md
@@ -27,12 +27,14 @@ Firebase-shaped package.
 ## Initialization
 
 ### `getDatabase(target?)`
+
 ```ts
 function getDatabase(): Database;
 function getDatabase(ctx: SandboxContext): Database;
 function getDatabase(sandbox: Sandbox): Database;
 function getDatabase(app: FirebaseApp): Database;
 ```
+
 Build a sandbox `Database` handle. Three overloads select its identity mode:
 
 - `SandboxContext` (from `sandbox.withAuth(...)`): sandbox-backed with a frozen identity.
@@ -46,16 +48,19 @@ A real production `FirebaseApp` or any foreign value throws a
 One backend per `Sandbox`: repeat calls for the same sandbox return handles that share data, matching `firebase/database`'s singleton-per-app behavior. The sandbox tree also registers as a persistable service, so `enablePersistence` includes RTDB data in the serialized blob and restores it on reload.
 
 ### `getAdminDatabase(target)`
+
 ```ts
 function getAdminDatabase(sandbox: Sandbox): Database;
 function getAdminDatabase(ctx: SandboxContext): Database;
 function getAdminDatabase(app: FirebaseApp): Database;
 ```
+
 Rules-bypass handle for sandbox setup and inspection, the RTDB counterpart of
 `getAdminFirestore`. Reads and writes through it skip rule evaluation. Foreign
 or non-sandbox app values throw a `TypeError`.
 
 ### `connectDatabaseEmulator(db, host, port, options?)`
+
 ```ts
 function connectDatabaseEmulator(
   db: Database,
@@ -64,12 +69,15 @@ function connectDatabaseEmulator(
   options?: { mockUserToken?: string | EmulatorMockTokenOptions },
 ): void;
 ```
+
 Accepted as a no-op because the selected backend already runs in-process.
 
 ### `TARGET_SYMBOL`
+
 ```ts
 const TARGET_SYMBOL: unique symbol;
 ```
+
 The hidden brand on every `Database` handle that routes each free function to its backend. Exported so advanced callers can detect a Pyric handle; there is no reason to read it in application code.
 
 ---
@@ -77,61 +85,79 @@ The hidden brand on every `Database` handle that routes each free function to it
 ## Refs, reads, and writes
 
 ### `ref(db, path?)`
+
 ```ts
 function ref(db: Database, path?: string): DatabaseReference;
 ```
+
 Build a `DatabaseReference` at `path` (default root). Leading and trailing slashes are stripped; an empty path or `'/'` is the root. Refs carry their routing internally, so every function below accepts a ref without the `db` handle.
 
 ### `child(parent, path)`
+
 ```ts
 function child(parent: DatabaseReference, path: string): DatabaseReference;
 ```
+
 Ref at `<parent>/<path>`. Empty segments are stripped; the result inherits the parent's target.
 
 ### `get(refOrQuery)`
+
 ```ts
 function get(r: DatabaseReference | Query): Promise<DataSnapshot>;
 ```
+
 One-shot read. An absent path resolves to a snapshot where `val()` is `null` and `exists()` is `false`. Passing a `Query` returns the ordered, windowed result.
 
 Sandbox reads run through the rule engine. A denial throws a plain `Error` (not a `FirebaseError`) with `code === 'PERMISSION_DENIED'` and message `'PERMISSION_DENIED: Permission denied'`, the exact shape recorded from production (oracle `rtdb-rules-denied-error-code.json`).
 
 ### `set(ref, value)`
+
 ```ts
 function set(r: DatabaseReference, value: unknown): Promise<void>;
 ```
+
 Replace the value at the ref's path. `set(ref, null)` deletes, the RTDB invariant (oracle `rtdb-remove-vs-set-null.json`). `serverTimestamp()` and `increment()` sentinels resolve at write time.
 
 ### `update(ref, values)`
+
 ```ts
 function update(r: DatabaseReference, values: Record<string, unknown>): Promise<void>;
 ```
+
 Partial update with two modes, decided by the keys:
 
 - Keys containing `/` make it a multi-path atomic update: every listed path is written as one transaction, and any denial fails the whole batch.
 - Plain keys make it a shallow merge at the ref's path: each top-level key replaces the corresponding child, and `null` values delete.
 
 ### `remove(ref)`
+
 ```ts
 function remove(r: DatabaseReference): Promise<void>;
 ```
+
 Delete the subtree at the ref's path. Dispatches through the same path as `set(ref, null)`.
 
 ### `push(ref, value?)`
+
 ```ts
 function push(r: DatabaseReference, value?: unknown): ThenableReference;
 ```
+
 Mint an auto-id child key under the ref's path, optionally writing `value` there. The key is minted client-side: the returned ref and its `.key` are available synchronously, even when the optional write is later denied by rules (the denial rejects the thenable's promise instead of throwing). Keys are 20 characters, start with `-`, and sort lexicographically by creation time (oracle `rtdb-push-autoid-format.json`).
 
 ### `pushKey()`
+
 ```ts
 function pushKey(): string;
 ```
+
 Pre-mint a push key without writing. Useful when a multi-path `update` needs the key up front:
+
 ```ts
 const key = pushKey();
 await update(ref(db), { [`/users/${key}/name`]: 'Alice', [`/index/${key}`]: true });
 ```
+
 ---
 
 ## Listeners
@@ -139,6 +165,7 @@ await update(ref(db), { [`/users/${key}/name`]: 'Alice', [`/index/${key}`]: true
 All subscribe functions return an `Unsubscribe` (`() => void`). Calling it twice is a no-op. A listener callback that throws is swallowed, matching `firebase/database`, so one observer's exception never blocks others.
 
 ### `onValue(refOrQuery, cb, options?)`
+
 ```ts
 function onValue(
   r: DatabaseReference | Query,
@@ -146,6 +173,7 @@ function onValue(
   options?: { onlyOnce?: boolean },
 ): Unsubscribe;
 ```
+
 Fires immediately on subscribe with the current value (`null` and `exists: false` for an absent path), then on every write touching the path or a descendant. With `onlyOnce: true` the listener auto-unsubscribes after its first fire.
 
 On a `Query`, the listener fires only when the windowed result changes: a write outside the window does not re-fire it, a write inside or one that displaces a member does (oracle `rtdb-modular-onvalue-with-query.json`).
@@ -153,30 +181,39 @@ On a `Query`, the listener fires only when the windowed result changes: a write 
 Subscribing under rules that deny the read throws the `PERMISSION_DENIED` plain-`Error` shape synchronously.
 
 ### `onChildAdded(refOrQuery, cb)`
+
 ```ts
 function onChildAdded(r: DatabaseReference | Query, cb: (snap: DataSnapshot) => void): Unsubscribe;
 ```
+
 On subscribe, replays every existing direct child (one fire per key). After that, fires exactly once per new direct child. On a `Query`, a child entering the window fires, and the current window is replayed in window order on subscribe.
 
 ### `onChildChanged(refOrQuery, cb)`
+
 ```ts
 function onChildChanged(r: DatabaseReference | Query, cb: (snap: DataSnapshot) => void): Unsubscribe;
 ```
+
 No initial replay. Fires when an existing direct child transitions to a new non-null value; the snapshot carries the new value. Does not fire for added or removed children.
 
 ### `onChildRemoved(refOrQuery, cb)`
+
 ```ts
 function onChildRemoved(r: DatabaseReference | Query, cb: (snap: DataSnapshot) => void): Unsubscribe;
 ```
+
 No initial replay. Fires when a direct child is deleted (`remove(child)` or `set(child, null)`); the snapshot carries the prior, now-removed value. On a `Query`, a child leaving the window (displaced past a `limitTo*` boundary, or filtered out) also fires with its prior value.
 
 ### `onChildMoved(refOrQuery, cb)`
+
 ```ts
 function onChildMoved(r: DatabaseReference | Query, cb: (snap: DataSnapshot) => void): Unsubscribe;
 ```
+
 Only meaningful under an ordered query; under a plain ref the subscription is accepted but never fires, matching the upstream SDK. **Sandbox divergence:** the sandbox accepts the subscription on a query but does not yet fire on reorders, while production does. The reorder and `previousChildName` semantics are held pending fresh oracle captures. This is a documented, pinned divergence.
 
 ### `off(ref, eventType?, callback?)`
+
 ```ts
 function off(
   r: DatabaseReference,
@@ -184,6 +221,7 @@ function off(
   callback?: (snap: DataSnapshot) => void,
 ): void;
 ```
+
 Unsubscribe variant (oracle `rtdb-modular-off-stops-child-fires.json`):
 
 - `off(ref)` removes all listeners at the ref, value and every child variety.
@@ -197,6 +235,7 @@ The unsubscribe function returned by `onValue` / `onChild*` is equivalent to the
 ## Transactions and write sentinels
 
 ### `runTransaction(ref, transactionUpdate, options?)`
+
 ```ts
 function runTransaction<T>(
   r: DatabaseReference,
@@ -204,6 +243,7 @@ function runTransaction<T>(
   options?: { applyLocally?: boolean },
 ): Promise<TransactionResult>;
 ```
+
 Atomic read-modify-write. The oracle-locked contract:
 
 1. `transactionUpdate` receives the current value; an absent path passes `null`, not `undefined`.
@@ -214,15 +254,19 @@ Atomic read-modify-write. The oracle-locked contract:
 `options.applyLocally` (default `true`): when `false`, listeners skip the optimistic intermediate value and see only the committed one. The single-client sandbox has no other writer to conflict with, so the update function runs once; the documented retry-on-conflict path never engages.
 
 ### `serverTimestamp()`
+
 ```ts
 function serverTimestamp(): ServerTimestampSentinel;
 ```
+
 Returns the `{ '.sv': 'timestamp' }` sentinel. Resolves to epoch milliseconds (a number) at write time on both targets (oracle `rtdb-servertimestamp-resolves.json`). The sentinel type itself is not exported; treat the return value as opaque.
 
 ### `increment(delta)`
+
 ```ts
 function increment(delta: number): IncrementSentinel;
 ```
+
 Returns the `{ '.sv': { increment: delta } }` sentinel that atomically adds `delta` to the value at the written field. Starts from `0` when the field is absent or non-numeric (oracle `rtdb-modular-increment-from-missing.json`).
 
 ---
@@ -230,22 +274,27 @@ Returns the `{ '.sv': { increment: delta } }` sentinel that atomically adds `del
 ## Query builder
 
 ### `query(refOrQuery, ...constraints)`
+
 ```ts
 function query(refOrQuery: DatabaseReference | Query, ...constraints: QueryConstraint[]): Query;
 ```
+
 Wrap a ref in an immutable constraint chain, then pass the result to `get`, `onValue`, or the `onChild*` listeners. Chaining folds: `query(query(ref, orderByChild('x')), limitToFirst(2))` merges both constraints into one spec.
 
 ### Ordering constraints
+
 ```ts
 function orderByChild(path: string): QueryConstraint;
 function orderByKey(): QueryConstraint;
 function orderByValue(): QueryConstraint;
 ```
+
 - `orderByChild(path)` orders children by the value at a nested child path (oracle `rtdb-modular-orderbychild-window.json`).
 - `orderByKey()` orders lexicographically by key string (oracle `rtdb-modular-orderbykey-window.json`).
 - `orderByValue()` orders by primitive value. Production requires `.indexOn: ".value"` and throws `Index not defined` without it; the sandbox does not enforce indexes (oracle `rtdb-modular-orderbyvalue-numeric.json`).
 
 ### Bound constraints
+
 ```ts
 function startAt(value: JsonValue, key?: string): QueryConstraint;
 function startAfter(value: JsonValue, key?: string): QueryConstraint;
@@ -253,19 +302,24 @@ function endAt(value: JsonValue, key?: string): QueryConstraint;
 function endBefore(value: JsonValue, key?: string): QueryConstraint;
 function equalTo(value: JsonValue, key?: string): QueryConstraint;
 ```
+
 `startAt` and `endAt` are inclusive; `startAfter` and `endBefore` are exclusive (oracle `rtdb-modular-startafter-endbefore-exclusive.json`). The optional `key` breaks ties when ordering by child or value and several children share the bound's value. `equalTo(v, key?)` is sugar for `startAt(v, key)` plus `endAt(v, key)` and returns all matching children, with no uniqueness assumption (oracle `rtdb-modular-equalTo-filter.json`).
 
 ### Limit constraints
+
 ```ts
 function limitToFirst(n: number): QueryConstraint;
 function limitToLast(n: number): QueryConstraint;
 ```
+
 Keep the first or last `n` children of the ordered window (oracle `rtdb-modular-limittofirst-vs-limittolast.json`).
 
 ### `QUERY_SYMBOL`
+
 ```ts
 const QUERY_SYMBOL: unique symbol;
 ```
+
 The brand on every `Query`, used internally to dispatch `get` / `onValue` between plain refs and query-wrapped refs. Exported for detection; not needed in application code.
 
 ---
@@ -274,6 +328,7 @@ The brand on every `Query`, used internally to dispatch `get` / `onValue` betwee
 
 Sandbox lifecycle operations retained as mirror extensions for compatibility.
 Prefer the owner-oriented `pyric/sandbox/database` entry for new code.
+
 ```ts
 const sandbox: {
   setRules(db: Database, rulesJson: { rules: Record<string, unknown> } | null): void;
@@ -281,6 +336,7 @@ const sandbox: {
   snapshotState(db: Database): JsonValue;
 };
 ```
+
 - `setRules(db, rulesJson)` replaces the deployed rules. Pass `null` to clear; the sandbox returns to default-allow. Rules evaluate through the same simulator engine that backs `simulate()` and the `rtdb_simulate_access` tool.
 - `setData(db, data)` bulk-loads fixtures bypassing rules. Keys are absolute paths (`'/users/alice'`); values land at those paths.
 - `snapshotState(db)` reads the full tree bypassing rules. Usually a keyed object; a primitive when the root holds one.
@@ -289,6 +345,7 @@ const sandbox: {
 ## Connection compatibility helpers
 
 These Firebase-shaped calls are accepted by the in-process mirror:
+
 ```ts
 function goOffline(db: Database): void;
 function goOnline(db: Database): void;
@@ -300,6 +357,7 @@ function enableLogging(
 ): void;
 function refFromURL(db: Database, url: string): DatabaseReference;
 ```
+
 The connection and transport controls are no-ops because the sandbox has no
 network connection to configure. `refFromURL` parses the URL locally and
 returns a reference owned by the supplied sandbox database.

--- a/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-constraints.md
@@ -98,11 +98,13 @@ Supported Zod types: `string`, `number`, `boolean`, `enum`, `literal` (string, n
 ## Assembly
 
 ### `defineRtdbRules(definition)`
+
 ```ts
 function defineRtdbRules(definition: {
   paths: Record<string, PathDef> | ((ctx: RulesetContext) => void);
 }): RtdbRulesDocument;
 ```
+
 The authoring entry, and the one to reach for first. The returned
 `RtdbRulesDocument` is an inert authored artifact: on the public surface it
 exposes no methods. Pass it to `rtdbRules()` for everything analytical:
@@ -122,16 +124,19 @@ environment-independent. The method-bearing document interface (with
 `pyric/rules/internal/rtdb`.
 
 ### `ruleset(input)`
+
 ```ts
 function ruleset(
   input: Record<string, PathDef> | ((ctx: RulesetContext) => void),
 ): CompiledRtdbRules;
 ```
+
 The raw compiled-tree builder underneath `defineRtdbRules`. Same path inputs,
 no document wrapper. Returns `CompiledRtdbRules` (the `RtdbNode` root), not a
 project-scoped IR.
 
 ### `PathDef`
+
 ```ts
 interface PathDef {
   read?: Expr;
@@ -143,6 +148,7 @@ interface PathDef {
   children?: Record<string, PathDef>;
 }
 ```
+
 Placement semantics worth knowing:
 
 - Path keys are literal strings with `$wildcards` as segments (`'/games/$gameId'`); every `$segment` becomes a path variable in scope for expression validation.

--- a/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
+++ b/packages/site-docs/src/content/docs/pyric-database-reference-rules-tooling.md
@@ -11,6 +11,7 @@ re-exported directly from `pyric/rules`. The engine underneath it (expression
 parser, validator, linter, compile/simulate/serialize, and replay) is
 engine-internal, on the `pyric/rules/internal/rtdb` subpath. That subpath isn't
 covered by the public `pyric/rules` contract and may change without notice.
+
 ```ts
 import { defineRtdbRules, rtdbRules } from 'pyric/rules';
 import {
@@ -21,11 +22,13 @@ import {
   parseExpression,
 } from 'pyric/rules/internal/rtdb';
 ```
+
 ## Constraints authoring
 
 ### `defineRtdbRules(definition): RtdbRulesDocument`
 
 Create an in-memory RTDB rules document from path constraints.
+
 ```ts
 import { defineRtdbRules, deny, pathOwnerOnly } from 'pyric/rules';
 
@@ -39,12 +42,15 @@ const rules = defineRtdbRules({
   },
 });
 ```
+
 `definition`:
+
 ```ts
 type RtdbRulesDefinition = {
   paths: Record<string, PathDef> | ((ctx: RulesetContext) => void);
 };
 ```
+
 There is no `databaseUrl` on the definition. Compilation is
 environment-independent; the database URL is a Firebase project concern when
 you ship with `firebase-tools`, not part of the authored artifact.
@@ -54,6 +60,7 @@ you ship with `firebase-tools`, not part of the authored artifact.
 The value `defineRtdbRules` returns. On the public surface it is an inert
 authored artifact: the type exposes no methods. You hand it to `rtdbRules()`,
 which is the one analysis surface.
+
 ```ts
 import { rtdbRules } from 'pyric/rules';
 
@@ -71,6 +78,7 @@ const summary = ruleset.simulate([
 ]);
 const json = ruleset.toJSON();   // { rules: {...} }
 ```
+
 `lint()` folds the document's parser and linter findings into one
 `RuleIssue[]` list; a compile failure arrives as a `COMPILE_ERROR` issue
 rather than a throw. `simulate(cases)` takes `RtdbCase[]` and returns
@@ -86,6 +94,7 @@ The method-bearing document interface (`toJSON` / `compile` / `check` /
 `simulate` method (the public `rtdbRules().simulate` takes `RtdbCase[]`
 instead). It accepts the existing simulation fields plus these authoring
 conveniences:
+
 ```ts
 type RtdbRulesSimulationInput = {
   operation: 'read' | 'write' | 'validate';
@@ -96,10 +105,12 @@ type RtdbRulesSimulationInput = {
   newData?: unknown;
 };
 ```
+
 `auth: 'alice'` becomes `{ uid: 'alice', token: {} }`. `data` is an alias for
 `mockData`; if both are supplied, `mockData` is used.
 
 `RtdbRulesCheckResult`:
+
 ```ts
 type RtdbRulesCheckResult = {
   ok: boolean;
@@ -107,6 +118,7 @@ type RtdbRulesCheckResult = {
   warnings: RtdbRulesFinding[];
 };
 ```
+
 Compile failures return an error finding with code `COMPILE_ERROR`.
 
 ### Generating `database.rules.json`
@@ -118,12 +130,14 @@ the same compilation and never recompiles the rules a second time.
 
 For scripts running in Node, `pyric/rules/internal/node` exports a helper that
 writes the file directly:
+
 ```ts
 import { writeRtdbRulesFile } from 'pyric/rules/internal/node';
 import { rules } from './database.rules.js';
 
 const path = await writeRtdbRulesFile(rules, 'database.rules.json');
 ```
+
 #### `writeRtdbRulesFile(doc, path): Promise<string>`
 
 Compiles `doc` and writes the rules JSON as pretty-printed output to `path`,
@@ -134,9 +148,11 @@ itself: `rtdbRules(rules).toJSON()`, from the public `pyric/rules`, never
 pulls in Node builtins.
 
 #### CLI
+
 ```sh
 pyric database rules generate [--config <path>] [--out <path>]
 ```
+
 Loads a constraints module (default `database.rules.ts`, or the `--config`
 path), looks for a named `rules` export or a default export produced by
 `defineRtdbRules(...)`, compiles it to rules JSON, and writes it to `--out`
@@ -154,6 +170,7 @@ returns the compiled `{ rulesJson }` without contacting a Firebase project.
 
 Constraints documents can be passed directly to `@pyric/cli/verify` as
 candidate RTDB rules:
+
 ```ts
 import { verifyFixture } from '@pyric/cli/verify';
 import { rules } from './database.rules.js';
@@ -165,12 +182,17 @@ const result = await verifyFixture(fixture, {
   rules: { rtdb: rules },
 });
 ```
+
 For CLI verification, generate JSON first and pass it as the RTDB rules file:
+
 ```ts
 await Bun.write('database.rules.json', JSON.stringify(rtdbRules(rules).toJSON(), null, 2));
-``````sh
+```
+
+```sh
 pyric verify --service rtdb --rules rtdb=database.rules.json
 ```
+
 Verification lives in `@pyric/cli/verify` because constraints are an authoring
 surface and captured-session replay is local tooling around an app session.
 The Firebase Rules Test API engine is Firestore-only; RTDB constraints verify by
@@ -190,6 +212,7 @@ Convert a compiled tree back to Firebase RTDB rules JSON.
 ### `simulateRtdbRules(compiled, input): SimulateResult`
 
 Evaluate one operation against a compiled rules tree.
+
 ```ts
 const compiled = compileRtdbRules({
   rules: {
@@ -208,7 +231,9 @@ const result = simulateRtdbRules(compiled, {
   mockData: {},
 });
 ```
+
 `SimulationInput`:
+
 ```ts
 type SimulationInput = {
   operation: 'read' | 'write' | 'validate';
@@ -218,6 +243,7 @@ type SimulationInput = {
   newData?: unknown;
 };
 ```
+
 ### `replay` / expression helpers
 
 Also on `pyric/rules/internal/rtdb`:
@@ -260,6 +286,7 @@ groups are:
 - assembly: `defineRtdbRules`, `ruleset`, `schemaRules`
 
 ### `PathDef`
+
 ```ts
 interface PathDef {
   read?: Expr;
@@ -271,6 +298,7 @@ interface PathDef {
   children?: Record<string, PathDef>;
 }
 ```
+
 `schema` supports Zod object fields composed from strings, numbers, booleans,
 enums, literals, unions of supported types, nested objects, and optional fields.
 Unsupported Zod types throw during compilation.

--- a/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-database-tutorials-01-author-rtdb-rules-with-constraints.md
@@ -21,6 +21,7 @@ You will build rules for room messages:
 ## Create the rules document
 
 Create `database.rules.ts`:
+
 ```ts
 import { z } from 'zod';
 import {
@@ -58,9 +59,11 @@ export const rules = defineRtdbRules({
   },
 });
 ```
+
 ## Check the document
 
 Save a small check script as `database.rules.check.ts`:
+
 ```ts
 import { rtdbRules } from 'pyric/rules';
 import { rules } from './database.rules.js';
@@ -75,10 +78,13 @@ if (issues.some((i) => i.severity === 'error')) {
 
 console.log(ruleset.toJSON());
 ```
+
 Run it:
+
 ```bash
 bun database.rules.check.ts
 ```
+
 You will see a complete Firebase RTDB rules JSON object. The `lint()` call
 returns warnings alongside errors (one flat `RuleIssue[]`), so you can decide
 whether to fail your own workflow on warnings.
@@ -86,6 +92,7 @@ whether to fail your own workflow on warnings.
 ## Simulate a write
 
 Save one simulation as `database.rules.simulate.ts`:
+
 ```ts
 import { rtdbRules } from 'pyric/rules';
 import { rules } from './database.rules.js';
@@ -109,26 +116,33 @@ const result = rtdbRules(rules).explain({
 
 console.log(result);
 ```
+
 Run it:
+
 ```bash
 bun database.rules.simulate.ts
 ```
+
 The result is allowed. Change `auth` to `'bob'` or change `newData.author` to a
 different uid and run it again; the same rule document now denies the write.
 
 ## Generate JSON for deployment
 
 Write the compiled JSON with the Node helper:
+
 ```ts
 import { writeRtdbRulesFile } from 'pyric/rules/internal/node';
 import { rules } from './database.rules.js';
 
 await writeRtdbRulesFile(rules, 'database.rules.json');
 ```
+
 or from the CLI, without writing a script at all:
+
 ```sh
 pyric database rules generate --config database.rules.ts --out database.rules.json
 ```
+
 Both routes run the same compilation `rtdbRules(rules).toJSON()` performs. See
 [RTDB rules tooling](../pyric-database-reference-rules-tooling/#generating-databaserulesjson)
 for the full reference, including the `rtdb_generate_rules` MCP tool.
@@ -141,6 +155,7 @@ generated the JSON expected by Firebase Realtime Database.
 After running `pyric dev` and exercising the app, the latest session is saved
 to `.pyric/last-session.json`. You can verify that capture against the in-memory
 rules document before generating JSON:
+
 ```ts
 import { verifyFixture } from '@pyric/cli/verify';
 import { rules } from './database.rules.js';
@@ -155,7 +170,9 @@ if (!result.ok) {
   process.exit(1);
 }
 ```
+
 For the CLI path, use the JSON file from the previous step:
+
 ```bash
 pyric verify --service rtdb --rules rtdb=database.rules.json
 ```

--- a/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
+++ b/packages/site-docs/src/content/docs/pyric-explanation-versioning-and-compatibility.md
@@ -17,9 +17,11 @@ Pyric ships a large surface that Firebase does not have: the sandbox runtime, th
 ## Firebase compatibility ships as a dist-tag
 
 The compatibility claim is an npm dist-tag of the form `fb<major>.<minor>`.
+
 ```
 npm install pyric@fb12.16
 ```
+
 A `fb<major>.<minor>` tag points at the newest pyric release whose conformance gates pass against that line of Firebase. Installing `pyric@fb12.16` gets you the pyric that has been conformance-tested against Firebase 12.16.
 
 The tag means "conformance-tested against Firebase 12.16." It does not mean "equal to Firebase 12.16" and it does not mean "full parity with Firebase 12.16." Those are claims pyric does not make and the conformance numbers do not back. The tag is a statement about what was tested, not a statement about how much matched.

--- a/packages/site-docs/src/content/docs/pyric-firestore-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-compat.md
@@ -3,7 +3,7 @@ title: "pyric/firestore compatibility matrix"
 navLabel: "Firestore"
 group: "Conformance"
 section: ""
-order: 8003
+order: 6005
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-rules-tooling-is-separate.md
@@ -53,10 +53,12 @@ These belong to a different audience than the data-plane consumers. A web app ra
 
 `setRules(sandbox, rules)` loads rules into the local Firestore environment owned
 by that sandbox. The implementation path is:
+
 ```ts
 setRules(sandbox, source) → LocalEnvironment.deployRules(source)
                           → lintFirestoreRules(source)
 ```
+
 The control receives the owner rather than a Firestore handle. This lets one
 sandbox own Firestore rules, documents, listeners, history, and diagnostics
 without widening the data-plane API.

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-target-symbol-opacity.md
@@ -8,11 +8,13 @@ order: 11016
 # The `TARGET_SYMBOL` opacity contract
 
 The public `Firestore` type has exactly one property:
+
 ```ts
 interface Firestore {
   readonly [TARGET_SYMBOL]: Target;
 }
 ```
+
 `TARGET_SYMBOL` is a `unique symbol`. No string keys, no methods. This page explains the choice.
 
 ## What it accomplishes
@@ -28,11 +30,13 @@ The handle's contents are an internal detail. Consumers never read `db.target` o
 Any property the package exposes becomes part of the public API. Removing or renaming it later is a breaking change. By exposing only `TARGET_SYMBOL`, the package keeps the freedom to restructure internals without affecting consumers.
 
 The package's *free functions* take `db: Firestore` as an argument and read the symbol internally:
+
 ```ts
 function targetOf(handle: Firestore): Target {
   return handle[TARGET_SYMBOL];
 }
 ```
+
 Consumers don't import `TARGET_SYMBOL`. They pass handles to functions that know how to use it.
 
 ## Why a `unique symbol`
@@ -54,6 +58,7 @@ The symbol is `Symbol('pyric/firestore/target')`. The string description is for 
 ## What consumers can do with the handle
 
 Pass it to functions. That's it. The intended usage:
+
 ```ts
 const db = getFirestore(target);
 doc(db, 'notes/n1');                // valid
@@ -62,6 +67,7 @@ db.doc;                              // type error
 db.collection;                       // type error
 db.toString();                       // works (inherited from Object), useless
 ```
+
 Consumers that need to inspect the backend (debug logs, instrumentation) can:
 
 - Track which path produced the handle and remember externally.

--- a/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-explanation-two-backends-one-surface.md
@@ -10,6 +10,7 @@ order: 11017
 Pyric and Firebase expose the same canonical module name in different
 environments. The environment chooses the package before either implementation
 loads:
+
 ```text
 import 'firebase/firestore'
            |
@@ -17,6 +18,7 @@ import 'firebase/firestore'
            |
            `-- Pyric active ----> pyric/firestore --> sandbox
 ```
+
 This is stronger than choosing a backend inside `getFirestore`. A sandbox
 module cannot accidentally acquire a production client, and a production
 module does not carry dormant simulator code.
@@ -30,6 +32,7 @@ the unswapped Firebase package is rejected.
 
 Production remains Firebase because the activation layer is absent. The Vite
 plugin and Node register hook are therefore the only switch:
+
 ```text
 source code
   import { getFirestore } from 'firebase/firestore'
@@ -39,6 +42,7 @@ source code
              Firebase SDK    Pyric mirror
               production       sandbox
 ```
+
 ## Why canonical imports matter
 
 Application source should keep importing `firebase/app` and

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-migrate-from-firebase-firestore.md
@@ -13,6 +13,7 @@ around the application instead of replacing imports with `pyric/firestore`.
 ## Node applications
 
 Given existing code such as:
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { doc, getDoc, getFirestore } from 'firebase/firestore';
@@ -21,10 +22,13 @@ const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const snapshot = await getDoc(doc(db, 'notes/n1'));
 ```
+
 run it through the register hook:
+
 ```bash
 PYRIC_SANDBOX=local node --import @pyric/cli/register app.mjs
 ```
+
 The hook resolves `firebase/app` and `firebase/firestore` to the sandbox
 mirrors. Without the environment variable and preload, Node resolves the real
 Firebase packages.
@@ -32,6 +36,7 @@ Firebase packages.
 ## Vite applications
 
 Add the plugin to the development configuration:
+
 ```ts
 import { defineConfig } from 'vite';
 import { pyricSandbox } from '@pyric/cli/vite';
@@ -40,6 +45,7 @@ export default defineConfig({
   plugins: [pyricSandbox()],
 });
 ```
+
 The plugin swaps canonical Firebase specifiers for application code and its
 dependencies. Production builds remain Firebase unless sandbox build swapping
 is explicitly enabled.
@@ -48,6 +54,7 @@ is explicitly enabled.
 
 Rules, fixtures, and state inspection are intentionally separate from the
 Firebase-shaped data plane:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { seedDocuments, setRules } from 'pyric/sandbox/firestore';
@@ -58,6 +65,7 @@ seedDocuments(sandbox, {
   'notes/n1': { title: 'fixture' },
 });
 ```
+
 Use direct sandbox construction in tests that need these controls. Application
 modules should continue using canonical Firebase imports.
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-pick-a-backend.md
@@ -11,6 +11,7 @@ Keep canonical Firebase imports in application source and select the backend by
 activating, or not activating, Pyric's package-resolution seam.
 
 ## Keep one application module
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
@@ -18,6 +19,7 @@ import { getFirestore } from 'firebase/firestore';
 const app = initializeApp({ projectId: 'your-project-id' });
 export const db = getFirestore(app);
 ```
+
 Do not add an environment conditional around `getFirestore`. The import
 resolver makes the choice before this module executes.
 
@@ -25,22 +27,27 @@ resolver makes the choice before this module executes.
 
 Run the application normally. Do not install a Pyric Vite plugin, preload the
 register hook, or set `PYRIC_SANDBOX`:
+
 ```bash
 node app.mjs
 ```
+
 `firebase/app` and `firebase/firestore` remain the real Firebase packages.
 
 ## Run the same source in the Node sandbox
 
 Let `pyric dev` activate the resolver for the child command:
+
 ```bash
 pyric dev -- node app.mjs
 ```
+
 The hook rewrites the canonical imports to `pyric/app` and
 `pyric/firestore`. The configuration object is retained for source
 compatibility but does not select a real project.
 
 ## Run the same source through Vite
+
 ```ts
 import { defineConfig } from 'vite';
 import { pyricSandbox } from '@pyric/cli/vite';
@@ -49,6 +56,7 @@ export default defineConfig({
   plugins: [pyricSandbox()],
 });
 ```
+
 `vite dev` activates the swap. A normal `vite build` leaves it inactive and
 produces the Firebase build.
 
@@ -56,6 +64,7 @@ produces the Firebase build.
 
 Use direct Pyric imports only when the test needs to control identity or
 sandbox state explicitly:
+
 ```ts
 import { getFirestore } from 'pyric/firestore';
 import { initializeSandbox } from 'pyric/sandbox';
@@ -63,6 +72,7 @@ import { initializeSandbox } from 'pyric/sandbox';
 const sandbox = initializeSandbox();
 const aliceDb = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 ```
+
 Do not pass a real `FirebaseApp` to `pyric/firestore`. The direct module is a
 sandbox-only mirror and rejects that input.
 

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-run-a-transaction.md
@@ -10,6 +10,7 @@ order: 11006
 Read a document and write based on its current value, atomically, with `runTransaction`. It works the same against either backend.
 
 ## The shape
+
 ```ts
 import { runTransaction, doc } from 'pyric/firestore';
 
@@ -23,6 +24,7 @@ const result = await runTransaction(db, async (tx) => {
 
 console.log('Counter is now:', result);
 ```
+
 `runTransaction` is a free function in the modular SDK shape; the admin shape puts it on the handle as `db.runTransaction(...)`. The first argument is the `Firestore` handle, the second is your async callback.
 
 ## All reads before any writes
@@ -32,6 +34,7 @@ Inside the callback, every read must come before every write. Read-after-write t
 ## Aborts
 
 If the callback throws, the transaction aborts: no writes apply, the original error re-throws.
+
 ```ts
 try {
   await runTransaction(db, async (tx) => {
@@ -43,6 +46,7 @@ try {
   console.error('Aborted:', e.message);
 }
 ```
+
 On sandbox, aborts are not undoable: they had no effect, so popping them as undo steps would skip a real prior write.
 
 ## Denied operations inside

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-onsnapshot.md
@@ -10,6 +10,7 @@ order: 11007
 Keep your UI live by registering snapshot listeners on documents and queries, in the modular Web SDK shape.
 
 ## Watch a document
+
 ```ts
 import { onSnapshot, doc, type DocumentSnapshot } from 'pyric/firestore';
 
@@ -24,7 +25,9 @@ const unsubscribe = onSnapshot(doc(db, 'notes', 'n1'), (snap: DocumentSnapshot) 
 // ... later
 unsubscribe();
 ```
+
 ## Watch a query
+
 ```ts
 import { onSnapshot, collection, query, where, type QuerySnapshot } from 'pyric/firestore';
 
@@ -36,11 +39,13 @@ const unsubscribe = onSnapshot(q, (snap: QuerySnapshot) => {
   }
 });
 ```
+
 `docChanges()` returns `added` / `modified` / `removed` events. On the initial fire, every matching doc is `added`.
 
 ## Observer form
 
 The Web-SDK-shaped observer takes any subset of three handlers:
+
 ```ts
 onSnapshot(doc(db, 'notes', 'n1'), {
   next: (snap) => render(snap.data()),
@@ -48,7 +53,9 @@ onSnapshot(doc(db, 'notes', 'n1'), {
   // complete is accepted but never fires.
 });
 ```
+
 ## React `useEffect` cleanup
+
 ```ts
 useEffect(() => {
   const unsubscribe = onSnapshot(doc(db, 'notes', 'n1'), (snap) => {
@@ -57,6 +64,7 @@ useEffect(() => {
   return unsubscribe;
 }, []);
 ```
+
 Returning the unsubscribe from the effect tells React to call it on unmount or re-run. Without it, every re-render registers a fresh listener and the old ones stay alive.
 
 ## Listener errors

--- a/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-how-to-use-sandbox-ops.md
@@ -9,6 +9,7 @@ order: 11008
 
 Load rules, seed data, snapshot documents, and inspect Firestore state in one
 local sandbox.
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import {
@@ -20,7 +21,9 @@ import {
 
 const sandbox = initializeSandbox();
 ```
+
 ## Deploy rules
+
 ```ts
 const lint = setRules(sandbox, `rules_version = '2';
 service cloud.firestore {
@@ -35,37 +38,45 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
   throw new Error('rules failed to lint');
 }
 ```
+
 `setRules` returns the `LintResult` from `pyric/rules`. Source with parse errors is not swapped, so check the warnings.
 
 ## Seed data
+
 ```ts
 seedDocuments(sandbox, {
   'notes/n1': { ownerId: 'alice', title: 'first' },
   'notes/n2': { ownerId: 'bob', title: 'second' },
 });
 ```
+
 Bulk-loads documents, bypassing rules. Active ruleset is preserved.
 
 ## Dump state
+
 ```ts
 const state = snapshotDocuments(sandbox);
 console.log(state);  // { 'notes/n1': {...}, 'notes/n2': {...} }
 ```
+
 Reads every stored document. Independent of rules. The returned object is a structural clone, so mutating it does not affect the sandbox.
 
 ## Inspect the service
+
 ```ts
 const report = inspect(sandbox, { recentEventLimit: 5 });
 console.log(report.rules.lint);
 console.log(report.documents.byCollection);
 console.log(report.events.recentDenials);
 ```
+
 The report is stable and JSON-serialisable, so it can be displayed by tools or
 stored as test output.
 
 ## Keep the owner and handle separate
 
 Pass the `Sandbox` to controls and the Firestore handle to data-plane functions:
+
 ```ts
 import { doc, getDoc, getFirestore } from 'pyric/firestore';
 
@@ -73,6 +84,7 @@ const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 setRules(sandbox, RULES);
 const note = await getDoc(doc(db, 'notes', 'n1'));
 ```
+
 This separation is intentional. Sandbox controls own service lifecycle and
 diagnostics; `getDoc`, `setDoc`, and the rest retain the
 `firebase/firestore`-compatible shape.

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-api.md
@@ -30,14 +30,17 @@ local. Production uses Firebase's untouched implementation through package
 resolution.
 
 ## Reference types
+
 ```ts
 interface DocumentReference<T = DocumentData> { readonly id: string; readonly path: string; }
 interface CollectionReference<T = DocumentData> { readonly id: string; readonly path: string; }
 interface Query<T = DocumentData> { readonly _isQuery?: true; }
 ```
+
 References and queries are backend-opaque. Don't read or mutate their properties beyond `id` and `path`; pass them to free functions instead.
 
 ## Snapshot types
+
 ```ts
 interface DocumentSnapshot<T = DocumentData> {
   readonly id: string;
@@ -60,6 +63,7 @@ interface QuerySnapshot<T = DocumentData> {
   docChanges(opts?: DocChangesOptions): DocumentChange<T>[];
 }
 ```
+
 ## Reads
 
 - `getDoc(ref)`
@@ -84,6 +88,7 @@ interface QuerySnapshot<T = DocumentData> {
 ## Queries
 
 Build a query by composing constraints:
+
 ```ts
 query(
   collection(db, 'notes'),
@@ -93,6 +98,7 @@ query(
   limit(20),
 );
 ```
+
 Constraint constructors:
 
 - `where(field, op, value)`
@@ -129,6 +135,7 @@ Returns an `Unsubscribe` (`() => void`).
 - `snapshotEqual(a, b)`: compare two `DocumentSnapshot`s or `QuerySnapshot`s.
 
 ## Sentinels
+
 ```ts
 import {
   FieldValue,
@@ -140,15 +147,19 @@ import {
   deleteField,
 } from 'pyric/firestore';
 ```
+
 The factory functions (`serverTimestamp()`, `increment(n)`, etc.) match `firebase/firestore`. `FieldValue` and `Timestamp` are also exported as classes for code that prefers the class form.
 
 ## Converters
+
 ```ts
 withConverter(parent, converter)
 ```
+
 Mirrors `firebase/firestore`'s `withConverter`. Apply to a `DocumentReference`, `CollectionReference`, or `Query`; the returned reference carries the converter through subsequent reads and writes.
 
 ## Sandbox-only operations
+
 ```ts
 import {
   inspect,
@@ -162,6 +173,7 @@ seedDocuments(sandbox, documents)
 snapshotDocuments(sandbox)
 inspect(sandbox)
 ```
+
 These controls accept the owning local `Sandbox`, not a `Firestore` handle. They
 are deliberately separate from the `firebase/firestore`-compatible data-plane
 surface. Remote sandboxes are rejected by the type contract.

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-getfirestore.md
@@ -9,32 +9,39 @@ order: 11011
 Constructs a Firestore handle owned by the Pyric sandbox mirror.
 
 ## Signatures
+
 ```ts
 function getFirestore(): Firestore;
 function getFirestore(context: SandboxContext): Firestore;
 function getFirestore(sandbox: Sandbox): Firestore;
 function getFirestore(app: FirebaseApp): Firestore;
 ```
+
 The `FirebaseApp` overload accepts the Firebase-shaped app returned after
 package resolution swaps canonical `firebase/app` imports to `pyric/app`.
 With no argument, `getFirestore()` resolves the registered default app,
 matching `firebase/firestore`.
 
 ## `SandboxContext`
+
 ```ts
 const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 ```
+
 The identity is frozen when the handle is constructed. Use this form for tests
 that name the acting identity explicitly.
 
 ## `Sandbox`
+
 ```ts
 const db = getFirestore(sandbox);
 ```
+
 Each operation reads `sandbox.currentUser`. This form follows authentication
 changes made through the matching `pyric/auth` sandbox.
 
 ## `FirebaseApp`
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
@@ -42,6 +49,7 @@ import { getFirestore } from 'firebase/firestore';
 const app = initializeApp({ projectId: 'demo' });
 const db = getFirestore(app);
 ```
+
 When a Pyric activation seam is active, both canonical imports resolve to the
 sandbox packages and the app is privately associated with the shared sandbox.
 Without activation, both imports remain Firebase and Firebase's own
@@ -51,10 +59,12 @@ Without activation, both imports remain Firebase and Firebase's own
 
 A direct `pyric/firestore` call rejects real Firebase apps and unrecognised
 objects:
+
 ```text
 TypeError: pyric/firestore is a sandbox-only mirror. Package resolution must
 leave firebase/firestore unchanged for production ...
 ```
+
 This error indicates that package selection happened at the wrong layer. Do
 not add a production branch to the direct mirror; import `firebase/firestore`
 without Pyric activation.

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-query-constraints.md
@@ -11,17 +11,20 @@ order: 11012
 ## Filters
 
 ### `where(field, op, value)`
+
 ```ts
 where('ownerId', '==', 'alice')
 where('priority', '>=', 5)
 where('tags', 'array-contains', 'urgent')
 where('status', 'in', ['open', 'pending'])
 ```
+
 `op` is one of `==`, `!=`, `<`, `<=`, `>`, `>=`, `array-contains`, `array-contains-any`, `in`, `not-in`.
 
 ### `or(...filters)`
 
 Compose multiple filters with OR semantics. The combined constraint matches a doc when any inner filter matches.
+
 ```ts
 query(
   collection(db, 'notes'),
@@ -31,23 +34,28 @@ query(
   ),
 );
 ```
+
 ### `and(...filters)`
 
 Compose multiple filters with AND semantics. Top-level constraints already AND together, so `and` is only needed inside an `or`.
+
 ```ts
 or(
   and(where('priority', '>=', 5), where('archived', '==', false)),
   where('flagged', '==', true),
 )
 ```
+
 ## Ordering
 
 ### `orderBy(field, direction?)`
+
 ```ts
 orderBy('createdAt')              // default 'asc'
 orderBy('createdAt', 'desc')
 orderBy('priority', 'desc')
 ```
+
 `direction` is `'asc'` or `'desc'`. Multiple `orderBy` calls in one query stack; later constraints are tiebreakers.
 
 ## Limits
@@ -79,6 +87,7 @@ Include everything up to and including the matching doc.
 ### `endBefore(snapshot)` / `endBefore(...values)`
 
 Exclude the matching doc; end just before it.
+
 ```ts
 const firstPage = await getDocs(query(
   collection(db, 'notes'),
@@ -94,6 +103,7 @@ const secondPage = await getDocs(query(
   limit(20),
 ));
 ```
+
 ## Sandbox-backend caveat
 
 Chained queries (`.where`, `.orderBy`, `.limit`) currently route to the underlying `LocalEnvironment` as whole-collection listeners when used with `onSnapshot`. The simulator fires for any change in the collection and the callback receives every document. Filter / order honouring at the listener layer is in a later slice. For `getDocs` calls, the constraints apply normally.
@@ -103,6 +113,7 @@ evaluates the filters correctly. In an inactive production run, the canonical
 import remains Firebase and uses Firebase's listener behaviour.
 
 ## Combining everything
+
 ```ts
 const q = query(
   collection(db, 'notes'),
@@ -115,6 +126,7 @@ const q = query(
   limit(20),
 );
 ```
+
 The order of constraints in the argument list doesn't change semantics. The engine sorts them into the right execution order, so keep them in a readable order for humans.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-sandbox-ops.md
@@ -9,6 +9,7 @@ order: 11013
 Firestore-specific controls are top-level exports from
 `pyric/sandbox/firestore`. They operate on the owning local `Sandbox`, not on a
 Firestore data-plane handle.
+
 ```ts
 import {
   inspect,
@@ -17,9 +18,11 @@ import {
   snapshotDocuments,
 } from 'pyric/sandbox/firestore';
 ```
+
 ## `setRules(sandbox, source): LintResult`
 
 Replace the sandbox's active Firestore ruleset.
+
 ```ts
 const lint = setRules(sandbox, `rules_version = '2';
 service cloud.firestore {
@@ -30,6 +33,7 @@ service cloud.firestore {
   }
 }`);
 ```
+
 The result contains the rules linter's findings. Source with parse-level errors
 is not installed. After a successful change, active snapshot listeners
 re-evaluate under the new rules.
@@ -39,31 +43,37 @@ re-evaluate under the new rules.
 Replace the sandbox's Firestore documents in bulk while preserving the current
 rules. Seeding bypasses rules evaluation and does not synthesise request events
 or listener callbacks.
+
 ```ts
 seedDocuments(sandbox, {
   'notes/n1': { ownerId: 'alice', title: 'first' },
   'notes/n2': { ownerId: 'bob', title: 'second' },
 });
 ```
+
 ## `snapshotDocuments(sandbox): Record<string, DocumentData>`
 
 Return a structural clone of every Firestore document without snapshotting any
 other sandbox service.
+
 ```ts
 const documents = snapshotDocuments(sandbox);
 console.log(documents['notes/n1']);
 ```
+
 Mutating the result does not affect the sandbox.
 
 ## `inspect(sandbox, options?): FirestoreInspectReport`
 
 Return a JSON-serialisable report containing the current rules and lint
 findings, document counts, and recent Firestore requests and denials.
+
 ```ts
 const report = inspect(sandbox, { recentEventLimit: 5 });
 console.log(report.documents.totalCount);
 console.log(report.events.recentDenials);
 ```
+
 `recentEventLimit` defaults to `10`.
 
 ## Ownership contract

--- a/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-reference-tool-factories.md
@@ -7,6 +7,7 @@ order: 11014
 # Tool factories
 
 `createFirestoreDataTools(deps)` wraps the modular Firestore data plane as `@inbrowser/agent` tool handlers.
+
 ```ts
 import { createFirestoreDataTools } from 'pyric/firestore';
 import { createToolRegistry } from '@inbrowser/agent';
@@ -18,12 +19,15 @@ const tools = createFirestoreDataTools({
 const registry = createToolRegistry();
 for (const h of tools) registry.register(h);
 ```
+
 ## `FirestoreDataToolDeps`
+
 ```ts
 interface FirestoreDataToolDeps {
   resolveDb: (as?: As) => Promise<Firestore> | Firestore;
 }
 ```
+
 The resolver fires per-dispatch with the op's `as` value. Hosts decide what backend to return:
 
 - **`'admin'` (or omitted)**: an admin-mode handle that BYPASSES rules. The default, for sandbox seeding.
@@ -32,6 +36,7 @@ The resolver fires per-dispatch with the op's `as` value. Hosts decide what back
 A sandbox resolver may default to admin. A resolver wired to a promoted/real backend MUST reject `'admin'` and require an explicit identity.
 
 ## `As`
+
 ```ts
 type As = 'admin' | UserAuth;
 
@@ -40,6 +45,7 @@ interface UserAuth {
   claims?: Record<string, unknown>;
 }
 ```
+
 The value passed to `resolveDb` from a tool call's `as` field. The explicit `'admin'` literal makes bypass **named** (you opt into it by writing `as: 'admin'` rather than it being the silent consequence of omitting an auth field), and `{ uid }` names the user to act as. Omitting `as` is treated as `'admin'`.
 
 ## What the factory exposes

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-01-write-a-sandbox-demo.md
@@ -10,14 +10,17 @@ order: 11002
 Build a tiny notes app with `pyric/firestore` against the sandbox backend. By the end you'll have set rules, seeded data, written, read, watched a query, and seen a denial, all in-process.
 
 ## Set up
+
 ```bash
 mkdir notes-demo && cd notes-demo
 bun init -y
 bun add pyric
 ```
+
 ## Step 1: Boot the sandbox and a Firestore handle
 
 Create `demo.ts`:
+
 ```ts
 import { initializeSandbox, SandboxError } from 'pyric/sandbox';
 import {
@@ -37,9 +40,11 @@ const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 
 console.log('Sandbox-backed Firestore ready.');
 ```
+
 Run with `bun run demo.ts`. You should see the line and nothing else.
 
 ## Step 2: Deploy rules
+
 ```ts
 const lint = setRules(sandbox, `rules_version = '2';
 service cloud.firestore {
@@ -56,10 +61,12 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 }
 console.log('Rules deployed.');
 ```
+
 Firestore controls receive the owning `Sandbox`, while data-plane functions
 receive `db`. Lint warnings are visible. Surface them if any are errors.
 
 ## Step 3: Write and read
+
 ```ts
 await setDoc(doc(db, 'notes', 'n1'), {
   ownerId: 'alice',
@@ -69,9 +76,11 @@ await setDoc(doc(db, 'notes', 'n1'), {
 const snap = await getDoc(doc(db, 'notes', 'n1'));
 console.log('Read back:', snap.data());
 ```
+
 Output: `Read back: { ownerId: "alice", title: "My first note" }`.
 
 ## Step 4: Query
+
 ```ts
 import { getDocs } from 'pyric/firestore';
 
@@ -93,15 +102,19 @@ const results = await getDocs(q);
 console.log(`Found ${results.size} unarchived notes:`);
 results.forEach((d) => console.log(' ', d.id, d.data().title));
 ```
+
 Output:
+
 ```
 Found 2 unarchived notes:
   n1 My first note
   n3 Third note
 ```
+
 The query runs against the sandbox's `LocalEnvironment`, no network. The filter evaluates correctly on `getDocs`.
 
 ## Step 5: Watch with `onSnapshot`
+
 ```ts
 const changes: string[] = [];
 const unsubscribe = onSnapshot(
@@ -123,14 +136,18 @@ await new Promise((resolve) => setTimeout(resolve, 10));  // let the listener fi
 console.log('Saw changes:', changes);
 unsubscribe();
 ```
+
 Output something like:
+
 ```
 Saw changes: [
   'added n1', 'added n2', 'added n3',  // initial fire
   'added n4',                          // write
 ]
 ```
+
 ## Step 6: Try a denied write
+
 ```ts
 const bob = getFirestore(sandbox.withAuth({ uid: 'bob' }));
 
@@ -145,12 +162,15 @@ try {
   }
 }
 ```
+
 Output: `Bob was denied: Rule #1 (write) → deny`. The write rule checks `request.auth.uid == request.resource.data.ownerId`. Bob's UID doesn't match Alice's, so the rule denies and `SandboxError` surfaces with full context.
 
 ## Step 7: Dump the state
+
 ```ts
 console.log('Final state:', snapshotDocuments(sandbox));
 ```
+
 Every stored document, including Alice's writes and excluding Bob's denied one.
 
 ## What you have learned

--- a/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore-tutorials-02-swap-to-prod-backend.md
@@ -16,6 +16,7 @@ You need a Firebase project with Firestore enabled and a Web app configuration.
 ## 1. Confirm the application uses canonical imports
 
 Your application module should import Firebase, not Pyric:
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { doc, getDoc, getFirestore, setDoc } from 'firebase/firestore';
@@ -31,9 +32,11 @@ const ref = doc(db, 'notes/n1');
 await setDoc(ref, { title: 'hello from production' });
 console.log((await getDoc(ref)).data());
 ```
+
 ## 2. Deploy rules that permit the exercise
 
 Create `firestore.rules`:
+
 ```text
 rules_version = '2';
 service cloud.firestore {
@@ -44,17 +47,20 @@ service cloud.firestore {
   }
 }
 ```
+
 Deploy the rules using your normal Firebase deployment workflow.
 
 ## 3. Sign in before the write
 
 Add Firebase Auth to the application:
+
 ```ts
 import { getAuth, signInAnonymously } from 'firebase/auth';
 
 const auth = getAuth(app);
 await signInAnonymously(auth);
 ```
+
 Place these lines before `setDoc`. Enable anonymous authentication in the
 Firebase console if the provider is not already enabled.
 
@@ -62,9 +68,11 @@ Firebase console if the provider is not already enabled.
 
 Do not set `PYRIC_SANDBOX`, preload `@pyric/cli/register`, or enable the Pyric
 Vite plugin for this run:
+
 ```bash
 node demo.mjs
 ```
+
 You should see the document read back from the real Firebase project. Notice
 that the application still imports `firebase/firestore`; only the environment
 changed.
@@ -73,9 +81,11 @@ changed.
 
 Run the same file through the activated development seam while `pyric dev`
 hosts the sandbox:
+
 ```bash
 pyric dev -- node demo.mjs
 ```
+
 This time package resolution selects the sandbox mirror. The Firebase
 configuration is unused, the operation completes locally, and no production
 request is made.

--- a/packages/site-docs/src/content/docs/pyric-firestore.md
+++ b/packages/site-docs/src/content/docs/pyric-firestore.md
@@ -22,6 +22,7 @@ Backend selection belongs to package resolution:
 ## Canonical application code
 
 Keep Firebase imports in application code:
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { doc, getDoc, getFirestore, setDoc } from 'firebase/firestore';
@@ -33,23 +34,29 @@ const ref = doc(db, 'notes/n1');
 await setDoc(ref, { title: 'hello' });
 console.log((await getDoc(ref)).data());
 ```
+
 Run the same source in a Node sandbox:
+
 ```bash
 PYRIC_SANDBOX=local node --import @pyric/cli/register app.mjs
 ```
+
 Or activate the Vite integration:
+
 ```ts
 import { defineConfig } from 'vite';
 import { pyricSandbox } from '@pyric/cli/vite';
 
 export default defineConfig({ plugins: [pyricSandbox()] });
 ```
+
 With neither activation seam present, the imports remain Firebase and use the
 real project configured by `initializeApp`.
 
 ## Direct sandbox construction
 
 Tests and sandbox tooling may construct a handle explicitly:
+
 ```ts
 import { getFirestore, doc, setDoc } from 'pyric/firestore';
 import { initializeSandbox } from 'pyric/sandbox';
@@ -58,6 +65,7 @@ const sandbox = initializeSandbox();
 const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 await setDoc(doc(db, 'notes/n1'), { title: 'hello' });
 ```
+
 Passing a real `FirebaseApp` to this direct mirror is an error. Production code
 must load `firebase/firestore` without sandbox activation.
 

--- a/packages/site-docs/src/content/docs/pyric-messaging-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-messaging-compat.md
@@ -3,7 +3,7 @@ title: "pyric messaging compatibility matrix"
 navLabel: "Messaging"
 group: "Conformance"
 section: ""
-order: 8008
+order: 6010
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-rules-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-compat.md
@@ -3,7 +3,7 @@ title: "pyric/rules compatibility matrix"
 navLabel: "Rules"
 group: "Conformance"
 section: ""
-order: 8007
+order: 6009
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-agent-failure-modes.md
@@ -29,16 +29,20 @@ The fix isn't to relax the linter. It's to give the agent a real diagnostic for 
 ## Silently removing predicates
 
 A subtler variant. The agent writes:
+
 ```rules
 allow update: if request.auth.uid == resource.data.ownerId
               && status == 'open';
 ```
+
 A test case fails because the test set `status` to `'closed'`. The agent doesn't update the test data. It removes the `status == 'open'` conjunct from the rule. The test passes. The deploy ships. Updates against closed records are no longer gated.
 
 `RULES_WEAKENED` exists for this. When you pass the previously-deployed source to the linter (via the engine-internal `lintFirestoreRules` on `pyric/rules/internal`, since the public `lint` and `firestoreRules(source).lint()` take no options):
+
 ```ts
 lintFirestoreRules(newSource, { previousSource: oldSource });
 ```
+
 …the linter normalises every match path, finds the corresponding allow rule by op-set, extracts the top-level conjuncts of each predicate (split only on `&&`, never `||`), and reports every conjunct that existed before and is missing now.
 
 `RULES_WEAKENED` is `warning`, not `error`. There are real reasons to delete a predicate: a refactor, a dedupe, an intentional broadening. The signal is "review this", not "refuse the deploy". A human (or a more careful agent) decides whether the removal is intentional.

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-runtime-budget-and-shared-gates.md
@@ -52,15 +52,19 @@ Even with a single rule sitting comfortably inside its budget, two rules in the 
 The scenario: two `allow update` rules whose conditions both start with the same first expression, say `request.auth.uid == resource.data.host`. The engine evaluates each rule against the request. Even though only one rule actually applies, the prefix evaluation happens in both. If each rule's body is near the budget on its own, their combined evaluation crosses the line.
 
 The fix is to give each rule a unique first expression, a discriminator. Instead of:
+
 ```rules
 allow update: if request.auth.uid == resource.data.host && validBigCheckA();
 allow update: if request.auth.uid == resource.data.host && validBigCheckB();
 ```
+
 route on something distinct:
+
 ```rules
 allow update: if request.resource.data.moveType == 'A' && validBigCheckA();
 allow update: if request.resource.data.moveType == 'B' && validBigCheckB();
 ```
+
 Now each rule short-circuits before its heavy body runs, and the engine doesn't end up evaluating both bodies in parallel.
 
 The linter detects `SHARED_GATE` by computing a structural fingerprint of every rule's first expression and grouping by fingerprint. Two or more rules with the same fingerprint produce a warning.

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-sentinel-expression-engine.md
@@ -16,9 +16,11 @@ The engine is small (a hand-written lexer, parser, evaluator) and intentionally 
 ## The shape
 
 A wrapper is an object whose *only* key is `$expr` and whose value is a string:
+
 ```ts
 { count: { $expr: 'doc.count + 1' } }
 ```
+
 Anything else (extra keys alongside `$expr`, non-string `$expr` values, nested wrappers without proper shape) is rejected with `ExpressionWalkError`. The strict shape is deliberate: it makes the wrapper instantly recognisable when scanning a payload, and it prevents accidental collisions with field names.
 
 ## The walker
@@ -66,12 +68,14 @@ The four types let tool authors translate each failure into a precise diagnostic
 ## When to reach for `$expr`
 
 The sandbox layer uses `$expr` in its declarative transaction API:
+
 ```ts
 await sandbox.firestore('/notes/n1').set({
   count: { $expr: 'doc.count + 1' },
   lastSeen: { $expr: 'now' },
 }, { merge: true });
 ```
+
 Outside the sandbox, you generally don't need it. The production Firestore data plane has `FieldValue.increment` and `FieldValue.serverTimestamp` for the common cases. The engine exists because the sandbox needs a way to express *any* depends-on-current-state write without each write becoming a four-step transaction.
 
 If you're building tooling that operates on `$expr`-bearing payloads (for example, a UI that displays pending writes), you'll want `resolveExpressionsInData` and `tokenize` / `parse` to inspect the expressions before they resolve. Both are exported for that reason.

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-simulator-vs-rules-test-api.md
@@ -13,11 +13,13 @@ Two surfaces evaluate rules against test cases. Underneath, they share a case sh
 The public front door only fronts one of the two: `firestoreRules(source).simulate(cases)` runs the local simulator, takes `FirestoreCase[]`, and returns a `SimulationSummary` (`{ passed, failed, unsupported, cases: CaseResult[] }`) that never carries a thrown-error branch, since a parse failure already threw `RulesCompileError` at construction.
 
 The Rules Test API has no public front door yet. Both engines still share their case and result vocabulary one level down, on `pyric/rules/internal`: `TestFirestoreRulesHandler.execute` (the Rules Test API client) and the internal `SimulateFirestoreRulesHandler.simulate` both take a rules source and a list of `TestCase` objects (the same shape as the public `FirestoreCase`), and both return a `TestFirestoreRulesResult`:
+
 ```ts
 type TestFirestoreRulesResult =
   | { success: true; data: { passed; failed; unsupported; results } }
   | { success: false; error: { code; message; recoverable } };
 ```
+
 Each `TestResult` in `results` carries `description`, `expectation`, `state`, and `debugMessages`. The `state` is `'PASSED' | 'FAILED' | 'UNSUPPORTED'`.
 
 The shared internal shape is a feature. You can swap one internal handler for the other, or route the same test suite to both, without rewriting any test-case code. See [How to test rules against the Firebase Rules Test API](../pyric-rules-how-to-test-rules-against-firebase/) for the escalation pattern built on the public `simulate` plus the internal test-API client.
@@ -71,6 +73,7 @@ When the simulator and the API disagree, we treat the API as authoritative and f
 - You're investigating a production discrepancy.
 
 The fastest agent loops use simulator-first with `UNSUPPORTED` escalation:
+
 ```ts
 const local = firestoreRules(source).simulate(testCases);
 const escalate = local.cases.filter((c) => c.unsupported).map((c) => c.case);
@@ -79,4 +82,5 @@ if (escalate.length > 0) {
   // merge remote.data.results back into local.cases by matching case
 }
 ```
+
 Local-first keeps the inner loop in sub-millisecond territory; the API is only paid when the simulator genuinely can't decide.

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-the-2-plus-modules-extension.md
@@ -13,6 +13,7 @@ Firestore rules don't have imports. The DSL has functions, but every function ha
 ## What it adds
 
 A new version string and an `import` statement:
+
 ```rules
 import { isAuthenticated, isOwner } from 'auth';
 import { hasOnly } from 'validation';
@@ -20,6 +21,7 @@ import { hasOnly } from 'validation';
 rules_version = '2+modules';
 service cloud.firestore { … }
 ```
+
 Module names are either:
 
 - **Stdlib** names like `auth`, `validation`, `lobby`: built-in modules bundled with the package.
@@ -27,6 +29,7 @@ Module names are either:
 - **In-memory entries**: passed via `options.modules` as a `Record<name, source>`.
 
 Functions inside a module file declare visibility with `export`:
+
 ```rules
 // auth.rules
 export function isAuthenticated() { return request.auth != null; }
@@ -34,6 +37,7 @@ export function isOwner(userId) { return isAuthenticated() && request.auth.uid =
 
 function _private() { return request.time != null; }
 ```
+
 `isAuthenticated` and `isOwner` are importable. `_private` is not. It's an internal helper.
 
 ## What it doesn't add

--- a/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-explanation-value-wrappers-design.md
@@ -36,6 +36,7 @@ We chose classes. The class-instances approach pulled together best in practice:
 ## The `RulesValue` base class
 
 All wrappers extend `RulesValue`. The base class is intentionally thin:
+
 ```ts
 abstract class RulesValue {
   readonly typeName: string;            // 'timestamp', 'path', 'bytes', ...
@@ -46,6 +47,7 @@ abstract class RulesValue {
   toString(): string;
 }
 ```
+
 `callMethod` and `binaryOp` exist so the evaluator can dispatch generically: `if (lhs instanceof RulesValue) return lhs.callMethod(method, args)`. The handler doesn't need a per-type switch; the polymorphism does the work.
 
 `typeName` is the lowercase identifier the rules engine uses for the `is` operator. `request.time is timestamp` works because `Timestamp.typeName === 'timestamp'`.

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-compare-rulesets-for-weakening.md
@@ -14,6 +14,7 @@ When you ship a rules change, the most dangerous mistake is silently removing a 
 ## Lint with the previous source
 
 Pass the previously-deployed source as `options.previousSource`:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules/internal';
 
@@ -24,6 +25,7 @@ for (const w of weakened) {
   console.log(`[WEAKENED] ${w.message}`);
 }
 ```
+
 The linter walks both rulesets, normalises every match path, and diffs the predicates conjunct-by-conjunct on each allow rule. Every conjunct that existed in `previousSource` but is missing from the current source produces one `RULES_WEAKENED` warning.
 
 ## What it detects
@@ -46,10 +48,13 @@ By design:
 ## Wire it into CI
 
 Pull the live ruleset before linting the candidate:
+
 ```bash
 firebase firestore:rules:get > previous.rules
 ```
+
 Then in your check script:
+
 ```ts
 import { readFileSync } from 'node:fs';
 import { lintFirestoreRules } from 'pyric/rules/internal';
@@ -66,6 +71,7 @@ if (weakened.length > 0) {
   process.exit(1);
 }
 ```
+
 `RULES_WEAKENED` is a `warning`, not an `error`. The deploy gate stays under your control: require human ack, or treat it as a hard block as above.
 
 ## When the previous source is malformed

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-inspect-rules-via-the-ast.md
@@ -14,6 +14,7 @@ The parser (`parseToAST`, `parseToASTOrError`, `parseFunctions`), the AST types,
 ## Parse to AST
 
 `parseToASTOrError` returns either the AST or a structured failure. Use it when you want a diagnostic on parse failure:
+
 ```ts
 import { parseToASTOrError } from 'pyric/rules/internal';
 
@@ -24,16 +25,20 @@ if (!result.ok) {
 }
 const ast = result.ast;
 ```
+
 When `null` is sufficient signal:
+
 ```ts
 import { parseToAST } from 'pyric/rules/internal';
 
 const ast = parseToAST(source);
 if (!ast) throw new Error('parse failed');
 ```
+
 ## Walk match blocks
 
 `FirestoreRules.service.match` is the root match (always `/databases/{db}/documents`). Walk its `children` recursively to enumerate every nested match block:
+
 ```ts
 import type { MatchBlock } from 'pyric/rules/internal';
 
@@ -47,6 +52,7 @@ function walk(block: MatchBlock, parentPath = ''): void {
 
 walk(ast.service.match);
 ```
+
 ## Inspect path patterns
 
 A `PathPattern` is `{ raw: string, segments: PathSegment[] }`. Each segment is one of three shapes:
@@ -56,6 +62,7 @@ A `PathPattern` is `{ raw: string, segments: PathSegment[] }`. Each segment is o
 - `{ type: 'recursive', name: 'document' }`: for `{document=**}`
 
 Branch on `seg.type` rather than parsing `raw`:
+
 ```ts
 for (const seg of block.path.segments) {
   if (seg.type === 'literal') console.log('static:', seg.value);
@@ -63,9 +70,11 @@ for (const seg of block.path.segments) {
   else console.log('recursive:', seg.name);
 }
 ```
+
 ## Walk expressions
 
 `Expression` is a discriminated union. The discriminator is `type`:
+
 ```ts
 import type { Expression } from 'pyric/rules/internal';
 
@@ -87,11 +96,13 @@ function walkExpr(expr: Expression, visit: (e: Expression) => void): void {
   }
 }
 ```
+
 See [AST reference](../pyric-rules-reference-ast/) for every node shape.
 
 ## Run the validator
 
 If your custom checks overlap with security or quality concerns, run the bundled validator and union the findings into your output:
+
 ```ts
 import { validateFirestoreRules } from 'pyric/rules/internal';
 
@@ -100,11 +111,13 @@ for (const f of findings) {
   console.log(`[${f.severity}] ${f.code} at ${f.path}: ${f.message}`);
 }
 ```
+
 The validator covers public-write detection, default-deny audit, duplicate function names, overlapping paths, and other structural issues. See [Validator findings reference](../pyric-rules-reference-validator-findings/) for the full code list.
 
 ## Parse just a function body
 
 Useful for editor pop-ups or function-level lint hooks:
+
 ```ts
 import { parseFunctions } from 'pyric/rules/internal';
 
@@ -113,6 +126,7 @@ const fns = parseFunctions(`
 `);
 if (fns) console.log(fns[0].name); // 'isAdmin'
 ```
+
 `parseFunctions` wraps the input in a minimal `rules_version='2'` shell and returns only the parsed `FunctionDef[]`, or `null` if parsing failed.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-lint-rules-source.md
@@ -10,16 +10,19 @@ order: 12004
 Lint a Firestore rules source, read the result, and gate a deploy on it. Everything here runs in-process.
 
 ## Lint a string
+
 ```ts
 import { lint } from 'pyric/rules';
 
 const issues = lint(source);
 ```
+
 `issues` is a `RuleIssue[]`. Each issue carries `origin`: `'parse'` for a compile blocker, `'validate'` for a structural/security finding, `'lint'` for a budget/quality/hallucination warning. `lint` never throws, even on empty or unparseable source.
 
 ## Branch on parse errors first
 
 A parse error means "this isn't a ruleset yet", a different category from any lint or validation finding. Filter on `origin === 'parse'` before acting on the rest:
+
 ```ts
 const issues = lint(source);
 const parseErrors = issues.filter((i) => i.origin === 'parse');
@@ -31,11 +34,13 @@ if (parseErrors.length > 0) {
 }
 // Safe to treat the rest of `issues` as validate/lint findings.
 ```
+
 Pre-parse syntax hints (JS-isms like `===`, `?.`, `??`, backtick strings) fire even when the file doesn't parse, so `issues` may already contain useful entries before the parse-error check.
 
 ## Block deploys on errors only
 
 `issues` mixes severities. Gate CI (and refuse to `firebase deploy`) when any issue has `severity: 'error'`. Mirror that behaviour:
+
 ```ts
 const errors = issues.filter((i) => i.severity === 'error');
 if (errors.length > 0) {
@@ -43,9 +48,11 @@ if (errors.length > 0) {
   process.exit(1);
 }
 ```
+
 ## Catch silent rule weakening on update, and pin `request.time`
 
 Two lint rules, `RULES_WEAKENED` and `REQUEST_TIME_NOT_PINNED`, need extra input beyond a bare source string: the previously-deployed source, and your test suite, respectively. Neither `lint(source)` nor `firestoreRules(source).lint()` takes options, so both checks are reached through the engine-internal `lintFirestoreRules(source, options)`, imported from `pyric/rules/internal`:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules/internal';
 
@@ -57,11 +64,13 @@ const result = lintFirestoreRules(newSource, {
 const weakened = result.warnings.filter((w) => w.rule === 'RULES_WEAKENED');
 const unpinned = result.warnings.filter((w) => w.rule === 'REQUEST_TIME_NOT_PINNED');
 ```
+
 `RULES_WEAKENED` is a `warning`, not an `error`. There are legitimate reasons to delete a predicate (refactor, dedupe). The signal is "review this", not "block the deploy". See [How to compare two rulesets for weakening](../pyric-rules-how-to-compare-rulesets-for-weakening/) and [Pin `request.time` for deterministic tests](../pyric-rules-how-to-pin-request-time/).
 
 ## Inspect structural metrics
 
 The internal `lintFirestoreRules` result also carries `metrics`, the structural summary. `lint(source)` has no equivalent on the public surface:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules/internal';
 
@@ -73,6 +82,7 @@ console.log(
   + `max let bindings ${m.maxLetBindings} in ${m.maxLetBindingsFunction || 'n/a'}`,
 );
 ```
+
 Use these to plot trends across PRs or to assert on growth in CI.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-pin-request-time.md
@@ -12,6 +12,7 @@ A rule that reads `request.time` evaluates against wallclock by default. That ma
 ## Set `requestTime` on every affected `FirestoreCase`
 
 `requestTime` accepts an ISO-8601 string. The simulator parses it into a `Timestamp` and uses it for `request.time`:
+
 ```ts
 import type { FirestoreCase } from 'pyric/rules';
 
@@ -36,11 +37,13 @@ const testCases: FirestoreCase[] = [
   },
 ];
 ```
+
 The same ISO string is forwarded to the Firebase Rules Test API when you run via the internal `TestFirestoreRulesHandler` (`pyric/rules/internal`), so the two evaluation paths stay in agreement.
 
 ## Find unpinned cases automatically
 
 Pass the test suite to the linter and look for `REQUEST_TIME_NOT_PINNED`. The public `lint(source)` and `firestoreRules(source).lint()` don't take a `testCases` option, so this check runs through the engine-internal `lintFirestoreRules`:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules/internal';
 
@@ -55,6 +58,7 @@ for (const w of unpinned) {
   // across runs.
 }
 ```
+
 The linter only flags a case if its `path` actually matches a rule that reads `request.time`. Cases that target unrelated paths aren't reported.
 
 ## When `requestTime` doesn't help

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-register-tools-with-an-agent.md
@@ -14,6 +14,7 @@ The tool factories (`createFirestoreRulesTools`, `createFirestoreSimulatorTools`
 ## Without project credentials: lint / resolve / simulate
 
 `createFirestoreRulesTools()` returns three handlers:
+
 ```ts
 import { createFirestoreRulesTools } from 'pyric/rules/internal/node';
 import { createToolRegistry } from '@inbrowser/agent';
@@ -26,11 +27,13 @@ for (const handler of createFirestoreRulesTools()) {
 registry.list().map((h) => h.name);
 // → ['firestore_lint_rules', 'firestore_resolve_modules', 'firestore_simulate_rules']
 ```
+
 These are pure-local: no network, no credentials, safe to expose anywhere.
 
 ## With a `ProjectScope`: also expose live testing
 
 Pass a `ProjectScope` and a fourth handler appears: `firestore_test_rules`, which calls Google's Rules Test API.
+
 ```ts
 import { fromServiceAccount } from '@pyric/cli/credentials/node';
 
@@ -44,11 +47,13 @@ registry.list().map((h) => h.name);
 // → ['firestore_lint_rules', 'firestore_resolve_modules',
 //    'firestore_simulate_rules', 'firestore_test_rules']
 ```
+
 Only attach `scope` when the host actually has credentials. The factory drops `firestore_test_rules` cleanly when `scope` is omitted, so an unsuspecting agent can't try to call it.
 
 ## Dispatch a tool call
 
 `@inbrowser/agent` does the dispatch:
+
 ```ts
 import { createDispatch } from '@inbrowser/agent';
 
@@ -66,11 +71,13 @@ const result = await dispatch.execute(
 console.log(result.summary); // 'Linted rules source'
 console.log(result.data);    // the full internal LintResult
 ```
+
 The `ToolResult` shape is uniform across handlers: `{ ok, summary, data }`. Look at `summary` for a one-line agent-facing message; `data` is the structured payload.
 
 ## Stateful simulator tools (Slice 8 scaffold)
 
 `createFirestoreSimulatorTools({ resolveSandbox })` is the entry point for the seven-tool simulator family that operates against a session-scoped `LocalEnvironment` from `pyric/sandbox`. It currently returns an empty array. The full implementation lands as consumers ask for it. The factory shape and dependency contract are stable; only the handlers are pending.
+
 ```ts
 import { createFirestoreSimulatorTools } from 'pyric/rules/internal/node';
 
@@ -79,6 +86,7 @@ const tools = createFirestoreSimulatorTools({
   resolveSandbox: () => sessionContext.localEnv,
 });
 ```
+
 The `resolveSandbox` resolver fires per dispatch, so hosts that reset or swap the sandbox transparently get a fresh environment without re-registering tools.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-resolve-module-imports.md
@@ -16,6 +16,7 @@ Write rules that import reusable helper functions, then resolve them into a stan
 ## Author rules with imports
 
 Set the version to `'2+modules'` and add `import` statements at the top of the file:
+
 ```rules
 import { isAuthenticated, isOwner } from 'auth';
 import { hasRequired, hasOnly } from 'validation';
@@ -34,7 +35,9 @@ service cloud.firestore {
   }
 }
 ```
+
 ## Resolve to standard rules
+
 ```ts
 import { resolveModules } from 'pyric/rules/internal/node';
 
@@ -47,6 +50,7 @@ if (!result.success) {
 console.log(result.data.resolved);   // standard '2' rules, ready to deploy
 console.log(result.data.modules);    // ['auth', 'validation']
 ```
+
 The output uses `rules_version = '2'` and has the imported functions inlined at the root scope of the match block.
 
 ## Use the stdlib
@@ -58,19 +62,24 @@ For the full list of exports, see [Standard library modules](../pyric-rules-refe
 ## Use your own `.rules` files
 
 For project-specific helpers, write a `.rules` file and use a relative import:
+
 ```rules
 import { hasModeratorClaim } from './lib/moderation';
 ```
+
 Then point the resolver at the base directory:
+
 ```ts
 const result = resolveModules(source, { basePath: './src' });
 // Loads './src/lib/moderation.rules'
 ```
+
 The resolved path is `${basePath}/${importPath}.rules`. Functions in your module file can be marked `export` (visible to importers) or left bare (private, renamed with a module prefix so they don't collide).
 
 ## Inject modules from memory
 
 For tests, ephemeral environments, or any case where the source isn't on disk, pass `modules`:
+
 ```ts
 const result = resolveModules(source, {
   modules: {
@@ -82,6 +91,7 @@ const result = resolveModules(source, {
   },
 });
 ```
+
 The `modules` map takes priority over both `basePath` lookups and the stdlib, so you can override a stdlib module by name if you need to.
 
 ## Handle resolve failures

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-simulate-rules-locally.md
@@ -10,6 +10,7 @@ order: 12008
 Evaluate Firestore rules in-process against a list of test cases, without deploying or contacting Google's servers.
 
 ## Run a suite
+
 ```ts
 import { firestoreRules } from 'pyric/rules';
 
@@ -17,11 +18,13 @@ const ruleset = firestoreRules(source); // throws RulesCompileError if source do
 
 const { passed, failed, unsupported, cases } = ruleset.simulate(testCases);
 ```
+
 `firestoreRules(source)` throws `RulesCompileError` (carrying `.issues: RuleIssue[]`) if the source doesn't parse. Past that point, `simulate` never throws on a rule outcome: `cases` is a `CaseResult[]`, one entry per input case, each with `passed`, `unsupported`, `decision`, `trace`, and `notes`.
 
 ## Mock `get()` and `exists()`
 
 When a rule calls `get(/databases/$(db)/documents/users/$(uid))`, the simulator looks the result up in your case's `functionMocks`. Provide them by document path:
+
 ```ts
 import type { FirestoreCase } from 'pyric/rules';
 
@@ -39,11 +42,13 @@ const testCases: FirestoreCase[] = [
   },
 ];
 ```
+
 For `get`, supply the document's data. For `exists`, supply a boolean. Paths are relative; the simulator handles the `/databases/(default)/documents/` prefix internally.
 
 ## Set `writeMode` for accurate update semantics
 
 By default, `tc.data` IS the after-state, which is fine for shallow `create`. For `update` or `set({ merge: true })`, set `writeMode` so the simulator projects the post-write document correctly:
+
 ```ts
 {
   description: 'patch a single field',
@@ -56,11 +61,13 @@ By default, `tc.data` IS the after-state, which is fine for shallow `create`. Fo
   writeMode: { kind: 'update' },  // ← merges data into resource
 },
 ```
+
 Without `writeMode`, `request.resource.data.archived` would read as `null`. With it, the simulator runs the same merge logic the admin SDK does. See [`FirestoreCase` schema](../pyric-rules-reference-test-case-schema/#writemode) for all four modes.
 
 ## Pin `request.time` for date-gated rules
 
 Any rule that reads `request.time` will evaluate against wallclock unless you pin it:
+
 ```ts
 {
   description: 'within trial window',
@@ -72,11 +79,13 @@ Any rule that reads `request.time` will evaluate against wallclock unless you pi
   requestTime: '2026-04-15T12:00:00Z',  // ← ISO-8601
 },
 ```
+
 To catch unpinned cases early, run the engine-internal `lintFirestoreRules(source, { testCases })` from `pyric/rules/internal` and look for `REQUEST_TIME_NOT_PINNED`; the public `lint(source)` and `firestoreRules(source).lint()` don't take a `testCases` option. See [Pin `request.time` for deterministic tests](../pyric-rules-how-to-pin-request-time/).
 
 ## Populate `request.query` for `list`
 
 `list` rules can read `request.query.limit / .offset / .orderBy`. Without `query` those fields read `null` and `request.query.limit < 100` becomes `null < 100 → false → DENY`. Set what your rule reads:
+
 ```ts
 {
   description: 'paged list under cap',
@@ -87,9 +96,11 @@ To catch unpinned cases early, run the engine-internal `lintFirestoreRules(sourc
   query: { limit: 25 },
 },
 ```
+
 ## Handle unsupported results
 
 An unsupported result means the simulator hit a feature it does not yet implement, not that your rule is wrong. It is *not* counted as a failure: `unsupported` is tallied separately from `failed` in the summary, and `passed` stays `false` on that case's `CaseResult`. If you have unsupported cases and need a verdict for them, route those cases to the live Rules Test API:
+
 ```ts
 const needsEscalation = cases.filter((c) => c.unsupported).map((c) => c.case);
 
@@ -97,11 +108,13 @@ if (needsEscalation.length > 0) {
   // Run these against the Rules Test API — see the test-rules-against-firebase guide.
 }
 ```
+
 See [Simulator vs Rules Test API](../pyric-rules-explanation-simulator-vs-rules-test-api/) for the full discussion.
 
 ## Read the trace
 
 Each `CaseResult` carries a `trace` (per-rule evaluation entries) and `notes` (top-level diagnostic strings), useful when a case fails and you can't tell which rule decided. `explainCase` renders both into one human-readable string, the same renderer `assertCase` uses as its thrown error's message:
+
 ```ts
 import { explainCase } from 'pyric/rules';
 
@@ -109,13 +122,16 @@ for (const c of cases) {
   if (!c.passed) console.log(explainCase(c));
 }
 ```
+
 A typical trace:
+
 ```
 FAIL: locked doc read
   get locked/x (expected ALLOW, got DENY)
   rules evaluated:
     #0 (read) [locked/{id}] (line 4) -> DENY: request.auth.uid == 'admin'
 ```
+
 For a single case, `ruleset.explain(oneCase)` runs it and returns the same structured `Explanation` without needing to slice it out of a batch result.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-how-to-test-rules-against-firebase.md
@@ -16,19 +16,24 @@ The Rules Test API does not deploy the rules. It evaluates them against your tes
 ## You need a `ProjectScope`
 
 `TestFirestoreRulesHandler.execute` takes a `ProjectScope` — a `{ projectId, resolveToken }` pair. Build it from a service-account file via `@pyric/cli/credentials/node`:
+
 ```ts
 import { fromServiceAccount } from '@pyric/cli/credentials/node';
 
 const scope = await fromServiceAccount('./service-account.json');
 ```
+
 Or build one by hand from any OAuth source, for example the current Firebase Auth user in a browser host:
+
 ```ts
 const scope = {
   projectId: 'your-project-id',
   resolveToken: () => firebaseAuth.currentUser!.getIdToken(),
 };
 ```
+
 ## Run a suite
+
 ```ts
 import {
   TestFirestoreRulesHandler,
@@ -38,11 +43,13 @@ import {
 const handler = new TestFirestoreRulesHandler();
 const result = await handler.execute(scope, source, testCases);
 ```
+
 The result shape is the same internal `TestCase` and `TestResult` types the simulator uses, in the same `{ passed, failed, results }` shape. The only difference is that `result.data.unsupported` is always `0` (the live API never abstains). `TestCase` here is the same shape as the public `FirestoreCase` re-export.
 
 ## Handle authentication failures
 
 If the service account lacks the required permission, the call returns `{ success: false, error: { code: 'PERMISSION_DENIED', ... } }`:
+
 ```ts
 if (!result.success) {
   if (result.error.code === 'PERMISSION_DENIED') {
@@ -56,6 +63,7 @@ if (!result.success) {
   process.exit(1);
 }
 ```
+
 `error.recoverable` tells you whether retrying makes sense (e.g. `INVALID_REQUEST` is recoverable, `PERMISSION_DENIED` is not).
 
 ## Choose simulator-then-test, or test-only
@@ -63,6 +71,7 @@ if (!result.success) {
 Two common patterns:
 
 **Local-first, escalate on `UNSUPPORTED`**: fast for the common case, accurate when needed.
+
 ```ts
 import { firestoreRules } from 'pyric/rules';
 import { TestFirestoreRulesHandler } from 'pyric/rules/internal';
@@ -80,10 +89,13 @@ if (needsEscalation.length > 0) {
   // merge `remote.data.results` back into `local.cases` by matching case
 }
 ```
+
 **Test-only**: slower, but bit-for-bit production parity.
+
 ```ts
 const result = await new TestFirestoreRulesHandler().execute(scope, source, testCases);
 ```
+
 For most agent workflows, local-first is the right default.
 
 ## Cost and latency

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-api.md
@@ -59,10 +59,12 @@ Throws on a failed or abstained case result. `RulesUnsupportedError` for an abst
 Simulates that single case and throws on a miss, with the same semantics as the result form: `RulesAssertionError` (message is the `explainCase` trace) when the decision didn't match the expectation, `RulesUnsupportedError` on a simulator abstention. The `source` form compiles Firestore source first (throwing `RulesCompileError` if it doesn't parse).
 
 Runner wiring:
+
 ```ts
 const ruleset = firestoreRules(source);
 for (const c of cases) test(c.description, () => assertCase(ruleset, c));
 ```
+
 ### `explainCase(result: CaseResult | RtdbCaseResult): string`
 
 The single sanctioned trace renderer. Used as the message of the errors `assertCase` throws, and available directly for logging a result without asserting.
@@ -80,6 +82,7 @@ See [Errors](../pyric-rules-reference-errors/) for the full picture, including t
 ## Unified issue type
 
 ### `RuleIssue`
+
 ```ts
 interface RuleIssue {
   code: string;
@@ -91,6 +94,7 @@ interface RuleIssue {
   origin: 'parse' | 'validate' | 'lint';
 }
 ```
+
 Replaces the old `LintWarning`, `ValidationFinding`, and `ParseError` shapes with one. `origin` records which stage produced the issue: `'parse'` for compile blockers, `'validate'` for structural/security findings, `'lint'` for budget/quality/hallucination warnings. Filtering on `origin === 'parse'` gets the compile blockers without needing three separate types.
 
 ## Case and result types

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-ast.md
@@ -9,6 +9,7 @@ order: 12011
 The AST is the typed tree produced by `parseToAST` / `parseToASTOrError`. These functions and the shapes below are exported from `pyric/rules/internal`, an internal, unstable surface not covered by the public `pyric/rules` contract: it may change without notice. Most callers reach the AST through the public front door instead: `firestoreRules(source).toJSON()` returns the same `FirestoreRules` tree without touching the parser directly. This page documents the shape for callers (and tooling like [Inspect rules via the AST](../pyric-rules-how-to-inspect-rules-via-the-ast/)) that need to walk it directly.
 
 ## Root: `FirestoreRules`
+
 ```ts
 interface FirestoreRules {
   version: string;          // 'rules_version' value, e.g. '2' or '2+modules'
@@ -16,21 +17,27 @@ interface FirestoreRules {
   service: ServiceBlock;
 }
 ```
+
 ## `ImportDecl`
+
 ```ts
 interface ImportDecl {
   functions: string[];   // imported function names
   module: string;        // module name (stdlib name or relative path)
 }
 ```
+
 ## `ServiceBlock`
+
 ```ts
 interface ServiceBlock {
   name: string;          // always 'cloud.firestore' for Firestore rules
   match: MatchBlock;     // the root match (/databases/{database}/documents)
 }
 ```
+
 ## `MatchBlock`
+
 ```ts
 interface MatchBlock {
   path: PathPattern;
@@ -39,7 +46,9 @@ interface MatchBlock {
   children: MatchBlock[];
 }
 ```
+
 ## `PathPattern`
+
 ```ts
 interface PathPattern {
   raw: string;              // original path text, e.g. '/users/{uid}'
@@ -51,7 +60,9 @@ type PathSegment =
   | { type: 'wildcard'; name: string }     // {name}
   | { type: 'recursive'; name: string };   // {name=**}
 ```
+
 ## `AllowRule`
+
 ```ts
 interface AllowRule {
   operations: Operation[];
@@ -60,7 +71,9 @@ interface AllowRule {
 
 type Operation = 'read' | 'write' | 'get' | 'list' | 'create' | 'update' | 'delete';
 ```
+
 ## `FunctionDef`
+
 ```ts
 interface FunctionDef {
   name: string;
@@ -75,9 +88,11 @@ interface LetBinding {
   value: Expression;
 }
 ```
+
 ## `Expression`
 
 Discriminated union. The discriminator is `type`.
+
 ```ts
 type Expression =
   | { type: 'literal'; value: string | number | boolean | null; raw: string }
@@ -96,6 +111,7 @@ type Expression =
   | { type: 'pathLiteral'; raw: string; segments: Array<string | Expression> }
   | { type: 'functionCall'; name: string; args: Expression[] };
 ```
+
 ### Notes per variant
 
 - `literal.raw` preserves the original source text of the literal, useful for diagnostics and for `RULES_WEAKENED`'s deterministic serialiser.

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-conformance-gaps.md
@@ -54,6 +54,7 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 
 A rule that gates on a digest. An upload token, a content checksum, a
 signature check:
+
 ```
 match /docs/{id} {
   allow create: if request.auth != null
@@ -61,6 +62,7 @@ match /docs/{id} {
        == request.resource.data.checksum;
 }
 ```
+
 Or any use of `hashing.md5()`, `hashing.crc32()`, `hashing.crc32c()`, or
 `Bytes.toBase64()`.
 
@@ -95,6 +97,7 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 ### What you would write
 
 A post-write check, usually to keep two documents consistent:
+
 ```
 match /orders/{id} {
   allow create: if request.auth != null
@@ -102,6 +105,7 @@ match /orders/{id} {
     && getAfter(request.path).data.total == request.resource.data.total;
 }
 ```
+
 ### What happens
 
 In pyric the write is ALLOWED. pyric models the post-write state and hands
@@ -133,11 +137,13 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 ### What you would write
 
 A rule that reads the identity of a document it looked up:
+
 ```
 match /pages/{id} {
   allow create: if get(/databases/$(database)/documents/cfg/site).id == 'site';
 }
 ```
+
 ### What happens
 
 In pyric the write is ALLOWED. pyric attaches a document identity to the
@@ -153,9 +159,11 @@ cross-document read in these captures.
 
 Read data off a `get()`, not identity. `get(...).data.<field>` matches
 production exactly, and so does `exists(...)`.
+
 ```
 allow create: if get(/databases/$(database)/documents/cfg/site).data.open == true;
 ```
+
 If you need the identity, you already have it. It is the path you passed to
 `get()`.
 
@@ -168,6 +176,7 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 ### What you would write
 
 A rule that inspects the query on a request that is not a list:
+
 ```
 match /notes/{id} {
   allow create: if request.auth != null
@@ -175,6 +184,7 @@ match /notes/{id} {
     && request.query.size() == 0;
 }
 ```
+
 ### What happens
 
 In pyric the write is ALLOWED. pyric models `request.query` as an empty map on
@@ -195,12 +205,14 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 ### What you would write
 
 A slice whose end index runs past the end of the value:
+
 ```
 match /notes/{id} {
   allow create: if request.resource.data.tags[1:99].size() == 3
     && request.resource.data.title[6:99] == 'world';
 }
 ```
+
 ### What happens
 
 In pyric both slices clamp to the length of the list or the string, the
@@ -211,10 +223,12 @@ slice end is DENIED, on lists and on strings alike.
 
 Never slice past the end. Check the size first, or slice with an index you
 know is in range:
+
 ```
 allow create: if request.resource.data.tags.size() >= 4
   && request.resource.data.tags[1:4].size() == 3;
 ```
+
 In-range slices, empty slices (`[i:i]`), and full-length slices all agree with
 production.
 
@@ -228,6 +242,7 @@ cost is trust: a legitimate write you validated locally is refused in the cloud.
 
 A `path()` call wrapped around something that is already a `Path`, usually
 because it came out of a helper:
+
 ```
 function asPath(p) {
   return path(p);
@@ -236,6 +251,7 @@ match /users/{uid} {
   allow read: if asPath(path('users/alice')) == path('users/alice');
 }
 ```
+
 ### What happens
 
 In pyric `path()` is idempotent. Passing it a `Path` gives the same `Path`
@@ -260,12 +276,14 @@ watch.
 ### What you would write
 
 A type check on a number in the payload:
+
 ```
 match /readings/{id} {
   allow create: if request.resource.data.x is float
     && !(request.resource.data.x is int);
 }
 ```
+
 ### What happens
 
 In pyric the write is DENIED. In Firebase it is ALLOWED.
@@ -284,11 +302,13 @@ not run locally: a rule you trusted to block, tested once, and shipped.
 
 Do not use `is float` or `is int` to tell payload numbers apart while testing
 locally. Test the property you actually care about, which is usually a range:
+
 ```
 allow create: if request.resource.data.x is number
   && request.resource.data.x >= 0
   && request.resource.data.x <= 100;
 ```
+
 Integer division, truncation, modulo, division by zero, and `is int` on a
 genuinely integral value all match production.
 

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-errors.md
@@ -13,11 +13,13 @@ order: 12013
 ### `RulesCompileError`
 
 Thrown by `firestoreRules(source)` / `rtdbRules(...)` when the source doesn't compile.
+
 ```ts
 class RulesCompileError extends Error {
   readonly issues: RuleIssue[];
 }
 ```
+
 Carries the compile-blocking issues on `.issues` so a caller can surface them without re-parsing.
 
 ### `RulesAssertionError`
@@ -37,6 +39,7 @@ These are not part of the public contract. They belong to the parser, evaluator,
 #### `ParseError`
 
 Returned internally by `parseToASTOrError` and embedded in the internal `LintResult.parseError`. Not thrown. On the public surface this shows up as a `RuleIssue` with `origin: 'parse'` (from `lint()`) or inside `RulesCompileError.issues` (from `firestoreRules()`).
+
 ```ts
 interface ParseError {
   line: number;        // 1-based
@@ -47,11 +50,13 @@ interface ParseError {
   message: string;     // ohm's human-readable message with a caret
 }
 ```
+
 Use `line` / `column` for editor diagnostics, `message` for terminal output, `expected` / `actual` for custom UIs.
 
 #### `ParseResult`
 
 Returned by `parseExpression` and `parseRulesFile`:
+
 ```ts
 interface ParseResult {
   valid: boolean;
@@ -59,6 +64,7 @@ interface ParseResult {
   parseError?: ParseError;
 }
 ```
+
 `errors` is the legacy surface; `parseError` is the structured form.
 
 ### Evaluator errors
@@ -80,12 +86,14 @@ The simulator hit a feature it does not yet implement: an unknown built-in funct
 #### `ExpressionWalkError`
 
 Thrown by `resolveExpressionsInData` when an `$expr` wrapper has the wrong shape (extra keys, non-string value, etc.). Carries `code: 'invalid-argument'` and a dotted `path` to the offending leaf.
+
 ```ts
 class ExpressionWalkError extends Error {
   readonly code: 'invalid-argument';
   readonly path: string;   // e.g. 'users.0.balance'
 }
 ```
+
 #### `ExpressionLexError` and `ExpressionParseError`
 
 Thrown by `tokenize` / `parse` in the sentinel expression DSL. Carry a `Position` so the caller can report `line:column` against the original `$expr` source.
@@ -93,11 +101,13 @@ Thrown by `tokenize` / `parse` in the sentinel expression DSL. Carry a `Position
 ### Handler results
 
 The handlers (`SimulateFirestoreRulesHandler`, `TestFirestoreRulesHandler`, the modules resolver) never throw for expected failure modes. They return `Outcome`-shaped objects:
+
 ```ts
 type Result<T> =
   | { success: true; data: T }
   | { success: false; error: { code: string; message: string; recoverable?: boolean } };
 ```
+
 #### Simulator `error.code` values
 
 - `PARSE_FAILED`: the source did not parse.

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-simulator-context.md
@@ -10,6 +10,7 @@ order: 12015
 The simulator evaluates expressions against a `SimulationContext`. This page describes its shape and the three result states a test case can land in. `SimulationContext` and `evaluate` are engine-internal, reached through `pyric/rules/internal`; the public front door is `firestoreRules(source).simulate(cases)` / `.explain(oneCase)`, which builds and consumes this context internally and returns a `CaseResult` / `Explanation` instead. This page documents the internals for callers who need them directly, and to explain what the public result fields mean underneath.
 
 ## `SimulationContext`
+
 ```ts
 interface SimulationContext {
   request: SimRequest;
@@ -23,9 +24,11 @@ interface SimulationContext {
   existsAfter: boolean;
 }
 ```
+
 You don't construct this directly. `SimulateFirestoreRulesHandler.simulate` builds it from each case. The shape is documented because `evaluate(expression, ctx)` is exported from `pyric/rules/internal`, so callers writing custom evaluators do need to build it.
 
 ### `request: SimRequest`
+
 ```ts
 interface SimRequest {
   auth: { uid: string; token: Record<string, unknown> } | null;
@@ -36,9 +39,11 @@ interface SimRequest {
   time: Timestamp;
 }
 ```
+
 The rule sees this as `request`. `request.auth` is `null` for unauthenticated cases.
 
 ### `resource: SimResource`
+
 ```ts
 interface SimResource {
   data: Record<string, unknown>;   // existing document data
@@ -46,6 +51,7 @@ interface SimResource {
   __name__: Path;                  // full Path
 }
 ```
+
 The rule sees this as `resource`. On `create`, `resource.data` is `{}` and `existsAfter` is `true` for the post-write doc.
 
 ### `mockDocuments`

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-stdlib-modules.md
@@ -9,10 +9,12 @@ order: 12016
 Fifteen modules ship with `pyric/rules`. Each module is a `.rules` file living under `src/rules/modules/stdlib/`; imports resolve automatically without any configuration.
 
 Use them by setting `rules_version = '2+modules'` and adding import statements:
+
 ```rules
 import { isAuthenticated, isOwner } from 'auth';
 import { hasOnly } from 'validation';
 ```
+
 Then run `resolveModules(source)` to inline the exports into a standard `'2'` source. `resolveModules` is an internal engine seam, imported from `pyric/rules/internal/node`, not the public `pyric/rules` front door. See [How to resolve `2+modules` imports](../pyric-rules-how-to-resolve-module-imports/).
 
 Convention: modules either operate against `request` / `resource` / `request.auth` only (self-contained) or take explicit parameters (no implicit lookups).
@@ -105,6 +107,7 @@ Movement-game validation via a config-document lookup. The caller must pass the 
 | `validJumpMove(cfg)` | `cfg.jumps[piece][from][to] == captured` |
 
 Usage:
+
 ```rules
 import { validSimpleMove, validJumpMove } from 'geometry';
 
@@ -117,6 +120,7 @@ match /games/{gameId} {
   allow update: if validJumpMove(config()) && captureValid();
 }
 ```
+
 ## Importing private functions
 
 Functions in a module that aren't marked `export` are still inlined by the resolver, but renamed with a module prefix (`{module}__{name}`) so they don't collide with source-defined functions or with private helpers in other modules. You can't import a private function by name; doing so produces `UNKNOWN_FUNCTION` with a message that explains the function exists but isn't exported.
@@ -124,6 +128,7 @@ Functions in a module that aren't marked `export` are still inlined by the resol
 ## Overriding a stdlib module
 
 Pass a `modules` map to `resolveModules` to shadow a stdlib name:
+
 ```ts
 import { resolveModules } from 'pyric/rules/internal/node';
 
@@ -140,4 +145,5 @@ resolveModules(source, {
   },
 });
 ```
+
 The `modules` map takes priority over both stdlib and `basePath` resolution.

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-test-case-schema.md
@@ -45,6 +45,7 @@ The existing document, if any. Becomes `resource.data` for the rule evaluation. 
 ### `functionMocks: FunctionMock[]`
 
 Mock results for `get()` and `exists()` calls the rule makes:
+
 ```ts
 interface FunctionMock {
   function: 'get' | 'exists';
@@ -52,11 +53,13 @@ interface FunctionMock {
   result: Record<string, unknown> | boolean;          // doc data for get; boolean for exists
 }
 ```
+
 For `get`, supply the document data. For `exists`, supply `true` (the mock will produce a document) or `false` (no result, the rule will see absence). Paths are relative. The simulator handles the `/databases/(default)/documents/` prefix.
 
 ### `query: ListQuery`
 
 Only honoured for `method: 'list'`. Populates `request.query`:
+
 ```ts
 interface ListQuery {
   limit?: number;
@@ -64,6 +67,7 @@ interface ListQuery {
   orderBy?: string;
 }
 ```
+
 Unset fields read as `null` from rules. If your rule reads `request.query.limit`, set it. Otherwise `null < 100` evaluates to `false` and the rule silently denies.
 
 ### `requestTime: string`
@@ -73,6 +77,7 @@ ISO-8601 timestamp used as `request.time`. Defaults to the wallclock at simulati
 ### `writeMode`
 
 Explicit write-mode discriminator. When set, the simulator runs `projectAfterState(writeMode, resource, data)` to derive both `request.resource.data` and the value `getAfter(path)` returns. When unset, the simulator falls back to "`tc.data` IS the after-state", which is correct for shallow `create` but wrong for nested-map updates.
+
 ```ts
 type WriteMode =
   | { kind: 'create' }
@@ -80,6 +85,7 @@ type WriteMode =
   | { kind: 'update' }
   | { kind: 'delete' };
 ```
+
 | Mode | After-state |
 |---|---|
 | `{ kind: 'create' }` | `data` (asserts the doc did not exist) |
@@ -91,6 +97,7 @@ type WriteMode =
 ## Server-timestamp sentinels in `data`
 
 When your write payload contains a server-timestamp sentinel (exactly `{ __type: 'serverTimestamp' }`), the simulator resolves every occurrence to the same `Timestamp` instance (matching `request.time`). Use the `serverTimestamp()` value helper for clarity:
+
 ```ts
 import { serverTimestamp, type FirestoreCase } from 'pyric/rules';
 
@@ -104,14 +111,17 @@ const tc: FirestoreCase = {
   requestTime: '2026-04-15T12:00:00Z',
 };
 ```
+
 The single-instance invariant matters because `data.createdAt == request.time` succeeds via field-compare on the `Timestamp` wrapper.
 
 ## Validation
 
 `TestCaseSchema`, the Zod schema behind `FirestoreCase`, lives on `pyric/rules/internal` (an internal, unstable surface):
+
 ```ts
 import { TestCaseSchema } from 'pyric/rules/internal';
 
 const parsed = TestCaseSchema.parse(input);  // throws on schema mismatch
 ```
+
 `TestCaseSchema` is a Zod schema, so you can also `safeParse` it or compose it into your own validators.

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-validator-findings.md
@@ -7,6 +7,7 @@ order: 12018
 # Validator findings
 
 The validator runs as part of `lint(source)` and `firestoreRules(source).lint()`, both from `pyric/rules`. Each finding surfaces as a `RuleIssue` with `origin: 'validate'`. The validator's own internal shape, `ValidationFinding`, still exists on `pyric/rules/internal` (via `validateFirestoreRules(ast)`) for callers that need the raw four-level severity scale:
+
 ```ts
 interface ValidationFinding {
   code: string;
@@ -16,6 +17,7 @@ interface ValidationFinding {
   message: string;
 }
 ```
+
 On the public `RuleIssue`, `critical` and `high` fold to `'error'`, `medium` folds to `'warning'`, and `low` folds to `'info'`.
 
 Findings are grouped by code family:

--- a/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
+++ b/packages/site-docs/src/content/docs/pyric-rules-reference-value-wrappers.md
@@ -17,6 +17,7 @@ You reach for the classes on `pyric/rules/internal` directly when:
 - Writing your own wrapper for a type the built-ins don't model.
 
 ## `RulesValue` (base class)
+
 ```ts
 abstract class RulesValue {
   readonly typeName: string;
@@ -27,11 +28,13 @@ abstract class RulesValue {
   toString(): string;
 }
 ```
+
 `NO_OP` is the sentinel returned from `callMethod` and `binaryOp` when a wrapper doesn't implement a method or operation. The evaluator translates `NO_OP` into an `UnsupportedError`, which the handler maps to `state: 'UNSUPPORTED'`.
 
 ## `Timestamp`
 
 Wraps `request.time`, `getAfter()` timestamps, and any field value that was `FieldValue.serverTimestamp()` in the request payload.
+
 ```ts
 class Timestamp extends RulesValue {
   readonly seconds: number;
@@ -44,6 +47,7 @@ class Timestamp extends RulesValue {
   toMillis(): number;
 }
 ```
+
 Methods exposed to rules (via `callMethod`): `date`, `day`, `dayOfWeek`, `dayOfYear`, `hours`, `minutes`, `month`, `nanos`, `seconds`, `time`, `toMillis`, `year`.
 
 Binary ops: `==`, `!=`, `<`, `<=`, `>`, `>=` against another `Timestamp`; `+`/`-` against a `Duration` returning a new `Timestamp`; `-` against another `Timestamp` returning a `Duration`.
@@ -53,6 +57,7 @@ Internal storage uses signed `seconds` and non-negative `nanos` (protobuf conven
 ## `Path`
 
 Wraps `request.path`, `__name__`, and path literals constructed from `path(...)`.
+
 ```ts
 class Path extends RulesValue {
   readonly segments: readonly string[];
@@ -64,11 +69,13 @@ class Path extends RulesValue {
   field(name: string): unknown;                 // named-binding access
 }
 ```
+
 Methods: standard accessors. `bindings` is the wildcard map from the matched path pattern. `request.path.<name>` returns `bindings[name]` for `<name>` that was a wildcard in the match path. Without bindings, named-field access returns `null`.
 
 ## `Reference`
 
 Wraps DocumentReference values inside test data.
+
 ```ts
 class Reference extends RulesValue {
   readonly path: Path;
@@ -76,11 +83,13 @@ class Reference extends RulesValue {
 
 function referenceToResourceName(ref: Reference): string;
 ```
+
 Use `referenceToResourceName` to get the full `/databases/.../documents/...` form when calling the Rules Test API.
 
 ## `Duration`
 
 Wraps `request.time - resource.data.<ts>` results and `duration.value(n, 'h')` constructions.
+
 ```ts
 class Duration extends RulesValue {
   readonly seconds: number;
@@ -91,11 +100,13 @@ class Duration extends RulesValue {
   static abs(d: Duration): Duration;
 }
 ```
+
 Unit codes for `fromValue`: `'w'`, `'d'`, `'h'`, `'m'`, `'s'`, `'ms'`. Binary ops mirror `Timestamp`'s.
 
 ## `Bytes`
 
 Wraps `bytes` values.
+
 ```ts
 class Bytes extends RulesValue {
   readonly data: Uint8Array;
@@ -108,11 +119,13 @@ class Bytes extends RulesValue {
   toHexString(): string;
 }
 ```
+
 Slice access (`bytes[start:end]`) is supported via `sliceAccess` expressions and produces a new `Bytes`.
 
 ## `LatLng`
 
 Wraps geo-point values.
+
 ```ts
 class LatLng extends RulesValue {
   readonly lat: number;
@@ -123,14 +136,17 @@ class LatLng extends RulesValue {
   // distance(other) returns metres via the haversine formula.
 }
 ```
+
 ## `Vector`
 
 Wraps embedding vectors.
+
 ```ts
 class Vector extends RulesValue {
   readonly values: readonly number[];
 }
 ```
+
 ## `RulesValue` and `NO_OP`
 
 Exported for callers writing custom wrappers. To add support for a new type:

--- a/packages/site-docs/src/content/docs/pyric-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-rules.md
@@ -22,12 +22,15 @@ The surface is grouped around the things you can do with a rules source:
 Parse, Lint, Validate, Simulate, and Test all sit behind the public front door: `firestoreRules`, `rtdbRules`, `lint`, `assertCase`, and `explainCase`. The parser, linter, validator, simulator, modules resolver, and agent-tool factories are internal engine seams, exposed only under `pyric/rules/internal*` for callers that need them directly. They may change without notice.
 
 ## Install
+
 ```bash
 bun add pyric
 # or
 npm install pyric
 ```
+
 ## A 30-second example
+
 ```ts
 import { firestoreRules } from 'pyric/rules';
 
@@ -55,16 +58,21 @@ const { passed, failed } = ruleset.simulate([
 ]);
 console.log(passed, failed); // 1 0
 ```
+
 `firestoreRules(source)` throws `RulesCompileError` if the source doesn't parse. `simulate` never throws on rule outcomes; failures and unsupported cases come back in the result, not as exceptions.
 
 The RTDB constraints DSL (`defineRtdbRules`, `ruleset`, `schemaRules`, and the combinators) is public and lives on the same root entry:
+
 ```ts
 import { rtdbRules, defineRtdbRules, ruleset, allow } from 'pyric/rules';
 ```
+
 The parser, validator, simulator internals, modules resolver, and agent-tool factories live on `pyric/rules/internal` and `pyric/rules/internal/node`. They're not part of the public contract:
+
 ```ts
 import { resolveModules, createFirestoreRulesTools } from 'pyric/rules/internal/node';
 ```
+
 ## Where to go next
 
 Documentation is organised under [`docs/`](../pyric-rules/) following the [Diataxis](https://diataxis.fr/) framework:

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-every-op-is-a-request.md
@@ -22,6 +22,7 @@ The reframe: **every op the simulator evaluates is a request worth seeing.** Den
 ## Denials are now a filter, not a channel
 
 The unified-channel rollout collapsed the prior three channels into one:
+
 ```
 sandbox.onEvent         — every observable event
   ├ kind: 'request'
@@ -33,6 +34,7 @@ sandbox.onEvent         — every observable event
   │   └ filter kind === 'listener_errored'  →  what onSnapshotError used to deliver
   └ kind: 'session_boundary'
 ```
+
 One subscription, one mental model. A consumer that wants only denials filters `kind === 'request' && result === 'deny'`. The event carries strictly more information than the old `DenialEvent` did (`evalMs`, `origin`, `matchedRule`, `groupKind`, `groupId`).
 
 ## The substrate sits at the right layer
@@ -91,6 +93,7 @@ By keeping the substrate purely fire-and-forget, we kept it simple and let consu
 ## Relationship to `MutationEvent`
 
 `@inbrowser/agent` has its own append-only event log at `~/.pyric/projects/<id>/events.ndjson`, populated by `wrapMutating`. The shape there is `MutationEvent`:
+
 ```ts
 interface MutationEvent {
   id: string;
@@ -104,6 +107,7 @@ interface MutationEvent {
   reverse?: ReverseOp;
 }
 ```
+
 `RequestEvent` and `MutationEvent` aren't the same thing, even though they overlap in spirit.
 
 | | `RequestEvent` | `MutationEvent` |

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-identity-is-a-context.md
@@ -12,6 +12,7 @@ The most-visible architectural decision in `pyric/sandbox` is that `Sandbox` doe
 ## What the alternative would look like
 
 A simpler API exposes `auth` as a field on the sandbox:
+
 ```ts
 // Hypothetical, not the actual API.
 const sandbox = initializeSandbox({ auth: { uid: 'alice' } });
@@ -19,6 +20,7 @@ sandbox.firestore.collection('notes').doc('n1').set(...);  // runs as alice
 sandbox.setAuth({ uid: 'bob' });
 sandbox.firestore.collection('notes').doc('n1').get();     // runs as bob
 ```
+
 This is closest to how the Firebase client SDK works: the client knows who you are because you signed in earlier. It's intuitive. So why didn't we ship it?
 
 ## Three problems with auth-on-sandbox
@@ -26,6 +28,7 @@ This is closest to how the Firebase client SDK works: the client knows who you a
 ### 1. Multi-tenant tests need many identities, often simultaneously
 
 A test that asserts "alice can read her own note but not bob's" needs two identities live at the same time. With auth-on-sandbox, the test has to swap auth back and forth:
+
 ```ts
 sandbox.setAuth({ uid: 'alice' });
 await sandbox.firestore.collection('notes').doc('alice-1').set({ ownerId: 'alice' });
@@ -33,7 +36,9 @@ sandbox.setAuth({ uid: 'bob' });
 try { await sandbox.firestore.collection('notes').doc('alice-1').get(); } catch { /* expected */ }
 sandbox.setAuth({ uid: 'alice' });  // restore
 ```
+
 This is tedious and error-prone. Forget to restore and the next operation runs as `bob` accidentally. With contexts, the same test is straightforward:
+
 ```ts
 const aliceDb = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 const bobDb = getFirestore(sandbox.withAuth({ uid: 'bob' }));
@@ -41,11 +46,13 @@ const bobDb = getFirestore(sandbox.withAuth({ uid: 'bob' }));
 await aliceDb.collection('notes').doc('alice-1').set({ ownerId: 'alice' });
 try { await bobDb.collection('notes').doc('alice-1').get(); } catch { /* expected */ }
 ```
+
 Two named variables, two identities, no swapping. The test reads like the assertion it's making.
 
 ### 2. Concurrent operations from different identities
 
 Two simultaneous writes from different users:
+
 ```ts
 // With auth-on-sandbox — concurrent setAuth calls race.
 await Promise.all([
@@ -53,13 +60,16 @@ await Promise.all([
   (async () => { sandbox.setAuth({ uid: 'bob' }); await write(); })(),
 ]);
 ```
+
 The behaviour depends on event-loop scheduling. The same code passes most runs and fails sometimes. With contexts:
+
 ```ts
 await Promise.all([
   aliceDb.collection('notes').doc('a1').set({ ... }),
   bobDb.collection('notes').doc('b1').set({ ... }),
 ]);
 ```
+
 Each operation's identity is captured in the handle it was issued through. No race.
 
 ### 3. Identity-agnostic operations should be obvious
@@ -67,6 +77,7 @@ Each operation's identity is captured in the handle it was issued through. No ra
 Admin reads, listener subscribers, `reset`, `dispose`, `snapshot`: none of these are tied to a user. With auth-on-sandbox, where do they live? On the sandbox, alongside the user-bound operations? That blurs the line. With contexts, the identity-agnostic surface is exactly what's on `Sandbox`; everything else (data operations) requires a context. A reader of the type signature can tell at a glance.
 
 ## The mental model
+
 ```
 Sandbox          ← data, rules, lifecycle. Identity-agnostic.
    │
@@ -78,6 +89,7 @@ SandboxContext   ← (sandbox, auth) pair. Cheap, immutable.
    ▼
 FirestoreHandle  ← data-plane API. Operations evaluate under ctx.auth.
 ```
+
 Three layers, each with one job. Operations that mutate data flow down the chain. Operations that don't (listener subscriptions, admin reads, lifecycle) live at the top.
 
 ## What about per-operation auth overrides?

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-internal-adapter-protocol.md
@@ -32,6 +32,7 @@ The gate is by convention, not enforcement. `pyric/sandbox/internal` is a regula
 A typical adapter does three things with `/internal`:
 
 ### 1. Resolve the runtime substrate
+
 ```ts
 import { getInternalEnv } from 'pyric/sandbox/internal';
 import type { SandboxContext } from 'pyric/sandbox';
@@ -41,9 +42,11 @@ function getFirestore(ctx: SandboxContext): FirestoreHandle {
   return buildHandleAroundEnv(env, ctx.auth);
 }
 ```
+
 `getInternalEnv` throws if the `Sandbox` wasn't produced by `initializeSandbox`, so adapters can rely on it to reject malformed input early.
 
 ### 2. Translate user calls to substrate operations
+
 ```ts
 import type { Operation, OperationResult } from 'pyric/sandbox/internal';
 
@@ -59,12 +62,15 @@ async function set(handle, path, data) {
   return result;
 }
 ```
+
 Operations are plain shapes. Each adapter writes its own translation logic: `pyric-admin` translates chainable calls, `pyric/firestore` translates modular function calls. Both produce `Operation` and consume `OperationResult`.
 
 ### 3. Resolve sentinels
+
 ```ts
 import { resolveValueTree, registerDefaultConverters } from 'pyric/sandbox/internal';
 ```
+
 Sentinels (`FieldValue.increment`, `serverTimestamp`, `arrayUnion`) are values the substrate doesn't store directly. They describe an operation on the current document. The adapter resolves them via `resolveValueTree(payload, env, method)` before handing the payload to `LocalEnvironment.execute`.
 
 ## What adapters shouldn't do

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-listener-re-evaluation.md
@@ -60,6 +60,7 @@ The distinction:
 The re-evaluation loop walks every active listener. A callback may add or remove listeners during the loop (React StrictMode does this routinely; HMR likewise). Iterating the map directly while it mutates is a bug.
 
 The loop snapshots the listener IDs first, then checks `snapshotListeners.has(id)` per iteration:
+
 ```ts
 const records = Array.from(this.snapshotListeners.values());
 for (const record of records) {
@@ -67,6 +68,7 @@ for (const record of records) {
   // ... re-evaluate
 }
 ```
+
 The same pattern appears in write-driven listener notification. The mutating-during-iteration risk is the same in both cases; the fix is the same.
 
 ## The "once-per-stream" error contract

--- a/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-explanation-why-adapters-are-siblings.md
@@ -39,6 +39,7 @@ Keeping the split visible at the package level makes the dependency direction ob
 ## What the adapters do
 
 Both adapters are thin. The pattern, abstracted:
+
 ```
 User call (getDoc, db.collection.get, etc.)
   ↓
@@ -52,6 +53,7 @@ OperationResult { allowed, data?, debugMessages, event }
   ↓
 Adapter translates back to user-facing types (QuerySnapshot, DocumentSnapshot, etc.)
 ```
+
 The adapter is mostly translation. Each one does a few extra things to match its upstream SDK's idiosyncrasies (`pyric-admin` constructs a per-call compatibility implementation to keep reference semantics right; `pyric/firestore` adapts the modular Web SDK shape), but the core flow is the same.
 
 This is what makes "the substrate is shared" workable. Both adapters bottom out at the same `LocalEnvironment` methods. Two contexts derived from one sandbox, one through `pyric-admin` and one through `pyric/firestore`, see the same data.

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-multiple-isolated-sandboxes.md
@@ -12,6 +12,7 @@ Keep multiple sandboxes alive at once, for fleet tests, multi-tenant simulations
 ## Sandboxes are fully isolated
 
 Two `initializeSandbox()` calls produce two independent sandboxes. No shared state, no shared listeners, no shared event log. Run them in parallel without coordination:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -31,9 +32,11 @@ console.log(sbA.admin.getDocument('notes/a1'));  // { from: 'sandbox A' }
 console.log(sbB.admin.getDocument('notes/b1'));  // { from: 'sandbox B' }
 console.log(sbA.admin.getDocument('notes/b1'));  // null — different sandbox
 ```
+
 ## Fleet test pattern
 
 For N parallel scenarios:
+
 ```ts
 async function runScenario(scenarioName: string) {
   const sandbox = initializeSandbox();
@@ -43,6 +46,7 @@ async function runScenario(scenarioName: string) {
 
 await Promise.all(scenarios.map(runScenario));
 ```
+
 Each scenario gets its own sandbox. `dispose` at the end is defensive. Once the variable goes out of scope, the garbage collector will reclaim the sandbox anyway. `dispose` matters when listeners are involved, because subscribers might keep the sandbox reachable longer than you intended.
 
 ## Cost considerations
@@ -58,6 +62,7 @@ For thousands of sandboxes, profile before assuming linearity. For tens or hundr
 ## Sharing rules across sandboxes
 
 `SandboxConfig` is reserved for future bulk-config options. Today, each sandbox sets rules independently. To share a ruleset across many:
+
 ```ts
 const RULES = `rules_version = '2'; …`;
 
@@ -70,6 +75,7 @@ function makeSeeded() {
 
 const sandboxes = Array.from({ length: 10 }, makeSeeded);
 ```
+
 The rules text is shared (by reference); the underlying state is per-sandbox.
 
 ## Vitest / Bun test parallelism

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-observe-events.md
@@ -24,6 +24,7 @@ One subscription covers everything observable. `sandbox.onEvent(cb)` fires a [`S
 | Attribute a listener re-eval to the originating write | `kind === 'snapshot_delivery'`, read `triggeredBy` |
 
 ## Subscribe
+
 ```ts
 import { initializeSandbox, type SandboxEvent } from 'pyric/sandbox';
 
@@ -35,9 +36,11 @@ const unsubscribe = sandbox.onEvent((event) => events.push(event));
 // ... later:
 unsubscribe();
 ```
+
 The subscription **survives `sandbox.reset()`**. The underlying environment swaps but the user callback stays in the sandbox-level registry. A `session_boundary` event with `phase: 'reset'` fires immediately before the swap so consumers can segment their stream. On `sandbox.dispose()` the boundary fires once with `phase: 'dispose'` and the registry clears.
 
 ## Render a traffic panel
+
 ```tsx
 function TrafficPanel() {
   const [events, setEvents] = useState<SandboxEvent[]>([]);
@@ -66,20 +69,24 @@ function TrafficPanel() {
   );
 }
 ```
+
 ## Derive denials as a filter
 
 The previous `onDenial` channel is gone. Denials are a one-line filter:
+
 ```ts
 const unsubscribe = sandbox.onEvent((event) => {
   if (event.kind !== 'request' || event.result !== 'deny') return;
   showBanner(`${event.method} ${event.path} denied`);
 });
 ```
+
 The same `request` event carries `auth`, `reasons`, `request.resourceData`, and `resourceBefore`: every field the old `DenialEvent` carried, plus the per-eval `evalMs` the request channel always had.
 
 ## Capture snapshot deliveries
 
 `onRequest` used to fire one listener-origin event per write that touched a watched path, even when the listener's diff-check determined the result was identical to the prior snapshot. That over-counted: consumers saw "the listener was woken up", not "the listener delivered to user code". The new `snapshot_delivery` and `snapshot_suppressed` events disambiguate.
+
 ```ts
 sandbox.onEvent((event) => {
   if (event.kind === 'snapshot_delivery') {
@@ -93,9 +100,11 @@ sandbox.onEvent((event) => {
   }
 });
 ```
+
 The initial-fire event (when a listener attaches) emits `snapshot_delivery` with every existing doc as `added` and no `triggeredBy`. Write-driven re-evals carry `triggeredBy: { method, path }`.
 
 ## Track listener lifecycle
+
 ```ts
 sandbox.onEvent((event) => {
   if (event.kind === 'listener_attach') console.log(`+ ${event.target.kind}: ${describe(event.target)}`);
@@ -103,6 +112,7 @@ sandbox.onEvent((event) => {
   else if (event.kind === 'listener_errored') console.log(`! ${event.listenerId}: ${event.error?.message}`);
 });
 ```
+
 Attach fires once before the initial-snapshot delivery. Detach fires when the returned unsubscribe is called against a still-registered listener (idempotent calls don't double-emit; listeners dropped by `reset()` don't emit detach, the `session_boundary` event covers the rollover). Errored fires when a stream-level rule denial silently terminates the listener.
 
 ## Volume: default-hide listener re-evals
@@ -112,6 +122,7 @@ Per the issue #307 probe data: a query listener can re-evaluate on every write t
 The decision-doc recommendation: in a UI panel, default-hide `kind: 'request' && origin: 'listener'` events behind a toggle. Default-show: user-origin requests + snapshot deliveries + listener lifecycle + denials. `snapshot_suppressed` is opt-in (inspector mode).
 
 ## Capture committed writes for replay
+
 ```ts
 sandbox.onEvent((event) => {
   if (event.kind !== 'write') return;
@@ -128,11 +139,13 @@ sandbox.onEvent((event) => {
   });
 });
 ```
+
 `write` events fire only for writes that the rule engine allowed AND the keyspace successfully applied. Denied or rolled-back writes surface as `kind: 'request' && result: 'deny'` with no companion `write` event.
 
 The `sentinels`, `autoId`, and `requestTime` fields on `WriteSandboxEvent` are populated so a captured stream can be replayed. See [Replay a captured event stream](../pyric-sandbox-how-to-replay-events/). For live observation you can ignore them.
 
 ## Segment around reset()
+
 ```ts
 let session = 1;
 sandbox.onEvent((event) => {
@@ -142,6 +155,7 @@ sandbox.onEvent((event) => {
   }
 });
 ```
+
 `session_boundary` fires BEFORE the env swap on `reset()` and BEFORE teardown on `dispose()`. The subscription survives reset; only dispose clears it.
 
 ## Subscriber contract

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-pick-an-adapter.md
@@ -12,6 +12,7 @@ Two adapter packages sit on top of `pyric/sandbox`. Both expose Firestore. They 
 ## The two surfaces
 
 **`pyric-admin`** mirrors `firebase-admin/firestore`: chainable, class-shaped.
+
 ```ts
 import { getFirestore } from 'pyric-admin';
 
@@ -21,7 +22,9 @@ await db.collection('notes').doc('n1').set({ title: 'hello' });
 const snap = await db.collection('notes').where('owner', '==', 'alice').get();
 await db.runTransaction(async (tx) => { /* ... */ });
 ```
+
 **`pyric/firestore`** mirrors `firebase/firestore` (the modular Web SDK): function-shaped, tree-shakable.
+
 ```ts
 import { initializeFirestore, getDoc, setDoc, doc, query, where, getDocs } from 'pyric/firestore';
 
@@ -31,6 +34,7 @@ await setDoc(doc(db, 'notes', 'n1'), { title: 'hello' });
 const q = query(db.collection('notes'), where('owner', '==', 'alice'));
 const snap = await getDocs(q);
 ```
+
 Both back onto the same `LocalEnvironment` under the hood. The runtime behaviour is identical; only the API shape differs.
 
 ## Decision matrix
@@ -49,6 +53,7 @@ Both back onto the same `LocalEnvironment` under the hood. The runtime behaviour
 The right choice is whatever shape your *production* code already uses. The sandbox is a development tool, and keeping the test code's surface identical to production avoids translation bugs.
 
 If you're working in both environments (a hybrid app, a Cloud Functions backend with a web frontend), use both. They share the same sandbox cleanly:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore as getAdmin } from 'pyric-admin';
@@ -64,6 +69,7 @@ await adminDb.collection('notes').doc('n1').set({ title: 'from backend' });
 const snap = await getDoc(doc(webDb, 'notes', 'n1'));
 console.log(snap.data());  // { title: 'from backend' }
 ```
+
 ## Can I use both inside one test?
 
 Yes. Each adapter is a thin wrapper over `SandboxContext` and `LocalEnvironment`. The two adapters don't conflict, and their objects don't interfere with each other.

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-replay-events.md
@@ -19,6 +19,7 @@ The sandbox captures every `SandboxEvent` it emits. Hand the captured stream to 
 | Debug "why did `serverTimestamp()` resolve differently" | check `time-drift` divergences (turn off `pinRequestTime` if you want to see the drift) |
 
 ## Capture
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -36,11 +37,13 @@ const state = sandbox.snapshot().firestore ?? {};
 
 // Persist `events` and `state` wherever you want (file, Firebase Storage, etc).
 ```
+
 `sandbox.history()` returns a defensive copy of every `SandboxEvent` the sandbox has emitted: request, write, snapshot delivery, listener lifecycle, session_boundary. The replay engine only consumes `kind: 'write'` events; the rest pass through untouched (useful if you persist the full log for diagnostic purposes).
 
 The captured `request.resourceData` and `write.data` ship **pre-resolution**. `FieldValue.serverTimestamp()` arrives as `{ __type: 'serverTimestamp' }`, not a materialized Timestamp; `FieldValue.increment(1)` arrives as `{ __type: 'increment', value: 1 }`, etc. This is what lets the replay engine re-resolve them against a fresh sandbox (and lets `pinRequestTime` actually do something). `write.priorState` / `write.nextState` carry the **post-resolution** values, the actual stored state at that moment.
 
 ## Replay
+
 ```ts
 import { replay } from 'pyric/sandbox';
 
@@ -51,15 +54,18 @@ const { sandbox: replayed, divergences, pathAliases } = replay(
   state,                      // optional — enables divergence classification
 );
 ```
+
 The function builds a fresh sandbox with the same rules, walks every captured write, re-issues it (with sentinels intact), and, if you passed `state`, diffs the replayed final state against it.
 
 ## Classify divergences
 
 The `divergences` array is a discriminated union. Filter on `kind` and handle each case. `real-divergence` is the only kind that signals an actual bug; the others are intentional by-design differences (auto-id minting, clock drift on unpinned replay, sentinel resolution against a different prior).
+
 ```ts
 const real = divergences.filter((d) => d.kind === 'real-divergence');
 expect(real).toHaveLength(0);    // typical CI assertion
 ```
+
 See the [`Divergence` reference](../pyric-sandbox-reference-divergences/) for the full union shape, per-kind semantics, and field-path syntax.
 
 ## `pinRequestTime`: the default that prevents flake

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-reset-between-tests.md
@@ -16,6 +16,7 @@ Keep one sandbox alive across many tests without state leakage.
 That means you can hoist the sandbox to the top of a test file and reset before each case without re-deriving every context.
 
 ## Per-test reset with a shared sandbox
+
 ```ts
 import { beforeEach } from 'bun:test';
 import { initializeSandbox } from 'pyric/sandbox';
@@ -31,11 +32,13 @@ beforeEach(() => {
   // … see "Seed initial data and rules"
 });
 ```
+
 After `reset`, the environment is empty: no documents, no rules (default-deny), no listeners. The `aliceDb` and `anonDb` references are still valid.
 
 ## Fresh sandbox per test
 
 If your tests touch many sandboxes or you want truly nothing in common between them, build a new one each time:
+
 ```ts
 import { beforeEach } from 'bun:test';
 
@@ -46,6 +49,7 @@ beforeEach(() => {
   sandbox = initializeSandbox();
 });
 ```
+
 `dispose()` drops listener registries on the outgoing instance defensively, useful when consumer code (rare; mostly tests) still holds a reference to the old sandbox.
 
 ## When listeners are involved
@@ -53,6 +57,7 @@ beforeEach(() => {
 `reset()` calls `dispose()` on the outgoing environment before swapping. Snapshot listeners attached to that env are dropped, because their target docs were wiped.
 
 `onEvent` subscribers, in contrast, **survive `reset()`**. The registry lives on the `Sandbox` itself; the env swap doesn't invalidate it. A `session_boundary` event with `phase: 'reset'` fires immediately before the swap so observers know the rollover happened. Code that subscribed in `beforeAll` keeps working across every `beforeEach` reset:
+
 ```ts
 beforeAll(() => {
   unsubscribe = sandbox.onEvent((event) => {
@@ -69,6 +74,7 @@ beforeEach(() => {
   events.length = 0;  // events array is shared; clear between tests.
 });
 ```
+
 Resubscribing on every reset works too, but isn't required.
 
 ## When parallel tests run in the same process

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-seed-data-and-rules.md
@@ -19,6 +19,7 @@ Bring a fresh sandbox up to a known state (rules deployed, documents in place) b
 Most consumers use the adapter path. The `/internal` path is for higher-level tooling (the playground, the agent runtime) that wants to load a whole snapshot atomically.
 
 ## Adapter-driven seed
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -46,9 +47,11 @@ await adminDb.collection('notes').doc('n1').set({
   title: 'first note',
 });
 ```
+
 This path is the most natural for tests because every operation goes through the same SDK surface your production code uses. If your rules deny `admin`-authed writes too, fall back to `/internal`.
 
 ## `/internal` seed for tooling
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getInternalEnv } from 'pyric/sandbox/internal';
@@ -76,6 +79,7 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
   throw new Error('rules failed to lint');
 }
 ```
+
 `seed` returns the `LintResult` from `pyric/rules`. Check it before treating the seed as successful. A ruleset with errors leaves the sandbox in default-deny.
 
 `/internal` is documented as adapter-only. Tooling that uses it accepts that the surface may change between minor versions.
@@ -85,20 +89,25 @@ if (lint.warnings.some((w) => w.severity === 'error')) {
 Two patterns work. Choose by how much your tests share state.
 
 ### Seed once at module top
+
 ```ts
 const sandbox = initializeSandbox();
 seed(sandbox);  // your helper
 
 beforeEach(() => sandbox.reset());
 ```
+
 After `reset`, the sandbox is empty. Re-seed if the next test depends on the initial state. A helper makes that cheap:
+
 ```ts
 beforeEach(() => {
   sandbox.reset();
   seed(sandbox);
 });
 ```
+
 ### Build per test
+
 ```ts
 let sandbox: Sandbox;
 
@@ -107,6 +116,7 @@ beforeEach(() => {
   seed(sandbox);
 });
 ```
+
 Heavier (rebuilds the environment per test) but isolates state changes more strictly. Use when tests are touching listeners or when seed cost is negligible.
 
 ## Order matters

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-switch-users.md
@@ -10,6 +10,7 @@ order: 13009
 Evaluate rules under different auth identities against the same sandbox.
 
 ## Two contexts, one sandbox
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -20,21 +21,25 @@ const aliceDb = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 const adminDb = getFirestore(sandbox.withAuth({ uid: 'admin', token: { admin: true } }));
 const anonDb  = getFirestore(sandbox.withAuth(null));
 ```
+
 Three contexts, three identities, shared data. Writes through `aliceDb` evaluate with `request.auth.uid == 'alice'`; reads through `adminDb` evaluate with `request.auth.token.admin == true`; everything through `anonDb` sees `request.auth == null`.
 
 ## Chain from a context
 
 `SandboxContext.withAuth` replaces the auth and returns a new sibling context:
+
 ```ts
 const adminCtx = sandbox.withAuth({ uid: 'admin', token: { admin: true } });
 const userCtx = adminCtx.withAuth({ uid: 'alice' });
 // adminCtx and userCtx share the same sandbox but evaluate as different users.
 ```
+
 Use this when a chunk of code already has a context and wants to derive another one without going back to the sandbox.
 
 ## Tokens are claims, not just JWTs
 
 The `token` field on `AuthState` becomes `request.auth.token.*` in rules. Pass any custom claims your rules care about:
+
 ```ts
 sandbox.withAuth({
   uid: 'employee-42',
@@ -45,11 +50,14 @@ sandbox.withAuth({
   },
 });
 ```
+
 Inside a rule:
+
 ```rules
 allow update: if request.auth.token.role == 'editor'
               || request.auth.token.role == 'admin';
 ```
+
 ## Anonymous must be explicit
 
 `withAuth(undefined)` throws `SandboxError('invalid-argument')`. For anonymous access, say `withAuth(null)`. The call site is then unambiguous about whether anonymous was intended or omitted.

--- a/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-how-to-use-admin-reads.md
@@ -12,23 +12,27 @@ Use `sandbox.admin` to verify state in tests without writing rules that permit y
 ## The problem
 
 A test asserts "the write went through":
+
 ```ts
 await aliceDb.collection('notes').doc('n1').set({ title: 'hello' });
 
 const snap = await aliceDb.collection('notes').doc('n1').get();
 expect(snap.exists).toBe(true);
 ```
+
 The `aliceDb.get` evaluates `allow read` against `alice`'s identity. If your read rule rejects this (for example, because it requires the doc to be in a specific status), the assertion will fail even though the write succeeded. You can't tell whether the bug is in the write or in the read rule.
 
 ## The fix
 
 Use `sandbox.admin` for the assertion:
+
 ```ts
 await aliceDb.collection('notes').doc('n1').set({ title: 'hello' });
 
 const data = sandbox.admin.getDocument('notes/n1');
 expect(data).toEqual({ title: 'hello' });
 ```
+
 `sandbox.admin.getDocument` ignores rules entirely. It tells you what the *data* is, not what `alice` is allowed to see.
 
 ## When to use admin reads
@@ -44,13 +48,16 @@ expect(data).toEqual({ title: 'hello' });
 - **To verify rules permit a read.** Use a user-shaped read for that. Admin reads tell you the data exists; they don't tell you the rules let your user see it. Mix both: admin to assert the write, user-shaped read to assert the rule.
 
 ## Listing under a collection
+
 ```ts
 const docs = sandbox.admin.listDocuments('notes');
 for (const { path, data } of docs) {
   console.log(path, data);
 }
 ```
+
 The result includes **phantom** parents: synthesised entries for paths that have descendants but no stored data of their own. Phantom records carry `phantom: true` and `data: {}`:
+
 ```ts
 // Wrote rooms/alpha/messages/m1 directly. List 'rooms':
 const rooms = sandbox.admin.listDocuments('rooms');
@@ -58,13 +65,17 @@ const rooms = sandbox.admin.listDocuments('rooms');
 //   { path: 'rooms/alpha', data: {}, phantom: true },
 // ]
 ```
+
 Filter phantoms out if your test only cares about explicitly-written docs:
+
 ```ts
 const written = docs.filter((d) => !d.phantom);
 ```
+
 ## Snapshot for whole-state assertions
 
 `sandbox.snapshot()` returns the full state in one call:
+
 ```ts
 const snap = sandbox.snapshot();
 expect(snap.firestore).toEqual({
@@ -72,6 +83,7 @@ expect(snap.firestore).toEqual({
   'users/alice': { name: 'Alice' },
 });
 ```
+
 Useful for round-tripping (capture before, restore after a destructive operation) and for diagnostic dumps when a test fails. The returned object is a structural clone; mutating it does not affect the sandbox.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-api.md
@@ -13,9 +13,11 @@ Every symbol re-exported from `pyric/sandbox`. The `/internal` sub-path is docum
 ### `initializeSandbox(config?: SandboxConfig): Sandbox`
 
 Create a new sandbox with no identity attached. `SandboxConfig` is reserved for future service-agnostic options; today it must be `{}` or omitted.
+
 ```ts
 const sandbox = initializeSandbox();
 ```
+
 Identity is **not** part of init. Derive a `SandboxContext` via `sandbox.withAuth(...)` before reaching for any service handle.
 
 ## Types
@@ -23,6 +25,7 @@ Identity is **not** part of init. Derive a `SandboxContext` via `sandbox.withAut
 ### `Sandbox`
 
 The data + rules + lifecycle handle. Identity-agnostic by design.
+
 ```ts
 interface Sandbox {
   withAuth(auth: AuthState): SandboxContext;
@@ -34,11 +37,13 @@ interface Sandbox {
   snapshot(): SandboxSnapshot;
 }
 ```
+
 See [`Sandbox`, `SandboxContext`, `AuthState`](../pyric-sandbox-reference-sandbox-and-context/).
 
 ### `SandboxContext`
 
 Immutable `(sandbox, auth)` pair. Service factories (`getFirestore` and friends) accept this.
+
 ```ts
 interface SandboxContext {
   readonly sandbox: Sandbox;
@@ -46,10 +51,13 @@ interface SandboxContext {
   withAuth(auth: AuthState): SandboxContext;
 }
 ```
+
 ### `AuthState`
+
 ```ts
 type AuthState = { uid: string; token?: Record<string, unknown> } | null;
 ```
+
 `null` is anonymous. The `token` object becomes `request.auth.token` in rules.
 
 ### `SandboxConfig`
@@ -59,15 +67,18 @@ Reserved for future config (rules, seed data, multi-service options). Empty in v
 ### `SandboxSnapshot`
 
 Coarse capture of every service's state:
+
 ```ts
 interface SandboxSnapshot {
   firestore?: Record<string, unknown>;
   [service: string]: unknown;
 }
 ```
+
 ### `SandboxAdmin`
 
 Rule-bypass reads, exposed on `sandbox.admin`. Identity-agnostic by design.
+
 ```ts
 interface SandboxAdmin {
   getDocument(path: string): unknown | null;
@@ -75,6 +86,7 @@ interface SandboxAdmin {
     { path: string; data: unknown; phantom?: true }[];
 }
 ```
+
 See [`SandboxSnapshot` and admin reads](../pyric-sandbox-reference-snapshot-and-admin/).
 
 ### `SandboxEvent`
@@ -90,10 +102,12 @@ Structured denial frame attached to `SandboxError` for `permission-denied` codes
 ### `class SandboxError extends Error`
 
 Typed error family. Construct via either positional or options-bag form:
+
 ```ts
 new SandboxError(code, message, denialContext?);
 new SandboxError({ code, message, denialContext?, remediation? });
 ```
+
 Properties:
 
 - `code: SandboxErrorCode`
@@ -101,6 +115,7 @@ Properties:
 - `remediation?: string`: optional human-readable guidance, appended to `.message`.
 
 ### `type SandboxErrorCode`
+
 ```
 // Firebase-aligned
 'invalid-argument' | 'permission-denied' | 'not-found' | 'already-exists'
@@ -108,6 +123,7 @@ Properties:
 // Sandbox-specific
 'unimplemented' | 'not-seeded' | 'rules-not-loaded'
 ```
+
 See [`SandboxError` codes](../pyric-sandbox-reference-error-codes/).
 
 ## Classes (for `instanceof` routing)

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-divergences.md
@@ -20,6 +20,7 @@ Two design rules govern the classifier:
 2. **Leaf-precise.** The engine walks both documents recursively and reports field paths at the leaf (`profile.lastSeen`, `tags[0]`, `arr[2].nested`). A sentinel-bearing parent doesn't mask sibling changes.
 
 ## The union
+
 ```ts
 type Divergence =
   | {
@@ -34,12 +35,15 @@ type Divergence =
   | { kind: 'time-drift';     path: string; field: string;  before: unknown; after: unknown }
   | { kind: 'real-divergence';path: string; field?: string; before: unknown; after: unknown };
 ```
+
 ## `kind: 'autoid-alias'`
 
 A write that originated from `LocalEnvironment.createWithAutoId` minted a fresh document ID on replay: same content, different path.
+
 ```ts
 { kind: 'autoid-alias', originalPath: 'notes/Iy5CGRl0HlP1XZo4GGiI', replayedPath: 'notes/5MM3PdzWUQvqRCi3wthO' }
 ```
+
 Re-using the original ID would be incorrect: auto-id semantics include "the id is unique." Two replays of the same log on different sandboxes legitimately mint different ids. The engine emits one alias entry per such write and exposes the full mapping on `ReplayResult.pathAliases` so consumers that index by path can map original → replayed.
 
 Not a bug. Consumers comparing document presence should consult `pathAliases` before flagging "missing doc."
@@ -47,6 +51,7 @@ Not a bug. Consumers comparing document presence should consult `pathAliases` be
 ## `kind: 'sentinel-drift'`
 
 A captured `FieldValue.*` sentinel (other than `serverTimestamp`, which has its own kind) sits at this exact field path, and the subtree differs between original and replayed state.
+
 ```ts
 {
   kind: 'sentinel-drift',
@@ -57,6 +62,7 @@ A captured `FieldValue.*` sentinel (other than `serverTimestamp`, which has its 
   after: 7,
 }
 ```
+
 Usually means **the prior state differed**, not that the sentinel itself misbehaved. `increment`, `arrayUnion`, `arrayRemove`, and `deleteField` are deterministic given the same prior. If their result differs, the prior was different. Look for an upstream `real-divergence` that explains why.
 
 In practice, with the same captured stream replayed onto a fresh sandbox, sentinel-drift is rare. It surfaces most often when you replay onto state that *isn't* the captured starting point (e.g., partial replays, splicing two logs).
@@ -64,6 +70,7 @@ In practice, with the same captured stream replayed onto a fresh sandbox, sentin
 ## `kind: 'time-drift'`
 
 A captured `serverTimestamp()` sentinel at this exact field path resolved to a different `Timestamp` on replay.
+
 ```ts
 {
   kind: 'time-drift',
@@ -73,6 +80,7 @@ A captured `serverTimestamp()` sentinel at this exact field path resolved to a d
   after:  { __type: 'timestamp', seconds: 1778955966, nanos: 657000000 },
 }
 ```
+
 Only fires when `pinRequestTime: false`. With the default `pinRequestTime: true`, the engine re-issues the captured `request.time` to the fresh sandbox so the sentinel resolves to the same value: zero `time-drift`.
 
 Not a bug. Useful for two scenarios:
@@ -83,6 +91,7 @@ Not a bug. Useful for two scenarios:
 ## `kind: 'real-divergence'`
 
 Anything else. Captured metadata doesn't license this difference, so the engine flags it.
+
 ```ts
 {
   kind: 'real-divergence',
@@ -92,10 +101,13 @@ Anything else. Captured metadata doesn't license this difference, so the engine 
   after: 'NOT-alice',
 }
 ```
+
 The `field` may be absent. For example, when an entire document is present on one side and missing on the other, the path alone identifies the divergence:
+
 ```ts
 { kind: 'real-divergence', path: 'notes/x', before: { /* doc */ }, after: undefined }
 ```
+
 This is the only kind that signals an actual bug. Common causes:
 
 - **Rules changed between capture and replay**: a write that succeeded originally gets denied; the doc is missing in replayed state.
@@ -103,6 +115,7 @@ This is the only kind that signals an actual bug. Common causes:
 - **Replay state seeded incorrectly**: if you persisted state separately from events and they drift apart, fields can disagree.
 
 ## Classifying in code
+
 ```ts
 for (const d of divergences) {
   switch (d.kind) {
@@ -121,6 +134,7 @@ for (const d of divergences) {
   }
 }
 ```
+
 A typical CI assertion: `expect(divergences.filter(d => d.kind === 'real-divergence')).toHaveLength(0)`.
 
 ## Field-path syntax

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-error-codes.md
@@ -7,6 +7,7 @@ order: 13013
 # `SandboxError` codes
 
 Every error the sandbox raises is a `SandboxError` carrying a `code`. Catch with `instanceof SandboxError`, switch on `code`.
+
 ```ts
 import { SandboxError } from 'pyric/sandbox';
 
@@ -18,6 +19,7 @@ try {
   }
 }
 ```
+
 ## Firebase-aligned codes
 
 These match Firebase / gRPC conventions so production-shaped `catch (e) { if (e.code === 'permission-denied') }` code keeps working.
@@ -90,6 +92,7 @@ Similar to `'not-seeded'`, but specifically signals that rules haven't been depl
 ## Constructing errors yourself
 
 Two forms:
+
 ```ts
 // Positional — backwards-compatible.
 throw new SandboxError('permission-denied', 'Denied: …', denialContext);
@@ -101,6 +104,7 @@ throw new SandboxError({
   remediation: 'For anonymous: withAuth(null). For users: withAuth({ uid: "…" }).',
 });
 ```
+
 When `remediation` is set, it is appended to the error's `.message` with a blank-line separator so consumers that surface `.message` (logs, UIs) see the guidance without an API change. The structured form is also available on the instance as `error.remediation`.
 
 ## What carries `denialContext`

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-internal-protocol.md
@@ -12,9 +12,11 @@ The `pyric/sandbox/internal` sub-path is the **adapter-only** surface. Service-a
 It is **not** part of the public API. The shape is subject to change without breaking-change semantics across `pyric/sandbox` versions. External adapter authors should not depend on it directly. When the protocol stabilises (after the multi-service architecture lands) it will be promoted.
 
 ## What lives there
+
 ```ts
 import { getInternalEnv, LocalEnvironment, EventLog /* … */ } from 'pyric/sandbox/internal';
 ```
+
 The major surfaces:
 
 ### `getInternalEnv(sandbox): LocalEnvironment`
@@ -43,6 +45,7 @@ Append-only audit trail of every operation. Adapters that need to surface "what 
 ### Field-value sentinels
 
 For `pyric-admin` and `pyric/firestore` to translate user-facing sentinels into the simulator's shape:
+
 ```ts
 import {
   INCREMENT,
@@ -53,7 +56,9 @@ import {
   incrementConverter, arrayUnionConverter, arrayRemoveConverter, deleteFieldConverter,
 } from 'pyric/sandbox/internal';
 ```
+
 ### Transaction primitives
+
 ```ts
 import {
   Transaction,
@@ -64,9 +69,11 @@ import {
   type DeleteResult,
 } from 'pyric/sandbox/internal';
 ```
+
 These shapes describe the per-operation results inside a batch or transaction so adapters can map them onto upstream-SDK return types.
 
 ### Error translation helpers
+
 ```ts
 import {
   FirestoreSimError,
@@ -74,9 +81,11 @@ import {
   FIRESTORE_ERROR_CODES,
 } from 'pyric/sandbox/internal';
 ```
+
 Adapters use these to translate simulator-shaped errors into upstream-SDK error shapes (`FirebaseError` with `firestore/permission-denied`-style codes).
 
 ### Value resolver
+
 ```ts
 import {
   resolveValueTree,
@@ -85,6 +94,7 @@ import {
   type ResolveMethod,
 } from 'pyric/sandbox/internal';
 ```
+
 Walk a payload tree, replacing sentinel values (`INCREMENT(1)`, `serverTimestamp()`, etc.) with their resolved equivalents under the current document state.
 
 ## What stays out

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-and-context.md
@@ -12,6 +12,7 @@ The three core types. Every other surface in the package builds on them.
 ## `Sandbox`
 
 The data + rules + lifecycle handle.
+
 ```ts
 interface Sandbox {
   withAuth(auth: AuthState): SandboxContext;
@@ -23,6 +24,7 @@ interface Sandbox {
   snapshot(): SandboxSnapshot;
 }
 ```
+
 A `Sandbox` is **identity-agnostic**. It does not know who you are; that's what `SandboxContext` is for. The `Sandbox` only holds:
 
 - The current `LocalEnvironment` (documents, rules, listeners).
@@ -34,11 +36,13 @@ Construct via `initializeSandbox()`. Custom implementations are not supported. A
 ### `withAuth(auth)`
 
 Derive a `SandboxContext` bound to this sandbox under the given auth identity.
+
 ```ts
 const aliceCtx = sandbox.withAuth({ uid: 'alice' });
 const adminCtx = sandbox.withAuth({ uid: 'admin', token: { role: 'admin' } });
 const anonCtx  = sandbox.withAuth(null);
 ```
+
 `undefined` is rejected: say `withAuth(null)` for anonymous explicitly so the call site is unambiguous. Empty UIDs are rejected. Non-object `token` is rejected. See the [error-handling notes](../pyric-sandbox-reference-error-codes/#invalid-argument) for the exact rules.
 
 ### `onEvent(cb)`
@@ -82,6 +86,7 @@ Drop listener registries on this sandbox's environment without replacing it. Use
 Capture a typed snapshot of every service's state. v1 carries only `firestore`; future services add their own keys.
 
 ## `SandboxContext`
+
 ```ts
 interface SandboxContext {
   readonly sandbox: Sandbox;
@@ -89,23 +94,28 @@ interface SandboxContext {
   withAuth(auth: AuthState): SandboxContext;
 }
 ```
+
 A `(sandbox, auth)` pair. Cheap to create, immutable, freely shareable. Service factories require this; passing a bare `Sandbox` is a type error.
 
 Many contexts can coexist for one sandbox. Data is shared; rules evaluate per-context under the context's auth identity.
 
 ### Chaining
+
 ```ts
 const adminCtx = sandbox.withAuth({ uid: 'admin', token: { admin: true } });
 const userCtx = adminCtx.withAuth({ uid: 'alice' });
 ```
+
 `SandboxContext.withAuth` **replaces** auth, it does not merge. The new context carries only the new auth.
 
 ## `AuthState`
+
 ```ts
 type AuthState =
   | { uid: string; token?: Record<string, unknown> }
   | null;
 ```
+
 - `null` → unauthenticated; `request.auth` evaluates to `null` in rules.
 - `{ uid }` → authenticated; `request.auth.uid` carries the value.
 - `{ uid, token }` → authenticated with custom claims; `request.auth.token.<key>` carries each entry.
@@ -113,6 +123,7 @@ type AuthState =
 The same shape feeds the rules simulator's `TestCase.auth` field (`pyric/rules`), so test data written against one surface works with the other.
 
 ## Lifecycle in pictures
+
 ```
 initializeSandbox()
        │
@@ -132,4 +143,5 @@ initializeSandbox()
    │ box   │
    └───────┘
 ```
+
 The sandbox object identity is stable for the life of the consumer. Only the underlying environment swaps. Contexts holding references to the sandbox don't need to be re-derived after a `reset`.

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-sandbox-event.md
@@ -11,6 +11,7 @@ recover any individual event family. The unified channel replaces the prior
 `onRequest` / `onDenial` / `onSnapshotError` triplet.
 
 ## The union
+
 ```ts
 type SandboxEvent =
   | RequestEvent              // kind: 'request'
@@ -20,9 +21,11 @@ type SandboxEvent =
   | ListenerLifecycleEvent    // kind: 'listener_attach' | 'listener_detach' | 'listener_errored'
   | SessionBoundaryEvent;     // kind: 'session_boundary'
 ```
+
 Every event carries `kind: <discriminator>`, `id: string` (unique within the sandbox process; React-list-key safe), and `at: number` (`Date.now()` at emission).
 
 ## `kind: 'request'`: every evaluated op
+
 ```ts
 interface RequestEvent {
   kind: 'request';
@@ -44,6 +47,7 @@ interface RequestEvent {
   triggeredBy?: { method: string; path: string };
 }
 ```
+
 Fires once per simulator-evaluated op. Denials surface here with `result: 'deny'`; the previous `DenialEvent` shape lives on as a derived field-projection. Filter `kind === 'request' && result === 'deny'` to recover it.
 
 **`method`** preserves the caller's verb. `set` stays `'set'` (the rule engine maps it internally to `'create'` or `'update'` based on whether the doc exists; that mapping appears on `matchedRule.operations`).
@@ -55,6 +59,7 @@ Fires once per simulator-evaluated op. Denials surface here with `result: 'deny'
 **`evalMs`** is the wall-clock duration of `simulator.simulate(...)`. Sub-millisecond for trivial rules; a traffic-monitor validation probe measured ~95ms p99 on connect-four's deep boolean chains.
 
 ## `kind: 'write'`: committed writes only
+
 ```ts
 interface WriteSandboxEvent {
   kind: 'write';
@@ -73,6 +78,7 @@ interface WriteSandboxEvent {
   requestTime: { seconds: number; nanoseconds: number };
 }
 ```
+
 Fires AFTER the corresponding `kind: 'request'` event for the same op, and ONLY for writes that the rule engine allowed AND the keyspace successfully applied. Denied or rolled-back writes don't emit a write event. They surface as `kind: 'request' && result: 'deny'` only.
 
 **`data`** is the **pre-resolution** payload: the user's intent. `FieldValue.*` sentinels are preserved as their marker shapes (`{ __type: 'serverTimestamp' }`, etc.); plain values pass through unchanged. The replay engine re-resolves the markers against a fresh sandbox so `pinRequestTime: false` actually drifts and `pinRequestTime: true` matches capture. Absent on `delete`. The materialized values the keyspace applied live on `nextState`.
@@ -86,6 +92,7 @@ Fires AFTER the corresponding `kind: 'request'` event for the same op, and ONLY 
 **`requestTime`** pins the `request.time` the rule engine evaluated against. The shape mirrors the Firestore Web SDK Timestamp (`{ seconds, nanoseconds }`). Required. The replay engine re-issues this exact value when re-resolving `serverTimestamp()` sentinels so resolved fields are bit-identical on replay; rules that branch on `request.time` evaluate identically. Within a batch or transaction, all sub-ops share the same `requestTime`.
 
 ## `kind: 'snapshot_delivery'`: listener callback fired
+
 ```ts
 interface SnapshotDeliveryEvent {
   kind: 'snapshot_delivery';
@@ -104,6 +111,7 @@ interface SnapshotDeliveryEvent {
   triggeredBy?: { method: string; path: string };
 }
 ```
+
 Fires AFTER the user callback runs, corresponding 1:1 with actual snapshot deliveries.
 
 **`addedCount` + `modifiedCount` + `removedCount`** match `QuerySnapshot.docChanges()`. Doc-target listeners report exactly one of (added=1, removed=1, modified=1) per fire. Query-target listeners can report any combination; the initial fire surfaces every doc as `added`.
@@ -115,6 +123,7 @@ Fires AFTER the user callback runs, corresponding 1:1 with actual snapshot deliv
 **`triggeredBy`** absent on initial fire (no user op caused it) and on `deployRules`-driven re-evals.
 
 ## `kind: 'snapshot_suppressed'`: re-eval ran but didn't deliver
+
 ```ts
 interface SnapshotSuppressedEvent {
   kind: 'snapshot_suppressed';
@@ -127,11 +136,13 @@ interface SnapshotSuppressedEvent {
   triggeredBy?: { method: string; path: string };
 }
 ```
+
 Fires when a listener wakes up on a write but the diff against the prior snapshot finds nothing observable changed (the no-op suppression). Useful for "why didn't my listener fire" debugging.
 
 **`reason`** is `'no-op'` in v1. The discriminator exists so future suppression sources (auth changes, rules changes mid-listen) can land without reshape.
 
 ## `kind: 'listener_attach' | 'listener_detach' | 'listener_errored'`
+
 ```ts
 interface ListenerLifecycleEvent {
   kind: 'listener_attach' | 'listener_detach' | 'listener_errored';
@@ -147,6 +158,7 @@ interface ListenerLifecycleEvent {
   };
 }
 ```
+
 **`listener_attach`** fires once when `onSnapshot` registers a record, BEFORE the initial-snapshot delivery.
 
 **`listener_detach`** fires once when the returned unsubscribe is called against a still-registered listener. Idempotent unsubscribes don't double-emit. Listeners dropped by `sandbox.reset()` don't emit detach; the `session_boundary` event covers the rollover.
@@ -156,6 +168,7 @@ interface ListenerLifecycleEvent {
 **`error`** is populated on `listener_errored` only. The shape mirrors what the previous `SnapshotErrorEvent` carried.
 
 ## `kind: 'session_boundary'`: reset / dispose
+
 ```ts
 interface SessionBoundaryEvent {
   kind: 'session_boundary';
@@ -165,11 +178,13 @@ interface SessionBoundaryEvent {
   priorOpCount: number;
 }
 ```
+
 Fires BEFORE the env swap on `sandbox.reset()` and BEFORE registry teardown on `sandbox.dispose()`. The subscription itself survives `reset()`; only `dispose()` clears it.
 
 **`priorOpCount`** is the cumulative count of events emitted from this sandbox prior to the boundary. Useful for verifying a persisted stream's segmentation against the sandbox's own bookkeeping.
 
 ## Filter cookbook
+
 ```ts
 // All denials (replaces the old onDenial channel).
 const isDenial = (e: SandboxEvent): e is RequestEvent =>
@@ -187,6 +202,7 @@ const isCommittedWrite = (e: SandboxEvent): e is WriteSandboxEvent =>
 const isLiveDelivery = (e: SandboxEvent): e is SnapshotDeliveryEvent =>
   e.kind === 'snapshot_delivery';
 ```
+
 ## See also
 
 - [Observe sandbox events](../pyric-sandbox-how-to-observe-events/): usage patterns + subscriber contract.

--- a/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-reference-snapshot-and-admin.md
@@ -10,15 +10,18 @@ order: 13017
 Two related surfaces. `SandboxSnapshot` is the shape returned by `Sandbox.snapshot()`. `SandboxAdmin` is the rule-bypass read surface exposed on `Sandbox.admin`.
 
 ## `SandboxSnapshot`
+
 ```ts
 interface SandboxSnapshot {
   firestore?: Record<string, unknown>;
   [service: string]: unknown;
 }
 ```
+
 Coarse capture of every service's state, keyed by service name. In v1 only `firestore` is populated; future services (`auth`, `database`, `storage`) will add their own keys.
 
 The `firestore` value is a flat map of document path → document data:
+
 ```ts
 const snap = sandbox.snapshot();
 console.log(snap.firestore);
@@ -28,6 +31,7 @@ console.log(snap.firestore);
 //   'notes/n1':    { owner: 'alice', title: 'hello' },
 // }
 ```
+
 Use this for:
 
 - **Round-tripping**: capture snapshot before a destructive test, restore after.
@@ -37,6 +41,7 @@ Use this for:
 The snapshot is a structural clone of the state at call time. Mutating the returned object does not affect the sandbox.
 
 ## `SandboxAdmin`
+
 ```ts
 interface SandboxAdmin {
   getDocument(path: string): unknown | null;
@@ -44,20 +49,24 @@ interface SandboxAdmin {
     { path: string; data: unknown; phantom?: true }[];
 }
 ```
+
 Available on `sandbox.admin`. Identity-agnostic: admin reads aren't gated on auth, so they live on the sandbox (not on a context).
 
 ### `getDocument(path)`
 
 Read a single Firestore document by full path, ignoring rules. Returns `null` if the document doesn't exist.
+
 ```ts
 const doc = sandbox.admin.getDocument('users/alice');
 // doc is { name: 'Alice', ... } or null
 ```
+
 Use this in tests to assert "did the write actually land?" without needing a separate admin context.
 
 ### `listDocuments(prefix)`
 
 List Firestore documents under a collection path, ignoring rules.
+
 ```ts
 const docs = sandbox.admin.listDocuments('users');
 // [
@@ -65,9 +74,11 @@ const docs = sandbox.admin.listDocuments('users');
 //   { path: 'users/bob',   data: { name: 'Bob' } },
 // ]
 ```
+
 ### Phantom documents
 
 `listDocuments` includes **phantom** records: synthesised parent docs that have descendants but no stored data of their own. These match what a live Firestore listing would expose for nested collections:
+
 ```ts
 // Wrote 'rooms/alpha/messages/m1' directly. Now list rooms:
 const rooms = sandbox.admin.listDocuments('rooms');
@@ -75,6 +86,7 @@ const rooms = sandbox.admin.listDocuments('rooms');
 //   { path: 'rooms/alpha', data: {}, phantom: true },
 // ]
 ```
+
 The `phantom: true` flag lets test code distinguish "this doc was explicitly written and is empty" from "this doc exists only because something underneath it was written". The discover crawler in `pyric/rules` uses this signal to walk structure without confusing the two cases.
 
 ## Why this surface is on the root sandbox

--- a/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox-tutorials-01-your-first-sandbox-session.md
@@ -15,16 +15,19 @@ No Firebase project, no network, no setup beyond an `npm install`.
 A standalone script that creates a sandbox, runs three operations against it, and prints what happened.
 
 ## Step 1: Set up
+
 ```bash
 mkdir sandbox-tutorial && cd sandbox-tutorial
 bun init -y
 bun add pyric/sandbox pyric-admin
 ```
+
 `pyric-admin` gives us the Admin-SDK-shaped data plane that sits on top of the sandbox. (You could use `pyric/firestore` for the modular Web shape instead; the choice doesn't matter for this tutorial.)
 
 ## Step 2: Create the sandbox and deploy rules
 
 Create `session.ts`:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -46,6 +49,7 @@ service cloud.firestore {
 
 console.log('Sandbox ready, rules deployed.');
 ```
+
 Notice three things:
 
 - `initializeSandbox()` takes no arguments. Identity comes later, via `withAuth`.
@@ -53,14 +57,17 @@ Notice three things:
 - `setRules` is part of `pyric-admin`'s handle, not the sandbox itself. The sandbox is identity-agnostic; deploying rules is conceptually identity-agnostic too, but the surface lives on the data-plane adapter for ergonomics.
 
 Run it:
+
 ```bash
 bun run session.ts
 ```
+
 You should see `Sandbox ready, rules deployed.` and nothing else.
 
 ## Step 3: Write as one user, read as another
 
 Add to `session.ts`:
+
 ```ts
 const alice = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 const bob = getFirestore(sandbox.withAuth({ uid: 'bob' }));
@@ -76,17 +83,21 @@ console.log('Alice sees:', aliceRead.data());
 const bobRead = await bob.collection('notes').doc('n1').get();
 console.log('Bob sees:', bobRead.data());
 ```
+
 Run it again. You will see:
+
 ```
 Sandbox ready, rules deployed.
 Alice sees: { ownerId: "alice", title: "My first note" }
 Bob sees: { ownerId: "alice", title: "My first note" }
 ```
+
 Both reads succeed because the rule says `allow read: if request.auth != null`. Any signed-in user can read any note. The two contexts share data; they differ only in the identity rules evaluate under.
 
 ## Step 4: Watch a denial
 
 Add:
+
 ```ts
 import { SandboxError } from 'pyric/sandbox';
 
@@ -105,12 +116,15 @@ try {
   }
 }
 ```
+
 Run. You will see:
+
 ```
 Bob was denied.
   Reasons: [ "Rule #1 (write) → deny", "Simulated: DENY" ]
   Request method: update
 ```
+
 The write rule is `request.auth.uid == request.resource.data.ownerId`. Bob's `auth.uid` is `'bob'`; the proposed payload's `ownerId` is `'alice'`. They don't match, the rule denies, the SDK throws `SandboxError` with `code: 'permission-denied'`.
 
 `denialContext` carries the full eval-time payload: what the rule saw, why it said no. Production Firebase strips this server-side for security; the sandbox can show it because it's a development tool.
@@ -118,13 +132,17 @@ The write rule is `request.auth.uid == request.resource.data.ownerId`. Bob's `au
 ## Step 5: Use admin reads to confirm state
 
 Add:
+
 ```ts
 console.log('Actual data:', sandbox.admin.getDocument('notes/n1'));
 ```
+
 Output:
+
 ```
 Actual data: { ownerId: "alice", title: "My first note" }
 ```
+
 `sandbox.admin.getDocument` bypasses rules entirely. It tells you what the data is, regardless of whether any specific user can read it. Bob's attempted overwrite never happened (the rule denied it), so the document still has Alice's original payload.
 
 This is how you assert state in tests without worrying about whether your test fixture's identity can read what you want to verify.
@@ -132,16 +150,20 @@ This is how you assert state in tests without worrying about whether your test f
 ## Step 6: Watch a reset
 
 Add at the end:
+
 ```ts
 sandbox.reset();
 console.log('After reset:', sandbox.admin.getDocument('notes/n1'));
 console.log('Alice context still works:', !!alice);
 ```
+
 Output:
+
 ```
 After reset: null
 Alice context still works: true
 ```
+
 `reset` wipes data, rules, and listeners, but the `alice` and `bob` contexts still work. Their sandbox reference is stable; the underlying environment was replaced. The next operation through `alice` would evaluate against the fresh environment (and would fail because rules are gone, so default-deny applies).
 
 ## What you have learned

--- a/packages/site-docs/src/content/docs/pyric-sandbox.md
+++ b/packages/site-docs/src/content/docs/pyric-sandbox.md
@@ -18,17 +18,22 @@ Three concepts:
 The sandbox does *not* ship the data-plane API itself. The Admin-SDK-shaped surface lives in `pyric-admin`; the modular Web-SDK surface lives in `pyric/firestore`. This package is the substrate they share.
 
 ## Install
+
 ```bash
 bun add pyric/sandbox
 # or
 npm install pyric/sandbox
 ```
+
 You will usually install one of the service-adapter packages alongside it:
+
 ```bash
 bun add pyric/sandbox pyric-admin       # admin-SDK-shaped
 bun add pyric/sandbox pyric/firestore   # modular Web-SDK-shaped
 ```
+
 ## A 30-second example
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -42,6 +47,7 @@ const anonDb = getFirestore(sandbox.withAuth(null));
 const snap = await anonDb.collection('notes').doc('n1').get();
 console.log(snap.exists, snap.data());
 ```
+
 Two contexts, one sandbox, shared data. The rules engine evaluates `aliceDb`'s write under `request.auth.uid == 'alice'`; the same writes are visible to `anonDb`'s read with `request.auth == null`.
 
 ## Where to go next

--- a/packages/site-docs/src/content/docs/pyric-storage-compat.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-compat.md
@@ -3,7 +3,7 @@ title: "pyric/storage compatibility matrix"
 navLabel: "Storage"
 group: "Conformance"
 section: ""
-order: 8006
+order: 6008
 ---
 <!-- Generated from packages/conformance/registry/*.ts. Do not edit by hand; run bun run compat:generate. -->
 

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-implementation-scope.md
@@ -28,11 +28,13 @@ End-to-end coverage: see `packages/pyric/test/storage/session-archive.test.ts`.
 ### The sandbox `getDownloadURL` boundary
 
 The sandbox mirror returns a page-local `blob:` URL over the rules-checked bytes. Production builds resolve `firebase/storage` directly and therefore receive Firebase's token-signed HTTPS URL:
+
 ```ts
 const url = await getDownloadURL(ref(storage, 'sessions/n1'));
 // ... use url ...
 URL.revokeObjectURL(url);  // free the memory when done
 ```
+
 The sandbox URL is a snapshot, not a Firebase download token. It cannot be shared outside the page and expires when revoked or when the page unloads.
 
 ## What's deferred

--- a/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-explanation-session-archive-use-case.md
@@ -31,6 +31,7 @@ A real Cloud Storage round-trip per session save is the wrong shape. So is "save
 ## Why rules mattered
 
 The eventual upload to production is gated by rules. We wanted those rules visible at session-save time so the user sees "this would be rejected" before they hit upload. The rule shape:
+
 ```rules
 service firebase.storage {
   match /b/{bucket}/o {
@@ -44,6 +45,7 @@ service firebase.storage {
   }
 }
 ```
+
 Four real-world bits embedded:
 
 - **Anonymous denials.** Anyone hitting "save" while not signed in gets blocked.

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-enforce-rules.md
@@ -10,6 +10,7 @@ order: 14002
 This guide shows you how to wire Storage rules into a sandbox-backed handle and watch them gate uploads, reads, and deletes.
 
 ## Pass rules at config time
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getStorageSandbox } from 'pyric/storage';
@@ -31,17 +32,20 @@ const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
   rules: RULES,
 });
 ```
+
 The `rules` source is parsed eagerly: malformed source throws a `SyntaxError` at handle construction. After config, every operation evaluates against the rules.
 
 ## The `request.resource == null` carve-out
 
 Notice this in the rule:
+
 ```rules
 allow write: if request.auth != null
              && (request.resource == null
                  || (request.resource.size < 10 * 1024 * 1024
                      && request.resource.contentType == 'application/json'));
 ```
+
 `deleteObject` doesn't carry a payload, so `request.resource` evaluates to `null`. Without the carve-out, the size and content-type checks would fail (you can't read `.size` from `null`) and every delete would deny.
 
 The pattern is standard in production Storage rules. Match it.
@@ -63,6 +67,7 @@ Write rules with the umbrella verbs (`read`/`write`) when the distinction doesn'
 Under `pyric dev`, rules load into the served worker at boot and gate every operation the same as the in-process sandbox. Unlike `firestore.rules` and `database.rules.json`, `storage.rules` doesn't hot-reload — editing it while the dev server is running requires a restart to take effect.
 
 ## Switching users to test rules
+
 ```ts
 const aliceStorage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { rules: RULES });
 const anonStorage = getStorageSandbox(sandbox.withAuth(null), { rules: RULES });
@@ -77,6 +82,7 @@ try {
   console.log(e.code);  // 'storage/unauthenticated'
 }
 ```
+
 The rules engine sees `request.auth.uid == 'alice'` in the first call and `request.auth == null` in the second.
 
 The `rules` option only takes effect on the *first* `getStorageSandbox` call per sandbox. Subsequent calls return the cached handle, and its rules apply uniformly to every user via that sandbox.
@@ -84,6 +90,7 @@ The `rules` option only takes effect on the *first* `getStorageSandbox` call per
 ## Catching denials
 
 `pyric/storage` throws `FirebaseError` (from `firebase/app`) with Firebase-aligned codes:
+
 ```ts
 import { FirebaseError } from 'firebase/app';
 
@@ -99,11 +106,13 @@ try {
   }
 }
 ```
+
 See [Error codes](../pyric-storage-reference-error-codes/) for every code the sandbox can emit.
 
 ## Testing rule expressions without uploading
 
 If you want to test a rule expression in isolation:
+
 ```ts
 import { parseStorageRules, evaluateStorageRules } from 'pyric/storage';
 
@@ -116,6 +125,7 @@ const decision = evaluateStorageRules(parsed, {
 });
 console.log(decision);  // { allowed: true }
 ```
+
 Useful when iterating on rule logic. See [Test rule expressions independently](../pyric-storage-how-to-test-rule-expressions/).
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-list-and-delete.md
@@ -10,6 +10,7 @@ order: 14003
 This guide shows you how to enumerate objects under a prefix and remove them.
 
 ## List a prefix
+
 ```ts
 import { ref, listAll } from 'pyric/storage';
 
@@ -17,11 +18,13 @@ const result = await listAll(ref(storage, 'sessions'));
 console.log('Items:', result.items.map((r) => r.name));
 console.log('Prefixes:', result.prefixes.map((r) => r.name));
 ```
+
 `items` is direct children; `prefixes` is sub-folders (deduplicated). For `listAll(ref(storage))` (no path), the operation scans the whole bucket.
 
 ## Iterate recursively
 
 `listAll` returns only direct children. To walk the full tree, recurse:
+
 ```ts
 async function walk(folderRef: StorageReference, out: string[] = []): Promise<string[]> {
   const result = await listAll(folderRef);
@@ -32,19 +35,23 @@ async function walk(folderRef: StorageReference, out: string[] = []): Promise<st
 
 const all = await walk(ref(storage));
 ```
+
 `fullPath` carries the absolute path (including the bucket prefix). Use `.name` for the leaf name only.
 
 ## Delete a single object
+
 ```ts
 import { deleteObject } from 'pyric/storage';
 
 await deleteObject(ref(storage, 'sessions/n1'));
 ```
+
 Atomically removes both the blob data and the metadata. No-op on missing paths.
 
 ## Bulk delete
 
 The package doesn't ship a bulk-delete helper, so compose one:
+
 ```ts
 async function deleteFolder(folderRef: StorageReference): Promise<void> {
   const result = await listAll(folderRef);
@@ -54,6 +61,7 @@ async function deleteFolder(folderRef: StorageReference): Promise<void> {
 
 await deleteFolder(ref(storage, 'sessions'));
 ```
+
 On sandbox this is fast (sub-millisecond per delete). On prod it makes one HTTPS call per object, costly for large folders.
 
 ## Pagination is deferred
@@ -67,6 +75,7 @@ If you have a use case that needs pagination, file an issue.
 `listAll` enforces the rules engine. Firebase's `read` permission governs both download and list, evaluated against the *prefix path*, so `listAll` requires `read` on the folder you're listing. A denied prefix throws `storage/unauthorized`.
 
 A `read` rule scoped to an item (`match /sessions/{id} { allow read }`) does NOT grant list on the parent `/sessions`; give the folder its own rule:
+
 ```rules
 match /sessions {
   allow read: if request.auth != null; // covers listAll of /sessions
@@ -75,6 +84,7 @@ match /sessions/{sessionId} {
   allow read: if request.auth != null; // covers downloads of items
 }
 ```
+
 This mirrors production Firebase. With no rules configured, `listAll` is open-by-default like every other operation. (A distinct `allow list:` verb is deferred: the v1 scope's two-verb model folds get+list into `read`.)
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-switch-backends.md
@@ -8,6 +8,7 @@ order: 14004
 # Select the Storage runtime
 
 Keep application imports canonical:
+
 ```ts
 import { initializeApp } from 'firebase/app';
 import { getStorage, ref, uploadBytes } from 'firebase/storage';
@@ -16,6 +17,7 @@ const app = initializeApp(firebaseConfig);
 const storage = getStorage(app);
 await uploadBytes(ref(storage, 'sessions/n1'), bytes);
 ```
+
 The package resolver chooses the implementation before this code runs.
 
 ## Development uses the sandbox mirror
@@ -26,26 +28,31 @@ but the single-bucket sandbox stores bytes in IndexedDB and enforces the rules
 loaded by the development runtime.
 
 `getDownloadURL` returns a page-local `blob:` snapshot. Revoke it when done:
+
 ```ts
 const url = await getDownloadURL(ref(storage, 'avatars/ada.png'));
 image.src = url;
 image.addEventListener('load', () => URL.revokeObjectURL(url), { once: true });
 ```
+
 ## Production uses Firebase directly
 
 A normal production build does not activate the Pyric swap. The same
 `firebase/storage` import resolves to Firebase, so `getStorage(app)` reaches the
 configured bucket and `getDownloadURL` returns Firebase's token-signed HTTPS
 URL. `pyric/storage` is not loaded and does not delegate the call.
+
 ```text
 firebase/storage import
 ├── Vite dev / pyric dev ──> Pyric sandbox mirror
 └── production build ──────> Firebase Storage
 ```
+
 ## Direct Pyric imports are sandbox-only
 
 Use `getStorageSandbox(target, options?)` when a test or tool explicitly owns a
 `Sandbox` or `SandboxContext`:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getStorageSandbox, ref, uploadBytes } from 'pyric/storage';
@@ -54,6 +61,7 @@ const sandbox = initializeSandbox();
 const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }));
 await uploadBytes(ref(storage, 'sessions/n1'), bytes);
 ```
+
 There is no Pyric production factory. Import `firebase/storage` for production.
 
 ## Where to look next

--- a/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-how-to-test-rule-expressions.md
@@ -10,13 +10,16 @@ order: 14005
 This guide shows you how to verify a Storage rule expression without uploading anything. Useful when iterating on a complex rule or building a rules-test harness.
 
 ## The two functions
+
 ```ts
 import { parseStorageRules, evaluateStorageRules } from 'pyric/storage';
 ```
+
 - **`parseStorageRules(source)`** returns a `ParsedRules` object. Throws a `SyntaxError` with line/column info if the source is malformed.
 - **`evaluateStorageRules(rules, input)`** takes parsed rules plus a synthetic request shape and returns `{ allowed: true } | { allowed: false; reason }`.
 
 ## A complete test
+
 ```ts
 const source = `service firebase.storage {
   match /b/{bucket}/o {
@@ -50,9 +53,11 @@ const denied = evaluateStorageRules(rules, {
 console.log(denied);
 // { allowed: false, reason: 'request.auth != null failed' }
 ```
+
 The synthetic input mirrors what the actual handler builds when an operation runs against a sandbox-backed handle.
 
 ## The input shape
+
 ```ts
 {
   path: string;                          // full path, including bucket prefix
@@ -62,6 +67,7 @@ The synthetic input mirrors what the actual handler builds when an operation run
   existing?: { size: number; contentType: string; metadata?: Record<string, string> };  // for read/update/delete
 }
 ```
+
 `resource` represents `request.resource` (what's being uploaded). `existing` represents `resource` (what's already stored). Set whichever the rule references.
 
 ## Why not go through the handler

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-api.md
@@ -13,9 +13,11 @@ Every symbol exported from `pyric/storage`.
 ## Entry points
 
 ### `getStorage(app?, bucketUrl?): FirebaseStorage`
+
 ```ts
 function getStorage(app?: FirebaseApp, bucketUrl?: string): FirebaseStorage
 ```
+
 Firebase-shaped sandbox entry point. Package resolution selects this mirror
 before it loads, and the app's private association resolves the shared sandbox
 plus its app-local Auth session. `bucketUrl` is accepted for call-site
@@ -37,14 +39,17 @@ The private brand carrying the handle's sandbox service, identity, bucket, and a
 ## Errors
 
 ### `class StorageError extends Error`
+
 ```ts
 class StorageError extends Error {
   readonly code: `storage/${StorageErrorCode}`;
 }
 ```
+
 Every sandbox operation that fails throws one of these, so consumer code can branch on `err.code === 'storage/...'`. Production code receives Firebase's own errors because it imports `firebase/storage` directly. See [Error codes](../pyric-storage-reference-error-codes/).
 
 ### `StorageErrorCode`
+
 ```ts
 type StorageErrorCode =
   | 'unknown'
@@ -56,6 +61,7 @@ type StorageErrorCode =
   | 'invalid-format'
   | 'invalid-argument';
 ```
+
 ## Reference construction
 
 ### `ref(storage)` / `ref(storage, path)` / `ref(parent, path)`
@@ -63,12 +69,15 @@ type StorageErrorCode =
 Build a `StorageReference`. Two overloads matching `firebase/storage`.
 
 Path normalisation: leading/trailing slashes stripped, repeated internal slashes collapsed. Empty path = root reference (no parent).
+
 ```ts
 const root = ref(storage);                           // root
 const sessions = ref(storage, 'sessions');           // 'sessions/'
 const one = ref(sessions, 'gen-123');                // 'sessions/gen-123'
 ```
+
 ### `StorageReference`
+
 ```ts
 interface StorageReference {
   readonly name: string;
@@ -79,15 +88,18 @@ interface StorageReference {
   readonly storage: FirebaseStorage;
 }
 ```
+
 ## Upload
 
 ### `uploadBytes(ref, data, metadata?): Promise<UploadResult>`
+
 ```ts
 await uploadBytes(ref(storage, 'sessions/n1'), bytes, {
   contentType: 'application/json',
   customMetadata: { sessionId: 'n1' },
 });
 ```
+
 `data` is `Blob | Uint8Array | ArrayBuffer`. Returns `{ ref, metadata: FullMetadata }`. Throws `storage/invalid-root-operation` when `ref` targets the root.
 
 ### `uploadString(ref, value, format?, metadata?): Promise<UploadResult>`
@@ -95,9 +107,11 @@ await uploadBytes(ref(storage, 'sessions/n1'), bytes, {
 `format` is a `StringFormat` (default `'raw'`). Delegates to `uploadBytes` after decoding.
 
 ### `StringFormat`
+
 ```ts
 type StringFormat = 'raw' | 'base64' | 'data_url';
 ```
+
 `raw` defaults `contentType` to `text/plain;charset=utf-8` when nothing else supplies one. `data_url` reads the MIME prefix before the comma unless the caller's metadata overrides `contentType`. `base64` is standard base64.
 
 ## Download
@@ -110,10 +124,12 @@ Throws `storage/object-not-found` on missing path. When `maxDownloadSizeBytes` i
 ### `getDownloadURL(ref): Promise<string>`
 
 Returns a page-owned `blob:` URL that fetches the stored sandbox object:
+
 ```ts
 const url = await getDownloadURL(ref(storage, 'avatars/ada.png'));
 image.src = url;
 ```
+
 The sandbox URL is a snapshot of the bytes at call time. It cannot be shared outside the page and remains alive until `URL.revokeObjectURL(url)` or page unload. Missing objects and rules denials use the same `storage/object-not-found` and `storage/unauthorized` errors as `getBlob`.
 
 ### `deleteObject(ref): Promise<void>`
@@ -131,6 +147,7 @@ Read every metadata field, both client-settable and server-set.
 Replace the client-settable fields. Bumps `metageneration` and refreshes `updated`. Server-set fields (`generation`, `timeCreated`, `bucket`, `size`, `md5Hash`) stay pinned. Blob content untouched. Passing `undefined` for a field leaves the previous value; there's no `null`-to-clear support in the v1 scope.
 
 ### `SettableMetadata`
+
 ```ts
 interface SettableMetadata {
   contentType?: string;
@@ -141,7 +158,9 @@ interface SettableMetadata {
   customMetadata?: { [key: string]: string };
 }
 ```
+
 ### `FullMetadata`
+
 ```ts
 interface FullMetadata extends SettableMetadata {
   bucket: string;
@@ -155,13 +174,16 @@ interface FullMetadata extends SettableMetadata {
   md5Hash?: string;
 }
 ```
+
 ### `UploadResult`
+
 ```ts
 interface UploadResult {
   metadata: FullMetadata;
   ref: StorageReference;
 }
 ```
+
 ## Listing
 
 ### `listAll(ref): Promise<ListResult>`
@@ -169,6 +191,7 @@ interface UploadResult {
 Returns `{ items, prefixes }`. Items are direct children; sub-folders surface in `prefixes` (deduplicated). `listAll(ref(storage))` scans the entire bucket. Enforces `read` on the scanned path: Storage's `read` permission governs both download and list, so `listAll` on an unauthorized tree throws `storage/unauthorized`.
 
 ### `ListResult`
+
 ```ts
 interface ListResult {
   items: StorageReference[];
@@ -176,6 +199,7 @@ interface ListResult {
   nextPageToken?: string;
 }
 ```
+
 `nextPageToken` is always absent (`undefined`) from `listAll`; the field exists for forward compatibility with paginated `list`, which is deferred. See [Boundaries](#boundaries).
 
 Paginated `list(ref, { maxResults, pageToken })` is deferred. `listAll` covers every v1 scope scenario.
@@ -195,6 +219,7 @@ Typically you don't call these directly. Pass the source to `getStorageSandbox(t
 See [Storage rules subset](../pyric-storage-reference-rules-subset/) for the grammar these functions accept.
 
 ### Rules types
+
 ```ts
 type StorageMethod = 'read' | 'write';
 
@@ -230,6 +255,7 @@ interface StorageRules {
   readonly _root: unknown; // opaque
 }
 ```
+
 `StorageRules` is opaque outside the package; only `parseStorageRules` produces one and only `evaluateStorageRules` (or `getStorageSandbox(target, { rules })` internally) consumes one.
 
 ## Service types
@@ -239,6 +265,7 @@ interface StorageRules {
 The opaque handle. Carries the target via `TARGET_SYMBOL`; consumed by free functions only.
 
 ### `StorageOptions`
+
 ```ts
 interface StorageOptions {
   bucket?: string;
@@ -246,6 +273,7 @@ interface StorageOptions {
   rules?: string;
 }
 ```
+
 See [`StorageOptions`](../pyric-storage-reference-storage-options/).
 
 ### `Target`, `SandboxTarget`
@@ -259,9 +287,11 @@ Beyond the data-plane adapter above, `pyric/storage` exports a control plane for
 ### `getStorageServiceState(accessToken, projectId): Promise<ServiceEnableState>`
 
 Probe whether the `firebasestorage.googleapis.com` service is enabled on the project. Cheap read; requires `serviceusage.services.get`. Returns `'unknown'` on permission failure rather than throwing, so callers can downgrade to "try the operation, observe `SERVICE_DISABLED`" instead of blocking.
+
 ```ts
 type ServiceEnableState = 'enabled' | 'disabled' | 'unknown';
 ```
+
 ### `enableStorageService(accessToken, projectId): Promise<void>`
 
 Enable `firebasestorage.googleapis.com` on the project. Requires `serviceusage.services.enable`, part of `roles/owner` or `roles/serviceusage.serviceUsageAdmin`. The default Firebase Admin SDK service account does not have this. Throws `StorageProvisioningError` on failure.
@@ -277,6 +307,7 @@ Set the project's default GCP resources location. **Irreversible**: once set, th
 ### `listFirebaseBuckets(accessToken, projectId): Promise<FirebaseStorageBucket[]>`
 
 List Firebase-linked Storage buckets on the project. Returns an empty list when none exist yet. Throws when the underlying service is disabled; call `getStorageServiceState` first to distinguish that case.
+
 ```ts
 interface FirebaseStorageBucket {
   name: string;       // projects/{p}/buckets/{bucketId}
@@ -284,6 +315,7 @@ interface FirebaseStorageBucket {
   reconciling?: boolean;
 }
 ```
+
 ### `addFirebaseToBucket(accessToken, projectId, bucketId): Promise<FirebaseStorageBucket>`
 
 Link a Cloud Storage bucket to Firebase Storage. Idempotent: if the bucket is already Firebase-linked, the call returns the existing record. For the default bucket name (`{projectId}.firebasestorage.app`), Firebase auto-creates the underlying GCS bucket on first call.
@@ -299,6 +331,7 @@ Read the current CORS configuration for a bucket. Requires `storage.buckets.get`
 ### `setBucketCors(accessToken, bucketId, cors): Promise<void>`
 
 Replace the bucket's CORS configuration wholesale (the GCS API replaces, not merges, the `cors` field on `PATCH`). Pass an empty array to clear all rules. Requires `storage.buckets.update`, granted by `roles/storage.admin` or the default Firebase Admin SDK service-agent role bundle in modern projects.
+
 ```ts
 interface CorsRule {
   origin: string[];
@@ -307,6 +340,7 @@ interface CorsRule {
   maxAgeSeconds?: number;
 }
 ```
+
 ### `defaultPlaygroundCors(hostingOrigin): CorsRule[]`
 
 A starter CORS rule for a browser playground hosted on Firebase Hosting: allows `GET/POST/PUT/DELETE/HEAD/OPTIONS` from the hosting origin plus common localhost dev ports, with the response headers the Firebase Storage Web SDK needs.
@@ -314,6 +348,7 @@ A starter CORS rule for a browser playground hosted on Firebase Hosting: allows 
 ### `provisionStorage(accessToken, projectId, options?): Promise<ProvisionStorageResult>`
 
 End-to-end Storage enablement: enable the service if needed, finalize the default location if unset, link the default bucket if not already linked, optionally deploy rules, optionally apply CORS. Each step probes state before mutating, so repeat calls are safe. Throws `StorageProvisioningError` carrying a `reason` (e.g. `AUTH_PERMISSION_DENIED`, `SERVICE_DISABLED`) the caller can route on.
+
 ```ts
 interface ProvisionStorageOptions {
   locationId?: string;   // default: 'us-central'. Irreversible once set.
@@ -335,9 +370,11 @@ interface ProvisionStorageResult {
   corsApplied: boolean;
 }
 ```
+
 The `onProgress` callback's shape (named `ProvisionProgress` internally) is not itself an exported type; annotate inline or let it infer from `ProvisionStorageOptions['onProgress']`.
 
 ### `class StorageProvisioningError extends Error`
+
 ```ts
 class StorageProvisioningError extends Error {
   readonly status: number;
@@ -345,6 +382,7 @@ class StorageProvisioningError extends Error {
   readonly reason: string | undefined;
 }
 ```
+
 Thrown by every admin function above on a non-2xx response. `reason` is the Google API's structured error reason when present (e.g. `SERVICE_DISABLED`, `AUTH_PERMISSION_DENIED`); `body` is the raw response text, truncated to 400 characters in the surfaced message.
 
 ## Agent tools
@@ -352,12 +390,15 @@ Thrown by every admin function above on a non-2xx response. `reason` is the Goog
 Wraps the admin surface above behind a `ProjectScope` (`{ projectId, resolveToken(): Promise<string> }`) contract, the same credential shape the deploy tooling's factories accept.
 
 ### `class InspectStorageHandler`
+
 ```ts
 class InspectStorageHandler {
   execute(scope: ProjectScope): Promise<InspectStorageResult>;
 }
 ```
+
 Resolves a token from `scope`, then reads service state, default location, and (when the service is enabled) the linked bucket list, in parallel. Never throws for a normal probe: a bucket-list failure with the service otherwise enabled degrades to an empty `buckets` array rather than surfacing an error.
+
 ```ts
 interface InspectStorageResult {
   serviceState: 'enabled' | 'disabled' | 'unknown';
@@ -365,7 +406,9 @@ interface InspectStorageResult {
   buckets: Array<{ name: string; bucketId: string }>;
 }
 ```
+
 ### `class ProvisionStorageHandler`
+
 ```ts
 class ProvisionStorageHandler {
   execute(
@@ -375,7 +418,9 @@ class ProvisionStorageHandler {
   ): Promise<ProvisionStorageOutcome>;
 }
 ```
+
 Calls `provisionStorage` with a token resolved from `scope`, and maps a thrown `StorageProvisioningError` onto a typed `ProvisionStorageOutcome` failure (via its `reason` and message, pattern-matched to a `ProvisionStorageErrorCode`) instead of letting it propagate. Callers branch on `outcome.success` rather than catching.
+
 ```ts
 interface ProvisionStorageInput {
   locationId?: string;
@@ -414,7 +459,9 @@ type ProvisionStorageOutcome =
       };
     };
 ```
+
 ### `createStorageAdminTools(deps): ToolHandler[]`
+
 ```ts
 function createStorageAdminTools(deps: StorageAdminToolDeps): ToolHandler[];
 
@@ -422,6 +469,7 @@ interface StorageAdminToolDeps {
   scope: ProjectScope;
 }
 ```
+
 Returns two `@inbrowser/agent` `ToolHandler`s built on the handlers above: `storage_get_status` (wraps `InspectStorageHandler`) and `storage_provision` (wraps `ProvisionStorageHandler`, JSON-Schema-typed against `ProvisionStorageInput`). Mirrors the shape of the Firestore rules and deploy tool factories elsewhere in Pyric, so a registry can compose them uniformly.
 
 ## Boundaries

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-conformance-gaps.md
@@ -56,6 +56,7 @@ differs: locally it uploads, in production it is refused.
 
 The create-if-absent guard. Anyone may upload a new object, nobody may
 overwrite one:
+
 ```
 rules_version = '2';
 service firebase.storage {
@@ -67,14 +68,17 @@ service firebase.storage {
   }
 }
 ```
+
 ### What happens
 
 Upload to `uploads/report.pdf` when no such object exists yet:
+
 ```ts
 import { getStorage, ref, uploadBytes } from 'pyric/storage';
 
 await uploadBytes(ref(getStorage(app), 'uploads/report.pdf'), bytes);
 ```
+
 In pyric the create is ALLOWED. `resource` is null before the object exists,
 so `resource == null` is true and the rule passes.
 
@@ -96,6 +100,7 @@ the genuinely new object, differs.
 Delete the existence check. Storage rules already give it to you: `create`
 only fires when there is no existing object, and `update` only fires when
 there is one. The verb is the existence check.
+
 ```
 match /uploads/{fileId} {
   allow create: if request.auth != null;
@@ -103,6 +108,7 @@ match /uploads/{fileId} {
                 && resource.metadata.owner == request.auth.uid;
 }
 ```
+
 Do not reference `resource` anywhere inside a `create` rule. Not
 `resource == null`, not `resource != null`, not `resource.size`. There is no
 object to read, and in production reading it errors, which denies. Put your

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-error-codes.md
@@ -31,6 +31,7 @@ Reserved on the `StorageErrorCode` union for upstream parity. The sandbox does *
 A function argument failed validation. Common cases: empty path, malformed string format in `uploadString`, non-string `contentType`.
 
 ## Branching
+
 ```ts
 try {
   await getBlob(ref(storage, 'sessions/n1'));
@@ -52,6 +53,7 @@ try {
   }
 }
 ```
+
 The sandbox throws `StorageError`, an `Error` subclass whose `.code` carries the Firebase-shaped value. Production code imports `firebase/storage` directly and receives Firebase's own error class; branching on `.code` works in both environments without coupling application code to either constructor.
 
 ## What the sandbox does not emit

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-rules-subset.md
@@ -9,11 +9,13 @@ order: 14009
 The Storage rules grammar in the v1 scope. Anything not listed is out of scope and will produce a parse error.
 
 ## Service header
+
 ```rules
 service firebase.storage {
   // ...
 }
 ```
+
 Required. Anything other than `firebase.storage` fails parsing.
 
 ## Path matching
@@ -25,6 +27,7 @@ Three segment types:
 - **Multi-segment wildcards**: `{allPaths=**}` matches the rest of the path.
 
 Nested `match` blocks compose naturally:
+
 ```rules
 match /b/{bucket}/o {
   match /users/{uid} {
@@ -34,6 +37,7 @@ match /b/{bucket}/o {
   }
 }
 ```
+
 Path variables bind to the surrounding scope: `uid` from the parent match is in scope in the inner allow condition.
 
 ## Allow conditions
@@ -53,12 +57,14 @@ A granular grant covers only its own verb: `allow get` does not grant `list`, an
 ## Rule functions
 
 User-defined functions are supported, including `let` bindings:
+
 ```rules
 function isOwner(uid) {
   let owner = resource.metadata['owner'];
   return request.auth != null && request.auth.uid == owner;
 }
 ```
+
 Recursion depth is capped; a function that errors mid-evaluation denies rather than throwing past the rule (deny-on-error).
 
 ## Request bindings
@@ -86,17 +92,21 @@ For existing objects:
 - `resource.timeCreated` / `resource.updated`: the object's creation and last-update timestamps. The update-time field is `updated`; the language has no `resource.timeUpdated`.
 
 `duration.value(n, unit)` builds a duration, so a freshness window reads:
+
 ```
 allow delete: if request.time < resource.timeCreated + duration.value(1, 'h');
 ```
+
 Reading a field an object does not carry is an evaluation error, and an error **denies** — including through a negation, so `resource.name != 'x'` on an object with no name denies rather than allowing.
 
 ## Cross-service lookups
 
 `firestore.get(path)` and `firestore.exists(path)` read a Firestore document from inside a Storage rule, with `$(expr)` interpolation for dynamic path segments:
+
 ```rules
 allow write: if firestore.exists(/databases/(default)/documents/sessions/$(request.auth.uid));
 ```
+
 ## String matching
 
 `matches()` does whole-string-anchored regex matching, evaluated with RE2 semantics. Constructs RE2 can't express (backreferences, lookahead/lookbehind) are denied at parse time rather than silently mismatching.

--- a/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
+++ b/packages/site-docs/src/content/docs/pyric-storage-reference-storage-options.md
@@ -7,6 +7,7 @@ order: 14010
 # `StorageOptions`
 
 The options bag for `getStorageSandbox(target, options?)`.
+
 ```ts
 interface StorageOptions {
   bucket?: string;
@@ -14,6 +15,7 @@ interface StorageOptions {
   rules?: string;
 }
 ```
+
 ## `bucket`
 
 The bucket identifier recorded in `metadata.bucket` on upload. v1 has a single implicit bucket: passing different values doesn't isolate data, but it round-trips through metadata.
@@ -25,16 +27,19 @@ When real multi-bucket support lands, this option will partition data. For the v
 ## `dbName`
 
 The IndexedDB database name. Tests pass a per-case unique name so state doesn't leak between runs:
+
 ```ts
 const storage = getStorageSandbox(sandbox.withAuth(null), {
   dbName: `test-${crypto.randomUUID()}`,
 });
 ```
+
 Only takes effect on the **first** `getStorageSandbox` call per `Sandbox`. Subsequent calls return the cached handle bound to the original `dbName`. To change the IndexedDB name, build a new sandbox.
 
 ## `rules`
 
 Storage rules source, parsed eagerly at config time. Malformed sources throw a `SyntaxError` from the parser before the handle is returned. Fail fast.
+
 ```ts
 const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
   rules: `service firebase.storage {
@@ -48,6 +53,7 @@ const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), {
   }`,
 });
 ```
+
 Only takes effect on the **first** call per `Sandbox`. Subsequent calls return the cached handle with the original rules. To change rules, build a new sandbox.
 
 If `rules` is omitted, the storage handle accepts every operation (anonymous and authenticated alike). Useful for non-rule-related tests but explicitly insecure. Set rules whenever the test is about access control.

--- a/packages/site-docs/src/content/docs/pyric-storage.md
+++ b/packages/site-docs/src/content/docs/pyric-storage.md
@@ -16,12 +16,15 @@ Built for the agent-session-archive use case. The scope is bounded; the architec
 This package implements a deliberate subset of Firebase Storage. See [Implementation scope and deferred features](../pyric-storage-explanation-implementation-scope/) before adopting in production-style code.
 
 ## Install
+
 ```bash
 bun add pyric/storage pyric/sandbox
 # or
 npm install pyric/storage pyric/sandbox
 ```
+
 ## A 30-second example
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getStorageSandbox, ref, uploadBytes, getBlob } from 'pyric/storage';
@@ -38,6 +41,7 @@ await uploadBytes(
 const blob = await getBlob(ref(storage, 'sessions/gen-123'));
 console.log(await blob.text());
 ```
+
 ## Control-plane surface
 
 Beyond the data-plane adapter, the package exports a control-plane surface for provisioning and managing real Cloud Storage buckets: `provisionStorage`, `getStorageServiceState`, `enableStorageService`, bucket listing, CORS management (`getBucketCors` / `setBucketCors`), and `deployStorageRules`. Alongside those sits `createStorageAdminTools`, a `ToolHandler[]` factory for an `@inbrowser/agent` registry. It also ships a local Storage rules engine (`parseStorageRules` / `evaluateStorageRules`).

--- a/packages/site-docs/src/content/docs/read-a-denial.md
+++ b/packages/site-docs/src/content/docs/read-a-denial.md
@@ -1,9 +1,9 @@
 ---
 title: "Never debug a bare permission-denied again"
 navLabel: "Read a denial and understand it"
-group: "Secure & debug"
-section: ""
-order: 3004
+group: "Inspect and correct"
+section: "Inspect the sandbox"
+order: 3002
 description: "See which rule denied an operation, on what path, with what data, the moment it happens."
 ---
 
@@ -16,6 +16,7 @@ In Pyric, every operation the backend evaluates produces a verdict you can read,
 ## Every operation carries a verdict
 
 While your app runs against the sandbox, every read, write, and query passes through the rules engine, and each evaluation emits a typed event. Denials are not a separate channel. They are the same stream, filtered:
+
 ```ts
 sandbox.onEvent((e) => {
   if (e.kind === 'request' && e.result === 'deny') {
@@ -23,6 +24,7 @@ sandbox.onEvent((e) => {
   }
 });
 ```
+
 A denial event tells you the story in one object:
 
 - **`method` and `path`**: what was attempted, and where. `update` on `notes/n1`.
@@ -41,12 +43,14 @@ If you are running `pyric dev --ui`, you do not have to write the subscription. 
 A denial that should not happen is one failure mode. The quieter one is its opposite: an operation that should be denied and no longer is, because a rules edit removed a predicate somewhere. This usually happens while making a failing test pass.
 
 Pyric catches it by diffing rulesets. Lint the candidate with the previously deployed source:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules';
 
 const result = lintFirestoreRules(newSource, { previousSource: oldSource });
 const weakened = result.warnings.filter((w) => w.rule === 'RULES_WEAKENED');
 ```
+
 The linter normalizes every match path and diffs the predicates conjunct by conjunct. It reports three shapes of weakening:
 
 - a match block that had `allow` rules and is gone

--- a/packages/site-docs/src/content/docs/receive-messages.md
+++ b/packages/site-docs/src/content/docs/receive-messages.md
@@ -1,0 +1,51 @@
+---
+title: "Receive Firebase Cloud Messaging locally"
+navLabel: "Receive messages"
+group: "Develop with Firebase APIs"
+section: ""
+order: 2005
+description: "Keep Firebase Cloud Messaging receive code unchanged while tokens and deliveries stay in the local sandbox."
+---
+
+# Receive Firebase Cloud Messaging locally
+
+Keep using the Firebase Cloud Messaging Web API:
+
+```ts
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+
+const messaging = getMessaging(app);
+const token = await getToken(messaging);
+
+onMessage(messaging, payload => {
+  console.log(payload.data);
+});
+```
+
+During development, the token and message broker belong to the local sandbox. No registration reaches Firebase Cloud Messaging. A production build runs the same application code through Firebase. Use the [Firebase Cloud Messaging Web documentation](https://firebase.google.com/docs/cloud-messaging/web/get-started) for normal registration and the [message handling guide](https://firebase.google.com/docs/cloud-messaging/web/receive-messages) for foreground and background behavior.
+
+## Deliver a message during local development
+
+Tests and development harnesses can inject a message through Pyric's sandbox-only driver:
+
+```ts
+import { getMessaging, onMessage, sandbox as messagingSandbox } from 'pyric/messaging';
+
+const messaging = getMessaging(app);
+onMessage(messaging, payload => {
+  console.log(payload.data);
+});
+
+await messagingSandbox.deliver(messaging, {
+  visibilityState: 'visible',
+  data: { event: 'report-ready' },
+});
+```
+
+Keep this driver outside application code that ships. A visible client routes the delivery to `onMessage`. A hidden client routes it to the service-worker `onBackgroundMessage` path. The local broker also models token stability and deletion, but it does not request browser notification permission or contact the FCM transport.
+
+## Check the supported boundary
+
+Read the generated [Messaging conformance matrix](../pyric-messaging-compat/) for the current client, service-worker, and Admin send surfaces, including verified behavior and tracked limitations.
+
+Continue with [Inspect and correct](../see-whats-happening/) or [verify the production boundary](../pyric-cli-how-to-verify-against-a-captured-session/).

--- a/packages/site-docs/src/content/docs/rtdb-rules-in-typescript.md
+++ b/packages/site-docs/src/content/docs/rtdb-rules-in-typescript.md
@@ -1,9 +1,9 @@
 ---
 title: "Write Realtime Database rules in TypeScript"
 navLabel: "RTDB rules in TypeScript"
-group: "Secure & debug"
-section: ""
-order: 3007
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3009
 description: "Compose RTDB rules from typed constraints, prove them in-process, and deploy the compiled JSON."
 ---
 
@@ -14,6 +14,7 @@ description: "Compose RTDB rules from typed constraints, prove them in-process, 
 Realtime Database rules are strings inside a JSON tree. Pyric lets you write them as TypeScript instead: typed builders compose into expressions, the expressions assemble into a ruleset, and the ruleset checks itself, simulates requests, and compiles to the exact JSON Firebase deploys. A typo becomes a compile error instead of a production surprise.
 
 ## Define the rules in code
+
 ```ts
 import {
   defineRtdbRules, all, authenticated,
@@ -30,16 +31,20 @@ const rules = defineRtdbRules({
   },
 });
 ```
+
 `$noteId` is a real wildcard. `ownerOrNew('ownerId')` compiles to the signed-in-and-owner-or-new expression you would have written by hand, and `immutable('createdAt')` pins a field after creation. Every builder's output is pinned by tests, so what you compose is what deploys.
 
 ## Check it before anything runs
+
 ```ts
 const result = rules.check();
 // { ok: true, errors: [], warnings: [] }
 ```
+
 `check()` parses, validates, and lints every expression in the tree. A `==` where you meant `===` comes back as a `LOOSE_EQUALITY` warning with its path and rule. An unsupported schema type is a `COMPILE_ERROR`. No deploy, no network.
 
 ## Simulate a request
+
 ```ts
 const verdict = rules.simulate({
   operation: 'write',
@@ -49,22 +54,28 @@ const verdict = rules.simulate({
   newData: { ownerId: 'alice', createdAt: 1, title: 'edited' },
 });
 ```
+
 The simulator runs in-process against the same grammar the sandbox enforces. `auth: 'alice'` is shorthand for `{ uid: 'alice', token: {} }`. Ask the denial question the same way: change `auth` to `'mallory'` and read the verdict.
 
 ## Ship the JSON
+
 ```ts
 import { writeFileSync } from 'node:fs';
 writeFileSync('database.rules.json', JSON.stringify(rules.toJSON(), null, 2));
-``````bash
+```
+
+```bash
 pyric database rules lint database.rules.json
 # or: pyric database rules generate
 firebase deploy --only database
 ```
+
 `toJSON()` emits the `{ rules: ... }` document Firebase expects. Generate or write that file locally (`pyric database rules generate`), then ship it with `firebase-tools` (or the Console) using the path your `firebase.json` points at. The CLI's `database rules lint`, `database rules validate`, and `database rules simulate` operations run the same checks against the JSON file, so CI can gate on them without TypeScript in the loop.
 
 ## Turn enforcement, from a deployed game
 
 The tic-tac-toe [case study](../whats-possible/) is built from these same parts, deployed and playable:
+
 ```ts
 import {
   ruleset, deny, any, isNew, authenticated,
@@ -86,6 +97,7 @@ const game = ruleset({
   },
 });
 ```
+
 Three constraints carry the whole game. `turnGuard` reads stored state, never the incoming write, so a player cannot hand themselves the turn. `flip` makes turn order a validation rule. And `winCheckHelper` verifies a win claim against the actual board, so the winner field only accepts the truth.
 
 ## And from an agent

--- a/packages/site-docs/src/content/docs/rules-patterns.md
+++ b/packages/site-docs/src/content/docs/rules-patterns.md
@@ -1,9 +1,9 @@
 ---
 title: "The techniques hard rules are built from"
 navLabel: "Rules patterns"
-group: "Secure & debug"
-section: ""
-order: 3006
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3007
 description: "Learn the five moves that turn \"rules can't do that\" into a ruleset that deploys."
 ---
 
@@ -16,6 +16,7 @@ The rules language cannot loop. It cannot build a map key out of strings. And it
 **The problem.** Validating a transition like "a knight on b1 may reach a3 or c3" looks like it needs one hand-written OR branch per legal pair. For checkers that was 49 branches per direction per piece type. For chess, thousands.
 
 **The move.** Store the legal transitions as data in a config document. Rules read it once with `get()` and validate with nested dynamic access:
+
 ```rules
 function config() {
   return get(/databases/$(database)/documents/gameConfig/checkers).data;
@@ -28,6 +29,7 @@ function validGeometry() {
   return config().moves[piece][mf][mt] == true;
 }
 ```
+
 Three expressions replace hundreds of branches. It works because of three engine facts:
 
 - Dynamic map access is legal when the key is a stored field value. Computed strings are not.
@@ -43,6 +45,7 @@ One operational note: the config document must exist before the rules go live. I
 **The problem.** Some transitions are valid only when everything between two points is clear. A rook moving a1 to e1 requires b1, c1, and d1 empty. Hardcoded, every from-to pair needs its own emptiness checks.
 
 **The move.** Store the between-cells in the config document, where `paths[from][to]` holds a length and the cell names, then check them with short-circuit OR:
+
 ```rules
 function pathClear() {
   let mf = request.resource.data.moveFrom;
@@ -54,6 +57,7 @@ function pathClear() {
       // ...continue to c5 for the longest path on an 8x8 board
 }
 ```
+
 `path.len < 2` is true for short paths, so the check skips cells the path does not have. The discovery that makes this expressible at all: a value retrieved from `get()` can be used as a dynamic key into `resource.data`. That one fact was probed and confirmed against production, and it is what sliding pieces stand on.
 
 ## Look up by type, don't branch by type
@@ -76,6 +80,7 @@ A client cannot claim a pawn moved like a queen, because the pawn's identity was
 This was discovered the hard way, debugging chess: pawn moves denied while every rule tested fine in isolation, and reordering the rules changed which category failed.
 
 **The move.** Open every allow rule with a cheap discriminator that is unique to it:
+
 ```rules
 allow update: if request.resource.data.moveType == 'pawn_forward'
   && isMyTurn() && validPawnForward(config());
@@ -83,6 +88,7 @@ allow update: if request.resource.data.moveType == 'pawn_forward'
 allow update: if request.resource.data.moveType == 'capture'
   && isMyTurn() && validCapture(config()) && pathClear();
 ```
+
 A non-matching write now fails each foreign rule in one expression. Chess ships eleven distinct `moveType` values for exactly this reason. Pyric's linter flags the violation as SHARED_GATE when two rules in a match block open with the same gate expression.
 
 ## Data over code, the pattern under the patterns

--- a/packages/site-docs/src/content/docs/rules-standard-library.md
+++ b/packages/site-docs/src/content/docs/rules-standard-library.md
@@ -1,15 +1,16 @@
 ---
 title: "Build your rules from tested parts"
 navLabel: "The rules standard library"
-group: "Secure & debug"
-section: ""
-order: 3005
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3008
 description: "Compose security rules from tested modules, with an import system that compiles away before Firebase ever sees it."
 ---
 
 # Build your rules from tested parts
 
 This is a Firestore rules file:
+
 ```rules
 rules_version = '2+modules';
 import { isMyTurn, turnFlipped } from 'turns';
@@ -22,6 +23,7 @@ service cloud.firestore {
   }
 }
 ```
+
 The rules language has no import statement. This file deploys anyway, and what lands on Firebase is stock `rules_version = '2'` with the two functions inlined at the top of the match tree. `isMyTurn` and `turnFlipped` are not snippets you pasted. They are functions from a tested module, pulled in by name.
 
 ## An import system that compiles away
@@ -45,6 +47,7 @@ Two things to know once you are inside it:
 Fifteen modules ship with Pyric. A few exist specifically because the received wisdom says they can't.
 
 **Rules can rate-limit.** `timing.cooldownElapsed('lastMoveAt', 2)` allows an update only when the stored timestamp is more than two seconds old. On its own that is forgeable, because the client writes the timestamp and could write one from last week. So pair it with `isServerTimestamp('lastMoveAt')` from `lifecycle` on the same write, which forces the field to be the server's own clock:
+
 ```rules
 import { cooldownElapsed } from 'timing';
 import { isServerTimestamp } from 'lifecycle';
@@ -53,6 +56,7 @@ import { isServerTimestamp } from 'lifecycle';
 allow update: if cooldownElapsed('lastMoveAt', 2)
   && isServerTimestamp('lastMoveAt');
 ```
+
 A missing or non-timestamp field errors, and an error denies. Verified against the production rules engine, not a simulation of it.
 
 **Rules can enforce integrity across a batch.** The `atomic` module uses the `get()`/`getAfter()` pair, where `getAfter()` reads another document as it will be after the current batch commits. `companionChangedBy(before, after, 'taskCount', 1)` allows a write only if a companion document's counter moved by exactly one in the same batch.

--- a/packages/site-docs/src/content/docs/run-ai-logic-locally.md
+++ b/packages/site-docs/src/content/docs/run-ai-logic-locally.md
@@ -1,0 +1,51 @@
+---
+title: "Run Firebase AI Logic locally"
+navLabel: "Run AI Logic locally"
+group: "Develop with Firebase APIs"
+section: ""
+order: 2006
+description: "Keep Firebase AI Logic application code unchanged while model responses stay deterministic or come from a local model."
+---
+
+# Run Firebase AI Logic locally
+
+Keep using the Firebase AI Logic Web API:
+
+```ts
+import { getAI, getGenerativeModel } from 'firebase/ai';
+
+const ai = getAI(app);
+const model = getGenerativeModel(ai, {
+  model: 'gemini-flash-lite-latest',
+});
+const result = await model.generateContent('Summarize this report.');
+```
+
+During development, Pyric answers through a local engine instead of a Google AI endpoint. A production build runs the same application code through Firebase. Use the [Firebase AI Logic Web guide](https://firebase.google.com/docs/ai-logic/get-started?platform=web) for normal model, prompt, chat, streaming, schema, and function-calling APIs.
+
+## Choose how the sandbox answers
+
+The default scripted engine is deterministic and makes no network requests. Test setup can queue an exact response through the sandbox-only scripting entry point:
+
+```ts
+import { getAI } from 'pyric/ai';
+import { script } from 'pyric/ai/scripting';
+
+const ai = getAI(app);
+script(ai, [
+  {
+    match: 'Summarize this report.',
+    respond: { text: 'The report is ready for review.' },
+  },
+]);
+```
+
+Keep scripted setup outside application code that ships. Pyric also supports an OpenAI-compatible local engine through the `engine` option and the `pyric dev` AI proxy. This can connect the same Firebase AI Logic calls to Ollama or another local server. The [AI chat example](https://github.com/davideast/pyric/tree/main/examples/ai-chat) shows both engines with streaming, chat history, and function calling.
+
+Local engines do not reproduce model quality, safety policy, latency, quotas, billing, or service availability. Verify model-dependent behavior against the production backend before release.
+
+## Check the supported boundary
+
+Read the generated [AI Logic conformance matrix](../pyric-ai-compat/) for the mirrored API, verified wire behavior, documented differences, unsupported APIs, and unverified rows.
+
+Continue with [Inspect and correct](../see-whats-happening/) or [ship unchanged](../ship-to-production/).

--- a/packages/site-docs/src/content/docs/secure-it-with-rules.md
+++ b/packages/site-docs/src/content/docs/secure-it-with-rules.md
@@ -1,9 +1,9 @@
 ---
 title: "Prove a user can touch only their own data"
 navLabel: "Security Rules"
-group: "Secure & debug"
-section: ""
-order: 3001
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3005
 description: "Write a rule, simulate a request against it, read the verdict, and deploy knowing what it allows."
 ---
 
@@ -18,6 +18,7 @@ Here is the loop.
 ## Write the rule
 
 A notes collection. Anyone signed in can read. Only the owner can write.
+
 ```rules
 rules_version = '2';
 service cloud.firestore {
@@ -29,9 +30,11 @@ service cloud.firestore {
   }
 }
 ```
+
 ## Simulate a request
 
 Now ask the question. No deploy, no network, no Firebase project. The simulator runs in-process.
+
 ```ts
 import { SimulateFirestoreRulesHandler } from 'pyric/rules';
 
@@ -59,14 +62,17 @@ const { data } = sim.simulate(source, [
 
 console.log(`${data.passed} passed, ${data.failed} failed`); // 2 passed, 0 failed
 ```
+
 ## Read the verdict
 
 Each result carries the decision and a trace of which rule made it. When a case surprises you, the trace is where you look:
+
 ```
 Rule #0 (read) → deny
 Rule #1 (write) → ALLOW
 Simulated: ALLOW
 ```
+
 And this is not only a test-time thing. While `pyric dev` runs, your `firestore.rules` is loaded into the sandbox and hot-reloaded on save, and every operation your app performs carries this same verdict.
 
 A denial in your running app tells you the rule, the path, and the data that produced it. See [read a denial and understand it](../read-a-denial/).
@@ -74,9 +80,11 @@ A denial in your running app tells you the rule, the path, and the data that pro
 ## Deploy
 
 When the answers hold, ship the same file to production with `firebase-tools`:
+
 ```bash
 firebase deploy --only firestore:rules
 ```
+
 Gate on error-severity lint findings in CI first (`lintFirestoreRules` / `pyric firestore rules lint`), so the mistakes that produce opaque production failures get stopped at the door.
 
 ## Where the wing goes deeper

--- a/packages/site-docs/src/content/docs/see-whats-happening.md
+++ b/packages/site-docs/src/content/docs/see-whats-happening.md
@@ -1,9 +1,9 @@
 ---
 title: "Watch every read, write, and denial live"
 navLabel: "Traffic & rule verdicts"
-group: "Observe & shape"
-section: ""
-order: 4001
+group: "Inspect and correct"
+section: "Inspect the sandbox"
+order: 3001
 description: "See every operation your backend performs, with its rules verdict, without writing a log line."
 ---
 
@@ -12,14 +12,17 @@ description: "See every operation your backend performs, with its rules verdict,
 Every operation your app performs produces a typed event: the request with its rules verdict, the committed write, the snapshot a listener delivered. You don't instrument anything. The stream is already there, and you can watch it two ways: in Studio, or with one subscription in code.
 
 ## Open the Traffic view
+
 ```bash
 pyric dev --ui
 ```
+
 Studio mounts at `/__pyric/ui/` on your dev server. The Traffic tab shows the stream live: each request, who made it, the allow or deny verdict, and how long the rules evaluation took. Sign in, write a document, break a rule on purpose. Each one appears as it happens, in the same backend your open tabs are using.
 
 ## Read the stream yourself
 
 One subscription covers everything observable:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 
@@ -29,6 +32,7 @@ const unsubscribe = sandbox.onEvent((event) => {
   console.log(event.kind);
 });
 ```
+
 The kinds at a glance:
 
 | `event.kind` | What it tells you |
@@ -41,6 +45,7 @@ The kinds at a glance:
 | `session_boundary` | A `reset()` or `dispose()` happened, so you can segment a persisted stream |
 
 Denials are a one-line filter over the same stream:
+
 ```ts
 sandbox.onEvent((event) => {
   if (event.kind === 'request' && event.result === 'deny') {
@@ -48,6 +53,7 @@ sandbox.onEvent((event) => {
   }
 });
 ```
+
 The subscription survives `sandbox.reset()`. A `session_boundary` event fires before each rollover, so a subscriber attached once keeps working across every test.
 
 ## When a denial needs explaining
@@ -57,12 +63,14 @@ A `deny` event is not a bare `permission-denied` string. It carries the method a
 ## Build your own monitor
 
 Studio's Traffic view is a consumer of `onEvent`, and you can build your own in about seventy lines. Subscribe, format each kind, and you get a terminal log like this:
+
 ```
 [#3] request    allow set    notes/n1  by alice  1.4ms
 [#4] write      set    notes/n1  by alice  (was: null)
 [#5] snapshot_delivery query notes (+1 ~0 -0) size=1 by alice  triggered by set notes/n1
 [#7] request    deny   get    notes/n1  by bob    0.2ms  Rule #0 (read,write) deny
 ```
+
 Two things to know before you ship one:
 
 - Listener re-evaluations dominate the raw stream. Default your view to user-origin requests, deliveries, lifecycle, and denials, and put `origin: 'listener'` traffic behind a toggle.

--- a/packages/site-docs/src/content/docs/set-up-the-project.md
+++ b/packages/site-docs/src/content/docs/set-up-the-project.md
@@ -1,68 +1,27 @@
 ---
-title: "Stand up the real Firebase project without leaving the terminal"
-navLabel: "Set up the project"
-group: "Ship & test"
+title: "Prepare the Firebase project"
+navLabel: "Set up the Firebase project"
+group: "Ship unchanged"
 section: ""
 order: 5002
-description: "Enable providers, authorize domains, and provision databases, Storage, and hosting sites from the Console or firebase-tools."
+description: "Configure the real Firebase services that production will use, without confusing project setup with local development."
 ---
 
-# Stand up the real Firebase project
+# Prepare the Firebase project
 
-Between "the app works in the sandbox" and "the app works in production" sits project configuration: sign-in providers to enable, domains to authorize, a database and a bucket to provision. Pyric does not replace that control plane — use the [Firebase Console](https://console.firebase.google.com/) and [`firebase-tools`](https://firebase.google.com/docs/cli) for production project administration.
+Pyric does not create, configure, or administer production Firebase projects. Local development needs no Firebase account or project. Production does.
 
-These steps change a real project. There is no dry run. Confirm which project is selected (`firebase use` / Console project picker) before mutating.
+Before shipping, create or select the real project and complete only the Firebase setup the application requires:
 
-## Enable the sign-in providers your app uses
+- [Register the web app and copy its Firebase configuration](https://firebase.google.com/docs/web/setup).
+- [Enable the Authentication providers used by the app](https://firebase.google.com/docs/auth/web/start).
+- [Create the Firestore database](https://firebase.google.com/docs/firestore/quickstart), if the app uses Firestore.
+- [Create the Realtime Database](https://firebase.google.com/docs/database/web/start), if the app uses Realtime Database.
+- [Create the default Storage bucket](https://firebase.google.com/docs/storage/web/start), if the app uses Storage.
+- [Install and select a project with the Firebase CLI](https://firebase.google.com/docs/cli) before deploying rules, indexes, Hosting, or Functions.
 
-In the Console: **Authentication → Sign-in method**. Enable `Anonymous`, `Email/Password`, `Phone`, and `Google` as your app needs.
+These steps affect a real project. Confirm the selected project before running a Firebase CLI command.
 
-Honest edges:
+The resulting Firebase configuration stays in the application code. During local development, Pyric accepts that configuration while resolving `firebase/*` to the sandbox. A production build resolves the same imports to Firebase and uses the configuration for the real project.
 
-- Enabling phone succeeds in the Console, but SMS delivery needs a billing account.
-- Google sign-in needs an OAuth client; the first enable happens in the Console (Authentication → Sign-in method → Google).
-
-## Authorize the domains you sign in from
-
-Firebase Auth keeps an allowlist of domains for OAuth redirects. Deploy to a new hosting domain without adding it, and Google sign-in fails on the new site. In the Console: **Authentication → Settings → Authorized domains**. Add the production (and preview) hosts; keep `localhost` for local development.
-
-## Create a hosting site
-
-A project's default site exists from the start; additional named sites are created in the Console (**Hosting**) or with `firebase hosting:sites:create`. Deploying to a site that doesn't exist fails — create the site first, then:
-```bash
-firebase deploy --only hosting
-```
-## Provision a Firestore database
-
-Create the database in the Console (**Firestore Database → Create database**) or with the Firebase CLI / gcloud flow your org already uses. A newly created database can take a short while for its data plane to come online; wait before issuing writes that must land.
-
-## Provision Storage, end to end
-
-Storage enablement is a multi-step sequence. For a scripted path inside pyric (sandbox / playground-style hosts), `provisionStorage` from `pyric/storage` still covers the sequence:
-```ts
-import { provisionStorage, defaultPlaygroundCors } from 'pyric/storage';
-
-const result = await provisionStorage(accessToken, 'my-app', {
-  rules: storageRulesSource,
-  cors: defaultPlaygroundCors('https://my-app.web.app'),
-});
-```
-Five steps, each skipped when already done:
-
-1. **Enable the Storage service**, then wait a few seconds for propagation, because immediate calls still return `SERVICE_DISABLED`.
-2. **Finalize the project's default location.** This one is irreversible: once set, the location cannot be changed. Skip when a location already exists; pick the location on purpose the first time.
-3. **Create and link the default bucket** (`my-app.firebasestorage.app`) if it isn't linked yet.
-4. **Deploy rules to the bucket's own release.** Storage rules apply through per-bucket release names. The project-wide `firebase.storage` release still exists as a legacy alias, but it is not bound to modern buckets, so deploying there quietly leaves the bucket's default deny-all in place. Target the per-bucket release.
-5. **Set browser-ready CORS.** A bucket without CORS configuration blocks the Storage Web SDK from any non-Firebase origin, surfacing as `No 'Access-Control-Allow-Origin' header` on the first request. Pass the origins your app serves from.
-
-For ordinary production projects, prefer the Console / `firebase-tools` Storage setup unless you specifically need this scripted helper.
-
-The result reports which steps ran, so a second invocation returns with everything marked already done.
-
-## APIs enable themselves (firebase-tools)
-
-Firebase CLI deploys typically enable required Google APIs as part of the deploy preflight. When your credential lacks permission to enable an API, that surfaces as an actionable error instead of a mysterious downstream failure.
-
-## Where to go next
-
-With the project stood up, [Ship to production](../ship-to-production/) covers rules, indexes, verification, and the deploy itself.
+Continue with [Ship to production](../ship-to-production/) for the unchanged build and deployment path.

--- a/packages/site-docs/src/content/docs/set-up-your-agent.md
+++ b/packages/site-docs/src/content/docs/set-up-your-agent.md
@@ -1,9 +1,9 @@
 ---
 title: "Point your agent at the sandbox"
 navLabel: "Set up your agent"
-group: "Work with an agent"
+group: "Run locally"
 section: ""
-order: 6001
+order: 1003
 description: "Connect Claude Code, Cursor, Codex, or any MCP client to your backend in minutes."
 ---
 
@@ -12,33 +12,42 @@ description: "Connect Claude Code, Cursor, Codex, or any MCP client to your back
 One connection and your agent has the whole backend as tools. It can read and write documents as any user, run queries, lint and simulate rules, seed data, and inspect everything, against the same sandbox your app and Studio see. Nothing it does leaves your machine.
 
 The seam is one endpoint. `pyric dev --bridge` mounts an MCP server on your dev server at `/__pyric/mcp`, and every client below connects to it, directly or through a small stdio proxy that finds it for you.
+
 ```bash
 pyric dev --bridge
 ```
+
 One requirement to know up front: the sandbox lives inside the served page, so keep the app open in a browser tab while the agent works. If data tools return nothing, the page is not open. Open it and try again.
 
 ## Claude Code
 
 The plugin does the whole thing, including finding the port.
+
 ```bash
 claude plugin install https://github.com/davideast/pyric   # path: pyric-plugin/
 ```
+
 Then, inside Claude Code, run `/pyric:pyric-start`. It scaffolds a project if you need one, starts `pyric dev --bridge --persist`, opens the app so the sandbox connects, and wires MCP through a stdio proxy that discovers the running server on its own. There is no `claude mcp add` step and no port to configure.
 
 Prefer manual wiring? Register the stdio server:
+
 ```bash
 claude mcp add pyric -- npx --package @pyric/cli pyric mcp
 ```
+
 `pyric mcp` attaches to a running `pyric dev --bridge` by reading the `.pyric/serve.json` pointer the dev server writes. If nothing is running, it hosts a headless sandbox of its own and persists it to `.pyric/state/headless.json`. Or, if you pin the port, point Claude Code at the HTTP endpoint directly:
+
 ```bash
 pyric dev --bridge --port 5173
 claude mcp add pyric --transport http --url http://localhost:5173/__pyric/mcp
 ```
+
 First thing to ask: "Inspect the sandbox." One tool call comes back with the current rules, a lint summary, a document census, and recent denials.
 
 ## Cursor
 
 Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the port is never your problem:
+
 ```json
 {
   "mcpServers": {
@@ -46,16 +55,19 @@ Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the po
   }
 }
 ```
+
 Start `pyric dev --bridge`, open the app, then ask Cursor to inspect the sandbox.
 
 ## Codex
 
 Same shape, Codex config. In `~/.codex/config.toml`:
+
 ```toml
 [mcp_servers.pyric]
 command = "npx"
 args = ["--package", "@pyric/cli", "pyric", "mcp"]
 ```
+
 Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
 
 ## Any MCP client
@@ -70,9 +82,11 @@ Whatever your client's config file looks like, one of those two lines is the who
 ## If your app uses the Vite plugin
 
 One option in `vite.config.ts` makes your own `vite dev` the bridge:
+
 ```ts
 plugins: [pyricSandbox({ bridge: true })],
 ```
+
 Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx --package @pyric/cli pyric mcp` finds it the same way.
 
 ## Where to go next

--- a/packages/site-docs/src/content/docs/shape-your-data.md
+++ b/packages/site-docs/src/content/docs/shape-your-data.md
@@ -1,9 +1,9 @@
 ---
 title: "Seed, snapshot, reset, and replay the backend like source"
 navLabel: "Seed, snapshot, replay"
-group: "Observe & shape"
-section: ""
-order: 4002
+group: "Inspect and correct"
+section: "Inspect the sandbox"
+order: 3003
 description: "Put the backend in any state you want, capture the good ones, and get them back on demand."
 ---
 
@@ -14,12 +14,15 @@ Your backend is local state. That changes what you can do with it. You can seed 
 ## Seed a scenario
 
 The fastest path is a fixture file served at startup:
+
 ```bash
 pyric dev --seed fixtures/onboarding.json
 ```
+
 A fixture carries documents and auth users, so the app opens onto a populated backend with people already signed up. The seed applies only into an empty sandbox; if earlier data exists, it is skipped and a console line says why.
 
 In tests, seed in code. Rules first, then documents, because writes before rules evaluate against default-deny:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric-admin';
@@ -30,20 +33,26 @@ const adminDb = getFirestore(sandbox.withAuth({ uid: 'admin', token: { admin: tr
 adminDb.setRules(RULES);
 await adminDb.collection('notes').doc('n1').set({ ownerId: 'alice', title: 'first note' });
 ```
+
 ## Snapshot the moment it looks right
 
 You've been working interactively: signing in test users, creating documents, getting the data into exactly the shape you want. Don't rebuild that by hand. Promote it:
+
 ```bash
 pyric dev --persist        # work in the app; state persists as you go
 pyric snapshot --out fixtures/onboarding.json
 ```
+
 `pyric snapshot` reads the live dev server and writes a committable fixture with both documents and users. Passwords are redacted by default, so the file is safe to commit, and the redaction round-trips: re-served users still sign in through the helper. Commit it, and everyone on the team, plus CI, starts from the same place:
+
 ```bash
 pyric dev --seed fixtures/onboarding.json
 ```
+
 ## Reset between tests
 
 `sandbox.reset()` wipes documents, rules, and listeners, but the sandbox object and every context derived from it keep working. So hoist one sandbox to the top of the file and reset before each case:
+
 ```ts
 beforeEach(() => {
   sandbox.reset();
@@ -51,24 +60,29 @@ beforeEach(() => {
   // re-seed whatever the next test needs
 });
 ```
+
 After reset the sandbox is empty and in default-deny. Nothing is re-run for you: re-deploy rules and re-seed in the hook. `onEvent` subscriptions survive the reset, so a monitor attached in `beforeAll` keeps watching.
 
 ## Switch users mid-session
 
 Identity is a context, and contexts are cheap. Derive one per user and evaluate the same data as different people:
+
 ```ts
 const aliceDb = getFirestore(sandbox.withAuth({ uid: 'alice' }));
 const anonDb  = getFirestore(sandbox.withAuth(null));
 const editor  = getFirestore(sandbox.withAuth({ uid: 'em-42', token: { role: 'editor' } }));
 ```
+
 Writes through `aliceDb` evaluate with `request.auth.uid == 'alice'`. The `token` object becomes `request.auth.token.*` in rules, so custom claims are one field away. Anonymous is explicit: `withAuth(null)`, never `undefined`.
 
 ## Replay a captured session
 
 While you work, `pyric dev` records the session to `.pyric/last-session.json` by default: every write, with its real identity, real server timestamps, real auto-ids. A replay re-issues those writes against a fresh sandbox and a candidate ruleset and reports what changed:
+
 ```bash
 pyric verify --rules firestore=firestore.rules
 ```
+
 That recording is a rules regression suite you didn't write. It knows a re-resolved `serverTimestamp()` is not a change, and a freshly minted auto-id is not a change, so what surfaces is the signal: the operation that used to be allowed and now is not.
 
 The place this pays off is the deploy gate, where the same replay runs against the rules you're about to ship. See [Ship to production](../ship-to-production/). You can also replay in code with `sandbox.history()` and `replay(events, rules)` when you want the divergence list programmatically.

--- a/packages/site-docs/src/content/docs/ship-to-production.md
+++ b/packages/site-docs/src/content/docs/ship-to-production.md
@@ -1,7 +1,7 @@
 ---
 title: "The same code goes live"
 navLabel: "Ship to production"
-group: "Ship & test"
+group: "Ship unchanged"
 section: ""
 order: 5001
 description: "Deploy rules, indexes, hosting, and functions, and learn what would change before production does."
@@ -10,52 +10,68 @@ description: "Deploy rules, indexes, hosting, and functions, and learn what woul
 # The same code goes live
 
 There is no graduation step. The `firebase/*` imports that resolved to the sandbox all through development resolve to real Firebase in your production build, and the config you passed to `initializeApp`, ignored in dev, is the config the built app uses in production. Your source does not change.
+
 ```bash
 vite build            # ships the real firebase package, your config, your code
 firebase deploy --only hosting
 ```
+
 One guard stands between the two worlds. A sandbox build (from `vite build --mode development`) carries a marker in its `index.html`. Production hosting deploys should use an unmarked build (`vite build` / production mode) so a sandbox-wired dist never reaches production by accident. Prefer `firebase-tools` (or the Console) for the deploy itself.
 
 ## Deploy your rules
+
 ```bash
 firebase deploy --only firestore:rules
 ```
+
 This pushes the `firestore.rules` named in `firebase.json` to your project. By the time you run it, those rules have already been exercised: every operation your app performed in development was evaluated against them, verdict by verdict. You are not deploying a guess.
 
 ## Deploy indexes from your query shapes
 
 Composite indexes usually live in a hand-kept file that drifts from the queries. Pyric derives them instead: index extraction reads your `query(collection, where, orderBy)` call sites in source and produces the `firestore.indexes.json` those shapes require (`pyric firestore indexes generate src`). Then:
+
 ```bash
 firebase deploy --only firestore:indexes
 ```
+
 Index builds are long-running on Firebase's side; the Firebase CLI starts them and reports status.
 
 ## Learn what flips before production does
 
 This is the step the others earn. While you worked, `pyric dev` captured the session to `.pyric/last-session.json`: every write, every identity, every timestamp. Replay that session against the rules you are about to ship:
+
 ```bash
 pyric verify --rules firestore=firestore.rules
 ```
+
 The output names each operation whose verdict changed:
+
 ```
 ✗ chat - rtdb: 1 failure(s)
     [rtdb] now-denied: set /rooms/r1/messages/m1 (PERMISSION_DENIED)
 ```
+
 `now-denied` means a write that succeeded during development would be rejected under the new rules. `now-allowed` means the reverse, a loosening. Auto-id aliases and timestamp drift are reported as informational, not failures, because replaying generated values is supposed to produce them. The exit code is 1 on any real divergence, which makes the CI gate one line:
+
 ```yaml
 - run: pyric verify journeys/ --rules firestore=firestore.rules
 ```
+
 By default verification runs on the local sandbox engine. For Firestore you can also send the derived cases to Firebase's hosted Rules Test API, or run both:
+
 ```bash
 pyric verify --service firestore --engine both --project my-app --rules firestore=firestore.rules
 ```
+
 `both` cross-checks the two engines against each other and flags any disagreement. That checks your rules and, at the same time, checks Pyric's own engine against Google's answer for your exact traffic. The Rules Test API evaluates cases only: it does not deploy rules or change a project. Hosted verification needs a project id plus `FIREBASE_SA_BASE64` or `GOOGLE_APPLICATION_CREDENTIALS` (or ADC); build a `ProjectScope` programmatically with `@pyric/cli/credentials/node` (`fromServiceAccount` / `fromAdc`).
 
 ## Deploy hosting and functions
+
 ```bash
 firebase deploy --only hosting                      # preview channels via firebase hosting:channel:deploy
 firebase deploy --only functions
 ```
+
 Use `firebase-tools` (or the Console) for production shipping. Preview channels give you a shareable URL with an expiry before anything touches the live site.
 
 ## Credentials for verify (and CI)

--- a/packages/site-docs/src/content/docs/sign-in-and-manage-users.md
+++ b/packages/site-docs/src/content/docs/sign-in-and-manage-users.md
@@ -1,109 +1,58 @@
 ---
-title: "Sign users in and manage them"
+title: "Run Firebase Authentication locally"
 navLabel: "Sign in and manage users"
-group: "Build"
+group: "Develop with Firebase APIs"
 section: ""
 order: 2001
-description: "Run real auth flows against a local user database, seed test users with claims, and design an identity model your rules can trust."
+description: "Keep Firebase Authentication code unchanged while identities, sessions, and provider flows stay in the local sandbox."
 ---
 
-# Sign users in
+# Run Firebase Authentication locally
 
-The auth code you would write against Firebase works as-is under `pyric dev`, and the users it creates live in your sandbox. Auth is v1 in Pyric: the surface is tested against recorded production behavior, so what signs in here signs in there.
+Keep using the Firebase Authentication Web API:
+
 ```ts
-import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
+import { getAuth, signInAnonymously } from 'firebase/auth';
 
 const auth = getAuth(app);
-
-onAuthStateChanged(auth, (user) => {
-  render(user ? `Signed in as ${user.uid}` : 'Signed out');
-});
-
 await signInAnonymously(auth);
 ```
-Email and password work the way you expect, creation and sign-in as separate flows:
-```ts
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 
-await createUserWithEmailAndPassword(auth, 'alice@example.com', 'correct-horse');
-await signInWithEmailAndPassword(auth, 'alice@example.com', 'correct-horse');
-```
-And the Google flow:
-```ts
-import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+During development, this creates and signs into a local identity. A production build runs the same call through Firebase. Use the [Firebase Authentication documentation](https://firebase.google.com/docs/auth/web/start) for normal sign-in, account, provider, and observer APIs.
 
-await signInWithPopup(auth, new GoogleAuthProvider());
-```
-Under `pyric dev`, that call opens an account picker instead of a Google window. Pick an existing sandbox identity or create one on the spot, with a display name and custom claims if you want them.
+## What changes locally
 
-No OAuth app, no consent screen, and the identity flows into your rules like any other. `signInWithRedirect` and `getRedirectResult` follow the same path.
+The sandbox owns the user database and active sessions. No identity is created in a Firebase project. Auth state remains available to Firestore, Realtime Database, and Storage Security Rules through the same Firebase-shaped user and token fields used by the application.
 
-## Manage users in the sandbox
+Popup and redirect providers do not contact Google, GitHub, or another identity provider. Pyric presents a local identity picker so provider-dependent application paths can run without OAuth configuration or external accounts.
 
-The user database is local state, so you can load it. In a test harness or seed script, `seedUsers` bulk-loads identities, claims included:
+Pyric Studio shows the local users and current authentication state. It can create, edit, select, and remove test identities without adding those controls to application code.
+
+## Seed identities for tests
+
+Sandbox-only identity controls belong in test or setup code, never in the application path that ships:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
-import { getAuth, signInWithEmailAndPassword, sandbox as authSandbox } from 'pyric/auth';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 
 const sandbox = initializeSandbox();
 const auth = getAuth(sandbox);
 
 authSandbox.seedUsers(auth, [
-  { uid: 'alice', email: 'alice@example.com', password: 'pw' },
-  { uid: 'admin', email: 'admin@example.com', password: 'pw', customClaims: { role: 'admin' } },
+  {
+    uid: 'alice',
+    email: 'alice@example.com',
+    password: 'local-only',
+    customClaims: { role: 'editor' },
+  },
 ]);
-
-await signInWithEmailAndPassword(auth, 'admin@example.com', 'pw');
 ```
-To flip between identities without a sign-in flow, `setUser` forces the current user directly (it takes a full user object) and notifies `onAuthStateChanged` subscribers like a real sign-in. Pass `null` to sign out:
-```ts
-authSandbox.setUser(auth, aliceUser);
-authSandbox.setUser(auth, null);
-```
-Keep the `sandbox` namespace out of app source. The real `firebase/auth` has no equivalent, so it belongs in your harness and seed code, where switching users mid-test is the point. In the running app, the account picker and `pyric snapshot` cover the same ground: lived users can be promoted to a committable fixture and re-seeded on boot.
 
-## Design an identity model
+Those claims reach `request.auth.token` when local Security Rules evaluate an operation.
 
-Authentication answers who the user is. Rules answer what that identity may do. Connecting the two is a design task, and it has three moves.
+## Check the supported boundary
 
-**Name your identities.** Anonymous visitor, signed-in user, owner, member, admin. Every access boundary in your app should map to one of these names before any rule mentions it.
+Authentication is not a complete reimplementation of every Firebase Auth feature. Read the generated [Auth conformance matrix](../pyric-auth-compat/) for the current public surface, verified behavior, documented differences, unsupported APIs, and unverified rows.
 
-**Make the UID the bridge.** The `uid` is the stable key that connects Authentication to your data. Put profile documents at `users/{uid}`, use the UID as the document ID wherever a record belongs to one person, and decide early which profile fields are public and which are private.
-
-**Split claims from roles data.** Custom claims carry coarse, global, slow-changing roles (`admin`, `moderator`), and rules read them as `request.auth.token.role`. Membership, ownership, and anything resource-specific belongs in document data, where a rule can `get()` it.
-
-One caution that pays for itself: users must never be able to grant themselves a role through a writable profile field. Your rules have to protect the shape of profile creates and updates, not only who performs them.
-
-## How identity reaches your rules
-
-Every operation in the sandbox carries `request.auth`, exactly as production rules see it:
-```rules
-match /posts/{postId} {
-  allow update, delete: if request.auth != null
-    && (request.auth.uid == resource.data.ownerId
-        || request.auth.token.role == 'admin');
-}
-```
-- `request.auth` is `null` when nobody is signed in.
-- `request.auth.uid` is the owner check.
-- `request.auth.token.*` carries the custom claims, and the claims you pass to `seedUsers` flow through end to end, so a rules test with an admin claim exercises the same path production will.
-
-When a rule denies, the verdict names the rule and the data it saw. [Prove your rules protect the app](../secure-it-with-rules/) picks up from here.
-
-## The boundaries, plainly
-
-Not in v1, and loud about it:
-
-- Phone auth and email-link sign-in.
-- Multi-factor auth and account linking.
-- Password-reset emails.
-
-Code that reaches for these fails with a remediation message instead of returning bad data. The full deny list lives in the reference.
-
-## And from an agent
-
-The `firebase-auth-model` skill designs or audits an identity model end to end: it names the actors, maps UIDs to data shapes, weighs claims against document roles, and then verifies each rule branch by simulating the identities it defined. Point it at an existing app and it reports where the model and the rules disagree. Install it from the [skills catalog](../skills/).
-
-## Where to go next
-
-Your users exist and your rules can see them. [Store and query data](../store-and-query-data/) puts them to work, and [secure it with rules](../secure-it-with-rules/) proves what they can touch.
+Continue with [Store and query data](../store-and-query-data/) or [inspect a local operation](../see-whats-happening/).

--- a/packages/site-docs/src/content/docs/simulate-and-lint.md
+++ b/packages/site-docs/src/content/docs/simulate-and-lint.md
@@ -1,9 +1,9 @@
 ---
 title: "Catch the error before Firebase's opaque 400"
 navLabel: "Simulate and lint before you deploy"
-group: "Secure & debug"
-section: ""
-order: 3002
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3006
 description: "Get a rules verdict and a lint report locally, before production answers with an unexplained 400 or 403."
 ---
 
@@ -16,6 +16,7 @@ Simulation tells you what a rule decides. Linting tells you what the production 
 ## Simulate a hypothetical request
 
 Ask the simulator whether a specific request would be allowed. It runs in-process, no network, no project:
+
 ```ts
 import { SimulateFirestoreRulesHandler } from 'pyric/rules';
 
@@ -29,25 +30,32 @@ const result = sim.simulate(source, [
   },
 ]);
 ```
+
 Each result is `PASSED`, `FAILED`, or `UNSUPPORTED`, and each carries `debugMessages`, a trace naming the rule that decided:
+
 ```
 Rule #0 (read) → deny
 Simulated: DENY
 ```
+
 `UNSUPPORTED` means the simulator hit a feature it does not implement and abstained rather than guessed. Those cases can be routed to Google's own engine. See [write a rules test suite](../write-a-rules-test-suite/).
 
 The same simulator is on the command line as `pyric firestore rules simulate`, and it is what evaluates every operation inside your running sandbox.
 
 ## Lint before the compiler can reject you
+
 ```bash
 pyric firestore rules lint firestore.rules
 ```
+
 Or in code:
+
 ```ts
 import { lintFirestoreRules } from 'pyric/rules';
 
 const { warnings, metrics } = lintFirestoreRules(source);
 ```
+
 The linter checks two different kinds of failure.
 
 **The production limits.** The rules compiler enforces hard caps: a 256 KB source ceiling, a boolean chain depth of 98, 11 `let` bindings per function, `get()` call counts, and a runtime evaluation budget that fails as a silent `permission-denied` under load. The linter carries each cap as an exact threshold, measured by probing the production engine. The numbers live in [the limits that actually bite](../limits-that-bite/).
@@ -70,20 +78,24 @@ Code like `resource.data.tags.includes('x')` parses fine and then fails at runti
 | `undefined` | `null` |
 
 Each of these emits a warning that names the mistake:
+
 ```
 [HALLUCINATED_METHOD] `.includes()` does not exist in Firestore rules.
   Use `x in list` instead of `list.includes(x)`
 ```
+
 The syntax-level catches (`===`, `?.`, `??`, arrow functions, backtick strings) fire even when the file fails to parse, because the parse error alone would point you at a stray parenthesis instead of the actual cause.
 
 ## Let the errors block the ship
 
 Warnings carry a severity. Gate CI (and refuse to `firebase deploy`) when any finding has `severity: 'error'`:
+
 ```ts
 const errors = lintFirestoreRules(source).warnings
   .filter((w) => w.severity === 'error');
 if (errors.length > 0) process.exit(1);
 ```
+
 A hallucinated method is always an error, because the named method literally does not exist. Blocking on it is never a false alarm.
 
 ## And from an agent

--- a/packages/site-docs/src/content/docs/skills.md
+++ b/packages/site-docs/src/content/docs/skills.md
@@ -1,9 +1,9 @@
 ---
 title: "Teach your agent the hard Firebase things"
 navLabel: "Skills"
-group: "Work with an agent"
-section: ""
-order: 6003
+group: "Inspect and correct"
+section: "Work with an agent"
+order: 3013
 description: "Packaged expert procedures for the problems that need a method, not more tools."
 ---
 

--- a/packages/site-docs/src/content/docs/start-building.md
+++ b/packages/site-docs/src/content/docs/start-building.md
@@ -1,43 +1,41 @@
 ---
-title: "Your backend in one command"
+title: "Run Firebase locally"
 navLabel: "Quickstart"
-group: "Get started"
+group: "Run locally"
 section: ""
 order: 1001
-description: "Run a working Firebase backend locally, in a new app or the one you already have."
+description: "Start a new Firebase application or add Pyric to an existing Vite application without connecting development to production."
 ---
 
-# Your backend in one command
+# Run Firebase locally
+
+Pyric adds a development-only resolution layer to a Firebase application. During Vite development, supported `firebase/*` imports resolve to a browser-local backend. A normal production build resolves those imports to Firebase again.
+
+## Start a new application
+
+Create a Vite application with canonical Firebase imports, Firestore rules, and the Pyric plugin already configured:
+
 ```bash
-npm install -D @pyric/cli
-npx pyric dev
-```
-That is a full Firebase backend, running inside the browser tab you are about to open. No account. No cloud project. No emulator, no Java, no port to babysit.
-
-`pyric dev` works in any directory with a `firebase.json`. It serves your app, resolves its ordinary `firebase/*` imports to a local sandbox, and enforces your `firestore.rules` from the first request.
-
-No app yet? Scaffold one.
-
-## Scaffold a new app
-```bash
-mkdir hello-pyric && cd hello-pyric
-pyric init --template web
+npx create-pyric my-app
+cd my-app
 npm install
-pyric dev
+npm run dev
 ```
-Open <http://localhost:3473>. The scaffold is a small posts app with canonical `firebase/app`, `firebase/auth`, and `firebase/firestore` imports, owner-based rules, and a seed file with two posts already in it. Sign in and create a post. It appears.
 
-Now prove the rules are real. Open `firestore.rules`, change the posts rule to `allow read: if false;`, and save. The rules hot-reload and the post list becomes a permission error.
+`npm create pyric my-app` runs the same scaffold.
 
-Put the rule back and the posts return. That loop, edit rules and watch real enforcement respond, is the loop everything else builds on.
+Open the local URL printed by Vite. The application and Pyric Studio use the same local backend. Studio is mounted at `/__pyric/ui/` on that origin.
 
-Building a script or a test suite instead of a page? `pyric init --template node` scaffolds the Node shape.
+## Add Pyric to an existing Vite application
 
-## Add Pyric to an app you already have
+Install the development plugin:
 
-Pick by how your app is built.
+```bash
+npm install --save-dev @pyric/cli
+```
 
-**You build with Vite.** Add one plugin and keep your own dev loop, HMR and all:
+Add it to the Vite configuration:
+
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
@@ -47,28 +45,28 @@ export default defineConfig({
   plugins: [pyricSandbox()],
 });
 ```
-`vite dev` now swaps `firebase/app`, `firebase/auth`, and `firebase/firestore` to the sandbox at module resolution, deploys your `firestore.rules` at page load, and hot-reloads them on save. A plain `vite build` still ships the real `firebase` package. Nothing in your source changes.
 
-**Your app is static or already built.** Run `pyric dev` in the directory. It serves the files and injects an import map that resolves the page's bare `firebase/*` imports to the sandbox at load time. Same swap, different layer.
+Start the normal development server:
 
-It can run your own dev command too: `pyric dev -- npm run dev`.
-
-## Your data survives
-
-The sandbox runs in a SharedWorker, so every tab shares one backend and a write in one tab shows up live in the others. The data lives in IndexedDB and survives a refresh. Three flags control it:
-
-- `--persist` keeps a committable on-disk copy at `.pyric/state/state.json`.
-- `--seed <file>` loads a fixture on boot.
-- `--fresh` starts over.
-
-## And from an agent
-
-One flag gives your agent the same backend:
 ```bash
-pyric dev --bridge
+npm run dev
 ```
-`--bridge` mounts an MCP endpoint on the dev server, and any MCP client (Claude Code, Cursor, Codex) can seed data, run queries, and check rules verdicts against the exact sandbox your tabs are using. [Set up your agent](../set-up-your-agent/) walks through each client.
 
-## Where to go next
+No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. The plugin discovers Firestore rules from `firebase.json`, or uses `firestore.rules` when no path is configured.
 
-You have a backend. [How the swap works](../how-the-swap-works/) explains the swap in one page, or go straight to [signing users in](../sign-in-and-manage-users/).
+## Use a static application or Node process
+
+`pyric dev` provides the same development-only package swap outside the Vite plugin:
+
+```bash
+npm install --save-dev @pyric/cli
+npx pyric dev
+```
+
+It can serve static files or start an existing development command. [The CLI guide](../pyric-cli/) covers those paths. [Test in Node](../test-in-node/) covers an in-process sandbox for tests and scripts.
+
+## What remains local
+
+The mirrored services do not connect to a production Firebase project. Local data changes stay in the sandbox. Local Security Rules changes are enforced there and are not deployed. Firebase configuration passed to `initializeApp(config)` is accepted so the application code stays unchanged, but it does not select a cloud backend during development.
+
+Continue with [How the swap works](../how-the-swap-works/), then [develop with the Firebase APIs](../sign-in-and-manage-users/).

--- a/packages/site-docs/src/content/docs/store-and-query-data.md
+++ b/packages/site-docs/src/content/docs/store-and-query-data.md
@@ -1,100 +1,41 @@
 ---
-title: "Store and query data"
-group: "Build"
+title: "Run Cloud Firestore locally"
+navLabel: "Store and query data"
+group: "Develop with Firebase APIs"
 section: ""
 order: 2002
-description: "Read, write, query, and stream Firestore documents locally, and derive the composite indexes your queries need from your source."
+description: "Keep Cloud Firestore application code unchanged while data, listeners, transactions, and Security Rules stay local."
 ---
 
-# Store and query your data
+# Run Cloud Firestore locally
 
-Firestore in Pyric is v1. The modular SDK surface, reads and writes, queries, snapshots, transactions, and aggregations, runs locally with your rules enforced, and it is tested against recorded production behavior. Your imports stay `firebase/firestore`.
+Keep using the modular Cloud Firestore Web API:
 
-## Write and read documents
 ```ts
-import {
-  getFirestore, collection, doc,
-  addDoc, setDoc, getDoc, serverTimestamp,
-} from 'firebase/firestore';
+import { collection, getDocs, getFirestore } from 'firebase/firestore';
 
 const db = getFirestore(app);
-
-const noteRef = await addDoc(collection(db, 'notes'), {
-  title: 'First note',
-  ownerId: uid,
-  createdAt: serverTimestamp(),
-});
-
-const snap = await getDoc(noteRef);
-console.log(snap.data());
+const notes = await getDocs(collection(db, 'notes'));
 ```
-`setDoc` writes to a known path (pass `{ merge: true }` to update in place), `updateDoc` patches fields, `deleteDoc` removes. Field sentinels work: `serverTimestamp`, `increment`, `arrayUnion`, `arrayRemove`, `deleteField`.
 
-## Query with where, orderBy, limit
-```ts
-import { query, where, orderBy, limit, getDocs } from 'firebase/firestore';
+During development, the call reads the local sandbox. A production build runs it through Firebase. Use the [Cloud Firestore Web documentation](https://firebase.google.com/docs/firestore/quickstart) for ordinary reads, writes, queries, listeners, transactions, batches, and data types.
 
-const recent = query(
-  collection(db, 'notes'),
-  where('ownerId', '==', uid),
-  where('archived', '==', false),
-  orderBy('createdAt', 'desc'),
-  limit(20),
-);
+## What changes locally
 
-const page = await getDocs(recent);
+Documents stay in the browser-local backend. Tabs on the same development origin share that backend through one SharedWorker, so Firestore listeners observe writes across tabs. Pyric Studio reads the same documents and requests.
+
+Every application operation is evaluated against the active local Firestore Security Rules. A denial stays local and appears in Studio with the request path and verdict. Saving the configured rules file replaces the active local ruleset without deploying it.
+
+The sandbox does not reproduce Firebase billing, network latency, regional behavior, or production indexes. A query that succeeds locally can still require a composite index in Firebase. Generate the index file from application query shapes before deployment:
+
+```bash
+npx pyric firestore indexes generate src
 ```
-Multiple `where` clauses AND together; the `or` and `and` combinators handle the rest. Cursors (`startAfter`, `endAt`) paginate, and collection groups query across every subcollection with a given name. Aggregations run without fetching the documents:
-```ts
-import { getCountFromServer } from 'firebase/firestore';
 
-const count = await getCountFromServer(query(collection(db, 'notes'), where('archived', '==', false)));
-console.log(count.data().count);
-```
-`sum` and `average` follow the same shape through `getAggregateFromServer`.
+Deploy the resulting Firebase index configuration with `firebase-tools`.
 
-## Keep the UI live
-```ts
-import { onSnapshot } from 'firebase/firestore';
+## Check the supported boundary
 
-const unsubscribe = onSnapshot(recent, (snap) => {
-  for (const change of snap.docChanges()) {
-    console.log(change.type, change.doc.id);
-  }
-});
-```
-Listeners fire on every matching change, across tabs, because every tab shares one backend. If your rules deny a listener, the error callback fires with a verdict that names the rule, not a bare `permission-denied`.
+Read the generated [Firestore conformance matrix](../pyric-firestore-compat/) before depending on a less common API or production edge. It separates public surface coverage from verified behavior and lists every documented difference, bug, unsupported behavior, and unverified row.
 
-## Read, then write, atomically
-
-When a write depends on the current value, use a transaction:
-```ts
-import { runTransaction } from 'firebase/firestore';
-
-await runTransaction(db, async (tx) => {
-  const counter = await tx.get(doc(db, 'counters', 'main'));
-  const current = counter.exists() ? counter.data().count : 0;
-  tx.set(doc(db, 'counters', 'main'), { count: current + 1 });
-});
-```
-All reads must come before any writes inside the callback. Production enforces that because the engine retries on conflict, and the sandbox enforces it for parity, so the mistake surfaces on your machine instead of in a retry storm. For multiple writes with no read dependency, `writeBatch` is the cheaper shape.
-
-## Design queries and the indexes they need
-
-A query with combined filters and ordering needs a composite index in production, and the missing-index error arrives at the worst time. Pyric derives the index file from your code instead: `firestore_extract_indexes` statically reads your `query(collection(...), where(...), orderBy(...))` call sites and returns the `firestore.indexes.json` they require, with warnings where it suspects overshoot.
-
-When branchy code enumerates more shapes than your app will ever run, guide the extractor with JSDoc annotations on the function:
-
-- `@firestore-mutex { fieldA, fieldB }` drops combinations where those filters would coexist.
-- `@firestore-required fieldA` drops combinations missing a filter that is always present.
-- `@firestore-budget N` is a soft cap that warns when exceeded.
-
-The index file stops being a hand-kept artifact. It becomes derived output, and [ship to production](../ship-to-production/) deploys it.
-
-## And from an agent
-
-The `firestore-query-indexes` skill designs read shapes the way a review would: it inventories every query the product performs, proves each list query is constrained the way the rules demand, then runs `firestore_extract_indexes` after every change so the index file tracks the code. Install it from the [skills catalog](../skills/).
-
-## Where to go next
-
-Data without protection is a liability, so [secure it with rules](../secure-it-with-rules/). And when you need scenarios instead of hand-typed documents, [shape your data](../shape-your-data/) covers seeding, snapshots, and resets.
+Continue with [Inspect and correct](../see-whats-happening/) or [secure the data with local Security Rules](../secure-it-with-rules/).

--- a/packages/site-docs/src/content/docs/store-files.md
+++ b/packages/site-docs/src/content/docs/store-files.md
@@ -1,101 +1,33 @@
 ---
-title: "Store files"
-group: "Build"
+title: "Run Cloud Storage locally"
+navLabel: "Store files"
+group: "Develop with Firebase APIs"
 section: ""
 order: 2004
-description: "Upload, list, download, and delete files locally, with storage rules enforced in-process."
+description: "Keep Cloud Storage application code unchanged while objects, metadata, and Security Rules stay local."
 ---
 
-# Store files
+# Run Cloud Storage locally
 
-> **Experimental.** Storage works and is documented, but most of its behavior is not yet pinned to a recorded production observation the way Auth and Firestore are. Read [what's experimental](../whats-experimental/) before you rely on it.
+Keep using the Cloud Storage for Firebase Web API:
 
-Files land in your sandbox the way documents do: locally, with rules deciding what gets in.
-
-## Upload and download
 ```ts
-import { initializeSandbox } from 'pyric/sandbox';
-import { getStorageSandbox, ref, uploadBytes, getBlob } from 'pyric/storage';
+import { getStorage, ref, uploadBytes } from 'firebase/storage';
 
-const sandbox = initializeSandbox();
-const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }));
-
-const bytes = new TextEncoder().encode(JSON.stringify({ task: 'build a notes app' }));
-await uploadBytes(ref(storage, 'sessions/s1'), bytes, { contentType: 'application/json' });
-
-const blob = await getBlob(ref(storage, 'sessions/s1'));
-console.log(JSON.parse(await blob.text()));
+const storage = getStorage(app);
+await uploadBytes(ref(storage, 'attachments/report.txt'), file);
 ```
-`uploadString` covers text without the encoder, and `getBytes` returns an `ArrayBuffer` when you want raw bytes instead of a `Blob`. Under `pyric dev`, a served page's `firebase/storage` imports resolve to the sandbox's shared object store, so uploads show up across tabs like every other write. `pyric dev` enforces `storage.rules` the same as `firestore.rules` and `database.rules.json` — but unlike those two, storage rules load at server boot and don't hot-reload. Edit `storage.rules` and you need to restart the dev server to pick up the change.
 
-## List and delete
-```ts
-import { listAll, deleteObject } from 'pyric/storage';
+During development, the object is written to the local sandbox. A production build runs the same call through Firebase. Use the [Cloud Storage Web documentation](https://firebase.google.com/docs/storage/web/start) for ordinary uploads, downloads, metadata, references, and listing behavior.
 
-const listing = await listAll(ref(storage, 'sessions'));
-console.log(listing.items.map((item) => item.name)); // ['s1']
+## What changes locally
 
-await deleteObject(ref(storage, 'sessions/s1'));
-```
-## Metadata rides along
+Objects and metadata remain in the browser-local backend. Pyric Studio browses the same object tree used by the application. Local Storage Security Rules evaluate application requests without deploying rules or contacting a Firebase bucket.
 
-Set it at upload, read it back, patch it later:
-```ts
-import { getMetadata, updateMetadata } from 'pyric/storage';
+The sandbox does not reproduce bucket provisioning, CORS configuration, transfer latency, quotas, billing, or every resumable and streaming behavior. Those remain production concerns.
 
-await uploadBytes(ref(storage, 'sessions/s1'), bytes, {
-  contentType: 'application/json',
-  customMetadata: { sessionId: 's1', version: '1.0' },
-});
+## Check the supported boundary
 
-const meta = await getMetadata(ref(storage, 'sessions/s1'));
-console.log(meta.size, meta.customMetadata?.sessionId);
+Read the generated [Storage conformance matrix](../pyric-storage-compat/) for the current public API surface, verified operations, documented differences, unsupported behavior, and unverified rows.
 
-await updateMetadata(ref(storage, 'sessions/s1'), {
-  customMetadata: { ...meta.customMetadata, version: '1.1' },
-});
-```
-Two contracts worth knowing, both matching the upstream SDK:
-
-- `updateMetadata` replaces the settable fields rather than merging. Fetch first and spread, as above.
-- `customMetadata` is string-to-string, so numbers and objects need serializing.
-
-## Enforce storage rules in-process
-
-Pass rules when you configure the handle, and every operation evaluates against them, no deploy anywhere:
-```ts
-const RULES = `service firebase.storage {
-  match /b/{bucket}/o {
-    match /sessions/{id} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null
-                   && (request.resource == null
-                       || (request.resource.size < 10 * 1024 * 1024
-                           && request.resource.contentType == 'application/json'));
-    }
-  }
-}`;
-
-const storage = getStorageSandbox(sandbox.withAuth({ uid: 'alice' }), { rules: RULES });
-```
-An anonymous upload now throws `FirebaseError` with `storage/unauthenticated`. An 11 MiB payload throws `storage/unauthorized`, the signed-in-but-not-allowed code.
-
-Notice the `request.resource == null` carve-out. `deleteObject` carries no payload, so without it every delete would fail the size check. The pattern is standard in production Storage rules, and it is enforced identically here.
-
-One rule-shape gotcha carried over faithfully from production: `listAll` requires `read` on the listed folder itself. A rule scoped to `match /sessions/{id}` grants nothing on `/sessions`, so give the folder its own read rule.
-
-## The boundaries, plainly
-
-The v1 scope is deliberate. What is not in it:
-
-- **No `getDownloadURL`.** For a renderable URL in dev, use `getBlob` and `URL.createObjectURL`. In production the upstream `firebase/storage` has the real one.
-- **No resumable uploads.** `uploadBytesResumable`, with its pause and progress machinery, is deferred. `uploadBytes` and `uploadString` are the write path.
-- **No paginated `list`.** `listAll` only.
-- **`resource.timeCreated` / `resource.updated` aren't exposed on `resource`.** Everything else on `resource` and `request` — including `request.time`, `matches()`, rule functions, and the granular verbs (`get`, `list`, `create`, `update`, `delete`) — works.
-- **One implicit bucket.** The `bucket` option round-trips through metadata but does not partition data.
-
-Each of these fails loudly at the call site instead of drifting quietly.
-
-## Where to go next
-
-If the data is structured rather than binary, [which data service should I use?](../which-data-service/) sorts it out. And [what's experimental](../whats-experimental/) says exactly what experimental costs you.
+Continue with [Inspect and correct](../see-whats-happening/) or [enforce Storage rules](../pyric-storage-how-to-enforce-rules/).

--- a/packages/site-docs/src/content/docs/sync-realtime-data.md
+++ b/packages/site-docs/src/content/docs/sync-realtime-data.md
@@ -1,78 +1,35 @@
 ---
-title: "Sync realtime data"
-group: "Build"
+title: "Run Realtime Database locally"
+navLabel: "Sync realtime data"
+group: "Develop with Firebase APIs"
 section: ""
 order: 2003
-description: "Store and watch a Realtime Database tree locally, model it around your reads, and guard writes with schema and rules checks."
+description: "Keep Realtime Database application code unchanged while the data tree, listeners, and Security Rules stay local."
 ---
 
-# Sync realtime data
+# Run Realtime Database locally
 
-> **Experimental.** Realtime Database works and is documented, but most of its behavior is not yet pinned to a recorded production observation the way Auth and Firestore are. Read [what's experimental](../whats-experimental/) before you rely on it.
+Keep using the Firebase Realtime Database Web API:
 
-Realtime Database is one JSON tree that many clients watch at once. In Pyric it runs locally, rules enforced, with the modular calls you already know.
-
-## Store and read
-
-Under `pyric dev`, your `firebase/database` imports resolve to the sandbox:
 ```ts
-import { getDatabase, ref, set, get, onValue } from 'firebase/database';
+import { getDatabase, onValue, ref } from 'firebase/database';
 
-const db = getDatabase();
-
-await set(ref(db, 'status/alice'), { state: 'online', changedAt: Date.now() });
-
-const snap = await get(ref(db, 'status/alice'));
-console.log(snap.val()); // { state: 'online', changedAt: ... }
-
-onValue(ref(db, 'status'), (snap) => {
-  renderPresence(snap.val());
+const db = getDatabase(app);
+onValue(ref(db, 'rooms/main'), (snapshot) => {
+  renderRoom(snapshot.val());
 });
 ```
-`push` appends with chronologically sortable IDs, `update` patches, `remove` deletes. One boundary to know: the Vite plugin does not swap `firebase/database` yet, so this path runs under `pyric dev`. In Node, import the same functions from `pyric/database` and hand `getDatabase` a sandbox:
-```ts
-import { initializeSandbox } from 'pyric/sandbox';
-import { getDatabase, ref, set } from 'pyric/database';
 
-const sandbox = initializeSandbox();
-const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));
-```
-## Model the tree around your reads
+During development, the listener reads the sandbox tree. A production build runs it through Firebase. Use the [Realtime Database Web documentation](https://firebase.google.com/docs/database/web/start) for normal data modeling, reads, writes, queries, listeners, and transactions.
 
-Every RTDB path is an endpoint, and reading a path downloads everything below it. So structure follows the reads, not the entities. The defaults that hold up:
+## What changes locally
 
-- **Flat, top-level collections.** `/users`, `/posts`, `/postSummaries`. Never nest one entity type inside another, or one read drags the whole subtree.
-- **Index tables for reverse lookups.** `/userGroups/$uid/$groupId: true` answers "which groups is this user in" with one cheap read, and lets membership gate access in rules.
-- **Summary nodes sized for list screens.** The list reads `/postSummaries`, the detail screen fetches one `/posts/$id`.
-- **Push IDs for anything append-only.** Sequential numeric keys collide under concurrent writers; push IDs never do.
+The database tree and listener state remain in the local backend. Pyric Studio can browse and edit the same tree used by the application. Local Realtime Database Security Rules evaluate application operations without deploying a ruleset or contacting a Firebase database.
 
-Duplicated data stays consistent through fan-out: one `update` at the root with full paths as keys commits atomically.
-```ts
-import { update } from 'firebase/database';
+Production concerns such as region, connection latency, billing, and deployed database configuration are outside the sandbox. Validate those in a Firebase environment before release.
 
-await update(ref(db), {
-  'posts/p1/title': 'New title',
-  'postSummaries/p1/title': 'New title',
-});
-```
-Either both paths change or neither does. Queries take one `orderBy`, so multi-field filters want a precomputed composite key (`"lang_level": "en_5"`) rather than a clever query.
+## Check the supported boundary
 
-## Inspect and simulate locally
+Read the generated [Realtime Database conformance matrix](../pyric-database-compat/) for the current modular API surface, verified behavior, rules evidence, documented differences, unsupported behavior, and unverified rows.
 
-Pyric keeps RTDB inspection and rules checks inside the sandbox. Studio and the
-CLI can crawl the current sandbox snapshot, while `rtdbRules(...).simulate()`
-evaluates reads and writes without contacting a production database. Production
-access happens only when the canonical Firebase package is selected outside the
-sandbox swap.
-
-## And from an agent
-
-The `rtdb-data-model` skill designs the tree the way this page describes,
-starting from an inventory of reads. In a Pyric session, local inspection tools
-map the sandbox snapshot without reaching production. Install the skill from the
-[catalog](../skills/), and see [set up your agent](../set-up-your-agent/)
-for the wiring.
-
-## Where to go next
-
-Not sure the tree is the right home for this data? [Which data service should I use?](../which-data-service/) is the one-page answer. When the paths are settled, write the rules that hold them in TypeScript: [RTDB rules in TypeScript](../rtdb-rules-in-typescript/).
+For Pyric-specific rules authoring, see [RTDB rules in TypeScript](../rtdb-rules-in-typescript/). Continue with [Inspect and correct](../see-whats-happening/) to observe local writes and denials.

--- a/packages/site-docs/src/content/docs/test-in-node.md
+++ b/packages/site-docs/src/content/docs/test-in-node.md
@@ -1,9 +1,9 @@
 ---
 title: "The same backend in tests and scripts"
 navLabel: "Test in Node"
-group: "Ship & test"
+group: "Run locally"
 section: ""
-order: 5003
+order: 1004
 description: "Run your rules and data logic in a Node test suite, with no browser and no emulator."
 ---
 
@@ -14,6 +14,7 @@ The backend that runs in your browser tab runs in a Node process the same way. T
 ## A test harness against the sandbox
 
 One sandbox at module scope, contexts derived once, reset in `beforeEach`. This is Bun's runner; the structure is identical with Vitest or Jest.
+
 ```ts
 import { describe, it, beforeEach, expect } from 'bun:test';
 import { initializeSandbox, SandboxError } from 'pyric/sandbox';
@@ -58,6 +59,7 @@ describe('notes rules', () => {
   });
 });
 ```
+
 Notice the division of labor. Writes go through user contexts, so the rules are what's under test. Assertions go through `sandbox.admin.getDocument`, which bypasses rules, so a test can confirm the state without depending on a read rule.
 
 The denial test asserts three layers: the throw, the error code, and that the state did not change.
@@ -65,12 +67,14 @@ The denial test asserts three layers: the throw, the error code, and that the st
 ## The admin shape, one line from production
 
 Server code written against `firebase-admin` runs on the sandbox with a single changed line:
+
 ```ts
 import { initializeSandbox } from 'pyric/sandbox';
 import { initializeApp } from 'pyric-admin/app';
 
 const app = initializeApp({ sandbox: initializeSandbox() });
 ```
+
 Or with zero changed lines. Under `pyric dev`, the activated
 `@pyric/cli/register` resolver maps canonical `firebase-admin/*` imports to
 `pyric-admin/*` and a bare `initializeApp()` uses the sandbox. With activation
@@ -92,9 +96,11 @@ It is a relay, so it has edges worth knowing:
 ## Verification is a test too
 
 Your captured dev sessions double as a suite:
+
 ```bash
 pyric verify journeys/
 ```
+
 It replays every fixture in the directory against candidate rules and exits non-zero on a real divergence, which slots straight into CI next to your unit tests. See [Ship to production](../ship-to-production/).
 
 ## Where to go next

--- a/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authsigninhelper.md
@@ -11,16 +11,19 @@ Emulator-style sign-in helper for sandbox auth: when an app calls
 `signInWithPopup` / `signInWithRedirect` against a sandbox `Auth` handle, the
 flow parks on a helper request; this pair renders an account picker +
 add-account form and settles the app's promise.
+
 ```ts
 import { AuthSignInHelper, useAuthFlowHelper } from '@pyric/ui/auth';
 // hook-only entry:
 import { useAuthFlowHelper } from '@pyric/ui/auth/hooks';
 ```
+
 Sandbox-only: the underlying controller drives `pyric/auth`'s
 `sandbox.setAuthFlowResolver` seam, which throws `failed-precondition` on a
 prod-backed handle.
 
 ## Example
+
 ```tsx
 import { getAuth } from 'pyric/auth';
 import { AuthSignInHelper, useAuthFlowHelper } from '@pyric/ui/auth';
@@ -43,6 +46,7 @@ function SignInHelper({ sandbox }) {
   );
 }
 ```
+
 The component is positioning-agnostic — wrap it in your own modal/panel.
 `onCancel` rejects the app's promise with the faithful
 `auth/popup-closed-by-user`.
@@ -81,9 +85,11 @@ Non-React hosts can use the exported `AuthFlowController` class directly
 The add form validates the claims textarea with the same checks and messages
 as the Firebase emulator UI: must be a JSON **object**, ≤ 1000 characters,
 and no reserved JWT keys (`sub`, `iss`, `exp`, …). Exposed for reuse:
+
 ```ts
 import { validateSerializedClaims, FORBIDDEN_CUSTOM_CLAIMS } from '@pyric/ui/auth';
 ```
+
 ## Provider labels
 
 `providerLabel(providerId)` maps the emulator's provider-id set to text

--- a/packages/site-docs/src/content/docs/ui-auth-authusers.md
+++ b/packages/site-docs/src/content/docs/ui-auth-authusers.md
@@ -10,6 +10,7 @@ order: 23030
 Emulator-style user administration for a sandbox `Auth` handle: a live
 users table, an add/edit form with emulator-grade validation, and
 confirm-gated destructive actions.
+
 ```ts
 import {
   useAuthUsers,
@@ -21,11 +22,13 @@ import {
   ClearUsersWithConfirm,
 } from '@pyric/ui/auth';
 ```
+
 Sandbox-only (drives `sandbox.listUsers` / `subscribeUsers` / CRUD, which
 throw `failed-precondition` on prod-backed handles — the hook surfaces
 that via `error`).
 
 ## Example
+
 ```tsx
 import { getAuth } from 'pyric/auth';
 import { ConfirmProvider } from '@pyric/ui/primitives';
@@ -77,6 +80,7 @@ function AuthTab({ sandbox }) {
   );
 }
 ```
+
 ## `useAuthUsers(auth)`
 
 | Returns | Type | Description |
@@ -135,6 +139,7 @@ invalid, or pristine in edit mode.
 Every field is wrapped in `label[data-pyric-field-label="<name>"]`
 containing a visible `span[data-pyric-label-text]` and (for email/password)
 the field's error alert — so a labeled grid layout is pure CSS:
+
 ```css
 [data-pyric-ui='auth-user-form'] [data-pyric-field-label] {
   display: grid;
@@ -145,8 +150,10 @@ the field's error alert — so a labeled grid layout is pure CSS:
   display: none;
 }
 ```
+
 For layout beyond CSS reach (two-column grids with mixed groupings, custom
 label/error placement), use the `renderField` slot:
+
 ```tsx
 <AuthUserForm
   onSubmit={save}
@@ -163,6 +170,7 @@ label/error placement), use the `renderField` slot:
   }
 />
 ```
+
 ## Destructive actions
 
 `<DeleteUserWithConfirm user onDelete>` and

--- a/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-collectionlist.md
@@ -7,10 +7,13 @@ order: 23009
 # `<CollectionList>`
 
 Headless list renderer for collections under a parent. The component is purely presentational — fetching is the consumer's job (via `useCollectionList` or otherwise).
+
 ```ts
 import { CollectionList } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 import { useCollectionList } from '@pyric/ui/firestore/hooks';
 
@@ -32,6 +35,7 @@ function CollectionsPane({ firestore, parent }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -46,6 +50,7 @@ function CollectionsPane({ firestore, parent }) {
 ## The `listCollections` problem
 
 The modular Web SDK has no `listCollections()` on the client. The full list is only available to admin-SDK callers. `useCollectionList` therefore takes an injected lister:
+
 ```ts
 useCollectionList({
   firestore,
@@ -59,9 +64,11 @@ useCollectionList({
   },
 });
 ```
+
 See `packages/playground/src/components/FirestoreTab.tsx` for a sandbox-introspection example using `getRunner().readState()`.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="collection-list"]
 [data-pyric-ui="collection-list"][data-pyric-loading]
@@ -71,6 +78,7 @@ See `packages/playground/src/components/FirestoreTab.tsx` for a sandbox-introspe
 [data-pyric-collection-entry][data-pyric-collection-id="users"]
 [data-pyric-collection-select]
 ```
+
 ## See also
 
 - [`<DocumentList>`](../ui-firestore-documentlist/) — the docs-in-collection counterpart.

--- a/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-deletewithconfirm.md
@@ -7,10 +7,13 @@ order: 23010
 # `<DeleteWithConfirm>`
 
 Composition of [`useConfirm`](../ui-primitives-confirmdialog/) + `useRecursiveDelete` for safe deletion of a document or collection with progress tracking.
+
 ```ts
 import { DeleteWithConfirm } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 import {
   DeleteWithConfirm,
@@ -41,6 +44,7 @@ function DocRow({ ref }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -55,12 +59,14 @@ function DocRow({ ref }) {
 | `className` | `string` | no | Forwarded to the default trigger. |
 
 ## `RecursiveDeleteImpl`
+
 ```ts
 interface RecursiveDeleteImpl {
   start: (target: DocumentReference | CollectionReference)
     => AsyncIterableIterator<{ deletedCount: number; done: boolean }>;
 }
 ```
+
 Yield progress events as you delete. The final yield must have `done: true`. The hook tracks `deletedCount` from the most recent event and exposes it via `progress`.
 
 Two common implementations:
@@ -71,6 +77,7 @@ Two common implementations:
 The library doesn't ship either — they're consumer-specific.
 
 ## Direct hook access
+
 ```tsx
 import { useRecursiveDelete } from '@pyric/ui/firestore/hooks';
 
@@ -78,14 +85,17 @@ const { delete: runDelete, progress, isRunning, error } = useRecursiveDelete(imp
 
 await runDelete(target);  // resolves on completion; errors land on `error`, not thrown
 ```
+
 Use the hook directly for richer UIs (a progress bar, a Cancel button, etc.).
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="delete-with-confirm"]
 [data-pyric-ui="delete-with-confirm"][data-pyric-destructive]
 [data-pyric-ui="delete-with-confirm"][data-pyric-running]
 ```
+
 (Plus the [`<ConfirmDialog>` selectors](../ui-primitives-confirmdialog/#styling-hooks).)
 
 ## Notes

--- a/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documenteditor.md
@@ -7,10 +7,13 @@ order: 23011
 # `<DocumentEditor>`
 
 Compound component over `useDocumentEditor`. The hook owns a reducer-backed normalized field tree; the component renders the tree with per-type Edit widgets and add/remove affordances.
+
 ```ts
 import { DocumentEditor, type UseDocumentEditorResult } from '@pyric/ui/firestore';
 ```
+
 ## Save-button gating pattern
+
 ```tsx
 function MyEditor({ snap }: { snap: DocumentSnapshot }) {
   const [editor, setEditor] = useState<UseDocumentEditorResult | null>(null);
@@ -32,6 +35,7 @@ function MyEditor({ snap }: { snap: DocumentSnapshot }) {
   );
 }
 ```
+
 ## `<DocumentEditor.Root>` props
 
 | Prop | Type | Description |
@@ -53,6 +57,7 @@ No props. Must render inside a `<DocumentEditor.Root>`.
 ## Direct hook access
 
 Sometimes the default `<DocumentEditor.Fields>` layout isn't what you want — e.g., you need a custom field order, or only edit a subset. Drop down to the hook:
+
 ```tsx
 import { useDocumentEditor } from '@pyric/ui/firestore/hooks';
 
@@ -62,7 +67,9 @@ function CustomEditor() {
   return <pre>{JSON.stringify(editor.tree, null, 2)}</pre>;
 }
 ```
+
 Inside a `<DocumentEditor.Root>`, `useDocumentEditorContext()` gives you the same hook return value:
+
 ```tsx
 import { DocumentEditor, useDocumentEditorContext } from '@pyric/ui/firestore';
 
@@ -71,6 +78,7 @@ function Inner() {
   return <span>{editor.errorCount} errors</span>;
 }
 ```
+
 ## Field types supported
 
 `string`, `number`, `boolean`, `null`, `timestamp`, `geopoint`, `reference`, `bytes`, `map`, `array`. See [`DocumentPreview.md`](../ui-firestore-documentpreview/) for the read-mode rendering of each; edit-mode widgets:
@@ -89,6 +97,7 @@ function Inner() {
 | `array` | recursive; nested arrays rejected at the reducer |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="document-editor"]
 [data-pyric-ui="document-editor"][data-pyric-is-valid]
@@ -106,6 +115,7 @@ function Inner() {
 [data-pyric-map-children]
 [data-pyric-array-children]
 ```
+
 ## Notes
 
 - **`initial` is captured once.** The hook builds the tree on first mount and ignores later changes to the prop. If the underlying document changes externally, remount the editor (`<DocumentEditor.Root key={ref.path}>`) or call `editor.reset()` after updating your local state.

--- a/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentlist.md
@@ -7,10 +7,13 @@ order: 23012
 # `<DocumentList>`
 
 Headless list renderer for documents in a collection. Above `virtualizeThreshold` (default 100), switches to virtualized rendering via `<VirtualList>`; below, renders a plain `<ul>`.
+
 ```ts
 import { DocumentList } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 import { useDocumentList } from '@pyric/ui/firestore/hooks';
 
@@ -43,6 +46,7 @@ function DocsPane({ collection }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -67,6 +71,7 @@ function DocsPane({ collection }) {
 This is **read-via-get, not realtime.** For realtime, use `useFirestoreCollection(query)` directly. Combining pagination + realtime is non-trivial; deferred until a real use case demands it.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="document-list"]
 [data-pyric-ui="document-list"][data-pyric-loading]
@@ -79,6 +84,7 @@ This is **read-via-get, not realtime.** For realtime, use `useFirestoreCollectio
 [data-pyric-document-select]
 [data-pyric-load-more]
 ```
+
 ## Notes
 
 - **Infinite scroll** isn't built in. Wire your own `IntersectionObserver` against the last rendered row's element and call `onLoadMore` when it intersects.

--- a/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-documentpreview.md
@@ -7,10 +7,13 @@ order: 23013
 # `<DocumentPreview>`
 
 Read-only renderer for a Firestore document. Iterates top-level fields in lexicographic order; dispatches each value through the field-editor registry on its inferred type.
+
 ```ts
 import { DocumentPreview } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 import { useFirestoreDoc } from '@pyric/ui/firestore';
 
@@ -27,6 +30,7 @@ function UserPreview({ ref }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -61,6 +65,7 @@ The root emits `data-size="narrow" \| "medium" \| "wide"` (breakpoints: 480 / 76
 ## Customizing per-type rendering
 
 Pass a partial `fieldEditors` registry to override one type. The override merges into the defaults, so unspecified types keep the built-in renderer.
+
 ```tsx
 import {
   defaultFieldEditors,
@@ -77,6 +82,7 @@ const customString: FieldEditorContract<string> = {
   fieldEditors={{ string: customString }}
 />
 ```
+
 ## See also
 
 - [`<DocumentEditor>`](../ui-firestore-documenteditor/) — the editable counterpart.

--- a/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-querybuilder.md
@@ -7,10 +7,13 @@ order: 23014
 # `<QueryBuilder>`
 
 Single-level where/orderBy/limit query builder. Composes state into a real Firestore `Query` via the hook's `buildQuery(base)`.
+
 ```ts
 import { QueryBuilder } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 import { useState } from 'react';
 import { collection } from 'pyric/firestore';
@@ -37,6 +40,7 @@ function FilteredDocs({ firestore }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -58,6 +62,7 @@ The value input is JSON-parsed on every change. So:
 For non-JSON Firestore values (Timestamp, GeoPoint, Reference, Bytes), the bundled component isn't enough — use `useQueryBuilder` directly with your own value editor.
 
 ## Direct hook access
+
 ```tsx
 import {
   useQueryBuilder,
@@ -72,12 +77,14 @@ const builder = useQueryBuilder({ initial: { conditions: [...] } });
 //   setOrderBy, setLimit, reset, buildQuery,
 // }
 ```
+
 ## What's not in v1
 
 - **Compound `and()` / `or()` groups.** Single-level only — every condition is implicitly AND-joined. Compound groups deferred.
 - **Cursor-based pagination (`startAfter`).** Use `useDocumentList` with the composed query — pagination is its job.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="query-builder"]
 [data-pyric-query-conditions]
@@ -94,6 +101,7 @@ const builder = useQueryBuilder({ initial: { conditions: [...] } });
 [data-pyric-query-limit]
 [data-pyric-query-limit-input]
 ```
+
 ## Notes
 
 - **Empty-field conditions are dropped** silently in `buildQuery`. The UI lets users add a row and fill it in over multiple keystrokes; passing a `where('', '==', '')` to Firestore would throw.

--- a/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
+++ b/packages/site-docs/src/content/docs/ui-firestore-referencepicker.md
@@ -7,10 +7,13 @@ order: 23015
 # `<ReferencePicker>`
 
 Pick a `DocumentReference` by typing a path OR by browsing the tree. Improvement over firebase-tools-ui's plain text input.
+
 ```ts
 import { ReferencePicker } from '@pyric/ui/firestore';
 ```
+
 ## Example
+
 ```tsx
 <ReferencePicker
   firestore={fs}
@@ -23,6 +26,7 @@ import { ReferencePicker } from '@pyric/ui/firestore';
   }}
 />
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -49,6 +53,7 @@ Either way, the text input updates to reflect the committed path so the two path
 - **Back** — pops the navigation history. Disabled at root.
 
 ## Direct hook access
+
 ```tsx
 import { useReferencePicker } from '@pyric/ui/firestore/hooks';
 
@@ -60,9 +65,11 @@ const picker = useReferencePicker({ firestore, listCollections });
 //   drillBack, clear,
 // }
 ```
+
 Use the hook directly for custom layouts (popover trigger inside another component, etc).
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="reference-picker"]
 [data-pyric-reference-path-label]
@@ -84,6 +91,7 @@ Use the hook directly for custom layouts (popover trigger inside another compone
 [data-pyric-browse-pick]
 [data-pyric-browse-drill]
 ```
+
 ## Notes
 
 - **Path validation** uses `doc(firestore, path)` wrapped in try/catch. Empty paths are valid (no commit available). Paths with an odd number of segments fail with `"Must point to a document (even segment count)"`.

--- a/packages/site-docs/src/content/docs/ui-primitives-badge.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-badge.md
@@ -9,16 +9,20 @@ order: 23002
 Headless pill / tag. An inline `<span>` carrying `data-pyric-badge` and an
 optional `data-pyric-badge-kind` so consumers style categories with attribute
 selectors.
+
 ```ts
 import { Badge } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 <Badge kind="deny">DENY</Badge>
 <Badge kind="get">GET</Badge>
 // Terse glyph with a spoken label:
 <Badge kind="deny" ariaLabel="denied">✕</Badge>
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -29,11 +33,13 @@ import { Badge } from '@pyric/ui/primitives';
 | `className` | `string` | no | Forwarded to the `<span>`. |
 
 ## Styling hooks
+
 ```
 [data-pyric-badge]
 [data-pyric-badge-kind="allow"]
 [data-pyric-badge-kind="deny"]
 ```
+
 ## Notes
 
 - Ships no visual styling — not even `display`. A bare `<Badge>` is an inline

--- a/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-confirmdialog.md
@@ -10,6 +10,7 @@ Headless confirmation dialog. Two ways to use:
 
 - **Controlled** — `<ConfirmDialog open onOpenChange title onConfirm>`. You hold the open state.
 - **Imperative** — wrap your app in `<ConfirmProvider>` and call `useConfirm()` from anywhere; the returned function opens the dialog and resolves to `Promise<boolean>`.
+
 ```ts
 import {
   ConfirmDialog,
@@ -17,7 +18,9 @@ import {
   useConfirm,
 } from '@pyric/ui/primitives';
 ```
+
 ## Imperative (recommended)
+
 ```tsx
 function App() {
   return (
@@ -41,7 +44,9 @@ function Inner() {
   return <button onClick={handleDelete}>Delete</button>;
 }
 ```
+
 ## Controlled
+
 ```tsx
 const [open, setOpen] = useState(false);
 
@@ -56,6 +61,7 @@ const [open, setOpen] = useState(false);
   }}
 />
 ```
+
 The dialog does **not** auto-close on confirm — `onConfirm` runs your action and you dismiss when ready. This lets you keep the dialog open while a slow operation completes and dismiss on success.
 
 ## `<ConfirmDialog>` props
@@ -73,6 +79,7 @@ The dialog does **not** auto-close on confirm — `onConfirm` runs your action a
 | `className` | `string` | no | Forwarded to the content node. |
 
 ## `useConfirm` API
+
 ```ts
 const confirm: (options: {
   title: string;
@@ -82,9 +89,11 @@ const confirm: (options: {
   cancelLabel?: string;
 }) => Promise<boolean>;
 ```
+
 Resolves to `true` on confirm, `false` on cancel / Escape / overlay click. Throws if called without a `<ConfirmProvider>` ancestor.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="confirm-portal"]
 [data-pyric-ui="confirm-overlay"]
@@ -97,6 +106,7 @@ Resolves to `true` on confirm, `false` on cancel / Escape / overlay click. Throw
 [data-pyric-confirm-confirm]
 [data-pyric-confirm-confirm][data-pyric-destructive]
 ```
+
 ## Notes
 
 - **Hand-rolled, not Radix.** Initial M4 implementation tried Radix Dialog; Radix's Presence + Portal stack doesn't render under our bun:test + JSDOM env even with `forceMount`. The hand-rolled component provides focus trap, Escape, overlay click, ARIA wiring, and focus restoration in ~110 lines.

--- a/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-copybutton.md
@@ -7,20 +7,26 @@ order: 23004
 # `<CopyButton>`
 
 Clipboard button that exposes a `data-copied` attribute on the underlying `<button>` so consumers can style the success state. Ships no visual treatment of its own.
+
 ```ts
 import { CopyButton } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 <CopyButton text="users/alice" className="my-btn" />
 ```
+
 Style the success state with an attribute selector:
+
 ```css
 .my-btn[data-copied] {
   background: var(--success-bg);
   color: var(--success-fg);
 }
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |

--- a/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-jsonview.md
@@ -9,16 +9,20 @@ order: 23005
 Headless collapsible JSON tree — one structural step above a `<pre>` dump.
 Object/array nodes are independently expandable; there's no editing and no
 syntax-color theme, just `data-pyric-*` hooks.
+
 ```ts
 import { JsonView } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 <JsonView value={{ uid: 'alice', roles: ['admin', 'beta'] }} />
 
 // Collapse everything below the root on first render:
 <JsonView value={largePayload} defaultCollapsedDepth={1} />
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -28,6 +32,7 @@ import { JsonView } from '@pyric/ui/primitives';
 | `className` | `string` | no | Forwarded to the root. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="json-view"]              /* root */
 [data-pyric-json-node]                   /* every node, + data-pyric-json-type */
@@ -38,6 +43,7 @@ import { JsonView } from '@pyric/ui/primitives';
 [data-pyric-json-summary]                /* the {…} / […] placeholder when collapsed */
 [data-pyric-json-children]               /* the expanded children wrapper */
 ```
+
 ## Notes
 
 - `data-pyric-json-type` is one of `object` / `array` / `string` / `number` /

--- a/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-segmentedcontrol.md
@@ -8,10 +8,13 @@ order: 23006
 
 Headless single-select chip group — reads as one widget, wired as an ARIA
 radiogroup.
+
 ```ts
 import { SegmentedControl } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 <SegmentedControl
   ariaLabel="Result filter"
@@ -24,6 +27,7 @@ import { SegmentedControl } from '@pyric/ui/primitives';
   onChange={setResult}
 />
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -38,12 +42,14 @@ import { SegmentedControl } from '@pyric/ui/primitives';
 / `error` to tint the active label. The library doesn't enumerate tones.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="segmented-control"]              /* container */
 [data-pyric-segment]                             /* each option button */
 [data-pyric-segment][data-pyric-active]          /* the selected one */
 [data-pyric-segment-tone="error"]                /* tone-tinted options */
 ```
+
 ## Notes
 
 - Type-parameterized — `SegmentedControl<MyUnion>` keeps `value` / `onChange`

--- a/packages/site-docs/src/content/docs/ui-primitives-toast.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-toast.md
@@ -7,10 +7,13 @@ order: 23007
 # `<ToastProvider>` + `useToast`
 
 Imperative toast queue. One `<ToastProvider>` per scope; any descendant calls `useToast()` to push toasts. Renders to `document.body` via portal.
+
 ```ts
 import { ToastProvider, useToast } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 function App() {
   return (
@@ -38,6 +41,7 @@ function Inner() {
   return <button onClick={handleSave}>Save</button>;
 }
 ```
+
 ## `<ToastProvider>` props
 
 | Prop | Type | Default | Description |
@@ -47,6 +51,7 @@ function Inner() {
 | `regionLabel` | `string` | `"Notifications"` | `aria-label` on the container. |
 
 ## `useToast` API
+
 ```ts
 const { toast, dismiss, toasts } = useToast();
 
@@ -60,9 +65,11 @@ toast({
 dismiss(id: string): void;
 toasts: ReadonlyArray<ToastRecord>;
 ```
+
 Throws if called without a `<ToastProvider>` ancestor.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="toast-region"]
 [data-pyric-toast]
@@ -71,6 +78,7 @@ Throws if called without a `<ToastProvider>` ancestor.
 [data-pyric-toast-body]
 [data-pyric-toast-dismiss]
 ```
+
 Error toasts get `role="alert"`; others get `role="status"`. The container is `aria-live="polite"`.
 
 ## Notes

--- a/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
+++ b/packages/site-docs/src/content/docs/ui-primitives-virtuallist.md
@@ -7,10 +7,13 @@ order: 23008
 # `<VirtualList>`
 
 Thin wrapper around [`@tanstack/react-virtual`](https://tanstack.com/virtual). Renders a scrollable container with absolutely-positioned rows; only the rows in view (plus `overscan` neighbors) mount to the DOM.
+
 ```ts
 import { VirtualList } from '@pyric/ui/primitives';
 ```
+
 ## Example
+
 ```tsx
 <VirtualList<Row>
   items={rows}
@@ -24,6 +27,7 @@ import { VirtualList } from '@pyric/ui/primitives';
   )}
 />
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -37,12 +41,14 @@ import { VirtualList } from '@pyric/ui/primitives';
 | `className` | `string` | no | Forwarded to the scroll container. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="virtual-list"]      /* scroll container */
 [data-pyric-virtual-inner]          /* total-height spacer */
 [data-pyric-virtual-row]            /* each rendered row */
 [data-pyric-virtual-row][data-index="42"]  /* specific row */
 ```
+
 ## Notes
 
 - **Height must be constrained.** The scroll container fills its parent via `height` (default `100%`). If the parent's height is unbounded, nothing scrolls and the virtualizer renders everything — defeating the point. Either set `height` explicitly or constrain via CSS.

--- a/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
+++ b/packages/site-docs/src/content/docs/ui-storage-deleteselectionwithconfirm.md
@@ -7,10 +7,13 @@ order: 23016
 # `<DeleteSelectionWithConfirm>`
 
 Bulk + recursive delete behind the confirm-dialog primitive, with **toasts on outcome** — the storage counterpart of the Firestore half's `<DeleteWithConfirm>`. Objects delete via `deleteObject`; folders walk recursively (default impl: `listAll`-driven, including the create-folder placeholder sweep). Requires `<ConfirmProvider>` **and** `<ToastProvider>` ancestors.
+
 ```ts
 import { DeleteSelectionWithConfirm } from '@pyric/ui/storage';
 ```
+
 ## Example
+
 ```tsx
 import { useStorageList, useStorageSelection } from '@pyric/ui/storage/hooks';
 
@@ -34,6 +37,7 @@ function Toolbar({ storage, path }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -51,6 +55,7 @@ function Toolbar({ storage, path }) {
 | `className` | `string` | Forwarded to the default trigger. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="delete-selection"]                       /* default trigger */
 [data-pyric-ui="delete-selection"][data-pyric-destructive]
@@ -60,6 +65,7 @@ function Toolbar({ storage, path }) {
 [data-pyric-delete-selection-paths]                      /* default dialog body */
 [data-pyric-delete-selection-failures]                   /* error-toast body */
 ```
+
 (The dialog and toasts style via the primitives' own hooks —
 `[data-pyric-ui="confirm-dialog"]`, `[data-pyric-toast]`.)
 

--- a/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectbrowser.md
@@ -7,10 +7,13 @@ order: 23017
 # `<ObjectBrowser>`
 
 Headless row list for a storage path — folders first, then objects, from `useStorageList`'s `entries`. Folder rows **navigate**, object rows **select**. Above `virtualizeThreshold` (default 100), switches to virtualized rendering via `<VirtualList>`; below, renders a plain `<ul>`.
+
 ```ts
 import { ObjectBrowser } from '@pyric/ui/storage';
 ```
+
 ## Example
+
 ```tsx
 import { useStorageList, usePathState } from '@pyric/ui/storage/hooks';
 
@@ -38,6 +41,7 @@ function Browser({ storage }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -57,6 +61,7 @@ function Browser({ storage }) {
 | `virtualizedHeight` | `number \| string` | Scroll-container height when virtualized. Default `'60vh'`. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="object-browser"]                       /* root; also stamps data-size */
 [data-pyric-ui="object-browser"][data-pyric-loading]
@@ -75,6 +80,7 @@ function Browser({ storage }) {
 [data-pyric-entry-select]                              /* the row button */
 [data-pyric-entry-select][data-pyric-selected]
 ```
+
 ## Notes
 
 - **`listAll` has no pagination** — a big prefix arrives as one flat result; virtualization is the defense, which is why the threshold mechanics mirror `<DocumentList>`.

--- a/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
+++ b/packages/site-docs/src/content/docs/ui-storage-objectinspector.md
@@ -7,10 +7,13 @@ order: 23018
 # `<ObjectInspector>`
 
 Headless inspector for one storage object: metadata fields + a **content-type-driven preview**. Previews come from a registry — `image/*` (blob-URL `<img>`) and `text/* + application/json` (text panel, 256KB cap, JSON pretty-printed) ship built in; consumers extend by prepending their own matchers. Bytes load lazily and only when the matched preview asks; blob URLs are revoked on path change/unmount.
+
 ```ts
 import { ObjectInspector, defaultStoragePreviews } from '@pyric/ui/storage';
 ```
+
 ## Example
+
 ```tsx
 function Inspector({ storage, selectedPath }) {
   return (
@@ -32,6 +35,7 @@ function Inspector({ storage, selectedPath }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -54,6 +58,7 @@ function Inspector({ storage, selectedPath }) {
 | `render` | `(ctx: { metadata, blob, blobUrl }) => ReactNode` | The preview body. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="object-inspector"]                 /* root; stamps data-size */
 [data-pyric-ui="object-inspector"][data-pyric-idle]
@@ -71,6 +76,7 @@ function Inspector({ storage, selectedPath }) {
 [data-pyric-preview-image]                         /* the built-in <img> */
 [data-pyric-preview-text]                          /* the built-in <pre> */
 ```
+
 ## Notes
 
 - **No `getDownloadURL` anywhere** — previews go `getBlob` →

--- a/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
+++ b/packages/site-docs/src/content/docs/ui-storage-pathbreadcrumb.md
@@ -7,10 +7,13 @@ order: 23019
 # `<PathBreadcrumb>`
 
 Headless breadcrumb for a storage path. Renders a root crumb plus one crumb per segment; every crumb (including the current one) is a real `<button>` firing `onNavigate` with that ancestor's absolute path.
+
 ```ts
 import { PathBreadcrumb } from '@pyric/ui/storage';
 ```
+
 ## Example
+
 ```tsx
 import { usePathState } from '@pyric/ui/storage/hooks';
 
@@ -26,6 +29,7 @@ function Crumbs() {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -37,6 +41,7 @@ function Crumbs() {
 | `className` | `string` | Forwarded to the `<nav>` root. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="path-breadcrumb"]            /* the <nav> */
 [data-pyric-breadcrumb-list]                 /* the <ol> */
@@ -46,6 +51,7 @@ function Crumbs() {
 [data-pyric-breadcrumb-root]                 /* the root crumb's button */
 [data-pyric-breadcrumb-separator]            /* the separators (aria-hidden) */
 ```
+
 ## Notes
 
 - **The current crumb is clickable** — wiring `onNavigate` to a path-keyed loader makes it a free "refresh this level" affordance. Disable via CSS (`[data-pyric-current] { pointer-events: none }`) if you'd rather not.

--- a/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
+++ b/packages/site-docs/src/content/docs/ui-storage-rules-aware-affordances.md
@@ -13,10 +13,12 @@ sandbox enforces with; the components annotate themselves from its
 verdicts. No emulator-UI equivalent exists.
 
 ## The wiring
+
 ```tsx
 const gate = useStorageRulesGate(storage);          // sandbox: zero config
 const pathVerdict = gate.verdictFor(nav.path);
 ```
+
 | Component | Verdict consumed | Affordance |
 |---|---|---|
 | `<ObjectBrowser gate={gate}>` | `read` per row path | Read-denied rows stamped `data-pyric-denied` (+ the evaluator trace on `data-pyric-denied-reason`). Rows stay **clickable** — navigating into a denied folder surfaces the real `storage/unauthorized` through the existing error UI; the stamp is the early warning. |

--- a/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
+++ b/packages/site-docs/src/content/docs/ui-storage-uploaddropzone.md
@@ -7,10 +7,13 @@ order: 23021
 # `<UploadDropzone>`
 
 Headless drop target for file **and folder** uploads. Slot-based — the children render the chrome; the component owns the drag wiring, flattens the drop (folders traverse recursively via `webkitGetAsEntry`), and emits `DroppedFile { file, relativePath }[]` ready for `useObjectUpload`.
+
 ```ts
 import { UploadDropzone } from '@pyric/ui/storage';
 ```
+
 ## Example
+
 ```tsx
 import { useObjectUpload, useStorageList, usePathState } from '@pyric/ui/storage/hooks';
 
@@ -39,6 +42,7 @@ function Uploader({ storage }) {
   );
 }
 ```
+
 ## Props
 
 | Prop | Type | Description |
@@ -50,12 +54,14 @@ function Uploader({ storage }) {
 | `className` | `string` | Forwarded to the root. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="upload-dropzone"]                 /* root */
 [data-pyric-ui="upload-dropzone"][data-dragging]  /* a drag is hovering */
 [data-pyric-ui="upload-dropzone"][data-disabled]
 [data-pyric-ui="upload-dropzone"][data-disabled-reason]  /* why (rules gate) */
 ```
+
 ## Notes
 
 - **Folder drops** traverse the `webkitGetAsEntry` tree (batched

--- a/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
+++ b/packages/site-docs/src/content/docs/ui-storage-usestoragerulesgate.md
@@ -7,10 +7,13 @@ order: 23023
 # `useStorageRulesGate`
 
 Pre-flight rules evaluation — evaluate the current identity against storage paths **before the click**, so the UI can mark denied affordances (`data-pyric-denied` rows, disabled-with-reason buttons) instead of letting the user discover a denial through a thrown `storage/unauthorized`. Built on the pure evaluator exports from `pyric/storage` (`parseStorageRules` + `evaluateStorageRules`) — the same evaluator the sandbox enforces with.
+
 ```ts
 import { useStorageRulesGate } from '@pyric/ui/storage/hooks';
 ```
+
 ## Example
+
 ```tsx
 function GatedAdmin({ storage }) {
   const nav = usePathState();
@@ -37,7 +40,9 @@ function GatedAdmin({ storage }) {
   );
 }
 ```
+
 ## Signature
+
 ```ts
 useStorageRulesGate(storage, {
   paths?, rules?, identity?, writeResource?,
@@ -45,6 +50,7 @@ useStorageRulesGate(storage, {
   status, source, advisory, identity, verdicts, verdictFor, error,
 }
 ```
+
 ### Options
 
 | Option | Type | Description |

--- a/packages/site-docs/src/content/docs/ui-storage.md
+++ b/packages/site-docs/src/content/docs/ui-storage.md
@@ -12,6 +12,7 @@ bulk delete (the write path), plus rules-aware affordances (the gate
 pre-evaluates rules so denied actions warn BEFORE the click). Same one-handle
 contract as the Firestore half: every hook takes the sandbox
 `FirebaseStorage` handle from `pyric/storage`.
+
 ```ts
 import {
   // read path
@@ -34,7 +35,9 @@ import {
 } from '@pyric/ui/storage';
 // hooks-only entry: '@pyric/ui/storage/hooks'
 ```
+
 ## The wiring (one screen)
+
 ```tsx
 function StorageAdmin({ storage }) {
   const nav = usePathState();
@@ -78,6 +81,7 @@ function StorageAdmin({ storage }) {
   );
 }
 ```
+
 ## Components
 
 - [ObjectBrowser](../ui-storage-objectbrowser/) — the folder/object row list;

--- a/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-ruleheatmap.md
@@ -8,10 +8,13 @@ order: 23025
 
 Per-rule fire / deny rollup — one row per rule, busiest first. Pairs with
 `useRuleHeatmap`, which does the aggregation.
+
 ```ts
 import { RuleHeatmap, useRuleHeatmap } from '@pyric/ui/traffic';
 ```
+
 ## Example
+
 ```tsx
 const { entries } = useRuleHeatmap({ events: monitor.events });
 
@@ -21,6 +24,7 @@ const { entries } = useRuleHeatmap({ events: monitor.events });
   onSelectRule={(i) => setSelectedRule((cur) => (cur === i ? null : i))}
 />
 ```
+
 Wire `onSelectRule` to your log filter for the cross-view "click a rule, see
 its traffic" interaction — the showcase narrows the event list to
 `matchedRule.ruleIndex === selectedRule` before the origin/result filter runs.
@@ -46,6 +50,7 @@ Each row exposes the deny intensity two ways — use whichever fits:
   target element).
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="rule-heatmap"]
 [data-pyric-rule-row]                  /* + data-pyric-rule-index / -heat, data-pyric-selected */
@@ -54,6 +59,7 @@ Each row exposes the deny intensity two ways — use whichever fits:
 [data-pyric-rule-total] / -allows / -denies
 [data-pyric-rule-bar]                  /* read --pyric-deny-ratio off the row */
 ```
+
 ## Notes
 
 - Events with no `matchedRule` aren't attributed to any row — `useRuleHeatmap`

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficdetail.md
@@ -9,10 +9,13 @@ order: 23026
 The drill-in panel for one traffic event — header, a consumer classification
 slot, then JSON sections for auth / request / resource before+after, the
 reasons list, `triggeredBy`, and `groupId`.
+
 ```ts
 import { TrafficDetail } from '@pyric/ui/traffic';
 ```
+
 ## Example
+
 ```tsx
 <TrafficDetail
   event={selectedEvent}
@@ -22,6 +25,7 @@ import { TrafficDetail } from '@pyric/ui/traffic';
   }
 />
 ```
+
 ## Props
 
 | Prop | Type | Required | Description |
@@ -40,6 +44,7 @@ import { TrafficDetail } from '@pyric/ui/traffic';
 [`<JsonView>`](../ui-primitives-jsonview/).
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="traffic-detail"]
 [data-pyric-traffic-detail-header] / -meta / -title
@@ -51,6 +56,7 @@ import { TrafficDetail } from '@pyric/ui/traffic';
 [data-pyric-traffic-eval-ms]
 [data-pyric-traffic-triggered-by] / [data-pyric-traffic-group]
 ```
+
 ## Notes
 
 - `evalMs` appears here as a minor header field — it is not a log column

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficlog.md
@@ -10,10 +10,13 @@ order: 23027
 The event stream — a Chrome DevTools Network-panel-style list. Below 100 rows
 it's a plain `<ul>`; above, it virtualizes via `<VirtualList>`. Pass `items`
 (from `useTrafficGroups`) instead of `events` for collapsible group rows.
+
 ```ts
 import { TrafficLog, TrafficRow, TrafficGroupRow } from '@pyric/ui/traffic';
 ```
+
 ## Example
+
 ```tsx
 // Flat, virtualized:
 <TrafficLog
@@ -29,6 +32,7 @@ import { TrafficLog, TrafficRow, TrafficGroupRow } from '@pyric/ui/traffic';
 const { items } = useTrafficGroups({ events: ordered });
 <TrafficLog events={[]} items={items} onSelect={openDetail} />
 ```
+
 ## `<TrafficLog>` props
 
 | Prop | Type | Required | Description |
@@ -49,6 +53,7 @@ const { items } = useTrafficGroups({ events: ordered });
 their own list — see their source JSDoc for props.
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="traffic-log"]                    /* root */
 [data-pyric-ui="traffic-log"][data-pyric-grouped]
@@ -60,6 +65,7 @@ their own list — see their source JSDoc for props.
 [data-pyric-traffic-group][data-pyric-expanded]
 [data-pyric-traffic-group-members]
 ```
+
 Method + result render as [`<Badge>`](../ui-primitives-badge/) — style via
 `[data-pyric-badge-kind="…"]`.
 

--- a/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
+++ b/packages/site-docs/src/content/docs/ui-traffic-trafficstats.md
@@ -8,15 +8,19 @@ order: 23028
 
 The aggregation panel — totals, deny rate, and count breakdowns by method /
 origin / path. Pairs with `useTrafficStats`.
+
 ```ts
 import { TrafficStats, useTrafficStats } from '@pyric/ui/traffic';
 ```
+
 ## Example
+
 ```tsx
 const stats = useTrafficStats({ events: filtered, topPaths: 10 });
 
 <TrafficStats stats={stats} />
 ```
+
 Feed it the filtered or full event list depending on what the panel should
 reflect — it's pure derivation either way.
 
@@ -28,6 +32,7 @@ reflect — it's pure derivation either way.
 | `className` | `string` | no | Forwarded to the root. |
 
 ## Styling hooks
+
 ```
 [data-pyric-ui="traffic-stats"]          /* root; carries --pyric-deny-rate */
 [data-pyric-stat-totals]
@@ -38,6 +43,7 @@ reflect — it's pure derivation either way.
 [data-pyric-stat-bucket]                 /* + data-pyric-stat-key */
 [data-pyric-stat-bucket-label] / [data-pyric-stat-bucket-count]
 ```
+
 ## Notes
 
 - The deny rate is exposed twice — as a `%` text value and as the

--- a/packages/site-docs/src/content/docs/ui-traffic.md
+++ b/packages/site-docs/src/content/docs/ui-traffic.md
@@ -11,6 +11,7 @@ DevTools Network-panel-style **log** and a per-rule **heatmap**, plus stats
 and grouping. Decoupled from `pyric/sandbox`: the data hook takes a `source`
 function, so the same components work against the sandbox or a production
 log feed.
+
 ```ts
 import {
   useTrafficMonitor,
@@ -28,10 +29,13 @@ import {
   type TrafficSource,
 } from '@pyric/ui/traffic';
 ```
+
 ## The decoupling contract
+
 ```ts
 type TrafficSource = (cb: (event: TrafficEvent) => void) => () => void;
 ```
+
 `pyric/sandbox`'s `Sandbox.onRequest` matches this signature exactly —
 `useTrafficMonitor({ source: sandbox.onRequest })` wires with zero adapter
 code. `TrafficEvent` is structurally identical to the sandbox's `RequestEvent`
@@ -66,6 +70,7 @@ return-shape interface commented per field. Summary:
   listener-run aggregation.
 
 ## Minimal wiring
+
 ```tsx
 function TrafficPanel({ sandbox }) {
   const monitor = useTrafficMonitor({ source: sandbox.onRequest });
@@ -85,6 +90,7 @@ function TrafficPanel({ sandbox }) {
   );
 }
 ```
+
 ## Notes
 
 - **Latency is de-featured.** `evalMs` stays on `TrafficEvent` and shows in

--- a/packages/site-docs/src/content/docs/ui.md
+++ b/packages/site-docs/src/content/docs/ui.md
@@ -87,9 +87,11 @@ Highlights:
 ## Styling pattern (all components)
 
 The library ships **no CSS**. Components emit structural `data-pyric-*` attributes that consumers target with attribute selectors:
+
 ```css
 [data-pyric-ui='document-preview'] { /* root */ }
 [data-pyric-field-type='reference'][data-pyric-clickable] { /* clickable refs */ }
 [data-pyric-toast][data-pyric-toast-kind='error'] { /* error toast */ }
 ```
+
 See `examples/admin-playground/src/styles/global.css` for a complete set of Tailwind-based rules covering every component the library ships.

--- a/packages/site-docs/src/content/docs/watch-and-review.md
+++ b/packages/site-docs/src/content/docs/watch-and-review.md
@@ -1,9 +1,9 @@
 ---
 title: "Watch the agent work, then check it"
 navLabel: "Review agent activity"
-group: "Work with an agent"
-section: ""
-order: 6004
+group: "Inspect and correct"
+section: "Inspect the sandbox"
+order: 3004
 description: "See every operation your agent performs, live, with the verdict that decided it."
 ---
 
@@ -14,9 +14,11 @@ An agent you cannot see is an agent you cannot trust. Pyric makes the agent's wo
 ## Watch it live in Studio
 
 Start the sandbox with Studio on:
+
 ```bash
 pyric dev --ui
 ```
+
 Studio opens at `/__pyric/ui/` against the same sandbox your app tab and MCP client use.
 
 Ask your connected agent for a feature and watch documents appear in the Firestore tab as it writes them, because there is one backend and everyone is looking at it. When the agent claims it seeded ten users, the Auth tab either shows ten users or it does not.

--- a/packages/site-docs/src/content/docs/what-your-agent-can-do.md
+++ b/packages/site-docs/src/content/docs/what-your-agent-can-do.md
@@ -1,9 +1,9 @@
 ---
 title: "Hand your agent the whole backend"
 navLabel: "What your agent can do"
-group: "Work with an agent"
-section: ""
-order: 6002
+group: "Inspect and correct"
+section: "Work with an agent"
+order: 3012
 description: "Every backend capability, callable as a tool: inspect, query, simulate, shape, ship, verify."
 ---
 

--- a/packages/site-docs/src/content/docs/whats-experimental.md
+++ b/packages/site-docs/src/content/docs/whats-experimental.md
@@ -1,8 +1,8 @@
 ---
 title: "What's experimental"
-group: "Trust"
+group: "Conformance"
 section: ""
-order: 7002
+order: 6002
 description: "Know exactly which parts of Pyric are v1 and which are still earning it."
 ---
 

--- a/packages/site-docs/src/content/docs/whats-possible.md
+++ b/packages/site-docs/src/content/docs/whats-possible.md
@@ -1,9 +1,9 @@
 ---
 title: "Case studies in pure security rules"
 navLabel: "Case studies"
-group: "Secure & debug"
-section: ""
-order: 3010
+group: "Inspect and correct"
+section: "Correct Security Rules"
+order: 3011
 description: "See working, deployed rulesets that enforce chess, checkers, connect four, and US tax math, built from the patterns this wing teaches."
 ---
 
@@ -22,10 +22,12 @@ Every artifact below enforces its logic entirely in security rules. No server, n
 ## Chess
 
 Rules cannot iterate, and check detection means examining every opponent piece. The answer is to stop scanning and start tracking. All thirty-two piece locations live as document fields, so check becomes sixteen targeted lookups against a config document:
+
 ```
 // Is the king's square in this piece's attack table?
 kingSquare in cfg.moves[board[piecePos]][piecePos]
 ```
+
 Checkmate is not computed at all. The rules deny any move that leaves your own king in check, so checkmate is emergent: the state from which no legal write exists. Seventeen scenarios pass against a deployed ruleset, including a false checkmate claim, denied.
 
 Stated plainly: castling, en passant, and promotion are written into the rules but were not among the seventeen deployed tests.
@@ -33,9 +35,11 @@ Stated plainly: castling, en passant, and promotion are written into the rules b
 ## Checkers
 
 Where the lookup-document pattern was born. The first build hardcoded geometry into 30 KB of rules across 611 lines. The rebuild stores the same geometry as data and reads it back with one expression:
+
 ```
 cfg.moves[piece][from][to] == true
 ```
+
 That took the ruleset to 7 KB and 86 lines, a 77 percent reduction, with a React UI playing against it over live snapshots.
 
 ## Connect Four

--- a/packages/site-docs/src/content/docs/which-data-service.md
+++ b/packages/site-docs/src/content/docs/which-data-service.md
@@ -1,31 +1,19 @@
 ---
-title: "Which data service should I use?"
+title: "Choose a Firebase database"
 navLabel: "Which data service?"
-group: "Build"
+group: "Develop with Firebase APIs"
 section: ""
-order: 2005
-description: "Pick between Firestore and Realtime Database in one short read."
+order: 2008
+description: "Make the Firestore or Realtime Database decision from Firebase's production model, then check the corresponding Pyric boundary."
 ---
 
-# Which data service should I use?
+# Choose a Firebase database
 
-The short answer: Firestore, unless your data is a small shared tree that many clients watch at once.
+Choosing between Cloud Firestore and Realtime Database is a Firebase architecture decision, not a Pyric decision. Compare their production data models, query capabilities, scaling behavior, availability, locations, and pricing in the official [Firebase database comparison](https://firebase.google.com/docs/database/rtdb-vs-firestore).
 
-| | Firestore | Realtime Database |
-|---|---|---|
-| Model | documents and subcollections | one JSON tree |
-| Queries | combined filters, ordering, aggregations, cursors | path reads, one `orderBy` |
-| Built for | structured app data, almost every CRUD app | presence, live cursors, game state, counters |
-| Maturity in Pyric | v1, tested against recorded production behavior | [experimental](../whats-experimental/) |
+After choosing the production service, use the matching local path:
 
-**Choose Firestore for query power and structured documents.** Documents and subcollections grow with your app's shape, and access rules attach naturally to paths and document data. Most apps land here.
+- [Run Cloud Firestore locally](../store-and-query-data/), then inspect the [Firestore conformance matrix](../pyric-firestore-compat/).
+- [Run Realtime Database locally](../sync-realtime-data/), then inspect the [Realtime Database conformance matrix](../pyric-database-compat/).
 
-**Choose Realtime Database for low-latency tree sync.** The model is deliberately simpler, and that simplicity is the feature. It stops being a fit the moment you want multi-field queries, so [model the tree around your reads](../sync-realtime-data/) before committing.
-
-Maturity belongs in the decision too. If either service would fit, pick Firestore.
-
-They also combine. A common shape is Firestore for the documents your app is made of and RTDB for the ephemeral layer on top, presence and typing indicators, where a two-field tree beats a document write per keystroke.
-
-## Where to go next
-
-[Store and query data](../store-and-query-data/) for the Firestore path, or [sync realtime data](../sync-realtime-data/) for the tree.
+The conformance matrices describe Pyric's current local boundary. They should not replace Firebase's production architecture guidance.

--- a/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
+++ b/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
@@ -1,9 +1,9 @@
 ---
 title: "Rules you trust because they are tested"
 navLabel: "Write a rules test suite"
-group: "Secure & debug"
+group: "Verify the boundary"
 section: ""
-order: 3003
+order: 4002
 description: "A suite of allow/deny cases that runs in-process, gates CI, and can escalate to Google's own engine."
 ---
 
@@ -16,6 +16,7 @@ In Pyric a rules test is a small fixture, a `TestCase`, and a whole suite runs i
 ## The fixtures
 
 A `TestCase` describes one hypothetical request and the verdict you expect:
+
 ```ts
 import {
   SimulateFirestoreRulesHandler,
@@ -55,9 +56,11 @@ const testCases: TestCase[] = [
   },
 ];
 ```
+
 The fields map straight onto what the rule sees. `resource` is the existing document, `data` is the proposed write, `auth.uid` becomes `request.auth.uid`, and `auth.token` becomes `request.auth.token` for rules that check custom claims.
 
 ## Run the suite
+
 ```ts
 const sim = new SimulateFirestoreRulesHandler();
 const result = sim.simulate(source, testCases);
@@ -65,6 +68,7 @@ const result = sim.simulate(source, testCases);
 const { passed, failed, unsupported, results } = result.data;
 console.log(`${passed} passed · ${failed} failed · ${unsupported} unsupported`);
 ```
+
 A failed case means the simulator's verdict disagreed with your `expectation`, and its `debugMessages` trace shows which rule decided. An `UNSUPPORTED` case means the simulator hit a feature it does not implement and abstained. It is not counted as a failure, and it is never a guess.
 
 Two fixture fields worth knowing before your suite grows:
@@ -75,6 +79,7 @@ Two fixture fields worth knowing before your suite grows:
 ## Gate CI on it
 
 The suite is a script, so CI is one exit code away:
+
 ```ts
 if (!result.success || result.data.failed > 0) {
   for (const r of result.data.results) {
@@ -83,11 +88,13 @@ if (!result.success || result.data.failed > 0) {
   process.exit(1);
 }
 ```
+
 Sub-millisecond per case once the rules are parsed. There is no reason not to run this on every push.
 
 ## When you want Google's own answer
 
 The hosted Rules Test API evaluates your cases on Google's servers, in the same engine production uses, without deploying anything. It takes the same `TestCase` objects and returns the same result shape. It needs a real project and credentials:
+
 ```ts
 import { TestFirestoreRulesHandler } from 'pyric/rules';
 import { fromServiceAccount } from '@pyric/cli/credentials/node';
@@ -96,7 +103,9 @@ const scope = await fromServiceAccount('./service-account.json');
 const remote = await new TestFirestoreRulesHandler()
   .execute(scope, source, testCases);
 ```
+
 The practical pattern is local-first: run everything through the simulator, then send only the `UNSUPPORTED` cases to the hosted engine.
+
 ```ts
 const escalate = testCases.filter(
   (_, i) => result.data.results[i].state === 'UNSUPPORTED',
@@ -106,6 +115,7 @@ if (escalate.length > 0) {
     .execute(scope, source, escalate);
 }
 ```
+
 Each hosted call is one HTTP round-trip, tens to hundreds of milliseconds. The simulator itself is held to that engine's answers by a parity corpus that runs in CI, so for most suites the local verdicts are the same verdicts, sooner.
 
 ## And from an agent

--- a/packages/site-docs/src/lib/docs.ts
+++ b/packages/site-docs/src/lib/docs.ts
@@ -116,13 +116,11 @@ export async function navGroups(): Promise<NavGroup[]> {
  */
 export const GUIDE_GROUP_LABELS: ReadonlySet<string> = new Set([
   'Overview',
-  'Get started',
-  'Build',
-  'Secure & debug',
-  'Observe & shape',
-  'Ship & test',
-  'Work with an agent',
-  'Trust',
+  'Run locally',
+  'Develop with Firebase APIs',
+  'Inspect and correct',
+  'Verify the boundary',
+  'Ship unchanged',
   'Conformance',
 ]);
 


### PR DESCRIPTION
Reorganizes the docs around the local-to-production workflow, so the primary path teaches what to do with Pyric before exposing package and product inventory.

```text
Run locally
→ Develop with Firebase APIs
↔ Inspect and correct
→ Verify the boundary
→ Ship unchanged

Conformance remains a separate evidence path.
```

## Firebase products appear when application code reaches them

Auth, Firestore, Realtime Database, Storage, Messaging, AI Logic, and Functions now sit under development instead of becoming top-level documentation taxonomies. Product pages explain the local behavior that differs in Pyric, then link to Firebase for ordinary API instruction.

The existing Functions and captured-session verification guides move into the workflow without changing their routes or duplicating their package-owned sources. Generated TypeDoc and deeper package documentation remain searchable beneath Reference.

## Inspection and correction form one development loop

Studio traffic, denial inspection, state correction, Security Rules, and agent review now share one phase. Application verification remains distinct from Pyric conformance. The former checks whether an application can cross the production boundary safely. The latter explains and exposes the evidence that Pyric matches Firebase.

## The porter preserves Markdown source boundaries

The porter now restores line breaks between fenced and prose segments. This corrects malformed generated Markdown and accounts for most of the generated-file churn in this PR. A post-build assertion prevents fused fences from returning.

## Risk

The primary risk is navigation or generated-content drift across 198 pages. Existing routes remain unchanged. The verifier pins workflow order, promoted routes, product discoverability, package coverage, generated twins, links, fragments, and search-index inputs.

This PR depends on #321 and targets its branch. It completes #312, contributes to #307, and recovers the workflow structure sought in #219 without transplanting that PR's stale content or data model.

<details>
<summary>Implementation notes and verification</summary>

- Classified every authored guide and recorded its final disposition in the workflow inventory.
- Rewrote the Vite-first quickstart and product guide boundaries from current source.
- Added focused local-behavior pages for Messaging and AI Logic.
- Promoted the existing RTDB Functions and captured-session verification pages in place.
- Changed no `packages/conformance` source, registry status, baseline, denominator, or published value.
- `bun run --cwd packages/site-docs build`
- `DOCS_BASE=/__pyric/ui/ bun run --cwd packages/site-docs verify`
- `bun run build`
- `bun run test`
- `bun run compat:check`
- `git diff --check`

</details>

Closes #312
