### PR TITLE
fix(database): bypass read rules for admin RTDB onValue listeners

### DIFF
--- a/packages/cli/test/functions-rtdb/dev.e2e.test.ts
+++ b/packages/cli/test/functions-rtdb/dev.e2e.test.ts
@@ -25,10 +25,14 @@ let command: ChildProcess | undefined;
 let peer: { close(): Promise<void> } | undefined;
 let observer: RemoteSandbox | undefined;
 
-async function connectWorkerPeer(url: string): Promise<{ close(): Promise<void> }> {
+async function connectWorkerPeer(
+  url: string,
+  databaseRules?: { rules: Record<string, unknown> },
+): Promise<{ close(): Promise<void> }> {
   const ctx = await createFunctionsWorkerHostCtx({
     persistenceKeyPrefix: 'functions-dev',
     instanceId: 'functions-dev-e2e',
+    databaseRules,
   });
   return connectFunctionsWorkerPeer({ url, ctx, sandboxId: 'functions-dev-peer' });
 }
@@ -145,6 +149,115 @@ exports.makeUppercase = onValueCreated(
         if (command?.exitCode === null) command.kill('SIGKILL');
         command = undefined;
       }
+    }
+  }, 30_000);
+
+  test('an auth-gated read on the watched path does NOT deny the trigger (admin lens) — #401', async () => {
+    if (!existsSync(cliEntry)) throw new Error(`build the CLI first: ${cliEntry}`);
+    const cwd = mkdtempSync(join(tmpdir(), 'pyric-functions-dev-rules-'));
+    mkdirSync(join(cwd, 'public'));
+    mkdirSync(join(cwd, 'functions/node_modules'), { recursive: true });
+    writeFileSync(join(cwd, 'public/index.html'), '<!doctype html><body>fixture</body>');
+    writeFileSync(join(cwd, '.firebaserc'), JSON.stringify({
+      projects: { default: 'demo-project' },
+    }));
+    writeFileSync(join(cwd, 'firebase.json'), JSON.stringify({
+      hosting: { public: 'public' },
+      functions: { source: 'functions' },
+    }));
+    writeFileSync(join(cwd, 'functions/package.json'), JSON.stringify({
+      name: 'rules-gated-functions',
+      private: true,
+      type: 'module',
+      main: 'index.js',
+    }));
+    writeFileSync(join(cwd, 'functions', 'index.js'),
+      `import { onValueCreated } from 'firebase-functions/v2/database';
+export const makeUppercase = onValueCreated(
+  '/messages/{pushId}/original',
+  event => event.data.ref.parent.child('uppercase')
+    .set(event.data.val().toUpperCase()),
+);
+`);
+    symlinkSync(
+      join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+      join(cwd, 'functions/node_modules/firebase-functions'),
+    );
+
+    // The trigger watches `/messages` (the literal prefix of the reference).
+    // Gating `.read` there behind auth is exactly the live #401 failure: a
+    // non-admin subscription is PERMISSION_DENIED and the Functions child dies
+    // at startup. The relayed trigger subscription must carry `actAs: admin`
+    // all the way to the sandbox, where the admin listener bypasses this rule.
+    // Note `.read: true` deeper (on `/messages/$id/original`) would NOT help —
+    // an RTDB read grant does not cascade UP to the subscribed parent.
+    const databaseRules = {
+      rules: {
+        messages: {
+          '.read': 'auth != null',
+          '.write': 'auth != null',
+        },
+      },
+    };
+
+    let stdout = '';
+    let stderr = '';
+    command = spawn('node', [
+      cliEntry,
+      'dev',
+      '--port=0',
+      '--host=127.0.0.1',
+      '--no-open',
+      '--no-capture',
+    ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    command.stdout?.setEncoding('utf8');
+    command.stderr?.setEncoding('utf8');
+    command.stdout?.on('data', (chunk: string) => { stdout += chunk; });
+    command.stderr?.on('data', (chunk: string) => { stderr += chunk; });
+
+    try {
+      const pointer = await waitFor(() => {
+        const path = join(cwd, '.pyric/serve.json');
+        return existsSync(path)
+          ? JSON.parse(readFileSync(path, 'utf8')) as { url: string }
+          : null;
+      });
+      peer = await connectWorkerPeer(
+        `${pointer.url.replace(/^http/, 'ws')}/__pyric/sandbox`,
+        databaseRules,
+      );
+      observer = await connectRemoteSandbox({ url: pointer.url });
+
+      // The trigger's admin subscription established despite the auth-gated
+      // read — the child neither PERMISSION_DENIED nor exited at startup.
+      await waitFor(() =>
+        stdout.includes('✔ functions 1 onValueCreated trigger') ? true : null);
+      expect(stderr).not.toContain('PERMISSION_DENIED');
+      expect(stderr).not.toContain('failed to start');
+
+      // The trigger fires and its Firestore-adjacent effect (the uppercase
+      // stamp) lands — end to end through the rules-gated path.
+      await observer.rtdb.set('messages/id/original', 'hello');
+      await waitFor(async () =>
+        (await observer!.rtdb.get('messages/id/uppercase')) === 'HELLO' ? true : null);
+      await waitFor(() =>
+        stdout.includes('✔ function  makeUppercase ← /messages/id/original') ? true : null);
+
+      command.kill('SIGTERM');
+      const code = await Promise.race([
+        new Promise<number>((resolveExit) =>
+          command!.once('exit', (exit) => resolveExit(exit ?? 1))),
+        Bun.sleep(5_000).then(() => -1),
+      ]);
+      expect(code).toBe(0);
+      expect(stderr).not.toContain('Functions child exited unexpectedly');
+    } finally {
+      observer?.close();
+      observer = undefined;
+      await peer?.close().catch(() => {});
+      peer = undefined;
+      if (command?.exitCode === null) command.kill('SIGKILL');
+      command = undefined;
     }
   }, 30_000);
 

--- a/packages/cli/test/functions-rtdb/worker-peer.ts
+++ b/packages/cli/test/functions-rtdb/worker-peer.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 import { createMemoryBackend, initializeSandbox } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
+import { setRules as setDatabaseRules } from 'pyric/sandbox/database';
 import {
   isBridgeMessage,
   WORKER_RELAY_CAPABILITY,
@@ -19,6 +20,13 @@ import type {
 export interface FunctionsWorkerHostOptions {
   persistenceKeyPrefix: string;
   instanceId: string;
+  /**
+   * Optional RTDB security rules to load into the stand-in sandbox. Used by the
+   * #401 regression to gate the trigger's watched path behind auth: the trigger
+   * subscription must reach the sandbox through the admin (rules-bypass) lens,
+   * so an auth-gated `.read` there must NOT deny it.
+   */
+  databaseRules?: { rules: Record<string, unknown> };
 }
 
 export interface FunctionsWorkerPeerOptions {
@@ -35,6 +43,7 @@ export async function createFunctionsWorkerHostCtx(
     key: `${options.persistenceKeyPrefix}-${Math.random()}`,
     injectedBackend: createMemoryBackend(),
   });
+  if (options.databaseRules) setDatabaseRules(sandbox, options.databaseRules);
   return {
     db: getFirestore(sandbox),
     sandbox,

--- a/packages/pyric/src/database/modular.ts
+++ b/packages/pyric/src/database/modular.ts
@@ -696,19 +696,24 @@ export function onValue(
   if (isQuery(r as object)) {
     const q = r as Query;
     const target = targetOf(q.ref as unknown as object);
-    return subscribeWithLiveAuth(target, (auth) => target.backend.onValue(
-      auth,
-      q.ref._path,
-      (raw) => {
-        const snap = buildSandboxSnapFromRaw(target, q.ref, raw.val);
-        try {
-          cb(snap);
-        } catch {
-          // Listener throws are swallowed.
-        }
-      },
-      q._spec,
-    ));
+    const deliver = (raw: { val: JsonValue; key: string | null }): void => {
+      const snap = buildSandboxSnapFromRaw(target, q.ref, raw.val);
+      try {
+        cb(snap);
+      } catch {
+        // Listener throws are swallowed.
+      }
+    };
+    // Admin (rules-bypass) listeners skip the read-rule gate entirely — the
+    // listen-plane sibling of `adminGet`/`adminSet` (#401). `admin` is set
+    // only on server-minted `getAdminDatabase` handles, never anything a page
+    // controls, so a page's `onValue` stays on the rule-gated path below.
+    return target.admin
+      ? target.backend.adminOnValue(q.ref._path, deliver, q._spec)
+      : subscribeWithLiveAuth(
+        target,
+        (auth) => target.backend.onValue(auth, q.ref._path, deliver, q._spec),
+      );
   }
   const ref0 = r as DatabaseReference;
   const target = targetOf(ref0 as unknown as object);
@@ -721,10 +726,12 @@ export function onValue(
       // behavior where one observer's exception doesn't block others.
     }
   };
-  const unsub = subscribeWithLiveAuth(
-    target,
-    (auth) => target.backend.onValue(auth, ref0._path, wrapper),
-  );
+  const unsub = target.admin
+    ? target.backend.adminOnValue(ref0._path, wrapper)
+    : subscribeWithLiveAuth(
+      target,
+      (auth) => target.backend.onValue(auth, ref0._path, wrapper),
+    );
   const registration: ListenerRegistration = { unsubscribe: unsub };
   listenerRegistry.add(target, ref0._path, 'value', cb, registration);
   return () => {

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -805,7 +805,6 @@ export class RtdbBackend {
     // Rules check at subscribe time. A denied subscribe never gets
     // the initial fire — matches production where the listener errors
     // out before any callback.
-    const listenerId = this.nextListenerId();
     const at = Date.now();
     const evaluation = this.rules.evaluate('read', path === '/' ? '/' : path, {
       auth,
@@ -818,7 +817,7 @@ export class RtdbBackend {
         request: query ? { query } : undefined,
         origin: 'listener',
       });
-      this.emitListener('errored', { id: listenerId, path }, auth, {
+      this.emitListener('errored', { id: this.nextListenerId(), path }, auth, {
         event: 'value',
         result: 'deny',
         error: {
@@ -829,11 +828,67 @@ export class RtdbBackend {
       });
       throw permissionDenied();
     }
-    this.emitOperation(auth, 'listen', path, 'allow', evaluation, {
+    return this.attachValueListener(auth, path, cb, query, {
+      origin: 'listener',
+      result: 'allow',
+      evaluation,
+      at,
+    });
+  }
+
+  /**
+   * Rules-BYPASS `onValue` — the listen-plane sibling of {@link adminGet} /
+   * {@link adminSet}. Cloud Functions RTDB triggers read via firebase-admin,
+   * which bypasses security rules; the sandbox relays that trigger
+   * subscription through the worker host's `{ mode: 'admin' }` lens
+   * ({@link getAdminDatabase}), and this is where that lens actually skips the
+   * read-rule gate. Without it an auth-gated `.read` on the watched path
+   * (or the RTDB root default-deny above it) would `PERMISSION_DENIED` the
+   * trigger subscription at startup — see issue #401.
+   *
+   * The admin flag lives ONLY on server-minted admin handles; it is never
+   * derived from anything a page peer controls, so a page's `onValue` still
+   * routes through the rule-gated {@link onValue} above.
+   */
+  adminOnValue(
+    path: string,
+    cb: (snap: { val: JsonValue; exists: boolean; key: string | null }) => void,
+    query?: QuerySpec,
+  ): () => void {
+    return this.attachValueListener(null, path, cb, query, {
+      origin: 'admin',
+      result: 'not-applicable',
+      evaluation: undefined,
+      at: Date.now(),
+    });
+  }
+
+  /**
+   * Register a value listener AFTER any read-rule gate and run its initial
+   * fire. Shared by the rule-gated {@link onValue} and the rules-bypass
+   * {@link adminOnValue} so the fan-out registration, initial snapshot and
+   * emitted operation/listener events stay byte-identical across both paths —
+   * the only difference is whether the read rule was evaluated first.
+   */
+  private attachValueListener(
+    auth: AuthState,
+    path: string,
+    cb: (snap: { val: JsonValue; exists: boolean; key: string | null }) => void,
+    query: QuerySpec | undefined,
+    provenance: {
+      origin: 'listener' | 'admin';
+      result: 'allow' | 'not-applicable';
+      evaluation: RuleEvaluationDetails | undefined;
+      at: number;
+    },
+  ): () => void {
+    const { at } = provenance;
+    const listenerId = this.nextListenerId();
+    this.emitOperation(auth, 'listen', path, provenance.result, provenance.evaluation, {
       at,
       durationMs: Date.now() - at,
       request: query ? { query } : undefined,
-      origin: 'listener',
+      origin: provenance.origin,
     });
     const listener: ValueListener = { id: listenerId, auth, cb, path, query };
     this.valueListeners.add(listener);

--- a/packages/pyric/test/database/admin-onvalue.test.ts
+++ b/packages/pyric/test/database/admin-onvalue.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #401 — Cloud Functions RTDB triggers read via firebase-admin, which bypasses
+ * security rules. The sandbox relays that trigger subscription through the
+ * `getAdminDatabase` (rules-bypass) handle. These tests lock the listen-plane
+ * bypass — the sibling of `adminGet`/`adminSet` — and the invariant that the
+ * ordinary (page) `onValue` stays rule-gated.
+ */
+import { describe, expect, test } from 'bun:test';
+import { getAdminDatabase, getDatabase, onValue, ref, set } from 'pyric/database';
+import { initializeSandbox } from 'pyric/sandbox';
+import { setData, setRules } from 'pyric/sandbox/database';
+
+const AUTH_GATED = {
+  rules: {
+    status: {
+      $uid: {
+        '.read': 'auth != null',
+        '.write': 'auth != null',
+      },
+    },
+  },
+};
+
+describe('admin onValue bypasses read rules (#401)', () => {
+  test('an admin listener on an auth-gated path fires and keeps streaming', async () => {
+    const sandbox = initializeSandbox();
+    setData(sandbox, { '/status/alice': { online: false } });
+    setRules(sandbox, AUTH_GATED);
+
+    const adminDb = getAdminDatabase(sandbox);
+    const seen: unknown[] = [];
+    const unsub = onValue(ref(adminDb, '/status/alice'), (snap) => {
+      seen.push(snap.val());
+    });
+
+    // Initial fire is synchronous — the admin subscribe skipped the read gate.
+    expect(seen).toEqual([{ online: false }]);
+
+    // A later admin write re-fires the listener (proving it stayed alive, not
+    // torn down by a deferred denial).
+    await set(ref(adminDb, '/status/alice'), { online: true });
+    expect(seen).toEqual([{ online: false }, { online: true }]);
+
+    unsub();
+  });
+
+  test('a page (rule-gated) listener on the same path is denied', () => {
+    const sandbox = initializeSandbox();
+    setData(sandbox, { '/status/alice': { online: false } });
+    setRules(sandbox, AUTH_GATED);
+
+    // Signed-out page handle → `auth == null` → the read gate throws
+    // synchronously (the live #401 failure shape), so the page cannot read
+    // rules-protected data by requesting a listener.
+    const pageDb = getDatabase(sandbox.withAuth(null));
+    expect(() => onValue(ref(pageDb, '/status/alice'), () => {})).toThrow(
+      'PERMISSION_DENIED',
+    );
+  });
+});


### PR DESCRIPTION
```js
// functions/index.js — the trigger's subscription now bypasses read rules, as in production
export const onPresenceOnline = onValueCreated('/presence/{uid}/state', async (event) => { /* ... */ });
```
```jsonc
// database.rules.json — a realistic auth-gated read no longer starves the trigger
{ "rules": { "presence": { ".read": "auth !== null", "$uid": { ".write": "auth !== null && auth.uid === $uid" } } } }
```

## An RTDB trigger's subscription now bypasses read rules, so triggers start under real rulesets

A Cloud Functions RTDB trigger died at startup with `PERMISSION_DENIED` whenever the watched path had a non-trivial read rule — its subscription was rules-enforced and evaluated as `auth == null`. Production triggers read via admin and bypass rules. The admin lens actually reached the sandbox correctly; the gap was the last step: `pyric/database`'s `onValue` was the one operation with no `target.admin` bypass branch (the backend had `adminGet`/`adminSet`/`adminRemove` but no `adminOnValue`), so every admin subscription fell through to the read gate. This adds `RtdbBackend.adminOnValue` and routes admin-target subscriptions to it; the rule-gated and bypass paths share one listener body so registration and event delivery are byte-identical apart from the gate.

This is why relaxing the app's read rule didn't help during testing: the trigger watches the literal prefix (`/messages`, up to the first `{param}`), and a grant on a deeper path doesn't cascade up.

Fixes #401. Completes the functions kitchen-sink alongside #394 (admin Firestore writes) — the trigger can now subscribe *and* stamp Firestore across services under auth-gated rules.

## Risk

This widens admin RTDB subscriptions from "evaluated as `auth==null`" to full rules-bypass, so the question is whether any page can obtain one. It cannot, and an adversarial security pass confirmed it: `target.admin` is set at exactly one server-only site (`getAdminDatabase`, not exported on the page's `firebase/database` surface); a page connects to the bridge as a *peer*, and peer frames never forward a `worker-sub` to the sandbox — only a trusted *consumer* (the functions child) can originate a subscription, the same boundary admin ops already ride (#394). One conscious behavior change: Studio's live RTDB viewer (`adminSubscribeRtdbValue`, first-party worker client) now genuinely bypasses read rules where it previously silently evaluated as `auth==null` — intended for the admin viewer. The normal page `onValue` path is unchanged (read rule still evaluated before any listener registration).

<details>
<summary>Verification</summary>

- `test/functions-rtdb/dev.e2e.test.ts` (new case): an auth-gated ruleset (`.read: "auth != null"`) loaded into the headless worker-peer; the trigger starts with no `PERMISSION_DENIED`, fires, and its stamp lands. With the fix stashed and rebuilt, this exact test fails (trigger never starts) — matching the live child-death.
- `packages/pyric/test/database/admin-onvalue.test.ts` (new): admin listener on the auth-gated path streams; a page `getDatabase(sandbox.withAuth(null))` listener on the same path throws `PERMISSION_DENIED`.
- `packages/pyric` database+sandbox: 1627 pass. `packages/cli` functions-rtdb+serve: 657 pass. Typechecks clean.

</details>
