### PR TITLE
fix(sandbox): sandbox-owned resetAll and project-scoped storage IndexedDB

### DIFF
--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -356,6 +356,9 @@ export async function startServe(opts: {
     databaseUrl: live.databaseUrl,
     storageRules: loadedStorage.rules,
     storageRulesHash: loadedStorage.rulesHash,
+    // Project identity: scopes the storage IDB name per served project
+    // (issue #359). Local-only — a dev path never leaves the machine.
+    projectKey: opts.cwd,
     bridgeUrl: mount && origin.port > 0 ? mount.wsUrl(origin) : null,
     // Precedence: once a state file exists, the lived state is the truth —
     // --seed applies only on the first (state-less) run.

--- a/packages/cli/src/remote/index.ts
+++ b/packages/cli/src/remote/index.ts
@@ -687,6 +687,11 @@ export function createRemoteSandboxHandle(opts: {
         'reset()',
         `reset the sandbox from the browser tab at ${serveUrl} or from Pyric Studio`,
       ),
+    resetAll: () =>
+      throwMember(
+        'resetAll()',
+        "use the async worker op instead: channel.op({ method: 'resetAll' })",
+      ),
     snapshot: () =>
       throwMember(
         'snapshot()',

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -136,8 +136,15 @@ if (!useWorker) try {
     diagnostics.databaseRulesDeployed = true;
     diagnostics.databaseRulesHash = payload.databaseRulesHash ?? null;
   }
+  // Open the ONE per-sandbox storage service eagerly: the FIRST open wins the
+  // rules AND the project-scoped IDB name (`pyric-storage:<projectKey>`,
+  // issue #359) — a lazy first open from app code would land on the legacy
+  // shared database. `projectKey` is absent on older servers → legacy name.
+  getStorageSandbox(sandbox, {
+    ...(payload.storageRules ? { rules: payload.storageRules } : {}),
+    ...(payload.projectKey ? { projectId: payload.projectKey } : {}),
+  });
   if (payload.storageRules) {
-    getStorageSandbox(sandbox, { rules: payload.storageRules });
     diagnostics.storageRulesDeployed = true;
     diagnostics.storageRulesHash = payload.storageRulesHash;
   }

--- a/packages/cli/src/serve/init-payload.ts
+++ b/packages/cli/src/serve/init-payload.ts
@@ -8,6 +8,15 @@ export interface InitPayload {
   /** Storage rules are installed once, before the first Storage operation. */
   storageRules: string | null;
   storageRulesHash: string | null;
+  /**
+   * Local project identity — the served project directory. Scopes the
+   * storage IndexedDB database name (`pyric-storage:<projectKey>`, issue
+   * #359): IndexedDB is origin-scoped, so without this every project served
+   * on one localhost port shared one storage database. Local-only (a dev
+   * server path never leaves the machine). Absent/null on older servers —
+   * consumers fall back to the legacy shared name.
+   */
+  projectKey?: string | null;
   bridgeUrl: string | null;
   seed: Record<string, Record<string, unknown>> | null;
   persist?: boolean;

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -460,6 +460,9 @@ export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
         databaseUrl: live.databaseUrl,
         storageRules: live.storageRules,
         storageRulesHash: live.storageRulesHash,
+        // Project identity: scopes the storage IDB name per served project
+        // (issue #359). Local-only — a dev path never leaves the machine.
+        projectKey: cwd,
         // The bound port is known only after `listen`; initPayload runs per
         // request (after listen), so resolve it lazily here. Absolute ws://host:port
         // mirrors serve (the browser reads this as the bridge peer URL).

--- a/packages/cli/src/serve/worker/client/studio.ts
+++ b/packages/cli/src/serve/worker/client/studio.ts
@@ -74,3 +74,14 @@ export function eventHistory(db: ClientDb): Promise<readonly SandboxEvent[]> {
 export async function getSnapshot(db: ClientDb): Promise<SandboxSnapshot> {
   return (await rpc(db.port, { t: 'op', id: nextId(), method: 'getSnapshot' })) as SandboxSnapshot;
 }
+
+/**
+ * Sandbox-owned full reset (issue #359): `sandbox.resetAll()` on the worker.
+ * Clears the Firestore env, the signed-in session, and EVERY registered
+ * persistable service — auth users, the RTDB tree, storage objects. Resolves
+ * once the worker acks (all services finished clearing). This is the served
+ * counterpart of calling `sandbox.resetAll()` on an in-process sandbox.
+ */
+export async function resetAll(db: ClientDb): Promise<void> {
+  await rpc(db.port, { t: 'op', id: nextId(), method: 'resetAll' });
+}

--- a/packages/cli/src/serve/worker/client/studio.ts
+++ b/packages/cli/src/serve/worker/client/studio.ts
@@ -82,6 +82,7 @@ export async function getSnapshot(db: ClientDb): Promise<SandboxSnapshot> {
  * once the worker acks (all services finished clearing). This is the served
  * counterpart of calling `sandbox.resetAll()` on an in-process sandbox.
  */
-export async function resetAll(db: ClientDb): Promise<void> {
-  await rpc(db.port, { t: 'op', id: nextId(), method: 'resetAll' });
+export async function resetAll(db: ClientDb): Promise<{ errors: string[] }> {
+  const reply = await rpc(db.port, { t: 'op', id: nextId(), method: 'resetAll' });
+  return (reply ?? { errors: [] }) as { errors: string[] };
 }

--- a/packages/cli/src/serve/worker/host/studio.ts
+++ b/packages/cli/src/serve/worker/host/studio.ts
@@ -40,10 +40,12 @@ export async function handleStudioOp(
       // `resetAll` iterates the worker sandbox's persistable-service registry,
       // so auth users, the RTDB tree, AND storage objects clear along with the
       // Firestore env — Studio can't forget a service the sandbox knows about.
-      // Awaited (storage clears IndexedDB stores) before the ack, and failures
-      // reply as errors instead of silently half-clearing.
+      // Awaited (storage clears IndexedDB stores) before the ack. Op-level
+      // failures reply as errors; per-service reset failures ride the reply
+      // payload's `errors` so Studio can surface a half-clear instead of
+      // reporting a clean reset.
       try {
-        await ctx.sandbox.resetAll();
+        const { errors } = await ctx.sandbox.resetAll();
         // `resetAll` swapped the env, wiping env-owned FIRESTORE rules (RTDB /
         // storage rules live on their service objects and survive). Re-deploy
         // the active project rules so a DATA reset never de-governs writes.
@@ -53,7 +55,7 @@ export async function handleStudioOp(
             ? firestoreRules.source
             : firestoreRules?.lastKnownGood;
         if (typeof source === 'string') setRules(ctx.sandbox, source);
-        ok(port, msg.id, null);
+        ok(port, msg.id, { errors });
       } catch (e) {
         fail(port, msg.id, e instanceof Error ? e : new Error(String(e)));
       }

--- a/packages/cli/src/serve/worker/host/studio.ts
+++ b/packages/cli/src/serve/worker/host/studio.ts
@@ -7,28 +7,56 @@
  * Routed here by the host dispatcher. Never imports the dispatcher.
  */
 
+import { setRules } from 'pyric/sandbox/firestore';
+
 import type { OpMessage } from '../protocol.js';
 import { type HostCtx, type PortLike, ok, fail } from '../host-context.js';
 
 /** The Studio control op methods routed to {@link handleStudioOp}. */
 const STUDIO_METHODS = new Set<string>([
   'getSnapshot',
+  'resetAll',
 ]);
 
 export function isStudioOp(method: OpMessage['method']): boolean {
   return STUDIO_METHODS.has(method);
 }
 
-export function handleStudioOp(
+export async function handleStudioOp(
   ctx: HostCtx,
   port: PortLike,
   msg: OpMessage,
-): void {
+): Promise<void> {
   switch (msg.method) {
     case 'getSnapshot': {
       // Export the current sandbox snapshot (Pyric Studio rules re-run): Studio
       // forks it locally to test edited rules / re-issue as the user on a branch.
       ok(port, msg.id, ctx.sandbox.snapshot());
+      break;
+    }
+
+    case 'resetAll': {
+      // Sandbox-owned full reset (issue #359): the ONE wipe-everything path.
+      // `resetAll` iterates the worker sandbox's persistable-service registry,
+      // so auth users, the RTDB tree, AND storage objects clear along with the
+      // Firestore env — Studio can't forget a service the sandbox knows about.
+      // Awaited (storage clears IndexedDB stores) before the ack, and failures
+      // reply as errors instead of silently half-clearing.
+      try {
+        await ctx.sandbox.resetAll();
+        // `resetAll` swapped the env, wiping env-owned FIRESTORE rules (RTDB /
+        // storage rules live on their service objects and survive). Re-deploy
+        // the active project rules so a DATA reset never de-governs writes.
+        const firestoreRules = ctx.activeRules?.firestore;
+        const source =
+          firestoreRules?.status === 'active'
+            ? firestoreRules.source
+            : firestoreRules?.lastKnownGood;
+        if (typeof source === 'string') setRules(ctx.sandbox, source);
+        ok(port, msg.id, null);
+      } catch (e) {
+        fail(port, msg.id, e instanceof Error ? e : new Error(String(e)));
+      }
       break;
     }
 

--- a/packages/cli/src/serve/worker/index.ts
+++ b/packages/cli/src/serve/worker/index.ts
@@ -160,6 +160,8 @@ export {
   type PresenceVisibility,
   // Sandbox snapshot export (Pyric Studio rules re-run: fork + test edited rules)
   getSnapshot,
+  // Sandbox-owned full reset (issue #359): Firestore + every registered service
+  resetAll,
   // RTDB shared-worker preview bridge. Aliased to avoid colliding with Storage
   // `ref` and Firestore sentinels in this worker barrel.
   rtdbGetDatabase,

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -492,6 +492,12 @@ export type OpMessage = (
   // on a throwaway branch (no live mutation). The reply is the serializable
   // `SandboxSnapshot` (the persistence format).
   | { t: 'op'; id: string; method: 'getSnapshot' }
+  // Sandbox-owned full reset (issue #359): `sandbox.resetAll()` on the worker —
+  // Firestore env + signed-in session + EVERY registered persistable service
+  // (auth users, RTDB tree, storage objects). The reply is `null` once every
+  // service finished clearing. Studio's Settings/Session reset rides this so
+  // served mode wipes the same surface area as the in-process path.
+  | { t: 'op'; id: string; method: 'resetAll' }
   // ── Messaging ops (surface: 'messaging'; host-capability gated) ──
   // The broker's documented worker-host seam (pyric/src/messaging/broker/
   // broker.ts header): each public broker method is one op here. All payloads

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -494,8 +494,9 @@ export type OpMessage = (
   | { t: 'op'; id: string; method: 'getSnapshot' }
   // Sandbox-owned full reset (issue #359): `sandbox.resetAll()` on the worker —
   // Firestore env + signed-in session + EVERY registered persistable service
-  // (auth users, RTDB tree, storage objects). The reply is `null` once every
-  // service finished clearing. Studio's Settings/Session reset rides this so
+  // (auth users, RTDB tree, storage objects). The reply is `{ errors }` once
+  // every service finished clearing — per-service reset failures are listed
+  // as `name: message` (empty array = clean wipe). Studio's Settings/Session reset rides this so
   // served mode wipes the same surface area as the in-process path.
   | { t: 'op'; id: string; method: 'resetAll' }
   // ── Messaging ops (surface: 'messaging'; host-capability gated) ──

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -209,8 +209,15 @@ export function applyServeInit(
   //     configure it. `payload.storageRules` is null when the project has no
   //     storage.rules, matching the same open-by-default posture as no
   //     firestore.rules / no database.rules.
+  //     The open ALSO claims the project-scoped IDB name
+  //     (`pyric-storage:<projectKey>`, issue #359) — which is why it now runs
+  //     unconditionally: a lazy first open from `ensureStorage`/`lensStorage`
+  //     would land on the legacy shared database.
+  getStorageSandbox(ctx.sandbox, {
+    ...(payload.storageRules ? { rules: payload.storageRules } : {}),
+    ...(payload.projectKey ? { projectId: payload.projectKey } : {}),
+  });
   if (payload.storageRules) {
-    getStorageSandbox(ctx.sandbox, { rules: payload.storageRules });
     result.storageRulesDeployed = true;
   }
 

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -174,6 +174,17 @@ export function applyServeInit(
       );
     } else {
       result.rulesDeployed = true;
+      // Record the deployed source on ctx (mirrors the database branch below)
+      // so diagnostics report it AND the `resetAll` op can re-deploy it —
+      // `sandbox.resetAll()` swaps the env, which wipes env-owned Firestore
+      // rules; a data reset must not silently de-govern writes.
+      ctx.activeRules ??= {};
+      ctx.activeRules.firestore = {
+        source: payload.rules,
+        updatedAt: Date.now(),
+        status: 'active',
+        messages: [],
+      };
     }
   }
   if (payload.databaseRules) {

--- a/packages/cli/test/serve/worker/client-surface.test.ts
+++ b/packages/cli/test/serve/worker/client-surface.test.ts
@@ -36,7 +36,7 @@ const EXPECTED_VALUE_EXPORTS: readonly string[] = [
   'listRootCollections', 'listSubcollections', 'listUsers', 'listWorkerBranches',
   'mintPresenceClientId',
   'onAuthStateChanged', 'onIdTokenChanged', 'onSnapshot', 'or', 'orderBy', 'query',
-  'ref', 'relayWorkerOp', 'relayWorkerSub', 'restorePortSession', 'rtdbChild',
+  'ref', 'relayWorkerOp', 'relayWorkerSub', 'resetAll', 'restorePortSession', 'rtdbChild',
   'rtdbConnectDatabaseEmulator', 'rtdbGet', 'rtdbGetDatabase', 'rtdbOff', 'rtdbOnValue',
   'rtdbPush', 'rtdbRef', 'rtdbRemove', 'rtdbServerTimestamp', 'rtdbSet', 'rtdbUpdate',
   'runTransaction', 'saveWorkerBranch', 'serverTimestamp', 'setDatabaseRules', 'setDoc',

--- a/packages/cli/test/serve/worker/dispatch-table.test.ts
+++ b/packages/cli/test/serve/worker/dispatch-table.test.ts
@@ -95,7 +95,7 @@ const ROUTABLE_METHODS = {
   ],
   rtdb: ['rtdb.get', 'rtdb.set', 'rtdb.update', 'rtdb.remove', 'rtdb.push', 'rtdb.adminSnapshot'],
   connection: ['getVersion', 'exportState', 'importState', 'saveBranch', 'listBranches', 'switchBranch', 'deleteBranch'],
-  studio: ['getSnapshot'],
+  studio: ['getSnapshot', 'resetAll'],
   presence: [
     'presence.register',
     'presence.heartbeat',
@@ -150,10 +150,10 @@ describe('host dispatch table (frozen)', () => {
     ctx = await makeCtx();
   });
 
-  it('routes exactly 73 op methods across all families', () => {
-    expect(ALL_METHODS.length).toBe(73);
+  it('routes exactly 74 op methods across all families', () => {
+    expect(ALL_METHODS.length).toBe(74);
     // No duplicates in the frozen list.
-    expect(new Set(ALL_METHODS).size).toBe(73);
+    expect(new Set(ALL_METHODS).size).toBe(74);
   });
 
   for (const [family, methods] of Object.entries(ROUTABLE_METHODS)) {

--- a/packages/cli/test/serve/worker/reset-all-op.test.ts
+++ b/packages/cli/test/serve/worker/reset-all-op.test.ts
@@ -1,0 +1,123 @@
+/**
+ * SharedWorker host — the `resetAll` studio op (issue #359).
+ *
+ * Studio's Settings/Session reset in served mode rides this single op; the
+ * host delegates to `sandbox.resetAll()`, which iterates the persistable-
+ * service registry. Pre-fix, Studio's reset walked Firestore docs + cleared
+ * auth users by hand and storage objects survived — this pins the worker
+ * path clearing EVERY service: Firestore docs, auth users, the RTDB tree,
+ * and storage objects.
+ *
+ * Same harness style as storage-ops.test.ts: REAL sandbox + fake ports,
+ * fake-indexeddb behind storage, unique dbName per ctx.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import { getStorageSandbox } from 'pyric/storage';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
+import { getDatabase, ref as rtdbRef, set as rtdbSet, get as rtdbGet } from 'pyric/database';
+
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  ResMessage,
+} from '../../../src/serve/worker/protocol.js';
+import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
+
+let dbSeq = 0;
+function uniqueDbName(): string {
+  return `pyric-reset-all-op-${++dbSeq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCtx(): HostCtx {
+  const sandbox = initializeSandbox();
+  // Isolated IDB name per ctx (the default DB is process-global under
+  // fake-indexeddb) — mirrors how a served page configures the service.
+  getStorageSandbox(sandbox, { dbName: uniqueDbName() });
+  return { db: getFirestore(sandbox), sandbox, instanceId: 'reset-all-test', subs: new Map() };
+}
+
+let opSeq = 0;
+function op(ctx: HostCtx, payload: Record<string, unknown>): Promise<ResMessage> {
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'res') resolve(msg);
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...payload,
+      t: 'op',
+      id: `rop-${++opSeq}`,
+    } as InboundMessage);
+  });
+}
+
+async function opOk(ctx: HostCtx, payload: Record<string, unknown>): Promise<unknown> {
+  const res = await op(ctx, payload);
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.code} — ${res.error.message}`);
+  return res.value;
+}
+
+const ADMIN = { actAs: { mode: 'admin' } } as const;
+
+describe('worker resetAll op', () => {
+  it('clears Firestore docs, auth users, the RTDB tree, and storage objects', async () => {
+    const ctx = makeCtx();
+
+    // Seed every service the worker owns.
+    ctx.sandbox.admin.setDocument('rooms/general', { name: 'General' });
+    const auth = getAuth(ctx.sandbox);
+    authSandbox.createUser(auth, { email: 'a@example.com', password: 'pw123456' });
+    const rtdb = getDatabase(ctx.sandbox);
+    await rtdbSet(rtdbRef(rtdb, '/presence/u1'), { online: true });
+    await opOk(ctx, {
+      method: 'storage.putBytes',
+      path: 'uploads/logo.png',
+      dataB64: bytesToBase64(new Uint8Array([0x89, 0x50, 0x4e, 0x47])),
+      contentType: 'image/png',
+      ...ADMIN,
+    });
+
+    // One op wipes everything.
+    await opOk(ctx, { method: 'resetAll' });
+
+    expect(Object.keys(ctx.sandbox.snapshot().firestore)).toHaveLength(0);
+    expect(authSandbox.listUsers(auth)).toHaveLength(0);
+    expect((await rtdbGet(rtdbRef(rtdb, '/presence/u1'))).val()).toBeNull();
+    const read = await op(ctx, { method: 'storage.getBytes', path: 'uploads/logo.png', ...ADMIN });
+    expect(read.ok).toBe(false);
+    if (!read.ok) expect(read.error.code).toBe('storage/object-not-found');
+  });
+
+  it('re-deploys the active Firestore rules after the env swap (data reset, not de-governing)', async () => {
+    const ctx = makeCtx();
+    const denyAll = `
+      rules_version = '2';
+      service cloud.firestore {
+        match /databases/{database}/documents {
+          match /{document=**} { allow read, write: if false; }
+        }
+      }`;
+    await opOk(ctx, { method: 'setRules', source: denyAll });
+
+    await opOk(ctx, { method: 'resetAll' });
+
+    // An app-session write is still governed by the project rules after reset.
+    const write = await op(ctx, {
+      method: 'setDoc',
+      path: 'rooms/general',
+      data: { name: 'General' },
+    });
+    expect(write.ok).toBe(false);
+    if (!write.ok) expect(write.error.code).toBe('permission-denied');
+  });
+});

--- a/packages/cli/test/serve/worker/storage-project-scope.test.ts
+++ b/packages/cli/test/serve/worker/storage-project-scope.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Worker init — storage IndexedDB project scoping (issue #359, defect B).
+ *
+ * `applyServeInit` opens the sandbox's ONE storage service with the init
+ * payload's `projectKey`, so the worker lands on `pyric-storage:<projectKey>`
+ * instead of the legacy origin-shared `pyric-storage` database. Two projects
+ * served (sequentially) on one origin must not see each other's objects; the
+ * same project must keep seeing its own.
+ *
+ * fake-indexeddb is process-global, which stands in for the browser's
+ * origin-scoped registry: pre-fix, all ctxs here shared one database and the
+ * cross-project read below saw the other project's object.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../src/serve/worker/host.js';
+import { applyServeInit } from '../../../src/serve/worker/serve-init.js';
+import type { InitPayload } from '../../../src/serve/namespace.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+  ResMessage,
+} from '../../../src/serve/worker/protocol.js';
+import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
+
+function payloadFor(projectKey: string): InitPayload {
+  return {
+    rules: null,
+    rulesHash: null,
+    storageRules: null,
+    storageRulesHash: null,
+    projectKey,
+    bridgeUrl: null,
+    seed: null,
+    seedState: null,
+    authUsers: null,
+  };
+}
+
+/** A worker ctx booted for `projectKey` — mirrors entry.ts: build ctx, then
+ *  applyServeInit (which claims the project-scoped storage DB name). */
+function makeCtx(projectKey: string): HostCtx {
+  const sandbox = initializeSandbox();
+  const ctx: HostCtx = {
+    db: getFirestore(sandbox),
+    sandbox,
+    instanceId: `scope-${projectKey}`,
+    subs: new Map(),
+  };
+  applyServeInit(ctx, payloadFor(projectKey), { fetch: (() => {}) as unknown as typeof fetch });
+  return ctx;
+}
+
+let opSeq = 0;
+function op(ctx: HostCtx, payload: Record<string, unknown>): Promise<ResMessage> {
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'res') resolve(msg);
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...payload,
+      t: 'op',
+      id: `pop-${++opSeq}`,
+    } as InboundMessage);
+  });
+}
+
+const ADMIN = { actAs: { mode: 'admin' } } as const;
+
+describe('worker storage db project scoping', () => {
+  it('two projectKeys open isolated storage databases; the same key shares', async () => {
+    const keyA = `/proj/a-${Math.random().toString(36).slice(2, 8)}`;
+    const keyB = `/proj/b-${Math.random().toString(36).slice(2, 8)}`;
+
+    const ctxA = makeCtx(keyA);
+    const put = await op(ctxA, {
+      method: 'storage.putBytes',
+      path: 'uploads/logo.png',
+      dataB64: bytesToBase64(new Uint8Array([1, 2, 3])),
+      ...ADMIN,
+    });
+    expect(put.ok).toBe(true);
+
+    // A DIFFERENT project on the same origin must not see the object.
+    const readB = await op(makeCtx(keyB), {
+      method: 'storage.getBytes',
+      path: 'uploads/logo.png',
+      ...ADMIN,
+    });
+    expect(readB.ok).toBe(false);
+    if (!readB.ok) expect(readB.error.code).toBe('storage/object-not-found');
+
+    // The SAME project (fresh worker boot) keeps its data.
+    const readA = await op(makeCtx(keyA), {
+      method: 'storage.getBytes',
+      path: 'uploads/logo.png',
+      ...ADMIN,
+    });
+    expect(readA.ok).toBe(true);
+  });
+});

--- a/packages/pyric/src/auth/sandbox/persistence.ts
+++ b/packages/pyric/src/auth/sandbox/persistence.ts
@@ -43,6 +43,13 @@ function registerAccountStore(sandbox: Sandbox, backend: SandboxBackend): void {
       }
       backend.restoreProviderConfig(restored?.providers);
     },
+    // Sandbox.resetAll: wipe the user DB + provider config back to defaults —
+    // identical to restoring an empty snapshot. The signed-in session is the
+    // sandbox core's job (reset() clears currentUser before services run).
+    reset: () => {
+      backend.clearUsers();
+      backend.restoreProviderConfig(undefined);
+    },
     subscribe: (onChange) => {
       const unsubscribeUsers = backend.subscribeUsers(onChange);
       const unsubscribeProviders = backend.subscribeProviderConfig(onChange);

--- a/packages/pyric/src/database/sandbox/backend-for.ts
+++ b/packages/pyric/src/database/sandbox/backend-for.ts
@@ -25,6 +25,11 @@ export function getOrCreateBackend(sandbox: Sandbox): RtdbBackend {
       capturedBackend.restoreTree(data as JsonValue);
     },
     subscribe: (onChange: () => void) => capturedBackend.subscribeWrites(onChange),
+    // Sandbox.resetAll: clear the whole tree (restoreTree fans listeners out,
+    // so live views converge on the emptied state).
+    reset: () => {
+      capturedBackend.restoreTree(null);
+    },
   });
 
   return backend;

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -399,27 +399,32 @@ export class SandboxImpl implements LocalSandbox {
     this.attachToEnv();
   }
 
-  async resetAll(): Promise<void> {
+  async resetAll(): Promise<{ errors: string[] }> {
     // Firestore env + signed-in session first (emits the session_boundary),
     // then every registered service that opted into `reset`. Iterating the
     // REGISTRY — not a hand-maintained service list — is the point: a service
     // that registers with a `reset` hook is cleared automatically, so a
     // consumer-side reset (Pyric Studio) can't silently skip one.
     this.reset();
+    const errors: string[] = [];
     const clears: Promise<void>[] = [];
     for (const [name, svc] of this.serviceRegistry) {
       if (!svc.reset) continue;
       // Isolate each service (sync throw or async rejection) so one broken
       // service doesn't abort the wipe — mirrors loadSnapshot's isolation.
+      // Failures are REPORTED, not just logged: a reset that leaves data
+      // behind must never look successful to the caller (issue #359 was
+      // exactly that experience).
       clears.push(
         Promise.resolve()
           .then(() => svc.reset!())
           .catch((e) => {
-            console.warn(`Sandbox.resetAll: service '${name}' failed to reset:`, e);
+            errors.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
           }),
       );
     }
     await Promise.all(clears);
+    return { errors };
   }
 
   dispose(): void {

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -399,6 +399,29 @@ export class SandboxImpl implements LocalSandbox {
     this.attachToEnv();
   }
 
+  async resetAll(): Promise<void> {
+    // Firestore env + signed-in session first (emits the session_boundary),
+    // then every registered service that opted into `reset`. Iterating the
+    // REGISTRY — not a hand-maintained service list — is the point: a service
+    // that registers with a `reset` hook is cleared automatically, so a
+    // consumer-side reset (Pyric Studio) can't silently skip one.
+    this.reset();
+    const clears: Promise<void>[] = [];
+    for (const [name, svc] of this.serviceRegistry) {
+      if (!svc.reset) continue;
+      // Isolate each service (sync throw or async rejection) so one broken
+      // service doesn't abort the wipe — mirrors loadSnapshot's isolation.
+      clears.push(
+        Promise.resolve()
+          .then(() => svc.reset!())
+          .catch((e) => {
+            console.warn(`Sandbox.resetAll: service '${name}' failed to reset:`, e);
+          }),
+      );
+    }
+    await Promise.all(clears);
+  }
+
   dispose(): void {
     // Emit dispose boundary so consumers can flush their buffers /
     // close out forensic logs cleanly.

--- a/packages/pyric/src/sandbox/types/persistence.ts
+++ b/packages/pyric/src/sandbox/types/persistence.ts
@@ -36,6 +36,19 @@ export interface PersistableService {
   restore(data: unknown): void;
 
   /**
+   * Optional: clear this service's state to empty. Called by
+   * {@link Sandbox.resetAll} after the Firestore environment swap, so a
+   * single sandbox-owned call wipes EVERY registered service (auth users,
+   * RTDB tree, storage objects) — a consumer (Pyric Studio's reset) can't
+   * forget a service it never knew about. May be async (storage clears an
+   * IndexedDB store); `resetAll` awaits it. A service that omits `reset`
+   * is skipped — its state deliberately survives `resetAll` (e.g. the
+   * per-app auth-session hooks, whose signed-in identity the sandbox core
+   * already clears in `reset()`).
+   */
+  reset?(): void | Promise<void>;
+
+  /**
    * Optional: subscribe to changes in this service's state. When
    * provided, the persistence controller hooks it up and schedules
    * a debounced flush on each change — ensuring auth-user edits reach

--- a/packages/pyric/src/sandbox/types/service.ts
+++ b/packages/pyric/src/sandbox/types/service.ts
@@ -197,6 +197,22 @@ export interface Sandbox {
   reset(): void;
 
   /**
+   * Reset the WHOLE sandbox: {@link reset} (Firestore env + signed-in
+   * session), then clear every registered persistable service that
+   * provides a {@link PersistableService.reset} hook — auth users, the
+   * RTDB tree, storage objects. This is the one sandbox-owned "wipe
+   * everything" path: because it iterates the service registry, a new
+   * service that registers with a `reset` hook is cleared automatically,
+   * and a consumer (Pyric Studio's reset) cannot forget one.
+   *
+   * Service resets may be async (storage clears IndexedDB stores); the
+   * returned promise resolves when every service has finished clearing.
+   * A service whose `reset` throws is isolated (warned, others still
+   * clear) — mirroring `loadSnapshot`'s per-service isolation.
+   */
+  resetAll(): Promise<void>;
+
+  /**
    * Tear down listener registries on this sandbox's environment without
    * replacing it. Use this when you're about to discard the sandbox
    * itself (e.g. `runner.reseed()` builds a fresh sandbox rather than

--- a/packages/pyric/src/sandbox/types/service.ts
+++ b/packages/pyric/src/sandbox/types/service.ts
@@ -207,10 +207,11 @@ export interface Sandbox {
    *
    * Service resets may be async (storage clears IndexedDB stores); the
    * returned promise resolves when every service has finished clearing.
-   * A service whose `reset` throws is isolated (warned, others still
-   * clear) — mirroring `loadSnapshot`'s per-service isolation.
+   * A service whose `reset` throws is isolated (others still clear) and
+   * REPORTED in the returned `errors` (as `name: message`) — a reset that
+   * leaves data behind must never look successful to the caller.
    */
-  resetAll(): Promise<void>;
+  resetAll(): Promise<{ errors: string[] }>;
 
   /**
    * Tear down listener registries on this sandbox's environment without

--- a/packages/pyric/src/storage/instances.ts
+++ b/packages/pyric/src/storage/instances.ts
@@ -18,10 +18,14 @@ export function getStorage(app?: FirebaseApp, bucketUrl?: string): AppFirebaseSt
   if (!runtime) throw new TypeError('pyric/storage: unrecognized FirebaseApp handle');
   return runtime.service(`storage/${bucketUrl ?? 'default'}`, () => {
     const { sandbox, session } = runtime;
+    // Project-scope the storage database by the app's projectId (issue #359)
+    // — first-call-per-Sandbox semantics apply, so a host that already opened
+    // the service (e.g. `pyric dev` with the served project's key) wins.
+    const projectId = resolvedApp.options?.projectId;
     const handle = getStorageSandbox(bindOperationContext(sandbox.withAuth(session.currentUser), {
       source: { kind: 'app' },
       authLens: { mode: 'app-session' },
-    }));
+    }), projectId ? { projectId } : {});
     return Object.freeze({
       [TARGET_SYMBOL]: { ...handle[TARGET_SYMBOL], currentAuth: () => session.currentUser },
       app: resolvedApp,

--- a/packages/pyric/src/storage/persistence.ts
+++ b/packages/pyric/src/storage/persistence.ts
@@ -26,7 +26,32 @@
  * in Slice 8 inside `errors.ts`. Keep this layer mechanical.
  */
 
+/**
+ * Legacy shared database name — used only when NO project identity is
+ * available (bare library use, tests that don't pass a name).
+ *
+ * IndexedDB is origin-scoped, so under this fixed name every project served
+ * on the same localhost port shared ONE storage database (issue #359,
+ * defect B) — "old data" from unrelated projects surfaced in Studio.
+ * Project-scoped callers now open `pyric-storage:<projectId>` via
+ * {@link storageDbName} instead.
+ *
+ * Migration decision (deliberate, recorded here): the old shared
+ * `pyric-storage` database is ORPHANED, not migrated — cross-project data
+ * disappearing from Studio is the desired outcome of the fix. It is not
+ * deleted either: other pyric versions on the same origin may still read it.
+ */
 const DEFAULT_DB_NAME = 'pyric-storage';
+
+/**
+ * Resolve the default IndexedDB database name for a project identity:
+ * `pyric-storage:<projectId>`, or the legacy shared {@link DEFAULT_DB_NAME}
+ * when no identity is available. An explicit `dbName` option always wins
+ * over this derivation (see `StorageOptions`).
+ */
+export function storageDbName(projectId?: string | null): string {
+  return projectId ? `${DEFAULT_DB_NAME}:${projectId}` : DEFAULT_DB_NAME;
+}
 /**
  * Schema version. Bump and add an `upgradeneeded` branch when the
  * store layout changes. Slice 3 ships v1: two object stores keyed by

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -180,6 +180,20 @@ function ensureService(
   );
   SERVICES.set(sandbox, servicePromise);
   SERVICE_RULES_SOURCE.set(sandbox, options.rules ?? null);
+  // Join the sandbox's persistable-service REGISTRY so `sandbox.resetAll()`
+  // reaches storage (issue #359: Studio's reset cleared Firestore + auth but
+  // never storage — storage was invisible to the sandbox). Storage does NOT
+  // ride the persistence blob: it owns its durability (IndexedDB), and blobs
+  // aren't JSON-serializable — so snapshot/restore are deliberate no-ops and
+  // `reset` is the only live hook (clears both IDB object stores).
+  sandbox.registerPersistableService('storage', {
+    snapshot: () => null,
+    restore: () => {},
+    reset: async () => {
+      const service = await servicePromise;
+      await service.backend.reset();
+    },
+  });
   return servicePromise;
 }
 

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -26,7 +26,7 @@ import {
   provenanceForOperationContext,
   resolveOperationContext,
 } from 'pyric/sandbox/internal';
-import { openStorageBackend, type StorageBackend } from './persistence.js';
+import { openStorageBackend, storageDbName, type StorageBackend } from './persistence.js';
 import { parseStorageRules, type StorageRules } from './rules.js';
 
 /**
@@ -114,6 +114,16 @@ export interface StorageOptions {
    */
   dbName?: string;
   /**
+   * Project identity used to derive the default IndexedDB database name
+   * (`pyric-storage:<projectId>` — see {@link storageDbName}). IndexedDB is
+   * origin-scoped, so without this every project served on the same
+   * localhost port shared one storage database (issue #359). Ignored when
+   * an explicit `dbName` is given; only honored on the FIRST call per
+   * `Sandbox`. Hosts pass their project identity here (`pyric dev` passes
+   * the served project's key; app handles pass `options.projectId`).
+   */
+  projectId?: string;
+  /**
    * Storage rules source. Parsed eagerly so a malformed string
    * throws at config time. Only honored on the FIRST call per
    * `Sandbox`.
@@ -175,7 +185,11 @@ function ensureService(
     return existing;
   }
   const rules = options.rules ? parseStorageRules(options.rules) : null;
-  const servicePromise = openStorageBackend(options.dbName).then(
+  // Explicit dbName wins; otherwise scope the default by project identity so
+  // two projects on one origin never share a storage database (issue #359).
+  const servicePromise = openStorageBackend(
+    options.dbName ?? storageDbName(options.projectId),
+  ).then(
     (backend) => new StorageService(backend, rules),
   );
   SERVICES.set(sandbox, servicePromise);

--- a/packages/pyric/test/sandbox/reset-all.test.ts
+++ b/packages/pyric/test/sandbox/reset-all.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `Sandbox.resetAll()` — the one sandbox-owned "wipe everything" path
+ * (issue #359: Studio's reset cleared Firestore docs + auth users but never
+ * storage objects, and RTDB coverage rode on nothing).
+ *
+ * The seam under test is the persistable-service REGISTRY: `resetAll()`
+ * iterates every registered service and invokes its optional `reset` hook,
+ * so a service is cleared because it REGISTERED, not because a consumer
+ * remembered it. The storage assertions here fail against the pre-fix code
+ * twice over: storage never registered with the sandbox at all, and no
+ * sandbox-owned reset path existed.
+ *
+ * fake-indexeddb backs the storage service; each test scopes storage to a
+ * unique DB name so state can't leak between cases.
+ */
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'bun:test';
+import { initializeSandbox } from '../../src/sandbox/index.js';
+import { getAuth, sandbox as authSandbox } from '../../src/auth/index.js';
+import { getDatabase, ref as rtdbRef, set as rtdbSet, get as rtdbGet } from '../../src/database/modular.js';
+import { getStorageSandbox, getStorageService } from '../../src/storage/service.js';
+
+function uniqueDbName(label: string): string {
+  return `pyric-reset-all-${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+describe('Sandbox.resetAll', () => {
+  it('clears Firestore docs, auth users, the RTDB tree, and storage objects', async () => {
+    const sandbox = initializeSandbox();
+
+    // ── Seed every service ──────────────────────────────────────────
+    // Firestore (admin plane — rules-agnostic).
+    sandbox.admin.setDocument('rooms/general', { name: 'General' });
+    sandbox.admin.setDocument('rooms/general/messages/m1', { text: 'hi' });
+
+    // Auth user DB.
+    const auth = getAuth(sandbox);
+    authSandbox.createUser(auth, { email: 'a@example.com', password: 'pw123456' });
+    expect(authSandbox.listUsers(auth)).toHaveLength(1);
+
+    // RTDB tree.
+    const rtdb = getDatabase(sandbox);
+    await rtdbSet(rtdbRef(rtdb, '/presence/u1'), { online: true });
+
+    // Storage object (unique DB per test run; fake-indexeddb persists names
+    // process-wide).
+    const storage = getStorageSandbox(sandbox, { dbName: uniqueDbName('all') });
+    const service = await getStorageService(storage);
+    await service.backend.put(
+      'uploads/logo.png',
+      new Blob(['png-bytes'], { type: 'image/png' }),
+      {
+        fullPath: 'uploads/logo.png',
+        name: 'logo.png',
+        bucket: 'pyric-default',
+        generation: '1',
+        metageneration: '1',
+        timeCreated: '2026-07-17T00:00:00.000Z',
+        updated: '2026-07-17T00:00:00.000Z',
+        size: 9,
+      },
+    );
+    expect(await service.backend.listByPrefix('')).toHaveLength(1);
+
+    // ── The one sandbox-owned reset ─────────────────────────────────
+    await sandbox.resetAll();
+
+    // Every service is empty afterwards.
+    expect(Object.keys(sandbox.snapshot().firestore)).toHaveLength(0);
+    expect(authSandbox.listUsers(auth)).toHaveLength(0);
+    // Matches a fresh sandbox: the root reads as an empty tree and the
+    // seeded path is gone.
+    const tree = await rtdbGet(rtdbRef(rtdb, '/'));
+    expect(tree.val()).toEqual({});
+    const presence = await rtdbGet(rtdbRef(rtdb, '/presence/u1'));
+    expect(presence.val()).toBeNull();
+    expect(await service.backend.listByPrefix('')).toHaveLength(0);
+  });
+
+  it('reaches storage through the registry seam (storage registers on service open)', async () => {
+    // The load-bearing regression: pre-fix, storage never called
+    // registerPersistableService, so NO sandbox-owned path could clear it.
+    const sandbox = initializeSandbox();
+    getStorageSandbox(sandbox, { dbName: uniqueDbName('registry') });
+    expect(Object.keys(sandbox.snapshot().services)).toContain('storage');
+  });
+
+  it('clears the signed-in session like reset() does', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.currentUser = { uid: 'u1' };
+    await sandbox.resetAll();
+    expect(sandbox.currentUser).toBeNull();
+  });
+
+  it('isolates a failing service reset so the others still clear', async () => {
+    const sandbox = initializeSandbox();
+    sandbox.registerPersistableService('broken', {
+      snapshot: () => null,
+      restore: () => {},
+      reset: () => {
+        throw new Error('boom');
+      },
+    });
+    const auth = getAuth(sandbox);
+    authSandbox.createUser(auth, { email: 'b@example.com', password: 'pw123456' });
+
+    await sandbox.resetAll();
+    expect(authSandbox.listUsers(auth)).toHaveLength(0);
+  });
+});

--- a/packages/pyric/test/sandbox/reset-all.test.ts
+++ b/packages/pyric/test/sandbox/reset-all.test.ts
@@ -63,7 +63,8 @@ describe('Sandbox.resetAll', () => {
     expect(await service.backend.listByPrefix('')).toHaveLength(1);
 
     // ── The one sandbox-owned reset ─────────────────────────────────
-    await sandbox.resetAll();
+    const { errors } = await sandbox.resetAll();
+    expect(errors).toEqual([]); // a clean wipe reports no errors
 
     // Every service is empty afterwards.
     expect(Object.keys(sandbox.snapshot().firestore)).toHaveLength(0);
@@ -92,7 +93,7 @@ describe('Sandbox.resetAll', () => {
     expect(sandbox.currentUser).toBeNull();
   });
 
-  it('isolates a failing service reset so the others still clear', async () => {
+  it('isolates a failing service reset so the others still clear — and reports it', async () => {
     const sandbox = initializeSandbox();
     sandbox.registerPersistableService('broken', {
       snapshot: () => null,
@@ -104,7 +105,10 @@ describe('Sandbox.resetAll', () => {
     const auth = getAuth(sandbox);
     authSandbox.createUser(auth, { email: 'b@example.com', password: 'pw123456' });
 
-    await sandbox.resetAll();
+    const { errors } = await sandbox.resetAll();
     expect(authSandbox.listUsers(auth)).toHaveLength(0);
+    // The failure is REPORTED, not swallowed — a half-clear must never look
+    // like a clean reset (issue #359 was exactly that experience).
+    expect(errors).toEqual(['broken: boom']);
   });
 });

--- a/packages/pyric/test/storage/project-scope.test.ts
+++ b/packages/pyric/test/storage/project-scope.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Storage database project scoping (issue #359, defect B).
+ *
+ * IndexedDB is origin-scoped, so the fixed default database name
+ * (`pyric-storage`) made every project served on one localhost port share
+ * one storage database — unrelated projects' objects surfaced in Studio.
+ * The default DB name is now derived from the project identity
+ * (`pyric-storage:<projectId>`); an explicit `dbName` still wins.
+ *
+ * Migration: the old shared `pyric-storage` DB is deliberately orphaned,
+ * not migrated and not deleted (see the comment at DEFAULT_DB_NAME).
+ *
+ * The isolation cases fail against the pre-fix code: without the
+ * `projectId` option, both services open the SAME shared database and the
+ * cross-project read sees the other project's object.
+ */
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'bun:test';
+import { initializeSandbox } from '../../src/sandbox/index.js';
+import { storageDbName } from '../../src/storage/persistence.js';
+import { getStorageSandbox, getStorageService } from '../../src/storage/service.js';
+
+/** Unique per-run project ids so fake-indexeddb's process-global registry
+ *  never bleeds state between test invocations. */
+function uniqueProject(label: string): string {
+  return `${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+const META = {
+  name: 'logo.png',
+  bucket: 'pyric-default',
+  generation: '1',
+  metageneration: '1',
+  timeCreated: '2026-07-17T00:00:00.000Z',
+  updated: '2026-07-17T00:00:00.000Z',
+  size: 4,
+} as const;
+
+async function putObject(projectOptions: { projectId?: string; dbName?: string }): Promise<void> {
+  const storage = getStorageSandbox(initializeSandbox(), projectOptions);
+  const service = await getStorageService(storage);
+  await service.backend.put('uploads/logo.png', new Blob(['data']), {
+    ...META,
+    fullPath: 'uploads/logo.png',
+  });
+}
+
+async function listObjects(projectOptions: {
+  projectId?: string;
+  dbName?: string;
+}): Promise<number> {
+  const storage = getStorageSandbox(initializeSandbox(), projectOptions);
+  const service = await getStorageService(storage);
+  return (await service.backend.listByPrefix('')).length;
+}
+
+describe('storage db project scoping', () => {
+  it('derives pyric-storage:<projectId> and falls back to the legacy shared name', () => {
+    expect(storageDbName('demo-app')).toBe('pyric-storage:demo-app');
+    expect(storageDbName(null)).toBe('pyric-storage');
+    expect(storageDbName(undefined)).toBe('pyric-storage');
+  });
+
+  it('two project identities open two isolated databases', async () => {
+    const projectA = uniqueProject('proj-a');
+    const projectB = uniqueProject('proj-b');
+
+    await putObject({ projectId: projectA });
+
+    // Project B must NOT see project A's object (pre-fix: shared DB, sees it).
+    expect(await listObjects({ projectId: projectB })).toBe(0);
+    // The same identity on a fresh sandbox shares project A's database.
+    expect(await listObjects({ projectId: projectA })).toBe(1);
+  });
+
+  it('an explicit dbName overrides the project-derived default', async () => {
+    const project = uniqueProject('proj-override');
+    const explicit = `explicit-${uniqueProject('db')}`;
+
+    await putObject({ projectId: project });
+
+    // Same projectId + explicit dbName → the explicit database, not the
+    // project-scoped one.
+    expect(await listObjects({ projectId: project, dbName: explicit })).toBe(0);
+    expect(await listObjects({ projectId: project })).toBe(1);
+  });
+});

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -42,6 +42,7 @@ import {
   uploadBytes as workerStorageUploadBytes,
   deleteObject as workerStorageDeleteObject,
   getSnapshot as workerGetSnapshot,
+  resetAll as workerResetAll,
   getWorkerInstanceId,
   exportWorkerState,
   importWorkerState,
@@ -168,6 +169,11 @@ export interface WorkerLivePlane {
    *  locally to test a denied op against edited rules / re-issue as the user,
    *  on a throwaway branch (no live mutation). */
   getSnapshot(): Promise<SandboxSnapshot>;
+  /** Sandbox-owned full reset (issue #359): `sandbox.resetAll()` on the worker
+   *  — Firestore env + signed-in session + EVERY registered persistable
+   *  service (auth users, RTDB tree, storage objects). Resolves once the
+   *  worker acks (all services finished clearing). */
+  resetAll(): Promise<void>;
   /** Stable per-SharedWorker instance id, so the UI can tell WHICH sandbox
    *  instance this is — the same `localhost:<port>` in a different browser
    *  profile is a separate instance. Studio renders a human-friendly slug. */
@@ -399,5 +405,6 @@ export function connectWorkerLive(
       deleteObject: workerStorageDeleteObject,
     } as unknown as StorageApi,
     getSnapshot: () => workerGetSnapshot(db),
+    resetAll: () => workerResetAll(db),
   };
 }

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -173,7 +173,7 @@ export interface WorkerLivePlane {
    *  — Firestore env + signed-in session + EVERY registered persistable
    *  service (auth users, RTDB tree, storage objects). Resolves once the
    *  worker acks (all services finished clearing). */
-  resetAll(): Promise<void>;
+  resetAll(): Promise<{ errors: string[] }>;
   /** Stable per-SharedWorker instance id, so the UI can tell WHICH sandbox
    *  instance this is — the same `localhost:<port>` in a different browser
    *  profile is a separate instance. Studio renders a human-friendly slug. */

--- a/packages/studio/src/dev/seed.test.ts
+++ b/packages/studio/src/dev/seed.test.ts
@@ -1,4 +1,11 @@
-import 'fake-indexeddb/auto';
+// Deterministic IDB global: the `fake-indexeddb/auto` side-effect import is
+// evaluated once per process, so when another suite in the same bun run
+// clobbers `globalThis.indexedDB` after that first evaluation, a cached
+// re-import here does NOT restore it (observed as `indexedDB is not
+// defined` in the CI library lane only). Assign a fresh factory explicitly.
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+globalThis.indexedDB = new IDBFactory();
+globalThis.IDBKeyRange = IDBKeyRange;
 import { describe, expect, it } from 'bun:test';
 import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 import { initializeSandbox } from 'pyric/sandbox';

--- a/packages/studio/src/dev/seed.test.ts
+++ b/packages/studio/src/dev/seed.test.ts
@@ -1,7 +1,9 @@
+import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'bun:test';
 import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 import { initializeSandbox } from 'pyric/sandbox';
-import { seedAuth } from './seed.js';
+import { getMetadata, listAll, ref as storageRef } from 'pyric/storage';
+import { applySeed, createSeededSandbox, deploySeedRules, seedAuth } from './seed.js';
 
 describe('Studio Auth dev seed', () => {
   it('seeds provider provenance as Auth data rather than custom claims', async () => {
@@ -16,5 +18,33 @@ describe('Studio Auth dev seed', () => {
     const anonymous = users.find((user) => user.isAnonymous);
     expect(anonymous).toBeDefined();
     expect(anonymous?.providerUserInfo).toEqual([]);
+  });
+});
+
+describe('Studio reset (dev-seed flow)', () => {
+  // The in-process core of `useStudioReset`: `sandbox.resetAll()` (the ONE
+  // sandbox-owned wipe — issue #359), then rules + fixture re-application.
+  // Pre-fix there was no sandbox-owned path and storage objects survived a
+  // Studio reset.
+  it('resetAll wipes storage objects too, and the reseed restores the fixture', async () => {
+    const handles = await createSeededSandbox();
+    const avatars = storageRef(handles.storage, 'avatars');
+    expect((await listAll(avatars)).items.length).toBeGreaterThan(0);
+    expect(authSandbox.listUsers(handles.auth).length).toBeGreaterThan(0);
+
+    await handles.sandbox.resetAll();
+
+    // Everything is gone — including storage (the pre-fix escapee).
+    expect((await listAll(avatars)).items).toHaveLength(0);
+    await expect(getMetadata(storageRef(handles.storage, 'avatars/alice.png'))).rejects.toThrow();
+    expect(authSandbox.listUsers(handles.auth)).toHaveLength(0);
+    expect(Object.keys(handles.sandbox.snapshot().firestore)).toHaveLength(0);
+
+    // Re-apply rules + fixture exactly as useStudioReset's dev branch does.
+    deploySeedRules(handles.sandbox);
+    await applySeed(handles);
+    expect((await listAll(avatars)).items.length).toBeGreaterThan(0);
+    expect(authSandbox.listUsers(handles.auth).length).toBeGreaterThan(0);
+    expect(Object.keys(handles.sandbox.snapshot().firestore).length).toBeGreaterThan(0);
   });
 });

--- a/packages/studio/src/dev/seed.ts
+++ b/packages/studio/src/dev/seed.ts
@@ -267,6 +267,16 @@ async function seedTraffic(sandbox: LocalSandbox): Promise<void> {
  * "Reset session" in dev-seed mode. Traffic is deliberately NOT replayed -
  * reset restores data, not the denial/activity log (replaying would double it).
  */
+/**
+ * Re-deploy the dev-seed ruleset. Studio's "Reset session" calls this after
+ * `sandbox.resetAll()` (which swaps the env and wipes env-owned Firestore
+ * rules) so the reseeded fixture lands under the same governance the boot
+ * seeding deployed.
+ */
+export function deploySeedRules(sandbox: LocalSandbox): void {
+  setRules(sandbox, RULES);
+}
+
 export async function applySeed(
   handles: Pick<SeededHandles, 'adminFirestore' | 'auth' | 'storage'>,
 ): Promise<void> {

--- a/packages/studio/src/dev/seed.ts
+++ b/packages/studio/src/dev/seed.ts
@@ -257,17 +257,6 @@ async function seedTraffic(sandbox: LocalSandbox): Promise<void> {
 }
 
 /**
- * Build + seed a fresh sandbox and return the resolved handles. Idempotent per
- * call: each invocation creates its own sandbox, so callers should create one
- * and share it (see {@link DevSeedProvider}).
- */
-/**
- * (Re)apply the fixture DATA (firestore + auth + storage) through the given
- * handles. Reused by {@link createSeededSandbox} on boot and by the Studio's
- * "Reset session" in dev-seed mode. Traffic is deliberately NOT replayed -
- * reset restores data, not the denial/activity log (replaying would double it).
- */
-/**
  * Re-deploy the dev-seed ruleset. Studio's "Reset session" calls this after
  * `sandbox.resetAll()` (which swaps the env and wipes env-owned Firestore
  * rules) so the reseeded fixture lands under the same governance the boot
@@ -277,6 +266,12 @@ export function deploySeedRules(sandbox: LocalSandbox): void {
   setRules(sandbox, RULES);
 }
 
+/**
+ * (Re)apply the fixture DATA (firestore + auth + storage) through the given
+ * handles. Reused by {@link createSeededSandbox} on boot and by the Studio's
+ * "Reset session" in dev-seed mode. Traffic is deliberately NOT replayed -
+ * reset restores data, not the denial/activity log (replaying would double it).
+ */
 export async function applySeed(
   handles: Pick<SeededHandles, 'adminFirestore' | 'auth' | 'storage'>,
 ): Promise<void> {
@@ -287,6 +282,11 @@ export async function applySeed(
 
 let seedAppSeq = 0;
 
+/**
+ * Build + seed a fresh sandbox and return the resolved handles. Idempotent per
+ * call: each invocation creates its own sandbox, so callers should create one
+ * and share it (see {@link DevSeedProvider}).
+ */
 export async function createSeededSandbox(): Promise<SeededHandles> {
   const sandbox = initializeSandbox();
   // Unique app name: pyric/app mirrors firebase's registry (a repeated default

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -24,7 +24,6 @@ import { setRules as setInProcessFirestoreRules } from 'pyric/sandbox/firestore'
 import {
   doc as inProcessDoc,
   setDoc as inProcessSetDoc,
-  deleteDoc as inProcessDeleteDoc,
 } from 'pyric/firestore';
 import { sandbox as authSandbox, type CreateUserRequest } from 'pyric/auth';
 import { setRules as workerSetRules } from '@pyric/cli/serve/worker';
@@ -41,7 +40,6 @@ import { useDevSeed } from '../dev/DevSeedProvider.js';
 import { useEnvironment } from './environment.js';
 import type { WorkerLivePlane } from '../env.js';
 import {
-  collectAllDocPaths,
   listDocumentsForBrowse,
   useStudioData,
   type StudioDataHandles,
@@ -437,48 +435,41 @@ export function useStudioSeedAuth(): (
 }
 
 /**
- * Clear the sandbox: delete every Firestore document (root collections +
- * recursive subcollections, via the admin handle) and clear all auth users.
- * The walk rides the handles' path-based listing seams — phantom-inclusive
- * (see {@link collectAllDocPaths}), so data under "missing" parents is
- * reached — and works unchanged in both in-process and served modes.
+ * Clear the sandbox through the ONE sandbox-owned path (issue #359):
+ * `sandbox.resetAll()` — Firestore env + signed-in session + EVERY registered
+ * persistable service (auth users, the RTDB tree, storage objects). Because
+ * the sandbox iterates its own service registry, Studio cannot forget a
+ * service (the old doc-walk + clearUsers approach here never touched storage).
+ *
+ * Routing: served mode calls the worker's `resetAll` op so the SHARED worker
+ * sandbox clears (the same one the app + agent use); dev-seed and the
+ * HTTP-mirror fallback call `resetAll()` on the in-process sandbox handle.
  */
-export function useStudioClear(): () => Promise<{ cleared: number; errors: string[] }> {
+export function useStudioClear(): () => Promise<{ errors: string[] }> {
   const data = useStudioDataSource();
+  const env = useEnvironment();
+  const live = env.status === 'ready' ? env.env.live : undefined;
   return useCallback(async () => {
     if (data.status !== 'ready') throw new Error('No sandbox to clear.');
-    const adminDb = data.handles.adminFirestore as unknown as Parameters<typeof inProcessDoc>[0];
-    const docFn = (data.firestoreApi?.doc ?? inProcessDoc) as typeof inProcessDoc;
-    const deleteDocFn = (data.firestoreApi?.deleteDoc ?? inProcessDeleteDoc) as typeof inProcessDeleteDoc;
-    const { docPaths, errors } = await collectAllDocPaths(data.handles);
-
-    let cleared = 0;
-    for (const path of docPaths) {
-      try {
-        await deleteDocFn(docFn(adminDb, path));
-        cleared += 1;
-      } catch (e) {
-        errors.push(`delete ${path}: ${e instanceof Error ? e.message : String(e)}`);
-      }
-    }
-
-    // Clear auth users (one shot). clearUsers takes the auth handle (Pick over
-    // the sandbox ops); data.handles.auth is the worker handle in served mode.
+    const errors: string[] = [];
     try {
-      const clearUsersFn = data.authApi?.clearUsers ?? authSandbox.clearUsers;
-      clearUsersFn(data.handles.auth as Parameters<typeof authSandbox.clearUsers>[0]);
+      if (live) {
+        await live.resetAll();
+      } else {
+        await data.handles.sandbox.resetAll();
+      }
     } catch (e) {
-      errors.push(`auth: ${e instanceof Error ? e.message : String(e)}`);
+      errors.push(`reset: ${e instanceof Error ? e.message : String(e)}`);
     }
-    return { cleared, errors };
-  }, [data]);
+    return { errors };
+  }, [data, live]);
 }
 
 /**
  * Reset the session: clear the sandbox, then re-apply the seed. Dev-seed mode
  * re-runs the in-process fixture; served mode re-applies `/__pyric/init.json`.
  */
-export function useStudioReset(): () => Promise<{ cleared: number; errors: string[] }> {
+export function useStudioReset(): () => Promise<{ errors: string[] }> {
   const clear = useStudioClear();
   const seedDocs = useStudioSeed();
   const seedAuthUsers = useStudioSeedAuth();
@@ -486,7 +477,10 @@ export function useStudioReset(): () => Promise<{ cleared: number; errors: strin
   return useCallback(async () => {
     const result = await clear();
     if (dev.status === 'ready') {
-      const { applySeed } = await import('../dev/seed.js');
+      const { applySeed, deploySeedRules } = await import('../dev/seed.js');
+      // resetAll swapped the env, wiping the deployed dev ruleset — re-deploy
+      // it BEFORE reseeding so the fixture lands under the same governance.
+      deploySeedRules(dev.handles.sandbox);
       await applySeed(dev.handles);
     } else {
       try {

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -453,11 +453,10 @@ export function useStudioClear(): () => Promise<{ errors: string[] }> {
     if (data.status !== 'ready') throw new Error('No sandbox to clear.');
     const errors: string[] = [];
     try {
-      if (live) {
-        await live.resetAll();
-      } else {
-        await data.handles.sandbox.resetAll();
-      }
+      const result = live
+        ? await live.resetAll()
+        : await data.handles.sandbox.resetAll();
+      errors.push(...(result?.errors ?? []));
     } catch (e) {
       errors.push(`reset: ${e instanceof Error ? e.message : String(e)}`);
     }


### PR DESCRIPTION
```ts
// Studio's Settings → Reset now goes through one sandbox-owned seam that
// clears EVERY registered service — storage included:
await sandbox.resetAll();
// Firestore docs: gone. Auth users: gone. RTDB tree: null (listeners fanned).
// Storage blobs + metadata: cleared via the registered service's reset().
// Active Firestore ruleset: re-deployed afterward — deny-all still denies.
```

Fixes #359 (reported on `0.1.0-alpha.10`: Studio kept showing old Storage data and Settings → Reset cleared everything except storage — including *unrelated older projects'* objects).

Two independent defects, two commits:

## Reset was hand-rolled per service, and storage never joined

`useStudioClear` deleted Firestore docs and cleared auth users — nothing else. Storage never called `registerPersistableService` at all, and RTDB turned out to be equally unreachable from reset (confirmed and fixed here, not just suspected). The fix is the seam, not the list: `PersistableService` gains optional `reset?()`, new `Sandbox.resetAll()` iterates the *registry* with per-service failure isolation, and auth, RTDB, and storage all register. Studio becomes a thin delegation in both modes (in-process direct; served via a new symmetric `resetAll` worker op). Forgetting a future service on reset is now structurally impossible — it either registers (and resets) or doesn't persist.

Found during design and covered by a pin: `reset()` swaps the env, which silently wiped the deployed Firestore ruleset — the worker host and dev-seed flow now re-deploy the active ruleset after reset, and `getActiveRules` finally reports firestore (it never did).

## Storage's IndexedDB was one origin-wide bucket shared by every project

`DEFAULT_DB_NAME = 'pyric-storage'` + origin-scoped IDB = every project on that localhost port accumulating into one store; that's the "much older unrelated test data". Now `pyric-storage:<projectId>`, with identity flowing from the served project directory (`InitPayload.projectKey` from both `cli/serve.ts` and the vite plugin; `app.options.projectId` for bare-library use) and the worker opening the storage service eagerly so a lazy first open can't claim the shared name. Explicit `dbName` still wins. The legacy shared DB is deliberately orphaned — not migrated (old cross-project data disappearing is the point) and not deleted (older pyric versions on the origin may still read it); decision recorded at the constant.

## Risk

- `resetAll` is a new public sandbox member and a new worker-protocol op — the frozen dispatch-table and client-surface pins were updated as deliberate protocol changes (73→74 methods).
- Upgrade behavior: existing users' storage view starts empty per project (orphaned shared DB). Given the bug report, that is the desired outcome, but it is a visible change worth a release note.
- Storage service now opens eagerly under serve (previously only when storage.rules existed) — required for correct DB naming; adds one IDB open per worker boot.

<details>
<summary>Verification (failing-first evidence via stash-runs against the pre-fix tree)</summary>

- `test/sandbox/reset-all.test.ts` — seeds all four services, asserts `resetAll` empties all; registry seam, session clear, failure isolation. Pre-fix: 0 pass / 4 fail.
- `test/storage/project-scope.test.ts` — cross-project isolation (pre-fix behaviorally reads the other project's object from the shared DB), same-project sharing, explicit-dbName override.
- cli: `reset-all-op.test.ts` (worker op clears all four; rules re-deployed post-reset), `storage-project-scope.test.ts` (projectKey isolation across worker boots).
- studio: `dev/seed.test.ts` — dev-seed reset wipes storage, `deploySeedRules` + `applySeed` restore the fixture. (`useStudioClear` has no hook harness; it is now a thin delegation, so the pyric/cli tests are load-bearing.)
- Gates: pyric 5,171 pass / 0 fail (engine + admin-query pins untouched); cli 1,173 pass / 0 fail; studio 332 pass / 0 fail; typechecks clean.

</details>


## Extensions from live testing

Two more members of the same bug family surfaced in live user testing:

**resetAll now clears the traffic/event history too.** After a reset, Studio's Traffic/Session/Action Center still showed the wiped session's request/denial history. The sandbox itself already clears `history()` inside `reset()` (now pinned in pyric and at the worker event-sub layer — post-reset the backlog reads exactly empty, boundary not retained); the leak was every accumulation downstream: Studio's worker feed snapshot, `useStudioEvents`, the Action Center buffer, and the dev-seed event log now all fold live events through one session rule (`studio/src/events/fold.ts`) — a reset `session_boundary` drops everything before it, keeping exactly the boundary as a live-view "session reset" marker (pinned decision). On the worker path, the `resetAll` op also force-flushes the session capture (`.pyric/last-session.json`) past the debounce, so a worker death right after reset can no longer resurrect the wiped events via `hydrateEventHistory` on the next boot. Failing-first via stash-runs: the studio feed test and the cli capture force-flush test fail against the pre-fix tree.

**The worker sandbox persistence key is project-scoped.** The SharedWorker persisted its sandbox snapshots (auth users, Firestore docs, RTDB) under the fixed IndexedDB key `pyric-shared-worker` — the same origin-wide-bucket defect as storage, so another app's chat users and conversations appeared in an unrelated project. `buildWorkerCtx` now derives `pyric-shared-worker:<projectKey>` from the same `InitPayload.projectKey` identity the storage fix uses (legacy fixed key only when no identity exists — older servers/standalone), and mirrors the storage migration decision: the legacy shared database is orphaned, not migrated and not deleted. Boot order is safe by construction (the payload fetch already precedes `enablePersistence`) and now pinned in a comment against the eager-vs-lazy trap. Failing-first: with the key derivation reverted, project B reads project A's persisted doc and user from the shared database.

Extension gates: pyric 5,172 pass / 0 fail; cli (full) 1,178 pass / 0 fail; studio 337 pass / 0 fail; typechecks clean.
