### PR TITLE
feat(cli)!: rename the Vite plugin export from pyricSandbox to pyric

### DIFF
--- a/docs/local-build-testing.md
+++ b/docs/local-build-testing.md
@@ -58,9 +58,9 @@ special configuration on this path: `@pyric/cli/vite` is a real
 ```ts
 // vite.config.ts — identical to the published-package experience
 import { defineConfig } from 'vite';
-import { pyricSandbox } from '@pyric/cli/vite';
+import { pyric } from '@pyric/cli/vite';
 
-export default defineConfig({ plugins: [pyricSandbox()] });
+export default defineConfig({ plugins: [pyric()] });
 ```
 
 Re-vendoring after a change means recompiling (step 1) and re-running
@@ -96,7 +96,7 @@ Application source keeps `firebase/*` imports throughout — package resolution
 owns backend selection (ADR-001). Two ways to activate the swap:
 
 - **Vite plugin**: the same `vite.config.ts` as above, then `bun run dev`
-  (i.e. `vite`). `pyricSandbox()` maps supported `firebase/*` imports to the
+  (i.e. `vite`). `pyric()` maps supported `firebase/*` imports to the
   workspace `pyric/*` mirrors while the dev server runs; a production
   `vite build` ships real Firebase.
 - **`pyric dev`** (serves static/pre-built apps via import maps, runs Node

--- a/examples/vite-sandbox-app/vite.config.ts
+++ b/examples/vite-sandbox-app/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
-import { pyricSandbox } from '@pyric/cli/vite';
+import { pyric } from '@pyric/cli/vite';
 
-// Under `vite dev` pyricSandbox() swaps firebase/* to the in-process pyric
+// Under `vite dev` pyric() swaps firebase/* to the in-process pyric
 // sandbox and deploys + hot-reloads firestore.rules — no Firebase project,
 // credentials, or emulators. `vite build` (mode production) ships the real
 // firebase package; the swap never reaches the deployed artifact. For a
@@ -9,5 +9,5 @@ import { pyricSandbox } from '@pyric/cli/vite';
 // non-production mode: `vite build --mode development` (see the `build:sandbox`
 // script). That output is marked and can never be deployed.
 export default defineConfig({
-  plugins: [pyricSandbox()],
+  plugins: [pyric()],
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,9 +86,9 @@ rulesHash}`.
 | `@pyric/cli/conformance/browser` | Compact browser query surface: `canIUse` returns availability, fidelity, assurance, summary, caveats, and the evidence slug without the full claim graph. |
 | `@pyric/cli/assurance` | Assurance campaign types and tools |
 | `@pyric/cli/assurance/browser` | Browser attachment for assurance campaigns |
-| `@pyric/cli/bridge` | `createBridge`, `startServer` (Node) / `connectBridge` (browser via conditional export). Vite integration is `pyricSandbox({ bridge })` in `@pyric/cli/vite`. |
+| `@pyric/cli/bridge` | `createBridge`, `startServer` (Node) / `connectBridge` (browser via conditional export). Vite integration is `pyric({ bridge })` in `@pyric/cli/vite`. |
 | `@pyric/cli/bridge/client` | Browser bridge client helpers |
-| `@pyric/cli/vite` | `pyricSandbox(opts)`, the dev-only firebase→sandbox swap plugin. Opts: `rules`, `persist`/`fresh`, `seed`, `capture`, `bridge` (MCP), `ui` (Pyric Studio at `/__pyric/ui/`, parity with `dev --ui`). |
+| `@pyric/cli/vite` | `pyric(opts)`, the dev-only firebase→sandbox swap plugin. Opts: `rules`, `persist`/`fresh`, `seed`, `capture`, `bridge` (MCP), `ui` (Pyric Studio at `/__pyric/ui/`, parity with `dev --ui`). |
 | `@pyric/cli/discover` | Credential-free crawl helpers for sandbox discovery (`crawl`, `findCollectionGroup`, `createFirestoreDiscoverTools`). Not registered on the default MCP bridge. |
 | `@pyric/cli/serve/worker` | SharedWorker serve runtime |
 | `@pyric/cli/remote` | Remote / headless helpers |

--- a/packages/cli/src/bridge/server.ts
+++ b/packages/cli/src/bridge/server.ts
@@ -3,7 +3,7 @@
  *
  * Resolved by the `node` condition in `package.json`'s exports map.
  * Exports the bridge core (`createBridge`) and the standalone server
- * (`startServer`). The Vite integration is the `pyricSandbox({ bridge })`
+ * (`startServer`). The Vite integration is the `pyric({ bridge })`
  * plugin in `@pyric/cli/vite` (the firebase→sandbox swap AND the bridge in
  * one plugin), not a bridge-only plugin here.
  *

--- a/packages/cli/src/bridge/server/peer.ts
+++ b/packages/cli/src/bridge/server/peer.ts
@@ -8,7 +8,7 @@
  * parsed JSON for the stateless MCP transport.
  *
  * Both are consumed by `serve/bridge-mount.ts` (the `pyric dev --bridge` and
- * `pyricSandbox({ bridge })` mount) and `serve/namespace.ts` (capture route).
+ * `pyric({ bridge })` mount) and `serve/namespace.ts` (capture route).
  * They live here — not inline in a plugin file — so retiring the standalone
  * bridge Vite plugin doesn't drag its consumers with it.
  */

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -209,7 +209,7 @@ export async function startServe(opts: {
           `  (a) plain \`pyric dev\` runs the child dev-server flow (the @pyric/cli/vite ` +
           `plugin swaps firebase/* live) — use \`bun run dev\`;\n` +
           `  (b) rebuild as a self-contained sandbox bundle and serve THAT: ` +
-          `\`vite build --mode development\` (or pyricSandbox({ swapInBuild: true })) then ` +
+          `\`vite build --mode development\` (or pyric({ swapInBuild: true })) then ` +
           `\`pyric dev\`.\n` +
           `A plain \`vite build\` is your production build — deploy it, don't sandbox it.`,
       );

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -14,7 +14,7 @@
  * mode) produces a SANDBOX build that bundles pyric's in-page adapters instead
  * of the real SDK: self-contained, meant to be previewed under `pyric dev`, and
  * stamped with the sandbox-build marker so it can never be deployed (`pyric
- * deploy hosting` refuses it). `pyricSandbox({ swapInBuild })` forces the build
+ * deploy hosting` refuses it). `pyric({ swapInBuild })` forces the build
  * behavior on/off regardless of mode. See `sandbox-marker.ts`.
  *
  * This is a thin adapter over serve's proven machinery. It REUSES, not reimplements:
@@ -157,7 +157,7 @@ function packageRootOf(file: string): string {
   return dir;
 }
 
-export interface PyricSandboxOptions {
+export interface PyricOptions {
   /** firestore.rules path (relative to `root`). Default: `firebase.json`'s
    *  `firestore.rules`, else `firestore.rules` in the project root. */
   rules?: string;
@@ -206,7 +206,7 @@ export interface PyricSandboxOptions {
    * replacement for threading `engine` through every app `getAI(...)` call,
    * which is first-call-wins and easy to get wrong).
    *
-   *   pyricSandbox({
+   *   pyric({
    *     ai: {
    *       engine: { kind: 'openai', model: 'llama3.2', baseUrl: '/__pyric/ai-proxy' },
    *       proxyUpstream: 'http://localhost:11434/v1', // your Ollama
@@ -239,10 +239,10 @@ export interface PyricSandboxOptions {
 /**
  * The dev-only Vite plugin. Add to `vite.config`:
  *
- *   import { pyricSandbox } from '@pyric/cli/vite';
- *   export default defineConfig({ plugins: [pyricSandbox()] });
+ *   import { pyric } from '@pyric/cli/vite';
+ *   export default defineConfig({ plugins: [pyric()] });
  */
-export function pyricSandbox(options: PyricSandboxOptions = {}): Plugin {
+export function pyric(options: PyricOptions = {}): Plugin {
   // Resolved once. `defaultSdkEntries()` prefers compiled dist `.js` and falls
   // back to source `.ts` in the workspace.
   const entries = defaultSdkEntries(); // { app, auth, firestore, init } → abs paths

--- a/packages/cli/src/vite.ts
+++ b/packages/cli/src/vite.ts
@@ -3,11 +3,11 @@
  * in-process pyric sandbox during `vite dev` (the serve analog for source-driven
  * apps). See `./serve/vite-plugin.ts` and the design rationale.
  *
- *   import { pyricSandbox } from '@pyric/cli/vite';
- *   export default defineConfig({ plugins: [pyricSandbox()] });
+ *   import { pyric } from '@pyric/cli/vite';
+ *   export default defineConfig({ plugins: [pyric()] });
  */
-export { pyricSandbox } from './serve/vite-plugin.js';
-export type { PyricSandboxOptions } from './serve/vite-plugin.js';
+export { pyric } from './serve/vite-plugin.js';
+export type { PyricOptions } from './serve/vite-plugin.js';
 
 // The benign node-builtin shims serve's bundler and this plugin apply when
 // bundling pyric's browser graph (`fs`/`path`/`url` reached via the rules

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -73,7 +73,7 @@ describe('pyric init v2 — web template (default, Vite)', () => {
     // the swap lives in vite.config, not the app
     const viteConfig = readFileSync(join(dir, 'vite.config.ts'), 'utf8');
     expect(viteConfig).toContain("from '@pyric/cli/vite'");
-    expect(viteConfig).toContain('pyricSandbox(');
+    expect(viteConfig).toContain('pyric(');
 
     // hosting serves Vite's build output
     const fb = JSON.parse(readFileSync(join(dir, 'firebase.json'), 'utf8'));

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -395,7 +395,7 @@ describe('pyric init output contract', () => {
         'src/main.ts': '3e165d28c4d22df0b868d26cd4071950a6c47cfd0c8944d01c2dadc66c0dfab2',
         'src/vite-env.d.ts': '65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5',
         'tsconfig.json': '5bb892360953642d2644a442a81abbad91e62be2f7fcb646505cc7f33a6bcc08',
-        'vite.config.ts': '2c4fd6ee8faa56bc468283b99d587d25f89c0c26efebdbb9d5046b76c2f4a005',
+        'vite.config.ts': 'fd229518462c98b4b2874b5580762a98a9ef8bc5f1b94ed6f93bbefdedb3ad49',
       },
       node: {
         '.env.example': '20b0fec5308501f75cab4d6026678eefbbbef0001bfabaa17c66d92e67c9d582',

--- a/packages/cli/test/serve/vite-plugin-ai.test.ts
+++ b/packages/cli/test/serve/vite-plugin-ai.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 import type { ViteDevServer } from 'vite';
 
 import { bundleWorker, workerSourceHash } from '../../src/serve/bundler.js';
-import { pyricSandbox } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 
 let server: ViteDevServer | undefined;
 let fixtureRoot: string | undefined;
@@ -71,7 +71,7 @@ export async function run() {
         configFile: false,
         logLevel: 'silent',
         root: fixtureRoot,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { middlewareMode: true },
         optimizeDeps: { noDiscovery: true },
       });
@@ -140,7 +140,7 @@ export async function run() {
         configFile: false,
         logLevel: 'silent',
         root: fixtureRoot,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { middlewareMode: true },
         optimizeDeps: { noDiscovery: true },
       });

--- a/packages/cli/test/serve/vite-plugin-bridge-e2e.test.ts
+++ b/packages/cli/test/serve/vite-plugin-bridge-e2e.test.ts
@@ -27,7 +27,7 @@ import { initializeSandbox } from 'pyric/sandbox';
 import { connectBridge, type ConnectedBridge } from '../../src/bridge/client/bridge.js';
 import { DEFAULT_MCP_TOOL_NAMES } from '../../src/bridge/server/mcp-contract.js';
 import { defaultSdkEntries, bundleWorker, workerSourceHash } from '../../src/serve/bundler.js';
-import { pyricSandbox } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 
 const GATED = !process.env.PYRIC_BRIDGE_E2E;
 const entries = defaultSdkEntries();
@@ -90,7 +90,7 @@ describe.skipIf(GATED)('e2e — bridge through a real vite dev server (GATED: PY
         configFile: false,
         logLevel: 'silent',
         root: path.dirname(entries.init),
-        plugins: [pyricSandbox({ bridge: { disableAuditLog: true } })],
+        plugins: [pyric({ bridge: { disableAuditLog: true } })],
         server: { port: 0, host: 'localhost' },
         optimizeDeps: { noDiscovery: true },
       }),

--- a/packages/cli/test/serve/vite-plugin-firestore.test.ts
+++ b/packages/cli/test/serve/vite-plugin-firestore.test.ts
@@ -11,7 +11,7 @@ import {
   defaultSdkEntries,
   workerSourceHash,
 } from '../../src/serve/bundler.js';
-import { pyricSandbox } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 
 let server: ViteDevServer | undefined;
 let fixtureRoot: string | undefined;
@@ -83,7 +83,7 @@ export async function run() {
         configFile: false,
         logLevel: 'silent',
         root: fixtureRoot,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { middlewareMode: true },
         optimizeDeps: { noDiscovery: true },
       });

--- a/packages/cli/test/serve/vite-plugin-functions.test.ts
+++ b/packages/cli/test/serve/vite-plugin-functions.test.ts
@@ -1,6 +1,6 @@
 /**
  * Vite-plugin parity for RTDB-triggered Cloud Functions — the same slice
- * `pyric dev` runs (`onValueCreated`), now reachable under `pyricSandbox()`.
+ * `pyric dev` runs (`onValueCreated`), now reachable under `pyric()`.
  *
  * Mirrors `test/functions-rtdb/dev.e2e.test.ts`, but drives the plugin instead
  * of the CLI: a REAL Vite dev server listens, a worker-relay peer stands in for
@@ -18,7 +18,7 @@ import { join, resolve } from 'node:path';
 import type { ViteDevServer } from 'vite';
 import { bundleWorker, workerSourceHash } from '../../src/serve/bundler.js';
 import { discoverFunctionsRtdbProject } from '../../src/functions-rtdb/project.js';
-import { pyricSandbox } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 import { connectRemoteSandbox, type RemoteSandbox } from '../../src/remote/index.js';
 import { connectFunctionsWorkerPeer, createFunctionsWorkerHostCtx } from '../functions-rtdb/worker-peer.js';
 
@@ -70,7 +70,7 @@ afterEach(async () => {
   server = undefined;
 });
 
-describe('pyricSandbox() Functions RTDB parity', () => {
+describe('pyric() Functions RTDB parity', () => {
   test('discovers a functions codebase and fires an onValueCreated trigger through the plugin', async () => {
     if (!existsSync(builtChild)) throw new Error(`build the CLI first: ${builtChild}`);
     // Warm the SharedWorker bundle so configureServer's bundleWorker is a cache hit.
@@ -118,7 +118,7 @@ exports.makeUppercase = onValueCreated(
         configFile: false,
         logLevel: 'silent',
         root: cwd,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { port: 0, host: '127.0.0.1' },
         optimizeDeps: { noDiscovery: true },
         customLogger: {
@@ -177,7 +177,7 @@ exports.makeUppercase = onValueCreated(
         configFile: false,
         logLevel: 'silent',
         root: cwd,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { port: 0, host: '127.0.0.1' },
         optimizeDeps: { noDiscovery: true },
         customLogger: {

--- a/packages/cli/test/serve/vite-plugin-storage.test.ts
+++ b/packages/cli/test/serve/vite-plugin-storage.test.ts
@@ -7,7 +7,7 @@ import { dirname, extname, join } from 'node:path';
 import type { ViteDevServer } from 'vite';
 
 import { bundleWorker, defaultSdkEntries, workerSourceHash } from '../../src/serve/bundler.js';
-import { pyricSandbox } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 
 let server: ViteDevServer | undefined;
 let fixtureRoot: string | undefined;
@@ -66,7 +66,7 @@ export async function run() {
         configFile: false,
         logLevel: 'silent',
         root: fixtureRoot,
-        plugins: [pyricSandbox({ ui: false })],
+        plugins: [pyric({ ui: false })],
         server: { middlewareMode: true },
         optimizeDeps: { noDiscovery: true },
       });

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -9,7 +9,7 @@ import path, { join } from 'node:path';
 import { Writable } from 'node:stream';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import { pyricSandbox, engineConfigToWire } from '../../src/serve/vite-plugin.js';
+import { pyric, engineConfigToWire } from '../../src/serve/vite-plugin.js';
 import {
   SDK_MODULES,
   defaultSdkEntries,
@@ -33,7 +33,7 @@ beforeAll(async () => {
 }, 180_000);
 
 // The hooks are plain functions on the returned plugin; call them directly.
-const plugin = pyricSandbox();
+const plugin = pyric();
 const resolveId = (s: string, i?: string): unknown => (plugin.resolveId as (s: string, i?: string) => unknown)(s, i);
 const load = (id: string): unknown => (plugin.load as (id: string) => unknown)(id);
 const config = (): { optimizeDeps?: { exclude?: string[]; esbuildOptions?: { plugins?: unknown[] } }; server?: { fs?: { allow?: string[] } } } =>
@@ -43,7 +43,7 @@ const config = (): { optimizeDeps?: { exclude?: string[]; esbuildOptions?: { plu
 const applies = (p: typeof plugin, command: 'serve' | 'build', mode = 'production'): boolean =>
   (p.apply as (c: unknown, env: { command: string; mode: string }) => boolean)({}, { command, mode });
 
-describe('pyricSandbox — plugin shape', () => {
+describe('pyric — plugin shape', () => {
   it('is a pre-enforced plugin whose apply gates build on the mode', () => {
     expect(plugin.name).toBe('pyric:sandbox');
     expect(typeof plugin.apply).toBe('function');
@@ -62,9 +62,9 @@ describe('pyricSandbox — plugin shape', () => {
   });
 
   it('apply: swapInBuild option overrides the mode default in both directions', () => {
-    const forcedOn = pyricSandbox({ swapInBuild: true });
+    const forcedOn = pyric({ swapInBuild: true });
     expect(applies(forcedOn, 'build', 'production')).toBe(true); // forced sandbox even in prod mode
-    const forcedOff = pyricSandbox({ swapInBuild: false });
+    const forcedOff = pyric({ swapInBuild: false });
     expect(applies(forcedOff, 'build', 'development')).toBe(false); // never swap in build
     expect(applies(forcedOff, 'serve', 'production')).toBe(true); // dev still always on
   });
@@ -83,7 +83,7 @@ describe('pyricSandbox — plugin shape', () => {
   });
 
   it('sandbox build: transformIndexHtml stamps ONLY the marker (no init/@fs, no force-in-page)', () => {
-    const p = pyricSandbox();
+    const p = pyric();
     // Flag the plugin as a build (apply already gated it upstream).
     (p.config as (c: unknown, env: unknown) => unknown)({}, { command: 'build', mode: 'development' });
     const out = (p.transformIndexHtml as (h: string) => string)('<html><head></head><body></body></html>');
@@ -194,7 +194,7 @@ describe('transformIndexHtml — sandbox boot injection', () => {
   });
 
   it('injects the plugin AI engine as a synchronous global for the in-page path', () => {
-    const p = pyricSandbox({
+    const p = pyric({
       ai: { engine: { kind: 'openai', baseUrl: '/__pyric/ai-proxy', model: 'llama3.2' } },
     });
     const out = (p.transformIndexHtml as (h: string) => string)('<html><head></head></html>');
@@ -224,7 +224,7 @@ describe('integration — real vite dev pluginContainer', () => {
       configFile: false,
       logLevel: 'silent',
       root: path.dirname(entries.init), // any real dir; we only test resolution
-      plugins: [pyricSandbox()],
+      plugins: [pyric()],
       server: { middlewareMode: true },
       optimizeDeps: { noDiscovery: true },
     })) as unknown as typeof server;
@@ -254,7 +254,7 @@ describe('integration — bridge mounts in a real vite dev server (middlewareMod
       configFile: false,
       logLevel: 'silent',
       root: path.dirname(entries.init), // any real dir; rules optional (no firebase.json)
-      plugins: [pyricSandbox({ bridge: { disableAuditLog: true } })],
+      plugins: [pyric({ bridge: { disableAuditLog: true } })],
       server: { middlewareMode: true },
       optimizeDeps: { noDiscovery: true },
     })) as unknown as typeof server;
@@ -327,7 +327,7 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
     // port; `on` is a no-op here (the attachUpgrade spy test uses its own stub).
     httpServer: { address: () => ({ port: 5173 }), on() {}, once() {} },
   };
-  await (pyricSandbox(opts).configureServer as (s: unknown) => Promise<void>)(stub);
+  await (pyric(opts).configureServer as (s: unknown) => Promise<void>)(stub);
   if (!handler) throw new Error('plugin did not mount the /__pyric middleware');
   return handler;
 }
@@ -447,7 +447,7 @@ describe('M2 — worker bundle + persist (via the /__pyric middleware)', () => {
     // Drive configureServer with a stub so the worker bundle (cache-warmed in
     // beforeAll) flips workerReady=true, then assert the transformIndexHtml output.
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-stamp-'));
-    const p = pyricSandbox({});
+    const p = pyric({});
     const stub = {
       config: { root: tmp, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
       middlewares: { use() {} },
@@ -588,7 +588,7 @@ describe('M3 — bridge fold (handler-based)', () => {
     // (connectBridgePeer), so the app stays on the SharedWorker and shares the
     // ONE sandbox with Studio + the agent.
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-bridgeworker-'));
-    const p = pyricSandbox({ bridge: true });
+    const p = pyric({ bridge: true });
     const stub = {
       config: { root: tmp, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
       middlewares: { use() {} },
@@ -611,7 +611,7 @@ describe('M3 — bridge fold (handler-based)', () => {
       watcher: { add() {}, on() {} },
       httpServer: { address: () => ({ port: 5173 }), on(ev: string) { events.push(ev); }, once() {} },
     };
-    await (pyricSandbox({ bridge: true }).configureServer as (s: unknown) => Promise<void>)(stub);
+    await (pyric({ bridge: true }).configureServer as (s: unknown) => Promise<void>)(stub);
     expect(events).toContain('upgrade'); // attachUpgrade wired the peer listener
   });
 
@@ -672,7 +672,7 @@ describe('ui: Pyric Studio mount (parity with dev --ui)', () => {
     expect((await callPyric(handler, { path: '/__pyric/workspace' })).nexted).toBe(false);
   });
 
-  // Default-ON: a plain pyricSandbox() (no `ui`) serves Studio + mounts its routes.
+  // Default-ON: a plain pyric() (no `ui`) serves Studio + mounts its routes.
   it.skipIf(!studioBuilt)('ui defaults ON → /__pyric/ui/ served and workspace mounted with no ui passed', async () => {
     const tmp = mkTmp('pyric-vite-ui-default-');
     const handler = await bootPlugin({}, tmp);
@@ -707,7 +707,7 @@ describe('ui: Pyric Studio mount (parity with dev --ui)', () => {
       watcher: { add() {}, on() {} },
       httpServer: { address: () => ({ port: 5173 }), on() {}, once() {} },
     };
-    await (pyricSandbox({ ui: true, bridge: true }).configureServer as (s: unknown) => Promise<void>)(stub);
+    await (pyric({ ui: true, bridge: true }).configureServer as (s: unknown) => Promise<void>)(stub);
     expect(warnings.some((w) => /ui \+ bridge/.test(w))).toBe(false);
   });
 });
@@ -725,7 +725,7 @@ describe('bridge: .pyric/serve.json discovery pointer (A2)', () => {
   it('writes the pointer (port + mcpUrl + project) when the server binds', async () => {
     const tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-pointer-'));
     let onListening: (() => void) | undefined;
-    await (pyricSandbox({ bridge: true }).configureServer as (s: unknown) => Promise<void>)(
+    await (pyric({ bridge: true }).configureServer as (s: unknown) => Promise<void>)(
       pointerStub(tmp, (cb) => { onListening = cb; }),
     );
     expect(typeof onListening).toBe('function'); // hooked, not written until bound
@@ -740,7 +740,7 @@ describe('bridge: .pyric/serve.json discovery pointer (A2)', () => {
   it('writes NO pointer without bridge', async () => {
     const tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-nopointer-'));
     let onListening: (() => void) | undefined;
-    await (pyricSandbox({}).configureServer as (s: unknown) => Promise<void>)(
+    await (pyric({}).configureServer as (s: unknown) => Promise<void>)(
       pointerStub(tmp, (cb) => { onListening = cb; }),
     );
     onListening?.();

--- a/packages/create-pyric/src/templates.ts
+++ b/packages/create-pyric/src/templates.ts
@@ -469,9 +469,9 @@ onSnapshot(collection(db, 'posts'), (snap) => {
 `;
 
 const VITE_CONFIG = `import { defineConfig } from 'vite';
-import { pyricSandbox } from '@pyric/cli/vite';
+import { pyric } from '@pyric/cli/vite';
 
-// Under \`vite dev\` pyricSandbox() swaps firebase/* to the in-process pyric
+// Under \`vite dev\` pyric() swaps firebase/* to the in-process pyric
 // sandbox and deploys + hot-reloads firestore.rules — no Firebase project,
 // credentials, or emulators. \`vite build\` (mode production) ships the real
 // firebase package; the swap never reaches the deployed artifact. For a
@@ -479,7 +479,7 @@ import { pyricSandbox } from '@pyric/cli/vite';
 // non-production mode: \`vite build --mode development\` (see the \`build:sandbox\`
 // script). That output is marked and can never be deployed.
 export default defineConfig({
-  plugins: [pyricSandbox()],
+  plugins: [pyric()],
 });
 `;
 

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -79,7 +79,7 @@ describe('runScaffold', () => {
     expect(paths).toContain('/tmp/hello/vite.config.ts');
     const vite = writeFn.mock.calls.find((c) => String(c[0]).endsWith('vite.config.ts'));
     expect(vite?.[1]).toContain("from '@pyric/cli/vite'");
-    expect(vite?.[1]).toContain('pyricSandbox()');
+    expect(vite?.[1]).toContain('pyric()');
     expect(io.getOut()).toContain('create-pyric: scaffolded web');
   });
 

--- a/packages/site-docs/src/content/agent/set-up-your-agent.md
+++ b/packages/site-docs/src/content/agent/set-up-your-agent.md
@@ -71,7 +71,7 @@ Whatever your client's config file looks like, one of those two lines is the who
 
 One option in `vite.config.ts` makes your own `vite dev` the bridge:
 ```ts
-plugins: [pyricSandbox({ bridge: true })],
+plugins: [pyric({ bridge: true })],
 ```
 Do not start a second `pyric dev` next to it. Two servers means two sandboxes, and your agent will be working in the one you are not looking at. The endpoints are the same, `/__pyric/mcp` on Vite's port, and `npx --package @pyric/cli pyric mcp` finds it the same way.
 

--- a/packages/site-docs/src/content/get-started/how-the-swap-works.md
+++ b/packages/site-docs/src/content/get-started/how-the-swap-works.md
@@ -25,8 +25,8 @@ Using Vite instead? The plugin does the same swap one layer earlier — at modul
 
 ```ts
 // vite.config.ts
-import { pyricSandbox } from '@pyric/cli/vite';
-export default { plugins: [pyricSandbox()] };
+import { pyric } from '@pyric/cli/vite';
+export default { plugins: [pyric()] };
 ```
 
 Because resolution happens before bundling, the swap reaches your dependencies too. A library that imports `firebase/firestore` on your behalf lands on the sandbox exactly like your own code.

--- a/packages/site-docs/src/content/get-started/start-building.md
+++ b/packages/site-docs/src/content/get-started/start-building.md
@@ -33,10 +33,10 @@ Add it to the Vite configuration:
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
-import { pyricSandbox } from '@pyric/cli/vite';
+import { pyric } from '@pyric/cli/vite';
 
 export default defineConfig({
-  plugins: [pyricSandbox()],
+  plugins: [pyric()],
 });
 ```
 Start the normal development server:

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -4,8 +4,8 @@ import tailwindcss from '@tailwindcss/vite';
 import {
   NODE_BUILTIN_RE,
   NODE_BUILTIN_SHIMS,
-  pyricSandbox,
-  type PyricSandboxOptions,
+  pyric,
+  type PyricOptions,
 } from '@pyric/cli/vite';
 
 /**
@@ -29,7 +29,7 @@ import {
 
 /**
  * Benign node-builtin shims (`fs`/`path`/`url`) — the SAME shims serve's
- * bundler and the `pyricSandbox` Vite plugin apply to pyric's browser graph.
+ * bundler and the `pyric` Vite plugin apply to pyric's browser graph.
  * Needed because Studio's bridge peer (clients/bridge-peer.ts) bundles
  * @pyric/cli' browser-side bridge client, whose default dispatcher statically
  * reaches the pyric rules module resolver (a Node module the browser path
@@ -53,7 +53,7 @@ function nodeBuiltinShims(): Plugin {
 export const studioSandboxOptions = {
   ui: true,
   capture: false,
-} satisfies PyricSandboxOptions;
+} satisfies PyricOptions;
 
 export default defineConfig({
   base: process.env.STUDIO_BASE ?? '/',
@@ -62,7 +62,7 @@ export default defineConfig({
     // runtime namespace here so the SharedWorker URL cannot fall through to
     // Vite's Studio index.html response. Review sessions should still avoid
     // writing capture files.
-    pyricSandbox(studioSandboxOptions),
+    pyric(studioSandboxOptions),
     nodeBuiltinShims(),
     react(),
     tailwindcss(),


### PR DESCRIPTION
```ts
// vite.config.ts — the plugin now carries the product's name
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [pyric({ rules: 'firestore.modules.rules', ai: { engine: { kind: 'openai', model: 'llama3.2' } } })],
});
```

## The Vite plugin export is `pyric`, not `pyricSandbox`

The plugin is the product's front door — the one line a new user writes — and it now carries the product's name. Clean break, no alias, no deprecation shim: nothing is published with the old name that anyone depends on. `PyricSandboxOptions` becomes `PyricOptions`. Every reference follows in the same commit: the export site, the plugin internals, seven test files, the CLI's own hint strings, `create-pyric` templates (new projects scaffold the new name from day one), the three docs pages that teach the import, the studio and example vite configs, and the README.

Stacked on #392 so the rename sweeps the new functions code too. Fixes #357.

## Risk

Breaking rename, deliberately unaliased — must ship in the same release as #387/#392 (it will: nothing publishes between). Mechanical word-boundary rename; the TypeDoc-generated API reference regenerates at build and picks up the new names.

<details>
<summary>Verification</summary>

- `bun test --cwd packages/cli test/serve`: 623 tests, 0 fail. `create-pyric`: 5 pass. `site-docs`: 4 pass. cli typecheck clean.
- Residual `pyricSandbox` occurrences: only the gitignored `.astro/typedoc-markdown` cache, regenerated at build.

</details>
