### PR TITLE
fix(ai): map reasoning_content to thought parts in the openai engine

### DIFF
--- a/packages/pyric/src/ai/broker/openai-engine.ts
+++ b/packages/pyric/src/ai/broker/openai-engine.ts
@@ -88,6 +88,7 @@ export interface OpenAIResponse {
       content: string | null;
       tool_calls?: OpenAIToolCall[];
       reasoning?: string;
+      reasoning_content?: string;
     };
     finish_reason: string | null;
   }>;
@@ -103,6 +104,7 @@ export interface OpenAIStreamChunk {
       role?: string;
       content?: string;
       reasoning?: string;
+      reasoning_content?: string;
       tool_calls?: Array<Partial<OpenAIToolCall> & { index: number }>;
     };
     finish_reason: string | null;
@@ -288,11 +290,15 @@ function messagePartsFromOpenAI(msg: {
   content: string | null;
   tool_calls?: OpenAIToolCall[];
   reasoning?: string;
+  reasoning_content?: string;
 }): WirePart[] {
   const parts: WirePart[] = [];
   // Ollama's OpenAI compat surfaces thinking-model output in a nonstandard
-  // `reasoning` field; Gemini represents it as a thought part.
-  if (msg.reasoning) parts.push({ text: msg.reasoning, thought: true });
+  // `reasoning` field; llama-server / deepseek-format servers use
+  // `reasoning_content` instead. Gemini represents either as a thought part.
+  // `reasoning` wins if both are somehow present (shouldn't happen in practice).
+  const reasoning = msg.reasoning ?? msg.reasoning_content;
+  if (reasoning) parts.push({ text: reasoning, thought: true });
   if (msg.content) parts.push({ text: msg.content });
   for (const tc of msg.tool_calls ?? []) {
     let args: Record<string, unknown> = {};
@@ -351,7 +357,8 @@ export function openAIToGeminiResponse(resp: OpenAIResponse): WireResponse {
 export function openAIChunkToParts(chunk: OpenAIStreamChunk): WirePart[] {
   const choice = chunk.choices?.[0];
   const parts: WirePart[] = [];
-  if (choice?.delta?.reasoning) parts.push({ text: choice.delta.reasoning, thought: true });
+  const reasoning = choice?.delta?.reasoning ?? choice?.delta?.reasoning_content;
+  if (reasoning) parts.push({ text: reasoning, thought: true });
   if (choice?.delta?.content) parts.push({ text: choice.delta.content });
   return parts;
 }

--- a/packages/pyric/test/ai/broker.test.ts
+++ b/packages/pyric/test/ai/broker.test.ts
@@ -536,6 +536,34 @@ describe('openai translation: response and chunk mapping', () => {
     });
   });
 
+  it('maps a non-streaming response with reasoning (Ollama) to a thought part', () => {
+    const resp: OpenAIResponse = {
+      id: 'x',
+      model: 'llama3',
+      choices: [
+        { index: 0, message: { role: 'assistant', content: 'hi', reasoning: 'hmm' }, finish_reason: 'stop' },
+      ],
+    };
+    const parts = openAIToGeminiResponse(resp).candidates![0]!.content.parts;
+    expect(parts).toEqual([{ text: 'hmm', thought: true }, { text: 'hi' }]);
+  });
+
+  it('maps a non-streaming response with reasoning_content (llama-server / deepseek-format) to a thought part', () => {
+    const resp: OpenAIResponse = {
+      id: 'x',
+      model: 'gemma-4-26b',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'gemma online', reasoning_content: 'thinking hard' },
+          finish_reason: 'stop',
+        },
+      ],
+    };
+    const parts = openAIToGeminiResponse(resp).candidates![0]!.content.parts;
+    expect(parts).toEqual([{ text: 'thinking hard', thought: true }, { text: 'gemma online' }]);
+  });
+
   it('malformed tool-call JSON maps to MALFORMED_FUNCTION_CALL', () => {
     const resp: OpenAIResponse = {
       id: 'x',
@@ -564,6 +592,17 @@ describe('openai translation: response and chunk mapping', () => {
       choices: [{ index: 0, delta: { reasoning: 'hmm', content: 'hi' }, finish_reason: null }],
     });
     expect(parts).toEqual([{ text: 'hmm', thought: true }, { text: 'hi' }]);
+  });
+
+  it('maps stream deltas with reasoning_content (llama-server / deepseek-format) to a thought part', () => {
+    const parts = openAIChunkToParts({
+      id: 'x',
+      model: 'm',
+      choices: [
+        { index: 0, delta: { reasoning_content: 'thinking hard', content: 'gemma online' }, finish_reason: null },
+      ],
+    });
+    expect(parts).toEqual([{ text: 'thinking hard', thought: true }, { text: 'gemma online' }]);
   });
 
   it('ToolCallBuffer accumulates streamed fragments into whole functionCall parts', () => {


### PR DESCRIPTION
```jsonc
// a gemma-4-26b completion via llama-server — thinking lands here, not in `reasoning`
{ "role": "assistant", "content": "gemma online", "reasoning_content": "..." }
```

## Thinking from llama-server now surfaces as a thought part

The openai engine mapped only the `reasoning` field (Ollama's name) to a Gemini thought part, so llama-server and other deepseek-format servers — which put thinking under `reasoning_content` — had it silently dropped. The answer `content` flowed through, but the thinking vanished. Both the non-streaming and streaming paths now read `msg.reasoning ?? msg.reasoning_content` (`reasoning` wins if both appear, which shouldn't happen since the two field names belong to mutually exclusive server families).

Verified live: gemma-4-26b through a local llama-server returned the shape above, and the mapping now emits its thought part.

Fixes #396

## Risk

None — additive field read; Ollama's `reasoning` path is unchanged.

<details>
<summary>Verification</summary>

`bun test --cwd packages/pyric test/ai` → 186 pass, 0 fail (four new cases: `reasoning` and `reasoning_content`, each non-streaming and streaming). Package typecheck clean.

</details>
