### PR TITLE
fix(messaging): prove native background notification display

### DIFF
--- a/packages/cli/test/e2e/fixture/messaging-service-worker.js
+++ b/packages/cli/test/e2e/fixture/messaging-service-worker.js
@@ -9,6 +9,15 @@ const messaging = getMessaging(app);
 const realmId = crypto.randomUUID();
 
 onBackgroundMessage(messaging, async (payload) => {
+  if (payload.notification) {
+    await self.registration.showNotification(
+      payload.notification.title ?? 'Pyric notification',
+      {
+        body: payload.notification.body,
+        tag: payload.messageId,
+      },
+    );
+  }
   const windows = await self.clients.matchAll({
     type: 'window',
     includeUncontrolled: true,

--- a/packages/cli/test/e2e/messaging-app-boundary.pw.ts
+++ b/packages/cli/test/e2e/messaging-app-boundary.pw.ts
@@ -101,7 +101,8 @@ test('served canonical Messaging imports stay app-owned over the SharedWorker', 
   });
 });
 
-test('firebase/messaging/sw receives the shared broker from a real module Service Worker', async ({ page }) => {
+test('firebase/messaging/sw receives the shared broker from a real module Service Worker', async ({ context, page }) => {
+  await context.grantPermissions(['notifications'], { origin: 'http://127.0.0.1:5180' });
   await page.goto('/');
   await page.waitForFunction(() => document.querySelector('#status')?.textContent !== 'loading');
 
@@ -155,6 +156,7 @@ test('firebase/messaging/sw receives the shared broker from a real module Servic
     const deliver = (
       id: string,
       source: string,
+      notification = false,
     ): Promise<{ route?: string; handlerCount?: number; payload?: unknown }> => {
       const worker = new SharedWorker('/__pyric/sdk/worker.js', {
         type: 'classic',
@@ -181,13 +183,32 @@ test('firebase/messaging/sw receives the shared broker from a real module Servic
           t: 'op',
           id,
           method: 'messaging.deliver',
-          spec: { data: { source }, messageId: id },
+          spec: {
+            data: { source },
+            ...(notification
+              ? { notification: { title: 'Pyric background notification' } }
+              : {}),
+            messageId: id,
+          },
         });
       });
     };
     const result = await deliver('sw-boundary-message', 'real-service-worker');
 
     const payload = await delivered as { messageId?: string; data?: Record<string, string> } | null;
+    let notificationTitles: string[] = [];
+    if (Notification.permission === 'granted') {
+      const notificationDelivered = new Promise<void>((resolve) => {
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === 'pyric-background-message'
+            && event.data.payload?.messageId === 'sw-native-notification') resolve();
+        }, { once: true });
+      });
+      await deliver('sw-native-notification', 'native-display', true);
+      await notificationDelivered;
+      notificationTitles = (await first.registration.getNotifications())
+        .map((notification) => notification.title);
+    }
     await first.registration.unregister();
 
     const second = await register();
@@ -200,16 +221,18 @@ test('firebase/messaging/sw receives the shared broker from a real module Servic
     await second.registration.unregister();
 
     return {
+      permission: Notification.permission,
       route: result.route ?? null,
       handlerCount: result.handlerCount ?? null,
       messageId: payload?.messageId ?? null,
       source: payload?.data?.source ?? null,
+      notificationTitles,
       replacedRealm: firstReady.realmId !== secondReady.realmId,
       restartedHandlerCount: restarted.handlerCount ?? null,
     };
   });
 
-  expect(actual).toEqual({
+  expect(actual).toMatchObject({
     route: 'background',
     handlerCount: 1,
     messageId: 'sw-boundary-message',
@@ -217,4 +240,8 @@ test('firebase/messaging/sw receives the shared broker from a real module Servic
     replacedRealm: true,
     restartedHandlerCount: 1,
   });
+  expect(['granted', 'denied']).toContain(actual.permission);
+  expect(actual.notificationTitles).toEqual(
+    actual.permission === 'granted' ? ['Pyric background notification'] : [],
+  );
 });

--- a/packages/pyric/src/messaging/sw.ts
+++ b/packages/pyric/src/messaging/sw.ts
@@ -58,9 +58,10 @@ export function getMessaging(app?: FirebaseApp): Messaging {
  * Called when a message arrives while the app has NO visible window client
  * (oracle: `messaging-web-onbackgroundmessage`,
  * `messaging-web-visibility-routing`). A DATA-ONLY message still fires with
- * no `notification` key (oracle: `messaging-web-data-only-background`), and
- * registering a handler suppresses the SDK auto-display — the sandbox has
- * no display plane, so suppression is the (only) modeled behavior.
+ * no `notification` key (oracle: `messaging-web-data-only-background`). As in
+ * Firebase, registering a handler suppresses SDK auto-display. A handler that
+ * runs in a real Service Worker may use `self.registration.showNotification()`;
+ * the in-page fallback has no native display plane.
  */
 export function onBackgroundMessage(
   messaging: Messaging,

--- a/packages/site-docs/src/content/build/cloud-messaging.md
+++ b/packages/site-docs/src/content/build/cloud-messaging.md
@@ -40,6 +40,61 @@ await messagingSandbox.deliver(messaging, {
 ```
 Keep this driver outside application code that ships. A visible client routes the delivery to `onMessage`; a hidden client routes it to the service-worker `onBackgroundMessage` path. The local broker does not request notification permission or contact FCM.
 
+## Show an OS notification in the background
+
+Run `onBackgroundMessage` in a real service worker when it needs to display a
+native notification. Registering the callback in page code can model hidden-tab
+routing while that page remains open, but it has no service-worker display or
+closed-page lifetime.
+
+For a Vite app, keep the worker in the source graph so the `pyric()` plugin can
+swap its unchanged Firebase imports during development. Vite's worker URL import
+also bundles the same source against the real Firebase SDK for production:
+
+```ts
+// src/firebase-messaging-sw.ts
+import { initializeApp } from 'firebase/app';
+import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
+import { firebaseConfig } from './firebase-config';
+
+const app = initializeApp(firebaseConfig);
+
+onBackgroundMessage(getMessaging(app), async (payload) => {
+  if (!payload.notification) return;
+  await self.registration.showNotification(
+    payload.notification.title ?? 'New notification',
+    {
+      body: payload.notification.body,
+      tag: payload.messageId,
+    },
+  );
+});
+```
+
+Register that worker from the page and pass the registration to `getToken`:
+
+```ts
+import messagingWorkerUrl from './firebase-messaging-sw.ts?worker&url';
+import { getMessaging, getToken } from 'firebase/messaging';
+
+const registration = await navigator.serviceWorker.register(
+  messagingWorkerUrl,
+  { type: 'module' },
+);
+
+const token = await getToken(getMessaging(app), {
+  serviceWorkerRegistration: registration,
+});
+```
+
+Request notification permission from a user gesture before registering for a
+token. Firebase suppresses automatic display when `onBackgroundMessage` is
+registered, so the handler owns `showNotification`. Data-only messages have no
+notification to display unless the application deliberately creates one.
+
+Pyric's local broker can deliver to this real worker while a page keeps the
+sandbox alive. Delivery after every page closes is not currently modeled.
+
 ## Check the supported boundary
 
 Per-feature support is tracked on the [Cloud Messaging conformance page](messaging-compat.md).


### PR DESCRIPTION
Documents and proves the real service-worker path that displays a background Firebase Messaging payload as an OS notification under `pyric dev`.

```ts
// src/firebase-messaging-sw.ts
import { initializeApp } from 'firebase/app';
import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';

const app = initializeApp({
  apiKey: 'demo-api-key',
  appId: '1:123456789:web:demo',
  messagingSenderId: '123456789',
  projectId: 'demo-project',
});

onBackgroundMessage(getMessaging(app), async (payload) => {
  if (!payload.notification) return;
  await self.registration.showNotification(
    payload.notification.title ?? 'New notification',
    {
      body: payload.notification.body,
      tag: payload.messageId,
    },
  );
});
```

```ts
// src/notifications.ts
import { initializeApp } from 'firebase/app';
import { getMessaging, getToken } from 'firebase/messaging';
import messagingWorkerUrl from './firebase-messaging-sw.ts?worker&url';

const app = initializeApp({
  apiKey: 'demo-api-key',
  appId: '1:123456789:web:demo',
  messagingSenderId: '123456789',
  projectId: 'demo-project',
});

const registration = await navigator.serviceWorker.register(
  messagingWorkerUrl,
  { type: 'module' },
);

const token = await getToken(getMessaging(app), {
  serviceWorkerRegistration: registration,
});
```

## Background callbacks now exercise the browser notification registration

The existing worker-backed Messaging transport already routes hidden-page deliveries into a real module service worker. The E2E fixture now handles notification payloads with `self.registration.showNotification()`, waits for that handler before inspecting the registration, and verifies the displayed title when Chromium grants notification permission.

The Messaging guide now shows how a Vite application keeps its worker in the source graph with `?worker&url`. The `pyric()` plugin swaps the worker's unchanged Firebase imports during development, while a production build bundles the same source against Firebase.

The service-worker API comment now distinguishes the real worker display surface from the in-page fallback. Registering `onBackgroundMessage` still suppresses Firebase SDK auto-display, and data-only messages remain undisplayed unless application code creates a notification.

## Risk

No production Messaging runtime behavior changes. The behavioral change is confined to the E2E fixture, which now displays notification payloads during the real-worker test. The documentation depends on Vite's worker URL import and requires notification permission to be requested from a user gesture.

Headless Chromium denies notification permission in this environment. The test therefore always retains background-routing and worker-restart coverage, and asserts the native notification only when the browser reports `Notification.permission === 'granted'`. The headed run exercises that branch.

<details>
<summary>Implementation notes</summary>

- `bun x playwright test messaging-app-boundary.pw.ts --config test/e2e/playwright.config.ts` — 2 passed.
- `bun x playwright test messaging-app-boundary.pw.ts --config test/e2e/playwright.config.ts --headed` — 2 passed; native notification observed through `registration.getNotifications()`.
- Focused Messaging suites — 26 passed.
- Pyric TypeScript check — passed.
- CLI TypeScript check — passed.
- Site documentation build — passed.
- `git diff --check` — passed.

The first browser regression failed with background delivery succeeding but `registration.getNotifications()` returning an empty array. After the worker awaited `showNotification()`, headed Chromium returned `Pyric background notification`. No automatic display behavior was added to the broker because Firebase suppresses SDK auto-display when an application registers `onBackgroundMessage`.

</details>
