### PR TITLE
fix(pyric-admin): route admin-shape getFirestore to the rules-bypass lens

### DIFF
--- a/packages/cli/test/functions-rtdb/dev.e2e.test.ts
+++ b/packages/cli/test/functions-rtdb/dev.e2e.test.ts
@@ -25,10 +25,14 @@ let command: ChildProcess | undefined;
 let peer: { close(): Promise<void> } | undefined;
 let observer: RemoteSandbox | undefined;
 
-async function connectWorkerPeer(url: string): Promise<{ close(): Promise<void> }> {
+async function connectWorkerPeer(
+  url: string,
+  opts: { firestoreRules?: string } = {},
+): Promise<{ close(): Promise<void> }> {
   const ctx = await createFunctionsWorkerHostCtx({
     persistenceKeyPrefix: 'functions-dev',
     instanceId: 'functions-dev-e2e',
+    ...(opts.firestoreRules !== undefined ? { firestoreRules: opts.firestoreRules } : {}),
   });
   return connectFunctionsWorkerPeer({ url, ctx, sandboxId: 'functions-dev-peer' });
 }
@@ -145,6 +149,127 @@ exports.makeUppercase = onValueCreated(
         if (command?.exitCode === null) command.kill('SIGKILL');
         command = undefined;
       }
+    }
+  }, 30_000);
+
+  test('an onValueCreated trigger stamps a Firestore doc via firebase-admin (admin bypasses deny rules; client-lens denied) (#394)', async () => {
+    if (!existsSync(cliEntry)) throw new Error(`build the CLI first: ${cliEntry}`);
+    // The pychat presence→users stamp shape: an RTDB write triggers a Cloud
+    // Function that writes a Firestore doc through firebase-admin/firestore.
+    // The ruleset DENIES a signed-out (client/anon) caller on `users/*` — only
+    // the row's own owner may write. firebase-admin bypasses rules, so the
+    // function's admin write must LAND; a client-lens (anon) write to the same
+    // path must be DENIED.
+    const RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /users/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}`;
+    const cwd = mkdtempSync(join(tmpdir(), 'pyric-functions-dev-firestore-'));
+    mkdirSync(join(cwd, 'public'));
+    mkdirSync(join(cwd, 'functions/node_modules'), { recursive: true });
+    writeFileSync(join(cwd, 'public/index.html'), '<!doctype html><body>fixture</body>');
+    writeFileSync(join(cwd, '.firebaserc'), JSON.stringify({ projects: { default: 'demo-project' } }));
+    writeFileSync(join(cwd, 'firebase.json'), JSON.stringify({
+      hosting: { public: 'public' },
+      functions: { source: 'functions' },
+    }));
+    writeFileSync(join(cwd, 'functions/package.json'), JSON.stringify({
+      name: 'firestore-stamp-functions',
+      private: true,
+      type: 'commonjs',
+      main: 'index.cjs',
+    }));
+    // Unchanged firebase-admin source — the register swap rewrites the imports.
+    writeFileSync(join(cwd, 'functions/index.cjs'),
+      `const { onValueCreated } = require('firebase-functions/v2/database');
+const { getFirestore } = require('firebase-admin/firestore');
+exports.stampPresence = onValueCreated('/presence/{uid}/state', async (event) => {
+  const uid = event.data.ref.parent.key;
+  await getFirestore().doc('users/' + uid).set({ lastSeenAt: event.data.val() });
+});
+`);
+    symlinkSync(
+      join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+      join(cwd, 'functions/node_modules/firebase-functions'),
+    );
+
+    let stdout = '';
+    let stderr = '';
+    command = spawn('node', [
+      cliEntry, 'dev', '--port=0', '--host=127.0.0.1', '--no-open', '--no-capture',
+    ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    command.stdout?.setEncoding('utf8');
+    command.stderr?.setEncoding('utf8');
+    command.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+    command.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+
+    try {
+      const pointer = await waitFor(() => {
+        const path = join(cwd, '.pyric/serve.json');
+        return existsSync(path)
+          ? JSON.parse(readFileSync(path, 'utf8')) as { url: string }
+          : null;
+      });
+      // The worker peer owns the sandbox where data lands — deploy the
+      // restrictive ruleset there (as a served page would).
+      peer = await connectWorkerPeer(
+        `${pointer.url.replace(/^http/, 'ws')}/__pyric/sandbox`,
+        { firestoreRules: RULES },
+      );
+      observer = await connectRemoteSandbox({ url: pointer.url });
+      await waitFor(() =>
+        stdout.includes('✔ functions 1 onValueCreated trigger') ? true : null);
+
+      // Trigger the function: an RTDB create at the watched path.
+      await observer.rtdb.set('presence/u1/state', 'online');
+
+      // ADMIN BYPASS: the function's firebase-admin write landed despite the
+      // deny-for-anon ruleset. Read it back through the worker (admin lens).
+      const stamped = await waitFor(async () => {
+        const snap = (await observer!.channel.op({
+          method: 'getDoc',
+          path: 'users/u1',
+          actAs: { mode: 'admin' },
+        })) as { exists: boolean; data?: { json: string } };
+        return snap.exists ? snap : null;
+      });
+      expect(JSON.parse(stamped.data!.json)).toEqual({ lastSeenAt: 'online' });
+
+      // NEGATIVE INVARIANT: a client-lens (signed-out / anon) write to the
+      // SAME rules-protected path is DENIED — the fix routes only the server
+      // admin context to the bypass lens, never a client lens.
+      let clientErr: { code?: string } | undefined;
+      try {
+        await observer.channel.op({
+          method: 'setDoc',
+          path: 'users/u1',
+          data: { lastSeenAt: 'spoofed' },
+          actAs: { mode: 'anon' },
+        });
+      } catch (e) {
+        clientErr = e as { code?: string };
+      }
+      expect(clientErr?.code).toBe('permission-denied');
+      // The denied client write did not mutate the admin-stamped doc.
+      const after = (await observer.channel.op({
+        method: 'getDoc',
+        path: 'users/u1',
+        actAs: { mode: 'admin' },
+      })) as { exists: boolean; data?: { json: string } };
+      expect(JSON.parse(after.data!.json)).toEqual({ lastSeenAt: 'online' });
+
+      expect(stderr).not.toContain('Functions child exited unexpectedly');
+    } finally {
+      observer?.close();
+      observer = undefined;
+      await peer?.close().catch(() => {});
+      peer = undefined;
+      if (command?.exitCode === null) command.kill('SIGKILL');
+      command = undefined;
     }
   }, 30_000);
 

--- a/packages/cli/test/functions-rtdb/worker-peer.ts
+++ b/packages/cli/test/functions-rtdb/worker-peer.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 import { createMemoryBackend, initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
+import { getFirestore as getBaseFirestore } from 'pyric/sandbox/admin-firestore';
 import {
   isBridgeMessage,
   WORKER_RELAY_CAPABILITY,
@@ -19,6 +20,12 @@ import type {
 export interface FunctionsWorkerHostOptions {
   persistenceKeyPrefix: string;
   instanceId: string;
+  /** Optional Firestore ruleset deployed on the worker's sandbox before any
+   *  relayed op — deployed synchronously through the LOCAL arm exactly as a
+   *  served page would. Lets a test prove that a functions child's admin
+   *  (rules-bypass) write lands against a ruleset that would DENY an
+   *  anonymous/client-lens caller (#394). */
+  firestoreRules?: string;
 }
 
 export interface FunctionsWorkerPeerOptions {
@@ -35,6 +42,9 @@ export async function createFunctionsWorkerHostCtx(
     key: `${options.persistenceKeyPrefix}-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });
+  if (options.firestoreRules !== undefined) {
+    getBaseFirestore(sandbox.withAuth(null)).setRules(options.firestoreRules);
+  }
   return {
     db: getFirestore(sandbox),
     sandbox,

--- a/packages/pyric-admin/src/firestore/index.ts
+++ b/packages/pyric-admin/src/firestore/index.ts
@@ -14,11 +14,30 @@
  * default-app resolution and throw the captured `app/no-app` error when
  * nothing is initialized. The original `getFirestore(ctx)` context form
  * (the load-bearing shape the existing suite uses) is preserved verbatim.
+ *
+ * RULES-BYPASS PARITY (#394): the two APP-resolution forms — `getFirestore(app)`
+ * and no-arg `getFirestore()` — mirror `firebase-admin/firestore`'s
+ * `getFirestore(app?)`, and REAL firebase-admin bypasses security rules. So both
+ * app forms resolve to the rules-BYPASS admin lens (`getAdminFirestore` →
+ * `{ mode: 'admin' }`), exactly as `pyric-admin/database`'s `getDatabase(app)`
+ * and `pyric-admin/storage`'s `getStorage(app)` already do. Previously the app
+ * forms routed through the anon-lens `getFirestore(sandbox.withAuth(null))`,
+ * which evaluates `request.auth == null` and is DENIED by any real ruleset — a
+ * deny-direction divergence from production that blocked the RTDB-trigger →
+ * Firestore-stamp pattern (a Cloud Function's admin write).
+ *
+ * The `getFirestore(ctx)` CONTEXT form is UNCHANGED and stays rules-ENFORCED
+ * (its captured identity is load-bearing for the rules-simulation suite). No
+ * page ever reaches this module: a page's `firebase/firestore` resolves to
+ * `pyric/firestore` (the rules-enforced client), not `pyric-admin`; only the
+ * `firebase-admin/*` → `pyric-admin/*` swap in the trusted functions child
+ * imports this. See {@link getFirestore}.
  */
 export * from 'pyric/sandbox/admin-firestore';
 
 import {
   getFirestore as baseGetFirestore,
+  getAdminFirestore as baseGetAdminFirestore,
   type SandboxFirestore,
 } from 'pyric/sandbox/admin-firestore';
 import type { SandboxContext } from 'pyric/sandbox';
@@ -30,13 +49,15 @@ import {
 } from '../app/index.js';
 import { assertAdminAppActive } from '../app/lifecycle.js';
 
-/** Narrow a `PyricAdminApp` to the anonymous {@link SandboxContext} the
- *  admin firestore backend runs against. Sandbox apps expose their
- *  `Sandbox` — LOCAL and REMOTE alike: the base `getFirestore` is
- *  remote-aware (it dispatches a remote-branded sandbox to the
- *  channel-backed arm), so no guard is needed here. Prod apps require
- *  firebase-admin's real Firestore, which the in-process backend does
- *  not model. */
+/** Narrow a `PyricAdminApp` to the {@link SandboxContext} the admin
+ *  firestore backend runs against. Sandbox apps expose their `Sandbox` —
+ *  LOCAL and REMOTE alike: the base resolvers are remote-aware (they
+ *  dispatch a remote-branded sandbox to the channel-backed arm), so no
+ *  guard is needed here. The context's captured auth is IRRELEVANT on the
+ *  admin path (rules are bypassed, so no rule reads `request.auth`); it is
+ *  normalised to `withAuth(null)` only to obtain a context. Prod apps
+ *  require firebase-admin's real Firestore, which the in-process backend
+ *  does not model. */
 function adminAppToContext(app: PyricAdminApp): SandboxContext {
   if (isSandboxAdminApp(app)) {
     return app.sandbox.withAuth(null);
@@ -50,22 +71,30 @@ function adminAppToContext(app: PyricAdminApp): SandboxContext {
 /**
  * Return the admin Firestore handle.
  *
- *   - `getFirestore(ctx)` — the original context form (rules-applied for the
+ *   - `getFirestore(ctx)` — the original context form (rules-APPLIED for the
  *     ctx's captured identity). Unchanged; idempotent per `SandboxContext`.
- *   - `getFirestore(app)` — resolves a {@link PyricAdminApp}'s sandbox.
- *   - `getFirestore()` — resolves the default app; throws `app/no-app` when
- *     nothing is initialized.
+ *     This is the pyric-internal rules-simulation shape, not a firebase-admin
+ *     shape, so it keeps rule evaluation.
+ *   - `getFirestore(app)` — resolves a {@link PyricAdminApp}'s sandbox to the
+ *     rules-BYPASS admin lens (firebase-admin parity, #394).
+ *   - `getFirestore()` — resolves the default app to the rules-BYPASS admin
+ *     lens; throws `app/no-app` when nothing is initialized.
+ *
+ * The app forms mirror `firebase-admin/firestore`'s `getFirestore(app?)`,
+ * which bypasses security rules — so a Cloud Function's admin write lands the
+ * same way it does in production, instead of being denied as `request.auth ==
+ * null` by the sandbox's anon lens (the #394 deny-direction divergence).
  */
 export function getFirestore(
   target?: SandboxContext | PyricAdminApp,
 ): SandboxFirestore {
   if (target === undefined) {
-    return baseGetFirestore(adminAppToContext(getApp()));
+    return baseGetAdminFirestore(adminAppToContext(getApp()));
   }
   if (typeof target === 'object' && target !== null && ADMIN_APP_TARGET in target) {
     const app = target as PyricAdminApp;
     assertAdminAppActive(app);
-    return baseGetFirestore(adminAppToContext(app));
+    return baseGetAdminFirestore(adminAppToContext(app));
   }
   return baseGetFirestore(target as SandboxContext);
 }

--- a/packages/pyric-admin/test/remote/remote-firestore.test.ts
+++ b/packages/pyric-admin/test/remote/remote-firestore.test.ts
@@ -257,15 +257,48 @@ describe('pyric-admin remote Firestore — arm selection', () => {
     expect(db.snapshot()['local/probe']).toEqual({ via: 'local-arm' });
   });
 
-  it("the wrapper's no-arg getFirestore() resolves the default app onto the remote arm", async () => {
-    const { ctx } = makeStack();
-    // No guard anymore: app-based resolution flows into the remote-aware
-    // base getFirestore. The default-app ctx is withAuth(null) → the anon
-    // lens; OPEN_RULES allow it, and the write must land in the worker.
+  it("the wrapper's no-arg getFirestore() resolves the default app onto the remote arm with the rules-BYPASS admin lens (#394)", async () => {
+    // Deny-everything rules on `locked/*`: an anon/client-lens write is
+    // DENIED there. firebase-admin bypasses rules, so the app-form
+    // getFirestore() must resolve to the admin lens and the write must land.
+    // (Before #394 the app form used the anon lens — `request.auth == null` —
+    // and this write would throw permission-denied, the deny-direction
+    // divergence that blocked the RTDB-trigger → Firestore-stamp pattern.)
+    const { ctx } = makeStack({ rules: MATRIX_RULES });
     const db = getFirestore();
-    await db.doc('ambient/probe').set({ via: 'wrapper-default-app' });
-    const raw = await workerGetDocRaw(ctx, 'ambient/probe');
-    expect(JSON.parse(raw.json!)).toEqual({ via: 'wrapper-default-app' });
+    await db.doc('locked/probe').set({ via: 'wrapper-default-app-admin' });
+    const raw = await workerGetDocRaw(ctx, 'locked/probe');
+    expect(raw.exists).toBe(true);
+    expect(JSON.parse(raw.json!)).toEqual({ via: 'wrapper-default-app-admin' });
+  });
+
+  it('the wrapper app-form getFirestore(app) bypasses deny rules; a client-lens write to the same path is DENIED (#394 invariant)', async () => {
+    // The trust boundary, both directions on ONE stack:
+    //   • server context (functions child) → app-form getFirestore(app) →
+    //     admin lens → bypasses `locked/*` deny rules (write lands).
+    //   • client context → withAuth(null) → the rules-ENFORCED `{ mode: 'anon' }`
+    //     worker lens. This is the IDENTICAL worker lens a page's
+    //     `firebase/firestore` (→ `pyric/firestore`) resolves to for a
+    //     signed-out client, so it faithfully models the client surface. The
+    //     fix does NOT weaken it — the same write is DENIED.
+    const { ctx, remote, app } = makeStack({ rules: MATRIX_RULES });
+
+    // Server (admin-SDK) surface — bypasses rules.
+    const adminDb = getFirestore(app);
+    await adminDb.doc('locked/server').set({ by: 'admin' });
+    expect((await workerGetDocRaw(ctx, 'locked/server')).exists).toBe(true);
+
+    // Client (rules-enforced anon) surface — same remote sandbox, DENIED.
+    const clientDb = getFirestore(remote.withAuth(null));
+    let clientErr: WireError | undefined;
+    try {
+      await clientDb.doc('locked/client').set({ by: 'client' });
+    } catch (e) {
+      clientErr = e as WireError;
+    }
+    expect(clientErr).toBeInstanceOf(SandboxError);
+    expect(clientErr!.code).toBe('permission-denied');
+    expect((await workerGetDocRaw(ctx, 'locked/client')).exists).toBe(false);
   });
 
   it('handles are idempotent per context / per handle kind', () => {


### PR DESCRIPTION
```js
// functions/index.js — an onValueCreated trigger writing across services with the admin SDK
export const onPresenceOnline = onValueCreated('/presence/{uid}/state', async (event) => {
  await getFirestore()                          // admin handle — bypasses rules, as in production
    .collection('users').doc(event.params.uid)
    .set({ lastSeenAt: event.data.val() }, { merge: true });
});
// firestore.rules denies this write for any anonymous caller; the function still lands it.
```

## A function's admin Firestore writes now bypass rules in the sandbox, matching production

`pyric-admin/firestore`'s app-shape `getFirestore(app)` / `getFirestore()` — what a Cloud Function's swapped `firebase-admin` code calls — resolved to the `{ mode: 'anon' }` rules-enforced lens, so `request.auth == null` and any owner-scoped ruleset denied the write. Real `firebase-admin` bypasses rules. That deny-direction divergence blocked the canonical RTDB-trigger → Firestore-stamp pattern (a boilerplate's presence → users demo). The app forms now route to the `{ mode: 'admin' }` rules-bypass lens, exactly as `pyric-admin/database` and `pyric-admin/storage` already do. The pyric-internal `getFirestore(ctx)` form stays rules-enforced.

Fixes #394.

## Risk

This is a rules-bypass path, so the review question is whether any client-lens code can reach it. It cannot, and an adversarial security pass confirmed it: page `firebase/firestore` resolves through a swap allowlist that structurally excludes `firebase-admin`; client writes carry no `actAs` lens; `pyric-admin` is reachable only through the Node-only `@pyric/cli/register` hook (refuses production, impossible in a browser); the bridge WebSocket is Origin/Host-guarded; and the admin arm is selected only by a genuine admin app (a `SandboxContext` can't masquerade — it lacks the admin-app symbol). The change touches only `pyric-admin/firestore` — no host, bridge, protocol, or page code. Storage and RTDB already worked this way and were left unchanged.

<details>
<summary>Verification</summary>

- `test/functions-rtdb/dev.e2e.test.ts`: a real `pyric dev` child runs unchanged `firebase-admin` source; the trigger's admin write lands against a ruleset that denies anon, and a client-lens (`actAs: anon`) write to the same path is `permission-denied` with the admin doc unchanged. 4 pass.
- `pyric-admin/test/remote/remote-firestore.test.ts`: both directions through the real worker host + bridge — app form bypasses `locked/*` deny rules; identical-lens anon client write denied. 39 pass.
- cli functions-rtdb + serve: 657 pass. pyric-admin: 646 pass. Typechecks clean.

</details>
