### PR TITLE
fix(create-pyric): pin matching CLI alpha

### DIFF
--- a/packages/create-pyric/src/bin.ts
+++ b/packages/create-pyric/src/bin.ts
@@ -8,6 +8,17 @@
 
 import { parseCreateArgs } from './parse-args.js';
 import { applyDepsMode, normalizeBoolFlags, runScaffold, TEMPLATES } from './scaffold.js';
+import { readFileSync } from 'node:fs';
+
+function packageVersion(): string {
+  const metadata = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { version?: unknown };
+  if (typeof metadata.version !== 'string' || metadata.version.length === 0) {
+    throw new Error('create-pyric package metadata has no version');
+  }
+  return metadata.version;
+}
 
 async function main(): Promise<number> {
   const args = parseCreateArgs(process.argv.slice(2));
@@ -35,7 +46,8 @@ async function main(): Promise<number> {
   const nameFlag = args.flags.get('name');
   const name = typeof nameFlag === 'string' && nameFlag.length > 0 ? nameFlag : undefined;
 
-  const effectiveTemplate = applyDepsMode(TEMPLATES[templateName], 'npm', { version: null });
+  const version = packageVersion();
+  const effectiveTemplate = applyDepsMode(TEMPLATES[templateName], 'npm', { version });
 
   return runScaffold(
     {
@@ -46,6 +58,7 @@ async function main(): Promise<number> {
       json: args.flags.get('json') === true,
       depsMode: 'npm',
       effectiveTemplate,
+      pinVersion: version,
       commandLabel: 'create-pyric',
     },
   );

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { parseCreateArgs } from '../src/parse-args.js';
 import { runScaffold, applyDepsMode, TEMPLATES } from '../src/scaffold.js';
 
@@ -28,6 +33,28 @@ describe('parseCreateArgs', () => {
 });
 
 describe('runScaffold', () => {
+  it('pins registry dependencies to the create-pyric package version', () => {
+    const root = mkdtempSync(join(tmpdir(), 'create-pyric-version-'));
+    const project = join(root, 'app');
+    try {
+      const bin = fileURLToPath(new URL('../src/bin.ts', import.meta.url));
+      const run = spawnSync(process.execPath, [bin, project], { encoding: 'utf8' });
+      expect(run.status).toBe(0);
+
+      const ownPackage = JSON.parse(
+        readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+      ) as { version: string };
+      const generated = JSON.parse(
+        readFileSync(join(project, 'package.json'), 'utf8'),
+      ) as { devDependencies: Record<string, string> };
+
+      expect(generated.devDependencies['@pyric/cli']).toBe(`^${ownPackage.version}`);
+      expect(run.stdout).toContain(`from npm (^${ownPackage.version})`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('writes the Vite web scaffold by default', async () => {
     const io = bufferIo();
     const writeFn = mock(async () => undefined);


### PR DESCRIPTION
`create-pyric` now gives generated projects a resolvable dependency on the matching `@pyric/cli` alpha.

```json
{
  "devDependencies": {
    "@pyric/cli": "^0.1.0-alpha.9"
  }
}
```

## Generated projects install the published CLI alpha

The published creator emitted `"@pyric/cli": "*"`. Because the registry currently contains only prerelease versions, Bun could not resolve that wildcard and the generated project's first install failed.

The creator now reads its own package version and passes it through the existing npm dependency rewrite. Each creator release therefore scaffolds the corresponding CLI version range without another hard-coded version.

```console
$ bun install
+ @pyric/cli@0.1.0-alpha.9
372 packages installed
```

## Risk

This relies on `create-pyric` and `@pyric/cli` continuing to publish with matching versions, which is already the alpha release contract. A mismatched release would now fail visibly instead of silently selecting another CLI version.

The existing `create-pyric@0.1.0-alpha.9` tarball is immutable and remains affected. This fix must ship in the next creator release.

<details>
<summary>Implementation notes</summary>

- The regression test failed before the fix with expected `^0.1.0-alpha.9`, received `*`.
- `bun test --cwd packages/create-pyric`: 5 passed.
- `bun run --cwd packages/create-pyric build`: passed.
- A generated project completed `bun install` and installed `@pyric/cli@0.1.0-alpha.9`.

</details>
