### PR TITLE
fix(sandbox): total reset clears event history; project-scope worker persistence

### DIFF
--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -20,9 +20,13 @@
  *
  * PERSISTENCE KEY
  * ---------------
- * Using `'pyric-shared-worker'` as the IDB persistence key. This is a
- * package-level default; serve integration (Phase 3) may want to scope
- * it per-project or per-port. Phase 1 keeps it simple.
+ * Project-scoped: `'pyric-shared-worker:<projectKey>'`, derived inside
+ * `buildWorkerCtx` from the init payload's `projectKey` (issue #359 family —
+ * IndexedDB is origin-scoped, so the old fixed key shared one sandbox
+ * snapshot database across every project on a localhost port). The legacy
+ * `'pyric-shared-worker'` key applies only when no project identity exists
+ * (older servers, standalone workers); see `workerPersistenceKey` in
+ * serve-init.ts for the orphan-don't-delete migration decision.
  *
  * RULES
  * -----

--- a/packages/cli/src/serve/worker/host-context.ts
+++ b/packages/cli/src/serve/worker/host-context.ts
@@ -148,6 +148,16 @@ export interface HostCtx {
    */
   sessionMode?: AuthPersistenceMode;
   /**
+   * Force an IMMEDIATE session-capture flush, bypassing the debounce — set
+   * by `applyServeInit` when `--capture` is on (see the capture block in
+   * serve-init.ts). The `resetAll` op invokes it so the server-persisted
+   * capture (`.pyric/last-session.json`) records the post-reset (empty)
+   * event history instead of the wiped session's traffic, which a rebooting
+   * worker would otherwise re-prime via `hydrateEventHistory` (issue #359
+   * extension). Absent when capture is off.
+   */
+  captureFlush?: () => void;
+  /**
    * Per-uid impersonation Firestore handles (Pyric Studio auth lens, T2).
    * Keyed by the impersonated uid. Each is a FROZEN-identity
    * `getFirestore(sandbox.withAuth({ uid }))` handle whose ops evaluate

--- a/packages/cli/src/serve/worker/host/studio.ts
+++ b/packages/cli/src/serve/worker/host/studio.ts
@@ -55,6 +55,12 @@ export async function handleStudioOp(
             ? firestoreRules.source
             : firestoreRules?.lastKnownGood;
         if (typeof source === 'string') setRules(ctx.sandbox, source);
+        // The server capture (`.pyric/last-session.json`) persists the event
+        // history a rebooting worker re-primes into Traffic. Flush it NOW —
+        // reset just emptied `sandbox.history()`, and waiting out the
+        // capture debounce leaves a window where a worker death resurrects
+        // the wiped session's events on the next boot.
+        ctx.captureFlush?.();
         ok(port, msg.id, { errors });
       } catch (e) {
         fail(port, msg.id, e instanceof Error ? e : new Error(String(e)));

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -572,10 +572,32 @@ export function setupServerAuthFlush(
 
 // ─── Worker boot: build the ONE shared HostCtx ──────────────────────────────
 
-/** Default persistence key — also the IndexedDB database name. Package-level
- *  default; stable across reloads (never derived from the page path, so every
- *  boot on an origin opens the SAME database). */
+/** Legacy shared persistence key — also the IndexedDB database name. Stable
+ *  across reloads (never derived from the page path). Used ONLY when no
+ *  project identity exists (older servers without `InitPayload.projectKey`,
+ *  standalone workers) — see {@link workerPersistenceKey}. */
 export const WORKER_PERSISTENCE_KEY = 'pyric-shared-worker';
+
+/**
+ * Resolve the worker's persistence key (= IndexedDB database name) for a
+ * project identity: `pyric-shared-worker:<projectKey>`, or the legacy shared
+ * {@link WORKER_PERSISTENCE_KEY} when none is available.
+ *
+ * IndexedDB is origin-scoped, so the FIXED key made every project served on
+ * one localhost port share ONE sandbox snapshot database — another app's auth
+ * users, Firestore docs, and RTDB tree appeared in an unrelated project
+ * (issue #359's storage defect, same family; identity flows from the same
+ * `InitPayload.projectKey` the storage fix uses).
+ *
+ * Migration decision — mirrors `storageDbName` in pyric's
+ * `storage/persistence.ts`, recorded here deliberately: the legacy shared
+ * `pyric-shared-worker` database is ORPHANED, not migrated (cross-project
+ * state disappearing from the sandbox is the point of the fix) and not
+ * deleted (older pyric versions on the same origin may still read it).
+ */
+export function workerPersistenceKey(projectKey?: string | null): string {
+  return projectKey ? `${WORKER_PERSISTENCE_KEY}:${projectKey}` : WORKER_PERSISTENCE_KEY;
+}
 
 const PERMISSIVE_RULES = `
   rules_version = '2';
@@ -594,7 +616,9 @@ export interface WorkerBootEnv extends ServeInitEnv {
   /** The raw local backend (IndexedDB in the real worker). Also used for the
    *  instance id + branches + (via the durable wrapper) the controller blob. */
   idb: PersistenceBackend;
-  /** Persistence key / IDB database name. Default {@link WORKER_PERSISTENCE_KEY}. */
+  /** Persistence key / IDB database name. An explicit key always wins (tests
+   *  isolate per-case state with it); the default is project-scoped via
+   *  {@link workerPersistenceKey} from the init payload's `projectKey`. */
   persistenceKey?: string;
   /** Hot-reload EventSource factory. Omit/null when unavailable (tests, hosts
    *  without EventSource). */
@@ -625,9 +649,14 @@ export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
   adminDb.setRules(PERMISSIVE_RULES);
 
   // Fetch serve's init payload FIRST — it decides the DURABLE strategy before
-  // we attach: `--persist` mirrors the controller blob to the committable
-  // server file (and primes from it on a fresh worker); a `seedState` fixture
-  // primes IDB once. Null when standalone (no `pyric dev` behind us).
+  // we attach (`--persist` mirrors the controller blob to the committable
+  // server file and primes from it on a fresh worker; a `seedState` fixture
+  // primes IDB once) AND it carries `projectKey`, which must exist BEFORE the
+  // first restore/save below: the persistence key is chosen exactly once at
+  // enablePersistence, so a lazy identity here would claim the legacy shared
+  // database — the same eager-vs-lazy trap the storage DB scoping hit (see
+  // applyServeInit's unconditional storage open). Null when standalone (no
+  // `pyric dev` behind us) — the legacy shared key then applies.
   const payload = await fetchInitPayload(env.fetch);
 
   // The persistence-controller backend. `--persist`/`seedState` wrap IDB (see
@@ -636,7 +665,7 @@ export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
   // file), so that is what we hand the host as `sessionBackend`.
   const durable = payload ? createWorkerDurableBackend(env.idb, payload, env) : env.idb;
   await sandbox.enablePersistence({
-    key: env.persistenceKey ?? WORKER_PERSISTENCE_KEY,
+    key: env.persistenceKey ?? workerPersistenceKey(payload?.projectKey),
     injectedBackend: durable,
   });
 

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -297,9 +297,24 @@ export function applyServeInit(
     });
 
     result.captureEnabled = true;
+    // Immediate-flush seam for the `resetAll` op (issue #359 extension):
+    // reset clears `sandbox.history()`, and the SERVER-persisted capture
+    // (`.pyric/last-session.json`) must follow NOW — inside the debounce
+    // window a dying worker leaves the wiped session's events on disk, and
+    // the next boot's `hydrateEventHistory` would prime them straight back
+    // into Traffic. Bypasses the debounce; cancels any pending flush (it
+    // would only re-write the same post-reset history).
+    ctx.captureFlush = (): void => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      flush();
+    };
     result.dispose = (): void => {
       if (timer) clearTimeout(timer);
       unsub();
+      ctx.captureFlush = undefined;
     };
   }
 

--- a/packages/cli/test/serve/worker/persistence-project-scope.test.ts
+++ b/packages/cli/test/serve/worker/persistence-project-scope.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Worker sandbox persistence — IndexedDB project scoping (issue #359 family).
+ *
+ * The SharedWorker persisted its sandbox snapshots (auth users, Firestore
+ * docs, the RTDB tree) under the FIXED key `'pyric-shared-worker'`, and
+ * IndexedDB is origin-scoped — so every project served on one localhost port
+ * shared ONE snapshot database: another app's chat users and conversations
+ * appeared in an unrelated project. `buildWorkerCtx` now derives the key from
+ * the init payload's `projectKey` (`pyric-shared-worker:<projectKey>`, the
+ * same identity the storage DB scoping uses), falling back to the legacy
+ * shared key only when no identity exists (older servers / standalone).
+ *
+ * Strategy mirrors persistence-durability.test.ts: boot the REAL worker boot
+ * path over fake-indexeddb (process-global, standing in for the browser's
+ * origin-scoped registry), ack ops, ABANDON the ctx, boot again.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { handleMessage, type HostCtx, type PortLike } from '../../../src/serve/worker/host.js';
+import {
+  buildWorkerCtx,
+  workerPersistenceKey,
+  WORKER_PERSISTENCE_KEY,
+} from '../../../src/serve/worker/serve-init.js';
+import type { InitPayload } from '../../../src/serve/namespace.js';
+import type { OutboundMessage, ResMessage } from '../../../src/serve/worker/protocol.js';
+import { createIndexedDBBackend } from 'pyric/sandbox';
+
+/** Serve `/__pyric/init.json` for `projectKey`; every other URL 404s. */
+function serveFetch(projectKey: string | null): typeof fetch {
+  const payload: InitPayload = {
+    rules: null,
+    rulesHash: null,
+    storageRules: null,
+    storageRulesHash: null,
+    // Older servers omit projectKey entirely — model that as absent.
+    ...(projectKey !== null ? { projectKey } : {}),
+    bridgeUrl: null,
+    seed: null,
+    seedState: null,
+    authUsers: null,
+  };
+  return (async (url: unknown) => {
+    if (String(url) === '/__pyric/init.json') {
+      return { ok: true, status: 200, json: async () => payload } as Response;
+    }
+    return { ok: false, status: 404, text: async () => '' } as Response;
+  }) as unknown as typeof fetch;
+}
+
+/** Boot the worker exactly as entry.ts does — the key derives from the payload. */
+function bootWorker(projectKey: string | null): Promise<HostCtx> {
+  return buildWorkerCtx({ fetch: serveFetch(projectKey), idb: createIndexedDBBackend() });
+}
+
+let seq = 0;
+async function op(ctx: HostCtx, msg: Record<string, unknown>): Promise<ResMessage> {
+  const id = `pps-${++seq}`;
+  return new Promise((resolve) => {
+    const port: PortLike = {
+      postMessage(m: OutboundMessage) {
+        if (m.t === 'res' && m.id === id) resolve(m);
+      },
+    };
+    void handleMessage(ctx, port, { t: 'op', id, ...msg } as never);
+  });
+}
+
+async function opOk(ctx: HostCtx, msg: Record<string, unknown>): Promise<unknown> {
+  const res = await op(ctx, msg);
+  if (!res.ok) throw new Error(`expected ok, got: ${res.error.code} — ${res.error.message}`);
+  return res.value;
+}
+
+const unique = (label: string): string =>
+  `/proj/${label}-${Math.random().toString(36).slice(2, 10)}`;
+
+describe('workerPersistenceKey', () => {
+  it('scopes by project identity and pins the legacy fallback (naming scheme)', () => {
+    expect(workerPersistenceKey('/home/me/app')).toBe('pyric-shared-worker:/home/me/app');
+    expect(workerPersistenceKey(null)).toBe(WORKER_PERSISTENCE_KEY);
+    expect(workerPersistenceKey(undefined)).toBe(WORKER_PERSISTENCE_KEY);
+    expect(WORKER_PERSISTENCE_KEY).toBe('pyric-shared-worker'); // legacy DB name, orphaned not deleted
+  });
+});
+
+describe('worker sandbox persistence: project scoping', () => {
+  it('two projectKeys do not see each other; the same projectKey shares', async () => {
+    const keyA = unique('a');
+    const keyB = unique('b');
+
+    // Project A: an acked doc write + an acked user creation.
+    const ctxA = await bootWorker(keyA);
+    await opOk(ctxA, { method: 'admin.setDocument', path: 'chats/general', data: { app: 'A' } });
+    await opOk(ctxA, { method: 'auth.createUser', email: 'a@example.com', password: 'pw123456' });
+    // Abrupt teardown: nothing runs after the acks.
+
+    // Project B on the SAME origin: pre-fix this booted the shared
+    // 'pyric-shared-worker' database and READ project A's chat doc and user.
+    const ctxB = await bootWorker(keyB);
+    expect(await opOk(ctxB, { method: 'admin.getDocument', path: 'chats/general' })).toBeNull();
+    expect(await opOk(ctxB, { method: 'auth.listUsers' })).toEqual([]);
+
+    // Project A again (fresh worker boot): its own state restored.
+    const ctxA2 = await bootWorker(keyA);
+    expect(await opOk(ctxA2, { method: 'admin.getDocument', path: 'chats/general' })).toEqual({
+      app: 'A',
+    });
+    const users = (await opOk(ctxA2, { method: 'auth.listUsers' })) as Array<{ email?: string }>;
+    expect(users.map((u) => u.email)).toEqual(['a@example.com']);
+  });
+
+  it('no project identity (older server) falls back to the shared legacy key', async () => {
+    // Two boots WITHOUT a projectKey share the legacy database — the pinned
+    // compatibility posture for servers that predate InitPayload.projectKey.
+    const marker = `legacy-${Math.random().toString(36).slice(2, 10)}`;
+    const ctx1 = await bootWorker(null);
+    await opOk(ctx1, { method: 'admin.setDocument', path: `legacy/${marker}`, data: { v: 1 } });
+
+    const ctx2 = await bootWorker(null);
+    expect(await opOk(ctx2, { method: 'admin.getDocument', path: `legacy/${marker}` })).toEqual({
+      v: 1,
+    });
+
+    // And a project-scoped boot does NOT see the legacy data.
+    const scoped = await bootWorker(unique('scoped'));
+    expect(await opOk(scoped, { method: 'admin.getDocument', path: `legacy/${marker}` })).toBeNull();
+  });
+});

--- a/packages/cli/test/serve/worker/reset-all-op.test.ts
+++ b/packages/cli/test/serve/worker/reset-all-op.test.ts
@@ -31,6 +31,8 @@ import type {
   ResMessage,
 } from '../../../src/serve/worker/protocol.js';
 import { bytesToBase64 } from '../../../src/serve/worker/protocol.js';
+import { applyServeInit } from '../../../src/serve/worker/serve-init.js';
+import type { InitPayload } from '../../../src/serve/namespace.js';
 
 let dbSeq = 0;
 function uniqueDbName(): string {
@@ -119,5 +121,77 @@ describe('worker resetAll op', () => {
     });
     expect(write.ok).toBe(false);
     if (!write.ok) expect(write.error.code).toBe('permission-denied');
+  });
+
+  it('empties the event history — a post-reset event subscription reads an empty backlog', async () => {
+    // "This is a total reset": Studio's Traffic feed sources the worker's
+    // `sandbox.history()` as the initial event-sub batch. After resetAll the
+    // wiped session's request/denial/delete record must be gone — the sandbox
+    // clears `history()` inside `reset()` (boundary not retained); this pins
+    // that contract at the layer Studio actually reads.
+    const ctx = makeCtx();
+    // A rules-governed write emits request/write events onto the history.
+    await op(ctx, { method: 'setDoc', path: 'rooms/general', data: { name: 'General' } });
+    expect(ctx.sandbox.history().length).toBeGreaterThan(0);
+
+    await opOk(ctx, { method: 'resetAll' });
+
+    const batches: (readonly unknown[])[] = [];
+    const subPort: PortLike = {
+      postMessage(msg: OutboundMessage) {
+        if (msg.t === 'event') batches.push(msg.events);
+      },
+    };
+    await handleMessage(ctx, subPort, {
+      t: 'sub',
+      subId: 'post-reset-events',
+      target: 'events',
+    } as InboundMessage);
+    expect(batches).toEqual([[]]); // initial history batch: nothing survived
+    expect(ctx.sandbox.history()).toEqual([]);
+  });
+
+  it('force-flushes the session capture so a rebooting worker cannot re-prime wiped events', async () => {
+    // The server capture (`.pyric/last-session.json`) persists the event
+    // history `hydrateEventHistory` primes back on the next worker boot.
+    // resetAll must push the post-reset (empty) history there IMMEDIATELY —
+    // pre-fix the write waited out the capture debounce, so a worker death in
+    // that window resurrected the wiped session's traffic.
+    const ctx = makeCtx();
+    const posts: string[] = [];
+    const fetchStub = (async (url: unknown, init?: { method?: string; body?: string }) => {
+      if (String(url) === '/__pyric/capture' && init?.method === 'POST') {
+        posts.push(init.body ?? '');
+        return { status: 200, ok: true } as Response;
+      }
+      return { status: 404, ok: false } as Response;
+    }) as unknown as typeof fetch;
+
+    const payload: InitPayload = {
+      rules: null,
+      rulesHash: null,
+      storageRules: null,
+      storageRulesHash: null,
+      bridgeUrl: null,
+      seed: null,
+      seedState: null,
+      authUsers: null,
+      capture: true,
+    };
+    // A debounce far beyond the test's lifetime: any capture POST observed
+    // below can only come from the resetAll op's forced flush.
+    applyServeInit(ctx, payload, { fetch: fetchStub, captureDebounceMs: 600_000 });
+
+    // A rules-governed write puts events on the history (and arms the
+    // debounced capture, which must NOT fire within this test's lifetime).
+    await op(ctx, { method: 'setDoc', path: 'rooms/general', data: { name: 'General' } });
+    expect(ctx.sandbox.history().length).toBeGreaterThan(0);
+    expect(posts).toHaveLength(0); // debounced — nothing flushed yet
+
+    await opOk(ctx, { method: 'resetAll' });
+
+    expect(posts.length).toBeGreaterThan(0);
+    const fixture = JSON.parse(posts[posts.length - 1]!) as { events?: unknown[] };
+    expect(fixture.events ?? []).toEqual([]); // the capture now records the empty log
   });
 });

--- a/packages/pyric/test/sandbox/reset-all.test.ts
+++ b/packages/pyric/test/sandbox/reset-all.test.ts
@@ -16,6 +16,7 @@
 import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'bun:test';
 import { initializeSandbox } from '../../src/sandbox/index.js';
+import { getInternalEnv } from '../../src/sandbox/internal/sandbox-impl.js';
 import { getAuth, sandbox as authSandbox } from '../../src/auth/index.js';
 import { getDatabase, ref as rtdbRef, set as rtdbSet, get as rtdbGet } from '../../src/database/modular.js';
 import { getStorageSandbox, getStorageService } from '../../src/storage/service.js';
@@ -84,6 +85,44 @@ describe('Sandbox.resetAll', () => {
     const sandbox = initializeSandbox();
     getStorageSandbox(sandbox, { dbName: uniqueDbName('registry') });
     expect(Object.keys(sandbox.snapshot().services)).toContain('storage');
+  });
+
+  it('empties the event history — the traffic/event record does not survive a total reset', async () => {
+    // Pin (issue #359 extension): the sandbox event log is cleared by the
+    // `reset()` inside resetAll — the closing session_boundary is emitted to
+    // live subscribers but NOT retained in `history()`, and the Firestore
+    // env's own event log dies with the env swap. Post-reset, `history()`
+    // reads EXACTLY empty; consumers (Studio Traffic / Action Center) rely
+    // on this rather than re-clearing engine state themselves.
+    const sandbox = initializeSandbox();
+    getInternalEnv(sandbox).execute({
+      method: 'set',
+      path: 'rooms/general',
+      auth: { uid: 'alice' },
+      data: { name: 'General' },
+    });
+    expect(sandbox.history().length).toBeGreaterThan(0);
+
+    const boundaries: unknown[] = [];
+    sandbox.onEvent((event) => {
+      if (event.kind === 'session_boundary') boundaries.push(event);
+    });
+
+    await sandbox.resetAll();
+
+    expect(sandbox.history()).toEqual([]);
+    // The boundary DID fire (live consumers see the session close)…
+    expect(boundaries).toHaveLength(1);
+    // …and post-reset activity starts a fresh log (the swapped-in env's log,
+    // with no boundary carried over).
+    getInternalEnv(sandbox).execute({
+      method: 'set',
+      path: 'rooms/next',
+      auth: { uid: 'alice' },
+      data: { name: 'Next' },
+    });
+    expect(sandbox.history().length).toBeGreaterThan(0);
+    expect(sandbox.history().every((e) => e.kind !== 'session_boundary')).toBe(true);
   });
 
   it('clears the signed-in session like reset() does', async () => {

--- a/packages/studio/src/clients/worker-live.test.ts
+++ b/packages/studio/src/clients/worker-live.test.ts
@@ -244,6 +244,47 @@ describe('workerEventFeed (F1 live-feed adapter)', () => {
     );
     expect(unsubMsg).toBeDefined();
   });
+
+  it('a reset session_boundary clears the running snapshot down to the boundary (issue #359 extension)', () => {
+    const sw = controllableSharedWorker();
+    restore = sw.restore;
+    const db: ClientDb = workerGetFirestore('worker://test');
+    const feed = workerEventFeed(db);
+    const seen: string[] = [];
+    feed.subscribe((e) => seen.push(e.id));
+
+    const subMsg = sw.port.sent.find(
+      (m): m is { t: 'sub'; subId: string; target: string } =>
+        (m as { t?: string }).t === 'sub' &&
+        (m as { target?: string }).target === 'events',
+    );
+    const subId = subMsg!.subId;
+
+    // Accumulate a session, then the worker resets: `sandbox.reset()` emits
+    // the boundary live and clears its own history. Pre-fix the feed's
+    // running snapshot kept the wiped session's traffic forever — Studio's
+    // Traffic pane still showed old requests after Settings → Reset.
+    sw.deliver({ t: 'event', subId, events: [fakeWrite('h1'), fakeWrite('h2')] });
+    sw.deliver({ t: 'event', subId, events: [fakeWrite('l1')] });
+    const boundary = {
+      kind: 'session_boundary',
+      id: 'b1',
+      at: 1,
+      phase: 'reset',
+      priorOpCount: 3,
+    } as unknown as SandboxEvent;
+    sw.deliver({ t: 'event', subId, events: [boundary] });
+
+    // Pinned decision (events/fold.ts): the live view keeps EXACTLY the
+    // boundary as a "session reset" marker — nothing else survives.
+    expect(feed.history().map((e) => e.id)).toEqual(['b1']);
+    // Subscribers still see every delivery (the boundary included).
+    expect(seen).toEqual(['h1', 'h2', 'l1', 'b1']);
+
+    // The next session accumulates fresh on top of the marker.
+    sw.deliver({ t: 'event', subId, events: [fakeWrite('n1')] });
+    expect(feed.history().map((e) => e.id)).toEqual(['b1', 'n1']);
+  });
 });
 
 describe('listDocuments (F2 phantom-inclusive browse)', () => {

--- a/packages/studio/src/clients/worker-live.ts
+++ b/packages/studio/src/clients/worker-live.ts
@@ -25,6 +25,7 @@
  */
 
 import type { SandboxEvent, SandboxSnapshot } from 'pyric/sandbox';
+import { isSessionResetBoundary } from '../events/fold.js';
 import type { Auth } from 'pyric/auth';
 import type { FirebaseStorage } from 'pyric/storage';
 import type { FirestoreApi } from '@pyric/ui/firestore';
@@ -237,14 +238,19 @@ export function workerEventFeed(db: ClientDb): LiveEventFeed {
     if (workerUnsub) return;
     workerUnsub = subscribeEvents(db, (events) => {
       const isHistoryBatch = !sawHistory;
-      if (isHistoryBatch) {
-        sawHistory = true;
-        // The first batch is the full `history()` snapshot: seed it…
-        historySnapshot = events;
-      } else {
-        // …subsequent batches are live; append to the running snapshot.
-        historySnapshot = [...historySnapshot, ...events];
+      sawHistory = true;
+      // The first batch is the full `history()` snapshot (REPLACES the
+      // snapshot); subsequent batches are live (append). Either way each
+      // event folds through the session rule: a reset `session_boundary`
+      // drops everything before it (see `events/fold.ts`) so the running
+      // snapshot mirrors the worker's now-cleared `history()` — pre-fix it
+      // kept the wiped session's traffic forever (issue #359 extension).
+      const next: SandboxEvent[] = isHistoryBatch ? [] : [...historySnapshot];
+      for (const event of events) {
+        if (isSessionResetBoundary(event)) next.length = 0;
+        next.push(event);
       }
+      historySnapshot = next;
       // Fan EVERY event (history backlog included) out to subscribers, so an
       // early subscriber that read an empty `history()` still gets the backlog.
       for (const event of events) {

--- a/packages/studio/src/dev/DevSeedProvider.tsx
+++ b/packages/studio/src/dev/DevSeedProvider.tsx
@@ -22,6 +22,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { SandboxEvent } from 'pyric/sandbox';
+import { foldSessionEventLog } from '../events/fold.js';
 import type { SeededHandles } from './seed.js';
 
 export type DevSeedState =
@@ -66,7 +67,10 @@ function DevSeedProviderImpl({ children }: { children: ReactNode }) {
         // Seed the event log from history, then stay live on the stream.
         setEvents(resolved.sandbox.history());
         unsubscribe = resolved.sandbox.onEvent((event) => {
-          setEvents((prev) => [...prev, event]);
+          // Fold through the session rule: "Reset session" emits a reset
+          // session_boundary and clears sandbox.history(); this accumulated
+          // mirror must drop the wiped session too (see `events/fold.ts`).
+          setEvents((prev) => foldSessionEventLog(prev, event));
         });
       } catch (e) {
         if (!cancelled) {

--- a/packages/studio/src/events/fold.test.ts
+++ b/packages/studio/src/events/fold.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Session-scoped event-log folding (issue #359 extension): the one rule every
+ * Studio accumulation applies so Settings → Reset also empties the
+ * traffic/event surfaces. Pins the decision recorded in `fold.ts`: a reset
+ * boundary keeps EXACTLY the boundary event; a dispose boundary appends.
+ */
+import { describe, expect, it } from 'bun:test';
+import type { SandboxEvent } from 'pyric/sandbox';
+import { foldSessionEventLog, isSessionResetBoundary } from './fold.js';
+
+function write(id: string): SandboxEvent {
+  return { kind: 'write', id, at: 1, path: `notes/${id}` } as unknown as SandboxEvent;
+}
+
+function boundary(id: string, phase: 'reset' | 'dispose'): SandboxEvent {
+  return {
+    kind: 'session_boundary',
+    id,
+    at: 2,
+    phase,
+    priorOpCount: 3,
+  } as unknown as SandboxEvent;
+}
+
+describe('foldSessionEventLog', () => {
+  it('appends ordinary events', () => {
+    const log = foldSessionEventLog([write('a')], write('b'));
+    expect(log.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  it('a reset boundary drops the wiped session, keeping only the boundary (pinned)', () => {
+    let log: readonly SandboxEvent[] = [];
+    for (const e of [write('a'), write('b'), boundary('r1', 'reset')]) {
+      log = foldSessionEventLog(log, e);
+    }
+    expect(log.map((e) => e.id)).toEqual(['r1']);
+    // The next session accumulates on top of the marker.
+    log = foldSessionEventLog(log, write('c'));
+    expect(log.map((e) => e.id)).toEqual(['r1', 'c']);
+  });
+
+  it('a dispose boundary does NOT clear — dispose closes, it does not wipe', () => {
+    const log = foldSessionEventLog([write('a')], boundary('d1', 'dispose'));
+    expect(log.map((e) => e.id)).toEqual(['a', 'd1']);
+  });
+});
+
+describe('isSessionResetBoundary', () => {
+  it('matches only session_boundary events with phase reset', () => {
+    expect(isSessionResetBoundary(boundary('r', 'reset'))).toBe(true);
+    expect(isSessionResetBoundary(boundary('d', 'dispose'))).toBe(false);
+    expect(isSessionResetBoundary(write('w'))).toBe(false);
+  });
+});

--- a/packages/studio/src/events/fold.ts
+++ b/packages/studio/src/events/fold.ts
@@ -1,0 +1,40 @@
+/**
+ * Session-scoped event-log folding — the ONE rule for what a Studio event
+ * accumulation keeps across a sandbox reset (issue #359 extension: Settings →
+ * Reset must also empty Traffic / Session / Action Center, not just the data).
+ *
+ * `sandbox.reset()` emits a `session_boundary` (phase `'reset'`) and THEN
+ * clears its own `history()` — the source of truth reads empty afterwards.
+ * Studio's surfaces, however, ACCUMULATE the live stream in their own state
+ * (the worker feed's running snapshot, `useStudioEvents`, the Action Center
+ * buffer, the dev-seed event log); without folding the boundary they keep
+ * showing the wiped session's traffic forever. Every accumulation site folds
+ * through here so the rule cannot drift per surface.
+ *
+ * PINNED DECISION: on a reset boundary the fold keeps EXACTLY the boundary
+ * event itself — the live view shows one "session reset" marker (see
+ * `features/home/activity.ts`) instead of a mysteriously blank log, while
+ * everything from the closed session drops. `sandbox.history()` itself keeps
+ * NOTHING (a worker reboot shows an empty feed); the marker is a live-view
+ * nicety only. A `'dispose'` boundary does NOT clear: dispose closes the
+ * sandbox, it doesn't wipe data.
+ */
+import type { SandboxEvent } from 'pyric/sandbox';
+
+/** True for the `session_boundary` a `sandbox.reset()` emits — the signal
+ *  that every event before it belongs to a wiped session. */
+export function isSessionResetBoundary(event: SandboxEvent): boolean {
+  return event.kind === 'session_boundary' && event.phase === 'reset';
+}
+
+/**
+ * Fold one live event into an accumulated log: append, except a reset
+ * boundary REPLACES the log with just itself. Pure/immutable — safe as a
+ * React `setState` updater.
+ */
+export function foldSessionEventLog(
+  prev: readonly SandboxEvent[],
+  event: SandboxEvent,
+): readonly SandboxEvent[] {
+  return isSessionResetBoundary(event) ? [event] : [...prev, event];
+}

--- a/packages/studio/src/features/action-center/useActionDigest.ts
+++ b/packages/studio/src/features/action-center/useActionDigest.ts
@@ -13,6 +13,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { SandboxEvent } from 'pyric/sandbox';
 import type { EventFeed } from './feed.js';
+import { isSessionResetBoundary } from '../../events/fold.js';
 import { digestFromEvents, type DigestItem } from './reducer.js';
 
 export interface UseActionDigestOptions {
@@ -46,6 +47,10 @@ export function useActionDigest(
 
     const unsubscribe = feed.subscribe((event) => {
       setEvents((prev) => {
+        // A reset session_boundary wipes the buffer down to the boundary
+        // itself (see `events/fold.ts`): the digest must not keep summarizing
+        // a session the sandbox just erased (issue #359 extension).
+        if (isSessionResetBoundary(event)) return [event];
         const next =
           prev.length >= bufferSizeRef.current ? prev.slice(1) : prev.slice();
         next.push(event);

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -36,6 +36,7 @@ import type {
 } from 'pyric/sandbox';
 import { toOperationRecord } from 'pyric/sandbox';
 import type { StudioTrafficEvent } from '../features/traffic/verdict.js';
+import { foldSessionEventLog } from '../events/fold.js';
 import { useDevSeed } from '../dev/DevSeedProvider.js';
 import { useEnvironment } from './environment.js';
 import type { WorkerLivePlane } from '../env.js';
@@ -238,9 +239,12 @@ export function useStudioEvents(): readonly SandboxEvent[] {
       return;
     }
     // Cap BOTH accumulation paths (the history seed and the live appends).
+    // Live appends fold through the session rule: a reset boundary drops the
+    // wiped session's events (see `events/fold.ts`) so Traffic/Session read
+    // (near-)empty after Settings → Reset — issue #359 extension.
     setLiveEvents(capNewest(liveFeed.history()));
     const unsub = liveFeed.subscribe((event) =>
-      setLiveEvents((prev) => capNewest([...prev, event])),
+      setLiveEvents((prev) => capNewest(foldSessionEventLog(prev, event))),
     );
     return unsub;
   }, [seedReady, liveFeed]);


### PR DESCRIPTION
```ts
// Post-reset, the sandbox's event record is EXACTLY empty — Studio's feeds keep
// only the closing session_boundary marker; and two projects on one origin no
// longer share persisted auth/Firestore/RTDB state:
await sandbox.resetAll();
sandbox.history();                       // []
// worker persistence: 'pyric-shared-worker:<projectKey>' (legacy key orphaned)
```

Continuation of #361 (merged while these two commits were in flight — same branch, same review context, issue #359 extensions from live testing).

## A reset that replays old traffic is not a reset

`reset()` already cleared `sandbox.history()`; the leak was every downstream accumulation — Studio's worker event feed snapshot, live-events buffer, action digest, dev-seed log (now folded through one rule in `studio/src/events/fold.ts`), and the worker's persisted capture file, which re-primed the old history on next boot (`resetAll` now force-flushes the empty log past the debounce). Pinned: post-reset `history()` is `[]`; Studio keeps exactly the `session_boundary` marker; a `dispose` boundary does not clear.

## The worker persistence key was the storage bug again

Fixed `pyric-shared-worker` key → every project on one localhost port shared persisted auth users, Firestore docs, and RTDB — observed live as another app's chat users appearing in an unrelated project. Now `pyric-shared-worker:<projectKey>` (same identity the storage scoping uses), legacy key only without identity, explicit `persistenceKey` wins, orphan-don't-delete per the recorded #359 decision. Boot order is safe by construction (init-payload fetch precedes `enablePersistence`) and pinned with a comment.

## Risk

- Upgrade: previously persisted cross-project state stops appearing (orphaned legacy key) — the desired outcome, same release-note item as #361's storage scoping.
- Studio event-feed consumers now share one fold rule — behavior pinned by `events/fold.test.ts`.

<details>
<summary>Verification</summary>

Failing-first via stash-runs: Ext 1 — studio feed retains `h1,h2,l1` pre-fix, capture force-flush absent; Ext 2 — with key derivation reverted, project B reads project A's persisted doc and auth user. Gates: pyric 5,172 / 0 fail (pins untouched), cli full 1,178 / 0, studio 337 / 0, typechecks clean.

</details>