### PR TITLE
feat(messaging): route sandbox.deliver through the worker so it reaches worker-backed apps

### DIFF
--- a/packages/cli/src/serve/entries/messaging-sw.ts
+++ b/packages/cli/src/serve/entries/messaging-sw.ts
@@ -8,7 +8,9 @@ import type {
   Unsubscribe,
 } from 'pyric/messaging/sw';
 import { getApp, type FirebaseApp } from 'pyric/app';
+import { registerSandboxDelivery } from 'pyric/messaging/internal';
 import {
+  messagingDeliver,
   messagingGetMessaging,
   messagingSubscribe,
   type ClientMessaging,
@@ -41,6 +43,9 @@ export function getMessaging(app?: FirebaseApp): Messaging {
     { app: resolved },
   ) as WorkerMessaging;
   workerMessagingByApp.set(resolved, handle);
+  // Symmetric with the client entry: let `pyric/messaging/sw`'s `sandbox.deliver`
+  // drive this worker-backed handle over the transport (same broker, same op).
+  registerSandboxDelivery(handle, (spec) => messagingDeliver(handle, spec));
   return handle;
 }
 

--- a/packages/cli/src/serve/entries/messaging.ts
+++ b/packages/cli/src/serve/entries/messaging.ts
@@ -10,8 +10,10 @@ import type {
 } from 'pyric/messaging';
 import { getApp, type FirebaseApp } from 'pyric/app';
 import { registerAppCleanup } from 'pyric/app/internal';
+import { registerSandboxDelivery } from 'pyric/messaging/internal';
 import {
   messagingDeleteToken,
+  messagingDeliver,
   messagingGetMessaging,
   messagingGetToken,
   messagingSetVisibility,
@@ -62,6 +64,11 @@ export function getMessaging(app?: FirebaseApp): Messaging {
   ) as WorkerMessaging;
   workerMessagingByApp.set(resolved, handle);
   wireVisibility(resolved, handle);
+  // The worker-backed handle isn't in pyric's in-page instance registry, so
+  // teach `pyric/messaging`'s `sandbox.deliver` to drive it over the transport
+  // (visibility+routing resolved host-side). Keeps `firebase/messaging` itself
+  // free of any `sandbox` surface — production parity is untouched.
+  registerSandboxDelivery(handle, (spec) => messagingDeliver(handle, spec));
   return handle;
 }
 

--- a/packages/cli/src/serve/worker/client/messaging.ts
+++ b/packages/cli/src/serve/worker/client/messaging.ts
@@ -1,5 +1,7 @@
 /** Worker-backed Firebase Messaging client/SW receive planes. */
 import type {
+  DeliverSpec,
+  DeliveryResult,
   GetTokenOptions,
   MessagePayload,
   NextFn,
@@ -72,6 +74,25 @@ export async function messagingSetVisibility(
     method: 'messaging.setVisibility',
     state,
   });
+}
+
+/**
+ * The worker transport for `pyric/messaging`'s `sandbox.deliver` — injects a
+ * simulated delivery into the app's real (worker-hosted) broker. The full
+ * {@link DeliverSpec} crosses the wire; the host sets this port's client
+ * visibility from `spec.visibilityState` before routing, so `visible` reaches
+ * `onMessage` and `hidden` reaches `onBackgroundMessage`.
+ */
+export async function messagingDeliver(
+  messaging: ClientMessaging,
+  spec: DeliverSpec,
+): Promise<DeliveryResult> {
+  return await rpc(messaging.port, {
+    t: 'op',
+    id: nextId(),
+    method: 'messaging.deliver',
+    spec,
+  }) as DeliveryResult;
 }
 
 export function messagingSubscribe(

--- a/packages/cli/src/serve/worker/host-messaging.ts
+++ b/packages/cli/src/serve/worker/host-messaging.ts
@@ -168,9 +168,16 @@ export async function handleMessagingOp(
 
     case 'messaging.deliver': {
       // Test/Studio driver — DeliveryResult { route, handlerCount, payload }
-      // is plain JSON.
+      // is plain JSON. `visibilityState` (the in-page driver's twin) sets THIS
+      // port's client visibility before routing, so `pyric/messaging`'s
+      // `sandbox.deliver(spec)` picks foreground/background over the transport
+      // exactly as in-page: visible → onMessage, hidden → onBackgroundMessage.
       try {
-        ok(port, msg.id, broker(ctx).deliver(msg.spec));
+        const { visibilityState, ...payload } = msg.spec;
+        if (visibilityState !== undefined) {
+          broker(ctx).setClientVisibility(clientIdFor(ctx, port), visibilityState);
+        }
+        ok(port, msg.id, broker(ctx).deliver(payload));
       } catch (e) { failMessaging(port, msg.id, e); }
       break;
     }

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -592,6 +592,15 @@ export type OpMessage = (
  * `MessagingBroker.deliver`'s parameter exactly; plain JSON throughout.
  */
 export interface MessagingDeliverSpec {
+  /**
+   * Simulated visibility of THIS port's window client at delivery time — the
+   * transport twin of the in-page driver's `DeliverSpec.visibilityState`. When
+   * present the host sets the delivering port's client visibility before
+   * routing (`visible` → foreground/`onMessage`, `hidden` →
+   * background/`onBackgroundMessage`); absent leaves the last-reported
+   * visibility untouched.
+   */
+  visibilityState?: ClientVisibilityState;
   data?: Record<string, string>;
   notification?: { title?: string; body?: string; image?: string };
   from?: string;

--- a/packages/cli/test/serve/worker/messaging-ops.test.ts
+++ b/packages/cli/test/serve/worker/messaging-ops.test.ts
@@ -310,6 +310,54 @@ describe('messaging.deliver and unsub', () => {
     expect((port.snaps[0]!.value as { data: { tag: string } }).data.tag).toBe('drive');
   });
 
+  it('deliver with visibility: visible sets THIS port visible then routes foreground', async () => {
+    // The transport twin of pyric/messaging `sandbox.deliver({ visibilityState })`:
+    // a fresh port with no prior setVisibility still lands foreground because
+    // the spec sets its client visible before routing (issue #397).
+    const ctx = makeCtx();
+    const page = fakePort();
+    const swPort = fakePort();
+    await sub(ctx, page, 'fg', 'messaging.foreground');
+    await sub(ctx, swPort, 'bg', 'messaging.background');
+    const result = (await opOk(ctx, page, {
+      method: 'messaging.deliver',
+      spec: { visibilityState: 'visible', data: { tag: 'fg' } },
+    })) as { route: string; handlerCount: number };
+    expect(result.route).toBe('foreground');
+    expect(page.snaps.map((s) => s.subId)).toEqual(['fg']);
+    expect(swPort.snaps.length).toBe(0);
+  });
+
+  it('deliver with visibility: hidden routes background (onBackgroundMessage)', async () => {
+    const ctx = makeCtx();
+    const page = fakePort();
+    const swPort = fakePort();
+    await sub(ctx, page, 'fg', 'messaging.foreground');
+    await sub(ctx, swPort, 'bg', 'messaging.background');
+    // The delivering page was visible a moment ago…
+    await opOk(ctx, page, { method: 'messaging.setVisibility', state: 'visible' });
+    const result = (await opOk(ctx, page, {
+      method: 'messaging.deliver',
+      spec: { visibilityState: 'hidden', notification: { title: 'bg' } },
+    })) as { route: string };
+    // …but the spec's hidden visibility wins for this delivery.
+    expect(result.route).toBe('background');
+    expect(swPort.snaps.map((s) => s.subId)).toEqual(['bg']);
+    expect(page.snaps.length).toBe(0);
+  });
+
+  it('deliver without visibilityState leaves last-reported visibility untouched', async () => {
+    const ctx = makeCtx();
+    const port = fakePort();
+    await sub(ctx, port, 'fg', 'messaging.foreground');
+    await opOk(ctx, port, { method: 'messaging.setVisibility', state: 'visible' });
+    const result = (await opOk(ctx, port, {
+      method: 'messaging.deliver',
+      spec: { data: { n: '1' } },
+    })) as { route: string };
+    expect(result.route).toBe('foreground');
+  });
+
   it('unsub stops delivery; duplicate sub ids are idempotent', async () => {
     const ctx = makeCtx();
     const port = fakePort();

--- a/packages/cli/test/serve/worker/messaging-sandbox-deliver.test.ts
+++ b/packages/cli/test/serve/worker/messaging-sandbox-deliver.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #397 — `pyric/messaging`'s `sandbox.deliver(getMessaging(app), spec)`
+ * must reach the app's REAL broker on the default SharedWorker path, not just
+ * the in-page plane. This exercises the whole seam end to end: a bridged
+ * client↔host port pair, the worker-backed messaging handle registered through
+ * `registerSandboxDelivery`, and pyric's transport-agnostic `sandbox.deliver`
+ * driving it over the `messaging.deliver` op.
+ *
+ * The visibility contract is the assertion that matters: `visible` → the
+ * worker-path `onMessage` subscriber (foreground), `hidden` → the worker-path
+ * `onBackgroundMessage` subscriber (background).
+ */
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+import * as fcm from 'pyric/messaging';
+import { registerSandboxDelivery, type DeliverSpec } from 'pyric/messaging/internal';
+import type { Messaging, MessagePayload } from 'pyric/messaging';
+
+import { handleMessage, type HostCtx, type PortLike } from '../../../src/serve/worker/host.js';
+import { wirePort } from '../../../src/serve/worker/client/core.js';
+import {
+  messagingDeliver,
+  messagingGetMessaging,
+  messagingSubscribe,
+} from '../../../src/serve/worker/client/messaging.js';
+import type { ClientDb, ClientPort } from '../../../src/serve/worker/client/handles.js';
+import type { InboundMessage, OutboundMessage } from '../../../src/serve/worker/protocol.js';
+
+/** A ClientPort whose messages drive a real host, replies routed back in-process. */
+function bridgedClient(): { db: ClientDb } {
+  const sandbox = initializeSandbox();
+  const ctx: HostCtx = {
+    sandbox,
+    db: getFirestore(sandbox),
+    instanceId: 'sandbox-deliver-test',
+    subs: new Map(),
+    messagingEnabled: true,
+  };
+
+  const hostPort: PortLike = {
+    postMessage(message: OutboundMessage) {
+      clientPort.onmessage?.({ data: message } as MessageEvent<OutboundMessage>);
+    },
+  };
+  const clientPort: ClientPort = {
+    onmessage: null,
+    postMessage(message: InboundMessage) {
+      void handleMessage(ctx, hostPort, message);
+    },
+  };
+  wirePort(clientPort);
+  return { db: { app: {} as ClientDb['app'], port: clientPort } };
+}
+
+/** The default-path handle: worker-backed + a `sandbox.deliver` transport, as `entries/messaging.ts` builds it. */
+function workerHandle(db: ClientDb): Messaging {
+  const handle = Object.assign(messagingGetMessaging(db), { app: {} }) as unknown as Messaging;
+  registerSandboxDelivery(handle, (spec: DeliverSpec) => messagingDeliver(handle as never, spec));
+  return handle;
+}
+
+describe('sandbox.deliver over the worker transport (#397)', () => {
+  it('visible reaches the worker-path onMessage subscriber', async () => {
+    const { db } = bridgedClient();
+    const messaging = workerHandle(db);
+    const foreground: MessagePayload[] = [];
+    messagingSubscribe(messaging as never, 'messaging.foreground', (p) => foreground.push(p));
+
+    const result = await fcm.sandbox.deliver(messaging, {
+      visibilityState: 'visible',
+      data: { hello: 'fg' },
+    });
+
+    expect(result.route).toBe('foreground');
+    expect(foreground.length).toBe(1);
+    expect(foreground[0]!.data!.hello).toBe('fg');
+  });
+
+  it('hidden reaches the worker-path onBackgroundMessage subscriber', async () => {
+    const { db } = bridgedClient();
+    const messaging = workerHandle(db);
+    const foreground: MessagePayload[] = [];
+    const background: MessagePayload[] = [];
+    messagingSubscribe(messaging as never, 'messaging.foreground', (p) => foreground.push(p));
+    messagingSubscribe(messaging as never, 'messaging.background', (p) => background.push(p));
+
+    const result = await fcm.sandbox.deliver(messaging, {
+      visibilityState: 'hidden',
+      notification: { title: 'bg' },
+    });
+
+    expect(result.route).toBe('background');
+    expect(foreground.length).toBe(0);
+    expect(background.length).toBe(1);
+    expect(background[0]!.notification!.title).toBe('bg');
+  });
+});

--- a/packages/pyric/src/messaging/instance.ts
+++ b/packages/pyric/src/messaging/instance.ts
@@ -136,6 +136,33 @@ export function stateOf(messaging: Messaging): InstanceState {
   return state;
 }
 
+// ── Transport-delivery hook (the `@pyric/cli` worker seam) ──────────────────
+
+/**
+ * A `sandbox.deliver` implementation for a `Messaging` handle whose broker
+ * lives across a transport, rather than in this process's instance registry.
+ */
+export type SandboxDeliveryTransport = (spec: DeliverSpec) => Promise<DeliveryResult>;
+
+/**
+ * Handles produced OUTSIDE this module (the `@pyric/cli` worker-backed
+ * messaging handle) register their own delivery here so `sandbox.deliver`
+ * recognizes them without their being in the in-page {@link instanceState}
+ * registry. The registered transport receives the FULL {@link DeliverSpec}
+ * (visibility included) and owns the visibility+deliver routing on the far
+ * side of the transport. This is an internal seam (`pyric/messaging/internal`),
+ * never part of the app-facing `firebase/messaging` surface.
+ */
+const transportDelivery = new WeakMap<Messaging, SandboxDeliveryTransport>();
+
+/** Register a worker-backed handle's `sandbox.deliver` transport. */
+export function registerSandboxDelivery(
+  messaging: Messaging,
+  deliver: SandboxDeliveryTransport,
+): void {
+  transportDelivery.set(messaging, deliver);
+}
+
 // ── The sandbox test/tooling driver shared by both entries ──────────────────
 
 export interface DeliverSpec {
@@ -157,6 +184,10 @@ export async function deliverToMessaging(
   messaging: Messaging,
   spec: DeliverSpec,
 ): Promise<DeliveryResult> {
+  // A worker-backed handle drives its broker across the transport — routing
+  // (visibility → foreground/background) happens on the far side.
+  const transport = transportDelivery.get(messaging);
+  if (transport !== undefined) return transport(spec);
   const state = stateOf(messaging);
   if (spec.visibilityState !== undefined) {
     state.broker.setClientVisibility(DEFAULT_CLIENT_ID, spec.visibilityState);

--- a/packages/pyric/src/messaging/internal.ts
+++ b/packages/pyric/src/messaging/internal.ts
@@ -9,3 +9,12 @@
  * breaking-change semantics across versions.
  */
 export * from './broker/index.js';
+
+/**
+ * Worker-transport seam (`@pyric/cli`): register a worker-backed `Messaging`
+ * handle's `sandbox.deliver` implementation so `pyric/messaging`'s
+ * `sandbox.deliver` reaches the app's real broker over the transport. Not
+ * part of the public API.
+ */
+export { registerSandboxDelivery, type SandboxDeliveryTransport } from './instance.js';
+export type { DeliverSpec } from './instance.js';


### PR DESCRIPTION
```js
// the same call now works on the default SharedWorker path, not only in-page
import { getMessaging, onMessage } from 'firebase/messaging';
import { sandbox } from 'pyric/messaging';

const messaging = getMessaging(app);                 // worker-backed handle
onMessage(messaging, (p) => renderToast(p));         // subscribes over the worker
await sandbox.deliver(messaging, {
  visibilityState: 'visible',                        // -> onMessage (hidden -> onBackgroundMessage)
  notification: { title: 'Hi', body: 'It arrived.' },
});
```

## sandbox.deliver reaches worker-backed messaging, not just the in-page plane

Cloud Messaging is a server-to-client push; with no backend, `sandbox.deliver` is how you simulate a push in a test or console. It only drove the in-page plane, so on the default SharedWorker path `getMessaging()` returned a worker-backed handle that `deliverToMessaging` rejected as "not produced by this module's getMessaging()" — a boilerplate app could never trigger its messaging demo.

The fix adds a transport seam in the `pyric` package: `deliverToMessaging` consults a `WeakMap<Messaging, transport>` before its in-page registry, and `@pyric/cli` registers the worker handle's transport (`registerSandboxDelivery`, exposed only on `pyric/messaging/internal`) to forward the whole spec over a `messaging.deliver` op extended with `visibilityState`. The host sets the delivering port's visibility, then routes — visible to `onMessage`, hidden to `onBackgroundMessage`. In-page handles register nothing and take the unchanged path.

## Risk

The app-facing `firebase/messaging` gains no surface — `registerSandboxDelivery` is an internal side effect inert unless someone imports `pyric/messaging`'s `sandbox` (which production apps never do), so production parity is untouched. One semantic to note: a `deliver` sets the delivering port's client visibility stickily (mirroring the in-page driver's `DEFAULT_CLIENT_ID` behavior); a later real `visibilitychange` resyncs it. Omitting `visibilityState` leaves visibility as-is.

<details>
<summary>Verification</summary>

- `packages/cli` `test/serve`: 624 pass, 7 skip, 0 fail (3 new host-op cases in `messaging-ops.test.ts`, 2 end-to-end in new `messaging-sandbox-deliver.test.ts`).
- `packages/pyric` `test/messaging`: 48 pass. Both packages typecheck clean.
- Covers: visible→onMessage and hidden→onBackgroundMessage over the worker; omitted visibility leaves state untouched; in-page path unregressed.

</details>
