### PR TITLE
fix(ci): full check-sets must run the documentation build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
     name: Authored documentation
     runs-on: ubuntu-latest
     needs: plan
-    if: needs.plan.outputs.predicted-check-set == 'docs-only'
+    if: contains(fromJSON('["docs-only", "full"]'), needs.plan.outputs.predicted-check-set)
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -21,8 +21,16 @@ const browserJobEnd = workflow.indexOf('\n  packaging:', browserJobStart);
 const browserJob = workflow.slice(browserJobStart, browserJobEnd);
 
 describe('served app conformance merge gate', () => {
-  test('required CI splits CLI and library tests without building documentation', () => {
+  test('required CI splits CLI and library tests; the docs build runs as its own job', () => {
     expect(workflow).not.toContain('\n  documentation:');
+    // The test lanes never build docs (--skip-docs below), but the
+    // documentation build itself must be selected for BOTH docs-only and
+    // full runs — a full PR must not be able to break `site-docs build`
+    // undetected (regression: the selector originally gated it to
+    // docs-only, so full runs skipped the docs build entirely).
+    expect(workflow).toContain(
+      `contains(fromJSON('["docs-only", "full"]'), needs.plan.outputs.predicted-check-set)`,
+    );
     expect(mainJobStart).toBeGreaterThanOrEqual(0);
     expect(mainJobEnd).toBeGreaterThan(mainJobStart);
     expect(mainJob).toContain('bash scripts/build.sh --skip-docs');

--- a/scripts/ci/required.test.ts
+++ b/scripts/ci/required.test.ts
@@ -7,7 +7,7 @@ const success = {
   'browser-conformance': 'success',
   'playground-caniuse': 'success',
   'release-contract': 'skipped',
-  'docs-only': 'skipped',
+  'docs-only': 'success',
   packaging: 'skipped',
   'install-matrix': 'skipped',
 };
@@ -18,7 +18,7 @@ describe('required CI result', () => {
     expect(requiredFailures({
       checkSet: 'release-only',
       requirePackaging: false,
-      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'playground-caniuse': 'skipped', 'release-contract': 'success' },
+      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'playground-caniuse': 'skipped', 'docs-only': 'skipped', 'release-contract': 'success' },
     })).toEqual([]);
   });
 
@@ -40,4 +40,12 @@ describe('required CI result', () => {
       results: success,
     })).toEqual(['packaging: skipped', 'install-matrix: skipped']);
   });
+});
+
+test('full runs require the documentation build (regression: docs gap)', () => {
+  expect(requiredFailures({
+    checkSet: 'full',
+    requirePackaging: false,
+    results: { 'build-and-test': 'success', 'library-tests': 'success', 'browser-conformance': 'success', 'playground-caniuse': 'success', 'docs-only': 'skipped' },
+  })).toEqual(['docs-only: skipped']);
 });

--- a/scripts/ci/required.ts
+++ b/scripts/ci/required.ts
@@ -9,7 +9,7 @@ interface RequiredInput {
 }
 
 const CHECK_SET_JOBS: Record<PrCheckSet, readonly string[]> = {
-  full: ['build-and-test', 'library-tests', 'browser-conformance', 'playground-caniuse'],
+  full: ['build-and-test', 'library-tests', 'browser-conformance', 'playground-caniuse', 'docs-only'],
   'release-only': ['release-contract'],
   'docs-only': ['docs-only'],
 };


### PR DESCRIPTION
```yaml
# .github/workflows/build.yml — the only job that runs `site-docs build`:
  docs-only:
    name: Authored documentation
-   if: needs.plan.outputs.predicted-check-set == 'docs-only'
+   if: contains(fromJSON('["docs-only", "full"]'), needs.plan.outputs.predicted-check-set)
```

A full PR could break `bun run --cwd packages/site-docs build` undetected: the selector gated the sole docs-build job to `docs-only` check-sets, and the test lanes deliberately build with `--skip-docs`. Found while merging the current PR train.

## The aggregate now requires it

`scripts/ci/required.ts` adds `docs-only` to the full set's required jobs, so `CI / required` fails a full run whose docs job skipped or failed. A new regression test pins exactly that (`requiredFailures` → `['docs-only: skipped']`), and the workflow gate test (`app-conformance-gate.test.ts`) positively asserts the selection condition instead of only asserting the test lanes skip docs.

## Risk

- Full PRs gain one parallel ~2-3 min job (checkout + `--packages-only` build + Astro build). It does not extend the critical path (runs alongside the unit lanes) but does add runner minutes to every full PR.
- `release-only` runs still skip the docs build — unchanged, and the updated fixture makes that explicit.

<details>
<summary>Verification</summary>

- `bun test scripts/ci/` — 18 pass / 0 fail (includes the new regression test).
- `packages/cli` gate test: 3 pass / 0 fail with the positive assertion.
- Chain-head `site-docs build` validation running separately; reported in the merge-queue thread.

</details>