### PR TITLE
test(firestore): characterize the admin-compat query surface (ADR-0009 pre-C pins)

### DIFF
--- a/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-cursors.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-cursors.test.ts
@@ -1,0 +1,175 @@
+/**
+ * ADR-0009 decision 6 — characterization pins for the admin-compat query
+ * surface: cursors. Public surface only.
+ *
+ * The surface does not expose Admin-SDK-named `startAt` / `startAfter` /
+ * `endAt` / `endBefore` methods — cursor positioning goes through
+ * `startCursor(values, inclusive)` / `endCursor(values, inclusive)` and
+ * the snapshot variants `startCursorFromSnapshot` / `endCursorFromSnapshot`.
+ * Both the supported semantics and the absent names are pinned here.
+ *
+ * Notable current behaviors locked below:
+ *   - Value cursors with more values than explicit orderBy clauses throw
+ *     invalid-argument at get() time (not at cursor-construction time).
+ *   - Snapshot cursors are legal without any orderBy — they position on
+ *     the implicit document-key ordering.
+ *   - Snapshot cursors from a nonexistent doc throw not-found at
+ *     cursor-construction time (synchronously).
+ */
+import { describe, it, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import {
+  createCompatFirestore,
+  FirestoreCompatError,
+} from '../../../../../src/sandbox/firestore/admin-compat/index.js';
+
+const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if request.auth != null; }
+  }
+}`;
+
+function seededDb(documents: Record<string, Record<string, unknown>>) {
+  const env = new LocalEnvironment();
+  env.seed({ rules: RULES, documents });
+  return createCompatFirestore(env, { auth: { uid: 'alice' } });
+}
+
+async function ids(q: { get: () => Promise<{ docs: { id: string }[] }> }): Promise<string[]> {
+  return (await q.get()).docs.map((d) => d.id);
+}
+
+const TICKETS = {
+  'tickets/T-1': { priority: 1, group: 'a' },
+  'tickets/T-2': { priority: 2, group: 'a' },
+  'tickets/T-3': { priority: 3, group: 'b' },
+  'tickets/T-4': { priority: 4, group: 'b' },
+  'tickets/T-5': { priority: 5, group: 'b' },
+} as const;
+
+describe('characterization — value cursors', () => {
+  it('startCursor inclusive (startAt) vs exclusive (startAfter)', async () => {
+    const db = seededDb(TICKETS);
+    const base = () => db.collection('tickets').orderBy('priority');
+    expect(await ids(base().startCursor([3], true))).toEqual(['T-3', 'T-4', 'T-5']);
+    expect(await ids(base().startCursor([3], false))).toEqual(['T-4', 'T-5']);
+  });
+
+  it('endCursor inclusive (endAt) vs exclusive (endBefore)', async () => {
+    const db = seededDb(TICKETS);
+    const base = () => db.collection('tickets').orderBy('priority');
+    expect(await ids(base().endCursor([3], true))).toEqual(['T-1', 'T-2', 'T-3']);
+    expect(await ids(base().endCursor([3], false))).toEqual(['T-1', 'T-2']);
+  });
+
+  it('start + end compose to a window; desc reverses the frame', async () => {
+    const db = seededDb(TICKETS);
+    expect(
+      await ids(
+        db.collection('tickets').orderBy('priority').startCursor([2], true).endCursor([4], true),
+      ),
+    ).toEqual(['T-2', 'T-3', 'T-4']);
+    expect(
+      await ids(db.collection('tickets').orderBy('priority', 'desc').startCursor([4], true)),
+    ).toEqual(['T-4', 'T-3', 'T-2', 'T-1']);
+  });
+
+  it('multi-field cursors compare lexicographically across orderBy clauses', async () => {
+    const db = seededDb(TICKETS);
+    expect(
+      await ids(
+        db.collection('tickets').orderBy('group').orderBy('priority').startCursor(['b', 4], true),
+      ),
+    ).toEqual(['T-4', 'T-5']);
+  });
+
+  it('a shorter cursor than the orderBy list is a legal prefix cursor', async () => {
+    const db = seededDb(TICKETS);
+    expect(
+      await ids(
+        db.collection('tickets').orderBy('group').orderBy('priority').startCursor(['b'], true),
+      ),
+    ).toEqual(['T-3', 'T-4', 'T-5']);
+  });
+
+  it('a repeated startCursor replaces the previous one', async () => {
+    const db = seededDb(TICKETS);
+    expect(
+      await ids(
+        db.collection('tickets').orderBy('priority').startCursor([4], true).startCursor([2], true),
+      ),
+    ).toEqual(['T-2', 'T-3', 'T-4', 'T-5']);
+  });
+
+  it('more cursor values than orderBy clauses throws invalid-argument at get()', async () => {
+    const db = seededDb(TICKETS);
+    // Construction succeeds — the throw is deferred to execution.
+    const q = db.collection('tickets').orderBy('priority').startCursor([1, 'x'], true);
+    let err: unknown;
+    try { await q.get(); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(FirestoreCompatError);
+    expect((err as FirestoreCompatError).code).toBe('invalid-argument');
+  });
+
+  it('a value cursor with no orderBy at all also throws invalid-argument at get()', async () => {
+    const db = seededDb(TICKETS);
+    let err: unknown;
+    try { await db.collection('tickets').startCursor([1], true).get(); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(FirestoreCompatError);
+    expect((err as FirestoreCompatError).code).toBe('invalid-argument');
+  });
+});
+
+describe('characterization — snapshot cursors', () => {
+  it('startCursorFromSnapshot pages after a fetched doc', async () => {
+    const db = seededDb(TICKETS);
+    const page1 = await db.collection('tickets').orderBy('priority').limit(2).get();
+    expect(page1.docs.map((d) => d.id)).toEqual(['T-1', 'T-2']);
+    const last = await db.doc(`tickets/${page1.docs[1]!.id}`).get();
+    expect(
+      await ids(
+        db.collection('tickets').orderBy('priority').startCursorFromSnapshot(last, false).limit(2),
+      ),
+    ).toEqual(['T-3', 'T-4']);
+  });
+
+  it('endCursorFromSnapshot bounds the window inclusively', async () => {
+    const db = seededDb(TICKETS);
+    const snap = await db.doc('tickets/T-3').get();
+    expect(
+      await ids(db.collection('tickets').orderBy('priority').endCursorFromSnapshot(snap, true)),
+    ).toEqual(['T-1', 'T-2', 'T-3']);
+  });
+
+  it('a snapshot cursor is legal with no orderBy — positions on the doc key', async () => {
+    const db = seededDb(TICKETS);
+    const snap = await db.doc('tickets/T-2').get();
+    expect(await ids(db.collection('tickets').startCursorFromSnapshot(snap, false))).toEqual([
+      'T-3', 'T-4', 'T-5',
+    ]);
+  });
+
+  it('a snapshot cursor from a missing doc throws not-found synchronously', async () => {
+    const db = seededDb(TICKETS);
+    const missing = await db.doc('tickets/nope').get();
+    expect(missing.exists).toBe(false);
+    let err: unknown;
+    try {
+      db.collection('tickets').orderBy('priority').startCursorFromSnapshot(missing, true);
+    } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(FirestoreCompatError);
+    expect((err as FirestoreCompatError).code).toBe('not-found');
+  });
+});
+
+describe('characterization — Admin-SDK cursor names are absent', () => {
+  it('startAt / startAfter / endAt / endBefore do not exist on the surface', () => {
+    const db = seededDb(TICKETS);
+    const q = db.collection('tickets').orderBy('priority') as unknown as Record<string, unknown>;
+    expect(q.startAt).toBeUndefined();
+    expect(q.startAfter).toBeUndefined();
+    expect(q.endAt).toBeUndefined();
+    expect(q.endBefore).toBeUndefined();
+  });
+});

--- a/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-edge-shapes.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-edge-shapes.test.ts
@@ -1,0 +1,182 @@
+/**
+ * ADR-0009 decision 6 — characterization pins for the admin-compat query
+ * surface: edge cases and snapshot shape invariants. Public surface only.
+ *
+ * Notable current behaviors locked below:
+ *   - Querying a nonexistent collection returns an empty snapshot, no
+ *     error (under rules that allow the read).
+ *   - Phantom parents (docs at deep paths whose parents hold no data of
+ *     their own) never appear in query results — a collection whose only
+ *     members are phantoms queries as empty.
+ *   - Duplicate where() on the same field ANDs (intersection).
+ *   - QuerySnapshot invariants: size/empty/docs agree, every doc has
+ *     exists === true, id matches the last path segment, data() returns
+ *     the stored fields, and forEach visits docs in docs[] order.
+ */
+import { describe, it, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import { createCompatFirestore } from '../../../../../src/sandbox/firestore/admin-compat/index.js';
+
+const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if request.auth != null; }
+  }
+}`;
+
+function seededDb(documents: Record<string, Record<string, unknown>>) {
+  const env = new LocalEnvironment();
+  env.seed({ rules: RULES, documents });
+  return createCompatFirestore(env, { auth: { uid: 'alice' } });
+}
+
+async function ids(q: { get: () => Promise<{ docs: { id: string }[] }> }): Promise<string[]> {
+  return (await q.get()).docs.map((d) => d.id);
+}
+
+describe('characterization — empty and nonexistent collections', () => {
+  it('a where() matching nothing returns an empty, well-shaped snapshot', async () => {
+    const db = seededDb({ 'items/a': { n: 1 } });
+    const snap = await db.collection('items').where('n', '==', 99).get();
+    expect(snap.size).toBe(0);
+    expect(snap.empty).toBe(true);
+    expect(snap.docs).toEqual([]);
+  });
+
+  it('querying a collection that has never existed returns empty, not an error', async () => {
+    const db = seededDb({ 'items/a': { n: 1 } });
+    const snap = await db.collection('never-created').get();
+    expect(snap.size).toBe(0);
+    expect(snap.empty).toBe(true);
+  });
+
+  it('collectionGroup over a nonexistent group id returns empty', async () => {
+    const db = seededDb({ 'items/a': { n: 1 } });
+    expect((await db.collectionGroup('ghosts').get()).size).toBe(0);
+  });
+});
+
+describe('characterization — subcollections and phantom parents', () => {
+  it('subcollection queries scope to the parent doc path', async () => {
+    const db = seededDb({
+      'teams/t1/members/m1': { name: 'ana' },
+      'teams/t1/members/m2': { name: 'bo' },
+      'teams/t2/members/m3': { name: 'cy' },
+    });
+    expect(await ids(db.collection('teams/t1/members'))).toEqual(['m1', 'm2']);
+    expect(await ids(db.collection('teams/t2/members'))).toEqual(['m3']);
+  });
+
+  it('a collection whose members are only phantom parents queries as empty', async () => {
+    // Only the deep doc exists; 'teams/t1' has no data of its own.
+    const db = seededDb({ 'teams/t1/members/m1': { name: 'ana' } });
+    const snap = await db.collection('teams').get();
+    expect(snap.size).toBe(0);
+    expect(snap.empty).toBe(true);
+  });
+
+  it('a real doc among phantom siblings is the only query result', async () => {
+    const db = seededDb({
+      'teams/t1/members/m1': { name: 'ana' },
+      'teams/t2': { name: 'real team' },
+    });
+    expect(await ids(db.collection('teams'))).toEqual(['t2']);
+  });
+
+  it('queries do not recurse — direct children only, never nested docs', async () => {
+    const db = seededDb({
+      'teams/t1': { level: 'top' },
+      'teams/t1/members/m1': { level: 'nested' },
+    });
+    const snap = await db.collection('teams').get();
+    expect(snap.docs.map((d) => d.ref.path)).toEqual(['teams/t1']);
+  });
+
+  it('collectionGroup finds same-named collections at every depth', async () => {
+    const db = seededDb({
+      'members/top': { at: 'root' },
+      'teams/t1/members/m1': { at: 'nested' },
+    });
+    const snap = await db.collectionGroup('members').get();
+    expect(snap.docs.map((d) => d.ref.path)).toEqual(['members/top', 'teams/t1/members/m1']);
+  });
+});
+
+describe('characterization — duplicate where on the same field', () => {
+  it('two ranges on one field intersect', async () => {
+    const db = seededDb({
+      'nums/n1': { v: 1 },
+      'nums/n2': { v: 2 },
+      'nums/n3': { v: 3 },
+      'nums/n4': { v: 4 },
+    });
+    expect(
+      await ids(db.collection('nums').where('v', '>', 1).where('v', '<', 4)),
+    ).toEqual(['n2', 'n3']);
+  });
+
+  it('contradictory equalities on one field match nothing', async () => {
+    const db = seededDb({ 'nums/n1': { v: 1 } });
+    expect(
+      await ids(db.collection('nums').where('v', '==', 1).where('v', '==', 2)),
+    ).toEqual([]);
+  });
+
+  it('a tighter repeat of the same range narrows (AND, not replace)', async () => {
+    const db = seededDb({
+      'nums/n1': { v: 1 },
+      'nums/n2': { v: 2 },
+      'nums/n3': { v: 3 },
+    });
+    expect(
+      await ids(db.collection('nums').where('v', '>', 0).where('v', '>', 2)),
+    ).toEqual(['n3']);
+  });
+});
+
+describe('characterization — QuerySnapshot shape invariants', () => {
+  it('docs carry id, ref.path, exists=true, and data() with the stored fields', async () => {
+    const db = seededDb({
+      'books/b1': { title: 'Dune', pages: 412 },
+      'books/b2': { title: 'Emma', pages: 474 },
+    });
+    const snap = await db.collection('books').orderBy('title').get();
+    expect(snap.size).toBe(2);
+    expect(snap.empty).toBe(false);
+    expect(snap.docs.length).toBe(2);
+    const first = snap.docs[0]!;
+    expect(first.id).toBe('b1');
+    expect(first.ref.path).toBe('books/b1');
+    expect(first.exists).toBe(true);
+    expect(first.data()).toEqual({ title: 'Dune', pages: 412 });
+  });
+
+  it('forEach visits docs in docs[] order', async () => {
+    const db = seededDb({
+      'books/b2': { n: 2 },
+      'books/b1': { n: 1 },
+      'books/b3': { n: 3 },
+    });
+    const snap = await db.collection('books').orderBy('n', 'desc').get();
+    const visited: string[] = [];
+    snap.forEach((d) => visited.push(d.id));
+    expect(visited).toEqual(snap.docs.map((d) => d.id));
+    expect(visited).toEqual(['b3', 'b2', 'b1']);
+  });
+
+  it('data() returns an independent value per snapshot read of the store', async () => {
+    const db = seededDb({ 'books/b1': { pages: 1 } });
+    const snap = await db.collection('books').get();
+    // Mutating the store after the get does not change the held snapshot.
+    await db.doc('books/b1').update({ pages: 2 });
+    expect(snap.docs[0]!.data()).toEqual({ pages: 1 });
+  });
+
+  it('doc refs on query results are usable for follow-up reads', async () => {
+    const db = seededDb({ 'books/b1': { pages: 1 } });
+    const snap = await db.collection('books').get();
+    const again = await db.doc(snap.docs[0]!.ref.path).get();
+    expect(again.exists).toBe(true);
+    expect(again.data()).toEqual({ pages: 1 });
+  });
+});

--- a/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-filters.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-filters.test.ts
@@ -1,0 +1,211 @@
+/**
+ * ADR-0009 decision 6 — characterization pins for the admin-compat query
+ * surface, `where()` semantics. These pins go only through the public
+ * surface (`createCompatFirestore` → `.collection().where().get()`) so
+ * they survive PR C's move of query execution behind the engine.
+ *
+ * Behavior pinned as-is; nothing here is a spec of what "should" happen.
+ * Notable current behaviors locked below:
+ *   - Range ops (`<` `<=` `>` `>=`) only match operands of the same
+ *     canonical type — `> 0` never matches the string `'5'`.
+ *   - A missing field never matches any operator, including `== null`.
+ *   - `!=` and `not-in` require the field to exist and be non-null.
+ *   - `not-in` with a `null` in the operand list matches nothing.
+ *   - `in` with a non-array operand silently matches nothing (no throw).
+ */
+import { describe, it, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import { createCompatFirestore } from '../../../../../src/sandbox/firestore/admin-compat/index.js';
+
+const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if request.auth != null; }
+  }
+}`;
+
+function seededDb(documents: Record<string, Record<string, unknown>>) {
+  const env = new LocalEnvironment();
+  env.seed({ rules: RULES, documents });
+  return createCompatFirestore(env, { auth: { uid: 'alice' } });
+}
+
+/** Result doc ids, in returned order. */
+async function ids(q: { get: () => Promise<{ docs: { id: string }[] }> }): Promise<string[]> {
+  return (await q.get()).docs.map((d) => d.id);
+}
+
+// Mixed-type fixture used by most op pins. Seed order is the map order.
+const MIXED = {
+  'items/a': { n: 1, s: 'x' },
+  'items/b': { n: 2 },
+  'items/c': { n: '5' },
+  'items/d': { n: null },
+  'items/e': {},
+} as const;
+
+describe('characterization — where() equality ops', () => {
+  it('== matches same-type values only (5 does not match "5")', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', '==', 2))).toEqual(['b']);
+    expect(await ids(db.collection('items').where('n', '==', '5'))).toEqual(['c']);
+    expect(await ids(db.collection('items').where('n', '==', 5))).toEqual([]);
+  });
+
+  it('== null matches an explicit null but not a missing field', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', '==', null))).toEqual(['d']);
+  });
+
+  it('missing field never matches ==', async () => {
+    const db = seededDb(MIXED);
+    // Only items/a has `s` — everything else is missing the field.
+    expect(await ids(db.collection('items').where('s', '==', 'x'))).toEqual(['a']);
+    expect(await ids(db.collection('items').where('s', '==', null))).toEqual([]);
+  });
+
+  it('== on object values is deep, key-order-independent equality', async () => {
+    const db = seededDb({
+      'profiles/p1': { prefs: { role: 'admin', active: true } },
+      'profiles/p2': { prefs: { role: 'member', active: true } },
+    });
+    expect(
+      await ids(db.collection('profiles').where('prefs', '==', { active: true, role: 'admin' })),
+    ).toEqual(['p1']);
+  });
+
+  it('!= requires the field to exist and be non-null, then differ (cross-type differs)', async () => {
+    const db = seededDb(MIXED);
+    // d (null) and e (missing) are excluded; the string '5' counts as != 1.
+    expect(await ids(db.collection('items').where('n', '!=', 1))).toEqual(['b', 'c']);
+  });
+
+  it('!= null matches nothing (null-valued and missing fields both excluded)', async () => {
+    const db = seededDb(MIXED);
+    // != demands value !== null before comparing, so even non-null docs
+    // pass the "differs from null" check — pin the actual output.
+    expect(await ids(db.collection('items').where('n', '!=', null))).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('characterization — where() range ops', () => {
+  it('> matches only same-type values (numbers vs strings never compare)', async () => {
+    const db = seededDb(MIXED);
+    // '5' (string), null, and missing are all excluded from `> 0`. The
+    // inequality also imposes an implicit orderBy on `n` (asc).
+    expect(await ids(db.collection('items').where('n', '>', 0))).toEqual(['a', 'b']);
+    expect(await ids(db.collection('items').where('n', '>', ''))).toEqual(['c']);
+  });
+
+  it('>= and <= are inclusive; < and > are exclusive', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', '>=', 2))).toEqual(['b']);
+    expect(await ids(db.collection('items').where('n', '>', 2))).toEqual([]);
+    expect(await ids(db.collection('items').where('n', '<=', 1))).toEqual(['a']);
+    expect(await ids(db.collection('items').where('n', '<', 1))).toEqual([]);
+  });
+
+  it('range ops never match null or missing fields', async () => {
+    const db = seededDb(MIXED);
+    // null has its own type rank, so `<` against a number excludes it.
+    expect(await ids(db.collection('items').where('n', '<', 100))).toEqual(['a', 'b']);
+  });
+
+  it('string ranges compare lexicographically within the string type', async () => {
+    const db = seededDb({
+      'words/w1': { t: 'apple' },
+      'words/w2': { t: 'banana' },
+      'words/w3': { t: 'cherry' },
+    });
+    expect(await ids(db.collection('words').where('t', '>', 'apple'))).toEqual(['w2', 'w3']);
+  });
+});
+
+describe('characterization — where() in / not-in', () => {
+  it('in matches any listed value, same-type equality per element', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'in', [1, '5']))).toEqual(['a', 'c']);
+    expect(await ids(db.collection('items').where('n', 'in', [5]))).toEqual([]);
+  });
+
+  it('in with null in the list matches null-valued fields', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'in', [null]))).toEqual(['d']);
+  });
+
+  it('in with an empty array matches nothing', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'in', []))).toEqual([]);
+  });
+
+  it('in with a non-array operand silently matches nothing (no throw)', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'in', 1))).toEqual([]);
+  });
+
+  it('not-in excludes listed values; null-valued and missing fields never match', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'not-in', [1]))).toEqual(['b', 'c']);
+  });
+
+  it('not-in with null anywhere in the operand list matches nothing', async () => {
+    const db = seededDb(MIXED);
+    expect(await ids(db.collection('items').where('n', 'not-in', [1, null]))).toEqual([]);
+  });
+});
+
+describe('characterization — where() array-contains(-any)', () => {
+  const TAGGED = {
+    'posts/p1': { tags: ['a', 'b'] },
+    'posts/p2': { tags: ['b', 'c'] },
+    'posts/p3': { tags: [] },
+    'posts/p4': { tags: 'a' },
+    'posts/p5': {},
+  } as const;
+
+  it('array-contains matches docs whose array field holds the value', async () => {
+    const db = seededDb(TAGGED);
+    expect(await ids(db.collection('posts').where('tags', 'array-contains', 'b'))).toEqual(['p1', 'p2']);
+  });
+
+  it('array-contains never matches non-array or missing fields', async () => {
+    const db = seededDb(TAGGED);
+    // p4 has the scalar 'a', not an array containing 'a'.
+    expect(await ids(db.collection('posts').where('tags', 'array-contains', 'a'))).toEqual(['p1']);
+  });
+
+  it('array-contains-any matches on any overlap; non-array operand matches nothing', async () => {
+    const db = seededDb(TAGGED);
+    expect(
+      await ids(db.collection('posts').where('tags', 'array-contains-any', ['a', 'c'])),
+    ).toEqual(['p1', 'p2']);
+    expect(
+      await ids(db.collection('posts').where('tags', 'array-contains-any', 'a')),
+    ).toEqual([]);
+  });
+});
+
+describe('characterization — multiple where() composition', () => {
+  it('chained where() calls AND together', async () => {
+    const db = seededDb({
+      'orders/o1': { region: 'us', total: 10 },
+      'orders/o2': { region: 'us', total: 50 },
+      'orders/o3': { region: 'eu', total: 50 },
+    });
+    expect(
+      await ids(db.collection('orders').where('region', '==', 'us').where('total', '>=', 50)),
+    ).toEqual(['o2']);
+  });
+
+  it('equality + range on different fields compose; range adds implicit order', async () => {
+    const db = seededDb({
+      'orders/o1': { region: 'us', total: 30 },
+      'orders/o2': { region: 'us', total: 10 },
+      'orders/o3': { region: 'us', total: 20 },
+    });
+    // Range on `total` sorts the result by total asc (implicit orderBy).
+    expect(
+      await ids(db.collection('orders').where('region', '==', 'us').where('total', '>', 5)),
+    ).toEqual(['o2', 'o3', 'o1']);
+  });
+});

--- a/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-order-limit.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-order-limit.test.ts
@@ -1,0 +1,194 @@
+/**
+ * ADR-0009 decision 6 — characterization pins for the admin-compat query
+ * surface: orderBy / limit / limitToLast, plus the shape of what is not
+ * supported (offset). Public surface only.
+ *
+ * Notable current behaviors locked below:
+ *   - With no orderBy, no cursor, and no inequality filter, results come
+ *     back in seed/insertion order (the raw candidate scan order).
+ *   - orderBy excludes any doc missing the ordered field.
+ *   - Mixed-type orderBy sorts by canonical type rank: null before
+ *     numbers before strings.
+ *   - Equal orderBy values tie-break on the document key (implicit
+ *     `__name__` clause).
+ *   - `offset` does not exist on the query surface at all.
+ */
+import { describe, it, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import {
+  createCompatFirestore,
+  FirestoreCompatError,
+} from '../../../../../src/sandbox/firestore/admin-compat/index.js';
+
+const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if request.auth != null; }
+  }
+}`;
+
+function seededDb(documents: Record<string, Record<string, unknown>>) {
+  const env = new LocalEnvironment();
+  env.seed({ rules: RULES, documents });
+  return createCompatFirestore(env, { auth: { uid: 'alice' } });
+}
+
+async function ids(q: { get: () => Promise<{ docs: { id: string }[] }> }): Promise<string[]> {
+  return (await q.get()).docs.map((d) => d.id);
+}
+
+// Deliberately seeded out of both id order and value order.
+const TICKETS = {
+  'tickets/T-3': { priority: 3, group: 'b' },
+  'tickets/T-1': { priority: 1, group: 'a' },
+  'tickets/T-5': { priority: 5, group: 'a' },
+  'tickets/T-2': { priority: 2, group: 'b' },
+  'tickets/T-4': { priority: 4, group: 'a' },
+} as const;
+
+describe('characterization — implicit ordering (no orderBy)', () => {
+  it('a bare collection get returns seed/insertion order, not id order', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets'))).toEqual(['T-3', 'T-1', 'T-5', 'T-2', 'T-4']);
+  });
+
+  it('later writes append after seeded docs in the bare scan order', async () => {
+    const db = seededDb(TICKETS);
+    await db.doc('tickets/T-0').set({ priority: 0, group: 'c' });
+    expect(await ids(db.collection('tickets'))).toEqual([
+      'T-3', 'T-1', 'T-5', 'T-2', 'T-4', 'T-0',
+    ]);
+  });
+
+  it('an equality-only where preserves the bare scan order', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').where('group', '==', 'a'))).toEqual([
+      'T-1', 'T-5', 'T-4',
+    ]);
+  });
+
+  it('an inequality where imposes an implicit orderBy on the filtered field', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').where('priority', '>=', 2))).toEqual([
+      'T-2', 'T-3', 'T-4', 'T-5',
+    ]);
+  });
+});
+
+describe('characterization — orderBy', () => {
+  it('orderBy defaults to ascending', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').orderBy('priority'))).toEqual([
+      'T-1', 'T-2', 'T-3', 'T-4', 'T-5',
+    ]);
+  });
+
+  it('orderBy desc reverses', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').orderBy('priority', 'desc'))).toEqual([
+      'T-5', 'T-4', 'T-3', 'T-2', 'T-1',
+    ]);
+  });
+
+  it('multi-key orderBy sorts lexicographically across keys', async () => {
+    const db = seededDb(TICKETS);
+    expect(
+      await ids(db.collection('tickets').orderBy('group').orderBy('priority', 'desc')),
+    ).toEqual(['T-5', 'T-4', 'T-1', 'T-3', 'T-2']);
+  });
+
+  it('equal orderBy values tie-break on the document key ascending', async () => {
+    const db = seededDb({
+      'rows/c': { v: 1 },
+      'rows/a': { v: 1 },
+      'rows/b': { v: 1 },
+    });
+    expect(await ids(db.collection('rows').orderBy('v'))).toEqual(['a', 'b', 'c']);
+  });
+
+  it('orderBy excludes docs missing the ordered field', async () => {
+    const db = seededDb({
+      'rows/a': { v: 2 },
+      'rows/b': {},
+      'rows/c': { v: 1 },
+    });
+    expect(await ids(db.collection('rows').orderBy('v'))).toEqual(['c', 'a']);
+  });
+
+  it('mixed-type orderBy ranks null before numbers before strings', async () => {
+    const db = seededDb({
+      'rows/a': { v: 'x' },
+      'rows/b': { v: 2 },
+      'rows/c': { v: null },
+    });
+    expect(await ids(db.collection('rows').orderBy('v'))).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('characterization — limit / limitToLast', () => {
+  it('limit slices the head of the ordered result', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').orderBy('priority').limit(2))).toEqual([
+      'T-1', 'T-2',
+    ]);
+  });
+
+  it('limit without orderBy slices the bare scan order', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').limit(2))).toEqual(['T-3', 'T-1']);
+  });
+
+  it('limit(0) returns an empty snapshot', async () => {
+    const db = seededDb(TICKETS);
+    const snap = await db.collection('tickets').limit(0).get();
+    expect(snap.size).toBe(0);
+    expect(snap.empty).toBe(true);
+  });
+
+  it('limit larger than the result set returns everything', async () => {
+    const db = seededDb(TICKETS);
+    expect((await db.collection('tickets').limit(99).get()).size).toBe(5);
+  });
+
+  it('a later limit replaces an earlier one', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').orderBy('priority').limit(4).limit(1))).toEqual([
+      'T-1',
+    ]);
+  });
+
+  it('limitToLast takes the tail but returns it in orderBy direction', async () => {
+    const db = seededDb(TICKETS);
+    expect(await ids(db.collection('tickets').orderBy('priority').limitToLast(2))).toEqual([
+      'T-4', 'T-5',
+    ]);
+  });
+
+  it('limitToLast without orderBy throws invalid-argument at get()', async () => {
+    const db = seededDb(TICKETS);
+    let err: unknown;
+    try {
+      await db.collection('tickets').limitToLast(2).get();
+    } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(FirestoreCompatError);
+    expect((err as FirestoreCompatError).code).toBe('invalid-argument');
+  });
+});
+
+describe('characterization — unsupported surface members', () => {
+  it('offset is not a method on Query or CollectionReference', () => {
+    const db = seededDb(TICKETS);
+    const coll = db.collection('tickets') as unknown as Record<string, unknown>;
+    expect(coll.offset).toBeUndefined();
+    const query = db.collection('tickets').where('priority', '>', 1) as unknown as Record<string, unknown>;
+    expect(query.offset).toBeUndefined();
+  });
+
+  it('select() and count() are not methods on the query surface', () => {
+    const db = seededDb(TICKETS);
+    const coll = db.collection('tickets') as unknown as Record<string, unknown>;
+    expect(coll.select).toBeUndefined();
+    // Counting goes through aggregate({ alias: { kind: 'count' } }) instead.
+    expect(coll.count).toBeUndefined();
+  });
+});

--- a/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-rules-interaction.test.ts
+++ b/packages/pyric/test/sandbox/firestore/admin-compat/characterization/query-rules-interaction.test.ts
@@ -1,0 +1,189 @@
+/**
+ * ADR-0009 decision 6 — characterization pins for how admin-compat
+ * queries interact with security rules. Public surface only.
+ *
+ * Current behavior locked here (contrary to the "admin always bypasses"
+ * guess): a default `createCompatFirestore` handle enforces rules — a
+ * closed ruleset blocks queries with permission-denied. The rules bypass
+ * is opt-in via `{ bypassRules: true }`, and with it a closed ruleset
+ * must not block admin queries.
+ *
+ * Also pinned: the query-proof model ("rules are not filters") — a
+ * data-dependent list rule that the query's equality constraints prove is
+ * allowed; an unprovable query is denied whole, never silently filtered.
+ * And the aggregate surface (count / sum / average via `aggregate()`).
+ */
+import { describe, it, expect } from 'bun:test';
+import { LocalEnvironment } from 'pyric/sandbox/internal';
+import {
+  createCompatFirestore,
+  FirestoreCompatError,
+} from '../../../../../src/sandbox/firestore/admin-compat/index.js';
+
+const DENY_ALL = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /{document=**} { allow read, write: if false; }
+  }
+}`;
+
+const AUTH_ONLY = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /widgets/{id} { allow read, write: if request.auth != null; }
+  }
+}`;
+
+const PUBLIC_ONLY = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /notes/{id} { allow read, write: if resource.data.public == true; }
+  }
+}`;
+
+const WIDGETS = {
+  'widgets/W-1': { name: 'first', qty: 1 },
+  'widgets/W-2': { name: 'second', qty: 2 },
+} as const;
+
+function seededEnv(rules: string, documents: Record<string, Record<string, unknown>>) {
+  const env = new LocalEnvironment();
+  env.seed({ rules, documents });
+  return env;
+}
+
+async function code(p: Promise<unknown>): Promise<string | undefined> {
+  try { await p; } catch (e) {
+    expect(e).toBeInstanceOf(FirestoreCompatError);
+    return (e as FirestoreCompatError).code;
+  }
+  return undefined;
+}
+
+describe('characterization — default handle enforces rules', () => {
+  it('deny-all rules block a query with permission-denied', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), { auth: { uid: 'alice' } });
+    expect(await code(db.collection('widgets').get())).toBe('permission-denied');
+  });
+
+  it('deny-all rules block aggregate() with permission-denied', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), { auth: { uid: 'alice' } });
+    expect(
+      await code(db.collection('widgets').aggregate({ count: { kind: 'count' } })),
+    ).toBe('permission-denied');
+  });
+
+  it('auth-gated rules deny an unauthenticated handle, allow an authenticated one', async () => {
+    const anon = createCompatFirestore(seededEnv(AUTH_ONLY, WIDGETS), { auth: null });
+    expect(await code(anon.collection('widgets').get())).toBe('permission-denied');
+    const alice = createCompatFirestore(seededEnv(AUTH_ONLY, WIDGETS), { auth: { uid: 'alice' } });
+    expect((await alice.collection('widgets').get()).size).toBe(2);
+  });
+
+  it('per-op auth override on get() beats the handle default', async () => {
+    const env = seededEnv(AUTH_ONLY, WIDGETS);
+    const anon = createCompatFirestore(env, { auth: null });
+    // Same handle: denied with its default auth, allowed with an override.
+    expect(await code(anon.collection('widgets').get())).toBe('permission-denied');
+    const snap = await anon.collection('widgets').get({ auth: { uid: 'bob' } });
+    expect(snap.size).toBe(2);
+  });
+});
+
+describe('characterization — rules are not filters (query proof)', () => {
+  const NOTES = {
+    'notes/n1': { public: true, t: 'a' },
+    'notes/n2': { public: false, t: 'b' },
+    'notes/n3': { public: true, t: 'c' },
+  } as const;
+
+  it('a bare query under a data-dependent rule is denied whole', async () => {
+    const db = createCompatFirestore(seededEnv(PUBLIC_ONLY, NOTES), { auth: { uid: 'alice' } });
+    expect(await code(db.collection('notes').get())).toBe('permission-denied');
+  });
+
+  it('a query whose equality discharges the rule predicate is allowed', async () => {
+    const db = createCompatFirestore(seededEnv(PUBLIC_ONLY, NOTES), { auth: { uid: 'alice' } });
+    const snap = await db.collection('notes').where('public', '==', true).get();
+    expect(snap.docs.map((d) => d.id)).toEqual(['n1', 'n3']);
+  });
+
+  it('an unprovable query is denied whole — never silently filtered', async () => {
+    const db = createCompatFirestore(seededEnv(PUBLIC_ONLY, NOTES), { auth: { uid: 'alice' } });
+    // t == 'a' matches only a public doc, but the constraint does not
+    // prove the rule, so the whole query is rejected.
+    expect(await code(db.collection('notes').where('t', '==', 'a').get())).toBe('permission-denied');
+  });
+});
+
+describe('characterization — bypassRules admin lens', () => {
+  it('a closed ruleset does not block a bypassRules handle', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), {
+      auth: { uid: 'alice' },
+      bypassRules: true,
+    });
+    const snap = await db.collection('widgets').get();
+    expect(snap.docs.map((d) => d.id)).toEqual(['W-1', 'W-2']);
+  });
+
+  it('chained where/orderBy/limit keep the bypass', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), {
+      auth: null,
+      bypassRules: true,
+    });
+    const snap = await db
+      .collection('widgets')
+      .where('qty', '>', 0)
+      .orderBy('qty', 'desc')
+      .limit(1)
+      .get();
+    expect(snap.docs.map((d) => d.id)).toEqual(['W-2']);
+  });
+
+  it('collectionGroup queries keep the bypass', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), {
+      auth: null,
+      bypassRules: true,
+    });
+    const snap = await db.collectionGroup('widgets').get();
+    expect(snap.docs.map((d) => d.ref.path)).toEqual(['widgets/W-1', 'widgets/W-2']);
+  });
+
+  it('aggregate() works under deny-all with the bypass', async () => {
+    const db = createCompatFirestore(seededEnv(DENY_ALL, WIDGETS), {
+      auth: null,
+      bypassRules: true,
+    });
+    const agg = await db.collection('widgets').aggregate({
+      c: { kind: 'count' },
+      total: { kind: 'sum', field: 'qty' },
+      avg: { kind: 'average', field: 'qty' },
+    });
+    expect(agg.data()).toEqual({ c: 2, total: 3, avg: 1.5 });
+  });
+});
+
+describe('characterization — aggregate surface shape', () => {
+  it('count/sum over an empty set is 0; average is null', async () => {
+    const db = createCompatFirestore(seededEnv(AUTH_ONLY, WIDGETS), { auth: { uid: 'alice' } });
+    const agg = await db
+      .collection('widgets')
+      .where('qty', '>', 100)
+      .aggregate({ c: { kind: 'count' }, s: { kind: 'sum', field: 'qty' }, a: { kind: 'average', field: 'qty' } });
+    expect(agg.data()).toEqual({ c: 0, s: 0, a: null });
+  });
+
+  it('sum/average silently skip non-numeric values', async () => {
+    const env = seededEnv(AUTH_ONLY, {
+      'widgets/W-1': { qty: 2 },
+      'widgets/W-2': { qty: 'lots' },
+      'widgets/W-3': { qty: 4 },
+    });
+    const db = createCompatFirestore(env, { auth: { uid: 'alice' } });
+    const agg = await db
+      .collection('widgets')
+      .aggregate({ c: { kind: 'count' }, s: { kind: 'sum', field: 'qty' }, a: { kind: 'average', field: 'qty' } });
+    // count counts all matched docs; sum/average only the numeric ones.
+    expect(agg.data()).toEqual({ c: 3, s: 6, a: 3 });
+  });
+});


### PR DESCRIPTION
```ts
// 81 pins through the public pyric/sandbox/admin-compat surface, e.g. the
// rules contract nobody had written down:
const db = createCompatFirestore(env);                          // rules ENFORCED
await expect(db.collection('users').get()).rejects.toMatchObject({ code: 'permission-denied' });
const admin = createCompatFirestore(env, { bypassRules: true }); // bypass is OPT-IN
await admin.collection('users').get();                           // closed rules don't block
```

Pure test addition on current main (`v0.1.0-alpha.10`) — no source changes. These are the characterization pins ADR-0009 decision 6 requires before PR C may absorb query execution behind the engine (`runQuery`). They drive only the public admin-compat surface, never `readQueryCandidates`/`scanDocuments` (the internals PR C deletes), so they must survive that restructuring unchanged. They also gate #322's query instrumentation in the meantime.

## What the pins established

- Admin-compat does **not** bypass rules by default — bypass is opt-in (`{ bypassRules: true }`); both directions pinned, along with query-proof "rules are not filters" whole-query denial.
- Filter edges: `!= null` matches every non-null doc; `in` with a non-array operand silently returns empty; missing fields match nothing, including `== null`; range ops are same-canonical-type only.
- Ordering: bare scans return seed/insertion order (not id order); an inequality imposes implicit orderBy on its field; `orderBy` silently excludes docs missing the field; null < number < string; doc-key tie-break.
- Cursors: value-cursor arity errors throw at `get()` time; snapshot-cursor from a missing doc throws `not-found` at construction. `offset`/`select`/Admin-SDK cursor names don't exist on this surface (pinned as absent).
- Aggregates: empty set → `count 0, sum 0, average null`; sum/average skip non-numerics while count counts them. Phantom parents never surface in query results.

## Risk

None to runtime — tests only. The pins freeze current behavior deliberately; if any pinned edge is later judged a bug, its fix updates the pin in the same reviewed change.

<details>
<summary>Verification</summary>

- New suite: 81 pass / 0 fail (126 expects) across 5 files under `test/sandbox/firestore/admin-compat/characterization/`.
- Full admin-compat suite: 221 pass / 0 fail (baseline 140 — no regressions).
- `bun run typecheck` clean; tests additionally strict-checked directly with tsc (repo tsconfig excludes `test/`).

</details>