### PR TITLE
release: v0.1.0-alpha.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -112,7 +112,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -184,7 +184,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -202,7 +202,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -266,7 +266,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.10`. Merging this PR marks the release; the changelog below is the record.

## Changes since the previous release

- chore(release): gate publishing on the full suite and packaging test (6ac059fb)
- chore(release): script the ceremonial release PR (3fbbdc55)
- feat(plugin): add Firebase improvement advisor (fb47712a)
- docs(conformance): Current gaps sections use the entry row component (cd85cc56)
- docs(conformance): repoint TBD placeholder comment at #344 (818db2cd)
- docs(conformance): gaps reuse the entry row component; basis reads 'public API' (c3cec892)
- docs(conformance): block-layout gaps, full-width score bars, delete notes (bd31f584)
- docs(conformance): TBD placeholder for surfaces without a denominator (70c27803)
- docs: reference is TypeDoc only; scoreboard becomes a real table (4e7e2053)
- docs: rewrite swap, security-rules front door, and audit pages (8d9cce14)
- docs: lead with npm create pyric; update README conformance links (77ae85af)
- docs(site-docs): delete hand-written package pages; Reference leads to TypeDoc (09dd23e9)
- docs(conformance): reduce compat pages to title, bars, legend, entries (d9a89b6e)
- feat(conformance): one combined public-API score per surface (17d69485)
- feat(conformance): de-prefix evidence slugs (storage-compat, conformance-scores, ...) (8708caad)
- docs(conformance): restore coverage bars, key legends to page data (d29592ab)
- chore: remove content linting from the docs pipeline (270a9c6b)
- docs(site-docs): cut upstream-decision pages, tighten versioning page (bbd796c9)
- docs(site-docs): point reference pages at generated API, strip duplicate signatures (228f5db0)
- docs(site-docs): remove API-duplicate CLI verify reference page (412481cb)
- docs(site-docs): name Build pages after their Firebase service (268c0fc7)
- fix(site-docs): actionable errors when _generated is absent (87f2b070)
- test: make API-reference route-universe test hermetic (6e58092c)
- docs: update CONTEXT.md for the one-home docs model (de0f0919)
- chore: repoint doc-path references after content move (3f2c24e0)
- docs: import.meta.glob content machinery, nested routes, remark links (1adc9d58)
- docs: stamp plain-YAML front matter onto moved pages (17acc939)
- docs: move authored docs into site-docs content tree (f919c434)
- docs: restore service titles and newer editorial decisions (db159199)
- test(conformance): widen model-derivation hook timeouts (061b4a8a)
- fix(docs): resolve receive-messages both-added conflict (dab2853f)
- fix(site-docs): restore guide groups in the left nav (bd29ccda)
- fix(scripts): follow the shared can-i-use factory in tool parity (4b347451)
- test(site-docs): align generated gates with merged inventory (604181b7)
- refactor(site-docs): move nav labels onto their own pages (aa8550cf)
- refactor(conformance): share one pyric_can_i_use handler shape (0895a4a3)
- refactor(conformance): split projection writer from the model (ef2664b8)
- refactor(conformance): inline identity helper, name levenshtein (93911d1e)
- refactor(conformance): drop no-op developer-surface casts (02bc4298)
- refactor(conformance): collapse duplicated disposition branches (34a9a5a1)
- test: update the web scaffold contract hash for the visible add-post form (eabaff6f)
- test: align provider-config coverage with enabled-by-default (78f1029d)
- fix: default sandbox auth providers on, repair Studio storage traffic and phantom rows (d2b77415)
- fix: pre-bundle CJS hashing deps in the sandbox vite plugin (5bb32188)
- fix(create-pyric): pin matching CLI alpha (b4c617bb)
- docs: expose accurate public reference (437bfbe8)
- docs: simplify production documentation (eeab8c72)
- add Firebase Hosting site deploy script (94b2787b)
- fix alpha publish version validation (ca9faac9)
- test: remove pre-release API deny lists (a251eaec)
- docs: generate complete API reference (7b96a489)
- docs: align headings with the workflow (b0a34c95)
- docs: organize the local-to-production workflow (676e3e9c)
- ci(conformance): provision clean trust gates (fc970bd5)
- fix(conformance): fail closed on trust queries (471cc4eb)
- feat(conformance): centralize can-i-use trust data (fe472a1f)
- fix(ci): ratify and split conformance gates (1768c513)
- perf(build): avoid duplicate conformance generation (db3af060)
- perf(conformance): share one model derivation per process (001552fa)
- fix(ci): bootstrap conformance within time budget (d816a5ee)
- fix(conformance): support clean-checkout model generation (f5479d0b)
- refactor(conformance): route projections through one model (64671dc4)
- refactor(conformance): derive runtime projections from one model (c7515037)
- refactor(conformance): stop tracking disposable projections (5c3a6ea6)
- feat(conformance): expose multi-axis feature query (c2cb0f31)
- refactor(conformance): move surface policy into JSON contracts (0d1ade08)
- refactor(conformance): derive runtime node verdicts (b14bc421)
- docs: plan conformance read-model epic (0a8e574d)
- docs(conformance): show five-state distributions (#321) (2cfd843d)
- docs: explain the conformance evidence chain (#320) (e5ced888)
- Remove three-minute CI job budget (#324) (6b872aef)
- conformance: measure the public Firebase surface (#317) (062232bb)
- docs: frame Pyric as a local-to-production workflow (#316) (7663f8d9)
- fix(functions): support ESM and CommonJS sources (#315) (42403b50)
- perf(ci): remove docs gate and parallelize test lanes (#306) (2fcb8c41)
- perf(ci): restore fast Build & Test feedback (#304) (291eaa21)
- feat: publish AI and Messaging without assurance MCP tools (#305) (2824eee7)
- fix(storage): enforce project rules across serve and Studio (#302) (10cb37e0)
- Functions: run RTDB onValueCreated under pyric dev (#292) (e5e4a8b9)
- test(packaging): assert public app registry contract (#301) (71c89040)
- feat(app): mirror Firebase app registry across SharedWorker sessions (#300) (b513f1ce)
- test(ai): upstream flows into modular probes (#299) (a0a88d27)
- test(database): mine upstream flows into modular probes (R1, R4, R2, R5) (#298) (f814d277)
- test(storage): upstream flows into modular probes (#296) (908727d2)
- test(auth): upstream flows into modular probes (#293) (8b39ea5d)
- test(firestore): mine upstream integration cases into modular probes (#290) (60419758)
- feat(cli): relay RTDB creates to a Functions child (#291) (10b1e373)
- Functions: build the RTDB create execution core (#289) (aee9a3aa)
- fix(studio): dedupe search and focus timeline traffic (#288) (3baebc88)
- fix(cli): resolve Functions admin prerequisites (#287) (a6d65e1e)
- test(conformance): admit RTDB onValueCreated integration (caa461d8)
- feat(studio): foreground observed traffic metrics (6e0f9ac9)
- fix(studio): open storage root list traffic (b825a02f)
- fix(studio): preserve storage list prefix navigation (8788d364)
- test(cli): ratify packed release contract (#279) (5c907f1f)
- Integrate the final @pyric/cli contract into documentation (#278) (3d951476)
- Remove Firebase SDK runtime dependencies from @pyric/cli (#277) (2f46749a)
- feat: add create-pyric for npm create pyric (#276) (b10c3238)
- refactor(cli): remove production discovery adapters (#275) (2998ce5c)
- refactor(cli): isolate credential-free discovery (#274) (02188c1c)
- feat(studio): show pages connected to the shared sandbox worker (#273) (5fc06049)
- docs: remove retired production control-plane and legacy RTDB surfaces (#259) (309f24f0)
- refactor(cli): make bridge sandbox-only (#271) (56915a19)
- refactor(cli): rename workspace to packages/cli (#270) (205db7f6)
- Publish three conformance axes: surface coverage (total/intended) and fidelity (#269) (f74f33b4)
- fix(studio): correct auth user list semantics (#263) (cc61105f)
- docs: refresh CONTEXT.md for @pyric/cli rename and new CLI surface (#262) (59010938)
- refactor(rules): remove RTDB IR lifecycle (#255) (46cf987b)
- refactor(cli): remove Auth and registry control plane (#254) (9580213d)
- refactor(studio): defer non-core surfaces (30449b23)
- refactor(cli): remove owned Google login (#252) (1d5b6916)
- refactor(cli): remove production command surface (#250) (0573709f)
- refactor(database): remove legacy production toolkit (#251) (49c666af)
- fix(studio): record operation provenance explicitly (#245) (f0a03df9)
- refactor(database): make the mirror sandbox-only (#249) (734eca72)
- test(cli): ratify MCP tool contract (#248) (6cd72866)
- feat(cli): adopt service command hierarchy (#247) (bc80f694)
- fix(ci): audit sandbox RTDB inspection tools (4f6d0b17)
- docs(database): describe sandbox RTDB inspection (6a5c0539)
- test(cli): pin local RTDB tool inventory (e2d9f7d6)
- feat(cli): crawl local RTDB structure (903c7b86)
- feat(cli): simulate RTDB access in the sandbox (0af0638d)
- feat(database): add sandbox owner controls (46fd4985)
- feat(rules): simulate compiled RTDB rules directly (772f8656)
- refactor(cli): remove production deployment surface (a8097738)
- refactor(playground): remove production deploy surface (bf5b937f)
- refactor(credentials): make project scope a credential contract (4a1496d5)
- refactor(credentials): move token adapters under credential ownership (2581a8c7)
- docs(firestore): document package resolution boundary (036415f7)
- refactor(firestore): make mirror sandbox-only (269f7020)
- fix(studio): stop recursive playground embeds (d225f9c2)
- fix(studio): serve worker in local development (59082402)
- fix(studio): align create and selection controls (4fcd245e)
- fix(studio): make destructive actions reliable (4b6df0ed)
- refactor(ai): harden the sandbox-only package boundary (#238) (574fbc9e)
- refactor(auth): make mirror sandbox-only (#237) (546a56a4)
- refactor(ai): make mirror sandbox-only (#236) (aed92ad5)
- refactor(app): make package resolution own backend selection (#234) (ebc32fec)
- refactor: move Firestore controls to sandbox owner (#233) (5566dde1)
- feat(storage): add sandbox download URLs and remove production dispatch (#231) (efa581d8)
- test: exercise packed CLI commands (#232) (415d1013)
- fix: deny missing Firestore resource guards (#230) (3972f618)
- fix: preserve admin lens for Firestore listeners (#228) (b021d90f)
- refactor: rename tooling package to @pyric/cli (#226) (1bcfd7f7)
- test: characterize retained Pyric tooling workflows (#223) (f08404a2)
- fix: conformance claims divergence-aware + fix RTDB ancestor validation (#220) (283bedf1)
- Remove the capability-id requirement path from probes; keep the catalog (#213) (3d9ac2cc)
- Add a pull request template: lead with the code, not the report (#209) (c608a401)
- Entry-path programs exercise every init entry point; derive the critical set instead of committing it (#212) (91870e2b)
- Report conformance-gap severity on two axes: fidelity and production impact (#211) (b8c2020c)
- feat: pyric assurance (#207) (e5edb486)
- Mirror auth passwordless, linking, and reauthentication (37.6% to 82.4% surface) (#210) (888d78f6)
- Carry derived facts, not derived prose, in the assurance artifacts (#208) (31c59eca)
- Add the coverage-adversary skill: hostile review for any PR that moves a trust number (#206) (49ca9762)
- Stop synthesizing Firestore resource identity; pin production's absent-property DENY (#204) (3c9b78b7)
- Rewrite the conformance docs and CONTEXT.md; wire the assurance gate into CI (#203) (c851da81)
- Unify production-verification behind one predicate; credit the RTDB cascade semantics behaviorally (#202) (2066491b)
- Raise RTDB rules-language verified coverage from 18/56 to 52/56 (#200) (a881a0c1)
- storage: model the resource object-identity and time fields (#199) (2b053458)
- Sound construct attribution: error-absorption, receiver typing, unattributable exclusions (#198) (a2356112)
- Generate assurance engine capabilities from the conformance graph (#197) (3921cd3c)
- chore: split the worker host into per-family modules (#193) (a06f538a)
- Admit rtdb-rules as a native surface; wire the rules-rtdb captures (#196) (7f82ad35)
- auth: close the two ruled net patches from the #188 mutation review (#195) (201581c1)
- Raise production-verified rules language coverage: firestore 96.8%, storage 98.0% (#194) (56638bb9)
- chore: auth sandbox-backend concept extraction (#188) (668b4b08)
- Mirror the client app surface: registry, evidence, conformance (#191) (b493f972)
- conventions: add the pyric surface anatomy (surface-local sandbox, admin face nested under firestore) (#190) (2fc53c86)
- Probe rules-language snapshots against production (issue #185 step 5) (#192) (90207a99)
- Rules language snapshots, analyzer, and capability probe (#189) (21e77f40)
- Add entry-path conformance: CLIFF gate over one canonical initialization program per service (#187) (c300c7d4)
- Rename pack to scenario in the conformance domain; move src/rigs to src/capture (#186) (4a9f5b34)
- Admit rules as a native conformance surface; reclassify classic rtdb as native (#184) (b2c31b77)
- Split the pyric/firestore entry into per-family modules (#183) (18761539)
- Add RTDB rules oracle chain: corpus, rig, runner, replay, twin validation (#182) (ae847b80)
- Split sandbox/admin-firestore into one-concept-per-file (#181) (0d7d05c6)
- Normalize packages/conformance to the ratified structure (#180) (144328bf)
- Replace the pyric/rules accidental public API with the ratified design (#177) (b55a2eb2)
- Split the rules conformance corpus into one pack record per file (#179) (369e977d)
- Elevate the conformance system to packages/conformance with per-file surface descriptors (#178) (18bb5764)
- Reconcile the ai mirror into the conformance system (#169) (a9a342d0)
- site-docs: scope the sidebar order counter per nav group (#176) (35f5f50c)
- messaging COMPAT: replace the stale climb banner with the conformance-held, not-yet-published state (#175) (b8373925)
- Split the serve worker client into per-family modules (#174) (022988a4)
- Split studio index.css into per-feature stylesheets (#173) (34e31c66)
- Reconcile the messaging mirror into the conformance system (#170) (0c5784f8)
- Land the versioning policy, conventions doc, and the fb dist-tag certificate (#171) (b45b36f0)
- Split sandbox/types.ts into per-subsystem type files (#172) (b0702b8e)
- Conformance integrity gates in CI; rig provenance as data (#168) (102ab1c1)
- Add compat:coverage — published, regression-guarded compatibility numbers (#155) (76bed7c8)
- Add compat terminology lint and scrub registry prose (#162) (a50a1262)
- Export honest no-op batch: RTDB connection/transport, storage emulator, firestore terminate (#163) (ff642787)
- auth: implement beforeAuthStateChanged blocking sign-in gate (#160) (75211550)
- Mirror 13 RTDB and Auth exports (aliases, no-ops, user-management) (#152) (7f496cee)
- Add RTDB rules generate surface to CLI, MCP, and SDK (#153) (#156) (efcac3a7)
- Wire all 18 orphan rules-firestore observations to compat-matrix rows (#154) (3a62a2f0)
- Storage rules conformance: resolve oracle divergence, un-stale storage#96/#104 (#148) (4d87f9b8)
- Mirror firestore tier-1 cache-init + get-from-* family (#144) (#147) (0a723b67)
- Stage storage rules conformance corpus and capture machinery (#143) (67488006)
- Support or()/and() composite queries over the SharedWorker (#145) (d00ad7b2)
- Mirror Firestore offline/persistence/network family as honest no-ops (#146) (635afeab)
- Close conformance Phase 2: commit observations, pin known divergences (#142) (52f01d03)
- Add PRIORITIES.md governance: focus law + wrist-slap enforcement (#141) (16df214e)
- Make Firestore rules resource null on create in the simulator (#123) (e1f4d43b)
- rules sim: abstain on Set.difference/union/intersection (#122) (8494687d)
- Fix exists() mock type error in rules capture harness (#121) (f429b88f)
- Stage rules conformance corpus + capture runner (no captures) (#120) (c9fb8299)
- docs: fix broken npx pyric commands, Node version, and install-step gap (#119) (0c7683f8)
- test: reload persistence is real now; assert it instead of expecting failure (#118) (f2537803)
- Docs rewrite: outcome-first guide, the rules wing, modernized reference, live on pyric-site (#101) (04c72325)
- Add live update highlights to Studio data views (#117) (d5db87be)
- Persist storage rules through the verify fixture (#108) (67aa6c9f)
- Support firestore.get/exists in Storage rules evaluator (#116) (63905ae6)
- Support request.time, matches(), and metadata access in Storage rules (#113) (bb690a3e)
- Support user-defined functions in Storage rules evaluator (#111) (3f918a70)
- Support granular Storage rule verbs (get/list/create/update/delete) (#107) (07f30a37)
- Emit storage rules-enforcement events on the unified sandbox stream (#114) (cba0852b)
- Thread storage-op provenance through async dispatch (#110) (873eb302)
- Enforce storage rules in served worker mode (#106) (bd7914dd)
- Report unparseable RTDB .validate/.write/.read as unsupported, not silent pass (#115) (6e665633)
- Fix RTDB atomic multi-path update rule projection (#109) (4b898988)
- Fix Firestore rules getAfter() to see sibling writes in the same batch/transaction (#112) (cb275005)
- Fix Firestore simulator to OR-combine overlapping match blocks (#105) (b72d56e4)
- Fix RTDB rules data/newData rooting false-allow (#103) (e22ccd21)
- studio: clear sandbox reaches data under missing parents (6ca52fce)
- studio: surface missing parent documents in the Firestore browser (f114635a)
- Refresh CONTEXT.md for npm alpha launch and post-launch changes (#91) (5c3e6212)
- Package metadata: repository and bugs links for npm (#90) (4e0d940b)
- Add the publish script: pack, publish alpha, move latest, verify (#89) (b791f938)
- README logo from pyric.dev — raw.githubusercontent 404s on a private repo (#88) (916136b8)
- Ship the root README on npm for the core packages (alpha.8) (#87) (5a3e8704)
- studio: Home hero with the Pyric logo, SVG favicon (d03a8612)
- studio: render the Prototype breadcrumb in the controls bar (6dcefdba)
- playground: page-direct BYOK inference and no GitHub in the static build (f64cfba4)
- site: recompose the static build on current main + Firebase Hosting config (174d8123)
- Static site build target for Pyric Studio (74333651)
- Reconcile the persistence matrix: RTDB durable, event history hydrated (#85) (efdfb183)
- Serve embedded docs under /__pyric/ui/docs for pyric dev --ui (#81) (0d8f47cc)
- Hide the Docs nav link when docs aren't composed alongside Studio (#76) (6e96ed6b)
- Traffic rows: fixed-width service + op labels, uppercase filter pills (#75) (25c46ae2)
- Traffic rules inspector: allowed operations open inspection too (#74) (23fabdda)
- Persistence: say the durability tier out loud (#79) (290343be)
- Add three persistence guardrails against data loss in pyric dev (#82) (e00e06f0)
- Hydrate served event history from the capture file on worker boot (#78) (81d00928)
- RTDB sandbox persistence: same durability contract as Firestore/auth (#80) (afda274a)
- docs: add a centered logo hero to the README (#83) (ba00a5f7)
- docs: reframe the README around the browser narrative (#77) (e89b4dd1)
- Serve fallback favicon: neutral placeholder square instead of the flame (#73) (52f61c04)
- feat(studio): shell, data views, denial inspection, traffic metrics (#71) (e6eeb1a1)
- Collapse settings sections with children behind a disclosure (#67) (f87d1ed5)
- External-agent skills under .agents/skills; retire broad playground skills (#66) (649ed486)
- Add session breadcrumb rail to escape a trapped playground session (#65) (ef113dbf)
- Add OpenRouter OAuth (PKCE) sign-in to the playground BYOK modal (#64) (4d3ec45c)
- Docs site inside the Studio shell (packages/site-docs) (#63) (743217b2)
- Fix worker persistence: acked writes now durable before reply (#62) (2af0bf2f)
- Revert "Studio: History-API routing, the sacred shell, and Home v1 (#37)" (#59) (179db0f2)
- Real-browser soak harness for the bridge lifecycle (#58) (2389ca81)
- Studio: History-API routing, the sacred shell, and Home v1 (#37) (41989853)
- Fix duplicate snapshots and peer-slot churn on the bridge (#57) (edc7af5f)
- pyric dev: wait for the browser tab before spawning the child (#42) (eed5934b)
- Gitignore .claude/worktrees (#41) (d0c7ee32)
- Remote Firestore for pyric-admin (alpha.8) (#38) (79159fbf)
- README: narrative rewrite around the sandbox and its tooling (#39) (094c2402)
- Remove design docs from the repo and gitignore them (#40) (e7b6dde0)
- Generated tool-exposure matrix with enforced classification (#34) (e4a1cb21)
- Server adoption guide: zero-code firebase-admin on the sandbox (#36) (ada99f31)
- A dev child implies the bridge mount (#35) (4976a637)
- Remote Storage for pyric-admin (#33) (69fea52a)
- Unblock the release gate: marker export on register, CI node pin (#32) (3331aa50)
- docs: how to run the conformance system (#30) (aa42d76a)
- One canonical URL, and Studio carries the bridge (#31) (80f9c33f)
- Default the dev server port to 3473 (FIRE on a phone keypad) (#29) (8bbc7e3c)
- Mirror firebase-admin's default-app registry, evidence-first (#28) (9ff75e85)
- Adoption stack: ambient init, register loader, and the pyric dev runner (#27) (24ca2ad6)
- feat: add pyric dev (#26) (64f975a8)
- compat: add tier-1 runtime surface census (7f5abd83)
- compat: reconcile registry with the closed divergences (bb3494ac)
- database: accept queries in onChild* listeners (f59bc0dc)
- firestore: route listener deliveries through an async scheduler (4f07bb9b)
- database: enforce .validate rules on sandbox writes (bff5f849)
- Route pyric-admin RTDB + Auth through remote sandboxes (#24) (213f88d0)
- feat: Remote sandbox transport - generic worker-relay over the bridge (#23) (5190b23d)
- Replay all firestore/RTDB oracle observations; reconcile registry (#22) (89a3971d)
- Lockstep alpha versions and alpha-honest package READMEs (#21) (5097299c)
- Type the compat evidence model; add storage oracle-conformance suite (#20) (e60c4cb1)
- Upgrade inbrowser runtime packages to 0.4.1 (#19) (d8b9195d)
- Update stale public package names (#18) (8f8d15ac)
- Gate unavailable Studio AI providers (#17) (537f2d0a)
- Centralize RTDB rules input handling (#16) (8237f392)
- Serve Firebase Storage through pyric tooling (#15) (bae68c1f)
- Simplify playground agent loop (#14) (9604b6b8)
- Own object boundary parsing by feature (#13) (00bc2a81)
- Own equality semantics by domain (#10) (6fe49baa)
- Add repository context document (#12) (eeafc10f)
- Make rules lint strip collapsible (#11) (f6db6bb0)
- Add unified verify engines and RTDB replay (#8) (22f4db5c)
- Treat Firestore admin writes as verify setup (#7) (e0467a28)
- Map RTDB SDK in pyric serve (#5) (aeee54bb)
- Wire RTDB data browsers into Studio and Playground (#9) (66d2df2f)
- Make Playground Firebase native by default (#6) (1e369b1a)
- Add service-adaptable verify fixtures (#4) (8b4cc434)
- Add RTDB constraints document API (#3) (b6c926e9)
- feat: Add RTDB rules tooling bridge (#2) (25b654c0)
- feat(studio): Integrate Studio Playground tooling workbench (#1) (973c22d7)
- Add playground capstone example (0fc5e2fe)
- Make compatibility registry the source of truth (cd450d74)
- Initial public Pyric release (b555f71d)

## After merging

- [ ] Manual tarball pass (npm install in a scratch project, can-i-use exact/fuzzy/exit codes, conformance subpaths) — the automated gates run inside publish-alpha.sh
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.10` from a clean merged-main checkout (OTP-capable terminal)
- [ ] `git tag v0.1.0-alpha.10 && git push origin v0.1.0-alpha.10` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
