### PR TITLE
fix(serve): detach the worker boot fetch — Illegal invocation silently killed hydration and capture

### DIFF
--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -639,7 +639,24 @@ export interface WorkerBootEnv extends ServeInitEnv {
  * gets no beforeunload/beforeterminate, so anything not committed to IDB when
  * the last tab closes is lost.
  */
-export async function buildWorkerCtx(env: WorkerBootEnv): Promise<HostCtx> {
+export async function buildWorkerCtx(bootEnv: WorkerBootEnv): Promise<HostCtx> {
+  // Detach `fetch` from the env record before ANY use (issue #364). Every call
+  // site in this module invokes it as `env.fetch(...)`, which binds `this` to
+  // the env object — and the real browser/worker `fetch` is this-sensitive:
+  // it throws "Illegal invocation" unless `this` is undefined or the global.
+  // That silent throw meant the capture flush never POSTed and
+  // `hydrateEventHistory`'s GET failed into its catch, so a REBOOTED worker
+  // always answered Studio's first event subscription with an EMPTY history —
+  // the Activity/Traffic first open showed nothing until new live events
+  // arrived. The wrapper restores a plain call (`this` undefined ⇒ the
+  // global); injected test stubs are unaffected.
+  const ambientFetch = bootEnv.fetch;
+  const env: WorkerBootEnv = {
+    ...bootEnv,
+    // Cast: Bun's `typeof fetch` also declares a `preconnect` member the
+    // plain-call wrapper doesn't need (nothing in this module uses it).
+    fetch: ((...args: Parameters<typeof fetch>) => ambientFetch(...args)) as typeof fetch,
+  };
   const sandbox = initializeSandbox();
 
   // Deploy permissive starter rules via admin-firestore.

--- a/packages/cli/test/serve/worker/serve-init.test.ts
+++ b/packages/cli/test/serve/worker/serve-init.test.ts
@@ -711,6 +711,64 @@ describe('buildWorkerCtx — boot-time hydration + reset non-resurrection', () =
     expect(ctx.sandbox.history().filter((e) => e.id.startsWith('cap-'))).toHaveLength(4);
   });
 
+  /**
+   * Issue #364 characterization. The REAL browser `fetch` is this-sensitive:
+   * invoked as a member call (`env.fetch(...)`) it sees `this === env` and
+   * throws "Illegal invocation" (verified against Chromium). Every capture /
+   * hydration call site in serve-init.ts invokes it exactly that way, so in a
+   * real worker the capture flush never POSTed and `hydrateEventHistory`'s GET
+   * failed into its catch — a rebooted worker answered Studio's first event
+   * subscription with an EMPTY history, and the Activity/Traffic first open
+   * showed nothing. Plain stub fetches can't catch this; this wrapper replays
+   * the browser's `this` contract.
+   */
+  function browserishFetch(impl: typeof fetch): typeof fetch {
+    return function (this: unknown, ...args: Parameters<typeof fetch>) {
+      if (this !== undefined && this !== globalThis) {
+        throw new TypeError(
+          "Failed to execute 'fetch' on 'WorkerGlobalScope': Illegal invocation",
+        );
+      }
+      return impl(...args);
+    } as typeof fetch;
+  }
+
+  it('hydrates boot history through a browser-faithful (this-sensitive) fetch — issue #364', async () => {
+    const idb = createMemoryBackend();
+    const instanceId = await (await import('../../../src/serve/worker/host.js')).getOrCreateInstanceId(idb);
+    const ctx = await buildWorkerCtx({
+      fetch: browserishFetch(bootFetch(captureFixture(4, instanceId))),
+      idb,
+    });
+    expect(ctx.sandbox.history().filter((e) => e.id.startsWith('cap-'))).toHaveLength(4);
+  });
+
+  it('POSTs the capture through a browser-faithful (this-sensitive) fetch — issue #364', async () => {
+    const posts: string[] = [];
+    const impl = ((url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (u === '/__pyric/init.json') {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(JSON.parse(initJson(true))) } as Response);
+      }
+      if (u === '/__pyric/capture' && init?.method === 'POST') {
+        posts.push(String(init.body ?? ''));
+        return Promise.resolve({ status: 204, ok: true, text: () => Promise.resolve('') } as Response);
+      }
+      return Promise.resolve({ status: 404, ok: false, text: () => Promise.resolve('null'), json: () => Promise.resolve({}) } as Response);
+    }) as unknown as typeof fetch;
+
+    const ctx = await buildWorkerCtx({
+      fetch: browserishFetch(impl),
+      idb: createMemoryBackend(),
+      captureDebounceMs: 1,
+    });
+    const port = fakePort();
+    await handleMessage(ctx, port, { t: 'op', id: 'w1', method: 'setDoc', path: 'notes/x', data: { v: 1 } });
+    await tick(20);
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    expect((JSON.parse(posts.at(-1)!) as { events: { kind: string }[] }).events.some((e) => e.kind === 'write')).toBe(true);
+  });
+
   it('does NOT resurrect pre-reset events: a post-reset capture reflects the cleared log', async () => {
     // 1. Boot, write, capture reflects the write.
     const store = { body: null as string | null };

--- a/packages/studio/test/shell/studio-events-hydration.test.tsx
+++ b/packages/studio/test/shell/studio-events-hydration.test.tsx
@@ -1,0 +1,124 @@
+// Install JSDOM globals before importing React or RTL.
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  pretendToBeVisual: true,
+});
+const g = globalThis as any;
+g.window = dom.window;
+g.document = dom.window.document;
+g.HTMLElement = dom.window.HTMLElement;
+g.SVGElement = dom.window.SVGElement;
+g.Element = dom.window.Element;
+g.Node = dom.window.Node;
+g.Event = dom.window.Event;
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Characterization of issue #364: opening Studio against a worker that ALREADY
+ * holds session history must render that history on first paint of the
+ * activity surfaces — before any further live event arrives.
+ *
+ * The shim below plays the worker HOST's documented event-stream contract
+ * (host-events.ts): on `{t:'sub', target:'events'}` it delivers the seeded
+ * `sandbox.history()` as the first batch, ASYNCHRONOUSLY (a real MessagePort
+ * round-trip is a macrotask). The hook under test is the real
+ * `useStudioEvents` over the real `EnvironmentProvider` + `workerEventFeed`.
+ */
+import { afterEach, describe, expect, it } from 'bun:test';
+import { act, cleanup, render } from '@testing-library/react';
+import { StrictMode } from 'react';
+import type { SandboxEvent } from 'pyric/sandbox';
+
+const HISTORY: SandboxEvent[] = ['h1', 'h2'].map(
+  (id) =>
+    ({
+      kind: 'write',
+      id,
+      at: 0,
+      method: 'create',
+      path: `users/${id}`,
+      auth: null,
+      priorState: null,
+      nextState: {},
+      requestTime: { seconds: 0, nanoseconds: 0 },
+    }) as SandboxEvent,
+);
+
+/** A SharedWorker shim whose port honors the host's event-stream contract:
+ *  ops get an ok reply, an events sub gets the seeded history batch — both
+ *  delivered asynchronously like a real port round-trip. */
+function installWorkerShim(history: readonly SandboxEvent[]) {
+  const prev = (globalThis as { SharedWorker?: unknown }).SharedWorker;
+  const sent: any[] = [];
+  const eventSubIds: string[] = [];
+  const port = {
+    sent,
+    onmessage: null as ((ev: { data: unknown }) => void) | null,
+    postMessage(msg: any) {
+      sent.push(msg);
+      setTimeout(() => {
+        if (msg.t === 'op') {
+          port.onmessage?.({ data: { t: 'res', id: msg.id, ok: true, value: {} } });
+        } else if (msg.t === 'sub' && msg.target === 'events') {
+          eventSubIds.push(msg.subId);
+          port.onmessage?.({ data: { t: 'event', subId: msg.subId, events: history } });
+        }
+      }, 0);
+    },
+    start() {},
+    addEventListener() {},
+  };
+  (globalThis as { SharedWorker?: unknown }).SharedWorker = class {
+    port = port;
+    constructor(_url: unknown, _opts: unknown) {}
+  };
+  return {
+    port,
+    /** Deliver one LIVE event to every open events sub (a later batch). */
+    deliverLive(event: SandboxEvent) {
+      for (const subId of eventSubIds) {
+        port.onmessage?.({ data: { t: 'event', subId, events: [event] } });
+      }
+    },
+    restore: () => {
+      (globalThis as { SharedWorker?: unknown }).SharedWorker = prev;
+    },
+  };
+}
+
+const flush = () => act(() => new Promise<void>((r) => setTimeout(r, 20)));
+
+afterEach(() => cleanup());
+
+describe('useStudioEvents first-open hydration (issue #364)', () => {
+  it('shows the worker history backlog before any new live event arrives', async () => {
+    const shim = installWorkerShim(HISTORY);
+    try {
+      const { EnvironmentProvider } = await import('../../src/shell/environment.js');
+      const { useStudioEvents } = await import('../../src/shell/studio-data.js');
+
+      function Probe() {
+        const events = useStudioEvents();
+        return <div data-testid="ids">{events.map((e) => e.id).join(',')}</div>;
+      }
+
+      let result: ReturnType<typeof render>;
+      await act(async () => {
+        result = render(
+          <StrictMode>
+          <EnvironmentProvider mode="local">
+            <Probe />
+          </EnvironmentProvider>
+          </StrictMode>,
+        );
+      });
+      await flush();
+
+      // The backlog must be visible NOW — no further live event has arrived.
+      expect(result!.getByTestId('ids').textContent).toBe('h1,h2');
+    } finally {
+      shim.restore();
+    }
+  });
+});


### PR DESCRIPTION
```ts
// serve-init.ts invoked the injected boot fetch as a member call:
env.fetch('/__pyric/init-events.json')   // this === env → browsers throw
                                         // TypeError: Illegal invocation
// …inside catch/fire-and-forget paths, so nothing ever surfaced.
```

Fixes #364 — but the bug was never where the symptom pointed. Studio's feed layer is sound (now pinned by a test that renders the worker backlog before any live event). The defect is in the worker boot: browser `fetch` is this-sensitive, and every member-call site (`hydrateEventHistory`, capture flush, `--persist` prime/mirror/clear, auth flush) threw `Illegal invocation` into swallowed catches. Verified against real Chromium via Playwright.

## What that actually broke

- A rebooted SharedWorker (tab close/reload gap — routine under vite dev) answered Studio's first event subscription with an **empty history** → the field report's "Activity initially empty, then backfills."
- The capture flush died before its `.catch` attached → `.pyric/last-session.json` was **never written** on the default worker path — silently breaking the `pyric verify` loop too.
- Only `fetchInitPayload(env.fetch)` passed fetch as a value (plain call), which is why rules/seed always worked and the bug looked Studio-shaped.

## Fix

One file: `buildWorkerCtx` detaches fetch before any use (`const ambientFetch = bootEnv.fetch; fetch: (...args) => ambientFetch(...args)`). `entry.ts` is the sole production caller, so every path is covered.

## Risk

Minimal by construction — a call-convention fix with no behavior change for test stubs (already this-insensitive). End-to-end re-verified in a real browser: worker death → Studio first open renders the full pre-open history; capture file written.

<details>
<summary>Verification</summary>

- Characterization (failing-first): `serve-init.test.ts` boots the real `buildWorkerCtx` through a `browserishFetch` that replays the browser's `this` contract — pre-fix: hydration primes 0 of 4 events, capture never POSTs (32 pass / 2 fail); post-fix green.
- Studio seam exonerated and pinned: `studio-events-hydration.test.tsx` — real `useStudioEvents` + `workerEventFeed` shows the backlog before any live event.
- Gates: cli `test/serve` 563 / 0 fail; studio 338 / 0; typechecks clean. (cli full suite has 11 pre-existing environment failures with no import edge to the changed module.)
- Real-browser probes (temporary, not committed) reproduced the exact field symptom pre-fix and its absence post-fix, on both `pyric dev --ui` and the vite plugin.

</details>