### PR TITLE
fix(test): disable color in the rtdb expression-engine subprocess probe

### DIFF
--- a/packages/pyric/test/rules/rtdb/expression-engine.test.ts
+++ b/packages/pyric/test/rules/rtdb/expression-engine.test.ts
@@ -9,6 +9,7 @@ function sourceUrl(path: string): string {
 function runProbe(source: string): string {
   const result = Bun.spawnSync([process.execPath, '--eval', source], {
     cwd: resolve(import.meta.dir, '../../../../..'),
+    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
     stdout: 'pipe',
     stderr: 'pipe',
   });


### PR DESCRIPTION
```ts
// packages/pyric/test/rules/rtdb/expression-engine.test.ts — the probe subprocess
const proc = Bun.spawnSync({
  cmd: ['bun', '--eval', source],
  env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },  // added
});
// before: expect(output).toBe('false') failed with
//   Expected: "false"
//   Received: "false"   ← byte-different: ANSI color codes around the boolean
```

## The probe's stdout carried invisible color codes, so the test failed on identical-looking strings

The test spawns `bun --eval` and asserts on captured stdout. Bun's `console.log` colorizes booleans when it thinks it has a terminal, and the subprocess inherited the color-enabled environment — so it printed `false` wrapped in escape codes, and the equality check failed while rendering identically in a terminal. Forcing color off in the subprocess env fixes it at the source; no output stripping.

This was the one persistent failure on main's pyric suite; three separate fresh checkouts hit it this week and each had to stash-verify it wasn't theirs.

Fixes #374

## Risk

None beyond the one line: the env override applies only to the spawned probe, and asserting on undecorated program output is the probe's entire purpose.

<details>
<summary>Verification</summary>

- Isolated: `bun test --cwd packages/pyric test/rules/rtdb/expression-engine.test.ts` → 2 pass, 0 fail (previously 1 pass, 1 fail).
- Full rules suite after `bash scripts/build.sh --packages-only`: 2381 pass, 28 skip, 0 fail (88 files).

</details>
