### PR TITLE
fix(conformance): derive ledger line numbers from one render pass

### DIFF
--- a/packages/conformance/src/generate-docs.ts
+++ b/packages/conformance/src/generate-docs.ts
@@ -426,59 +426,63 @@ function scoredBlocks(surface: CompatibilitySurfaceRegistry, projection: Documen
   });
 }
 
-export function renderSurfaceMarkdown(surface: CompatibilitySurfaceRegistry, projection: DocumentationProjection): string {
+/** The single source of truth for a surface's rendered projection: the exact
+ * sequence of output lines, plus the 1-based line number each registry row
+ * lands on. Both the published markdown and the line-number index derive from
+ * this one pass, so a renderer change (a heading, a legend row, whitespace)
+ * can never shift the line numbers the ledger points at without moving the
+ * rendered rows in lockstep — there is no parallel render to drift out of sync
+ * with. The row identity keyed here is `row.id` (a stable surface + entry-slug
+ * string, e.g. `auth#31`); line numbers are a derived read-time coordinate. */
+function renderSurfaceLines(
+  surface: CompatibilitySurfaceRegistry,
+  projection: DocumentationProjection,
+): { lines: string[]; rowLines: Map<string, number> } {
   const blocks = scoredBlocks(surface, projection);
   // The CDD climb header is intentionally not published on the reader-facing
   // pages (insider methodology). Climb data still drives internal reports and
   // gates via climb.ts; only the published line is dropped.
-  const parts: string[] = [GENERATED_HEADER, ''];
+  const lines: string[] = [];
+  const rowLines = new Map<string, number>();
+  // Append a part exactly as the published markdown would (parts joined with
+  // '\n'), while keeping each output line addressable for the row index. Split
+  // then join is an identity, so `lines.join('\n')` equals the flat-part join.
+  const emit = (part: string) => { for (const line of part.split('\n')) lines.push(line); };
+  emit(GENERATED_HEADER);
+  emit('');
   const rows = blocks.flatMap((block) => block.kind === 'table' ? block.rows : []);
   for (const [index, block] of blocks.entries()) {
     if (block.kind === 'markdown') {
-      parts.push(block.markdown);
+      emit(block.markdown);
       continue;
     }
-    parts.push(block.prefix);
-    parts.push('| API | Category | Behavior | Status | Probe | # |');
-    parts.push('|---|---|---|---|---|---|');
-    for (const row of block.rows) parts.push(renderRow(row));
+    emit(block.prefix);
+    emit('| API | Category | Behavior | Status | Probe | # |');
+    emit('|---|---|---|---|---|---|');
+    for (const row of block.rows) {
+      emit(renderRow(row));
+      rowLines.set(row.id, lines.length);
+    }
     const next = blocks[index + 1];
-    if (next?.kind === 'table' || (next?.kind === 'markdown' && !next.markdown.startsWith('\n'))) parts.push('');
+    if (next?.kind === 'table' || (next?.kind === 'markdown' && !next.markdown.startsWith('\n'))) emit('');
   }
   const gaps = consolidatedGapSections(rows);
-  if (gaps) parts.push('', gaps);
+  if (gaps) { emit(''); emit(gaps); }
   const dispositions = dispositionSection(surface, projection);
-  if (dispositions) parts.push('', dispositions);
-  return parts.join('\n').replace(/\s+$/, '') + '\n';
+  if (dispositions) { emit(''); emit(dispositions); }
+  return { lines, rowLines };
 }
 
+export function renderSurfaceMarkdown(surface: CompatibilitySurfaceRegistry, projection: DocumentationProjection): string {
+  return renderSurfaceLines(surface, projection).lines.join('\n').replace(/\s+$/, '') + '\n';
+}
+
+/** The 1-based line number, in the rendered surface page, of each registry
+ * row's table entry — keyed by the stable `row.id`. Derived from the same pass
+ * as {@link renderSurfaceMarkdown} so the coordinates can never desynchronize
+ * from the projection they describe. */
 export function generatedRowLineNumbers(surface: CompatibilitySurfaceRegistry, projection: DocumentationProjection): Map<string, number> {
-  const blocks = scoredBlocks(surface, projection);
-  const lines: string[] = [GENERATED_HEADER, ''];
-  const out = new Map<string, number>();
-  for (const [index, block] of blocks.entries()) {
-    if (block.kind === 'markdown') {
-      const markdown = block.markdown;
-      if (markdown) lines.push(...markdown.split('\n'));
-      continue;
-    }
-    const prefix = block.prefix;
-    if (prefix) lines.push(...prefix.split('\n'));
-    lines.push('| API | Category | Behavior | Status | Probe | # |');
-    lines.push('|---|---|---|---|---|---|');
-    for (const row of block.rows) {
-      lines.push(renderRow(row));
-      out.set(row.id, lines.length);
-    }
-    const next = blocks[index + 1];
-    if (next?.kind === 'table' || (next?.kind === 'markdown' && !next.markdown.startsWith('\n'))) lines.push('');
-  }
-  const rows = blocks.flatMap((block) => block.kind === 'table' ? block.rows : []);
-  const gaps = consolidatedGapSections(rows);
-  if (gaps) lines.push('', ...gaps.split('\n'));
-  const dispositions = dispositionSection(surface, projection);
-  if (dispositions) lines.push('', ...dispositions.split('\n'));
-  return out;
+  return renderSurfaceLines(surface, projection).rowLines;
 }
 
 export function renderAllCompatibilityMarkdown(model: ConformanceModel): Map<string, string> {

--- a/packages/conformance/test/src/generated-row-line-numbers.test.ts
+++ b/packages/conformance/test/src/generated-row-line-numbers.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import type { CompatibilitySurfaceRegistry } from '../../registry/types.ts';
+import { deriveConformanceModel, type ConformanceModel } from '../../src/conformance-model.ts';
+import {
+  generatedRowLineNumbers,
+  renderSurfaceMarkdown,
+  type DocumentationProjection,
+} from '../../src/generate-docs.ts';
+
+let model: ConformanceModel;
+let projection: DocumentationProjection;
+beforeAll(async () => {
+  model = await deriveConformanceModel();
+  projection = model.documentation;
+}, 60_000);
+
+/** The rendered table row for a registry row ends with its `rowRef` cell —
+ * a per-surface-unique marker. If a stored line number resolves to a line
+ * ending in this cell, the ledger points at the right row. */
+function rowRefCell(rowRef: string): string {
+  return `| ${rowRef.replace(/\|/g, '\\|')} |`;
+}
+
+/** A surface with at least one table block, for the drift scenarios. */
+function firstTableSurface(): CompatibilitySurfaceRegistry {
+  const surface = projection.registries.find((s) => s.blocks.some((b) => b.kind === 'table'));
+  if (!surface) throw new Error('expected at least one surface with a table block');
+  return surface;
+}
+
+describe('generatedRowLineNumbers ↔ rendered projection coupling', () => {
+  it('every keyed row identity resolves to its own rendered table row', () => {
+    for (const surface of projection.registries) {
+      const lines = renderSurfaceMarkdown(surface, projection).split('\n');
+      const rowLines = generatedRowLineNumbers(surface, projection);
+      const tableRows = surface.blocks.flatMap((b) => (b.kind === 'table' ? b.rows : []));
+      for (const row of tableRows) {
+        const line = rowLines.get(row.id);
+        expect(line, `no line number keyed for ${row.id}`).toBeDefined();
+        const rendered = lines[line! - 1];
+        expect(rendered, `line ${line} out of range for ${row.id}`).toBeDefined();
+        // Resolves to a markdown table data row, and to the right one.
+        expect(rendered!.startsWith('| ')).toBe(true);
+        expect(rendered!.endsWith(rowRefCell(row.rowRef))).toBe(true);
+      }
+    }
+  });
+
+  it('line numbers are derived from the same pass as the markdown (no parallel render)', () => {
+    // Line count of the index must never exceed the rendered line count: a
+    // divergent second render loop is exactly how the two drift apart.
+    for (const surface of projection.registries) {
+      const lineCount = renderSurfaceMarkdown(surface, projection).split('\n').length;
+      for (const [id, line] of generatedRowLineNumbers(surface, projection)) {
+        expect(line, `${id} points past end of rendered page`).toBeLessThanOrEqual(lineCount);
+        expect(line).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('survives a renderer change: an extra line before the rows shifts references in lockstep', () => {
+    const surface = firstTableSurface();
+    // Simulate a renderer/content edit — a new heading, legend row, or blank
+    // line inserted ahead of the table. A stored-line-number scheme would now
+    // point one row too high; because both the markdown and the line index are
+    // produced by one pass, every identity must still resolve to its own row.
+    const shifted: CompatibilitySurfaceRegistry = {
+      ...surface,
+      blocks: [{ kind: 'markdown', markdown: 'Inserted renderer note (drift probe).' }, ...surface.blocks],
+    };
+
+    const baseline = generatedRowLineNumbers(surface, projection);
+    const afterEdit = generatedRowLineNumbers(shifted, projection);
+    const lines = renderSurfaceMarkdown(shifted, projection).split('\n');
+    const tableRows = shifted.blocks.flatMap((b) => (b.kind === 'table' ? b.rows : []));
+
+    let anyShifted = false;
+    for (const row of tableRows) {
+      const before = baseline.get(row.id);
+      const after = afterEdit.get(row.id);
+      expect(after, `identity ${row.id} lost after renderer change`).toBeDefined();
+      // The reference still resolves to this row's own rendered line...
+      expect(lines[after! - 1]!.endsWith(rowRefCell(row.rowRef))).toBe(true);
+      // ...at a moved coordinate, proving the derivation tracked the change.
+      if (before !== undefined && after! !== before) anyShifted = true;
+    }
+    expect(anyShifted, 'inserting a line should move the derived line numbers').toBe(true);
+  });
+});


### PR DESCRIPTION
```ts
// packages/conformance/src/generate-docs.ts — one pass, two derivations
const { lines, rowLines } = renderSurfaceLines(surface, projection);
// renderSurfaceMarkdown  = lines.join('\n')
// generatedRowLineNumbers = rowLines   // Map<row.id, line>, same walk, same guards
```

## The ledger's line numbers came from a second, hand-synchronized render

`generatedRowLineNumbers` re-implemented `renderSurfaceMarkdown`'s loop line-for-line to count where each registry row lands, and the two copies had already drifted (conditional `if (prefix)` pushes in one, unconditional in the other). Any renderer edit could silently point `report.ts`'s `file:line` output at the wrong row with nothing asserting the coupling. Both are now thin derivations of a single `renderSurfaceLines` pass, so desynchronization is structurally impossible rather than merely untested.

Investigation note that narrows the original issue: the ledger persists nothing — `buildCompatibilityLedger` runs fresh per consumer, keys by the stable `${surface}#${rowRef}` identity, and derives locations at read time. No stored artifact carries line numbers, so no migration was needed; the defect was the duplicate render alone.

Fixes #376

## Risk

None functional: byte-identical markdown output (`compat:conformance:check` passes with no regeneration), same public functions. The new drift test locks the invariant: every keyed identity resolves to its own rendered row, no index points past the page, and an injected extra line moves the numbers without breaking resolution — mutation-tested by introducing an off-by-one and watching it fail.

<details>
<summary>Verification</summary>

- `bun test --cwd packages/conformance` → 233 pass, 0 fail (3 new drift cases in `generated-row-line-numbers.test.ts`)
- `bun run --cwd packages/conformance typecheck` → clean
- `bun run compat:check` → clean, no projection regeneration required (output byte-identical)

</details>
