### PR TITLE
docs: explain list-query provability on the audit page; isOwner list caveat

### DIFF
--- a/packages/pyric/src/rules/modules/stdlib/STDLIB.md
+++ b/packages/pyric/src/rules/modules/stdlib/STDLIB.md
@@ -36,7 +36,7 @@ Access control primitives.
 | Function | Params | Returns | Description |
 |----------|--------|---------|-------------|
 | `isAuthenticated()` | — | bool | `request.auth != null` |
-| `isOwner(userId)` | userId: string field path | bool | `request.auth.uid == userId` |
+| `isOwner(userId)` | userId: string field path | bool | `request.auth.uid == userId` — when `isOwner(resource.data.<field>)` guards a `list` rule, queries must carry `where('<field>', '==', request.auth.uid)` (rules are not filters) |
 
 File: `auth.rules` | Tests: `auth.test.json`
 

--- a/packages/site-docs/src/content/secure/audit-your-rules.md
+++ b/packages/site-docs/src/content/secure/audit-your-rules.md
@@ -64,6 +64,38 @@ RTDB access cascades downward and a child cannot revoke a parent's grant — `bi
 
 `.validate` runs only after `.write` allows — it never narrows a `.write` that is too broad. An open path needs both an access rule and a shape rule, and the simulation shows the malformed write landing when the shape rule is missing.
 
+## Rules are not filters
+
+A query is not a single read. When your app runs a `list` query, Firestore must prove from the query's filters alone that every possible result is readable, and it never quietly filters out the documents a rule would deny. So a rule can be exactly right for one `get` and still reject the `list` query that returns the same documents.
+
+Passing for one document is not the same as being provable for every possible result of a query. The fix is to carry the rule's condition into the query as a filter.
+
+Take an owner-scoped collection where the rule allows a list only to the owner:
+
+```rules
+match /notes/{noteId} {
+  allow list: if isOwner(resource.data.ownerUid);
+}
+```
+
+A query that carries the matching equality filter is provable, and the same shape works for a one-shot read or a live listener:
+
+```ts
+const mine = query(collection(db, 'notes'), where('ownerUid', '==', uid));
+const page = await getDocs(mine);        // allowed
+const stop = onSnapshot(mine, render);   // same proof, same result
+```
+
+Drop the filter and Firestore can no longer show every note belongs to the caller, so it denies the whole query:
+
+```ts
+const all = query(collection(db, 'notes'));
+await getDocs(all);
+// deny: unprovable query — rules are not filters
+```
+
+The sandbox enforces the same proof production does, so a query that lists in development lists in production.
+
 ## Audit the whole project, not just the rules
 
 Rules can be individually correct and collectively wrong. The project audit crosses three sources — deployed rules, the actual data shape (found by crawling the sandbox), and enabled auth providers — and the disagreements are the findings: data no rule protects, rules matching paths with no data, user-writable paths with no validation, rules gating on an identity no enabled provider can produce.


### PR DESCRIPTION
```rules
match /notes/{noteId} {
  allow list: if isOwner(resource.data.ownerUid);
}
```
```ts
const mine = query(collection(db, 'notes'), where('ownerUid', '==', uid));
const page = await getDocs(mine);        // allowed
const stop = onSnapshot(mine, render);   // same proof, same result

await getDocs(query(collection(db, 'notes')));
// deny: unprovable query — rules are not filters
```

## The audit page now explains why a correct rule can reject a query

A rule can be exactly right for one `get` and still reject the `list` query returning the same documents — Firestore proves from the query's filters alone that every possible result is readable, and never quietly filters. This tripped a real user into rewriting a correct rule; the "Rules are not filters" section on `secure/audit-your-rules` now walks the owner-scoped case: the provable query, the same shape on `getDocs` and `onSnapshot`, and the failing variant with the denial they'll see. The `isOwner` row in the stdlib reference gains the same one-line caveat `canReadContent` already carried.

Merge after #382 — the worked example shows a helper in the `list` rule, which is provable only once function inlining lands (it is how production behaves either way).

## Risk

None beyond ordering: docs-only, one section plus one table cell.

<details>
<summary>Verification</summary>

site-docs tests: 3 pass; the api-reference test requires built packages (known, unrelated to markdown). Section placement: before "Audit the whole project" on the audit page — the page's thesis is rules that look right and aren't, which is exactly this class.

</details>
