### PR TITLE
ci: make Playground contract non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,27 +55,6 @@ jobs:
           CI_PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: bun scripts/ci/plan.ts
 
-  playground-caniuse:
-    name: Playground can-i-use browser contract
-    runs-on: ubuntu-latest
-    needs: plan
-    if: needs.plan.outputs.check-set == 'full'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.11'
-
-      - name: Install browser workspace
-        run: bun install --frozen-lockfile
-
-      - name: Build clean-checkout package graph and conformance projections
-        run: bash scripts/build.sh --packages-only
-
-      - name: Test tool, prompt, registration, and browser bundle budget
-        run: bun run --cwd packages/playground test:can-i-use
-
   build-and-test:
     name: Build all packages + run tests
     runs-on: ubuntu-latest
@@ -343,7 +322,7 @@ jobs:
     name: CI / required
     runs-on: ubuntu-latest
     if: always()
-    needs: [plan, playground-caniuse, build-and-test, library-tests, browser-conformance, release-contract, docs-only, packaging, install-matrix]
+    needs: [plan, build-and-test, library-tests, browser-conformance, release-contract, docs-only, packaging, install-matrix]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/playground-contract.yml
+++ b/.github/workflows/playground-contract.yml
@@ -1,0 +1,61 @@
+# Visible, non-blocking contract for the Playground prototype.
+#
+# This workflow intentionally remains outside the required CI aggregate. Its
+# failures should be investigated, but they must never prevent a merge.
+
+name: Playground Contract
+
+on:
+  pull_request:
+    paths:
+      - 'packages/playground/**'
+      - 'packages/conformance/**'
+      - 'packages/cli/src/conformance/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'scripts/build.sh'
+      - '.github/workflows/playground-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/playground/**'
+      - 'packages/conformance/**'
+      - 'packages/cli/src/conformance/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'scripts/build.sh'
+      - '.github/workflows/playground-contract.yml'
+  schedule:
+    - cron: '43 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: playground-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playground-caniuse:
+    name: Playground can-i-use browser contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Scheduled and manually dispatched audits exercise the current main
+          # branch; PRs and pushes exercise the triggering revision.
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'main' || github.sha }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install browser workspace
+        run: bun install --frozen-lockfile
+
+      - name: Build clean-checkout package graph and conformance projections
+        run: bash scripts/build.sh --packages-only
+
+      - name: Test tool, prompt, registration, and browser bundle budget
+        run: bun run --cwd packages/playground test:can-i-use

--- a/scripts/ci/required.test.ts
+++ b/scripts/ci/required.test.ts
@@ -5,7 +5,6 @@ const success = {
   'build-and-test': 'success',
   'library-tests': 'success',
   'browser-conformance': 'success',
-  'playground-caniuse': 'success',
   'release-contract': 'skipped',
   'docs-only': 'success',
   packaging: 'skipped',
@@ -18,7 +17,20 @@ describe('required CI result', () => {
     expect(requiredFailures({
       checkSet: 'release-only',
       requirePackaging: false,
-      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'playground-caniuse': 'skipped', 'docs-only': 'skipped', 'release-contract': 'success' },
+      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'docs-only': 'skipped', 'release-contract': 'success' },
+    })).toEqual([]);
+  });
+
+  test('ignores a missing or failed independent Playground result', () => {
+    expect(requiredFailures({
+      checkSet: 'full',
+      requirePackaging: false,
+      results: success,
+    })).toEqual([]);
+    expect(requiredFailures({
+      checkSet: 'full',
+      requirePackaging: false,
+      results: { ...success, 'playground-caniuse': 'failure' },
     })).toEqual([]);
   });
 
@@ -46,6 +58,6 @@ test('full runs require the documentation build (regression: docs gap)', () => {
   expect(requiredFailures({
     checkSet: 'full',
     requirePackaging: false,
-    results: { 'build-and-test': 'success', 'library-tests': 'success', 'browser-conformance': 'success', 'playground-caniuse': 'success', 'docs-only': 'skipped' },
+    results: { 'build-and-test': 'success', 'library-tests': 'success', 'browser-conformance': 'success', 'docs-only': 'skipped' },
   })).toEqual(['docs-only: skipped']);
 });

--- a/scripts/ci/required.ts
+++ b/scripts/ci/required.ts
@@ -9,7 +9,7 @@ interface RequiredInput {
 }
 
 const CHECK_SET_JOBS: Record<PrCheckSet, readonly string[]> = {
-  full: ['build-and-test', 'library-tests', 'browser-conformance', 'playground-caniuse', 'docs-only'],
+  full: ['build-and-test', 'library-tests', 'browser-conformance', 'docs-only'],
   'release-only': ['release-contract'],
   'docs-only': ['docs-only'],
 };


### PR DESCRIPTION
Moves the Playground can-I-use contract into its own visible workflow so prototype failures no longer block `CI / required`.

```yaml
name: Playground Contract

on:
  pull_request:
    paths:
      - 'packages/playground/**'
      - 'packages/conformance/**'
      - 'packages/cli/src/conformance/**'
  schedule:
    - cron: '43 10 * * *'
  workflow_dispatch:

jobs:
  playground-caniuse:
    steps:
      - run: bash scripts/build.sh --packages-only
      - run: bun run --cwd packages/playground test:can-i-use
```

## `CI / required` no longer waits for the Playground prototype

Relevant pull requests and pushes to `main` still report the Playground contract as an ordinary failed or successful check. Nightly and manual runs check the current `main` branch. The existing install, package build, unit-contract, registration, prompt-budget, and browser-bundle checks are unchanged.

The full required proof still includes the package build, library tests, browser conformance, and documentation build. Playground results are absent from both the workflow dependency list and `requiredFailures`, including when a Playground result is explicitly `failure`.

## Risk

The path filter is now responsible for immediate Playground feedback. A missed dependency would defer detection until the nightly run; the filter includes the Playground, conformance model, browser projection, root dependency manifests, lockfile, package build script, and this workflow itself.

The judgment call is deliberate: Playground remains non-blocking even for pull requests that modify it directly. Its failed check stays visible because the workflow does not use `continue-on-error`.

<details>
<summary>Implementation notes</summary>

- `bun test scripts/ci/check-set.test.ts scripts/ci/plan.test.ts scripts/ci/required.test.ts` — 19 passed, 0 failed.
- `bash scripts/build.sh --packages-only` — passed on the rebased branch.
- `bun run --cwd packages/playground test:can-i-use` — 13 passed, 0 failed; browser projection 40,291 bytes gzip.
- Both workflow files parsed successfully as YAML; trigger-matrix assertions covered ordinary source, Playground, conformance-browser projection, scheduled, and manual cases.
- `git diff --check` passed.
- The active `main` ruleset has no required-status-check rule, so the Playground check is not protected.

</details>
