### PR TITLE
docs: align headings with the local-to-production workflow

### DIFF
--- a/docs/site-rewrite/INVENTORY.md
+++ b/docs/site-rewrite/INVENTORY.md
@@ -28,7 +28,7 @@ This inventory records the disposition of every authored guide page for issue #3
 | `content/secure/rules-patterns.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
 | `content/secure/rules-standard-library.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
 | `content/secure/rtdb-rules-in-typescript.md` | Pyric-specific rules guidance | Inspect and correct, Correct Security Rules |
-| `content/secure/limits-that-bite.md` | Production-measured rules guidance | Inspect and correct, Correct Security Rules; route retained pending the final heading pass |
+| `content/secure/firestore-rules-limits.md` | Production-measured rules guidance | Inspect and correct, Correct Security Rules; replaces the rejected playful route |
 | `content/secure/whats-possible.md` | Rules case studies | Inspect and correct, Correct Security Rules |
 | `content/agent/what-your-agent-can-do.md` | Pyric-specific workflow help | Inspect and correct, Work with an agent |
 | `content/agent/skills.md` | Pyric-specific workflow help | Inspect and correct, Work with an agent |

--- a/docs/site-rewrite/content/agent/set-up-your-agent.md
+++ b/docs/site-rewrite/content/agent/set-up-your-agent.md
@@ -1,11 +1,11 @@
 ---
-title: Point your agent at the sandbox
-navLabel: Set up your agent
+title: Connect an agent to the sandbox
+navLabel: Connect an agent
 outcome: Connect Claude Code, Cursor, Codex, or any MCP client to your backend in minutes.
 status: draft
 ---
 
-# Point your agent at the sandbox
+# Connect an agent to the sandbox
 
 One connection and your agent has the whole backend as tools. It can read and write documents as any user, run queries, lint and simulate rules, seed data, and inspect everything, against the same sandbox your app and Studio see. Nothing it does leaves your machine.
 
@@ -77,7 +77,7 @@ The generic recipe is two options, and every client above is one of them applied
 
 Whatever your client's config file looks like, one of those two lines is the whole setup. Then ask it to inspect the sandbox and read what comes back.
 
-## If your app uses the Vite plugin
+## Connect through the Vite plugin
 
 One option in `vite.config.ts` makes your own `vite dev` the bridge:
 

--- a/docs/site-rewrite/content/agent/skills.md
+++ b/docs/site-rewrite/content/agent/skills.md
@@ -1,11 +1,11 @@
 ---
-title: Teach your agent the hard Firebase things
-navLabel: Skills
+title: Give an agent methods for Firebase tasks
+navLabel: Agent skills
 outcome: Packaged expert procedures for the problems that need a method, not more tools.
 status: draft
 ---
 
-# Teach your agent the hard Firebase things
+# Give an agent methods for Firebase tasks
 
 Tools give an agent hands. Skills give it a method. A skill is a written procedure the agent follows step by step, with a completion check on every step and the specific Pyric moves each step uses named in place.
 
@@ -13,7 +13,7 @@ An auth-model skill does not say "think about identity." It says map every ident
 
 Six skills ship today, one per hard problem.
 
-## Install them
+## Install the skills
 
 The skills live in the Pyric repository under `.agents/skills/`, one folder per skill.
 
@@ -21,7 +21,7 @@ The skills live in the Pyric repository under `.agents/skills/`, one folder per 
 - For Claude Code, copy the folders you want into your project's `.claude/skills/` directory.
 - The Claude Code plugin ships its own operational pieces (`pyric-start` boots and wires the sandbox), so the domain skills below slot into a session that is already connected.
 
-## What each skill does
+## Choose a skill for the task
 
 **firebase-auth-model.** Design or audit an identity model that actually connects to your rules. It maps every identity your app has, chooses provider flows, decides where profile data lives and which document IDs use `uid`, and draws the line between custom claims and document roles so they never contradict, ending with test users you can seed. Serves [sign in and manage users](../build/sign-in-and-manage-users.md).
 

--- a/docs/site-rewrite/content/agent/watch-and-review.md
+++ b/docs/site-rewrite/content/agent/watch-and-review.md
@@ -21,7 +21,7 @@ Studio opens at `/__pyric/ui/` against the same sandbox your app tab and MCP cli
 
 Ask your connected agent for a feature and watch documents appear in the Firestore tab as it writes them, because there is one backend and everyone is looking at it. When the agent claims it seeded ten users, the Auth tab either shows ten users or it does not.
 
-## Review it through the event stream
+## Review activity through the event stream
 
 Every operation the backend performs is a typed event, and agent operations land in the same stream as your app's. Each event carries:
 
@@ -31,7 +31,7 @@ Every operation the backend performs is a typed event, and agent operations land
 
 Reviewing an agent session is reading the stream, not reconstructing it. That turns "the agent says it worked" into something you can check line by line. The Traffic tab shows the stream live, and [see what's happening](../observe/see-whats-happening.md) covers reading it yourself, including from code.
 
-## What the agent can and cannot touch
+## Understand the access boundary
 
 The trust posture is short:
 

--- a/docs/site-rewrite/content/agent/what-your-agent-can-do.md
+++ b/docs/site-rewrite/content/agent/what-your-agent-can-do.md
@@ -1,11 +1,11 @@
 ---
-title: Hand your agent the whole backend
-navLabel: What your agent can do
+title: Work with the sandbox through an agent
+navLabel: Work through an agent
 outcome: Every backend capability, callable as a tool: inspect, query, simulate, shape, ship, verify.
 status: draft
 ---
 
-# Hand your agent the whole backend
+# Work with the sandbox through an agent
 
 Once connected, your agent works on the backend the way you do, except every capability is a tool call it can make and check. This page walks the surface by what the agent can accomplish, not by tool name. The names appear where they matter.
 
@@ -18,7 +18,7 @@ Once connected, your agent works on the backend the way you do, except every cap
 | Operate the real project | the deploy and auth-config tools, with credentials you provide |
 | Check its own work | session replay against candidate rules |
 
-## Read, write, and query like the app does
+## Read, write, and query with application identity
 
 The data plane is the app's own surface, and the agent uses it as a specific identity, so a read that should be denied is denied for the agent too.
 
@@ -26,7 +26,7 @@ The data plane is the app's own surface, and the agent uses it as a specific ide
 - **Realtime Database**: get, set, update, and push.
 - **RTDB inspection**: crawls the active sandbox snapshot and reports its local structure without production access.
 
-## See what exists before guessing
+## Inspect state before changing it
 
 The single most-used move is one call. `sandbox_inspect` returns:
 
@@ -38,7 +38,7 @@ The tool's own source records why it exists. In a recorded debug session, diagno
 
 Discovery works on real projects too. Firestore has no schema, so Pyric infers one: the agent can crawl a live database by sampling, cost-bounded and cost-reported, and come back with the shape of what is actually there. The same goes for a Realtime Database tree.
 
-## Prove a rule before writing it
+## Simulate a rule before writing it
 
 The agent can ask whether a specific request, by a specific identity, would be allowed under a ruleset, and get the verdict with the rule and data that decided it. No deploy, no waiting.
 
@@ -51,13 +51,13 @@ For longer work it can open a stateful simulator session:
 
 A scratchpad for rules and data with a real undo stack, which means the agent can try something wrong and back out cleanly.
 
-## Shape the state it tests against
+## Shape the state under test
 
 Backend state is a tool input. The agent can seed a scenario, reset to clean, and snapshot what it built so the state survives as a fixture. Between test runs, between hypotheses, between conversations.
 
 The same seed, reset, and snapshot moves you make yourself, callable.
 
-## Operate the real project
+## Understand the credential boundary
 
 Given credentials you choose to hand it, the agent can run the control plane over REST, with no extra CLI:
 
@@ -67,13 +67,13 @@ Given credentials you choose to hand it, the agent can run the control plane ove
 
 This is the same path you walk in [set up the project](../ship/set-up-the-project.md) and [ship to production](../ship/ship-to-production.md). Without those credentials, none of it is reachable.
 
-## Check its own work
+## Check the result
 
 Verification is a tool, not a ritual. The agent can replay a captured session of real operations against a candidate ruleset and learn which operations change verdict, before anything deploys.
 
 It writes a rule, replays, reads the diff, and fixes what flipped. That loop is the difference between an agent that asserts its rules work and one that has evidence.
 
-## The honest shape of the surface
+## Understand the supported boundary
 
 The surface is wide because Firebase's is: data, rules, identity, deployment, and two database models.
 

--- a/docs/site-rewrite/content/get-started/how-the-swap-works.md
+++ b/docs/site-rewrite/content/get-started/how-the-swap-works.md
@@ -1,15 +1,15 @@
 ---
-title: How the swap works
+title: How firebase/* imports resolve locally and in production
 navLabel: How the swap works
 outcome: Understand how your firebase imports reached a local backend, and why production is untouched.
 status: draft
 ---
 
-# How the swap works
+# How firebase/* imports resolve locally and in production
 
 In activated development, your app's `firebase/*` imports resolve to a local backend with rules enforced, and no request leaves your machine. With that activation absent in production, the runtime resolves those imports to Firebase directly. Here is the whole mechanism, in three parts.
 
-## Your imports resolve differently in dev
+## Resolve imports to Pyric during development
 
 Your source says `import { getFirestore } from 'firebase/firestore'`. In development, that specifier resolves to Pyric instead of the Firebase SDK. The swap happens in one of two layers:
 

--- a/docs/site-rewrite/content/observe/see-whats-happening.md
+++ b/docs/site-rewrite/content/observe/see-whats-happening.md
@@ -17,7 +17,7 @@ pyric dev --ui
 
 Studio mounts at `/__pyric/ui/` on your dev server. The Traffic tab shows the stream live: each request, who made it, the allow or deny verdict, and how long the rules evaluation took. Sign in, write a document, break a rule on purpose. Each one appears as it happens, in the same backend your open tabs are using.
 
-## Read the stream yourself
+## Subscribe to the event stream
 
 One subscription covers everything observable:
 
@@ -58,7 +58,7 @@ The subscription survives `sandbox.reset()`. A `session_boundary` event fires be
 
 A `deny` event is not a bare `permission-denied` string. It carries the method and path, the identity the rules saw, the reasons, and the request data that was evaluated. That is enough to answer "which rule said no, and what did it see" without adding a single log line. [Read a denial and understand it](../secure/read-a-denial.md) walks through one.
 
-## Build your own monitor
+## Build a traffic monitor
 
 Studio's Traffic view is a consumer of `onEvent`, and you can build your own in about seventy lines. Subscribe, format each kind, and you get a terminal log like this:
 
@@ -74,7 +74,7 @@ Two things to know before you ship one:
 - Listener re-evaluations dominate the raw stream. Default your view to user-origin requests, deliveries, lifecycle, and denials, and put `origin: 'listener'` traffic behind a toggle.
 - Your callback runs synchronously with the operation that produced it, so push heavy work off the hot path with `queueMicrotask` or a worker.
 
-## And from an agent
+## Inspect the backend through an agent
 
 An agent doesn't scroll a panel. It calls `sandbox_inspect` and gets the current rules, a lint summary, a document census, and the recent requests and denials in one response. That one call replaced a debugging session that once took fifty-one tool calls. See [Set up your agent](../agent/set-up-your-agent.md).
 

--- a/docs/site-rewrite/content/observe/shape-your-data.md
+++ b/docs/site-rewrite/content/observe/shape-your-data.md
@@ -1,11 +1,11 @@
 ---
-title: Seed, snapshot, reset, and replay the backend like source
+title: Seed, snapshot, reset, and replay the backend
 navLabel: Seed, snapshot, replay
 outcome: Put the backend in any state you want, capture the good ones, and get them back on demand.
 status: draft
 ---
 
-# Seed, snapshot, reset, and replay the backend like source
+# Seed, snapshot, reset, and replay the backend
 
 Your backend is local state. That changes what you can do with it. You can seed a scenario, snapshot the moment it looks right, commit that file, wipe everything between tests, and replay a whole session later to see if it still holds. The same moves you make on source code, on your data.
 
@@ -85,7 +85,7 @@ That recording is a rules regression suite you didn't write. It knows a re-resol
 
 The place this pays off is the deploy gate, where the same replay runs against the rules you're about to ship. See [Ship to production](../ship/ship-to-production.md). You can also replay in code with `sandbox.history()` and `replay(events, rules)` when you want the divergence list programmatically.
 
-## And from an agent
+## Seed and reset through an agent
 
 Seed, reset, and snapshot are tools on the same MCP surface your editor connects to, so an agent can stand up a scenario, run its checks, and reset to a clean slate without your help. For scratch work it can open a stateful simulator session with its own undo stack, and `sandbox_inspect` tells it what state it's actually in. See [Set up your agent](../agent/set-up-your-agent.md).
 

--- a/docs/site-rewrite/content/overview.md
+++ b/docs/site-rewrite/content/overview.md
@@ -1,11 +1,11 @@
 ---
-title: Firebase that runs in your browser
+title: Run Firebase locally, ship unchanged
 navLabel: Overview
 outcome: Understand what Pyric is and what you get, in one short read.
 status: draft
 ---
 
-# Firebase that runs in your browser
+# Run Firebase locally, ship unchanged
 
 Pyric runs supported Firebase application code against a local backend during development. The application keeps its ordinary `firebase/*` imports and Firebase configuration. A normal production build resolves those imports to Firebase again. The source does not branch between local development and production.
 
@@ -31,11 +31,11 @@ Development moves back and forth between writing Firebase code and inspecting wh
 
 Conformance sits underneath the workflow as separate evidence. It records which Pyric behaviors have been compared with production Firebase, which differ, and which remain unsupported or unverified.
 
-## Your agent works the same backend
+## Give coding agents the same local backend
 
 The backend is local state with a tool surface, so a coding agent can work on it the way you do. Point Claude Code, Cursor, or any MCP client at the sandbox and the agent can seed data, run queries, simulate a rules verdict before writing, and check its own work. Nothing it does leaves your machine. Everything it does is inspectable, live, in the same event stream you watch.
 
-## It focuses on the hard parts
+## Inspect the difficult parts locally
 
 Firebase development has hard parts, and they are not the parts the manuals dwell on. Rules that pass locally and fail in production. A denial with no explanation. Query shapes that quietly demand indexes. Limits that are real but written down nowhere.
 

--- a/docs/site-rewrite/content/secure/audit-your-rules.md
+++ b/docs/site-rewrite/content/secure/audit-your-rules.md
@@ -1,17 +1,17 @@
 ---
-title: Find the holes before someone else does
-navLabel: Audit your rules and data
+title: Audit Security Rules and data before production
+navLabel: Audit rules and data
 outcome: Get an evidence-backed answer to who can access what, with every serious finding proven by a simulation.
 status: draft
 ---
 
-# Find the holes before someone else does
+# Audit Security Rules and data before production
 
 Your rules are a security boundary on the public internet, and anyone who cares to probe them can. An audit answers three questions with evidence: who can do what, whether the expressions mean what they appear to mean, and where the rules, the data, and the auth configuration disagree.
 
 Pyric packages each audit as a skill, a procedure you or your agent runs against the real project. A finding does not make the report on a reading alone. It has to cite a simulation, a test, or a lint result that demonstrates it.
 
-## Audit your Firestore rules
+## Audit Firestore Security Rules
 
 The `firestore-rules-audit` skill starts by building an access matrix: for every match block, identity by operation (get, list, create, update, delete), with no blank cells. Public writes, public reads on sensitive paths, and writes with no auth check fall out of the matrix immediately.
 
@@ -25,7 +25,7 @@ Then composition. Any matching allow grants access, so a recursive wildcard like
 
 Critical findings are proven with `firestore_simulate_rules` runs that vary the auth context, and the report arrives severity-ranked with a fix per finding.
 
-## Audit your Realtime Database rules
+## Audit Realtime Database Security Rules
 
 RTDB fails differently: access cascades downward. (Authoring those rules from typed constraints is its own page: [RTDB rules in TypeScript](../secure/rtdb-rules-in-typescript.md).) A `.read: true` near the root silently exposes every descendant, and a restrictive child cannot revoke what a permissive parent granted. The `rtdb-security-rules` skill walks every cascade from the root, so the effective access at each path is stated rather than assumed.
 
@@ -47,7 +47,7 @@ Rules can be individually correct and collectively wrong. The `firebase-audit` s
 
 The report is severity-ranked, critical findings first, each citing the simulation or lint result that proves it. The audit stays read-only. Remediation is proposed in the report and applied only when you ask.
 
-## And from an agent
+## Run the audits through an agent
 
 All three audits are agent skills. Install them once and "audit my rules" becomes a request your agent executes end to end, running the same simulations and returning the same evidence-backed report. Install and catalog: [skills](../agent/skills.md).
 

--- a/docs/site-rewrite/content/secure/firestore-rules-limits.md
+++ b/docs/site-rewrite/content/secure/firestore-rules-limits.md
@@ -1,11 +1,11 @@
 ---
-title: Firestore rules limits, measured
+title: Firestore Rules compiler and evaluator limits
 navLabel: Rules limits
-outcome: Know the measured limits of the production rules compiler and evaluator, with exact numbers, so your rules compile the first time.
+outcome: Use measured production compiler and evaluator limits before a ruleset reaches Firebase.
 status: draft
 ---
 
-# Firestore rules limits, measured
+# Firestore Rules compiler and evaluator limits
 
 A ruleset can be syntactically perfect and still fail two ways: a 400 at deploy with no useful message, or a silent 403 at runtime that looks exactly like a denial you wrote. Both come from real limits in the production compiler and evaluator. The numbers below are researched and observed behavior: Pyric's tooling probed production Firestore directly, isolating one variable at a time, and recorded what it measured. They ship inside Pyric's linter as thresholds, so you do not have to remember them. It helps to know they exist.
 
@@ -25,7 +25,7 @@ Eleven `let` bindings in a function compile. Twelve fail, with the same unexplai
 
 This limit is in Firebase's own documentation. What matters in practice is the caching: results are cached per unique path, so a shared `config()` helper called from six functions costs one read, while six different paths cost six. The linter warns past 5 distinct calls and errors at the documented 10.
 
-## The runtime budget, and its flaky zone
+## The runtime evaluation budget
 
 The compile-time limits fail loudly at deploy. This one does not. A rule whose evaluation is too expensive returns 403 PERMISSION_DENIED at runtime, indistinguishable from a denial you intended.
 
@@ -49,7 +49,7 @@ The config-document pattern has a ceiling on the data side. A 129 KB config docu
 
 The runtime expression budget is shared across all the allow rules of a match block, evaluated in order. Non-matching rules spend from the same account as the rule that will eventually match, and the evidence was unambiguous: with sixteen checkers rules, reordering them changed which category of move failed. The structural fix, a unique first expression per rule, is covered in [rules patterns](../secure/rules-patterns.md). The linter flags the hazard as SHARED_GATE.
 
-## The linter remembers so you don't
+## Use the measured limits in the linter
 
 `pyric firestore rules lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, without a deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`.
 

--- a/docs/site-rewrite/content/secure/read-a-denial.md
+++ b/docs/site-rewrite/content/secure/read-a-denial.md
@@ -1,11 +1,11 @@
 ---
-title: Never debug a bare permission-denied again
+title: Read a Security Rules denial
 navLabel: Read a denial and understand it
 outcome: See which rule denied an operation, on what path, with what data, the moment it happens.
 status: draft
 ---
 
-# Never debug a bare permission-denied again
+# Read a Security Rules denial
 
 In production, a blocked operation answers with one string: `permission-denied`. Not which rule. Not what the rule saw.
 
@@ -59,7 +59,7 @@ The linter normalizes every match path and diffs the predicates conjunct by conj
 
 One boundary stated plainly: the diff compares the predicates in `allow` statements, so weakening a helper function's body does not fire it. Your [test suite](../secure/write-a-rules-test-suite.md) is the net for that shape.
 
-## And from an agent
+## Diagnose a denial through an agent
 
 When an agent hits a denial, one `sandbox_inspect` call returns the current rules, a lint summary, and the recent denials from the event log together, so "why is my rule failing" is one tool call instead of an archaeology session. See [skills](../agent/skills.md).
 

--- a/docs/site-rewrite/content/secure/rules-patterns.md
+++ b/docs/site-rewrite/content/secure/rules-patterns.md
@@ -1,11 +1,11 @@
 ---
-title: The techniques hard rules are built from
+title: Apply production-tested Firestore Rules patterns
 navLabel: Rules patterns
 outcome: Learn the five moves that turn "rules can't do that" into a ruleset that deploys.
 status: draft
 ---
 
-# The techniques hard rules are built from
+# Apply production-tested Firestore Rules patterns
 
 The rules language cannot loop. It cannot build a map key out of strings. And it evaluates under budgets that are real but invisible. Every hard ruleset that exists anyway, chess included, is built from a small set of moves that work with those constraints instead of against them. Here they are, generalized from the game rules where they were proven against production.
 
@@ -101,10 +101,10 @@ There are three places the computation can go:
 
 The US tax example takes this the whole way. The client computes its own tax return, and the rules verify every intermediate figure against the bracket config. A return that lies about its math is a permission denial.
 
-## And from an agent
+## Load the patterns through an agent
 
 The patterns with stable shapes ship as standard library modules an agent imports instead of re-deriving: `geometry` for the config-document lookup, `counters` for the honest arithmetic, `timing` for cooldowns. `firestore_rules_stdlib_get` serves each with its gotchas attached, and `firestore_lint_rules` catches a shared gate before it costs a debugging session. See [skills](../agent/skills.md).
 
 ## Where to go next
 
-These techniques run up against real budgets, and the exact numbers are in [the measured limits](../secure/limits-that-bite.md). To see how far the techniques reach, read the [case studies](../secure/whats-possible.md).
+These techniques run up against real budgets, and the exact numbers are in [the measured limits](../secure/firestore-rules-limits.md). To see how far the techniques reach, read the [case studies](../secure/whats-possible.md).

--- a/docs/site-rewrite/content/secure/rules-standard-library.md
+++ b/docs/site-rewrite/content/secure/rules-standard-library.md
@@ -1,11 +1,11 @@
 ---
-title: Build your rules from tested parts
+title: Build Firestore Rules from tested modules
 navLabel: The rules standard library
 outcome: Compose security rules from tested modules, with an import system that compiles away before Firebase ever sees it.
 status: draft
 ---
 
-# Build your rules from tested parts
+# Build Firestore Rules from tested modules
 
 This is a Firestore rules file:
 
@@ -90,7 +90,7 @@ Every module ships with test fixtures that execute against the rules engine in C
 
 This page is a guide, not the catalog. The full module list, every signature with its gotchas, lives in the [module manifest](../../../../packages/pyric/src/rules/modules/stdlib/STDLIB.md) until the reference section lands.
 
-## And from an agent
+## Load standard modules through an agent
 
 An agent does not memorize any of this. `firestore_rules_stdlib_get({ key: 'timing' })` returns a module's signatures, examples, and gotchas, and the resolver runs in-process, so the agent composes a ruleset from modules, lints it, and simulates verdicts before anything deploys. See [skills](../agent/skills.md).
 

--- a/docs/site-rewrite/content/secure/secure-it-with-rules.md
+++ b/docs/site-rewrite/content/secure/secure-it-with-rules.md
@@ -1,11 +1,11 @@
 ---
-title: Prove a user can touch only their own data
+title: Prove a user can access only their own data
 navLabel: Security Rules
 outcome: Write a rule, simulate a request against it, read the verdict, and deploy knowing what it allows.
 status: draft
 ---
 
-# Prove a user can touch only their own data
+# Prove a user can access only their own data
 
 Before you deploy a ruleset, you can ask Pyric a direct question: would this specific request, from this specific user, be allowed? You get an answer, and the answer names the rule that decided it.
 
@@ -85,7 +85,7 @@ firebase deploy --only firestore:rules
 
 Gate on error-severity lint findings in CI first (`lintFirestoreRules` / `pyric firestore rules lint`), so the mistakes that produce opaque production failures get stopped at the door.
 
-## Where the wing goes deeper
+## Continue into deeper Rules guidance
 
 That loop is the core. The wing deepens each step.
 
@@ -94,11 +94,11 @@ That loop is the core. The wing deepens each step.
 - [Read a denial and understand it](../secure/read-a-denial.md). Every denial carries the rule, path, and data that produced it.
 - [The rules standard library](../secure/rules-standard-library.md). Tested rule modules, composed with an import the rules language does not have.
 - [Rules patterns](../secure/rules-patterns.md). The techniques the hard rules are built from.
-- [Rules limits, measured](../secure/limits-that-bite.md). The production compiler's real limits, with numbers.
+- [Firestore Rules limits](../secure/firestore-rules-limits.md). The production compiler's real limits, with numbers.
 - [Audit your rules and data](../secure/audit-your-rules.md). Find the holes before someone else does.
 - [Case studies](../secure/whats-possible.md). Deployed rulesets that enforce chess, connect four, and tax math.
 
-## And from an agent
+## Verify a denial through an agent
 
 An agent working in your sandbox can call `firestore_simulate_rules` to check a request's verdict before it writes, so it verifies its own rules instead of guessing. The audit skills go further: point one at your ruleset and it hunts for holes methodically. See [skills](../agent/skills.md).
 

--- a/docs/site-rewrite/content/secure/simulate-and-lint.md
+++ b/docs/site-rewrite/content/secure/simulate-and-lint.md
@@ -1,11 +1,11 @@
 ---
-title: Catch the error before Firebase's opaque 400
+title: Simulate and lint Security Rules before deployment
 navLabel: Simulate and lint before you deploy
 outcome: Get a rules verdict and a lint report locally, before production answers with an unexplained 400 or 403.
 status: draft
 ---
 
-# Catch the error before Firebase's opaque 400
+# Simulate and lint Security Rules before deployment
 
 A broken ruleset fails late: a `400` at deploy time, or a `403` at runtime. Pyric moves both failures to your machine, before the deploy.
 
@@ -40,7 +40,7 @@ Simulated: DENY
 
 The same simulator is on the command line as `pyric firestore rules simulate`, and it is what evaluates every operation inside your running sandbox.
 
-## Lint before the compiler can reject you
+## Lint before Firebase rejects the rules
 
 ```bash
 pyric firestore rules lint firestore.rules
@@ -56,7 +56,7 @@ const { warnings, metrics } = lintFirestoreRules(source);
 
 The linter checks two different kinds of failure.
 
-**The production limits.** The rules compiler enforces hard caps: a 256 KB source ceiling, a boolean chain depth of 98, 11 `let` bindings per function, `get()` call counts, and a runtime evaluation budget that fails as a silent `permission-denied` under load. The linter carries each cap as an exact threshold, measured by probing the production engine. The numbers live in [the limits that actually bite](../secure/limits-that-bite.md).
+**The production limits.** The rules compiler enforces hard caps: a 256 KB source ceiling, a boolean chain depth of 98, 11 `let` bindings per function, `get()` call counts, and a runtime evaluation budget that fails as a silent `permission-denied` under load. The linter carries each cap as an exact threshold, measured by probing the production engine. The numbers live in [the measured Firestore Rules limits](../secure/firestore-rules-limits.md).
 
 **JS-in-rules mistakes.** The rules language looks like JavaScript, and that resemblance is a trap. Models fall into it constantly, and humans do too.
 
@@ -84,7 +84,7 @@ Each of these emits a warning that names the mistake:
 
 The syntax-level catches (`===`, `?.`, `??`, arrow functions, backtick strings) fire even when the file fails to parse, because the parse error alone would point you at a stray parenthesis instead of the actual cause.
 
-## Let the errors block the ship
+## Block shipping on Rules errors
 
 Warnings carry a severity. Gate CI (and refuse to `firebase deploy`) when any finding has `severity: 'error'`:
 
@@ -96,10 +96,10 @@ if (errors.length > 0) process.exit(1);
 
 A hallucinated method is always an error, because the named method literally does not exist. Blocking on it is never a false alarm.
 
-## And from an agent
+## Correct Rules through an agent
 
 This is the loop that keeps an agent honest. It calls `firestore_lint_rules` on the rules it wrote, reads the fixes in the warnings, and corrects itself before anything deploys. Then `firestore_simulate_rules` confirms the behavior. The mistakes the linter catches are, in large part, the mistakes models make. See [what your agent can do](../agent/skills.md).
 
 ## Where to go next
 
-The exact numbers behind the limit checks are in [the limits that actually bite](../secure/limits-that-bite.md). To make simulation a habit rather than a one-off, [write a rules test suite](../secure/write-a-rules-test-suite.md).
+The exact numbers behind the limit checks are in [the measured Firestore Rules limits](../secure/firestore-rules-limits.md). To make simulation a habit rather than a one-off, [write a rules test suite](../secure/write-a-rules-test-suite.md).

--- a/docs/site-rewrite/content/secure/whats-possible.md
+++ b/docs/site-rewrite/content/secure/whats-possible.md
@@ -7,7 +7,7 @@ status: draft
 
 # Case studies in pure security rules
 
-Every artifact below enforces its logic entirely in security rules. No server, no Cloud Functions. The database is the referee. Each one deployed, each one is built from the same [patterns](../secure/rules-patterns.md) and [standard library](../secure/rules-standard-library.md) this wing teaches, and each one was engineered inside the [measured limits](../secure/limits-that-bite.md).
+Every artifact below enforces its logic entirely in security rules. No server, no Cloud Functions. The database is the referee. Each one deployed, each one is built from the same [patterns](../secure/rules-patterns.md) and [standard library](../secure/rules-standard-library.md) this wing teaches, and each one was engineered inside the [measured limits](../secure/firestore-rules-limits.md).
 
 | Case | Service | The rules enforce | The move that makes it work |
 |---|---|---|---|
@@ -56,4 +56,4 @@ A deployed, playable browser app on Realtime Database rules. Turn enforcement, p
 
 ## Calibration, not a feature list
 
-None of this is a feature you will ship on Monday. It is calibration. If rules can hold chess, they can hold your role model, your state machine, your billing invariants, and the parts are the ones you already have: the [patterns](../secure/rules-patterns.md), the [standard library](../secure/rules-standard-library.md), and the [limits](../secure/limits-that-bite.md) that keep all of it deployable.
+None of this is a feature you will ship on Monday. It is calibration. If rules can hold chess, they can hold your role model, your state machine, your billing invariants, and the parts are the ones you already have: the [patterns](../secure/rules-patterns.md), the [standard library](../secure/rules-standard-library.md), and the [limits](../secure/firestore-rules-limits.md) that keep all of it deployable.

--- a/docs/site-rewrite/content/secure/write-a-rules-test-suite.md
+++ b/docs/site-rewrite/content/secure/write-a-rules-test-suite.md
@@ -1,11 +1,11 @@
 ---
-title: Rules you trust because they are tested
+title: Write a Security Rules test suite
 navLabel: Write a rules test suite
 outcome: A suite of allow/deny cases that runs in-process, gates CI, and can escalate to Google's own engine.
 status: draft
 ---
 
-# Rules you trust because they are tested
+# Write a Security Rules test suite
 
 A ruleset is code that decides who sees what. It deserves tests like any other code that matters.
 
@@ -89,7 +89,7 @@ if (!result.success || result.data.failed > 0) {
 
 Sub-millisecond per case once the rules are parsed. There is no reason not to run this on every push.
 
-## When you want Google's own answer
+## Use Google's Rules Test API when production authority matters
 
 The hosted Rules Test API evaluates your cases on Google's servers, in the same engine production uses, without deploying anything. It takes the same `TestCase` objects and returns the same result shape. It needs a real project and credentials:
 
@@ -116,7 +116,7 @@ if (escalate.length > 0) {
 
 Each hosted call is one HTTP round-trip, tens to hundreds of milliseconds. The simulator itself is held to that engine's answers by a parity corpus that runs in CI, so for most suites the local verdicts are the same verdicts, sooner.
 
-## And from an agent
+## Run the suite through an agent
 
 An agent can run this exact loop through `firestore_simulate_rules` and `firestore_test_rules`, which means the rules it writes arrive with a passing suite instead of a promise. See [skills](../agent/skills.md).
 

--- a/docs/site-rewrite/content/ship/ship-to-production.md
+++ b/docs/site-rewrite/content/ship/ship-to-production.md
@@ -16,7 +16,7 @@ firebase deploy --only hosting
 
 One guard stands between the two worlds. A sandbox build (from `vite build --mode development`) carries a marker in its `index.html`. Production hosting deploys should use an unmarked build (`vite build` / production mode) so a sandbox-wired dist never reaches production by accident. Prefer `firebase-tools` (or the Console) for the deploy itself.
 
-## Deploy your rules
+## Deploy Security Rules
 
 ```bash
 firebase deploy --only firestore:rules
@@ -24,7 +24,7 @@ firebase deploy --only firestore:rules
 
 This pushes the `firestore.rules` named in `firebase.json` to your project. By the time you run it, those rules have already been exercised: every operation your app performed in development was evaluated against them, verdict by verdict. You are not deploying a guess.
 
-## Deploy indexes from your query shapes
+## Deploy indexes from application query shapes
 
 Composite indexes usually live in a hand-kept file that drifts from the queries. Pyric derives them instead: index extraction reads your `query(collection, where, orderBy)` call sites in source and produces the `firestore.indexes.json` those shapes require (`pyric firestore indexes generate src`). Then:
 
@@ -72,7 +72,7 @@ firebase deploy --only functions
 
 Use `firebase-tools` (or the Console) for production shipping. Preview channels give you a shareable URL with an expiry before anything touches the live site.
 
-## Credentials for verify (and CI)
+## Configure credentials for verification and CI
 
 `pyric verify` with the default `sandbox` engine needs no cloud credentials. For `--engine rules-test-api` or `both`:
 

--- a/docs/site-rewrite/content/ship/test-in-node.md
+++ b/docs/site-rewrite/content/ship/test-in-node.md
@@ -1,11 +1,11 @@
 ---
-title: The same backend in tests and scripts
+title: Run the same backend in tests and scripts
 navLabel: Test in Node
 outcome: Run your rules and data logic in a Node test suite, with no browser and no emulator.
 status: draft
 ---
 
-# The same backend in tests and scripts
+# Run the same backend in tests and scripts
 
 The backend that runs in your browser tab runs in a Node process the same way. That means your test suite gets a real Firestore with real rules enforcement, in-process, with nothing to start or tear down. No browser. No emulator. No port.
 

--- a/docs/site-rewrite/content/trust/whats-experimental.md
+++ b/docs/site-rewrite/content/trust/whats-experimental.md
@@ -11,7 +11,7 @@ Auth, Firestore, and Rules are v1: conformance-held against recorded production 
 
 Realtime Database and Storage are experimental. They are built, documented, and usable today, and they are explicitly not v1. This page is the exact meaning of that word.
 
-## What experimental costs you
+## What experimental status costs
 
 The experimental services are verified sandbox-side: unit probes check them against the documented `firebase/database` and `firebase/storage` contracts, and those probes pass. What most of their behavior lacks is a production observation, a recording of what the real service actually did, pinned and replayed in CI. Verified against the documentation is not the same as verified against production, and Pyric does not pretend otherwise.
 

--- a/packages/site-docs/scripts/port-content.ts
+++ b/packages/site-docs/scripts/port-content.ts
@@ -213,7 +213,7 @@ const GUIDE_GROUPS: GuideGroupSpec[] = [
       { dir: 'secure', file: 'rules-patterns.md', section: 'Correct Security Rules' },
       { dir: 'secure', file: 'rules-standard-library.md', section: 'Correct Security Rules' },
       { dir: 'secure', file: 'rtdb-rules-in-typescript.md', section: 'Correct Security Rules' },
-      { dir: 'secure', file: 'limits-that-bite.md', section: 'Correct Security Rules' },
+      { dir: 'secure', file: 'firestore-rules-limits.md', section: 'Correct Security Rules' },
       { dir: 'secure', file: 'whats-possible.md', section: 'Correct Security Rules' },
       { dir: 'agent', file: 'what-your-agent-can-do.md', section: 'Work with an agent' },
       { dir: 'agent', file: 'skills.md', section: 'Work with an agent' },

--- a/packages/site-docs/src/content/docs/audit-your-rules.md
+++ b/packages/site-docs/src/content/docs/audit-your-rules.md
@@ -1,19 +1,19 @@
 ---
-title: "Find the holes before someone else does"
-navLabel: "Audit your rules and data"
+title: "Audit Security Rules and data before production"
+navLabel: "Audit rules and data"
 group: "Verify the boundary"
 section: ""
 order: 4003
 description: "Get an evidence-backed answer to who can access what, with every serious finding proven by a simulation."
 ---
 
-# Find the holes before someone else does
+# Audit Security Rules and data before production
 
 Your rules are a security boundary on the public internet, and anyone who cares to probe them can. An audit answers three questions with evidence: who can do what, whether the expressions mean what they appear to mean, and where the rules, the data, and the auth configuration disagree.
 
 Pyric packages each audit as a skill, a procedure you or your agent runs against the real project. A finding does not make the report on a reading alone. It has to cite a simulation, a test, or a lint result that demonstrates it.
 
-## Audit your Firestore rules
+## Audit Firestore Security Rules
 
 The `firestore-rules-audit` skill starts by building an access matrix: for every match block, identity by operation (get, list, create, update, delete), with no blank cells. Public writes, public reads on sensitive paths, and writes with no auth check fall out of the matrix immediately.
 
@@ -27,7 +27,7 @@ Then composition. Any matching allow grants access, so a recursive wildcard like
 
 Critical findings are proven with `firestore_simulate_rules` runs that vary the auth context, and the report arrives severity-ranked with a fix per finding.
 
-## Audit your Realtime Database rules
+## Audit Realtime Database Security Rules
 
 RTDB fails differently: access cascades downward. (Authoring those rules from typed constraints is its own page: [RTDB rules in TypeScript](../rtdb-rules-in-typescript/).) A `.read: true` near the root silently exposes every descendant, and a restrictive child cannot revoke what a permissive parent granted. The `rtdb-security-rules` skill walks every cascade from the root, so the effective access at each path is stated rather than assumed.
 
@@ -49,7 +49,7 @@ Rules can be individually correct and collectively wrong. The `firebase-audit` s
 
 The report is severity-ranked, critical findings first, each citing the simulation or lint result that proves it. The audit stays read-only. Remediation is proposed in the report and applied only when you ask.
 
-## And from an agent
+## Run the audits through an agent
 
 All three audits are agent skills. Install them once and "audit my rules" becomes a request your agent executes end to end, running the same simulations and returning the same evidence-backed report. Install and catalog: [skills](../skills/).
 

--- a/packages/site-docs/src/content/docs/firestore-rules-limits.md
+++ b/packages/site-docs/src/content/docs/firestore-rules-limits.md
@@ -1,13 +1,13 @@
 ---
-title: "Firestore rules limits, measured"
+title: "Firestore Rules compiler and evaluator limits"
 navLabel: "Rules limits"
 group: "Inspect and correct"
 section: "Correct Security Rules"
 order: 3010
-description: "Know the measured limits of the production rules compiler and evaluator, with exact numbers, so your rules compile the first time."
+description: "Use measured production compiler and evaluator limits before a ruleset reaches Firebase."
 ---
 
-# Firestore rules limits, measured
+# Firestore Rules compiler and evaluator limits
 
 A ruleset can be syntactically perfect and still fail two ways: a 400 at deploy with no useful message, or a silent 403 at runtime that looks exactly like a denial you wrote. Both come from real limits in the production compiler and evaluator. The numbers below are researched and observed behavior: Pyric's tooling probed production Firestore directly, isolating one variable at a time, and recorded what it measured. They ship inside Pyric's linter as thresholds, so you do not have to remember them. It helps to know they exist.
 
@@ -27,7 +27,7 @@ Eleven `let` bindings in a function compile. Twelve fail, with the same unexplai
 
 This limit is in Firebase's own documentation. What matters in practice is the caching: results are cached per unique path, so a shared `config()` helper called from six functions costs one read, while six different paths cost six. The linter warns past 5 distinct calls and errors at the documented 10.
 
-## The runtime budget, and its flaky zone
+## The runtime evaluation budget
 
 The compile-time limits fail loudly at deploy. This one does not. A rule whose evaluation is too expensive returns 403 PERMISSION_DENIED at runtime, indistinguishable from a denial you intended.
 
@@ -51,7 +51,7 @@ The config-document pattern has a ceiling on the data side. A 129 KB config docu
 
 The runtime expression budget is shared across all the allow rules of a match block, evaluated in order. Non-matching rules spend from the same account as the rule that will eventually match, and the evidence was unambiguous: with sixteen checkers rules, reordering them changed which category of move failed. The structural fix, a unique first expression per rule, is covered in [rules patterns](../rules-patterns/). The linter flags the hazard as SHARED_GATE.
 
-## The linter remembers so you don't
+## Use the measured limits in the linter
 
 `pyric firestore rules lint` carries every number above as a threshold and reports the specific function, chain, or rule that crosses it, with a fix. It runs in-process, without a deploy, so the first time production sees your rules they already fit. From an agent, the same check is `firestore_lint_rules`.
 

--- a/packages/site-docs/src/content/docs/how-the-swap-works.md
+++ b/packages/site-docs/src/content/docs/how-the-swap-works.md
@@ -1,16 +1,17 @@
 ---
-title: "How the swap works"
+title: "How firebase/* imports resolve locally and in production"
+navLabel: "How the swap works"
 group: "Run locally"
 section: ""
 order: 1002
 description: "Understand how your firebase imports reached a local backend, and why production is untouched."
 ---
 
-# How the swap works
+# How firebase/* imports resolve locally and in production
 
 In activated development, your app's `firebase/*` imports resolve to a local backend with rules enforced, and no request leaves your machine. With that activation absent in production, the runtime resolves those imports to Firebase directly. Here is the whole mechanism, in three parts.
 
-## Your imports resolve differently in dev
+## Resolve imports to Pyric during development
 
 Your source says `import { getFirestore } from 'firebase/firestore'`. In development, that specifier resolves to Pyric instead of the Firebase SDK. The swap happens in one of two layers:
 

--- a/packages/site-docs/src/content/docs/overview.md
+++ b/packages/site-docs/src/content/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Firebase that runs in your browser"
+title: "Run Firebase locally, ship unchanged"
 navLabel: "Overview"
 group: "Overview"
 section: ""
@@ -7,7 +7,7 @@ order: 1
 description: "Understand what Pyric is and what you get, in one short read."
 ---
 
-# Firebase that runs in your browser
+# Run Firebase locally, ship unchanged
 
 Pyric runs supported Firebase application code against a local backend during development. The application keeps its ordinary `firebase/*` imports and Firebase configuration. A normal production build resolves those imports to Firebase again. The source does not branch between local development and production.
 
@@ -33,11 +33,11 @@ Development moves back and forth between writing Firebase code and inspecting wh
 
 Conformance sits underneath the workflow as separate evidence. It records which Pyric behaviors have been compared with production Firebase, which differ, and which remain unsupported or unverified.
 
-## Your agent works the same backend
+## Give coding agents the same local backend
 
 The backend is local state with a tool surface, so a coding agent can work on it the way you do. Point Claude Code, Cursor, or any MCP client at the sandbox and the agent can seed data, run queries, simulate a rules verdict before writing, and check its own work. Nothing it does leaves your machine. Everything it does is inspectable, live, in the same event stream you watch.
 
-## It focuses on the hard parts
+## Inspect the difficult parts locally
 
 Firebase development has hard parts, and they are not the parts the manuals dwell on. Rules that pass locally and fail in production. A denial with no explanation. Query shapes that quietly demand indexes. Limits that are real but written down nowhere.
 

--- a/packages/site-docs/src/content/docs/read-a-denial.md
+++ b/packages/site-docs/src/content/docs/read-a-denial.md
@@ -1,5 +1,5 @@
 ---
-title: "Never debug a bare permission-denied again"
+title: "Read a Security Rules denial"
 navLabel: "Read a denial and understand it"
 group: "Inspect and correct"
 section: "Inspect the sandbox"
@@ -7,7 +7,7 @@ order: 3002
 description: "See which rule denied an operation, on what path, with what data, the moment it happens."
 ---
 
-# Never debug a bare permission-denied again
+# Read a Security Rules denial
 
 In production, a blocked operation answers with one string: `permission-denied`. Not which rule. Not what the rule saw.
 
@@ -61,7 +61,7 @@ The linter normalizes every match path and diffs the predicates conjunct by conj
 
 One boundary stated plainly: the diff compares the predicates in `allow` statements, so weakening a helper function's body does not fire it. Your [test suite](../write-a-rules-test-suite/) is the net for that shape.
 
-## And from an agent
+## Diagnose a denial through an agent
 
 When an agent hits a denial, one `sandbox_inspect` call returns the current rules, a lint summary, and the recent denials from the event log together, so "why is my rule failing" is one tool call instead of an archaeology session. See [skills](../skills/).
 

--- a/packages/site-docs/src/content/docs/rules-patterns.md
+++ b/packages/site-docs/src/content/docs/rules-patterns.md
@@ -1,5 +1,5 @@
 ---
-title: "The techniques hard rules are built from"
+title: "Apply production-tested Firestore Rules patterns"
 navLabel: "Rules patterns"
 group: "Inspect and correct"
 section: "Correct Security Rules"
@@ -7,7 +7,7 @@ order: 3007
 description: "Learn the five moves that turn \"rules can't do that\" into a ruleset that deploys."
 ---
 
-# The techniques hard rules are built from
+# Apply production-tested Firestore Rules patterns
 
 The rules language cannot loop. It cannot build a map key out of strings. And it evaluates under budgets that are real but invisible. Every hard ruleset that exists anyway, chess included, is built from a small set of moves that work with those constraints instead of against them. Here they are, generalized from the game rules where they were proven against production.
 
@@ -103,10 +103,10 @@ There are three places the computation can go:
 
 The US tax example takes this the whole way. The client computes its own tax return, and the rules verify every intermediate figure against the bracket config. A return that lies about its math is a permission denial.
 
-## And from an agent
+## Load the patterns through an agent
 
 The patterns with stable shapes ship as standard library modules an agent imports instead of re-deriving: `geometry` for the config-document lookup, `counters` for the honest arithmetic, `timing` for cooldowns. `firestore_rules_stdlib_get` serves each with its gotchas attached, and `firestore_lint_rules` catches a shared gate before it costs a debugging session. See [skills](../skills/).
 
 ## Where to go next
 
-These techniques run up against real budgets, and the exact numbers are in [the measured limits](../limits-that-bite/). To see how far the techniques reach, read the [case studies](../whats-possible/).
+These techniques run up against real budgets, and the exact numbers are in [the measured limits](../firestore-rules-limits/). To see how far the techniques reach, read the [case studies](../whats-possible/).

--- a/packages/site-docs/src/content/docs/rules-standard-library.md
+++ b/packages/site-docs/src/content/docs/rules-standard-library.md
@@ -1,5 +1,5 @@
 ---
-title: "Build your rules from tested parts"
+title: "Build Firestore Rules from tested modules"
 navLabel: "The rules standard library"
 group: "Inspect and correct"
 section: "Correct Security Rules"
@@ -7,7 +7,7 @@ order: 3008
 description: "Compose security rules from tested modules, with an import system that compiles away before Firebase ever sees it."
 ---
 
-# Build your rules from tested parts
+# Build Firestore Rules from tested modules
 
 This is a Firestore rules file:
 
@@ -92,7 +92,7 @@ Every module ships with test fixtures that execute against the rules engine in C
 
 This page is a guide, not the catalog. The full module list, every signature with its gotchas, lives in the module manifest until the reference section lands.
 
-## And from an agent
+## Load standard modules through an agent
 
 An agent does not memorize any of this. `firestore_rules_stdlib_get({ key: 'timing' })` returns a module's signatures, examples, and gotchas, and the resolver runs in-process, so the agent composes a ruleset from modules, lints it, and simulates verdicts before anything deploys. See [skills](../skills/).
 

--- a/packages/site-docs/src/content/docs/secure-it-with-rules.md
+++ b/packages/site-docs/src/content/docs/secure-it-with-rules.md
@@ -1,5 +1,5 @@
 ---
-title: "Prove a user can touch only their own data"
+title: "Prove a user can access only their own data"
 navLabel: "Security Rules"
 group: "Inspect and correct"
 section: "Correct Security Rules"
@@ -7,7 +7,7 @@ order: 3005
 description: "Write a rule, simulate a request against it, read the verdict, and deploy knowing what it allows."
 ---
 
-# Prove a user can touch only their own data
+# Prove a user can access only their own data
 
 Before you deploy a ruleset, you can ask Pyric a direct question: would this specific request, from this specific user, be allowed? You get an answer, and the answer names the rule that decided it.
 
@@ -87,7 +87,7 @@ firebase deploy --only firestore:rules
 
 Gate on error-severity lint findings in CI first (`lintFirestoreRules` / `pyric firestore rules lint`), so the mistakes that produce opaque production failures get stopped at the door.
 
-## Where the wing goes deeper
+## Continue into deeper Rules guidance
 
 That loop is the core. The wing deepens each step.
 
@@ -96,11 +96,11 @@ That loop is the core. The wing deepens each step.
 - [Read a denial and understand it](../read-a-denial/). Every denial carries the rule, path, and data that produced it.
 - [The rules standard library](../rules-standard-library/). Tested rule modules, composed with an import the rules language does not have.
 - [Rules patterns](../rules-patterns/). The techniques the hard rules are built from.
-- [Rules limits, measured](../limits-that-bite/). The production compiler's real limits, with numbers.
+- [Firestore Rules limits](../firestore-rules-limits/). The production compiler's real limits, with numbers.
 - [Audit your rules and data](../audit-your-rules/). Find the holes before someone else does.
 - [Case studies](../whats-possible/). Deployed rulesets that enforce chess, connect four, and tax math.
 
-## And from an agent
+## Verify a denial through an agent
 
 An agent working in your sandbox can call `firestore_simulate_rules` to check a request's verdict before it writes, so it verifies its own rules instead of guessing. The audit skills go further: point one at your ruleset and it hunts for holes methodically. See [skills](../skills/).
 

--- a/packages/site-docs/src/content/docs/see-whats-happening.md
+++ b/packages/site-docs/src/content/docs/see-whats-happening.md
@@ -19,7 +19,7 @@ pyric dev --ui
 
 Studio mounts at `/__pyric/ui/` on your dev server. The Traffic tab shows the stream live: each request, who made it, the allow or deny verdict, and how long the rules evaluation took. Sign in, write a document, break a rule on purpose. Each one appears as it happens, in the same backend your open tabs are using.
 
-## Read the stream yourself
+## Subscribe to the event stream
 
 One subscription covers everything observable:
 
@@ -60,7 +60,7 @@ The subscription survives `sandbox.reset()`. A `session_boundary` event fires be
 
 A `deny` event is not a bare `permission-denied` string. It carries the method and path, the identity the rules saw, the reasons, and the request data that was evaluated. That is enough to answer "which rule said no, and what did it see" without adding a single log line. [Read a denial and understand it](../read-a-denial/) walks through one.
 
-## Build your own monitor
+## Build a traffic monitor
 
 Studio's Traffic view is a consumer of `onEvent`, and you can build your own in about seventy lines. Subscribe, format each kind, and you get a terminal log like this:
 
@@ -76,7 +76,7 @@ Two things to know before you ship one:
 - Listener re-evaluations dominate the raw stream. Default your view to user-origin requests, deliveries, lifecycle, and denials, and put `origin: 'listener'` traffic behind a toggle.
 - Your callback runs synchronously with the operation that produced it, so push heavy work off the hot path with `queueMicrotask` or a worker.
 
-## And from an agent
+## Inspect the backend through an agent
 
 An agent doesn't scroll a panel. It calls `sandbox_inspect` and gets the current rules, a lint summary, a document census, and the recent requests and denials in one response. That one call replaced a debugging session that once took fifty-one tool calls. See [Set up your agent](../set-up-your-agent/).
 

--- a/packages/site-docs/src/content/docs/set-up-your-agent.md
+++ b/packages/site-docs/src/content/docs/set-up-your-agent.md
@@ -1,13 +1,13 @@
 ---
-title: "Point your agent at the sandbox"
-navLabel: "Set up your agent"
+title: "Connect an agent to the sandbox"
+navLabel: "Connect an agent"
 group: "Run locally"
 section: ""
 order: 1003
 description: "Connect Claude Code, Cursor, Codex, or any MCP client to your backend in minutes."
 ---
 
-# Point your agent at the sandbox
+# Connect an agent to the sandbox
 
 One connection and your agent has the whole backend as tools. It can read and write documents as any user, run queries, lint and simulate rules, seed data, and inspect everything, against the same sandbox your app and Studio see. Nothing it does leaves your machine.
 
@@ -79,7 +79,7 @@ The generic recipe is two options, and every client above is one of them applied
 
 Whatever your client's config file looks like, one of those two lines is the whole setup. Then ask it to inspect the sandbox and read what comes back.
 
-## If your app uses the Vite plugin
+## Connect through the Vite plugin
 
 One option in `vite.config.ts` makes your own `vite dev` the bridge:
 

--- a/packages/site-docs/src/content/docs/shape-your-data.md
+++ b/packages/site-docs/src/content/docs/shape-your-data.md
@@ -1,5 +1,5 @@
 ---
-title: "Seed, snapshot, reset, and replay the backend like source"
+title: "Seed, snapshot, reset, and replay the backend"
 navLabel: "Seed, snapshot, replay"
 group: "Inspect and correct"
 section: "Inspect the sandbox"
@@ -7,7 +7,7 @@ order: 3003
 description: "Put the backend in any state you want, capture the good ones, and get them back on demand."
 ---
 
-# Seed, snapshot, reset, and replay the backend like source
+# Seed, snapshot, reset, and replay the backend
 
 Your backend is local state. That changes what you can do with it. You can seed a scenario, snapshot the moment it looks right, commit that file, wipe everything between tests, and replay a whole session later to see if it still holds. The same moves you make on source code, on your data.
 
@@ -87,7 +87,7 @@ That recording is a rules regression suite you didn't write. It knows a re-resol
 
 The place this pays off is the deploy gate, where the same replay runs against the rules you're about to ship. See [Ship to production](../ship-to-production/). You can also replay in code with `sandbox.history()` and `replay(events, rules)` when you want the divergence list programmatically.
 
-## And from an agent
+## Seed and reset through an agent
 
 Seed, reset, and snapshot are tools on the same MCP surface your editor connects to, so an agent can stand up a scenario, run its checks, and reset to a clean slate without your help. For scratch work it can open a stateful simulator session with its own undo stack, and `sandbox_inspect` tells it what state it's actually in. See [Set up your agent](../set-up-your-agent/).
 

--- a/packages/site-docs/src/content/docs/ship-to-production.md
+++ b/packages/site-docs/src/content/docs/ship-to-production.md
@@ -18,7 +18,7 @@ firebase deploy --only hosting
 
 One guard stands between the two worlds. A sandbox build (from `vite build --mode development`) carries a marker in its `index.html`. Production hosting deploys should use an unmarked build (`vite build` / production mode) so a sandbox-wired dist never reaches production by accident. Prefer `firebase-tools` (or the Console) for the deploy itself.
 
-## Deploy your rules
+## Deploy Security Rules
 
 ```bash
 firebase deploy --only firestore:rules
@@ -26,7 +26,7 @@ firebase deploy --only firestore:rules
 
 This pushes the `firestore.rules` named in `firebase.json` to your project. By the time you run it, those rules have already been exercised: every operation your app performed in development was evaluated against them, verdict by verdict. You are not deploying a guess.
 
-## Deploy indexes from your query shapes
+## Deploy indexes from application query shapes
 
 Composite indexes usually live in a hand-kept file that drifts from the queries. Pyric derives them instead: index extraction reads your `query(collection, where, orderBy)` call sites in source and produces the `firestore.indexes.json` those shapes require (`pyric firestore indexes generate src`). Then:
 
@@ -74,7 +74,7 @@ firebase deploy --only functions
 
 Use `firebase-tools` (or the Console) for production shipping. Preview channels give you a shareable URL with an expiry before anything touches the live site.
 
-## Credentials for verify (and CI)
+## Configure credentials for verification and CI
 
 `pyric verify` with the default `sandbox` engine needs no cloud credentials. For `--engine rules-test-api` or `both`:
 

--- a/packages/site-docs/src/content/docs/simulate-and-lint.md
+++ b/packages/site-docs/src/content/docs/simulate-and-lint.md
@@ -1,5 +1,5 @@
 ---
-title: "Catch the error before Firebase's opaque 400"
+title: "Simulate and lint Security Rules before deployment"
 navLabel: "Simulate and lint before you deploy"
 group: "Inspect and correct"
 section: "Correct Security Rules"
@@ -7,7 +7,7 @@ order: 3006
 description: "Get a rules verdict and a lint report locally, before production answers with an unexplained 400 or 403."
 ---
 
-# Catch the error before Firebase's opaque 400
+# Simulate and lint Security Rules before deployment
 
 A broken ruleset fails late: a `400` at deploy time, or a `403` at runtime. Pyric moves both failures to your machine, before the deploy.
 
@@ -42,7 +42,7 @@ Simulated: DENY
 
 The same simulator is on the command line as `pyric firestore rules simulate`, and it is what evaluates every operation inside your running sandbox.
 
-## Lint before the compiler can reject you
+## Lint before Firebase rejects the rules
 
 ```bash
 pyric firestore rules lint firestore.rules
@@ -58,7 +58,7 @@ const { warnings, metrics } = lintFirestoreRules(source);
 
 The linter checks two different kinds of failure.
 
-**The production limits.** The rules compiler enforces hard caps: a 256 KB source ceiling, a boolean chain depth of 98, 11 `let` bindings per function, `get()` call counts, and a runtime evaluation budget that fails as a silent `permission-denied` under load. The linter carries each cap as an exact threshold, measured by probing the production engine. The numbers live in [the limits that actually bite](../limits-that-bite/).
+**The production limits.** The rules compiler enforces hard caps: a 256 KB source ceiling, a boolean chain depth of 98, 11 `let` bindings per function, `get()` call counts, and a runtime evaluation budget that fails as a silent `permission-denied` under load. The linter carries each cap as an exact threshold, measured by probing the production engine. The numbers live in [the measured Firestore Rules limits](../firestore-rules-limits/).
 
 **JS-in-rules mistakes.** The rules language looks like JavaScript, and that resemblance is a trap. Models fall into it constantly, and humans do too.
 
@@ -86,7 +86,7 @@ Each of these emits a warning that names the mistake:
 
 The syntax-level catches (`===`, `?.`, `??`, arrow functions, backtick strings) fire even when the file fails to parse, because the parse error alone would point you at a stray parenthesis instead of the actual cause.
 
-## Let the errors block the ship
+## Block shipping on Rules errors
 
 Warnings carry a severity. Gate CI (and refuse to `firebase deploy`) when any finding has `severity: 'error'`:
 
@@ -98,10 +98,10 @@ if (errors.length > 0) process.exit(1);
 
 A hallucinated method is always an error, because the named method literally does not exist. Blocking on it is never a false alarm.
 
-## And from an agent
+## Correct Rules through an agent
 
 This is the loop that keeps an agent honest. It calls `firestore_lint_rules` on the rules it wrote, reads the fixes in the warnings, and corrects itself before anything deploys. Then `firestore_simulate_rules` confirms the behavior. The mistakes the linter catches are, in large part, the mistakes models make. See [what your agent can do](../skills/).
 
 ## Where to go next
 
-The exact numbers behind the limit checks are in [the limits that actually bite](../limits-that-bite/). To make simulation a habit rather than a one-off, [write a rules test suite](../write-a-rules-test-suite/).
+The exact numbers behind the limit checks are in [the measured Firestore Rules limits](../firestore-rules-limits/). To make simulation a habit rather than a one-off, [write a rules test suite](../write-a-rules-test-suite/).

--- a/packages/site-docs/src/content/docs/skills.md
+++ b/packages/site-docs/src/content/docs/skills.md
@@ -1,13 +1,13 @@
 ---
-title: "Teach your agent the hard Firebase things"
-navLabel: "Skills"
+title: "Give an agent methods for Firebase tasks"
+navLabel: "Agent skills"
 group: "Inspect and correct"
 section: "Work with an agent"
 order: 3013
 description: "Packaged expert procedures for the problems that need a method, not more tools."
 ---
 
-# Teach your agent the hard Firebase things
+# Give an agent methods for Firebase tasks
 
 Tools give an agent hands. Skills give it a method. A skill is a written procedure the agent follows step by step, with a completion check on every step and the specific Pyric moves each step uses named in place.
 
@@ -15,7 +15,7 @@ An auth-model skill does not say "think about identity." It says map every ident
 
 Six skills ship today, one per hard problem.
 
-## Install them
+## Install the skills
 
 The skills live in the Pyric repository under `.agents/skills/`, one folder per skill.
 
@@ -23,7 +23,7 @@ The skills live in the Pyric repository under `.agents/skills/`, one folder per 
 - For Claude Code, copy the folders you want into your project's `.claude/skills/` directory.
 - The Claude Code plugin ships its own operational pieces (`pyric-start` boots and wires the sandbox), so the domain skills below slot into a session that is already connected.
 
-## What each skill does
+## Choose a skill for the task
 
 **firebase-auth-model.** Design or audit an identity model that actually connects to your rules. It maps every identity your app has, chooses provider flows, decides where profile data lives and which document IDs use `uid`, and draws the line between custom claims and document roles so they never contradict, ending with test users you can seed. Serves [sign in and manage users](../sign-in-and-manage-users/).
 

--- a/packages/site-docs/src/content/docs/test-in-node.md
+++ b/packages/site-docs/src/content/docs/test-in-node.md
@@ -1,5 +1,5 @@
 ---
-title: "The same backend in tests and scripts"
+title: "Run the same backend in tests and scripts"
 navLabel: "Test in Node"
 group: "Run locally"
 section: ""
@@ -7,7 +7,7 @@ order: 1004
 description: "Run your rules and data logic in a Node test suite, with no browser and no emulator."
 ---
 
-# The same backend in tests and scripts
+# Run the same backend in tests and scripts
 
 The backend that runs in your browser tab runs in a Node process the same way. That means your test suite gets a real Firestore with real rules enforcement, in-process, with nothing to start or tear down. No browser. No emulator. No port.
 

--- a/packages/site-docs/src/content/docs/watch-and-review.md
+++ b/packages/site-docs/src/content/docs/watch-and-review.md
@@ -23,7 +23,7 @@ Studio opens at `/__pyric/ui/` against the same sandbox your app tab and MCP cli
 
 Ask your connected agent for a feature and watch documents appear in the Firestore tab as it writes them, because there is one backend and everyone is looking at it. When the agent claims it seeded ten users, the Auth tab either shows ten users or it does not.
 
-## Review it through the event stream
+## Review activity through the event stream
 
 Every operation the backend performs is a typed event, and agent operations land in the same stream as your app's. Each event carries:
 
@@ -33,7 +33,7 @@ Every operation the backend performs is a typed event, and agent operations land
 
 Reviewing an agent session is reading the stream, not reconstructing it. That turns "the agent says it worked" into something you can check line by line. The Traffic tab shows the stream live, and [see what's happening](../see-whats-happening/) covers reading it yourself, including from code.
 
-## What the agent can and cannot touch
+## Understand the access boundary
 
 The trust posture is short:
 

--- a/packages/site-docs/src/content/docs/what-your-agent-can-do.md
+++ b/packages/site-docs/src/content/docs/what-your-agent-can-do.md
@@ -1,13 +1,13 @@
 ---
-title: "Hand your agent the whole backend"
-navLabel: "What your agent can do"
+title: "Work with the sandbox through an agent"
+navLabel: "Work through an agent"
 group: "Inspect and correct"
 section: "Work with an agent"
 order: 3012
 description: "Every backend capability, callable as a tool: inspect, query, simulate, shape, ship, verify."
 ---
 
-# Hand your agent the whole backend
+# Work with the sandbox through an agent
 
 Once connected, your agent works on the backend the way you do, except every capability is a tool call it can make and check. This page walks the surface by what the agent can accomplish, not by tool name. The names appear where they matter.
 
@@ -20,7 +20,7 @@ Once connected, your agent works on the backend the way you do, except every cap
 | Operate the real project | the deploy and auth-config tools, with credentials you provide |
 | Check its own work | session replay against candidate rules |
 
-## Read, write, and query like the app does
+## Read, write, and query with application identity
 
 The data plane is the app's own surface, and the agent uses it as a specific identity, so a read that should be denied is denied for the agent too.
 
@@ -28,7 +28,7 @@ The data plane is the app's own surface, and the agent uses it as a specific ide
 - **Realtime Database**: get, set, update, and push.
 - **RTDB inspection**: crawls the active sandbox snapshot and reports its local structure without production access.
 
-## See what exists before guessing
+## Inspect state before changing it
 
 The single most-used move is one call. `sandbox_inspect` returns:
 
@@ -40,7 +40,7 @@ The tool's own source records why it exists. In a recorded debug session, diagno
 
 Discovery works on real projects too. Firestore has no schema, so Pyric infers one: the agent can crawl a live database by sampling, cost-bounded and cost-reported, and come back with the shape of what is actually there. The same goes for a Realtime Database tree.
 
-## Prove a rule before writing it
+## Simulate a rule before writing it
 
 The agent can ask whether a specific request, by a specific identity, would be allowed under a ruleset, and get the verdict with the rule and data that decided it. No deploy, no waiting.
 
@@ -53,13 +53,13 @@ For longer work it can open a stateful simulator session:
 
 A scratchpad for rules and data with a real undo stack, which means the agent can try something wrong and back out cleanly.
 
-## Shape the state it tests against
+## Shape the state under test
 
 Backend state is a tool input. The agent can seed a scenario, reset to clean, and snapshot what it built so the state survives as a fixture. Between test runs, between hypotheses, between conversations.
 
 The same seed, reset, and snapshot moves you make yourself, callable.
 
-## Operate the real project
+## Understand the credential boundary
 
 Given credentials you choose to hand it, the agent can run the control plane over REST, with no extra CLI:
 
@@ -69,13 +69,13 @@ Given credentials you choose to hand it, the agent can run the control plane ove
 
 This is the same path you walk in [set up the project](../set-up-the-project/) and [ship to production](../ship-to-production/). Without those credentials, none of it is reachable.
 
-## Check its own work
+## Check the result
 
 Verification is a tool, not a ritual. The agent can replay a captured session of real operations against a candidate ruleset and learn which operations change verdict, before anything deploys.
 
 It writes a rule, replays, reads the diff, and fixes what flipped. That loop is the difference between an agent that asserts its rules work and one that has evidence.
 
-## The honest shape of the surface
+## Understand the supported boundary
 
 The surface is wide because Firebase's is: data, rules, identity, deployment, and two database models.
 

--- a/packages/site-docs/src/content/docs/whats-experimental.md
+++ b/packages/site-docs/src/content/docs/whats-experimental.md
@@ -12,7 +12,7 @@ Auth, Firestore, and Rules are v1: conformance-held against recorded production 
 
 Realtime Database and Storage are experimental. They are built, documented, and usable today, and they are explicitly not v1. This page is the exact meaning of that word.
 
-## What experimental costs you
+## What experimental status costs
 
 The experimental services are verified sandbox-side: unit probes check them against the documented `firebase/database` and `firebase/storage` contracts, and those probes pass. What most of their behavior lacks is a production observation, a recording of what the real service actually did, pinned and replayed in CI. Verified against the documentation is not the same as verified against production, and Pyric does not pretend otherwise.
 

--- a/packages/site-docs/src/content/docs/whats-possible.md
+++ b/packages/site-docs/src/content/docs/whats-possible.md
@@ -9,7 +9,7 @@ description: "See working, deployed rulesets that enforce chess, checkers, conne
 
 # Case studies in pure security rules
 
-Every artifact below enforces its logic entirely in security rules. No server, no Cloud Functions. The database is the referee. Each one deployed, each one is built from the same [patterns](../rules-patterns/) and [standard library](../rules-standard-library/) this wing teaches, and each one was engineered inside the [measured limits](../limits-that-bite/).
+Every artifact below enforces its logic entirely in security rules. No server, no Cloud Functions. The database is the referee. Each one deployed, each one is built from the same [patterns](../rules-patterns/) and [standard library](../rules-standard-library/) this wing teaches, and each one was engineered inside the [measured limits](../firestore-rules-limits/).
 
 | Case | Service | The rules enforce | The move that makes it work |
 |---|---|---|---|
@@ -58,4 +58,4 @@ A deployed, playable browser app on Realtime Database rules. Turn enforcement, p
 
 ## Calibration, not a feature list
 
-None of this is a feature you will ship on Monday. It is calibration. If rules can hold chess, they can hold your role model, your state machine, your billing invariants, and the parts are the ones you already have: the [patterns](../rules-patterns/), the [standard library](../rules-standard-library/), and the [limits](../limits-that-bite/) that keep all of it deployable.
+None of this is a feature you will ship on Monday. It is calibration. If rules can hold chess, they can hold your role model, your state machine, your billing invariants, and the parts are the ones you already have: the [patterns](../rules-patterns/), the [standard library](../rules-standard-library/), and the [limits](../firestore-rules-limits/) that keep all of it deployable.

--- a/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
+++ b/packages/site-docs/src/content/docs/write-a-rules-test-suite.md
@@ -1,5 +1,5 @@
 ---
-title: "Rules you trust because they are tested"
+title: "Write a Security Rules test suite"
 navLabel: "Write a rules test suite"
 group: "Verify the boundary"
 section: ""
@@ -7,7 +7,7 @@ order: 4002
 description: "A suite of allow/deny cases that runs in-process, gates CI, and can escalate to Google's own engine."
 ---
 
-# Rules you trust because they are tested
+# Write a Security Rules test suite
 
 A ruleset is code that decides who sees what. It deserves tests like any other code that matters.
 
@@ -91,7 +91,7 @@ if (!result.success || result.data.failed > 0) {
 
 Sub-millisecond per case once the rules are parsed. There is no reason not to run this on every push.
 
-## When you want Google's own answer
+## Use Google's Rules Test API when production authority matters
 
 The hosted Rules Test API evaluates your cases on Google's servers, in the same engine production uses, without deploying anything. It takes the same `TestCase` objects and returns the same result shape. It needs a real project and credentials:
 
@@ -118,7 +118,7 @@ if (escalate.length > 0) {
 
 Each hosted call is one HTTP round-trip, tens to hundreds of milliseconds. The simulator itself is held to that engine's answers by a parity corpus that runs in CI, so for most suites the local verdicts are the same verdicts, sooner.
 
-## And from an agent
+## Run the suite through an agent
 
 An agent can run this exact loop through `firestore_simulate_rules` and `firestore_test_rules`, which means the rules it writes arrive with a passing suite instead of a promise. See [skills](../skills/).
 


### PR DESCRIPTION
Aligns the authored guide headings with the local-to-production workflow established in #325.

```md
# Run Firebase locally, ship unchanged

## Run Firebase locally
## Develop with Firebase APIs
## Inspect and correct
## Verify the boundary
## Ship unchanged
```

## Headings now teach the next action

The final heading pass replaces reader-addressed, noun-first, and playful headings with direct outcomes. It preserves the settled navigation and page bodies. Examples include `Connect an agent to the sandbox`, `Simulate and lint Security Rules before deployment`, `Write a Security Rules test suite`, and `Audit Security Rules and data before production`.

The old `limits-that-bite` source and route are removed. The same production-measured content now lives at `/docs/firestore-rules-limits/` under `Firestore Rules compiler and evaluator limits`. No redirect or dedicated route check remains.

## PR #219 headings are accounted for

Recovered concepts include its strong agent connection, state replay, Rules proof, simulation, test-suite, measured-limits, import-swap, and conformance headings. The conformance narrative structure was already retained by #320.

`Pyric is Firebase, running locally` is superseded by the workflow hook `Run Firebase locally, ship unchanged`. Playful, alarmist, and reader-addressed headings such as `Limits that bite`, `Find holes before someone else does`, and `Hand your agent the whole backend` are intentionally rejected.

This is the heading checkpoint from #307 and uses #219 only as editorial source material.

## Risk

Changed section headings also change generated anchors. A repository-wide scan found no inbound links to the replaced fragments, and the normal site verifier passes all current links and fragments. The removed limits route will no longer resolve, by design.

<details>
<summary>Implementation notes</summary>

- Base: `docs/312-workflow-navigation`
- No guide body rewrite
- No TypeDoc source change
- No conformance registry, observation, baseline, denominator, or published value change
- `DOCS_BASE=/__pyric/ui/ bun run --cwd packages/site-docs build` passes
- `DOCS_BASE=/__pyric/ui/ bun run --cwd packages/site-docs verify` passes for 198 pages
- `bun run build` passes
- `bun run test` passes
- `bun run compat:check` passes with unchanged values
- `git diff --check` passes

</details>

Closes #313.
Part of #307.
Source material: #219.
