### PR TITLE
feat(ai): warn on silent engine gaps; expose the resolved engine in events

### DIFF
--- a/packages/pyric/src/ai/broker/broker.ts
+++ b/packages/pyric/src/ai/broker/broker.ts
@@ -74,20 +74,53 @@ function isAnswerEngine(value: EngineConfig | AnswerEngine): value is AnswerEngi
   return typeof (value as AnswerEngine).generateContent === 'function';
 }
 
+/** What Studio's stream (and the construction log line) name the engine. */
+type EngineKind = 'scripted' | 'openai' | 'custom';
+
 export class AiBroker {
   readonly engine: AnswerEngine;
   private readonly sandbox: Sandbox | undefined;
+  private readonly engineKind: EngineKind;
+  private readonly engineModel: string | undefined;
+  private readonly engineBaseUrl: string | undefined;
 
   constructor(options: AiBrokerOptions = {}) {
     this.sandbox = options.sandbox;
     const engine = options.engine ?? { kind: 'scripted' as const };
     if (isAnswerEngine(engine)) {
       this.engine = engine;
+      this.engineKind = 'custom';
     } else if (engine.kind === 'scripted') {
       this.engine = new ScriptedEngine(engine.script ?? [], new Synthesizer());
+      this.engineKind = 'scripted';
     } else {
       this.engine = new OpenAiEngine(engine);
+      this.engineKind = 'openai';
+      this.engineModel = engine.model;
+      this.engineBaseUrl = engine.baseUrl;
     }
+    console.info(this.describeEngine());
+  }
+
+  /** One-line construction-time summary of what this broker resolved to. */
+  private describeEngine(): string {
+    if (this.engineKind === 'openai') {
+      return `[pyric/ai] engine resolved: openai (model=${this.engineModel ?? 'passthrough'}, upstream=${this.engineBaseUrl})`;
+    }
+    if (this.engineKind === 'custom') {
+      return '[pyric/ai] engine resolved: custom AnswerEngine';
+    }
+    return '[pyric/ai] engine resolved: scripted (zero-config unless a script is queued)';
+  }
+
+  /** Additive detail fields every emitted event carries so Studio can show the engine. */
+  private engineDetail(): Record<string, unknown> {
+    return {
+      engine: this.engineKind,
+      ...(this.engineKind === 'openai'
+        ? { model: this.engineModel, baseUrl: this.engineBaseUrl }
+        : {}),
+    };
   }
 
   async generateContent(req: GenerateContentRequest, model: string): Promise<WireResponse> {
@@ -191,7 +224,7 @@ export class AiBroker {
           op,
           path: model,
           auth: null,
-          detail,
+          detail: { ...detail, ...this.engineDetail() },
         }),
         { service: 'ai' },
       );

--- a/packages/pyric/src/ai/broker/openai-engine.ts
+++ b/packages/pyric/src/ai/broker/openai-engine.ts
@@ -447,6 +447,8 @@ export class OpenAiEngine implements AnswerEngine {
   private readonly fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   private readonly synth: Synthesizer;
 
+  private warnedDroppedFields = false;
+
   constructor(options: OpenAiEngineOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
     this.defaultModel = options.model;
@@ -458,6 +460,26 @@ export class OpenAiEngine implements AnswerEngine {
     this.synth = options.synthesizer ?? new Synthesizer();
   }
 
+  /**
+   * `thinkingConfig` and `topK` are visible on the request HERE, before
+   * {@link geminiToOpenAIRequest} silently drops them (no OpenAI-compat
+   * equivalent for either). Fires once per engine instance; production still
+   * honors both fields — only the local openai engine does not.
+   */
+  private warnDroppedFieldsOnce(req: GenerateContentRequest): void {
+    if (this.warnedDroppedFields) return;
+    const g = req.generationConfig;
+    const hasThinking = g?.thinkingConfig !== undefined;
+    const hasTopK = g?.topK !== undefined;
+    if (!hasThinking && !hasTopK) return;
+    this.warnedDroppedFields = true;
+    const fields = [hasThinking && 'thinkingConfig', hasTopK && 'topK'].filter(Boolean).join(' and ');
+    console.warn(
+      `[pyric/ai] the openai engine drops ${fields} — no OpenAI-compatible equivalent on the upstream request.\n` +
+        `Production still honors ${fields}; switch to a real Gemini-backed engine if this must take effect in development.`,
+    );
+  }
+
   /** Gemini model id → upstream model: modelMap[model] ?? config.model ?? passthrough. */
   resolveUpstreamModel(model: string): string {
     const bare = model.startsWith('models/') ? model.slice('models/'.length) : model;
@@ -465,6 +487,7 @@ export class OpenAiEngine implements AnswerEngine {
   }
 
   async generateContent(req: GenerateContentRequest, model: string): Promise<WireResponse> {
+    this.warnDroppedFieldsOnce(req);
     const body = geminiToOpenAIRequest(this.resolveUpstreamModel(model), req, false);
     const res = await this.post(body);
     const upstream = (await res.json()) as OpenAIResponse;
@@ -473,6 +496,7 @@ export class OpenAiEngine implements AnswerEngine {
   }
 
   streamGenerateContent(req: GenerateContentRequest, model: string): AsyncIterable<WireChunk> {
+    this.warnDroppedFieldsOnce(req);
     const body = geminiToOpenAIRequest(this.resolveUpstreamModel(model), req, true);
     const opts = { model, promptText: promptTextOf(req) };
     const synth = this.synth;

--- a/packages/pyric/src/ai/broker/scripted-engine.ts
+++ b/packages/pyric/src/ai/broker/scripted-engine.ts
@@ -72,21 +72,42 @@ function isRawEnvelope(respond: ScriptRespond): respond is RawEnvelope {
 export class ScriptedEngine implements AnswerEngine {
   private readonly queue: Array<{ entry: ScriptEntry; consumed: boolean }>;
   private readonly synth: Synthesizer;
+  /** True only if this engine has NEVER had a script entry (constructor or push). */
+  private everScripted: boolean;
+  private warnedSyntheticDefault = false;
 
   constructor(script: ScriptEntry[] = [], synthesizer: Synthesizer = new Synthesizer()) {
     this.queue = script.map((entry) => ({ entry, consumed: false }));
     this.synth = synthesizer;
+    this.everScripted = script.length > 0;
   }
 
   /** Append entries after construction (test-driver convenience). */
   push(...entries: ScriptEntry[]): void {
+    if (entries.length > 0) this.everScripted = true;
     for (const entry of entries) this.queue.push({ entry, consumed: false });
+  }
+
+  /**
+   * Fires once, ever, per engine — and only for the true zero-config case: no
+   * script entry was ever queued (constructor or {@link push}). A script that
+   * simply ran out mid-list is a deliberate authoring choice, not a silent
+   * gap, so it never warns.
+   */
+  private warnSyntheticDefaultOnce(): void {
+    if (this.everScripted || this.warnedSyntheticDefault) return;
+    this.warnedSyntheticDefault = true;
+    console.warn(
+      '[pyric/ai] no script was ever queued, so this request got a synthetic placeholder answer.\n' +
+        'Queue a response with pyric/ai/scripting, or pass a real engine to getAI().',
+    );
   }
 
   async generateContent(req: GenerateContentRequest, model: string): Promise<WireResponse> {
     const opts = this.opts(req, model);
     const respond = this.take(req);
     if (respond === undefined) {
+      this.warnSyntheticDefaultOnce();
       return specialDefault(this.synth, req, opts) ?? this.synth.text(defaultText(req), opts);
     }
     if (isRawEnvelope(respond)) return structuredClone(respond);
@@ -97,6 +118,7 @@ export class ScriptedEngine implements AnswerEngine {
     const opts = this.opts(req, model);
     const respond = this.take(req);
     const synth = this.synth;
+    if (respond === undefined) this.warnSyntheticDefaultOnce();
 
     return (async function* stream(): AsyncGenerator<WireChunk> {
       if (respond === undefined) {

--- a/packages/pyric/src/ai/broker/types.ts
+++ b/packages/pyric/src/ai/broker/types.ts
@@ -62,6 +62,8 @@ export interface GenerateContentRequest {
     responseSchema?: Record<string, unknown>;
     frequencyPenalty?: number;
     presencePenalty?: number;
+    /** Gemini 2.5+ thinking-budget config; no OpenAI-compat equivalent (dropped by the openai engine). */
+    thinkingConfig?: { thinkingBudget?: number; thinkingLevel?: string; includeThoughts?: boolean };
   };
 }
 

--- a/packages/pyric/src/ai/instances.ts
+++ b/packages/pyric/src/ai/instances.ts
@@ -7,11 +7,47 @@ import type { FirebaseApp } from '../app/types.js';
 import type { Sandbox } from '../sandbox/types/service.js';
 import { Backend, BackendType, GoogleAIBackend, VertexAIBackend } from './backend.js';
 import { AiBroker } from './broker/broker.js';
+import type { AnswerEngine, EngineConfig } from './broker/types.js';
 import { TARGET_SYMBOL, isSandbox } from './target.js';
 import type { AI, AIOptions, SandboxTarget } from './types.js';
 
 const handlesByOwner = new WeakMap<Sandbox | FirebaseApp, Map<string, AI>>();
 const brokersBySandbox = new WeakMap<Sandbox, AiBroker>();
+/** The `engine` option the sandbox's broker was actually built with (for the ignored-options warning). */
+const brokerEngineBySandbox = new WeakMap<Sandbox, EngineConfig | AnswerEngine | undefined>();
+const warnedIgnoredEngineFor = new WeakSet<Sandbox>();
+
+function isCustomEngine(value: EngineConfig | AnswerEngine): value is AnswerEngine {
+  return typeof (value as AnswerEngine).generateContent === 'function';
+}
+
+/**
+ * Structural difference, not identity: a fresh `{ kind: 'scripted' }` object
+ * literal on every call must NOT warn just because it is a new reference. A
+ * custom {@link AnswerEngine} (has functions) only ever compares by identity.
+ */
+function engineOptionsDiffer(
+  a: EngineConfig | AnswerEngine,
+  b: EngineConfig | AnswerEngine | undefined,
+): boolean {
+  if (a === b) return false;
+  if (b === undefined) return true;
+  if (isCustomEngine(a) || isCustomEngine(b)) return true;
+  try {
+    return JSON.stringify(a) !== JSON.stringify(b);
+  } catch {
+    return true;
+  }
+}
+
+function warnIgnoredEngineOnce(sandbox: Sandbox): void {
+  if (warnedIgnoredEngineFor.has(sandbox)) return;
+  warnedIgnoredEngineFor.add(sandbox);
+  console.warn(
+    "[pyric/ai] getAI() already resolved this sandbox's engine on an earlier call; this call's engine option is ignored.\n" +
+      "Configure the engine on the sandbox's first getAI() call instead.",
+  );
+}
 
 function describeBackend(backend: Backend): { key: string; location: string } {
   if (backend.backendType === BackendType.VERTEX_AI) {
@@ -37,7 +73,9 @@ function cachedHandles(owner: Sandbox | FirebaseApp): Map<string, AI> {
  *   - `getAI(app, options?)` preserves `ai.app === app`.
  *
  * Repeat calls for the same owner and backend return a stable handle; the
- * first call's options win.
+ * first call's options win. A later call passing a structurally different
+ * `engine` option is a no-op — `console.warn`s once per sandbox so the
+ * silent drop has a signal.
  */
 export function getAI(sandbox: Sandbox, options?: AIOptions): AI;
 export function getAI(app?: FirebaseApp, options?: AIOptions): import('./types.js').AppAI;
@@ -62,12 +100,18 @@ function sandboxAI(sandbox: Sandbox, options?: AIOptions, app?: FirebaseApp): AI
   const { key, location } = describeBackend(backend);
   const handles = cachedHandles(app ?? sandbox);
   const existing = handles.get(key);
-  if (existing) return existing;
+  if (existing) {
+    if (options?.engine !== undefined && engineOptionsDiffer(options.engine, brokerEngineBySandbox.get(sandbox))) {
+      warnIgnoredEngineOnce(sandbox);
+    }
+    return existing;
+  }
 
   let broker = brokersBySandbox.get(sandbox);
   if (!broker) {
     broker = new AiBroker({ engine: options?.engine, sandbox });
     brokersBySandbox.set(sandbox, broker);
+    brokerEngineBySandbox.set(sandbox, options?.engine);
   }
   const handle: AI = {
     ...(app !== undefined ? { app } : {}),

--- a/packages/pyric/test/ai/broker.test.ts
+++ b/packages/pyric/test/ai/broker.test.ts
@@ -815,3 +815,202 @@ describe('broker sandbox event emission', () => {
     );
   });
 });
+
+// ── Diagnostics: console signals for silent gaps ────────────────────────────
+
+/** Capture console.warn/info calls for the duration of `fn`, then restore. */
+async function captureConsole<T extends 'warn' | 'info'>(
+  method: T,
+  fn: () => Promise<void> | void,
+): Promise<string[]> {
+  const original = console[method];
+  const calls: string[] = [];
+  console[method] = ((...args: unknown[]) => {
+    calls.push(args.map(String).join(' '));
+  }) as typeof console[T];
+  try {
+    await fn();
+  } finally {
+    console[method] = original;
+  }
+  return calls;
+}
+
+describe('scripted-default warning (silent-gap signal)', () => {
+  it('warns once when zero-config synthesizes a default answer for a real request', async () => {
+    const engine = new ScriptedEngine();
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(userReq('first'), MODEL);
+      await engine.generateContent(userReq('second'), MODEL);
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('no script was ever queued');
+    expect(warnings[0]).toContain('pyric/ai/scripting');
+  });
+
+  it('never warns when a script was queued, even after it runs out mid-list', async () => {
+    const engine = new ScriptedEngine([{ respond: { text: 'only entry' } }]);
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(userReq('consumes the only entry'), MODEL); // matches
+      await engine.generateContent(userReq('queue now empty'), MODEL); // falls to synthetic default
+    });
+    expect(warnings.length).toBe(0);
+  });
+
+  it('never warns when entries were queued via push after construction', async () => {
+    const engine = new ScriptedEngine();
+    engine.push({ respond: { text: 'pushed' } });
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(userReq('consumes it'), MODEL);
+      await engine.generateContent(userReq('runs dry'), MODEL);
+    });
+    expect(warnings.length).toBe(0);
+  });
+
+  it('warns once for zero-config streaming too, and only once across generate + stream', async () => {
+    const engine = new ScriptedEngine();
+    const warnings = await captureConsole('warn', async () => {
+      await collect(engine.streamGenerateContent(userReq('stream default'), MODEL));
+      await engine.generateContent(userReq('unary default'), MODEL);
+    });
+    expect(warnings.length).toBe(1);
+  });
+});
+
+describe('openai dropped-fields warning (silent-gap signal)', () => {
+  function reqWith(generationConfig: Record<string, unknown>): GenerateContentRequest {
+    return { ...userReq('hi'), generationConfig: generationConfig as any };
+  }
+
+  it('warns once when thinkingConfig is present, naming the field and the fix', async () => {
+    const engine = new OpenAiEngine({
+      baseUrl: 'http://up/v1',
+      fetch: jsonFetch(() =>
+        Response.json({
+          id: 'x',
+          model: 'm',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+      ),
+    });
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(reqWith({ thinkingConfig: { thinkingBudget: 100 } }), MODEL);
+      await engine.generateContent(reqWith({ thinkingConfig: { thinkingBudget: 100 } }), MODEL);
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('thinkingConfig');
+    expect(warnings[0]).toContain('Production still honors thinkingConfig');
+  });
+
+  it('warns once when topK is present, naming the field', async () => {
+    const engine = new OpenAiEngine({
+      baseUrl: 'http://up/v1',
+      fetch: jsonFetch(() =>
+        Response.json({
+          id: 'x',
+          model: 'm',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+      ),
+    });
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(reqWith({ topK: 40 }), MODEL);
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('topK');
+  });
+
+  it('names both fields in one warning when both are present', async () => {
+    const engine = new OpenAiEngine({
+      baseUrl: 'http://up/v1',
+      fetch: jsonFetch(() =>
+        Response.json({
+          id: 'x',
+          model: 'm',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+      ),
+    });
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(reqWith({ topK: 40, thinkingConfig: { thinkingBudget: 1 } }), MODEL);
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('thinkingConfig and topK');
+  });
+
+  it('never warns when neither field is present', async () => {
+    const engine = new OpenAiEngine({
+      baseUrl: 'http://up/v1',
+      fetch: jsonFetch(() =>
+        Response.json({
+          id: 'x',
+          model: 'm',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+      ),
+    });
+    const warnings = await captureConsole('warn', async () => {
+      await engine.generateContent(reqWith({ temperature: 0.5 }), MODEL);
+    });
+    expect(warnings.length).toBe(0);
+  });
+});
+
+describe('engine construction visibility (console.info + event detail)', () => {
+  it('logs one info line at construction naming the resolved engine', async () => {
+    const infos = await captureConsole('info', () => {
+      new AiBroker({ engine: { kind: 'scripted' } });
+    });
+    expect(infos.length).toBe(1);
+    expect(infos[0]).toContain('engine resolved: scripted');
+  });
+
+  it('the info line for an openai engine names the model and upstream', async () => {
+    const infos = await captureConsole('info', () => {
+      new AiBroker({ engine: { kind: 'openai', baseUrl: 'http://up/v1', model: 'llama3' } });
+    });
+    expect(infos[0]).toContain('openai');
+    expect(infos[0]).toContain('llama3');
+    expect(infos[0]).toContain('http://up/v1');
+  });
+
+  it('emitted events carry the resolved engine kind (additive detail field)', async () => {
+    const sandbox = initializeSandbox();
+    const events: any[] = [];
+    sandbox.onEvent((e: any) => {
+      if (e.kind === 'service_mutation' && e.service === 'ai') events.push(e);
+    });
+    const broker = new AiBroker({ sandbox, engine: { kind: 'scripted' } });
+    await broker.generateContent(userReq('hello'), MODEL);
+    expect(events[0].detail.engine).toBe('scripted');
+    // Original fields are still there — additive, not replaced.
+    expect(events[0].detail.finishReason).toBe('STOP');
+  });
+
+  it('emitted events for an openai engine carry model and baseUrl in detail', async () => {
+    const sandbox = initializeSandbox();
+    const events: any[] = [];
+    sandbox.onEvent((e: any) => {
+      if (e.kind === 'service_mutation' && e.service === 'ai') events.push(e);
+    });
+    const broker = new AiBroker({
+      sandbox,
+      engine: {
+        kind: 'openai',
+        baseUrl: 'http://up/v1',
+        model: 'llama3',
+        fetch: jsonFetch(() =>
+          Response.json({
+            id: 'x',
+            model: 'llama3',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+          }),
+        ),
+      },
+    });
+    await broker.generateContent(userReq('hello'), MODEL);
+    expect(events[0].detail.engine).toBe('openai');
+    expect(events[0].detail.model).toBe('llama3');
+    expect(events[0].detail.baseUrl).toBe('http://up/v1');
+  });
+});

--- a/packages/pyric/test/ai/instances.test.ts
+++ b/packages/pyric/test/ai/instances.test.ts
@@ -121,3 +121,61 @@ describe('ai: initialization and dispatch', () => {
     }
   });
 });
+
+describe('ai: getAI ignored-options warning (diagnostics)', () => {
+  async function withWarnSpy(fn: () => void | Promise<void>): Promise<string[]> {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = ((...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    }) as typeof console.warn;
+    try {
+      await fn();
+    } finally {
+      console.warn = original;
+    }
+    return warnings;
+  }
+
+  test('warns once when a later call passes a structurally different engine option', async () => {
+    seam = await aiSeam();
+    const isolated = seam.sandboxMod.initializeSandbox();
+    const warnings = await withWarnSpy(() => {
+      seam.ai.getAI(isolated, { engine: { kind: 'scripted' } });
+      seam.ai.getAI(isolated, { engine: { kind: 'openai', baseUrl: 'http://x/v1' } });
+      seam.ai.getAI(isolated, { engine: { kind: 'openai', baseUrl: 'http://x/v1' } });
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('ignored');
+    expect(warnings[0]).toContain('first getAI() call');
+  });
+
+  test('never warns when the repeated engine option is structurally identical', async () => {
+    seam = await aiSeam();
+    const isolated = seam.sandboxMod.initializeSandbox();
+    const warnings = await withWarnSpy(() => {
+      seam.ai.getAI(isolated, { engine: { kind: 'scripted' } });
+      seam.ai.getAI(isolated, { engine: { kind: 'scripted' } });
+    });
+    expect(warnings.length).toBe(0);
+  });
+
+  test('never warns when a later call omits the engine option', async () => {
+    seam = await aiSeam();
+    const isolated = seam.sandboxMod.initializeSandbox();
+    const warnings = await withWarnSpy(() => {
+      seam.ai.getAI(isolated, { engine: { kind: 'openai', baseUrl: 'http://x/v1' } });
+      seam.ai.getAI(isolated);
+    });
+    expect(warnings.length).toBe(0);
+  });
+
+  test('never warns on the very first call for a sandbox', async () => {
+    seam = await aiSeam();
+    const isolated = seam.sandboxMod.initializeSandbox();
+    const warnings = await withWarnSpy(() => {
+      seam.ai.getAI(isolated, { engine: { kind: 'openai', baseUrl: 'http://x/v1' } });
+    });
+    expect(warnings.length).toBe(0);
+  });
+});


### PR DESCRIPTION
```
# the browser console, first request with no script queued
[pyric/ai] no script was ever queued, so this request got a synthetic placeholder answer.
Queue a response with pyric/ai/scripting, or pass a real engine to getAI().

# at broker construction
[pyric/ai] engine resolved: openai (model=llama3.2, upstream=/__pyric/ai-proxy)
```

## The AI sandbox's silent gaps now announce themselves

Three failure modes cost a real user hours because nothing signaled them: the scripted default fabricates `pyric scripted response for: …` for real requests when no script was ever queued; the openai engine drops `thinkingConfig` and `topK` without a trace; and a second `getAI` call with a different engine is silently ignored (the first call decides). Each now warns once per broker/engine lifetime, naming the fix, not just the problem. A `console.info` line at broker construction states the resolved engine, and every `service: 'ai'` event carries `detail.engine` (plus model/baseUrl for openai) so Studio's stream shows which engine answered — additive fields only.

The scripted-default boundary is deliberate: a queue that had entries and ran dry never warns (intentional authoring); only never-scripted engines do.

## Risk

Low: warnings and additive event fields, no behavioral change to responses. Known visibility limit: under the default SharedWorker path these fire in the worker's console; #372 relays them to the `pyric dev` terminal once #383's channel lands. Independent of every other open PR.

<details>
<summary>Verification</summary>

- `test/ai`: 183 pass, 0 fail (new: warn-once semantics per warning, trigger boundaries, additive event-detail fields; `custom` engine kind covered for raw `AnswerEngine` construction).
- pyric full suite: 5187 pass / 30 skip / 1 pre-existing unrelated fail (#374, fixed by #377). `test/serve` incl. worker ai-ops: 559 pass.
- The `thinkingConfig` strip location: it rides the untyped `generationConfig` all the way to the openai translation, which copies known keys only — detection sits before translation where the original object is visible; the pure translation function stays side-effect-free.

</details>
