### PR TITLE
docs: document the Ollama engine; use the real vite plugin export

### DIFF
--- a/packages/site-docs/src/content/build/ai-logic.md
+++ b/packages/site-docs/src/content/build/ai-logic.md
@@ -36,7 +36,23 @@ script(ai, [
   },
 ]);
 ```
-Keep scripted setup outside application code that ships. Pyric also supports an OpenAI-compatible local engine through the `engine` option and the `pyric dev` AI proxy. This can connect the same Firebase AI Logic calls to Ollama or another local server. The [AI chat example](https://github.com/davideast/pyric/tree/main/examples/ai-chat) shows both engines with streaming, chat history, and function calling.
+Keep scripted setup outside application code that ships.
+
+## Answer with a real local model (Ollama)
+
+The sandbox can answer through any OpenAI-compatible server — a local [Ollama](https://ollama.com), llama.cpp, anything speaking `/v1/chat/completions` — while your application keeps making unchanged Firebase AI Logic calls. Pass the `engine` option to `getAI`:
+
+```ts
+import { getAI } from 'pyric/ai';
+
+const ai = getAI(app, {
+  engine: { kind: 'openai', model: 'llama3.2' },
+});
+```
+
+`engine` is a pyric extension that only the sandbox reads — upstream `firebase/ai` ignores unknown options, so the same call is production-safe. With no `baseUrl`, answering routes through `pyric dev`'s same-origin AI proxy at `/__pyric/ai-proxy`, which forwards to `http://localhost:11434/v1` — a locally running Ollama works with zero CORS setup, no `OLLAMA_ORIGINS`, nothing. Point the proxy at a different server with the `PYRIC_AI_PROXY_UPSTREAM` environment variable on `pyric dev`.
+
+The translation is wire-level: Gemini-shaped requests in, OpenAI-compatible upstream out, Gemini-shaped responses back — so streaming, chat history, and function calling flow through. The [AI chat example](https://github.com/davideast/pyric/tree/main/examples/ai-chat) runs both engines side by side.
 
 Local engines do not reproduce model quality, safety policy, latency, quotas, billing, or service availability. Verify model-dependent behavior against the production backend before release.
 

--- a/packages/site-docs/src/content/get-started/how-the-swap-works.md
+++ b/packages/site-docs/src/content/get-started/how-the-swap-works.md
@@ -25,8 +25,8 @@ Using Vite instead? The plugin does the same swap one layer earlier — at modul
 
 ```ts
 // vite.config.ts
-import { pyric } from '@pyric/cli/vite';
-export default { plugins: [pyric()] };
+import { pyricSandbox } from '@pyric/cli/vite';
+export default { plugins: [pyricSandbox()] };
 ```
 
 Because resolution happens before bundling, the swap reaches your dependencies too. A library that imports `firebase/firestore` on your behalf lands on the sandbox exactly like your own code.


### PR DESCRIPTION
Documents the Ollama/OpenAI-compatible answer engine on `build/ai-logic`, and corrects `how-the-swap-works` to the Vite plugin export that actually ships.

```ts
// What the ai-logic page now teaches — unchanged firebase/ai calls,
// answered by a locally running Ollama:
import { getAI } from 'pyric/ai';

const ai = getAI(app, {
  engine: { kind: 'openai', model: 'llama3.2' },
});
// With no baseUrl, answering routes through pyric dev's same-origin proxy
// (/__pyric/ai-proxy → http://localhost:11434/v1) — zero CORS setup, no
// OLLAMA_ORIGINS. Point it elsewhere with PYRIC_AI_PROXY_UPSTREAM.
```

## The engine option was one drive-by sentence; it is now a section

The page previously mentioned "an OpenAI-compatible local engine" in passing with no code, no proxy explanation, and no env var. The new section shows the `getAI` call, states that `engine` is a pyric extension upstream `firebase/ai` ignores (so the call is production-safe), explains the zero-CORS proxy default, and notes the translation is wire-level — Gemini-shaped requests to any `/v1/chat/completions` server and back, so streaming, chat history, and function calling flow through.

## how-the-swap-works showed an import that does not exist

```ts
// before (fails at build time):
import { pyric } from '@pyric/cli/vite';
// after (what ships today):
import { pyricSandbox } from '@pyric/cli/vite';
```

`pyric()` was aspirational — the right name for the API, but not the exported one. #357 plans the rename (clean break, scaffold template moved in the same PR); the docs flip back to `pyric()` when it lands.

## Risk

Docs-only. The one judgment call: teaching `pyricSandbox()` now and renaming later means one more docs flip — the alternative (leaving a broken import published until #357 lands) loses.

<details>
<summary>Implementation notes</summary>

- Engine facts sourced from `packages/cli/src/serve/entries/ai.ts`, `serve/namespace.ts` (`AI_PROXY_DEFAULT_UPSTREAM`, `PYRIC_AI_PROXY_UPSTREAM`), and `examples/ai-chat/main.js`.
- Site build green: 89 pages, loader collections cached.
- #357 carries the rename plan: export rename in `vite.ts`/`serve/vite-plugin.ts`, ~11 internal references, `create-pyric` template, regenerated API reference, next-alpha breaking note.

</details>
