### PR TITLE
fix(site): dead docs paths return real 404s; scope the SPA rewrite to Studio tabs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,11 +9,27 @@
     ],
     "rewrites": [
       {
-        "source": "/docs/**",
-        "destination": "/docs/index.html"
+        "source": "/firestore/**",
+        "destination": "/index.html"
       },
       {
-        "source": "**",
+        "source": "/auth/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/rtdb/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/storage/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/traffic/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/settings/**",
         "destination": "/index.html"
       }
     ],

--- a/packages/site-docs/src/pages/404.astro
+++ b/packages/site-docs/src/pages/404.astro
@@ -1,0 +1,44 @@
+---
+import { withBase } from '../lib/content';
+import '../styles/site.css';
+
+const docsHome = withBase('/docs/');
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page not found · Pyric Studio</title>
+  </head>
+  <body>
+    <main class="not-found">
+      <h1>Page not found</h1>
+      <p>That page does not exist. <a href={docsHome}>Go to the docs</a>.</p>
+    </main>
+    <style>
+      .not-found {
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        gap: 8px;
+        padding: 24px;
+      }
+      .not-found h1 {
+        font-size: 20px;
+        font-weight: 600;
+        color: var(--ink);
+        margin: 0;
+      }
+      .not-found p {
+        color: var(--muted);
+        margin: 0;
+      }
+      .not-found a {
+        color: var(--accent);
+      }
+    </style>
+  </body>
+</html>

--- a/scripts/deploy-site.test.mjs
+++ b/scripts/deploy-site.test.mjs
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import {
   chmodSync,
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -13,6 +14,7 @@ import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const sourceScript = new URL('./deploy-site.sh', import.meta.url);
+const repoRoot = new URL('../', import.meta.url);
 const fixtures = [];
 
 afterEach(() => {
@@ -75,5 +77,42 @@ describe('deploy-site.sh', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('dist/site/index.html');
     expect(trace).toEqual(['bun run build --packages-only', 'build-site']);
+  });
+});
+
+describe('firebase.json hosting rewrites', () => {
+  const firebaseJson = JSON.parse(readFileSync(new URL('firebase.json', repoRoot), 'utf8'));
+
+  test('has no /docs/** (or other **) catch-all rewrite', () => {
+    // A catch-all under /docs/** (or a bare `**`) turns any dead docs URL —
+    // typo'd, removed, crawled by a stale link — into a 200'd app shell
+    // instead of a real 404 (issue #375). The docs are pure static output
+    // (Astro `directory` format: every page is its own <slug>/index.html),
+    // so real docs URLs need no rewrite at all; Firebase Hosting serves
+    // them, and dist/site/404.html, natively. Only the Studio SPA's own
+    // client-routed tabs get scoped rewrites.
+    const sources = firebaseJson.hosting.rewrites.map((rewrite) => rewrite.source);
+    expect(sources).not.toContain('/docs/**');
+    expect(sources).not.toContain('**');
+  });
+
+  test('scopes remaining rewrites to Studio SPA tab prefixes, all pointing at /index.html', () => {
+    for (const rewrite of firebaseJson.hosting.rewrites) {
+      expect(rewrite.destination).toBe('/index.html');
+      expect(rewrite.source).toMatch(/^\/[a-z]+\/\*\*$/);
+    }
+  });
+});
+
+describe('dist/site/404.html', () => {
+  // The composed site build (`bash scripts/build-site.sh`) is not part of
+  // this suite's `pretest` (packages-only). Skip when dist/site hasn't been
+  // composed rather than failing the root suite; run `bash scripts/build.sh
+  // --packages-only && bash scripts/build-site.sh` first to exercise this.
+  const distSite = new URL('../dist/site/', import.meta.url);
+  const built = existsSync(new URL('index.html', distSite));
+
+  test.skipIf(!built)('is a real file Firebase Hosting serves for any dead path', () => {
+    expect(existsSync(new URL('404.html', distSite))).toBe(true);
   });
 });

--- a/scripts/site/build.ts
+++ b/scripts/site/build.ts
@@ -16,6 +16,10 @@
  *                                  + /docs/index.json), built with DOCS_BASE=/
  *     _astro/…                     the docs pages' one shared stylesheet
  *     llms.txt                     the docs' generated agent entry point
+ *     404.html                     the docs' 404 page, copied to the site
+ *                                  root so Firebase Hosting serves it for
+ *                                  any dead path (no catch-all rewrite
+ *                                  swallows misses into a 200'd app shell)
  *
  * Every piece here is already output:'static'/pure-esbuild; this script's only
  * job is to run each build with the right base path and copy bytes into one
@@ -188,7 +192,18 @@ async function buildDocs(): Promise<void> {
   // root index.html (`dist/index.html`, "Pyric docs") — Studio owns / in the
   // composed site.
   cpSync(join(docsDist, 'llms.txt'), join(DIST, 'llms.txt'));
-  log('Docs + llms.txt composed → dist/site/docs, /_astro, /llms.txt');
+  // The site's real 404 page (packages/site-docs/src/pages/404.astro).
+  // Astro always emits this at the build root regardless of `format`, so it
+  // lands at dist/404.html here — copy it to the composed site's root, where
+  // Firebase Hosting serves it automatically whenever no static file and no
+  // rewrite matches a request (see firebase.json: no more `/docs/**` catch-all
+  // swallowing dead docs paths into a 200'd app shell).
+  const docs404 = join(docsDist, '404.html');
+  if (!existsSync(docs404)) {
+    throw new Error(`build-site: site-docs build did not produce ${docs404}`);
+  }
+  cpSync(docs404, join(DIST, '404.html'));
+  log('Docs + llms.txt + 404.html composed → dist/site/docs, /_astro, /llms.txt, /404.html');
 }
 
 await main();


### PR DESCRIPTION
```
$ curl -s -o /dev/null -w '%{http_code}' https://pyric.dev/docs/nonexistent-page
404    # was: 200 with the docs shell

$ curl -s -o /dev/null -w '%{http_code}' https://pyric.dev/firestore/users/abc
200    # Studio SPA routing, unchanged
```

## Dead docs paths now return a real 404 instead of the app shell

`firebase.json` rewrote `/docs/**` to `docs/index.html` and `**` to `index.html`, so every mistyped or removed URL answered 200 — crawlers index ghost pages and link checkers pass on broken links. The `/docs/**` rewrite served nothing: Astro builds every doc page as its own `<slug>/index.html`, and Hosting serves directory indexes natively. The bare `**` catch-all did serve Studio's client-side routing, so it is now scoped to the six real tab prefixes (`/firestore/**`, `/auth/**`, `/rtdb/**`, `/storage/**`, `/traffic/**`, `/settings/**`) instead of swallowing the world. A minimal `404.astro` (site tokens, one line, link back to `/docs/`) is copied into the composed site by `scripts/site/build.ts` with a fail-fast check.

Fixes #375

## Risk

A future Studio tab needs its prefix added to `firebase.json` or its deep links 404 — the new deploy-site test pins the rewrite list, so the omission fails a test rather than shipping silently. Nothing else changes: doc pages, `/docs/index.json` (Studio probe), `.md` agent twins, and `llms.txt` are all real files and were individually verified against the Hosting emulator.

<details>
<summary>Verification</summary>

Built the composed site and exercised it with the Firebase Hosting emulator:

- `/docs/nonexistent-page` → 404 (custom page); `/random-garbage-path` → 404
- `/docs/build/ai-logic/` → 200; `/docs/index.json` → 200; `/docs/get-started/how-the-swap-works.md` → 200; `/llms.txt` → 200; `/docs` → 301 → `/docs/` → 200
- `/firestore/users/abc` and `/auth/some/deep/path` → 200 SPA shell
- `bun test scripts/deploy-site.test.mjs` → 5 pass (404-exists test skips cleanly when `dist/site` is absent so the pretest-only CI path is unaffected)
- `bun run --cwd packages/site-docs test` → 4 pass with packages built

</details>
