### PR TITLE
chore(release): gate publishing on the full suite and packaging test

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -72,8 +72,7 @@ BODY_FILE="$(mktemp)"
   echo
   echo "## After merging"
   echo
-  echo '- [ ] Full gates on merged main (`bun run test`, packaging gate)'
-  echo '- [ ] Manual tarball pass (npm install in a scratch project, can-i-use exact/fuzzy/exit codes, conformance subpaths)'
+  echo '- [ ] Manual tarball pass (npm install in a scratch project, can-i-use exact/fuzzy/exit codes, conformance subpaths) — the automated gates run inside publish-alpha.sh'
   echo "- [ ] \`bash scripts/publish-alpha.sh ${V}\` from a clean merged-main checkout (OTP-capable terminal)"
   echo "- [ ] \`git tag v${V} && git push origin v${V}\` on the published commit"
   echo '- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release'

--- a/scripts/publish-alpha.sh
+++ b/scripts/publish-alpha.sh
@@ -3,7 +3,10 @@
 #
 #   bash scripts/publish-alpha.sh 0.1.0-alpha.9
 #
-# Steps: pack (full rebuild) → publish each tarball under the `alpha`
+# Steps: gates (`bun run test` + `bun run test:packaging` — publishing is
+# irreversible, so the tree proves itself first; skip with
+# PYRIC_PUBLISH_SKIP_GATES=1 only when they just ran on this exact tree)
+# → pack (full rebuild) → publish each tarball under the `alpha`
 # dist-tag → point `latest` at the same version → run `compat:check`
 # against the pinned Firebase version and move the `fb<major>.<minor>`
 # compatibility certificate tag if it is green → print the dist-tags for
@@ -38,6 +41,19 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 node "$ROOT/scripts/lib/check-publish-version.mjs" "$V" "$ROOT"
 
 cd "$ROOT"
+
+# ─── pre-publish gates ─────────────────────────────────────────────────
+# Publishing is irreversible, so the tree must prove itself before the
+# first npm publish. compat:check runs again later only to gate the fb
+# certificate tag; these two decide whether anything ships at all.
+# PYRIC_PUBLISH_SKIP_GATES=1 skips them when they demonstrably just ran
+# on this exact tree (e.g. rerunning after an OTP failure mid-publish).
+if [ "${PYRIC_PUBLISH_SKIP_GATES:-0}" != "1" ]; then
+  echo "━━━ pre-publish gates: bun run test ━━━"
+  bun run test
+  echo "━━━ pre-publish gates: bun run test:packaging ━━━"
+  bun run test:packaging
+fi
 
 bash scripts/pack-packages.sh
 


### PR DESCRIPTION
publish-alpha.sh now runs `bun run test` and `bun run test:packaging` before the first `npm publish` — previously it verified nothing pre-publish (compat:check runs only after publishing, to gate the fb tag). `PYRIC_PUBLISH_SKIP_GATES=1` skips the gates for the rerun-after-OTP-failure case where they demonstrably just passed on the same tree. The prepare-release PR checklist drops its manual gates line accordingly.