### PR TITLE
fix: pre-bundle CJS hashing deps in the sandbox vite plugin

### DIFF
--- a/examples/vite-sandbox-app/firestore.rules
+++ b/examples/vite-sandbox-app/firestore.rules
@@ -11,13 +11,6 @@ service cloud.firestore {
                             && resource.data.uid == request.auth.uid;
     }
 
-    match /zones/{zoneId} {
-      allow read, write: if true;
-    }
-    match /zones/{zoneId}/sensors/{sensorId} {
-      allow read, write: if true;
-    }
-
     // Default deny — opt in per collection.
     match /{document=**} {
       allow read, write: if false;

--- a/examples/vite-sandbox-app/firestore.rules
+++ b/examples/vite-sandbox-app/firestore.rules
@@ -11,6 +11,13 @@ service cloud.firestore {
                             && resource.data.uid == request.auth.uid;
     }
 
+    match /zones/{zoneId} {
+      allow read, write: if true;
+    }
+    match /zones/{zoneId}/sensors/{sensorId} {
+      allow read, write: if true;
+    }
+
     // Default deny — opt in per collection.
     match /{document=**} {
       allow read, write: if false;

--- a/examples/vite-sandbox-app/index.html
+++ b/examples/vite-sandbox-app/index.html
@@ -22,7 +22,9 @@
       <p class="status" id="auth-status">Signed out</p>
       <button id="sign-in">Sign in with Google</button>
       <button id="sign-out" hidden>Sign out</button>
-      <form id="add-post" hidden>
+      <!-- Visible even while signed out ON PURPOSE — submitting attempts the
+           write and the owner-based rules deny it (see main.ts). -->
+      <form id="add-post">
         <input id="post-title" placeholder="Post title" required />
         <button type="submit">Add post</button>
       </form>

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -278,6 +278,12 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
           // Keep firebase out of the optimizer's pre-bake; the resolver swaps it
           // per-importer at request time.
           exclude: [...SDK_MODULES],
+          // The excluded SDK is served as ESM straight from dist, so Vite never
+          // scans it for dependencies. js-md5 / js-sha256 are CJS-only (no ESM
+          // named exports); without a forced pre-bundle the browser gets the raw
+          // UMD source and `import { md5 }` throws a SyntaxError. Force-including
+          // them gives the dist imports the interop-wrapped optimized copies.
+          include: ['js-md5', 'js-sha256'],
           esbuildOptions: { plugins: [esbuildMirror] },
         },
         // Sandbox build only: the swapped-in runtime chunk uses TOP-LEVEL AWAIT

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -390,7 +390,7 @@ describe('pyric init output contract', () => {
         'firebase.json': '06ed33d14b46379011c4a805299016f8c03adf5f47994624fde82b794f09ec2b',
         'firestore.indexes.json': '6742255415c36daf631b52f233039190af819205cc41fa58d07dd7d9e180c2b9',
         'firestore.rules': '5251fb08767a1a8ae2242eb6784cd96838311499bd888fe5a975f65d3a0247ac',
-        'index.html': '12f621f10493b0556d5f38acc3a0625c97646e32bd2bca740098ec5715f50aad',
+        'index.html': 'b484dc3d63752ed4585fdbe2c2c71bbec7aba95b016c0d7da07c7d9b05b9e6c0',
         'package.json': 'f53371163698b81268f95d899c298d84c2f9bbf597909e77af430d71cef8eb10',
         'src/main.ts': '3e165d28c4d22df0b868d26cd4071950a6c47cfd0c8944d01c2dadc66c0dfab2',
         'src/vite-env.d.ts': '65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5',

--- a/packages/cli/test/serve/auth-helper.test.ts
+++ b/packages/cli/test/serve/auth-helper.test.ts
@@ -67,11 +67,12 @@ describe('ServeAuthHelper', () => {
     });
   });
 
-  it('non-delegated (in-page fallback) default: google.com popup throws operation-not-allowed', async () => {
+  it('non-delegated (in-page fallback): a disabled google.com popup throws operation-not-allowed', async () => {
     // The served NON-worker leg keeps local gating with the documented
-    // sandbox defaults — no silent pre-enabling in these tests anymore.
+    // sandbox defaults (everything enabled) — an explicit disable still bites.
     const sandbox = initializeSandbox();
     const auth = getAuth(sandbox);
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     const helper = helperForLocalAuth(auth);
     await expect(signInWithPopup(auth, new GoogleAuthProvider())).rejects.toMatchObject({
       code: 'auth/operation-not-allowed',

--- a/packages/cli/test/serve/worker/auth.test.ts
+++ b/packages/cli/test/serve/worker/auth.test.ts
@@ -531,9 +531,12 @@ describe('auth.acceptIdentity — provider sign-in bridge', () => {
   // ── Provider gating at the shared authority (the served OAuth blocker fix):
   // the page-local sandbox delegates its gate in worker mode, so THIS op is
   // where Studio's Sign-in-provider toggles must bite.
-  it('rejects auth/operation-not-allowed for a provider the worker has NOT enabled (default)', async () => {
+  it('rejects auth/operation-not-allowed for a provider the worker has disabled', async () => {
     const ctx = await makeCtx();
     const port = fakePort();
+    okValue(await sendOp(ctx, port, {
+      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: false,
+    }));
     const res = await sendOp(ctx, port, {
       t: 'op', id: id(), method: 'auth.acceptIdentity',
       identity: { uid: 'google.com:eve@x.com', email: 'eve@x.com', displayName: null, customClaims: {}, providerId: 'google.com' },
@@ -655,20 +658,20 @@ describe('auth.getProviderConfig / auth.setProviderConfig — worker op round-tr
     const port = fakePort();
 
     await sendOp(ctx, port, {
-      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: true,
+      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: false,
     });
     let config = okValue<Array<{ providerId: string; enabled: boolean }>>(
       await sendOp(ctx, port, { t: 'op', id: id(), method: 'auth.getProviderConfig' }),
     );
-    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(true);
+    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(false);
 
     await sendOp(ctx, port, {
-      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: false,
+      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: true,
     });
     config = okValue<Array<{ providerId: string; enabled: boolean }>>(
       await sendOp(ctx, port, { t: 'op', id: id(), method: 'auth.getProviderConfig' }),
     );
-    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(false);
+    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(true);
   });
 
   it('a disabled provider is enforced by the sign-in ops the SAME worker serves', async () => {
@@ -691,7 +694,7 @@ describe('auth.getProviderConfig / auth.setProviderConfig — worker op round-tr
     const before = port.messages.filter((m) => m.t === 'event').length;
 
     await sendOp(ctx, port, {
-      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'github.com', enabled: true,
+      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'github.com', enabled: false,
     });
     await tick();
     const eventMsgs = port.messages.filter((m): m is Extract<OutboundMessage, { t: 'event' }> => m.t === 'event');
@@ -707,7 +710,7 @@ describe('auth.getProviderConfig / auth.setProviderConfig — worker op round-tr
     const ctx1 = await makeCtx({ backend, key });
     const port1 = fakePort();
     await sendOp(ctx1, port1, {
-      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: true,
+      t: 'op', id: id(), method: 'auth.setProviderConfig', providerId: 'google.com', enabled: false,
     });
     await ctx1.sandbox.flush();
 
@@ -716,6 +719,6 @@ describe('auth.getProviderConfig / auth.setProviderConfig — worker op round-tr
     const config = okValue<Array<{ providerId: string; enabled: boolean }>>(
       await sendOp(ctx2, port2, { t: 'op', id: id(), method: 'auth.getProviderConfig' }),
     );
-    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(true);
+    expect(config.find((c) => c.providerId === 'google.com')?.enabled).toBe(false);
   });
 });

--- a/packages/create-pyric/src/templates.ts
+++ b/packages/create-pyric/src/templates.ts
@@ -371,7 +371,9 @@ const VITE_INDEX_HTML = (name: string): string => `<!doctype html>
       <p class="status" id="auth-status">Signed out</p>
       <button id="sign-in">Sign in with Google</button>
       <button id="sign-out" hidden>Sign out</button>
-      <form id="add-post" hidden>
+      <!-- Visible even while signed out ON PURPOSE — submitting attempts the
+           write and the owner-based rules deny it (see src/main.ts). -->
+      <form id="add-post">
         <input id="post-title" placeholder="Post title" required />
         <button type="submit">Add post</button>
       </form>

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -490,11 +490,11 @@ export class SandboxBackend {
   // ─── Provider config (sign-in method enablement) ─────────────────────
 
   /** Whether `providerId` is currently enabled. Unknown providers
-   *  (never toggled) default to `false` — matches a fresh real project,
-   *  EXCEPT `'password'`/`'anonymous'`, which start `true` (see the
-   *  {@link providerConfig} docstring for the rationale). */
+   *  (never toggled) default to `true` — every sign-in method works out
+   *  of the box until the sandbox grows a provider-enablement API and
+   *  UI. An explicit `false` entry still disables. */
   isProviderEnabled(providerId: string): boolean {
-    return this.providerConfig.get(providerId) ?? false;
+    return this.providerConfig.get(providerId) ?? true;
   }
 
   /** Every provider this backend has an explicit enablement for —
@@ -508,7 +508,7 @@ export class SandboxBackend {
    *  already what was requested — mirrors {@link setPersistenceMode}'s
    *  dedup so a redundant toggle doesn't churn subscribers / flushes. */
   setProviderConfig(providerId: string, enabled: boolean): void {
-    const before = this.providerConfig.get(providerId) ?? false;
+    const before = this.providerConfig.get(providerId) ?? true;
     if (before === enabled) return;
     this.providerConfig.set(providerId, enabled);
     this.notifyProviderConfigChanged();

--- a/packages/pyric/test/app/multi-app-listener-auth.test.ts
+++ b/packages/pyric/test/app/multi-app-listener-auth.test.ts
@@ -106,6 +106,7 @@ describe('named Firebase apps isolate listener authorization', () => {
     const defaultAuth = getAuth(defaultApp);
     const namedAuth = getAuth(namedApp);
 
+    authSandbox.setAuthProviderConfig(namedAuth, 'google.com', false);
     authSandbox.delegateProviderEnforcement(defaultAuth, true);
 
     await expect(signInWithPopup(namedAuth, new GoogleAuthProvider())).rejects.toMatchObject({

--- a/packages/pyric/test/auth/sandbox-linking-reauth.test.ts
+++ b/packages/pyric/test/auth/sandbox-linking-reauth.test.ts
@@ -152,8 +152,9 @@ describe('linkWithCredential — the anonymous upgrade', () => {
   it('a disabled provider throws operation-not-allowed, ahead of the resolver check', async () => {
     const auth = freshAuth();
     await signInAnonymously(auth);
-    // google.com is off by default — that code must stay distinct from the
-    // argument-error above, which means "enabled, but nothing wired".
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
+    // That code must stay distinct from the argument-error above, which
+    // means "enabled, but nothing wired".
     await expectCode(linkWithPopup(auth.currentUser!, new GoogleAuthProvider()), 'auth/operation-not-allowed');
   });
 });

--- a/packages/pyric/test/auth/sandbox-provider-config.test.ts
+++ b/packages/pyric/test/auth/sandbox-provider-config.test.ts
@@ -72,10 +72,10 @@ describe('sandbox.getAuthProviderConfig — defaults', () => {
 describe('sandbox.setAuthProviderConfig', () => {
   it('toggles a provider on/off and getAuthProviderConfig reflects it', () => {
     const auth = getAuth(initializeSandbox());
-    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
-    expect(authSandbox.getAuthProviderConfig(auth).find((c) => c.providerId === 'google.com')?.enabled).toBe(true);
     authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     expect(authSandbox.getAuthProviderConfig(auth).find((c) => c.providerId === 'google.com')?.enabled).toBe(false);
+    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
+    expect(authSandbox.getAuthProviderConfig(auth).find((c) => c.providerId === 'google.com')?.enabled).toBe(true);
   });
 
   it('disabling password blocks it; re-enabling restores it', () => {
@@ -147,8 +147,20 @@ describe('gating matrix: password provider', () => {
 });
 
 describe('gating matrix: signInWithPopup / signInWithRedirect (OAuth)', () => {
-  it('google.com disabled by default → auth/operation-not-allowed (even with a mock staged)', async () => {
+  it('google.com enabled by default + mock staged → succeeds', async () => {
     const auth = getAuth(initializeSandbox());
+    authSandbox.mockSignInResult(auth, {
+      user: makeFakeUser('g1', 'g1@example.com'),
+      providerId: 'google.com',
+      operationType: 'signIn',
+    });
+    const cred = await signInWithPopup(auth, new GoogleAuthProvider());
+    expect(cred.user.uid).toBe('g1');
+  });
+
+  it('google.com explicitly disabled → auth/operation-not-allowed (even with a mock staged)', async () => {
+    const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     authSandbox.mockSignInResult(auth, {
       user: makeFakeUser('g1', 'g1@example.com'),
       providerId: 'google.com',
@@ -177,23 +189,25 @@ describe('gating matrix: signInWithPopup / signInWithRedirect (OAuth)', () => {
 
   it('signInWithRedirect: same gating as popup', async () => {
     const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     await expectCode(signInWithRedirect(auth, new GoogleAuthProvider()), 'auth/operation-not-allowed');
     authSandbox.setAuthProviderConfig(auth, 'google.com', true);
     await expectCode(signInWithRedirect(auth, new GoogleAuthProvider()), 'auth/argument-error');
   });
 
-  it('a custom OAuth provider id is disabled by default; enabling it unblocks resolveFlow', async () => {
+  it('a custom OAuth provider id is enabled by default; disabling it blocks resolveFlow', async () => {
     const auth = getAuth(initializeSandbox());
     const provider = new OAuthProvider('microsoft.com');
-    await expectCode(signInWithPopup(auth, provider), 'auth/operation-not-allowed');
-    authSandbox.setAuthProviderConfig(auth, 'microsoft.com', true);
     await expectCode(signInWithPopup(auth, provider), 'auth/argument-error');
+    authSandbox.setAuthProviderConfig(auth, 'microsoft.com', false);
+    await expectCode(signInWithPopup(auth, provider), 'auth/operation-not-allowed');
   });
 });
 
 describe('gating matrix: signInWithCredential', () => {
   it('disabled providerId → auth/operation-not-allowed (even with a mock staged)', async () => {
     const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     authSandbox.mockSignInResult(auth, {
       user: makeFakeUser('g1', 'g1@example.com'),
       providerId: 'google.com',
@@ -297,6 +311,7 @@ describe('provider-enforcement delegation (the served-worker page-sandbox seam)'
 
   it('reclaiming enforcement (false) restores the default gate', async () => {
     const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     authSandbox.delegateProviderEnforcement(auth, true);
     authSandbox.delegateProviderEnforcement(auth, false);
     await expectCode(signInWithPopup(auth, new GoogleAuthProvider()), 'auth/operation-not-allowed');
@@ -304,6 +319,7 @@ describe('provider-enforcement delegation (the served-worker page-sandbox seam)'
 
   it('assertAuthProviderEnabled: the authority-side gate throws for disabled, passes for enabled', () => {
     const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     expect(() => authSandbox.assertAuthProviderEnabled(auth, 'google.com')).toThrow(
       expect.objectContaining({ code: 'auth/operation-not-allowed' }),
     );

--- a/packages/pyric/test/sandbox/auth-provider-config-persistence.test.ts
+++ b/packages/pyric/test/sandbox/auth-provider-config-persistence.test.ts
@@ -32,10 +32,10 @@ describe('SandboxSnapshot.services.auth.providers', () => {
   it('reflects toggles made via sandbox.setAuthProviderConfig', () => {
     const sandbox = initializeSandbox();
     const auth = getAuth(sandbox);
-    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     authSandbox.setAuthProviderConfig(auth, 'password', false);
     const authSnap = sandbox.snapshot().services.auth as { providers: Record<string, boolean> };
-    expect(authSnap.providers).toEqual({ password: false, anonymous: true, 'google.com': true });
+    expect(authSnap.providers).toEqual({ password: false, anonymous: true, 'google.com': false });
   });
 });
 
@@ -46,7 +46,7 @@ describe('auth provider-config persistence — round-trip', () => {
     const sandbox1 = initializeSandbox();
     await sandbox1.enablePersistence({ key: 'auth:providers:rt', injectedBackend: backend });
     const auth1 = getAuth(sandbox1);
-    authSandbox.setAuthProviderConfig(auth1, 'google.com', true);
+    authSandbox.setAuthProviderConfig(auth1, 'google.com', false);
     authSandbox.setAuthProviderConfig(auth1, 'anonymous', false);
     await sandbox1.flush();
 
@@ -56,7 +56,7 @@ describe('auth provider-config persistence — round-trip', () => {
 
     const config = authSandbox.getAuthProviderConfig(auth2);
     const byId = Object.fromEntries(config.map((c) => [c.providerId, c.enabled]));
-    expect(byId).toEqual({ password: true, anonymous: false, 'google.com': true });
+    expect(byId).toEqual({ password: true, anonymous: false, 'google.com': false });
   });
 
   it('legacy blob without a `providers` key restores to documented defaults', async () => {
@@ -94,7 +94,7 @@ describe('auth provider-config persistence — round-trip', () => {
     await sandbox.enablePersistence({ key: 'auth:providers:autoflush', injectedBackend: backend, flushIntervalMs: 20 });
     const auth = getAuth(sandbox);
 
-    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     await sleep(60);
 
     const records: [string, unknown][] = [];
@@ -103,7 +103,7 @@ describe('auth provider-config persistence — round-trip', () => {
     }
     const { services } = deserializeFromBuckets(records);
     const providers = (services as { auth?: { providers?: Record<string, boolean> } }).auth?.providers;
-    expect(providers?.['google.com']).toBe(true);
+    expect(providers?.['google.com']).toBe(false);
   });
 });
 
@@ -111,14 +111,14 @@ describe('sandbox.reset() and provider config', () => {
   it('reset() does NOT clear provider config — same precedent as the user DB', () => {
     const sandbox = initializeSandbox();
     const auth = getAuth(sandbox);
-    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
+    authSandbox.setAuthProviderConfig(auth, 'google.com', false);
     authSandbox.setAuthProviderConfig(auth, 'password', false);
 
     sandbox.reset();
 
     const config = authSandbox.getAuthProviderConfig(auth);
     const byId = Object.fromEntries(config.map((c) => [c.providerId, c.enabled]));
-    expect(byId).toEqual({ password: false, anonymous: true, 'google.com': true });
+    expect(byId).toEqual({ password: false, anonymous: true, 'google.com': false });
   });
 
   it('a brand-new sandbox (not a reset() of an existing one) starts at the documented defaults', () => {

--- a/packages/studio/src/features/data/FirestorePane.tsx
+++ b/packages/studio/src/features/data/FirestorePane.tsx
@@ -73,10 +73,19 @@ async function createDocWithProbe(
  * A "missing" parent doc (no stored fields, real descendants) rendered as a
  * navigable row. Queries correctly exclude these (Firebase parity), so the
  * DocumentColumn synthesizes just enough of a snapshot for `<DocumentList>`'s
- * surface (`.id` + `.ref`) and marks it so the renderers can style it.
+ * surface (`.id` + `.ref` + `.data()`) and marks it so the renderers can
+ * style it.
  */
 function makePhantomRow(ref: DocumentReference): QueryDocumentSnapshot {
-  return { id: ref.id, ref, __pyricPhantom: true } as unknown as QueryDocumentSnapshot;
+  // `data()` must exist: <DocumentList> calls it on every row to feed the
+  // update-highlight map. A phantom has no stored document, so `undefined`
+  // (a real DocumentSnapshot's miss value) is the honest answer.
+  return {
+    id: ref.id,
+    ref,
+    data: () => undefined,
+    __pyricPhantom: true,
+  } as unknown as QueryDocumentSnapshot;
 }
 
 function isPhantomRow(snap: QueryDocumentSnapshot): boolean {

--- a/packages/studio/src/features/home/useResourceIndex.ts
+++ b/packages/studio/src/features/home/useResourceIndex.ts
@@ -202,6 +202,14 @@ export function useResourceIndex(): ResourceIndexState {
           if (token !== buildToken.current) return; // a newer build already took over `building`
           inFlight.current = false;
           setBuilding(false);
+          // An EMPTY project completes a build with zero onBatch calls (the
+          // sources only batch what they found). `entries` must still leave
+          // `null` — "measured, nothing there" — or the first-build effect
+          // treats every completed build as never-built and refires on the
+          // per-event `data` churn the build's own list ops cause: a
+          // self-sustaining rebuild loop that floods Traffic with storage
+          // LIST events.
+          setEntries((previous) => previous ?? []);
           if (pendingRebuild.current) {
             const next = pendingRebuild.current;
             pendingRebuild.current = null;

--- a/packages/studio/src/features/traffic/traffic.css
+++ b/packages/studio/src/features/traffic/traffic.css
@@ -934,15 +934,44 @@
 /* Group rows (collapsed listener storms). */
 .traffic__log [data-pyric-traffic-group-row],
 .traffic__log [data-pyric-traffic-group] {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  padding: 8px 14px;
   border-bottom: 1px solid var(--line);
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--muted);
   background: var(--panel);
+}
+
+/* The header is a real disclosure control — make it read as one. */
+.traffic__log [data-pyric-traffic-group-header] {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 14px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.traffic__log [data-pyric-traffic-group-header]::before {
+  content: '▸';
+  color: var(--muted);
+}
+.traffic__log [data-pyric-traffic-group][data-pyric-expanded] [data-pyric-traffic-group-header]::before {
+  content: '▾';
+}
+.traffic__log [data-pyric-group-count] {
+  color: var(--fg);
+}
+.traffic__log [data-pyric-group-denies] {
+  color: var(--deny, #e5484d);
+}
+.traffic__log [data-pyric-traffic-group-members] {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 20px;
 }
 
 /* Pagination disclosure under the capped log (L6: bounded row count). */

--- a/packages/ui/src/auth/hooks/useAuthProviderConfig.ts
+++ b/packages/ui/src/auth/hooks/useAuthProviderConfig.ts
@@ -11,11 +11,11 @@ export interface AuthProviderConfigEntry {
 export interface UseAuthProviderConfigResult {
   /** Every provider this sandbox has an explicit enablement for. Unknown
    *  providers (never toggled) are simply absent — `isEnabled` treats an
-   *  absent entry as disabled, matching the backend default. */
+   *  absent entry as enabled, matching the backend default. */
   config: AuthProviderConfigEntry[];
   isLoading: boolean;
   error: Error | undefined;
-  /** Convenience lookup: `false` for a provider that's never been toggled. */
+  /** Convenience lookup: `true` for a provider that's never been toggled. */
   isEnabled: (providerId: string) => boolean;
   /** Toggle a provider on/off. Sync (in-process) failures throw to the
    *  caller, same policy as `useAuthUsers`'s mutation callbacks; an ASYNC
@@ -94,7 +94,7 @@ export function useAuthProviderConfig(auth: Auth): UseAuthProviderConfigResult {
   }, [auth, getAuthProviderConfig, subscribeAuthProviderConfig]);
 
   const isEnabled = useCallback(
-    (providerId: string) => config.find((c) => c.providerId === providerId)?.enabled ?? false,
+    (providerId: string) => config.find((c) => c.providerId === providerId)?.enabled ?? true,
     [config],
   );
 

--- a/packages/ui/src/traffic/components/TrafficGroupRow.tsx
+++ b/packages/ui/src/traffic/components/TrafficGroupRow.tsx
@@ -2,6 +2,15 @@ import { useState, type ReactNode } from 'react';
 import type { TrafficEvent } from '../types.js';
 import type { TrafficGroup } from '../hooks/useTrafficGroups.js';
 import { TrafficRow } from './TrafficRow.js';
+import type { TrafficGroupKind } from '../hooks/useTrafficGroups.js';
+
+/** Header text per group kind — the raw kind slug stays on the
+ *  `data-pyric-group-kind` attributes for styling/tests. */
+const GROUP_KIND_LABELS: Record<TrafficGroupKind, string> = {
+  batch: 'batch write',
+  transaction: 'transaction',
+  'listener-run': 'listener re-evals',
+};
 
 export interface TrafficGroupRowProps {
   group: TrafficGroup;
@@ -52,10 +61,10 @@ export function TrafficGroupRow({
         data-pyric-group-kind={group.kind}
         aria-expanded={expanded}
       >
-        <span data-pyric-group-kind-label="">{group.kind}</span>
-        <span data-pyric-group-count="">{group.count}</span>
+        <span data-pyric-group-kind-label="">{GROUP_KIND_LABELS[group.kind]}</span>
+        <span data-pyric-group-count="">×{group.count}</span>
         {group.denies > 0 ? (
-          <span data-pyric-group-denies="">{group.denies}</span>
+          <span data-pyric-group-denies="">{group.denies} denied</span>
         ) : null}
       </button>
       {expanded ? (

--- a/packages/ui/test/auth/hooks/useAuthProviderConfig.test.tsx
+++ b/packages/ui/test/auth/hooks/useAuthProviderConfig.test.tsx
@@ -13,26 +13,26 @@ function freshAuth(): Auth {
 }
 
 describe('useAuthProviderConfig', () => {
-  test('lists the default config on mount (password + anonymous enabled)', () => {
+  test('lists the default config on mount (everything enabled)', () => {
     const auth = freshAuth();
     const { result, unmount } = renderHook(() => useAuthProviderConfig(auth));
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeUndefined();
     expect(result.current.isEnabled('password')).toBe(true);
     expect(result.current.isEnabled('anonymous')).toBe(true);
-    expect(result.current.isEnabled('google.com')).toBe(false);
+    expect(result.current.isEnabled('google.com')).toBe(true);
     unmount();
   });
 
   test('setEnabled toggles a provider and the view stays live', () => {
     const auth = freshAuth();
     const { result, unmount } = renderHook(() => useAuthProviderConfig(auth));
-    expect(result.current.isEnabled('google.com')).toBe(false);
+    expect(result.current.isEnabled('google.com')).toBe(true);
 
     act(() => {
-      result.current.setEnabled('google.com', true);
+      result.current.setEnabled('google.com', false);
     });
-    expect(result.current.isEnabled('google.com')).toBe(true);
+    expect(result.current.isEnabled('google.com')).toBe(false);
 
     act(() => {
       result.current.setEnabled('password', false);
@@ -45,20 +45,20 @@ describe('useAuthProviderConfig', () => {
     const auth = freshAuth();
     const { result, unmount } = renderHook(() => useAuthProviderConfig(auth));
     act(() => {
-      authSandbox.setAuthProviderConfig(auth, 'github.com', true);
+      authSandbox.setAuthProviderConfig(auth, 'github.com', false);
     });
-    expect(result.current.isEnabled('github.com')).toBe(true);
+    expect(result.current.isEnabled('github.com')).toBe(false);
     unmount();
   });
 
   test('refresh re-reads the config manually', () => {
     const auth = freshAuth();
     const { result, unmount } = renderHook(() => useAuthProviderConfig(auth));
-    authSandbox.setAuthProviderConfig(auth, 'apple.com', true);
+    authSandbox.setAuthProviderConfig(auth, 'apple.com', false);
     act(() => {
       result.current.refresh();
     });
-    expect(result.current.isEnabled('apple.com')).toBe(true);
+    expect(result.current.isEnabled('apple.com')).toBe(false);
     unmount();
   });
 
@@ -66,9 +66,9 @@ describe('useAuthProviderConfig', () => {
     const auth = freshAuth();
     const { unmount } = renderHook(() => useAuthProviderConfig(auth));
     unmount();
-    authSandbox.setAuthProviderConfig(auth, 'microsoft.com', true);
+    authSandbox.setAuthProviderConfig(auth, 'microsoft.com', false);
     expect(
       authSandbox.getAuthProviderConfig(auth).find((c) => c.providerId === 'microsoft.com')?.enabled,
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/packages/ui/test/traffic/components/TrafficGroupRow.test.tsx
+++ b/packages/ui/test/traffic/components/TrafficGroupRow.test.tsx
@@ -44,11 +44,14 @@ describe('<TrafficGroupRow>', () => {
     )!;
     expect(header.getAttribute('data-pyric-group-kind')).toBe('listener-run');
     expect(
+      container.querySelector('[data-pyric-group-kind-label]')!.textContent,
+    ).toBe('listener re-evals');
+    expect(
       container.querySelector('[data-pyric-group-count]')!.textContent,
-    ).toBe('2');
+    ).toBe('×2');
     expect(
       container.querySelector('[data-pyric-group-denies]')!.textContent,
-    ).toBe('1');
+    ).toBe('1 denied');
     // Collapsed by default — no member rows.
     expect(
       container.querySelector('[data-pyric-traffic-group-members]'),


### PR DESCRIPTION
Fixes the crashes and traffic noise found by driving the served demo end-to-end: the browser SyntaxError on load, dead Google sign-in, a Firestore pane crash on phantom parents, and a runaway rebuild loop that flooded Traffic with storage LIST events.

```ts
// vite.config.ts — the consumer's setup, unchanged
import { defineConfig } from 'vite';
import { pyricSandbox } from '@pyric/cli/vite';

export default defineConfig({ plugins: [pyricSandbox()] });
```

Before this change, `vite dev` with that config failed on page load, before any app code ran:

```
Uncaught SyntaxError: The requested module '/node_modules/js-md5/src/md5.js'
does not provide an export named 'md5' (at evaluator.js:12)
```

## The optimizer never saw js-md5 because the SDK is excluded from it

The plugin puts the SDK modules in `optimizeDeps.exclude` so the resolver can swap `firebase/*` per-importer at request time. Vite does not scan excluded packages for dependencies, so `js-md5` and `js-sha256` (the evaluator's `hashing.md5` / `hashing.sha256` backends) were never pre-bundled. Both are CJS-only; served raw, the named imports throw at parse time, and the failed init entry left the auth resolver uninstalled — every `signInWithPopup` then failed as a cascade. Fixed with `optimizeDeps.include: ['js-md5', 'js-sha256']`, Vite's documented remedy for CJS dependencies of excluded packages.

## Sign-in methods work out of the box until the enablement API ships

Provider enablement landed ahead of its API and UI: OAuth providers defaulted off, so a scaffolded app's Google sign-in died with `auth/operation-not-allowed`, and the error's remediation (`sandbox.setAuthProviderConfig`) is not reachable from served app code. Unknown providers now default enabled in `isProviderEnabled`; `setProviderConfig`'s dedup default flips with it so an explicit `set(..., false)` on a never-toggled provider still lands (with the old default it early-returned as a no-op and could never disable). `useAuthProviderConfig` mirrors the same default.

## A resource-index build that finds nothing still counts as built

On a project where the Home palette's index build yields no entries, `buildResourceIndex` resolved without publishing a batch, `entries` stayed `null`, and the first-build effect refired on the per-event data churn the build's own storage LIST ops cause — a self-sustaining rebuild loop measured at 13,000+ `listAll` RPCs in four seconds, salting the Traffic timeline with multiplied LIST rows. A completed build now publishes `[]` ("measured, nothing there"). The same upload-and-inspect flow that recorded ~100 traffic rows now records 5.

## Firestore phantom rows honor the snapshot surface

`makePhantomRow` synthesized `.id` + `.ref` only, but `<DocumentList>` calls `.data()` on every row for the update-highlight map — clicking a collection containing a phantom parent (a path with a subcollection but no stored document) crashed the pane with `C.data is not a function`. Phantom rows now carry `data: () => undefined`, a real snapshot's miss value.

## Traffic group rows read as what they are

A collapsed listener storm rendered as the bare token `listener-run3` — kind slug and count in adjacent unstyled spans — indistinguishable from a broken filter. Group headers now render a disclosure row ("▸ listener re-evals ×3", denial rollup in red) and expand in place.

The example app and the create-pyric TS template also ship the add-post form visible: it was marked `hidden` with nothing unhiding it, contradicting the visible-on-purpose comment (submitting while signed out is the rules-teaching denial the demo exists for).

## Risk

The provider-default flip is the behavior change to weigh: sandbox sign-in methods are now permissive by default (prod ships everything off until enabled in the console). That divergence is deliberate for the alpha — there is no enablement API/UI yet, so the off-default made OAuth unusable rather than safe. The gate machinery and explicit disables still work; tests cover both directions.

<details>
<summary>Implementation notes</summary>

- Verified end-to-end against `examples/vite-sandbox-app`: clean load, Google sign-in completes through the dev helper, posts write and render, Studio loads at `/__pyric/ui/`, the zones phantom scenario renders both row kinds without crashing, and the storage upload/inspect flow records 5 traffic events (index LIST, pane LIST, CREATE, metadata GET, blob GET).
- The two GET rows per object inspection are two real reads (metadata + blob preview), not double-counting.
- Suites: pyric auth 319 pass, studio 331 pass, ui 716 pass across dom/no-dom, cli serve 550 pass.
- The example's `firestore.rules` gains non-recursive `zones` matches used while reproducing the phantom crash (the rules linter rejects the recursive-wildcard-always-true form).

</details>
