### PR TITLE
feat: add PyChat as a create-pyric template

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,54 @@
         "typescript": "^5.7.0",
       },
     },
+    "packages/create-pyric/templates/chat": {
+      "name": "@pyric/template-chat",
+      "version": "0.0.0",
+      "dependencies": {
+        "@base-ui/react": "^1.6.0",
+        "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource-variable/geist-mono": "^5.2.8",
+        "@inbrowser/agent": "^0.4.2",
+        "@inbrowser/model": "^0.4.2",
+        "@inbrowser/resumable": "^0.4.1",
+        "@inbrowser/workspace": "^0.4.2",
+        "@shadcn/react": "^0.2.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "esbuild-wasm": "^0.25.0",
+        "firebase": "^12.12.0",
+        "lucide-react": "^1.25.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
+        "shadcn": "^4.13.1",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0",
+      },
+      "devDependencies": {
+        "@pyric/cli": "*",
+        "@tailwindcss/vite": "^4.3.3",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.4",
+        "firebase-admin": "^13.10.0",
+        "firebase-functions": "^6.0.0",
+        "pyric": "*",
+        "react-test-renderer": "19.2.7",
+        "tailwindcss": "^4.3.3",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0",
+      },
+    },
+    "packages/create-pyric/templates/chat/functions": {
+      "name": "pychat-functions",
+      "version": "0.0.0",
+      "dependencies": {
+        "firebase-admin": "^13.10.0",
+        "firebase-functions": "^6.0.0",
+      },
+    },
     "packages/playground": {
       "name": "@pyric/playground",
       "version": "0.0.1",
@@ -351,15 +399,27 @@
 
     "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw=="],
+
     "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
 
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/helper-replace-supers": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/traverse": "^7.29.7", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg=="],
+
     "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
 
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong=="],
+
     "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.29.7", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
@@ -371,9 +431,19 @@
 
     "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.29.7", "", { "dependencies": { "@babel/helper-module-transforms": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ=="],
+
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/plugin-syntax-typescript": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw=="],
+
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "@babel/plugin-syntax-jsx": "^7.29.7", "@babel/plugin-transform-modules-commonjs": "^7.29.7", "@babel/plugin-transform-typescript": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -384,6 +454,10 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@base-ui/react": ["@base-ui/react@1.6.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.1", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.3.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -428,6 +502,10 @@
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
 
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
+
+    "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
+
+    "@dotenvx/primitives": ["@dotenvx/primitives@0.8.0", "", {}, "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
@@ -596,6 +674,18 @@
     "@firebase/util": ["@firebase/util@1.15.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g=="],
 
     "@firebase/webchannel-wrapper": ["@firebase/webchannel-wrapper@1.0.6", "", {}, "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.3.0", "", {}, "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.3.0", "", {}, "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw=="],
 
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
 
@@ -973,6 +1063,8 @@
 
     "@pyric/studio": ["@pyric/studio@workspace:packages/studio"],
 
+    "@pyric/template-chat": ["@pyric/template-chat@workspace:packages/create-pyric/templates/chat"],
+
     "@pyric/ui": ["@pyric/ui@workspace:packages/ui"],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
@@ -1029,6 +1121,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@shadcn/react": ["@shadcn/react@0.2.1", "", { "peerDependencies": { "@types/react": ">=19", "react": ">=19" }, "optionalPeers": ["@types/react", "react"] }, "sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ=="],
+
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
@@ -1044,6 +1140,8 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 
@@ -1092,6 +1190,8 @@
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -1169,6 +1269,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
@@ -1225,6 +1327,8 @@
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -1257,7 +1361,7 @@
 
     "as-array": ["as-array@2.0.0", "", {}, "sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg=="],
 
-    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "astro": ["astro@5.18.2", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.6", "@astrojs/markdown-remark": "6.3.11", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ=="],
 
@@ -1268,6 +1372,8 @@
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "atomically": ["atomically@1.7.0", "", {}, "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="],
 
     "autoprefixer": ["autoprefixer@10.5.3", "", { "dependencies": { "browserslist": "^4.28.6", "caniuse-lite": "^1.0.30001805", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-bJRzflk8GgE4JX+iZNEwz9f9p460NCHnU7bd+CZ9vIjIlZuTkt6F3WSl2oNO8StZBFx17nLEsiQ6H2wcZiY7nA=="],
 
@@ -1347,6 +1453,8 @@
 
     "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
@@ -1356,6 +1464,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
@@ -1389,6 +1499,8 @@
 
     "cjson": ["cjson@0.3.3", "", { "dependencies": { "json-parse-helpfulerror": "^1.0.3" } }, "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg=="],
 
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
     "clean-git-ref": ["clean-git-ref@2.0.1", "", {}, "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="],
 
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
@@ -1408,6 +1520,8 @@
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
     "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
 
@@ -1437,6 +1551,8 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "conf": ["conf@10.2.0", "", { "dependencies": { "ajv": "^8.6.3", "ajv-formats": "^2.1.1", "atomically": "^1.7.0", "debounce-fn": "^4.0.0", "dot-prop": "^6.0.1", "env-paths": "^2.2.1", "json-schema-typed": "^7.0.3", "onetime": "^5.1.2", "pkg-up": "^3.1.0", "semver": "^7.3.5" } }, "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg=="],
+
     "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
 
     "configstore": ["configstore@5.0.1", "", { "dependencies": { "dot-prop": "^5.2.0", "graceful-fs": "^4.1.2", "make-dir": "^3.0.0", "unique-string": "^2.0.0", "write-file-atomic": "^3.0.0", "xdg-basedir": "^4.0.0" } }, "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA=="],
@@ -1458,6 +1574,8 @@
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
@@ -1493,6 +1611,8 @@
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
+    "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
@@ -1501,15 +1621,25 @@
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
+    "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-freeze": ["deep-freeze@0.0.1", "", {}, "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -1555,6 +1685,8 @@
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -1583,11 +1715,15 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
+    "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1639,6 +1775,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
     "exegesis": ["exegesis@4.3.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^9.0.3", "ajv": "^8.3.0", "ajv-formats": "^2.1.0", "body-parser": "^1.18.3", "content-type": "^1.0.4", "deep-freeze": "0.0.1", "events-listener": "^1.1.0", "glob": "^10.3.10", "json-ptr": "^3.0.1", "json-schema-traverse": "^1.0.0", "lodash": "^4.17.11", "openapi3-ts": "^3.1.1", "promise-breaker": "^6.0.0", "qs": "^6.6.0", "raw-body": "^2.3.3", "semver": "^7.0.0" } }, "sha512-V90IJQ4XYO1SfH5qdJTOijXkQTF3hSpSHHqlf7MstUMDKP22iAvi63gweFLtPZ4Gj3Wnh8RgJX5TGu0WiwTyDQ=="],
 
     "exegesis-express": ["exegesis-express@4.0.0", "", { "dependencies": { "exegesis": "^4.1.0" } }, "sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw=="],
@@ -1685,11 +1823,15 @@
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
     "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
     "firebase": ["firebase@12.13.0", "", { "dependencies": { "@firebase/ai": "2.12.0", "@firebase/analytics": "0.10.22", "@firebase/analytics-compat": "0.2.28", "@firebase/app": "0.14.12", "@firebase/app-check": "0.11.3", "@firebase/app-check-compat": "0.4.3", "@firebase/app-compat": "0.5.12", "@firebase/app-types": "0.9.5", "@firebase/auth": "1.13.1", "@firebase/auth-compat": "0.6.6", "@firebase/data-connect": "0.7.0", "@firebase/database": "1.1.3", "@firebase/database-compat": "2.1.4", "@firebase/firestore": "4.14.1", "@firebase/firestore-compat": "0.4.9", "@firebase/functions": "0.13.4", "@firebase/functions-compat": "0.4.4", "@firebase/installations": "0.6.22", "@firebase/installations-compat": "0.2.22", "@firebase/messaging": "0.12.26", "@firebase/messaging-compat": "0.2.26", "@firebase/performance": "0.7.12", "@firebase/performance-compat": "0.2.25", "@firebase/remote-config": "0.8.3", "@firebase/remote-config-compat": "0.2.24", "@firebase/storage": "0.14.3", "@firebase/storage-compat": "0.4.3", "@firebase/util": "1.15.1" } }, "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA=="],
 
@@ -1735,6 +1877,8 @@
 
     "fuzzy": ["fuzzy@0.1.3", "", {}, "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w=="],
 
+    "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
+
     "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
@@ -1747,7 +1891,11 @@
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
+    "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
+
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -1845,6 +1993,8 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
@@ -1854,6 +2004,8 @@
     "ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-lazy": ["import-lazy@2.1.0", "", {}, "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A=="],
 
@@ -1881,6 +2033,8 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
@@ -1901,6 +2055,8 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-installed-globally": ["is-installed-globally@0.4.0", "", { "dependencies": { "global-dirs": "^3.0.0", "is-path-inside": "^3.0.2" } }, "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ=="],
@@ -1911,7 +2067,7 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+    "is-obj": ["is-obj@3.0.0", "", {}, "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ=="],
 
     "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
 
@@ -1920,6 +2076,8 @@
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -1976,6 +2134,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-parse-helpfulerror": ["json-parse-helpfulerror@1.0.3", "", { "dependencies": { "jju": "^1.1.0" } }, "sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg=="],
 
@@ -2045,6 +2205,8 @@
 
     "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
 
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash._objecttypes": ["lodash._objecttypes@2.4.1", "", {}, "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q=="],
@@ -2084,6 +2246,8 @@
     "lru-memoizer": ["lru-memoizer@2.3.0", "", { "dependencies": { "lodash.clonedeep": "^4.5.0", "lru-cache": "6.0.0" } }, "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug=="],
 
     "lsofi": ["lsofi@2.0.0", "", {}, "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A=="],
+
+    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
 
@@ -2144,6 +2308,8 @@
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -2213,7 +2379,9 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+    "mimic-fn": ["mimic-fn@3.1.0", "", {}, "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
@@ -2289,6 +2457,8 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -2296,6 +2466,8 @@
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
 
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
@@ -2333,11 +2505,15 @@
 
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
     "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
     "p-throttle": ["p-throttle@7.0.0", "", {}, "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA=="],
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -2351,6 +2527,8 @@
 
     "papaparse": ["papaparse@5.5.4", "", {}, "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ=="],
 
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
     "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
 
     "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
@@ -2359,7 +2537,11 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
@@ -2368,6 +2550,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
@@ -2415,6 +2599,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
     "planck": ["planck@1.5.0", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g=="],
 
     "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
@@ -2449,11 +2635,15 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
@@ -2492,6 +2682,8 @@
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "pupa": ["pupa@2.1.1", "", { "dependencies": { "escape-goat": "^2.0.0" } }, "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A=="],
+
+    "pychat-functions": ["pychat-functions@workspace:packages/create-pyric/templates/chat/functions"],
 
     "pyric": ["pyric@workspace:packages/pyric"],
 
@@ -2547,6 +2739,8 @@
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
@@ -2581,7 +2775,11 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -2608,6 +2806,8 @@
     "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -2643,6 +2843,8 @@
 
     "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
+    "shadcn": ["shadcn@4.13.1", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "kleur": "^4.1.5", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "undici": "^7.27.2", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-pSNPND8mVWGBytdd8l4Cksg7MyRZOsv28HpvNCtFtLwZoxLSGM6v3NMUpmpbOaIoreopS/UOpQvnCyttOHVLAQ=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -2661,7 +2863,7 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
@@ -2701,6 +2903,8 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+
     "stream-chain": ["stream-chain@2.2.5", "", {}, "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="],
 
     "stream-events": ["stream-events@1.0.5", "", { "dependencies": { "stubs": "^3.0.0" } }, "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg=="],
@@ -2719,9 +2923,15 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
+    "stringify-object": ["stringify-object@5.0.0", "", { "dependencies": { "get-own-enumerable-keys": "^1.0.0", "is-obj": "^3.0.0", "is-regexp": "^3.1.0" } }, "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg=="],
+
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -2751,6 +2961,10 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "systeminformation": ["systeminformation@5.32.0", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-7gfXs43T91miPxxTTtrYitotR/8MPsI2gy3XgUMs6kmOE/JCVqZp6nJpx4XkSutoSqDh6+Y2ovvb2A3RQCR+8w=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
+
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
@@ -2778,6 +2992,8 @@
     "three": ["three@0.177.0", "", {}, "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
@@ -2813,7 +3029,11 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
+    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
+
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
+    "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -2822,6 +3042,8 @@
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -2858,6 +3080,8 @@
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -2899,6 +3123,8 @@
 
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -2909,7 +3135,7 @@
 
     "valid-url": ["valid-url@1.0.9", "", {}, "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="],
 
-    "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -3009,6 +3235,8 @@
 
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
     "xdg-basedir": ["xdg-basedir@4.0.0", "", {}, "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
@@ -3063,6 +3291,8 @@
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
+    "@arethetypeswrong/core/validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
+
     "@astrojs/react/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "@astrojs/telemetry/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
@@ -3072,6 +3302,22 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "@dotenvx/dotenvx/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+
+    "@dotenvx/dotenvx/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "@dotenvx/dotenvx/yocto-spinner": ["yocto-spinner@1.2.2", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng=="],
 
     "@google-cloud/cloud-sql-connector/gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
 
@@ -3090,8 +3336,6 @@
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
-
-    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -3123,6 +3367,18 @@
 
     "@pyric/studio/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
+    "@pyric/template-chat/@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
+
+    "@pyric/template-chat/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "@pyric/template-chat/firebase-functions": ["firebase-functions@6.6.0", "", { "dependencies": { "@types/cors": "^2.8.5", "@types/express": "^4.17.21", "cors": "^2.8.5", "express": "^4.21.0", "protobufjs": "^7.2.2" }, "peerDependencies": { "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0" }, "bin": { "firebase-functions": "lib/bin/firebase-functions.js" } }, "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ=="],
+
+    "@pyric/template-chat/react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "@pyric/template-chat/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+
+    "@pyric/template-chat/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
@@ -3142,6 +3398,8 @@
     "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@ts-morph/common/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@types/request/form-data": ["form-data@2.5.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA=="],
 
@@ -3185,6 +3443,12 @@
 
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
+    "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
+    "conf/dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
+
+    "conf/json-schema-typed": ["json-schema-typed@7.0.3", "", {}, "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="],
+
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3193,7 +3457,15 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "exegesis/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
@@ -3204,6 +3476,8 @@
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "figures/is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "firebase-functions/express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
 
@@ -3223,11 +3497,11 @@
 
     "firebase-tools/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "gcp-metadata/gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
+
+    "get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
@@ -3283,7 +3557,13 @@
 
     "node-gyp/which": ["which@7.0.0", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA=="],
 
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -3307,6 +3587,8 @@
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
+    "pychat-functions/firebase-functions": ["firebase-functions@6.6.0", "", { "dependencies": { "@types/cors": "^2.8.5", "@types/express": "^4.17.21", "cors": "^2.8.5", "express": "^4.21.0", "protobufjs": "^7.2.2" }, "peerDependencies": { "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0" }, "bin": { "firebase-functions": "lib/bin/firebase-functions.js" } }, "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ=="],
+
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
@@ -3319,11 +3601,25 @@
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "semver-diff/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "shadcn/fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
+
+    "shadcn/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "shadcn/ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
+
+    "shadcn/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3389,6 +3685,10 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
     "yaml-language-server/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
@@ -3396,6 +3696,24 @@
     "@astrojs/react/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "@dotenvx/dotenvx/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "@dotenvx/dotenvx/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "@dotenvx/dotenvx/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
+
+    "@dotenvx/dotenvx/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "@dotenvx/dotenvx/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "@google-cloud/cloud-sql-connector/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -3428,6 +3746,20 @@
     "@opentui/core/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "@pyric/studio/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
+
+    "@pyric/template-chat/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "@pyric/template-chat/@vitejs/plugin-react/react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
+    "@pyric/template-chat/firebase-functions/express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
+
+    "@pyric/template-chat/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "@types/request/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
@@ -3503,6 +3835,8 @@
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "conf/dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
@@ -3512,6 +3846,8 @@
     "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "exegesis/raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
@@ -3608,6 +3944,20 @@
     "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pychat-functions/firebase-functions/express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
+
+    "shadcn/ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "shadcn/ora/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "shadcn/ora/is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "shadcn/ora/is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "shadcn/ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "shadcn/ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -3811,6 +4161,108 @@
 
     "@pyric/studio/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.24.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
+
+    "@pyric/template-chat/firebase-functions/express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "@pyric/template-chat/firebase-functions/express/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "@pyric/template-chat/firebase-functions/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "@pyric/template-chat/firebase-functions/express/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "@pyric/template-chat/firebase-functions/express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@pyric/template-chat/firebase-functions/express/finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "@pyric/template-chat/firebase-functions/express/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "@pyric/template-chat/firebase-functions/express/merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "@pyric/template-chat/firebase-functions/express/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "@pyric/template-chat/firebase-functions/express/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "@pyric/template-chat/firebase-functions/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@pyric/template-chat/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "@types/request/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "astro/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
@@ -3905,6 +4357,34 @@
 
     "just-bash/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "pychat-functions/firebase-functions/express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "pychat-functions/firebase-functions/express/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "pychat-functions/firebase-functions/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "pychat-functions/firebase-functions/express/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "pychat-functions/firebase-functions/express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "pychat-functions/firebase-functions/express/finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "pychat-functions/firebase-functions/express/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "pychat-functions/firebase-functions/express/merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "pychat-functions/firebase-functions/express/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "pychat-functions/firebase-functions/express/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "pychat-functions/firebase-functions/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "shadcn/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "shadcn/ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "shadcn/ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "update-notifier-cjs/boxen/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -3961,6 +4441,30 @@
 
     "vite-sandbox-app/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@pyric/template-chat/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@pyric/template-chat/firebase-functions/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@pyric/template-chat/firebase-functions/express/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "@pyric/template-chat/firebase-functions/express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "@pyric/template-chat/firebase-functions/express/send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "@pyric/template-chat/firebase-functions/express/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "@pyric/template-chat/firebase-functions/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "firebase-functions/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -3971,6 +4475,28 @@
 
     "firebase-tools/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "pychat-functions/firebase-functions/express/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "pychat-functions/firebase-functions/express/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "pychat-functions/firebase-functions/express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "pychat-functions/firebase-functions/express/send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "pychat-functions/firebase-functions/express/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "pychat-functions/firebase-functions/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "shadcn/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
     "update-notifier-cjs/boxen/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@pyric/template-chat/firebase-functions/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@pyric/template-chat/firebase-functions/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "pychat-functions/firebase-functions/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "pychat-functions/firebase-functions/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "workspaces": [
     "packages/*",
     "examples/admin-playground",
-    "examples/vite-sandbox-app"
+    "examples/vite-sandbox-app",
+    "packages/create-pyric/templates/chat",
+    "packages/create-pyric/templates/chat/functions"
   ],
   "overrides": {
     "firebase": "12.13.0"
@@ -17,9 +19,10 @@
     "build:cli": "bun run --cwd packages/cli build",
     "build:ui": "bun run --cwd packages/ui build",
     "pretest": "bash scripts/build.sh --packages-only",
-    "test": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun test --cwd packages/cli && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun run --cwd packages/site-docs test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs scripts/check-publish-version.test.mjs scripts/deploy-site.test.mjs",
+    "test": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun test --cwd packages/cli && bun run test:chat-template && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun run --cwd packages/site-docs test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs scripts/check-publish-version.test.mjs scripts/deploy-site.test.mjs",
     "test:ci:cli": "bun test --cwd packages/cli",
-    "test:ci:libraries": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun run --cwd packages/site-docs test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs scripts/check-publish-version.test.mjs scripts/deploy-site.test.mjs",
+    "test:ci:libraries": "bun test --cwd packages/pyric && bun test --cwd packages/pyric-admin && bun test --cwd packages/create-pyric && bun run test:chat-template && bun run --cwd packages/ui test && bun run --cwd packages/studio test && bun run --cwd packages/site-docs test && bun test --cwd packages/conformance && bun test scripts/tool-parity.test.mjs scripts/check-cloud-only-agent-install.test.mjs scripts/check-publish-version.test.mjs scripts/deploy-site.test.mjs",
+    "test:chat-template": "bun run --cwd packages/create-pyric/templates/chat test && bun run --cwd packages/create-pyric/templates/chat typecheck && bun run --cwd packages/create-pyric/templates/chat test:notifications",
     "tool:parity": "bun run scripts/tool-parity.mjs",
     "tool:parity:check": "bun run scripts/tool-parity.mjs --check",
     "test:soak": "bun run --cwd packages/cli test:soak",

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -1,7 +1,7 @@
 /**
  * `pyric init` — scaffold a pyric project (v2, agent-first).
  *
- *   pyric init [dir] [--name N] [--template web|node|static] [--force] [--json]
+ *   pyric init [dir] [--name N] [--template web|node|static|chat] [--force] [--json]
  *              [--deps vendor|npm] [--pyric-version X]
  *
  * Scaffold templates and file writing live in `create-pyric`. This module
@@ -13,7 +13,9 @@ import { join, basename, resolve } from 'node:path';
 import type { ParsedArgs } from './parse-args.js';
 import {
   TEMPLATES,
+  TEMPLATE_NAMES,
   applyDepsMode,
+  isTemplateName,
   mergeIntoExistingPackageJson,
   packageJsonFor,
   normalizeBoolFlags as normalizeScaffoldBoolFlags,
@@ -21,6 +23,7 @@ import {
   type ScaffoldTemplate,
   type DepsMode,
   type PackageJsonMerge,
+  type TemplateName,
 } from 'create-pyric';
 import {
   isStandalone,
@@ -44,7 +47,7 @@ export function resolveDepsMode(
 }
 
 export interface InitResult {
-  template: 'web' | 'node' | 'static';
+  template: TemplateName;
   dir: string;
   depsMode: DepsMode;
   created: string[];
@@ -84,8 +87,10 @@ export async function runInit(parsed: ParsedArgs, deps: InitDeps = {}): Promise<
 
   const templateFlag = parsed.flags.get('template');
   const templateName = typeof templateFlag === 'string' ? templateFlag : 'web';
-  if (templateName !== 'web' && templateName !== 'node' && templateName !== 'static') {
-    err.write(`pyric init: unknown template '${templateName}' (expected web|node|static)\n`);
+  if (!isTemplateName(templateName)) {
+    err.write(
+      `pyric init: unknown template '${templateName}' (expected ${TEMPLATE_NAMES.join('|')})\n`,
+    );
     return 1;
   }
 

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -215,6 +215,34 @@ describe('pyric init v2 — static template (serve-era, no bundler)', () => {
   });
 });
 
+describe('pyric init v2 — chat template', () => {
+  it('scaffolds the full app from the packaged source tree', async () => {
+    const dir = tmp();
+    const c = capture();
+    expect(
+      await runInit(
+        args([], { template: 'chat', name: 'idea-room', json: true }),
+        c.deps(dir),
+      ),
+    ).toBe(0);
+    const result = JSON.parse(c.out()) as InitResult;
+    expect(result.template).toBe('chat');
+    for (const file of [
+      'src/ui/chat/chat-page.tsx',
+      'src/firebase-messaging-sw.ts',
+      'functions/index.js',
+      'firestore.modules.rules',
+      'test/preview-component-state.test.js',
+    ]) {
+      expect(existsSync(join(dir, file))).toBe(true);
+    }
+    expect(readFileSync(join(dir, 'README.md'), 'utf8')).toContain('# idea-room');
+    expect(readFileSync(join(dir, 'vite.config.ts'), 'utf8')).not.toContain('node_modules/');
+    expect(existsSync(join(dir, 'bun.lock'))).toBe(false);
+    expect(existsSync(join(dir, '.pyric'))).toBe(false);
+  });
+});
+
 describe('pyric init v2 — CLI surface', () => {
   it('[dir] positional creates the directory; --name overrides', async () => {
     const root = tmp();
@@ -255,7 +283,7 @@ describe('pyric init v2 — CLI surface', () => {
     const c = capture();
     expect(await runInit(args([], { template: 'angularjs' }), c.deps(dir))).toBe(1);
     expect(c.err()).toContain("unknown template 'angularjs'");
-    expect(c.err()).toContain('web|node|static');
+    expect(c.err()).toContain('web|node|static|chat');
     expect(existsSync(join(dir, 'package.json'))).toBe(false);
   });
 
@@ -314,7 +342,7 @@ describe('pyric init v2 — CLI surface', () => {
 });
 
 describe('pyric init v2 — production handoff', () => {
-  for (const template of ['web', 'node', 'static'] as const) {
+  for (const template of ['web', 'node', 'static', 'chat'] as const) {
     it(`${template} delegates production deployment to firebase-tools`, async () => {
       const dir = tmp();
       expect(

--- a/packages/create-pyric/README.md
+++ b/packages/create-pyric/README.md
@@ -14,6 +14,9 @@ npm install
 npm run dev
 ```
 
-Flags: `--template web|node|static`, `--name`, `--force`, `--json`.
+Use `--template chat` for the full React/Firebase/AI reference app. The default
+remains the smaller Vite starter.
+
+Flags: `--template web|node|static|chat`, `--name`, `--force`, `--json`.
 
 The directory is the optional positional argument; omit it to scaffold in the current working directory. `--name` only sets the package name.

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "templates",
     "README.md",
     "LICENSE"
   ],

--- a/packages/create-pyric/src/bin.ts
+++ b/packages/create-pyric/src/bin.ts
@@ -7,7 +7,14 @@
  */
 
 import { parseCreateArgs } from './parse-args.js';
-import { applyDepsMode, normalizeBoolFlags, runScaffold, TEMPLATES } from './scaffold.js';
+import {
+  applyDepsMode,
+  isTemplateName,
+  normalizeBoolFlags,
+  runScaffold,
+  TEMPLATE_NAMES,
+  TEMPLATES,
+} from './scaffold.js';
 import { readFileSync } from 'node:fs';
 
 function packageVersion(): string {
@@ -26,7 +33,7 @@ async function main(): Promise<number> {
 
   if (args.flags.get('help') === true || args.flags.get('h') === true) {
     process.stdout.write(
-      `Usage: npm create pyric [dir] [--template web|node|static] [--name N] [--force] [--json]\n` +
+      `Usage: npm create pyric [dir] [--template ${TEMPLATE_NAMES.join('|')}] [--name N] [--force] [--json]\n` +
         `       npx create-pyric [dir] [flags]\n\n` +
         `Default template is web (Vite + @pyric/cli/vite).\n` +
         `Directory: optional positional; omit to scaffold in the current directory.\n`,
@@ -36,9 +43,9 @@ async function main(): Promise<number> {
 
   const templateFlag = args.flags.get('template');
   const templateName = typeof templateFlag === 'string' ? templateFlag : 'web';
-  if (templateName !== 'web' && templateName !== 'node' && templateName !== 'static') {
+  if (!isTemplateName(templateName)) {
     process.stderr.write(
-      `create-pyric: unknown template '${templateName}' (expected web|node|static)\n`,
+      `create-pyric: unknown template '${templateName}' (expected ${TEMPLATE_NAMES.join('|')})\n`,
     );
     return 1;
   }

--- a/packages/create-pyric/src/index.ts
+++ b/packages/create-pyric/src/index.ts
@@ -4,6 +4,8 @@
 
 export {
   TEMPLATES,
+  TEMPLATE_NAMES,
+  isTemplateName,
   applyDepsMode,
   mergeIntoExistingPackageJson,
   packageJsonFor,
@@ -15,5 +17,6 @@ export {
   type ScaffoldRequest,
   type ScaffoldIo,
   type PackageJsonMerge,
+  type TemplateName,
 } from './scaffold.js';
 export { parseCreateArgs, type CreateArgs, type FlagValue } from './parse-args.js';

--- a/packages/create-pyric/src/scaffold.ts
+++ b/packages/create-pyric/src/scaffold.ts
@@ -7,11 +7,17 @@
 
 import { writeFile, readFile, mkdir, access } from 'node:fs/promises';
 import { join, basename, resolve } from 'node:path';
-import { TEMPLATES, type ScaffoldTemplate } from './templates.js';
+import {
+  TEMPLATES,
+  TEMPLATE_NAMES,
+  isTemplateName,
+  type ScaffoldTemplate,
+  type TemplateName,
+} from './templates.js';
 import type { FlagValue } from './parse-args.js';
 
-export type { ScaffoldTemplate };
-export { TEMPLATES };
+export type { ScaffoldTemplate, TemplateName };
+export { TEMPLATES, TEMPLATE_NAMES, isTemplateName } from './templates.js';
 
 /** Where the scaffold's `pyric` / `@pyric/cli` deps come from. */
 export type DepsMode = 'vendor' | 'npm';
@@ -157,7 +163,7 @@ export function packageJsonFor(name: string, t: ScaffoldTemplate): string {
 
 /** Stable `--json` contract; agents parse this. */
 export interface ScaffoldResult {
-  template: 'web' | 'node' | 'static';
+  template: TemplateName;
   dir: string;
   depsMode: DepsMode;
   created: string[];
@@ -189,7 +195,7 @@ async function defaultExists(path: string): Promise<boolean> {
 export interface ScaffoldRequest {
   /** Absolute or relative project directory (relative resolved against cwd). */
   dir?: string;
-  template?: 'web' | 'node' | 'static';
+  template?: TemplateName;
   name?: string;
   force?: boolean;
   json?: boolean;
@@ -233,8 +239,10 @@ export async function runScaffold(
   const label = request.commandLabel ?? 'create-pyric';
 
   const templateName = request.template ?? 'web';
-  if (templateName !== 'web' && templateName !== 'node' && templateName !== 'static') {
-    err.write(`${label}: unknown template '${templateName}' (expected web|node|static)\n`);
+  if (!isTemplateName(templateName)) {
+    err.write(
+      `${label}: unknown template '${templateName}' (expected ${TEMPLATE_NAMES.join('|')})\n`,
+    );
     return 1;
   }
   const template = TEMPLATES[templateName];

--- a/packages/create-pyric/src/templates.ts
+++ b/packages/create-pyric/src/templates.ts
@@ -16,6 +16,17 @@
  * the production command.
  */
 
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const TEMPLATE_NAMES = ['web', 'node', 'static', 'chat'] as const;
+export type TemplateName = (typeof TEMPLATE_NAMES)[number];
+
+export function isTemplateName(value: string): value is TemplateName {
+  return (TEMPLATE_NAMES as readonly string[]).includes(value);
+}
+
 export interface ScaffoldTemplate {
   /** package.json pieces merged into existing files / written into new ones. */
   scripts: Record<string, string>;
@@ -30,6 +41,109 @@ export interface ScaffoldTemplate {
   files(name: string): Array<{ name: string; content: string }>;
   /** Literal commands for the report / `--json` consumers. */
   nextSteps: string[];
+}
+
+interface AssetManifest {
+  include: string[];
+}
+
+interface AssetFile {
+  name: string;
+  content: string;
+}
+
+const ASSET_IGNORES = new Set([
+  '.agents',
+  '.codex',
+  '.env',
+  '.env.local',
+  '.git',
+  '.pyric',
+  'bun.lock',
+  'dist',
+  'node_modules',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'test-results',
+  'yarn.lock',
+]);
+
+/** Load one allowlisted packaged tree; the runnable tree is the scaffold source. */
+export function loadAssetTemplate(templateName: string, templateRoot?: string): {
+  packageJson: {
+    scripts: Record<string, string>;
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+    overrides?: Record<string, string>;
+  };
+  dirs: string[];
+  files: AssetFile[];
+} {
+  const root = resolve(
+    templateRoot ?? fileURLToPath(new URL(`../templates/${templateName}/`, import.meta.url)),
+  );
+  const manifest = JSON.parse(readFileSync(resolve(root, 'scaffold.json'), 'utf8')) as AssetManifest;
+  const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+    scripts: Record<string, string>;
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+    overrides?: Record<string, string>;
+  };
+  if (!Array.isArray(manifest.include) || manifest.include.length === 0) {
+    throw new Error(`create-pyric: template '${templateName}' has no scaffold include list`);
+  }
+
+  const files: AssetFile[] = [];
+  const seenFiles = new Set<string>();
+  const dirs = new Set<string>();
+  const walk = (absolute: string): void => {
+    if (ASSET_IGNORES.has(basename(absolute))) return;
+    const stat = lstatSync(absolute);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`create-pyric: template '${templateName}' contains a symlink: ${absolute}`);
+    }
+    if (stat.isDirectory()) {
+      for (const entry of readdirSync(absolute).sort()) walk(resolve(absolute, entry));
+      return;
+    }
+    if (!stat.isFile()) {
+      throw new Error(
+        `create-pyric: template '${templateName}' contains a non-file asset: ${absolute}`,
+      );
+    }
+    const rawRelative = relative(root, absolute).split(sep).join('/');
+    const name = rawRelative === 'gitignore' ? '.gitignore' : rawRelative;
+    if (seenFiles.has(name)) {
+      throw new Error(`create-pyric: template '${templateName}' includes '${name}' more than once`);
+    }
+    seenFiles.add(name);
+    const bytes = readFileSync(absolute);
+    if (bytes.includes(0)) {
+      throw new Error(
+        `create-pyric: template '${templateName}' contains a binary asset: ${rawRelative}`,
+      );
+    }
+    let parent = dirname(name).split(sep).join('/');
+    while (parent !== '.') {
+      dirs.add(parent);
+      parent = dirname(parent).split(sep).join('/');
+    }
+    files.push({ name, content: bytes.toString('utf8') });
+  };
+
+  for (const entry of manifest.include) {
+    if (!entry || isAbsolute(entry) || entry.split(/[\\/]/).includes('..')) {
+      throw new Error(`create-pyric: template '${templateName}' has unsafe include '${entry}'`);
+    }
+    const absolute = resolve(root, entry);
+    if (absolute !== root && !absolute.startsWith(root + sep)) {
+      throw new Error(`create-pyric: template '${templateName}' include escapes its root: '${entry}'`);
+    }
+    walk(absolute);
+  }
+
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return { packageJson, dirs: [...dirs].sort(), files };
 }
 
 // ─── web template ─────────────────────────────────────────────────────
@@ -573,9 +687,11 @@ later releases. For a pre-built / no-build app, use \`pyric init --template stat
 + \`pyric dev\`.
 `;
 
+const chatAssets = loadAssetTemplate('chat');
+
 // ─── the registry ─────────────────────────────────────────────────────
 
-export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
+export const TEMPLATES: Record<TemplateName, ScaffoldTemplate> = {
   // web (default) — a Vite app on the @pyric/cli/vite plugin. `vite dev` runs
   // on the sandbox; `vite build` ships real firebase. One toolchain.
   web: {
@@ -653,5 +769,21 @@ export const TEMPLATES: Record<'web' | 'node' | 'static', ScaffoldTemplate> = {
       { name: '.gitignore', content: GITIGNORE },
     ],
     nextSteps: ['bun install', 'bun run dev', 'bun run dev:agent  # agents: MCP at /__pyric/mcp'],
+  },
+  chat: {
+    scripts: chatAssets.packageJson.scripts,
+    dependencies: chatAssets.packageJson.dependencies,
+    devDependencies: chatAssets.packageJson.devDependencies,
+    ...(chatAssets.packageJson.overrides ? { overrides: chatAssets.packageJson.overrides } : {}),
+    dirs: chatAssets.dirs,
+    files: (name) => chatAssets.files.map((file) => ({
+      name: file.name,
+      content: file.content.replaceAll('__PYRIC_PROJECT_NAME__', name),
+    })),
+    nextSteps: [
+      'npm install       # or: bun install',
+      'npm run dev       # scripted local AI by default',
+      'npm run typecheck',
+    ],
   },
 };

--- a/packages/create-pyric/templates/chat/.env.example
+++ b/packages/create-pyric/templates/chat/.env.example
@@ -1,0 +1,20 @@
+# Your real Firebase web-app config (Firebase console -> project settings).
+# UNUSED in `vite dev` (the pyric sandbox stands in); USED by `vite build` for
+# production. Vite only exposes `VITE_`-prefixed vars to client code.
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_DATABASE_URL=
+# Web Push certificate key pair (Cloud Messaging settings). Only needed for
+# production FCM token registration; the dev sandbox mints tokens without it.
+VITE_FIREBASE_VAPID_KEY=
+
+# Optional local OpenAI-compatible model. Leave both unset to use Pyric's
+# built-in scripted AI. MiniMax example:
+# PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
+# PYRIC_AI_MODEL=minimax-m2.7
+PYRIC_AI_PROXY_UPSTREAM=
+PYRIC_AI_MODEL=

--- a/packages/create-pyric/templates/chat/.npmignore
+++ b/packages/create-pyric/templates/chat/.npmignore
@@ -1,0 +1,7 @@
+dist/
+node_modules/
+.pyric/
+.env
+.env.local
+*.lock
+test-results/

--- a/packages/create-pyric/templates/chat/README.md
+++ b/packages/create-pyric/templates/chat/README.md
@@ -1,0 +1,58 @@
+# __PYRIC_PROJECT_NAME__
+
+A full Firebase + Pyric reference chat app. It includes authentication,
+conversation persistence, attachment storage, presence, streamed AI replies,
+browser-based React app generation, Cloud Messaging, and RTDB-triggered Cloud
+Functions.
+
+## Start locally
+
+```bash
+npm install # or: bun install
+npm run dev
+```
+
+With no model configuration, Pyric's built-in scripted engine answers locally.
+To use MiniMax or another OpenAI-compatible server, copy `.env.example` to
+`.env.local` and set both:
+
+```dotenv
+PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
+PYRIC_AI_MODEL=minimax-m2.7
+```
+
+Start that server separately, then restart Vite. The scaffold deliberately does
+not assume an operating system or a particular model launcher.
+
+## What runs in the sandbox
+
+During `npm run dev`, `@pyric/cli/vite` swaps the app's canonical `firebase/*`
+imports to the browser sandbox. Firestore, Realtime Database, Storage, Auth,
+Messaging, the MCP bridge, and the RTDB Functions child share that sandbox.
+
+The source of truth for rules is `firestore.modules.rules`. Run
+`npm run rules:resolve` before deploying to regenerate `firestore.rules`.
+
+For native notifications, sign in and use the bell once to grant permission.
+The same bundled module service worker handles `onBackgroundMessage` in local
+development and production. Local delivery still requires an open page to keep
+the Pyric sandbox alive.
+
+## Test and build
+
+```bash
+npm test
+npm run typecheck
+npm run test:notifications
+```
+
+`npm run build` uses the real Firebase packages. Fill the `VITE_FIREBASE_*`
+values in `.env.local`, resolve the rules, install the Functions dependencies,
+and deploy with the Firebase CLI:
+
+```bash
+npm --prefix functions install
+npm run rules:resolve
+npm run build
+npx firebase-tools deploy
+```

--- a/packages/create-pyric/templates/chat/components.json
+++ b/packages/create-pyric/templates/chat/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/packages/create-pyric/templates/chat/database.rules.json
+++ b/packages/create-pyric/templates/chat/database.rules.json
@@ -1,0 +1,20 @@
+{
+  "rules": {
+    "presence": {
+      ".read": "auth !== null",
+      "$uid": {
+        ".write": "auth !== null && auth.uid === $uid",
+        ".validate": "newData.hasChildren(['state', 'at']) && newData.child('state').isString()"
+      }
+    },
+    "notify": {
+      "$uid": {
+        ".read": "auth !== null && auth.uid === $uid",
+        ".write": "auth !== null && auth.uid === $uid",
+        "$pushId": {
+          ".validate": "newData.hasChildren(['title', 'body']) && newData.child('title').isString() && newData.child('body').isString()"
+        }
+      }
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/firebase.json
+++ b/packages/create-pyric/templates/chat/firebase.json
@@ -1,0 +1,19 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "functions": {
+    "source": "functions"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "hosting": {
+    "public": "dist",
+    "rewrites": [{ "source": "**", "destination": "/index.html" }]
+  }
+}

--- a/packages/create-pyric/templates/chat/firestore.indexes.json
+++ b/packages/create-pyric/templates/chat/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/packages/create-pyric/templates/chat/firestore.modules.rules
+++ b/packages/create-pyric/templates/chat/firestore.modules.rules
@@ -1,0 +1,128 @@
+rules_version = '2+modules';
+
+import { isAuthenticated, isOwner } from 'auth';
+import { hasRequired, hasOnly, validString, isOneOf } from 'validation';
+import { immutableFields, onlyFieldsChanged, isServerTimestamp } from 'lifecycle';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function conversationPath(conversationId) {
+      return /databases/$(database)/documents/conversations/$(conversationId);
+    }
+
+    function ownsConversation(conversationId) {
+      return isAuthenticated()
+        && exists(conversationPath(conversationId))
+        && get(conversationPath(conversationId)).data.ownerUid == request.auth.uid;
+    }
+
+    function validConversationCreate() {
+      return isAuthenticated()
+        && hasRequired(['ownerUid', 'title', 'model', 'createdAt', 'updatedAt', 'lastMessageAt', 'messageCount', 'archivedAt', 'attachmentCount', 'schemaVersion'])
+        && hasOnly(['ownerUid', 'title', 'model', 'createdAt', 'updatedAt', 'lastMessageAt', 'messageCount', 'archivedAt', 'attachmentCount', 'schemaVersion'])
+        && isOwner(request.resource.data.ownerUid)
+        && validString('title', 1, 120)
+        && isOneOf('model', ['gemini-2.5-flash'])
+        && request.resource.data.messageCount == 0
+        && request.resource.data.attachmentCount == 0
+        && request.resource.data.schemaVersion == 1
+        && isServerTimestamp('createdAt')
+        && isServerTimestamp('updatedAt');
+    }
+
+    function validUserMessageCreate(conversationId) {
+      return ownsConversation(conversationId)
+        && hasRequired(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion'])
+        && hasOnly(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion'])
+        && isOwner(request.resource.data.ownerUid)
+        && request.resource.data.conversationId == conversationId
+        && request.resource.data.role == 'user'
+        && validString('text', 1, 20000)
+        && request.resource.data.thoughts == null
+        && isServerTimestamp('createdAt')
+        && request.resource.data.model == null
+        && request.resource.data.finishReason == null
+        && request.resource.data.inputTokenCount == null
+        && request.resource.data.outputTokenCount == null
+        && request.resource.data.schemaVersion == 1;
+    }
+
+    function validAssistantMessageCreate(conversationId) {
+      return ownsConversation(conversationId)
+        && hasRequired(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion'])
+        && hasOnly(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion'])
+        && isOwner(request.resource.data.ownerUid)
+        && request.resource.data.conversationId == conversationId
+        && request.resource.data.role == 'assistant'
+        && validString('text', 1, 20000)
+        && validString('clientMessageId', 1, 200)
+        && (request.resource.data.thoughts == null || validString('thoughts', 1, 20000))
+        && isOneOf('model', ['gemini-2.5-flash'])
+        && isServerTimestamp('createdAt')
+        && request.resource.data.schemaVersion == 1;
+    }
+
+    match /users/{uid} {
+      allow read: if isAuthenticated() && isOwner(uid);
+      allow create: if isAuthenticated() && isOwner(uid)
+        && request.resource.data.keys().hasOnly(['uid', 'displayName', 'photoURL', 'createdAt', 'updatedAt', 'disabledAt'])
+        && request.resource.data.uid == uid
+        && isServerTimestamp('createdAt')
+        && isServerTimestamp('updatedAt');
+      allow update: if isAuthenticated() && isOwner(uid)
+        && onlyFieldsChanged(['displayName', 'photoURL', 'updatedAt'])
+        && request.resource.data.uid == resource.data.uid
+        && isServerTimestamp('updatedAt');
+      // The owner may store their own Cloud Messaging registration token so the
+      // notify trigger can read it via the admin SDK. Scoped to `fcmToken` only.
+      allow update: if isAuthenticated() && isOwner(uid)
+        && onlyFieldsChanged(['fcmToken'])
+        && validString('fcmToken', 1, 4096);
+      allow delete: if false;
+    }
+
+    match /conversations/{conversationId} {
+      // The owner equality must stay explicit so Firestore can prove the
+      // owner-scoped query is safe; Rules are not filters.
+      allow list: if isAuthenticated() && request.auth.uid == resource.data.ownerUid && request.query.limit <= 100;
+      allow get: if isAuthenticated() && isOwner(resource.data.ownerUid);
+      allow create: if validConversationCreate();
+      allow update: if isAuthenticated()
+        && isOwner(resource.data.ownerUid)
+        && immutableFields(['ownerUid', 'createdAt', 'messageCount', 'attachmentCount', 'schemaVersion'])
+        && onlyFieldsChanged(['title', 'updatedAt', 'lastMessageAt', 'archivedAt'])
+        && isServerTimestamp('updatedAt');
+      allow delete: if isAuthenticated() && isOwner(resource.data.ownerUid);
+
+      match /messages/{messageId} {
+        allow list: if isAuthenticated() && request.auth.uid == resource.data.ownerUid && request.query.limit <= 100;
+        allow get: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+        allow create: if validUserMessageCreate(conversationId) || validAssistantMessageCreate(conversationId);
+        allow update: if false;
+        allow delete: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+      }
+
+      match /attachments/{attachmentId} {
+        allow list: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid) && request.query.limit <= 100;
+        allow get: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+        allow create: if ownsConversation(conversationId)
+          && request.resource.data.keys().hasOnly(['ownerUid', 'conversationId', 'storagePath', 'fileName', 'contentType', 'sizeBytes', 'generation', 'createdAt', 'status', 'schemaVersion'])
+          && isOwner(request.resource.data.ownerUid)
+          && request.resource.data.conversationId == conversationId
+          && request.resource.data.status == 'uploading'
+          && request.resource.data.schemaVersion == 1
+          && isServerTimestamp('createdAt');
+        allow update: if ownsConversation(conversationId)
+          && isOwner(resource.data.ownerUid)
+          && resource.data.status == 'uploading'
+          && request.resource.data.status == 'ready'
+          && onlyFieldsChanged(['status', 'generation']);
+        allow delete: if false;
+      }
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/firestore.rules
+++ b/packages/create-pyric/templates/chat/firestore.rules
@@ -1,0 +1,78 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+    function isOwner(userId) {
+      return isAuthenticated() && request.auth.uid == userId;
+    }
+    function hasRequired(fields) {
+      return request.resource.data.keys().hasAll(fields);
+    }
+    function hasOnly(fields) {
+      return request.resource.data.keys().hasOnly(fields);
+    }
+    function validString(field, min, max) {
+      return request.resource.data[field] is string && request.resource.data[field].size() >= min && request.resource.data[field].size() <= max;
+    }
+    function isOneOf(field, values) {
+      return request.resource.data[field] in values;
+    }
+    function immutableFields(fields) {
+      return request.resource.data.diff(resource.data).unchangedKeys().hasAll(fields);
+    }
+    function onlyFieldsChanged(fields) {
+      return request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields);
+    }
+    function isServerTimestamp(field) {
+      return request.resource.data[field] == request.time;
+    }
+    function conversationPath(conversationId) {
+      return /databases/$(database)/documents/conversations/$(conversationId);
+    }
+    function ownsConversation(conversationId) {
+      return isAuthenticated() && exists(conversationPath(conversationId)) && get(conversationPath(conversationId)).data.ownerUid == request.auth.uid;
+    }
+    function validConversationCreate() {
+      return isAuthenticated() && hasRequired(['ownerUid', 'title', 'model', 'createdAt', 'updatedAt', 'lastMessageAt', 'messageCount', 'archivedAt', 'attachmentCount', 'schemaVersion']) && hasOnly(['ownerUid', 'title', 'model', 'createdAt', 'updatedAt', 'lastMessageAt', 'messageCount', 'archivedAt', 'attachmentCount', 'schemaVersion']) && isOwner(request.resource.data.ownerUid) && validString('title', 1, 120) && isOneOf('model', ['gemini-2.5-flash']) && request.resource.data.messageCount == 0 && request.resource.data.attachmentCount == 0 && request.resource.data.schemaVersion == 1 && isServerTimestamp('createdAt') && isServerTimestamp('updatedAt');
+    }
+    function validUserMessageCreate(conversationId) {
+      return ownsConversation(conversationId) && hasRequired(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion']) && hasOnly(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion']) && isOwner(request.resource.data.ownerUid) && request.resource.data.conversationId == conversationId && request.resource.data.role == 'user' && validString('text', 1, 20000) && request.resource.data.thoughts == null && isServerTimestamp('createdAt') && request.resource.data.model == null && request.resource.data.finishReason == null && request.resource.data.inputTokenCount == null && request.resource.data.outputTokenCount == null && request.resource.data.schemaVersion == 1;
+    }
+    function validAssistantMessageCreate(conversationId) {
+      return ownsConversation(conversationId) && hasRequired(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion']) && hasOnly(['ownerUid', 'conversationId', 'role', 'text', 'createdAt', 'clientMessageId', 'thoughts', 'model', 'finishReason', 'inputTokenCount', 'outputTokenCount', 'schemaVersion']) && isOwner(request.resource.data.ownerUid) && request.resource.data.conversationId == conversationId && request.resource.data.role == 'assistant' && validString('text', 1, 20000) && validString('clientMessageId', 1, 200) && (request.resource.data.thoughts == null || validString('thoughts', 1, 20000)) && isOneOf('model', ['gemini-2.5-flash']) && isServerTimestamp('createdAt') && request.resource.data.schemaVersion == 1;
+    }
+    match /users/{uid} {
+      allow read: if isAuthenticated() && isOwner(uid);
+      allow create: if isAuthenticated() && isOwner(uid) && request.resource.data.keys().hasOnly(['uid', 'displayName', 'photoURL', 'createdAt', 'updatedAt', 'disabledAt']) && request.resource.data.uid == uid && isServerTimestamp('createdAt') && isServerTimestamp('updatedAt');
+      allow update: if isAuthenticated() && isOwner(uid) && onlyFieldsChanged(['displayName', 'photoURL', 'updatedAt']) && request.resource.data.uid == resource.data.uid && isServerTimestamp('updatedAt');
+      allow update: if isAuthenticated() && isOwner(uid) && onlyFieldsChanged(['fcmToken']) && validString('fcmToken', 1, 4096);
+      allow delete: if false;
+    }
+    match /conversations/{conversationId} {
+      allow list: if isAuthenticated() && request.auth.uid == resource.data.ownerUid && request.query.limit <= 100;
+      allow get: if isAuthenticated() && isOwner(resource.data.ownerUid);
+      allow create: if validConversationCreate();
+      allow update: if isAuthenticated() && isOwner(resource.data.ownerUid) && immutableFields(['ownerUid', 'createdAt', 'messageCount', 'attachmentCount', 'schemaVersion']) && onlyFieldsChanged(['title', 'updatedAt', 'lastMessageAt', 'archivedAt']) && isServerTimestamp('updatedAt');
+      allow delete: if isAuthenticated() && isOwner(resource.data.ownerUid);
+      match /messages/{messageId} {
+        allow list: if isAuthenticated() && request.auth.uid == resource.data.ownerUid && request.query.limit <= 100;
+        allow get: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+        allow create: if validUserMessageCreate(conversationId) || validAssistantMessageCreate(conversationId);
+        allow update: if false;
+        allow delete: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+      }
+      match /attachments/{attachmentId} {
+        allow list: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid) && request.query.limit <= 100;
+        allow get: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid);
+        allow create: if ownsConversation(conversationId) && request.resource.data.keys().hasOnly(['ownerUid', 'conversationId', 'storagePath', 'fileName', 'contentType', 'sizeBytes', 'generation', 'createdAt', 'status', 'schemaVersion']) && isOwner(request.resource.data.ownerUid) && request.resource.data.conversationId == conversationId && request.resource.data.status == 'uploading' && request.resource.data.schemaVersion == 1 && isServerTimestamp('createdAt');
+        allow update: if ownsConversation(conversationId) && isOwner(resource.data.ownerUid) && resource.data.status == 'uploading' && request.resource.data.status == 'ready' && onlyFieldsChanged(['status', 'generation']);
+        allow delete: if false;
+      }
+    }
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/functions/index.js
+++ b/packages/create-pyric/templates/chat/functions/index.js
@@ -1,0 +1,57 @@
+import { onValueCreated } from 'firebase-functions/v2/database';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { getMessaging } from 'firebase-admin/messaging';
+
+// The Functions runtime provides the default admin app; the guard keeps the
+// same source valid when deployed to production Cloud Functions.
+if (getApps().length === 0) initializeApp();
+
+/**
+ * When a user first comes online, `/presence/{uid}` is created in Realtime
+ * Database (see PresenceService.goOnline). That create fires this trigger,
+ * which stamps the user's Firestore profile: `firstSeenAt` once, `lastSeenAt`
+ * on every online transition.
+ *
+ * The write goes through the trusted admin SDK, so it bypasses the client
+ * security rules in production — that is why `firstSeenAt` / `lastSeenAt` are
+ * deliberately absent from the client-writable field lists in
+ * firestore.modules.rules. Clients cannot forge them; only this function sets
+ * them.
+ */
+export const onPresenceOnline = onValueCreated('/presence/{uid}', async (event) => {
+  const { uid } = event.params;
+  const profile = getFirestore().collection('users').doc(uid);
+  const snapshot = await profile.get();
+  const now = FieldValue.serverTimestamp();
+  const seen = snapshot.exists && snapshot.get('firstSeenAt')
+    ? { lastSeenAt: now }
+    : { firstSeenAt: now, lastSeenAt: now };
+  await profile.set(seen, { merge: true });
+});
+
+/**
+ * When the client persists an assistant reply it writes `/notify/{uid}/{pushId}`
+ * in Realtime Database (see MessageService.notifyAssistantReply). That create
+ * fires this trigger, which reads the owner's Cloud Messaging token from their
+ * Firestore profile via the admin SDK (bypassing client security rules) and
+ * sends an OS notification. The sandbox broker routes the send by tab
+ * visibility: a hidden tab receives it on the background handler; a send
+ * failure is swallowed so a bad token never crashes the functions child.
+ */
+export const notifyOnAssistantReply = onValueCreated('/notify/{uid}/{pushId}', async (event) => {
+  const { uid } = event.params;
+  const record = event.data.val();
+  if (!record) return;
+  try {
+    const snap = await getFirestore().doc(`users/${uid}`).get();
+    const token = snap.data()?.fcmToken;
+    if (!token) return;
+    await getMessaging().send({
+      token,
+      notification: { title: record.title ?? 'PyChat', body: record.body ?? '' },
+    });
+  } catch (error) {
+    console.error('notifyOnAssistantReply failed', error);
+  }
+});

--- a/packages/create-pyric/templates/chat/functions/package.json
+++ b/packages/create-pyric/templates/chat/functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pychat-functions",
+  "version": "0.0.0",
+  "description": "Realtime Database triggered Cloud Functions for PyChat.",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "engines": {
+    "node": "20"
+  },
+  "dependencies": {
+    "firebase-admin": "^13.10.0",
+    "firebase-functions": "^6.0.0"
+  }
+}

--- a/packages/create-pyric/templates/chat/gitignore
+++ b/packages/create-pyric/templates/chat/gitignore
@@ -1,0 +1,16 @@
+node_modules/
+dist/
+.env
+.env.local
+.firebaserc
+.pyric/
+.codex/
+.claude/
+.antigravity/
+.impeccable/
+*.log
+
+# compiled from firestore.modules.rules
+firestore.rules
+
+plans/

--- a/packages/create-pyric/templates/chat/index.html
+++ b/packages/create-pyric/templates/chat/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>__PYRIC_PROJECT_NAME__ — private AI workspace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/create-pyric/templates/chat/package.json
+++ b/packages/create-pyric/templates/chat/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@pyric/template-chat",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:sandbox": "vite build --mode development",
+    "test": "node --experimental-strip-types --test test/*.test.*",
+    "test:notifications": "npm run build && node --experimental-strip-types scripts/check-notification-build.ts",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "rules:resolve": "pyric firestore rules resolve firestore.modules.rules --out firestore.rules"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.6.0",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
+    "@inbrowser/agent": "^0.4.2",
+    "@inbrowser/model": "^0.4.2",
+    "@inbrowser/resumable": "^0.4.1",
+    "@inbrowser/workspace": "^0.4.2",
+    "@shadcn/react": "^0.2.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "esbuild-wasm": "^0.25.0",
+    "firebase": "^12.12.0",
+    "lucide-react": "^1.25.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "shadcn": "^4.13.1",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0"
+  },
+  "devDependencies": {
+    "@pyric/cli": "*",
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "react-test-renderer": "19.2.7",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "pyric": "*",
+    "firebase-admin": "^13.10.0",
+    "firebase-functions": "^6.0.0"
+  }
+}

--- a/packages/create-pyric/templates/chat/scaffold.json
+++ b/packages/create-pyric/templates/chat/scaffold.json
@@ -1,0 +1,21 @@
+{
+  "include": [
+    ".env.example",
+    "README.md",
+    "components.json",
+    "database.rules.json",
+    "firebase.json",
+    "firestore.indexes.json",
+    "firestore.modules.rules",
+    "firestore.rules",
+    "functions",
+    "gitignore",
+    "index.html",
+    "scripts",
+    "src",
+    "storage.rules",
+    "test",
+    "tsconfig.json",
+    "vite.config.ts"
+  ]
+}

--- a/packages/create-pyric/templates/chat/scripts/check-notification-build.ts
+++ b/packages/create-pyric/templates/chat/scripts/check-notification-build.ts
@@ -1,0 +1,35 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const assetsDirectory = join(scriptDirectory, '..', 'dist', 'assets');
+const assetNames = await readdir(assetsDirectory);
+const workerName = assetNames.find((name) => /^firebase-messaging-sw-[^.]+\.js$/.test(name));
+const applicationBundles = assetNames.filter((name) => name.endsWith('.js') && name !== workerName);
+
+if (applicationBundles.length === 0) {
+  throw new Error('No production application bundle was found. Run `npm run build` first.');
+}
+
+const applicationSource = (await Promise.all(
+  applicationBundles.map((name) => readFile(join(assetsDirectory, name), 'utf8')),
+)).join('\n');
+
+// The window SDK shares the error-code string `only-available-in-sw`, so that
+// string alone is not evidence that the SW implementation was bundled. The
+// push-subscription event handler is unique to the worker implementation.
+if (applicationSource.includes('pushsubscriptionchange')) {
+  throw new Error('The browser bundle contains Firebase Messaging service-worker-only code.');
+}
+
+if (!workerName) {
+  throw new Error('The production build did not emit the Firebase Messaging service worker.');
+}
+const workerSource = await readFile(join(assetsDirectory, workerName), 'utf8');
+
+if (!workerSource.includes('messagingSenderId')) {
+  throw new Error('The messaging service worker is missing messagingSenderId configuration.');
+}
+
+console.log('Notification build checks passed.');

--- a/packages/create-pyric/templates/chat/src/chat-mode.ts
+++ b/packages/create-pyric/templates/chat/src/chat-mode.ts
@@ -1,0 +1,1 @@
+export type ChatMode = 'explore' | 'plan' | 'refine';

--- a/packages/create-pyric/templates/chat/src/components/ui/button.tsx
+++ b/packages/create-pyric/templates/chat/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/packages/create-pyric/templates/chat/src/components/ui/collapsible.tsx
+++ b/packages/create-pyric/templates/chat/src/components/ui/collapsible.tsx
@@ -1,0 +1,7 @@
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible';
+
+const Collapsible = CollapsiblePrimitive.Root;
+const CollapsibleTrigger = CollapsiblePrimitive.Trigger;
+const CollapsibleContent = CollapsiblePrimitive.Panel;
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/packages/create-pyric/templates/chat/src/components/ui/message-scroller.tsx
+++ b/packages/create-pyric/templates/chat/src/components/ui/message-scroller.tsx
@@ -1,0 +1,129 @@
+import * as React from "react"
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "@shadcn/react/message-scroller"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ArrowDownIcon } from "lucide-react"
+
+function MessageScrollerProvider(
+  props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
+) {
+  return <MessageScrollerPrimitive.Provider {...props} />
+}
+
+function MessageScroller({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn(
+        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn(
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn("flex h-max min-h-full flex-col gap-6", className)}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerItem({
+  className,
+  scrollAnchor = false,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn(
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerButton({
+  direction = "end",
+  className,
+  children,
+  render,
+  variant = "secondary",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Button> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-slot="message-scroller-button"
+      data-direction={direction}
+      data-variant={variant}
+      data-size={size}
+      direction={direction}
+      className={cn(
+        "absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180",
+        className
+      )}
+      render={render ?? <Button variant={variant} size={size} />}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ArrowDownIcon
+          />
+          <span className="sr-only">
+            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+          </span>
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  )
+}
+
+export {
+  MessageScrollerProvider,
+  MessageScroller,
+  MessageScrollerViewport,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerButton,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+}

--- a/packages/create-pyric/templates/chat/src/components/ui/message.tsx
+++ b/packages/create-pyric/templates/chat/src/components/ui/message.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function MessageGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-group"
+      className={cn("flex min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function Message({
+  className,
+  align = "start",
+  ...props
+}: React.ComponentProps<"div"> & { align?: "start" | "end" }) {
+  return (
+    <div
+      data-slot="message"
+      data-align={align}
+      className={cn(
+        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageAvatar({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-avatar"
+      className={cn(
+        "flex w-fit min-w-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full bg-muted group-has-data-[slot=message-footer]/message:-translate-y-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-content"
+      className={cn(
+        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-header"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-footer"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0 group-data-[align=end]/message:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  MessageGroup,
+  Message,
+  MessageAvatar,
+  MessageContent,
+  MessageFooter,
+  MessageHeader,
+}

--- a/packages/create-pyric/templates/chat/src/dev/test-notification.ts
+++ b/packages/create-pyric/templates/chat/src/dev/test-notification.ts
@@ -1,0 +1,28 @@
+// Dev-only helper to prove the Cloud Messaging path end to end without a
+// backend. Cloud Messaging is a server-to-client push; with no server calling
+// the FCM Send API, pyric's sandbox.deliver is the "a push arrived" stand-in.
+//
+// getMessaging comes from firebase/messaging (the worker-backed handle the app
+// actually uses); the sandbox driver comes from pyric/messaging. On the default
+// SharedWorker path this now routes through the worker (pyric#397), so no
+// ?inpage is needed. Fire one from DevTools:  await __pyricSendTestNotification()
+import { getMessaging } from 'firebase/messaging';
+import { sandbox as messagingSandbox } from 'pyric/messaging';
+import { firebaseApp } from '../firebase/app';
+
+declare global {
+  interface Window {
+    // visibility 'hidden' forces the onBackgroundMessage route (OS notification);
+    // 'visible' forces the onMessage route (in-app toast). Defaults to hidden so
+    // `await __pyricSendTestNotification()` tests the background path directly.
+    __pyricSendTestNotification?: (body?: string, visibility?: 'hidden' | 'visible') => Promise<unknown>;
+  }
+}
+
+if (import.meta.env.DEV) {
+  window.__pyricSendTestNotification = (body = 'A test notification arrived.', visibility: 'hidden' | 'visible' = 'hidden') =>
+    messagingSandbox.deliver(getMessaging(firebaseApp), {
+      visibilityState: visibility,
+      notification: { title: 'PyChat', body },
+    });
+}

--- a/packages/create-pyric/templates/chat/src/firebase-messaging-sw.ts
+++ b/packages/create-pyric/templates/chat/src/firebase-messaging-sw.ts
@@ -1,0 +1,35 @@
+/// <reference lib="webworker" />
+
+import { initializeApp } from 'firebase/app';
+import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
+import { firebaseConfig } from './firebase/config';
+
+const worker = globalThis as unknown as ServiceWorkerGlobalScope;
+const messaging = getMessaging(initializeApp(firebaseConfig));
+
+onBackgroundMessage(messaging, async (payload) => {
+  if (!payload.notification) return;
+  await worker.registration.showNotification(
+    payload.notification.title ?? 'PyChat',
+    {
+      body: payload.notification.body,
+      icon: payload.notification.icon,
+      tag: payload.messageId,
+      data: { link: payload.fcmOptions?.link ?? '/' },
+    },
+  );
+});
+
+worker.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil((async () => {
+    const windows = await worker.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    });
+    const existing = windows[0];
+    if (existing) return existing.focus();
+    const link = (event.notification.data as { link?: string } | undefined)?.link ?? '/';
+    return worker.clients.openWindow(link);
+  })());
+});

--- a/packages/create-pyric/templates/chat/src/firebase/app.ts
+++ b/packages/create-pyric/templates/chat/src/firebase/app.ts
@@ -1,0 +1,15 @@
+import { getAI } from 'firebase/ai';
+import { getAuth } from 'firebase/auth';
+import { getDatabase } from 'firebase/database';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+import { firebaseApp, firebaseConfig } from './config';
+
+export { firebaseApp, firebaseConfig };
+
+export const auth = getAuth(firebaseApp);
+export const db = getFirestore(firebaseApp);
+export const rtdb = getDatabase(firebaseApp);
+export const storage = getStorage(firebaseApp);
+export const ai = getAI(firebaseApp, { useLimitedUseAppCheckTokens: true });

--- a/packages/create-pyric/templates/chat/src/firebase/config.ts
+++ b/packages/create-pyric/templates/chat/src/firebase/config.ts
@@ -1,0 +1,14 @@
+import { getApp, getApps, initializeApp } from 'firebase/app';
+
+const config = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? 'demo',
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN ?? 'demo.firebaseapp.com',
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID ?? 'demo',
+  appId: import.meta.env.VITE_FIREBASE_APP_ID ?? 'demo',
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID ?? 'demo',
+  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL,
+};
+
+export const firebaseApp = getApps().length > 0 ? getApp() : initializeApp(config);
+export const firebaseConfig = config;

--- a/packages/create-pyric/templates/chat/src/firebase/types.ts
+++ b/packages/create-pyric/templates/chat/src/firebase/types.ts
@@ -1,0 +1,182 @@
+import type { Timestamp } from 'firebase/firestore';
+import type { ChatMode } from '../chat-mode';
+
+export type Brand<T, Name extends string> = T & { readonly __brand: Name };
+export type UserId = Brand<string, 'UserId'>;
+export type ConversationId = Brand<string, 'ConversationId'>;
+export type MessageId = Brand<string, 'MessageId'>;
+export type AttachmentId = Brand<string, 'AttachmentId'>;
+
+export const asUserId = (value: string): UserId => value as UserId;
+export const asConversationId = (value: string): ConversationId => value as ConversationId;
+export const asMessageId = (value: string): MessageId => value as MessageId;
+export const asAttachmentId = (value: string): AttachmentId => value as AttachmentId;
+
+export type AuthUser = {
+  uid: UserId;
+  displayName: string | null;
+  email: string | null;
+  photoURL: string | null;
+  emailVerified: boolean;
+};
+
+export type UserDocument = {
+  uid: UserId;
+  displayName: string | null;
+  photoURL: string | null;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  disabledAt: Timestamp | null;
+};
+
+export type ConversationDocument = {
+  ownerUid: UserId;
+  title: string;
+  model: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  lastMessageAt: Timestamp | null;
+  messageCount: number;
+  archivedAt: Timestamp | null;
+  attachmentCount: number;
+  schemaVersion: 1;
+};
+
+export type Conversation = ConversationDocument & { id: ConversationId };
+
+export type MessageRole = 'user' | 'assistant' | 'system';
+export type FinishReason = 'stop' | 'length' | 'safety' | 'error' | null;
+
+export type MessageDocument = {
+  ownerUid: UserId;
+  conversationId: ConversationId;
+  role: MessageRole;
+  text: string;
+  createdAt: Timestamp;
+  clientMessageId: string | null;
+  thoughts: string | null;
+  model: string | null;
+  finishReason: FinishReason;
+  inputTokenCount: number | null;
+  outputTokenCount: number | null;
+  schemaVersion: 1;
+};
+
+export type Message = MessageDocument & { id: MessageId };
+
+export type AttachmentStatus = 'uploading' | 'ready' | 'deleted' | 'rejected';
+export type AttachmentDocument = {
+  ownerUid: UserId;
+  conversationId: ConversationId;
+  storagePath: string;
+  fileName: string;
+  contentType: string;
+  sizeBytes: number;
+  generation: string | null;
+  createdAt: Timestamp;
+  status: AttachmentStatus;
+  schemaVersion: 1;
+};
+
+export type Attachment = AttachmentDocument & { id: AttachmentId; downloadUrl?: string };
+
+export type PresenceState = 'online' | 'offline';
+
+export type PresenceRecord = {
+  uid: UserId;
+  state: PresenceState;
+  displayName: string | null;
+  at: number | object;
+};
+
+export type PresenceEntry = {
+  uid: UserId;
+  state: PresenceState;
+  displayName: string | null;
+};
+
+export type NotificationMessage = {
+  title: string;
+  body: string | null;
+  data: Record<string, string>;
+};
+
+export type PageOptions = {
+  pageSize?: number;
+  cursor?: unknown;
+};
+
+export type Page<T> = {
+  items: T[];
+  nextCursor: unknown | null;
+};
+
+export type CreateConversationInput = {
+  title?: string;
+  model?: string;
+};
+
+export type AppendUserMessageInput = {
+  conversationId: ConversationId;
+  text: string;
+  clientMessageId?: string | null;
+};
+
+export type AppendAssistantMessageInput = {
+  conversationId: ConversationId;
+  text: string;
+  clientMessageId: string;
+  thoughts?: string | null;
+  model?: string | null;
+  finishReason?: FinishReason;
+  inputTokenCount?: number | null;
+  outputTokenCount?: number | null;
+};
+
+export type GenerateReplyInput = {
+  conversationId: ConversationId;
+  messages: Pick<Message, 'role' | 'text'>[];
+  mode?: ChatMode;
+  model?: string;
+  signal?: AbortSignal;
+};
+
+export type GenerateReplyResult = {
+  text: string;
+  model: string;
+  inputTokenCount: number | null;
+  outputTokenCount: number | null;
+  finishReason: FinishReason;
+};
+
+export type CreateAttachmentInput = {
+  conversationId: ConversationId;
+  fileName: string;
+  contentType: string;
+  sizeBytes: number;
+};
+
+export type UploadTarget = {
+  attachmentId: AttachmentId;
+  storagePath: string;
+};
+
+export type ServiceErrorCode =
+  | 'unauthenticated'
+  | 'forbidden'
+  | 'not-found'
+  | 'quota-exceeded'
+  | 'invalid-input'
+  | 'network'
+  | 'provider';
+
+export class ServiceError extends Error {
+  constructor(
+    readonly code: ServiceErrorCode,
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ServiceError';
+  }
+}

--- a/packages/create-pyric/templates/chat/src/index.css
+++ b/packages/create-pyric/templates/chat/src/index.css
@@ -1,0 +1,206 @@
+@import "tailwindcss";
+
+@keyframes chat-message-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.chat-message-in {
+  animation: chat-message-in 260ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-message-in,
+  .chat-message-in * {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}
+@import "./typeset.css";
+
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --font-geist: 'Geist Variable', sans-serif;
+  --font-geist-mono: 'Geist Mono Variable', monospace;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+@theme inline {
+  --font-sans: 'Geist Variable', sans-serif;
+  --font-mono: var(--font-geist-mono);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --font-heading: var(--font-sans);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+.typeset-chat {
+  --typeset-font-body: var(--font-geist);
+  --typeset-font-heading: var(--font-geist);
+  --typeset-font-mono: var(--font-geist-mono);
+  --typeset-size: 15px;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
+
+:root {
+  --background: oklch(0.985 0.004 90);
+  --foreground: oklch(0.18 0.02 70);
+  --card: oklch(0.995 0.002 90);
+  --card-foreground: oklch(0.18 0.02 70);
+  --popover: oklch(0.995 0.002 90);
+  --popover-foreground: oklch(0.18 0.02 70);
+  --primary: oklch(0.54 0.22 264);
+  --primary-foreground: oklch(0.99 0.01 270);
+  --secondary: oklch(0.94 0.012 85);
+  --secondary-foreground: oklch(0.25 0.03 70);
+  --muted: oklch(0.95 0.008 85);
+  --muted-foreground: oklch(0.48 0.025 70);
+  --accent: oklch(0.94 0 0);
+  --accent-foreground: oklch(0.2 0 0);
+  --destructive: oklch(0.58 0.2 25);
+  --border: oklch(0.88 0.012 80);
+  --input: oklch(0.88 0.012 80);
+  --ring: oklch(0.54 0.22 264);
+  --radius: 0.75rem;
+}
+
+* {
+  border-color: var(--border);
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-geist);
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.54 0.22 264);
+  --primary-foreground: oklch(0.99 0.01 270);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.54 0.22 264);
+  --sidebar-primary-foreground: oklch(0.99 0.01 270);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+html.dark {
+  color-scheme: dark;
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+  html {
+    @apply font-sans;
+  }
+}

--- a/packages/create-pyric/templates/chat/src/lib/utils.ts
+++ b/packages/create-pyric/templates/chat/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/create-pyric/templates/chat/src/main.tsx
+++ b/packages/create-pyric/templates/chat/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './ui/app';
+import './dev/test-notification';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/create-pyric/templates/chat/src/services/agent-run-store.ts
+++ b/packages/create-pyric/templates/chat/src/services/agent-run-store.ts
@@ -1,0 +1,78 @@
+import {
+  createIdbJobStore,
+  createJobEngine,
+  type IdbJobStore,
+  type JobEvent,
+  type JobStatus,
+  type ProducerCtx,
+} from '@inbrowser/resumable';
+
+export type AgentRunEvent =
+  | { kind: 'text'; chunk: string }
+  | { kind: 'thinking'; chunk: string }
+  | { kind: 'tool'; tool: unknown }
+  | { kind: 'usage'; usage: unknown };
+
+type QueueItem = AgentRunEvent | { kind: '__done'; status: JobStatus; reason?: string };
+
+/** Durable append-only event log for a browser agent run. */
+export class AgentRunRecorder {
+  private readonly store = createIdbJobStore({ dbName: 'PyChat-agent-runs' }) as IdbJobStore<AgentRunEvent>;
+  private readonly engine = createJobEngine({ store: this.store });
+  private readonly queue: QueueItem[] = [];
+  private readonly waiters: Array<(item: QueueItem) => void> = [];
+  private closed = false;
+  private readonly ready: Promise<{ jobId: string }>;
+
+  constructor(meta: Record<string, unknown>) {
+    this.ready = this.engine.start(this.producer.bind(this), { data: meta, ttlMs: 1000 * 60 * 60 * 24 * 14 });
+  }
+
+  async jobId(): Promise<string> {
+    return (await this.ready).jobId;
+  }
+
+  push(event: AgentRunEvent): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(event);
+    else this.queue.push(event);
+  }
+
+  finish(): void {
+    this.close({ kind: '__done', status: 'done' });
+  }
+
+  fail(reason: string): void {
+    this.close({ kind: '__done', status: 'error', reason });
+  }
+
+  async replay(from = 0, signal?: AbortSignal): Promise<AsyncIterable<JobEvent<AgentRunEvent>>> {
+    const { jobId } = await this.ready;
+    return this.engine.subscribe(jobId, { from, signal });
+  }
+
+  async dispose(): Promise<void> {
+    await this.engine.stop();
+    this.store.close();
+  }
+
+  private close(item: QueueItem): void {
+    if (this.closed) return;
+    this.closed = true;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(item);
+    else this.queue.push(item);
+  }
+
+  private async *producer(_ctx: ProducerCtx): AsyncIterable<AgentRunEvent> {
+    while (true) {
+      const item = this.queue.shift() ?? await new Promise<QueueItem>((resolve) => this.waiters.push(resolve));
+      if (item.kind === '__done') {
+        if (item.status === 'error') throw new Error(item.reason ?? 'Agent run failed');
+        return;
+      }
+      yield item;
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/ai-chat-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/ai-chat-service.ts
@@ -1,0 +1,85 @@
+import { getGenerativeModel } from 'firebase/ai';
+import type { Content, EnhancedGenerateContentResponse, GenerativeModel } from 'firebase/ai';
+import { ai, auth } from '../firebase/app';
+import { type FinishReason, type GenerateReplyInput, type GenerateReplyResult, ServiceError } from '../firebase/types';
+
+const MODEL = 'gemini-2.5-flash';
+const MAX_MESSAGES = 40;
+const MAX_TEXT = 20_000;
+const modeInstructions = {
+  explore: 'Help the user explore possibilities. Surface alternatives, assumptions, and useful questions before converging.',
+  plan: 'Help the user turn ideas into a practical plan. Clarify the desired outcome, sequence the work, and identify the next concrete step.',
+  refine: 'Help the user pressure-test and improve the current direction. Identify weaknesses, tradeoffs, and specific refinements without discarding useful intent.',
+} as const;
+const modeGenerationConfig = {
+  explore: { maxOutputTokens: 6144, thinkingConfig: { thinkingBudget: 768, includeThoughts: true } },
+  plan: { maxOutputTokens: 8192, thinkingConfig: { thinkingBudget: 1024, includeThoughts: true } },
+  refine: { maxOutputTokens: 6144, thinkingConfig: { thinkingBudget: 768, includeThoughts: true } },
+} as const;
+
+const toContent = (role: 'user' | 'assistant' | 'system', text: string): Content => ({
+  role: role === 'assistant' ? 'model' : role,
+  parts: [{ text: text.slice(0, MAX_TEXT) }],
+});
+
+const finishReason = (value: string | undefined): FinishReason => {
+  if (value === 'MAX_TOKENS') return 'length';
+  if (value === 'SAFETY' || value === 'BLOCKLIST' || value === 'PROHIBITED_CONTENT') return 'safety';
+  return value ? 'stop' : null;
+};
+
+const resultFromResponse = (response: EnhancedGenerateContentResponse, model: string): GenerateReplyResult => ({
+  text: response.text(),
+  model,
+  inputTokenCount: response.usageMetadata?.promptTokenCount ?? null,
+  outputTokenCount: response.usageMetadata?.candidatesTokenCount ?? null,
+  finishReason: finishReason(response.candidates?.[0]?.finishReason),
+});
+
+const modelFor = (model: string | undefined, mode: GenerateReplyInput['mode']): { name: string; client: GenerativeModel } => {
+  const name = model ?? MODEL;
+  if (name !== MODEL) throw new ServiceError('invalid-input', 'Unsupported model');
+  const selectedMode = mode ?? 'explore';
+  return {
+    name,
+    client: getGenerativeModel(ai, {
+      model: name,
+      systemInstruction: modeInstructions[selectedMode],
+      generationConfig: modeGenerationConfig[selectedMode],
+    }),
+  };
+};
+
+export class AiChatService {
+  async generate(input: GenerateReplyInput): Promise<GenerateReplyResult> {
+    if (!auth.currentUser) throw new ServiceError('unauthenticated', 'Sign in is required');
+    const model = modelFor(input.model, input.mode);
+    const contents = input.messages.slice(-MAX_MESSAGES).map((message) => toContent(message.role, message.text));
+    try {
+      const result = await model.client.generateContent({ contents });
+      return resultFromResponse(result.response, model.name);
+    } catch (error) {
+      throw new ServiceError('provider', 'The AI provider request failed', error);
+    }
+  }
+
+  async stream(input: GenerateReplyInput, onChunk: (chunk: string) => void, onThought?: (thought: string) => void): Promise<GenerateReplyResult> {
+    if (!auth.currentUser) throw new ServiceError('unauthenticated', 'Sign in is required');
+    const model = modelFor(input.model, input.mode);
+    const contents = input.messages.slice(-MAX_MESSAGES).map((message) => toContent(message.role, message.text));
+    try {
+      const result = await model.client.generateContentStream({ contents });
+      for await (const chunk of result.stream) {
+        if (input.signal?.aborted) throw new DOMException('Generation cancelled', 'AbortError');
+        const thought = (chunk as EnhancedGenerateContentResponse & { thoughtSummary?: () => string | undefined }).thoughtSummary?.();
+        if (thought) onThought?.(thought);
+        const text = chunk.text();
+        if (text) onChunk(text);
+      }
+      return resultFromResponse(await result.response, model.name);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
+      throw new ServiceError('provider', 'The AI provider request failed', error);
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/attachment-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/attachment-service.ts
@@ -1,0 +1,80 @@
+import { deleteObject, getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+import { collection, doc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
+import { auth, db, storage } from '../firebase/app';
+import { asAttachmentId, type Attachment, type AttachmentDocument, type CreateAttachmentInput, ServiceError, type UploadTarget } from '../firebase/types';
+import { mapFirestoreError, requireUid } from './firestore-helpers';
+
+const MAX_SIZE = 10 * 1024 * 1024;
+const CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'application/pdf', 'text/plain']);
+
+const safeName = (value: string): string => value.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 120) || 'file';
+
+export class AttachmentService {
+  async createUpload(input: CreateAttachmentInput): Promise<UploadTarget> {
+    const uid = requireUid(auth.currentUser?.uid);
+    if (input.sizeBytes <= 0 || input.sizeBytes > MAX_SIZE) throw new ServiceError('invalid-input', 'Attachment is too large');
+    if (!CONTENT_TYPES.has(input.contentType)) throw new ServiceError('invalid-input', 'Attachment type is not allowed');
+    try {
+      const attachment = doc(collection(db, 'conversations', input.conversationId, 'attachments'));
+      const storagePath = `users/${uid}/conversations/${input.conversationId}/attachments/${attachment.id}/${safeName(input.fileName)}`;
+      await setDoc(attachment, {
+        ownerUid: uid,
+        conversationId: input.conversationId,
+        storagePath,
+        fileName: safeName(input.fileName),
+        contentType: input.contentType,
+        sizeBytes: input.sizeBytes,
+        generation: null,
+        createdAt: serverTimestamp(),
+        status: 'uploading',
+        schemaVersion: 1,
+      });
+      return { attachmentId: asAttachmentId(attachment.id), storagePath };
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async upload(target: UploadTarget, file: Blob): Promise<Attachment> {
+    const uid = requireUid(auth.currentUser?.uid);
+    if (file.size > MAX_SIZE) throw new ServiceError('invalid-input', 'Attachment is too large');
+    try {
+      const storageReference = ref(storage, target.storagePath);
+      const result = await uploadBytes(storageReference, file, { contentType: file.type });
+      const url = await getDownloadURL(result.ref);
+      const conversationId = target.storagePath.split('/')[3];
+      await updateDoc(doc(db, 'conversations', conversationId, 'attachments', target.attachmentId), {
+        status: 'ready',
+        generation: result.metadata.generation ?? null,
+      });
+      return {
+        id: target.attachmentId,
+        ownerUid: uid as AttachmentDocument['ownerUid'],
+        conversationId: conversationId as AttachmentDocument['conversationId'],
+        storagePath: target.storagePath,
+        fileName: target.storagePath.split('/').at(-1) ?? 'file',
+        contentType: file.type,
+        sizeBytes: file.size,
+        generation: result.metadata.generation ?? null,
+        createdAt: Timestamp.now(),
+        status: 'ready',
+        schemaVersion: 1,
+        downloadUrl: url,
+      };
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async remove(conversationId: string, attachmentId: string, storagePath: string): Promise<void> {
+    requireUid(auth.currentUser?.uid);
+    try {
+      await deleteObject(ref(storage, storagePath));
+      // The metadata document is intentionally deleted only by the trusted lifecycle path.
+      void conversationId;
+      void attachmentId;
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/auth-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/auth-service.ts
@@ -1,0 +1,41 @@
+import {
+  GoogleAuthProvider,
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut as firebaseSignOut,
+  type User,
+} from 'firebase/auth';
+import { auth } from '../firebase/app';
+import { asUserId, type AuthUser } from '../firebase/types';
+
+const toAuthUser = (user: User | null): AuthUser | null =>
+  user
+    ? {
+        uid: asUserId(user.uid),
+        displayName: user.displayName,
+        email: user.email,
+        photoURL: user.photoURL,
+        emailVerified: user.emailVerified,
+      }
+    : null;
+
+export class FirebaseAuthService {
+  currentUser(): AuthUser | null {
+    return toAuthUser(auth.currentUser);
+  }
+
+  observe(callback: (user: AuthUser | null) => void): () => void {
+    return onAuthStateChanged(auth, (user) => callback(toAuthUser(user)));
+  }
+
+  async signIn(): Promise<AuthUser> {
+    const result = await signInWithPopup(auth, new GoogleAuthProvider());
+    const user = toAuthUser(result.user);
+    if (!user) throw new Error('Firebase returned no signed-in user');
+    return user;
+  }
+
+  async signOut(): Promise<void> {
+    await firebaseSignOut(auth);
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/browser-agent-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/browser-agent-service.ts
@@ -1,0 +1,317 @@
+import { getGenerativeModel } from 'firebase/ai';
+import type { Content } from 'firebase/ai';
+import * as React from 'react';
+import * as jsxRuntime from 'react/jsx-runtime';
+import * as jsxDevRuntime from 'react/jsx-dev-runtime';
+import esbuildWasmUrl from 'esbuild-wasm/esbuild.wasm?url';
+import { createFirebaseAiLogicModelClient } from '@inbrowser/model';
+import {
+  createAgentSession,
+  createAgentTools,
+  createMetricsCollector,
+  createReactLoopStrategy,
+  createToolRegistry,
+  editToolResults,
+  shouldCompact,
+} from '@inbrowser/agent';
+import type { ChatMessage, ModelUsage, SessionEvent } from '@inbrowser/agent';
+import { createBrowserWorkspace } from './browser-workspace-runtime';
+import type { BrowserWorkspace } from '@inbrowser/workspace';
+import type { WorkspaceAgentToolHandler } from '@inbrowser/workspace/agent-tools';
+import { ai, auth } from '../firebase/app';
+import type { ChatMode } from '../chat-mode';
+import type { UiMessage, UiToolCall, UiUsage } from '../ui/chat/chat-types';
+import { AgentRunRecorder } from './agent-run-store';
+
+const MODEL = 'gemini-2.5-flash';
+const MAX_MESSAGES = 40;
+const modeInstructions: Record<ChatMode, string> = {
+  explore: 'Help the user explore possibilities. Surface alternatives, assumptions, and useful questions before converging.',
+  plan: 'Help the user turn ideas into a practical plan. Clarify the desired outcome, sequence the work, and identify the next concrete step.',
+  refine: 'Help the user pressure-test and improve the current direction. Identify weaknesses, tradeoffs, and specific refinements without discarding useful intent.',
+};
+
+type AgentCallbacks = {
+  onChunk: (chunk: string) => void;
+  onThought?: (thought: string) => void;
+  onTool?: (tool: UiToolCall) => void;
+  onUsage?: (usage: UiUsage) => void;
+  onWorkspaceChanged?: () => void;
+};
+
+type AgentResult = {
+  text: string;
+  thoughts: string;
+  usage?: UiUsage;
+};
+
+const toAgentMessage = (message: Pick<UiMessage, 'role' | 'text'>, index: number): ChatMessage => ({
+  id: `history-${index}`,
+  role: message.role === 'system' ? 'system' : message.role,
+  text: message.text,
+});
+
+const toUiUsage = (usage: ModelUsage): UiUsage => ({
+  inputTokens: usage.promptTokens,
+  outputTokens: usage.outputTokens,
+  reasoningTokens: usage.reasoningTokens,
+  cachedTokens: usage.cachedTokens,
+  costUsd: usage.costUsd,
+});
+
+const generationConfig = {
+  maxOutputTokens: 8192,
+  thinkingConfig: { thinkingBudget: 1024, includeThoughts: true },
+};
+
+export class BrowserAgentService {
+  private workspacePromise: Promise<BrowserWorkspace> | null = null;
+  private readonly workspaceListeners = new Set<() => void>();
+
+  private workspace(): Promise<BrowserWorkspace> {
+    if (!this.workspacePromise) {
+      this.workspacePromise = createBrowserWorkspace({
+        id: 'PyChat-workspace',
+        root: '/work',
+        storage: 'opfs-with-memory-fallback',
+      }).then(async (workspace: BrowserWorkspace) => {
+        try {
+          await workspace.fs.promises.readFile('/work/src/App.tsx', 'utf8');
+        } catch {
+          await workspace.fs.promises.writeFile('/work/package.json', JSON.stringify({ name: 'PyChat-workspace', private: true, dependencies: { react: 'latest', 'react-dom': 'latest' } }, null, 2));
+          await workspace.fs.promises.writeFile('/work/src/App.tsx', "export default function App() {\n  return <main style={{ padding: 24, fontFamily: 'system-ui' }}>Your workspace is ready.</main>;\n}\n");
+        }
+        return workspace;
+      });
+    }
+    return this.workspacePromise!;
+  }
+
+  private notifyWorkspaceChanged(): void {
+    this.workspaceListeners.forEach((listener) => listener());
+  }
+
+  async readAppSource(): Promise<string> {
+    const workspace = await this.workspace();
+    return workspace.fs.promises.readFile('/work/src/App.tsx', 'utf8');
+  }
+
+  subscribe(callback: () => void): () => void {
+    this.workspaceListeners.add(callback);
+    return () => this.workspaceListeners.delete(callback);
+  }
+
+  async previewApp(source: string, hostModules: { react: Record<string, unknown>; jsxRuntime: Record<string, unknown>; jsxDevRuntime: Record<string, unknown> }): Promise<{ ok: true; component: unknown } | { ok: false; diagnostics: Array<{ message: string; line?: number; column?: number }> }> {
+    const workspace = await this.workspace();
+    const preview = await workspace.createReactPreview({
+      entry: '/work/src/App.tsx',
+      react: hostModules.react,
+      jsxRuntime: hostModules.jsxRuntime,
+      jsxDevRuntime: hostModules.jsxDevRuntime,
+      esbuildOptions: { wasmURL: esbuildWasmUrl },
+    });
+    const result = await preview.compile(source);
+    if (!result.ok) return result;
+    const evaluated = result.evaluate(preview.scope());
+    const component = (evaluated as { default?: unknown })?.default ?? evaluated;
+    return { ok: true, component };
+  }
+
+  async stream(input: { messages: Pick<UiMessage, 'role' | 'text'>[]; mode?: ChatMode; signal?: AbortSignal }, callbacks: AgentCallbacks): Promise<AgentResult> {
+    if (!auth.currentUser) throw new Error('Sign in is required');
+    const workspace = await this.workspace();
+    const handlers = createBrowserWorkspaceTools(workspace);
+    const registry = createToolRegistry();
+    handlers.forEach((handler) => registry.register(handler));
+    const model = getGenerativeModel(ai, {
+      model: MODEL,
+      systemInstruction: modeInstructions[input.mode ?? 'explore'],
+      generationConfig,
+    });
+    const llm = createFirebaseAiLogicModelClient(model, { id: `firebase-ai-logic:${MODEL}` });
+    const history = input.messages.slice(-MAX_MESSAGES).map(toAgentMessage);
+    const managedHistory = editToolResults(history);
+    const compaction = shouldCompact(managedHistory.messages, { windowTokens: 200_000 });
+    const activeSignal = input.signal ?? new AbortController().signal;
+    const run = new AgentRunRecorder({ model: MODEL, mode: input.mode ?? 'explore' });
+    const session = createAgentSession({
+      // A thinking-heavy local model often ends a turn after thinking with no
+      // tool call or text (gemini.thinking_only_stop). Under the default
+      // 'strict' policy that surfaces as "produced no output" even when the
+      // agent already did the work; 'complete-with-warning' lets the loop
+      // settle on the tool progress it made instead of failing the response.
+      strategy: createReactLoopStrategy({ maxTurns: 12, toolProgressErrorPolicy: 'complete-with-warning' }),
+      llm,
+      tools: createAgentTools(registry),
+      toolContext: () => ({ signal: activeSignal, workspace: workspace as never }),
+      systemPromptBuilder: () => `${modeInstructions[input.mode ?? 'explore']}\n\nYou are working inside PyChat's browser workspace. The workspace root is /work and already contains package.json and src/App.tsx — src/App.tsx is the app entry (a default-exported React component that renders into the preview). To build or change the app, write src/App.tsx. Paths resolve under /work, so "src/App.tsx", "/src/App.tsx", and "/work/src/App.tsx" all mean the same file, and "/" lists the root. This layout is fixed — do not spend turns probing for it; read or write src/App.tsx directly. Preview contract: src/App.tsx must \`export default\` a function component — literally \`export default function App() { return <h1>Hello</h1>; }\`. Do NOT export a JSX element (\`export default <h1>Hello</h1>\`) and do NOT call the component (\`export default App()\`); the export must be the function itself, which the preview mounts for you. Import hooks from 'react' (e.g. \`import { useState } from 'react'\`); 'react' is already provided, so never install it. Do NOT import 'react-dom' and do NOT call render() or createRoot() — those are not available and will fail to resolve; the preview does the mounting. A component that returns null compiles but shows a blank preview, so the default export must return the actual requested UI. For any request, make the change and call workspace_preview; a successful compile is not the same as rendering the requested content — verify the component returns visible JSX before claiming it renders. Keep the final response concise and tell the user what changed. ${compaction.compact ? 'Prefer the most recent context and verify the current files before editing.' : ''}`,
+      metrics: createMetricsCollector(),
+      history: managedHistory.messages,
+    });
+    let text = '';
+    let thoughts = '';
+    let usage: UiUsage | undefined;
+    const toolNames = new Map<string, string>();
+    const prompt = input.messages.at(-1)?.text ?? '';
+    const recordingCallbacks: AgentCallbacks = {
+      ...callbacks,
+      onTool: (tool) => {
+        run.push({ kind: 'tool', tool });
+        callbacks.onTool?.(tool);
+      },
+    };
+    try {
+      for await (const event of session.submit(prompt, activeSignal)) {
+        this.handleEvent(event, recordingCallbacks, toolNames, (chunk) => { text += chunk; run.push({ kind: 'text', chunk }); }, (chunk) => { thoughts += chunk; run.push({ kind: 'thinking', chunk }); }, (nextUsage) => { usage = nextUsage; run.push({ kind: 'usage', usage: nextUsage }); });
+      }
+      if (/workspace|render .*app|react app|app\.tsx/i.test(prompt)) {
+        const verificationId = `workspace_preview_${Date.now()}`;
+        const verificationTool: UiToolCall = { id: verificationId, name: 'workspace_preview', args: {}, status: 'running' };
+        run.push({ kind: 'tool', tool: verificationTool });
+        recordingCallbacks.onTool?.(verificationTool);
+        try {
+          const verification = await this.verifyWorkspacePreview(workspace);
+          const completed: UiToolCall = verification.ok
+            ? { ...verificationTool, status: 'complete', summary: 'preview compiled successfully' }
+            : { ...verificationTool, status: 'error', summary: verification.message };
+          run.push({ kind: 'tool', tool: completed });
+          recordingCallbacks.onTool?.(completed);
+        } catch (error) {
+          const failed: UiToolCall = { ...verificationTool, status: 'error', summary: error instanceof Error ? error.message : 'preview verification failed' };
+          run.push({ kind: 'tool', tool: failed });
+          recordingCallbacks.onTool?.(failed);
+        }
+      }
+      run.finish();
+    } catch (error) {
+      run.fail(error instanceof Error ? error.message : 'Agent run failed');
+      throw error;
+    } finally {
+      window.setTimeout(() => void run.dispose(), 30_000);
+    }
+    return { text, thoughts, usage };
+  }
+
+  private async verifyWorkspacePreview(workspace: BrowserWorkspace): Promise<{ ok: true } | { ok: false; message: string }> {
+    const source = await workspace.fs.promises.readFile('/work/src/App.tsx', 'utf8');
+    const preview = await workspace.createReactPreview({
+      entry: '/work/src/App.tsx',
+      react: React as unknown as Record<string, unknown>,
+      jsxRuntime: jsxRuntime as unknown as Record<string, unknown>,
+      jsxDevRuntime: jsxDevRuntime as unknown as Record<string, unknown>,
+      esbuildOptions: { wasmURL: esbuildWasmUrl },
+    });
+    const result = await preview.compile(source);
+    return result.ok ? { ok: true } : { ok: false, message: result.diagnostics.map((diagnostic) => diagnostic.message).join('; ') };
+  }
+
+  private handleEvent(event: SessionEvent, callbacks: AgentCallbacks, toolNames: Map<string, string>, appendText: (chunk: string) => void, appendThought: (chunk: string) => void, setUsage: (usage: UiUsage) => void): void {
+    if (event.kind === 'text') {
+      appendText(event.chunk);
+      callbacks.onChunk(event.chunk);
+    } else if (event.kind === 'thinking') {
+      appendThought(event.chunk);
+      callbacks.onThought?.(event.chunk);
+    } else if (event.kind === 'tool_started') {
+      toolNames.set(event.callId, event.name);
+      callbacks.onTool?.({ id: event.callId, name: event.name, args: event.args, status: 'running' });
+    } else if (event.kind === 'tool_finished') {
+      callbacks.onTool?.({ id: event.callId, name: toolNames.get(event.callId) ?? event.callId, args: {}, status: event.result.ok ? 'complete' : 'error', summary: event.result.summary });
+      this.notifyWorkspaceChanged();
+      callbacks.onWorkspaceChanged?.();
+    } else if (event.kind === 'turn_completed') {
+      const nextUsage = toUiUsage({ promptTokens: event.metrics.tokensIn, outputTokens: event.metrics.tokensOut, reasoningTokens: event.metrics.tokensReasoning, cachedTokens: event.metrics.tokensCached, costUsd: event.metrics.costUsd });
+      setUsage(nextUsage);
+      callbacks.onUsage?.(nextUsage);
+    } else if (event.kind === 'error') {
+      throw new Error(event.message);
+    }
+  }
+}
+
+const WORKSPACE_ROOT = '/work';
+
+/**
+ * Map an agent-supplied path into the workspace mount. The fs is rooted so
+ * everything lives under `/work`, but agents naturally reach for `/`, `/src`,
+ * or `src/App.tsx`. Resolve all of those under `/work` so a stray leading slash
+ * or a root listing never throws "outside /work" — that error gave the model
+ * nothing to correct toward and sent it into a path-guessing loop that spent
+ * its whole output budget on thinking, ending in finishReason=STOP with no
+ * tool call ("produced no output — response ended after thinking only").
+ */
+function resolveWorkspacePath(path: string): string {
+  const trimmed = (path ?? '').trim();
+  if (!trimmed || trimmed === '/' || trimmed === '.' || trimmed === './') return WORKSPACE_ROOT;
+  const cleaned = trimmed.replace(/^\.\//, '').replace(/\/+$/, '');
+  if (cleaned === WORKSPACE_ROOT || cleaned.startsWith(`${WORKSPACE_ROOT}/`)) return cleaned || WORKSPACE_ROOT;
+  const relative = cleaned.replace(/^\/+/, '');
+  return relative ? `${WORKSPACE_ROOT}/${relative}` : WORKSPACE_ROOT;
+}
+
+function createBrowserWorkspaceTools(workspace: BrowserWorkspace): WorkspaceAgentToolHandler[] {
+  const stringSchema = () => ({ type: 'string' });
+  const objectSchema = (properties: Record<string, unknown>, required: string[] = []) => ({ type: 'object', properties, required, additionalProperties: false });
+  return [
+    {
+      name: 'workspace_read_file',
+      description: 'Read a UTF-8 file from the browser workspace. Paths are under the workspace root /work; "/work/src/App.tsx", "src/App.tsx", and "/src/App.tsx" all resolve to the same file.',
+      parameters: objectSchema({ path: stringSchema() }, ['path']),
+      pure: true,
+      async execute(args: { path: string }) {
+        const path = resolveWorkspacePath(args.path);
+        const content = await workspace.fs.promises.readFile(path, 'utf8');
+        return { ok: true, summary: `read ${path}`, data: { path, content } };
+      },
+    },
+    {
+      name: 'workspace_write_file',
+      description: 'Write a UTF-8 file in the browser workspace, creating parent directories as needed. Paths are under the workspace root /work (e.g. "src/App.tsx").',
+      parameters: objectSchema({ path: stringSchema(), content: stringSchema() }, ['path', 'content']),
+      async execute(args: { path: string; content: string }) {
+        const path = resolveWorkspacePath(args.path);
+        await workspace.fs.promises.writeFile(path, args.content);
+        return { ok: true, summary: `wrote ${path}`, data: { path, bytes: new TextEncoder().encode(args.content).byteLength } };
+      },
+    },
+    {
+      name: 'workspace_list_files',
+      description: 'List files or directories in the browser workspace. Use "/" (or "/work") for the workspace root; paths resolve under /work.',
+      parameters: objectSchema({ path: stringSchema() }, ['path']),
+      pure: true,
+      async execute(args: { path: string }) {
+        const path = resolveWorkspacePath(args.path);
+        const entries = await workspace.fs.promises.readdir(path, { withFileTypes: true });
+        return { ok: true, summary: `listed ${path}`, data: { path, entries: entries.map((entry) => ({ name: entry.name, path: entry.path, type: entry.type })) } };
+      },
+    },
+    {
+      name: 'workspace_package_install',
+      description: 'Add a browser-compatible package to the workspace import map.',
+      parameters: objectSchema({ name: stringSchema(), version: stringSchema() }, ['name']),
+      async execute(args: { name: string; version?: string }) {
+        const installed = await workspace.packages.install({ name: args.name, version: args.version });
+        return { ok: true, summary: `installed ${installed.name}@${installed.version}`, data: installed };
+      },
+    },
+    {
+      name: 'workspace_preview',
+      description: 'Compile the current React app and report whether it renders successfully. Use after editing workspace files.',
+      parameters: objectSchema({}),
+      pure: true,
+      async execute() {
+        const source = await workspace.fs.promises.readFile('/work/src/App.tsx', 'utf8');
+        const preview = await workspace.createReactPreview({
+          entry: '/work/src/App.tsx',
+          react: React as unknown as Record<string, unknown>,
+          jsxRuntime: jsxRuntime as unknown as Record<string, unknown>,
+          jsxDevRuntime: jsxDevRuntime as unknown as Record<string, unknown>,
+          esbuildOptions: { wasmURL: esbuildWasmUrl },
+        });
+        const result = await preview.compile(source);
+        if (!result.ok) return { ok: false, summary: `preview failed: ${result.diagnostics.map((diagnostic) => diagnostic.message).join('; ')}`, data: result.diagnostics };
+        return { ok: true, summary: 'preview compiled successfully' };
+      },
+    },
+  ];
+}

--- a/packages/create-pyric/templates/chat/src/services/browser-workspace-runtime.ts
+++ b/packages/create-pyric/templates/chat/src/services/browser-workspace-runtime.ts
@@ -1,0 +1,63 @@
+import {
+  createMemoryFileSystem,
+  createOPFSFileSystem,
+  createScopedFileSystem,
+  normalizePath,
+  opfsAvailable,
+} from '@inbrowser/workspace/fs';
+import { createPackageRegistry } from '@inbrowser/workspace/packages';
+import { createWorkspaceSnapshotManager } from '@inbrowser/workspace/snapshots';
+import type { BrowserWorkspace, BrowserWorkspaceOptions } from '@inbrowser/workspace';
+
+/**
+ * Browser-only workspace entry. The package barrel also exports its shell
+ * adapter, which is useful in Node but causes Vite to bundle just-bash for
+ * the browser. Keep shell/git lazy and out of the application bundle.
+ */
+export async function createBrowserWorkspace(options: BrowserWorkspaceOptions): Promise<BrowserWorkspace> {
+  const root = normalizePath(options.root ?? '/work');
+  const storage = options.storage ?? 'opfs-with-memory-fallback';
+  const shouldUseOpfs = storage !== 'memory' && opfsAvailable();
+  if (storage === 'opfs' && !shouldUseOpfs) throw new Error('OPFS is not available in this browser context.');
+
+  const storageFs = shouldUseOpfs ? createOPFSFileSystem({ root: '/' }) : createMemoryFileSystem({ root: '/' });
+  const fs = createScopedFileSystem(storageFs, {
+    virtualRoot: root,
+    realRoot: `${workspaceStorageRoot(options.id)}${root}`,
+  });
+  await fs.promises.mkdir(root, { recursive: true });
+  const packages = createPackageRegistry({ fs });
+  const snapshots = createWorkspaceSnapshotManager({
+    workspaceFs: fs,
+    metadataFs: storageFs,
+    root,
+    storageRoot: `${workspaceStorageRoot(options.id)}/metadata`,
+  });
+
+  return {
+    id: options.id,
+    root,
+    storageStatus: shouldUseOpfs ? 'best-effort' : 'memory',
+    fs,
+    packages,
+    snapshots,
+    async createReactPreview(previewOptions) {
+      const { createReactPreviewRuntime } = await import('@inbrowser/workspace/preview/react');
+      return createReactPreviewRuntime({ ...previewOptions, fs, importMap: previewOptions.importMap });
+    },
+    async createShell(shellOptions = {}) {
+      void shellOptions;
+      throw new Error('Shell tools are not enabled in the browser preview.');
+    },
+    async createGit(gitOptions = {}) {
+      void gitOptions;
+      throw new Error('Git tools are not enabled in the browser preview.');
+    },
+    dispose() {},
+  };
+}
+
+function workspaceStorageRoot(id: string): string {
+  const safe = id.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+$/, '_');
+  return `/.inbrowser/workspaces/${safe}`;
+}

--- a/packages/create-pyric/templates/chat/src/services/conversation-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/conversation-service.ts
@@ -1,0 +1,151 @@
+import {
+  addDoc,
+  collection,
+  getDocs,
+  doc,
+  getDoc,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  startAfter,
+  updateDoc,
+  where,
+  writeBatch,
+  type Query,
+  type QueryDocumentSnapshot,
+  type QuerySnapshot,
+} from 'firebase/firestore';
+import { auth, db } from '../firebase/app';
+import {
+  asConversationId,
+  type Conversation,
+  type ConversationDocument,
+  type CreateConversationInput,
+  type MessageDocument,
+  type Page,
+  type PageOptions,
+  ServiceError,
+} from '../firebase/types';
+import { clampPageSize, mapFirestoreError, requireUid } from './firestore-helpers';
+
+const allowedModels = new Set(['gemini-2.5-flash']);
+const cleanTitle = (title: string): string => title.trim().slice(0, 120) || 'New conversation';
+
+const toConversation = (snapshot: QueryDocumentSnapshot): Conversation => ({
+  id: asConversationId(snapshot.id),
+  ...(snapshot.data() as ConversationDocument),
+});
+
+const conversationQuery = (uid: string, pageSize: number) =>
+  query(collection(db, 'conversations'), where('ownerUid', '==', uid), orderBy('updatedAt', 'desc'), limit(pageSize));
+const messageCollection = (conversationId: Conversation['id']) => collection(db, 'conversations', conversationId, 'messages');
+
+export class ConversationService {
+  async list(options: PageOptions = {}): Promise<Page<Conversation>> {
+    const uid = requireUid(auth.currentUser?.uid);
+    const pageSize = clampPageSize(options.pageSize);
+    try {
+      const constraints = [where('ownerUid', '==', uid), orderBy('updatedAt', 'desc'), limit(pageSize)];
+      const snapshot = await getDocs(
+        options.cursor
+          ? query(collection(db, 'conversations'), constraints[0], constraints[1], startAfter(options.cursor), constraints[2])
+          : query(collection(db, 'conversations'), ...constraints),
+      );
+      return { items: snapshot.docs.map(toConversation), nextCursor: snapshot.docs.at(-1) ?? null };
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  observeList(callback: (conversations: Conversation[]) => void, options: PageOptions = {}): () => void {
+    const uid = requireUid(auth.currentUser?.uid);
+    const pageSize = clampPageSize(options.pageSize);
+    return onSnapshot(conversationQuery(uid, pageSize), (snapshot) => callback(snapshot.docs.map(toConversation)));
+  }
+
+  async create(input: CreateConversationInput = {}): Promise<Conversation['id']> {
+    const uid = requireUid(auth.currentUser?.uid);
+    const model = input.model ?? 'gemini-2.5-flash';
+    if (!allowedModels.has(model)) throw new ServiceError('invalid-input', 'Unsupported model');
+    try {
+      const reference = await addDoc(collection(db, 'conversations'), {
+        ownerUid: uid,
+        title: cleanTitle(input.title ?? ''),
+        model,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        lastMessageAt: null,
+        messageCount: 0,
+        archivedAt: null,
+        attachmentCount: 0,
+        schemaVersion: 1,
+      });
+      return asConversationId(reference.id);
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async get(id: Conversation['id']): Promise<Conversation | null> {
+    requireUid(auth.currentUser?.uid);
+    try {
+      const snapshot = await getDoc(doc(db, 'conversations', id));
+      return snapshot.exists() ? ({ id, ...(snapshot.data() as ConversationDocument) } satisfies Conversation) : null;
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async updateTitle(id: Conversation['id'], title: string): Promise<void> {
+    requireUid(auth.currentUser?.uid);
+    if (!title.trim() || title.length > 120) throw new ServiceError('invalid-input', 'Title must be 1–120 characters');
+    try {
+      await updateDoc(doc(db, 'conversations', id), { title: cleanTitle(title), updatedAt: serverTimestamp() });
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async archive(id: Conversation['id']): Promise<void> {
+    requireUid(auth.currentUser?.uid);
+    try {
+      await updateDoc(doc(db, 'conversations', id), { archivedAt: serverTimestamp(), updatedAt: serverTimestamp() });
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async delete(id: Conversation['id']): Promise<void> {
+    const uid = requireUid(auth.currentUser?.uid);
+    try {
+      let cursor: QueryDocumentSnapshot | null = null;
+      while (true) {
+        const messageQuery = (cursor
+          ? query(messageCollection(id), where('ownerUid', '==', uid), orderBy('createdAt'), startAfter(cursor), limit(100))
+          : query(messageCollection(id), where('ownerUid', '==', uid), orderBy('createdAt'), limit(100))) as Query<MessageDocument>;
+        const snapshots: QuerySnapshot<MessageDocument> = await getDocs(messageQuery);
+        if (!snapshots.docs.length) break;
+        const batch = writeBatch(db);
+        snapshots.docs.forEach((snapshot: QueryDocumentSnapshot<MessageDocument>) => batch.delete(snapshot.ref));
+        await batch.commit();
+        cursor = snapshots.docs.at(-1) ?? null;
+        if (snapshots.docs.length < 100) break;
+      }
+
+      const batch = writeBatch(db);
+      batch.delete(doc(db, 'conversations', id));
+      await batch.commit();
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  observe(id: Conversation['id'], callback: (value: Conversation) => void): () => void {
+    requireUid(auth.currentUser?.uid);
+    return onSnapshot(doc(db, 'conversations', id), (snapshot) => {
+      if (snapshot.exists()) callback({ id, ...(snapshot.data() as ConversationDocument) });
+    });
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/firestore-helpers.ts
+++ b/packages/create-pyric/templates/chat/src/services/firestore-helpers.ts
@@ -1,0 +1,39 @@
+import {
+  doc,
+  type DocumentData,
+  type DocumentReference,
+  type Firestore,
+  type QueryDocumentSnapshot,
+  type SnapshotOptions,
+  type WithFieldValue,
+} from 'firebase/firestore';
+import { ServiceError } from '../firebase/types';
+
+export const requireUid = (uid: string | null | undefined): string => {
+  if (!uid) throw new ServiceError('unauthenticated', 'Sign in is required');
+  return uid;
+};
+
+export const mapFirestoreError = (error: unknown): ServiceError => {
+  const code = typeof error === 'object' && error && 'code' in error ? String(error.code) : '';
+  if (code.includes('permission-denied')) return new ServiceError('forbidden', 'The operation is not allowed', error);
+  if (code.includes('not-found')) return new ServiceError('not-found', 'The requested record was not found', error);
+  if (code.includes('resource-exhausted')) return new ServiceError('quota-exceeded', 'The service quota was exceeded', error);
+  if (code.includes('invalid-argument')) return new ServiceError('invalid-input', 'The request is invalid', error);
+  return new ServiceError('network', 'The Firebase operation failed', error);
+};
+
+export const converter = <T extends DocumentData>() => ({
+  toFirestore(value: WithFieldValue<T>): DocumentData {
+    return value;
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options: SnapshotOptions): T {
+    return snapshot.data(options) as T;
+  },
+});
+
+export const typedDoc = <T extends DocumentData>(firestore: Firestore, path: string): DocumentReference<T> =>
+  doc(firestore, path).withConverter(converter<T>());
+
+export const clampPageSize = (value: number | undefined, fallback = 50): number =>
+  Math.min(Math.max(Math.trunc(value ?? fallback), 1), 100);

--- a/packages/create-pyric/templates/chat/src/services/index.ts
+++ b/packages/create-pyric/templates/chat/src/services/index.ts
@@ -1,0 +1,8 @@
+export { FirebaseAuthService } from './auth-service';
+export { UserService } from './user-service';
+export { ConversationService } from './conversation-service';
+export { MessageService } from './message-service';
+export { AiChatService } from './ai-chat-service';
+export { AttachmentService } from './attachment-service';
+export { PresenceService } from './presence-service';
+export { NotificationService } from './notification-service';

--- a/packages/create-pyric/templates/chat/src/services/message-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/message-service.ts
@@ -1,0 +1,123 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  startAfter,
+  where,
+} from 'firebase/firestore';
+import { push, ref, serverTimestamp as rtdbServerTimestamp } from 'firebase/database';
+import { auth, db, rtdb } from '../firebase/app';
+import { asMessageId, type AppendAssistantMessageInput, type AppendUserMessageInput, type Message, type MessageDocument, type Page, type PageOptions, ServiceError } from '../firebase/types';
+import { clampPageSize, mapFirestoreError, requireUid } from './firestore-helpers';
+
+const toMessage = (snapshot: { id: string; data: () => unknown }): Message => ({
+  id: asMessageId(snapshot.id),
+  ...(snapshot.data() as MessageDocument),
+});
+
+const messageCollection = (conversationId: string) => collection(db, 'conversations', conversationId, 'messages');
+
+export class MessageService {
+  async list(conversationId: string, options: PageOptions = {}): Promise<Page<Message>> {
+    const uid = requireUid(auth.currentUser?.uid);
+    const pageSize = clampPageSize(options.pageSize);
+    try {
+      const constraints = [where('ownerUid', '==', uid), orderBy('createdAt', 'desc'), limit(pageSize)];
+      const messageQuery = options.cursor
+        ? query(messageCollection(conversationId), constraints[0], constraints[1], startAfter(options.cursor), constraints[2])
+        : query(messageCollection(conversationId), ...constraints);
+      const snapshot = await getDocs(messageQuery);
+      return { items: snapshot.docs.map(toMessage), nextCursor: snapshot.docs.at(-1) ?? null };
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async appendUserMessage(input: AppendUserMessageInput): Promise<Message['id']> {
+    const uid = requireUid(auth.currentUser?.uid);
+    const text = input.text.trim();
+    if (!text || text.length > 20_000) throw new ServiceError('invalid-input', 'Message must be 1–20,000 characters');
+    try {
+      const reference = await addDoc(messageCollection(input.conversationId), {
+        ownerUid: uid,
+        conversationId: input.conversationId,
+        role: 'user',
+        text,
+        createdAt: serverTimestamp(),
+        clientMessageId: input.clientMessageId ?? null,
+        thoughts: null,
+        model: null,
+        finishReason: null,
+        inputTokenCount: null,
+        outputTokenCount: null,
+        schemaVersion: 1,
+      });
+      return asMessageId(reference.id);
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  async appendAssistantMessage(input: AppendAssistantMessageInput): Promise<Message['id']> {
+    const uid = requireUid(auth.currentUser?.uid);
+    const text = input.text.trim();
+    if (!text || text.length > 20_000) throw new ServiceError('invalid-input', 'Message must be 1–20,000 characters');
+    try {
+      const reference = await addDoc(messageCollection(input.conversationId), {
+        ownerUid: uid,
+        conversationId: input.conversationId,
+        role: 'assistant',
+        text,
+        createdAt: serverTimestamp(),
+        clientMessageId: input.clientMessageId,
+        thoughts: input.thoughts?.trim() || null,
+        model: input.model ?? 'gemini-2.5-flash',
+        finishReason: input.finishReason ?? 'stop',
+        inputTokenCount: input.inputTokenCount ?? null,
+        outputTokenCount: input.outputTokenCount ?? null,
+        schemaVersion: 1,
+      });
+      // Fan out a backend notification request now that the reply is persisted.
+      // Best-effort and fire-and-forget: the message is already saved, so a
+      // notify failure must not surface as an append failure.
+      void this.notifyAssistantReply(uid, input.conversationId, text);
+      return asMessageId(reference.id);
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+
+  /**
+   * Write `/notify/{uid}/{pushId}` in Realtime Database. The create fires the
+   * `notifyOnAssistantReply` Cloud Function, which reads the owner's saved
+   * `fcmToken` (admin SDK) and sends the OS notification through Cloud
+   * Messaging — routed to a hidden tab's background handler.
+   */
+  private async notifyAssistantReply(uid: string, conversationId: string, text: string): Promise<void> {
+    try {
+      const conversation = await getDoc(doc(db, 'conversations', conversationId));
+      const title = (conversation.data()?.title as string | undefined) ?? 'PyChat';
+      await push(ref(rtdb, `notify/${uid}`), {
+        title,
+        body: text.slice(0, 80),
+        conversationId,
+        createdAt: rtdbServerTimestamp(),
+      });
+    } catch {
+      // The reply is already persisted; the notification is non-critical.
+    }
+  }
+
+  observeRecent(conversationId: string, callback: (messages: Message[]) => void): () => void {
+    const uid = requireUid(auth.currentUser?.uid);
+    const messageQuery = query(messageCollection(conversationId), where('ownerUid', '==', uid), orderBy('createdAt', 'desc'), limit(50));
+    return onSnapshot(messageQuery, (snapshot) => callback(snapshot.docs.map(toMessage).reverse()));
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/notification-display.ts
+++ b/packages/create-pyric/templates/chat/src/services/notification-display.ts
@@ -1,0 +1,16 @@
+type NotificationConstructor = new (title: string, options?: NotificationOptions) => Notification;
+type NotificationRegistration = Pick<ServiceWorkerRegistration, 'showNotification'>;
+
+/** Prefer the persistent service-worker display surface used by production FCM. */
+export async function showPersistentNotification(
+  registration: NotificationRegistration | null,
+  title: string,
+  options: NotificationOptions,
+  fallback: NotificationConstructor | undefined = globalThis.Notification,
+): Promise<void> {
+  if (registration) {
+    await registration.showNotification(title, options);
+    return;
+  }
+  if (fallback) new fallback(title, options);
+}

--- a/packages/create-pyric/templates/chat/src/services/notification-permission.ts
+++ b/packages/create-pyric/templates/chat/src/services/notification-permission.ts
@@ -1,0 +1,13 @@
+type NotificationPermissionApi = Pick<typeof Notification, 'permission' | 'requestPermission'>;
+
+/** Resolve whether this page may construct native OS notifications. */
+export async function requestNotificationPermission(
+  notificationApi: NotificationPermissionApi | undefined = globalThis.Notification,
+): Promise<boolean> {
+  if (!notificationApi || notificationApi.permission === 'denied') return false;
+  if (notificationApi.permission === 'granted') return true;
+  if (notificationApi.permission === 'default') {
+    return (await notificationApi.requestPermission()) === 'granted';
+  }
+  return false;
+}

--- a/packages/create-pyric/templates/chat/src/services/notification-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/notification-service.ts
@@ -1,0 +1,95 @@
+import { getMessaging, getToken, isSupported, onMessage, type GetTokenOptions, type Messaging, type MessagePayload } from 'firebase/messaging';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db, firebaseApp } from '../firebase/app';
+import { type NotificationMessage, ServiceError } from '../firebase/types';
+import { showPersistentNotification } from './notification-display';
+import { requestNotificationPermission } from './notification-permission';
+import messagingWorkerUrl from '../firebase-messaging-sw.ts?worker&url';
+
+// Optional in the sandbox (the local broker mints tokens without it); required
+// against production Firebase Cloud Messaging.
+const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY as string | undefined;
+
+const toMessage = (payload: MessagePayload): NotificationMessage => ({
+  title: payload.notification?.title ?? 'PyChat',
+  body: payload.notification?.body ?? null,
+  data: payload.data ?? {},
+});
+
+export class NotificationService {
+  private messaging: Messaging | null = null;
+  private foregroundRegistered = false;
+  private onForeground: ((message: NotificationMessage) => void) | null = null;
+  private displayRegistration: ServiceWorkerRegistration | null = null;
+
+  private async nativeDisplayRegistration(): Promise<ServiceWorkerRegistration | null> {
+    if (this.displayRegistration) return this.displayRegistration;
+    if (!('serviceWorker' in navigator)) return null;
+
+    this.displayRegistration = await navigator.serviceWorker.register(
+      messagingWorkerUrl,
+      { type: 'module' },
+    );
+    await navigator.serviceWorker.ready;
+    return this.displayRegistration;
+  }
+
+  private async showNative(message: NotificationMessage): Promise<void> {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    const options: NotificationOptions = {
+      body: message.body ?? undefined,
+      tag: message.data.conversationId ?? 'pychat',
+    };
+    const registration = await this.nativeDisplayRegistration();
+    await showPersistentNotification(registration, message.title, options);
+  }
+
+  private async tokenOptions(): Promise<GetTokenOptions | undefined> {
+    const options: GetTokenOptions = {};
+    if (vapidKey) options.vapidKey = vapidKey;
+    options.serviceWorkerRegistration = await this.nativeDisplayRegistration() ?? undefined;
+
+    return Object.keys(options).length > 0 ? options : undefined;
+  }
+
+  private async handle(): Promise<Messaging | null> {
+    if (this.messaging) return this.messaging;
+    if (!(await isSupported())) return null;
+    this.messaging = getMessaging(firebaseApp);
+    return this.messaging;
+  }
+
+  /**
+   * Request notification permission, register for a token, and forward every
+   * foreground message to `onForeground`. Returns the registration token, or
+   * `null` when the browser cannot receive messages / permission was denied.
+   * The same calls run unchanged against production Firebase Cloud Messaging.
+   */
+  async enable(onForeground: (message: NotificationMessage) => void): Promise<string | null> {
+    const messaging = await this.handle();
+    if (!messaging) return null;
+    if (!(await requestNotificationPermission())) return null;
+    try {
+      this.onForeground = onForeground;
+      const token = await getToken(messaging, await this.tokenOptions());
+      const uid = auth.currentUser?.uid;
+      // Persist the token so the notify trigger can read it via the admin SDK.
+      if (uid) await setDoc(doc(db, 'users', uid), { fcmToken: token }, { merge: true });
+      if (!this.foregroundRegistered) {
+        onMessage(messaging, (payload) => this.onForeground?.(toMessage(payload)));
+        this.foregroundRegistered = true;
+      }
+      return token;
+    } catch (error) {
+      throw new ServiceError('network', 'Could not register for notifications', error);
+    }
+  }
+
+  async showEnabledConfirmation(): Promise<void> {
+    await this.showNative({
+      title: 'PyChat notifications enabled',
+      body: 'Minimize PyChat to receive assistant reply alerts.',
+      data: { conversationId: 'pychat-enabled' },
+    });
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/presence-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/presence-service.ts
@@ -1,0 +1,68 @@
+import { onValue, ref, serverTimestamp, set } from 'firebase/database';
+import { auth, rtdb } from '../firebase/app';
+import { asUserId, type AuthUser, type PresenceEntry, type PresenceRecord, ServiceError } from '../firebase/types';
+import { requireUid } from './firestore-helpers';
+
+const mapRtdbError = (error: unknown): ServiceError => {
+  const code = typeof error === 'object' && error && 'code' in error ? String(error.code) : '';
+  if (code.includes('PERMISSION_DENIED') || code.includes('permission-denied')) {
+    return new ServiceError('forbidden', 'The presence write is not allowed', error);
+  }
+  return new ServiceError('network', 'The Realtime Database operation failed', error);
+};
+
+const presenceRef = (uid: string) => ref(rtdb, `presence/${uid}`);
+
+const toEntry = (uid: string, record: Partial<PresenceRecord> | null): PresenceEntry | null =>
+  record && (record.state === 'online' || record.state === 'offline')
+    ? { uid: asUserId(uid), state: record.state, displayName: record.displayName ?? null }
+    : null;
+
+export class PresenceService {
+  /**
+   * Publish the signed-in user as online. The initial `set` creates
+   * `/presence/{uid}` the first time a user comes online, which is what
+   * fires the `onPresenceOnline` Cloud Function.
+   *
+   * In a production build we also register a real `onDisconnect` so the node
+   * flips to offline when the socket drops. `onDisconnect` is not part of the
+   * sandbox's Realtime Database surface yet (RTDB support is incomplete), so
+   * under `vite dev` we rely on the explicit `goOffline` writes below.
+   */
+  async goOnline(user: AuthUser): Promise<void> {
+    const uid = requireUid(user.uid);
+    try {
+      const reference = presenceRef(uid);
+      if (import.meta.env.PROD) {
+        const { onDisconnect } = await import('firebase/database');
+        await onDisconnect(reference).set({ state: 'offline', displayName: user.displayName, at: serverTimestamp() });
+      }
+      await set(reference, { state: 'online', displayName: user.displayName, at: serverTimestamp() });
+    } catch (error) {
+      throw mapRtdbError(error);
+    }
+  }
+
+  async goOffline(): Promise<void> {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    try {
+      await set(presenceRef(uid), { state: 'offline', displayName: auth.currentUser?.displayName ?? null, at: serverTimestamp() });
+    } catch (error) {
+      throw mapRtdbError(error);
+    }
+  }
+
+  /** Observe every presence node; the callback receives the online members. */
+  observe(callback: (online: PresenceEntry[]) => void): () => void {
+    requireUid(auth.currentUser?.uid);
+    return onValue(ref(rtdb, 'presence'), (snapshot) => {
+      const entries: PresenceEntry[] = [];
+      snapshot.forEach((child) => {
+        const entry = toEntry(child.key ?? '', child.val() as Partial<PresenceRecord> | null);
+        if (entry && entry.state === 'online') entries.push(entry);
+      });
+      callback(entries);
+    });
+  }
+}

--- a/packages/create-pyric/templates/chat/src/services/user-service.ts
+++ b/packages/create-pyric/templates/chat/src/services/user-service.ts
@@ -1,0 +1,30 @@
+import { doc, getDoc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase/app';
+import { asUserId, type AuthUser, type UserDocument, ServiceError } from '../firebase/types';
+import { mapFirestoreError } from './firestore-helpers';
+
+export class UserService {
+  async provision(user: AuthUser): Promise<void> {
+    try {
+      const reference = doc(db, 'users', user.uid);
+      if ((await getDoc(reference)).exists()) {
+        await updateDoc(reference, {
+          displayName: user.displayName,
+          photoURL: user.photoURL,
+          updatedAt: serverTimestamp(),
+        });
+      } else {
+        await setDoc(reference, {
+          uid: user.uid,
+          displayName: user.displayName,
+          photoURL: user.photoURL,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+          disabledAt: null,
+        } as Partial<UserDocument>);
+      }
+    } catch (error) {
+      throw mapFirestoreError(error);
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/src/typeset.css
+++ b/packages/create-pyric/templates/chat/src/typeset.css
@@ -1,0 +1,490 @@
+/*
+ * shadcn/typeset
+ * https://ui.shadcn.com/docs/typeset.
+ */
+
+@layer components {
+  .typeset {
+    --typeset-font-body: inherit;
+    --typeset-font-heading: var(--font-heading);
+    --typeset-font-mono: var(--font-mono);
+    --typeset-size: 1em;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+  }
+}
+
+@layer components {
+  .typeset {
+    font-family: var(--typeset-font-body);
+    font-size: calc(var(--typeset-size) * 1.125);
+    line-height: var(--typeset-leading);
+    color: var(--color-foreground, currentColor);
+    overflow-wrap: break-word;
+    margin-trim: block-start;
+
+    @media (min-width: 48rem), print {
+      font-size: var(--typeset-size);
+    }
+
+    --typeset-muted: var(
+      --color-muted-foreground,
+      color-mix(in oklab, currentColor 60%, transparent)
+    );
+    --typeset-rule: var(
+      --color-border,
+      color-mix(in oklab, currentColor 20%, transparent)
+    );
+  }
+
+  .typeset
+    *:not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    /* Paragraphs. */
+    &:where(p) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Headings. */
+    &:where(h1, h2, h3, h4, h5, h6) {
+      color: var(--color-foreground, currentColor);
+      font-family: var(--typeset-font-heading);
+      font-weight: 600;
+      margin-block-end: 0;
+    }
+    &:where(h1) {
+      font-size: 1.75em;
+      line-height: 1.3;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h2) {
+      font-size: 1.25em;
+      line-height: 1.4;
+      margin-block-start: calc(var(--typeset-flow) * 1.4);
+    }
+    &:where(h3) {
+      font-size: 1.125em;
+      line-height: 1.45;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h4) {
+      font-size: 1em;
+      line-height: 1.5;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h5) {
+      font-size: 0.875em;
+      line-height: 1.5;
+      font-weight: 500;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+    }
+    &:where(h6) {
+      font-size: 0.8125em;
+      line-height: 1.5;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.8125);
+    }
+    /* Anchors. */
+    &:where([id]) {
+      scroll-margin-block-start: var(--typeset-flow);
+    }
+
+    /* Headings own the space below them. */
+    &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
+      margin-block-start: 1em;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(code)) {
+      font-size: 0.9em;
+    }
+
+    /* Links. */
+    &:where(a) {
+      color: inherit;
+      font-weight: 500;
+      text-decoration-line: underline;
+      text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+    }
+    &:where(a:hover) {
+      text-decoration-color: currentColor;
+    }
+    &:where(a:focus-visible) {
+      outline: 2px solid var(--color-ring, currentColor);
+      outline-offset: 2px;
+      border-radius: 0.125em;
+    }
+    &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
+      font-weight: inherit;
+    }
+
+    /* Inline semantics. */
+    &:where(strong, b) {
+      font-weight: 600;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
+      font-weight: 600;
+    }
+    &:where(mark) {
+      background-color: color-mix(
+        in oklab,
+        oklch(0.86 0.17 95) 40%,
+        transparent
+      );
+      color: inherit;
+      padding: 0.05em 0.15em;
+      border-radius: 0.2em;
+    }
+    &:where(abbr[title]) {
+      text-decoration-line: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 0.2em;
+      cursor: help;
+    }
+    &:where(del, s) {
+      color: var(--typeset-muted);
+      text-decoration-line: line-through;
+    }
+    &:where(sup, sub) {
+      font-size: 0.75em;
+      line-height: 0;
+      position: relative;
+      vertical-align: baseline;
+    }
+    &:where(sup) {
+      top: -0.5em;
+    }
+    &:where(sub) {
+      bottom: -0.25em;
+    }
+    &:where(sup a) {
+      text-decoration-line: none;
+      font-weight: 500;
+    }
+
+    /* Lists. */
+    &:where(ul) {
+      list-style-type: disc;
+    }
+    &:where(ol) {
+      list-style-type: decimal;
+    }
+    &:where(ul ul) {
+      list-style-type: circle;
+    }
+    &:where(ul ul ul) {
+      list-style-type: square;
+    }
+    &:where(ol[type="a" i]) {
+      list-style-type: lower-alpha;
+    }
+    &:where(ol[type="i" i]) {
+      list-style-type: lower-roman;
+    }
+    &:where(ol[type="A" s]) {
+      list-style-type: upper-alpha;
+    }
+    &:where(ol[type="I" s]) {
+      list-style-type: upper-roman;
+    }
+    &:where(ul, ol) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      padding-inline-start: 1.5em;
+    }
+    &:where(li) {
+      margin-block-start: 0.5em;
+      padding-inline-start: 0.4em;
+    }
+    &:where(li > p, li > ul, li > ol) {
+      margin-block-start: 0.5em;
+    }
+    &:where(ul > li)::marker {
+      color: var(--typeset-muted);
+    }
+    &:where(ol > li)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* GFM task lists. */
+    &:where(ul.contains-task-list) {
+      list-style-type: none;
+      padding-inline-start: 0.25em;
+    }
+    &:where(li.task-list-item > input[type="checkbox"]) {
+      margin-inline-end: 0.5em;
+      vertical-align: -0.1em;
+      accent-color: var(--color-primary, currentColor);
+    }
+
+    /* Disclosures. */
+    &:where(details) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(summary) {
+      cursor: pointer;
+      font-weight: 500;
+    }
+    &:where(summary)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* Keyboard keys. */
+    &:where(kbd) {
+      font-family: inherit;
+      font-size: 0.85em;
+      font-weight: 500;
+      border: 1px solid var(--typeset-rule);
+      border-block-end-width: 2px;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.0625em 0.35em;
+    }
+
+    /* Definition lists. */
+    &:where(dl) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(dt) {
+      font-weight: 500;
+      margin-block-start: 1em;
+    }
+    &:where(dt + dt) {
+      margin-block-start: 0.25em;
+    }
+    &:where(dd) {
+      margin-block-start: 0.25em;
+      margin-inline-start: 0;
+      padding-inline-start: 1em;
+      color: var(--typeset-muted);
+    }
+
+    /* Inline code. */
+    &:where(:not(pre) > code) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.85em;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.125em 0.3em;
+    }
+
+    /* Code blocks. */
+    &:where(pre) {
+      background-color: var(
+        --color-muted,
+        color-mix(in oklab, currentColor 8%, transparent)
+      );
+      font-family: var(--typeset-font-mono);
+      font-size: 0.875em;
+      line-height: 1.5;
+      tab-size: 2;
+      direction: ltr;
+      border-radius: var(--radius, 0.5em);
+      padding: 0.75em 1em;
+      overflow-x: auto;
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+      margin-block-end: 0;
+    }
+    &:where(pre code) {
+      background-color: transparent;
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    /* Blockquote. */
+    &:where(blockquote) {
+      border-inline-start: 2px solid var(--typeset-rule);
+      padding-inline-start: 1em;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+
+    /* Dividers. */
+    &:where(hr) {
+      border: 0;
+      border-block-start: 1px solid var(--typeset-rule);
+      margin-block-start: calc(var(--typeset-flow) * 2.4);
+      margin-block-end: 0;
+    }
+    &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
+      margin-block-start: var(--typeset-flow);
+    }
+
+    /* GFM footnotes. */
+    &:where(.footnotes, [data-footnotes]) {
+      margin-block-start: calc(var(--typeset-flow) * 2);
+      border-block-start: 1px solid var(--typeset-rule);
+      padding-block-start: var(--typeset-flow);
+      font-size: 0.875em;
+      color: var(--typeset-muted);
+    }
+
+    /* Math. */
+    &:where(math[display="block"]) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-block: 0.25em;
+    }
+
+    /* Media. */
+    &:where(img, video) {
+      border-radius: var(--radius, 0.5em);
+      max-width: 100%;
+      height: auto;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(p img) {
+      margin-block-start: 0;
+    }
+    &:where(figure) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+    &:where(figcaption, caption) {
+      color: var(--typeset-muted);
+      font-size: 0.875em;
+      text-align: center;
+      margin-block-start: calc(0.75em / 0.875);
+    }
+    &:where(caption) {
+      caption-side: bottom;
+    }
+
+    /* Tables. Separators sit on cells, not tr:last-child: append-safe.
+       Bare tables stay real tables (keep their semantics) and wrap to fit. */
+    &:where(table) {
+      max-width: 100%;
+      font-size: 1em;
+      line-height: 1.5;
+      font-variant-numeric: tabular-nums;
+      border-collapse: separate;
+      border-spacing: 0;
+      border-block-end: 1px solid var(--typeset-rule);
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
+       flow margin. Tables shrink to fit, so widen the table to make it scroll
+       instead of compress. */
+    &:where(.typeset-scroll) {
+      overflow-x: auto;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(.typeset-scroll > *) {
+      margin-block-start: 0;
+    }
+    &:where(.typeset-scroll table) {
+      width: max-content;
+      max-width: none;
+    }
+    &:where(thead th) {
+      font-weight: 500;
+      text-align: start;
+      white-space: nowrap;
+      padding: 0.65em 1em;
+    }
+    &:where(:is(tbody, tfoot) :is(td, th)) {
+      padding: 0.75em 1em;
+      text-align: start;
+      vertical-align: top;
+      border-block-start: 1px solid var(--typeset-rule);
+    }
+    &:where(tbody th, tfoot th) {
+      font-weight: 500;
+    }
+    &:where(th:first-child, td:first-child) {
+      padding-inline-start: 0;
+    }
+    &:where(th[align="center"], td[align="center"]) {
+      text-align: center;
+    }
+    &:where(th[align="right"], td[align="right"]) {
+      text-align: end;
+    }
+
+    /* Blocks inside list items keep the list's tighter rhythm. */
+    &:where(li > blockquote, li > table, li > figure) {
+      margin-block-start: 0.5em;
+    }
+    &:where(li > pre) {
+      margin-block-start: calc(0.5em / 0.875);
+    }
+
+    @media print {
+      &:where(pre, table, blockquote, figure) {
+        break-inside: avoid;
+      }
+      &:where(h1, h2, h3, h4) {
+        break-after: avoid;
+      }
+    }
+
+    /* Forced colors strips the code background, so give it a border. */
+    @media (forced-colors: active) {
+      &:where(:not(pre) > code) {
+        border: 1px solid;
+      }
+    }
+  }
+
+  /* First child adds no space above. Last so it wins ties. */
+  .typeset
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    > :where(:first-child)
+    > :where(:first-child):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ),
+  .typeset
+    :where(
+      li > :first-child,
+      blockquote > :first-child,
+      td > :first-child,
+      th > :first-child,
+      dd > :first-child,
+      figure > :first-child,
+      figure > picture > img
+    ):not(
+      :where(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block-start: 0;
+  }
+}

--- a/packages/create-pyric/templates/chat/src/ui/app.tsx
+++ b/packages/create-pyric/templates/chat/src/ui/app.tsx
@@ -1,0 +1,8 @@
+import { ChatPage } from './chat/chat-page';
+import { createFirebaseChatGateway } from './chat/firebase-chat-gateway';
+
+const services = createFirebaseChatGateway();
+
+export function App() {
+  return <ChatPage services={services} />;
+}

--- a/packages/create-pyric/templates/chat/src/ui/chat/chat-page.tsx
+++ b/packages/create-pyric/templates/chat/src/ui/chat/chat-page.tsx
@@ -1,0 +1,598 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as React from 'react';
+import * as jsxRuntime from 'react/jsx-runtime';
+import * as jsxDevRuntime from 'react/jsx-dev-runtime';
+import { createElement, isValidElement, type ComponentType } from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowUp, Bell, Check, CheckCircle2, ChevronsUpDown, Code2, Copy, LoaderCircle, LogIn, LogOut, MessageSquarePlus, PanelLeftClose, PanelLeftOpen, Square, TerminalSquare, Trash2, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Message, MessageAvatar, MessageContent, MessageFooter, MessageGroup, MessageHeader } from '@/components/ui/message';
+import { MessageScroller, MessageScrollerButton, MessageScrollerContent, MessageScrollerItem, MessageScrollerProvider, MessageScrollerViewport, useMessageScroller, useMessageScrollerScrollable } from '@/components/ui/message-scroller';
+import type { ChatPageServices, UiConversation, UiMessage, UiNotification, UiPresence, UiToolCall, UiUsage, UiUser } from './chat-types';
+import type { ChatMode } from '../../chat-mode';
+import { MarkdownMessage } from './markdown-message';
+import { storePreviewComponent } from './preview-component-state';
+
+const starterMessages: UiMessage[] = [{ id: 'welcome', role: 'assistant', text: 'Good morning. What would you like to work through?', status: 'complete' }];
+
+const initials = (user: UiUser | null): string =>
+  (user?.displayName ?? user?.email ?? 'You').split(' ').map((part) => part[0]).join('').slice(0, 2).toUpperCase();
+
+const formatTime = (date?: Date): string => date ? new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(date) : '';
+const errorMessage = (reason: unknown, fallback: string): string => reason instanceof Error ? reason.message : fallback;
+const isAbort = (reason: unknown): boolean => reason instanceof DOMException && reason.name === 'AbortError';
+const modeOptions: Array<{ id: ChatMode; label: string; description: string; placeholder: string }> = [
+  { id: 'explore', label: 'Explore', description: 'Open possibilities', placeholder: 'Explore an idea…' },
+  { id: 'plan', label: 'Plan', description: 'Make it actionable', placeholder: 'Turn an idea into a plan…' },
+  { id: 'refine', label: 'Refine', description: 'Pressure-test a direction', placeholder: 'Pressure-test a direction…' },
+];
+const chronological = (items: UiMessage[]): UiMessage[] => [...items].sort((a, b) => {
+  if (!a.createdAt || !b.createdAt) return 0;
+  return a.createdAt.getTime() - b.createdAt.getTime();
+});
+
+const conversationIdFromUrl = (): string | null => new URLSearchParams(window.location.search).get('conversation');
+
+const writeConversationUrl = (conversationId: string | null, replace = false): void => {
+  const url = new URL(window.location.href);
+  if (conversationId) url.searchParams.set('conversation', conversationId);
+  else url.searchParams.delete('conversation');
+  window.history[replace ? 'replaceState' : 'pushState']({}, '', `${url.pathname}${url.search}${url.hash}`);
+};
+
+const reconcileMessages = (serverMessages: UiMessage[], currentMessages: UiMessage[]): UiMessage[] => {
+  const seenServerMessages = new Set<string>();
+  const server = chronological(serverMessages).filter((message) => {
+    if (!message.clientMessageId) return true;
+    const key = `${message.role}:${message.clientMessageId}`;
+    if (seenServerMessages.has(key)) return false;
+    seenServerMessages.add(key);
+    return true;
+  });
+  const serverClientIds = new Set(server.map((message) => message.clientMessageId).filter(Boolean));
+  const localAssistants = currentMessages.filter((message) => message.role === 'assistant' && message.id !== 'welcome');
+  const persistedAssistantIds = new Set(server.filter((message) => message.role === 'assistant').map((message) => message.clientMessageId).filter(Boolean));
+  const linkedAssistants = new Set<string>();
+  const result: UiMessage[] = [];
+
+  const addReply = (message: UiMessage) => {
+    for (const assistant of localAssistants) {
+      if (assistant.replyToClientMessageId === message.clientMessageId && !persistedAssistantIds.has(assistant.id)) {
+        result.push(assistant);
+        linkedAssistants.add(assistant.id);
+      }
+    }
+  };
+
+  for (const message of server) {
+    result.push(message);
+    if (message.role === 'user') addReply(message);
+  }
+
+  for (const message of currentMessages) {
+    if (message.role === 'user' && message.clientMessageId && !serverClientIds.has(message.clientMessageId)) {
+      result.push(message);
+      addReply(message);
+    }
+  }
+
+  result.push(...localAssistants.filter((message) => !linkedAssistants.has(message.id) && !message.replyToClientMessageId));
+
+  const turnKey = (message: UiMessage): string => {
+    if (message.role === 'assistant') {
+      if (message.replyToClientMessageId) return message.replyToClientMessageId;
+      if (message.clientMessageId?.startsWith('assistant-')) return message.clientMessageId.slice('assistant-'.length);
+    }
+    return message.clientMessageId ?? message.id;
+  };
+  const turnOrder = new Map<string, number>();
+  result.forEach((message, index) => {
+    const key = turnKey(message);
+    if (!turnOrder.has(key)) turnOrder.set(key, index);
+  });
+  return result.length ? [...result].sort((a, b) => {
+    const orderDifference = (turnOrder.get(turnKey(a)) ?? 0) - (turnOrder.get(turnKey(b)) ?? 0);
+    if (orderDifference !== 0) return orderDifference;
+    if (a.role === 'user' && b.role !== 'user') return -1;
+    if (a.role !== 'user' && b.role === 'user') return 1;
+    return 0;
+  }) : starterMessages;
+};
+
+function CopyMessageButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Button variant="ghost" size="icon-xs" aria-label={copied ? 'Message copied' : 'Copy message'} title={copied ? 'Message copied' : 'Copy message'} onClick={() => void copy()} disabled={!text}>
+      {copied ? <Check /> : <Copy />}
+    </Button>
+  );
+}
+
+function StartPlanCard({ onStart, onDecline, onSendDirection }: { onStart: () => void; onDecline: () => void; onSendDirection: (direction: string) => void }) {
+  const [editing, setEditing] = useState(false);
+  const [direction, setDirection] = useState('');
+
+  const sendDirection = () => {
+    const value = direction.trim();
+    if (!value) return;
+    onSendDirection(value);
+  };
+
+  return (
+    <section aria-label="Start plan" className="mt-2 max-w-full rounded-lg border border-primary/30 bg-primary/5 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Ready to start the plan?</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">PyChat can turn this direction into the first actionable step.</p>
+        </div>
+        <span className="shrink-0 rounded-md bg-primary/10 px-2 py-1 text-[11px] font-medium text-primary">Plan</span>
+      </div>
+      {editing && <textarea value={direction} onChange={(event) => setDirection(event.target.value)} onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendDirection(); }} autoFocus rows={2} placeholder="Tell PyChat what to change…" aria-label="What should PyChat change?" className="mt-3 w-full resize-y rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50" />}
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <Button size="sm" onClick={onStart}>Start plan</Button>
+        {editing ? <Button size="sm" variant="secondary" onClick={sendDirection} disabled={!direction.trim()}>Send direction</Button> : <Button size="sm" variant="outline" onClick={() => setEditing(true)}>Tell PyChat what to change</Button>}
+        <Button size="sm" variant="ghost" onClick={onDecline}>Decline</Button>
+      </div>
+    </section>
+  );
+}
+
+function ToolActivity({ calls }: { calls: UiToolCall[] }) {
+  if (!calls.length) return null;
+  return (
+    <Collapsible className="mb-1 min-w-0 w-full max-w-full rounded-lg border bg-background/40 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="flex min-w-0 items-center gap-2 text-xs font-medium text-muted-foreground"><TerminalSquare className="size-3.5 shrink-0" /> Workspace activity <span className="font-normal">· {calls.length}</span></span>
+        <CollapsibleTrigger render={<Button variant="ghost" size="icon" className="size-7" />} aria-label="Toggle workspace activity"><ChevronsUpDown /></CollapsibleTrigger>
+      </div>
+      <CollapsibleContent className="space-y-1.5 pt-2">
+        {calls.map((call) => <div key={call.id} className="flex min-w-0 items-center gap-2 text-xs"><span className="shrink-0 text-muted-foreground">{call.status === 'running' ? <LoaderCircle className="size-3.5 animate-spin" /> : call.status === 'complete' ? <CheckCircle2 className="size-3.5 text-primary" /> : <XCircle className="size-3.5 text-destructive" />}</span><span className="truncate font-mono">{call.name}</span><span className="truncate text-muted-foreground">{call.summary ?? (call.status === 'running' ? 'Running…' : '')}</span></div>)}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function UsageSummary({ usage }: { usage?: UiUsage }) {
+  if (!usage) return null;
+  const total = usage.inputTokens + usage.outputTokens;
+  return <span className="inline-flex items-center gap-1.5"><span>{total.toLocaleString()} tokens</span>{usage.reasoningTokens ? <span>· {usage.reasoningTokens.toLocaleString()} thinking</span> : null}</span>;
+}
+
+function ThoughtsDisclosure({ thoughts, streaming }: { thoughts: string; streaming: boolean }) {
+  return (
+    <Collapsible defaultOpen={streaming} className="mb-1 min-w-0 w-full max-w-full rounded-lg border border-dashed bg-muted/30 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium text-muted-foreground">Thoughts</span>
+        <CollapsibleTrigger render={<Button variant="ghost" size="icon" className="size-7" />} aria-label="Toggle thoughts">
+          <ChevronsUpDown />
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent className="pt-2">
+        <MarkdownMessage content={thoughts} className="max-w-full text-xs leading-5 text-muted-foreground" />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function StreamingFollow({ revision, streaming }: { revision: string; streaming: boolean }) {
+  const { end } = useMessageScrollerScrollable();
+  const { scrollToEnd } = useMessageScroller();
+  const followingRef = useRef(true);
+
+  useEffect(() => {
+    if (!streaming) {
+      followingRef.current = true;
+      return;
+    }
+    if (!end) followingRef.current = false;
+  }, [end, streaming]);
+
+  useEffect(() => {
+    if (!streaming || !followingRef.current) return;
+    const frame = window.requestAnimationFrame(() => scrollToEnd());
+    return () => window.cancelAnimationFrame(frame);
+  }, [revision, scrollToEnd, streaming]);
+
+  return null;
+}
+
+class PreviewErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: string | null }> {
+  state: { error: string | null } = { error: null };
+  static getDerivedStateFromError(error: unknown) {
+    return { error: error instanceof Error ? error.message : 'The preview component threw while rendering.' };
+  }
+  render() {
+    return this.state.error
+      ? <div className="p-4 text-xs text-destructive">Runtime error: {this.state.error}</div>
+      : this.props.children;
+  }
+}
+
+// Turn the module's default export into something renderable, INSIDE the error
+// boundary: a function component is instantiated, an already-built element is
+// rendered as-is, and anything else throws so the boundary shows the reason
+// instead of the whole page crashing. Doing the createElement here (not in the
+// parent's render) keeps a bad export from escaping the boundary.
+function PreviewHost({ node }: { node: unknown }): React.ReactNode {
+  if (isValidElement(node)) return node;
+  if (typeof node === 'function') return createElement(node as ComponentType);
+  throw new Error('The default export is not a React component. Export default a function that returns JSX.');
+}
+
+function WorkspacePreview({ services, revision, onClose }: { services: ChatPageServices; revision: number; onClose: () => void }) {
+  const [source, setSource] = useState('');
+  const [component, setComponent] = useState<unknown>(null);
+  const [diagnostics, setDiagnostics] = useState<Array<{ message: string; line?: number; column?: number }>>([]);
+  const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+
+  // The preview renders through a portal into this iframe's document body: the
+  // component stays in the parent React tree (StrictMode and lifecycle handled
+  // by the app's root — the cross-realm createRoot mount silently failed), but
+  // its DOM lives in a separate document, isolated from the app. Mirror the
+  // host stylesheets in so framework CSS (Tailwind) still applies.
+  const handleFrameLoad = () => {
+    const doc = frameRef.current?.contentDocument;
+    if (!doc) return;
+    doc.head.querySelectorAll('[data-preview-style]').forEach((node) => node.remove());
+    document.querySelectorAll('style, link[rel="stylesheet"]').forEach((node) => {
+      const clone = node.cloneNode(true) as HTMLElement;
+      clone.setAttribute('data-preview-style', '');
+      doc.head.appendChild(clone);
+    });
+    setFrameBody(doc.body);
+  };
+
+  useEffect(() => {
+    let alive = true;
+    void services.workspace.readAppSource().then((nextSource) => { if (alive) setSource(nextSource); }).catch((reason: unknown) => { if (alive) setDiagnostics([{ message: reason instanceof Error ? reason.message : 'Could not read the workspace app' }]); });
+    return () => { alive = false; };
+  }, [revision, services]);
+
+  useEffect(() => {
+    let alive = true;
+    if (!source) return;
+    void services.workspace.previewApp(source, { react: React as unknown as Record<string, unknown>, jsxRuntime: jsxRuntime as unknown as Record<string, unknown>, jsxDevRuntime: jsxDevRuntime as unknown as Record<string, unknown> }).then((result) => {
+      if (!alive) return;
+      const exported = result.ok ? result.component : null;
+      if (result.ok && (typeof exported === 'function' || isValidElement(exported))) { storePreviewComponent(setComponent, exported); setDiagnostics([]); }
+      else { setComponent(null); setDiagnostics([{ message: 'Preview compiled, but the default export is not a React component. Export default a function that returns JSX (e.g. export default function App() { return <h1>Hi</h1>; }).' }]); }
+    }).catch((reason: unknown) => { if (alive) { setComponent(null); setDiagnostics([{ message: reason instanceof Error ? reason.message : 'Could not compile the workspace app' }]); } });
+    return () => { alive = false; };
+  }, [services, source]);
+
+  return <aside className="absolute inset-y-0 end-0 z-30 flex w-full max-w-xl flex-col border-s bg-card shadow-2xl lg:relative lg:inset-auto lg:w-[min(34rem,42vw)] lg:shadow-none" aria-label="Workspace preview"><header className="flex h-16 shrink-0 items-center gap-3 border-b px-4"><Code2 className="size-4 text-primary" /><div className="min-w-0 flex-1"><p className="text-sm font-semibold">Workspace</p><p className="truncate text-xs text-muted-foreground">/work/src/App.tsx · live preview</p></div><Button variant="ghost" size="icon" aria-label="Close workspace" onClick={onClose}><XCircle /></Button></header><div className="flex min-h-0 flex-1 flex-col gap-3 p-3"><div className="flex items-center justify-between text-xs text-muted-foreground"><span>Live preview of your default export</span><span>{diagnostics.length ? `${diagnostics.length} issue${diagnostics.length === 1 ? '' : 's'}` : component ? 'Ready' : 'Compiling…'}</span></div><div className="min-h-0 flex-1 overflow-hidden rounded-lg border bg-background">{diagnostics.length ? <div className="space-y-2 p-4 text-xs text-destructive">{diagnostics.map((diagnostic, index) => <p key={`${diagnostic.message}-${index}`}>{diagnostic.line ? `${diagnostic.line}:${diagnostic.column ?? 1} ` : ''}{diagnostic.message}</p>)}</div> : <><iframe ref={frameRef} title="Workspace app preview" sandbox="allow-scripts allow-same-origin" srcDoc="<!doctype html><html><head><style>html,body{margin:0;min-height:100%;box-sizing:border-box}body{padding:16px}</style></head><body></body></html>" onLoad={handleFrameLoad} className="size-full border-0" />{frameBody && component ? createPortal(<PreviewErrorBoundary key={source}><PreviewHost node={component} /></PreviewErrorBoundary>, frameBody) : null}</>}</div></div></aside>;
+}
+
+type ChatPageProps = { services: ChatPageServices };
+
+export function ChatPage({ services }: ChatPageProps) {
+  const [user, setUser] = useState<UiUser | null>(() => services.auth.currentUser());
+  const [authLoading, setAuthLoading] = useState(true);
+  const [conversationLoading, setConversationLoading] = useState(false);
+  const [messageLoading, setMessageLoading] = useState(false);
+  const [conversations, setConversations] = useState<UiConversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(() => conversationIdFromUrl());
+  const [messages, setMessages] = useState<UiMessage[]>(starterMessages);
+  const [draft, setDraft] = useState('');
+  const [mode, setMode] = useState<ChatMode>('explore');
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [deletingConversationId, setDeletingConversationId] = useState<string | null>(null);
+  const [planReadyMessageId, setPlanReadyMessageId] = useState<string | null>(null);
+  const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [workspaceRevision, setWorkspaceRevision] = useState(0);
+  const [online, setOnline] = useState<UiPresence[]>([]);
+  const [notice, setNotice] = useState<UiNotification | null>(null);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+  const [notificationsBusy, setNotificationsBusy] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const messagesRef = useRef(messages);
+  const activeConversationIdRef = useRef(activeConversationId);
+  const retryRef = useRef<(() => void) | null>(null);
+  const requestRef = useRef(0);
+
+  useEffect(() => { messagesRef.current = messages; }, [messages]);
+  useEffect(() => { activeConversationIdRef.current = activeConversationId; }, [activeConversationId]);
+
+  useEffect(() => {
+    setAuthLoading(true);
+    return services.auth.observe((nextUser) => {
+      setUser(nextUser);
+      setAuthLoading(false);
+    });
+  }, [services]);
+
+  useEffect(() => {
+    if (!user) {
+      setOnline([]);
+      return;
+    }
+    const unsubscribe = services.presence.observe(setOnline);
+    let alive = true;
+    if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+      void services.notifications.enable((message) => {
+        if (!alive) return;
+        setNotice(message);
+        window.setTimeout(() => setNotice((current) => (current === message ? null : current)), 6000);
+      }).then((enabled) => { if (alive) setNotificationsEnabled(enabled); }).catch(() => undefined);
+    }
+    return () => { alive = false; unsubscribe(); };
+  }, [services, user]);
+
+  useEffect(() => {
+    const onPopState = () => setActiveConversationId(conversationIdFromUrl());
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setSidebarOpen(false);
+    };
+    window.addEventListener('popstate', onPopState);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('popstate', onPopState);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    const request = ++requestRef.current;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    retryRef.current = null;
+    setStreaming(false);
+    setError(null);
+    if (!user) {
+      setConversations([]);
+      setActiveConversationId(null);
+      setMessages(starterMessages);
+      setConversationLoading(false);
+      setMessageLoading(false);
+      return;
+    }
+
+    setConversationLoading(true);
+    let alive = true;
+    const applyList = (nextItems: UiConversation[]) => {
+      if (!alive || request !== requestRef.current) return;
+      const items = nextItems.filter((item) => item.id !== deletingConversationId);
+      setConversations(items);
+      const currentId = activeConversationIdRef.current;
+      const nextId = currentId && items.some((item) => item.id === currentId) ? currentId : items[0]?.id ?? null;
+      activeConversationIdRef.current = nextId;
+      setActiveConversationId(nextId);
+      if (conversationIdFromUrl() !== nextId) writeConversationUrl(nextId, true);
+      setConversationLoading(false);
+    };
+    void services.conversations.list().then(applyList).catch((reason: unknown) => {
+      if (alive) { setError(errorMessage(reason, 'Could not load conversations')); setConversationLoading(false); }
+    });
+    const unsubscribe = services.conversations.observeList(applyList);
+    return () => { alive = false; unsubscribe(); };
+  }, [deletingConversationId, services, user]);
+
+  useEffect(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    retryRef.current = null;
+    setStreaming(false);
+    setPlanReadyMessageId(null);
+    setMessages(starterMessages);
+    if (!user || !activeConversationId) { setMessageLoading(false); return; }
+
+    let alive = true;
+    setMessageLoading(true);
+    const unsubscribeMessages = services.messages.observeRecent(activeConversationId, (nextMessages) => {
+      if (!alive) return;
+      setMessages((current) => reconcileMessages(nextMessages, current));
+      setMessageLoading(false);
+    });
+    const unsubscribeConversation = services.conversations.observe(activeConversationId, (conversation) => {
+      setConversations((current) => current.map((item) => item.id === conversation.id ? conversation : item));
+    });
+    return () => { alive = false; unsubscribeMessages(); unsubscribeConversation(); };
+  }, [activeConversationId, services, user]);
+
+  const activeConversation = useMemo(() => conversations.find((conversation) => conversation.id === activeConversationId), [activeConversationId, conversations]);
+  const messageRevision = useMemo(() => messages.map((message) => `${message.id}:${message.text.length}:${message.thoughts?.length ?? 0}:${message.status ?? ''}`).join('|'), [messages]);
+
+  const refreshConversations = async () => {
+    const items = await services.conversations.list();
+    setConversations((current) => {
+      const byId = new Map(current.map((item) => [item.id, item]));
+      items.forEach((item) => byId.set(item.id, item));
+      return [...byId.values()];
+    });
+  };
+
+  const startConversation = async () => {
+    if (!user || streaming) return;
+    setError(null);
+    try {
+      const id = await services.conversations.create();
+      await refreshConversations();
+      setActiveConversationId(id);
+      writeConversationUrl(id);
+    } catch (reason) { setError(errorMessage(reason, 'Could not start a conversation')); }
+  };
+
+  const selectConversation = (id: string) => {
+    if (id === activeConversationId) return;
+    abortRef.current?.abort();
+    setActiveConversationId(id);
+    writeConversationUrl(id);
+    if (window.innerWidth < 640) setSidebarOpen(false);
+  };
+
+  const deleteConversation = async (id: string) => {
+    if (!user || deletingConversationId) return;
+    const conversation = conversations.find((item) => item.id === id);
+    if (!conversation || !window.confirm(`Delete “${conversation.title}” and all its messages?`)) return;
+    setDeletingConversationId(id);
+    setError(null);
+    const deletingActive = id === activeConversationId;
+    if (deletingActive) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      retryRef.current = null;
+      setStreaming(false);
+      setMessages(starterMessages);
+      setActiveConversationId(null);
+      writeConversationUrl(null, true);
+    }
+    try {
+      await services.conversations.delete(id);
+      const remaining = conversations.filter((item) => item.id !== id);
+      setConversations(remaining);
+      if (deletingActive) {
+        const nextId = remaining[0]?.id ?? null;
+        activeConversationIdRef.current = nextId;
+        setActiveConversationId(nextId);
+        writeConversationUrl(nextId, true);
+      }
+    } catch (reason) {
+      setError(errorMessage(reason, 'Could not delete conversation'));
+    } finally {
+      setDeletingConversationId(null);
+    }
+  };
+
+  const streamAssistant = async (conversationId: string, history: Pick<UiMessage, 'role' | 'text'>[], placeholderId: string, selectedMode: ChatMode) => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStreaming(true);
+    let streamedText = '';
+    let streamedThoughts = '';
+    retryRef.current = () => {
+      void streamAssistant(conversationId, history, placeholderId, selectedMode).catch(() => undefined);
+    };
+    try {
+      const result = await services.ai.stream({ conversationId, messages: history, mode: selectedMode, signal: controller.signal }, (chunk) => {
+        streamedText += chunk;
+        setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, text: streamedText, status: 'streaming' } : message));
+      }, (thought) => {
+        streamedThoughts += thought;
+        setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, thoughts: `${message.thoughts ?? ''}${thought}`, status: 'streaming' } : message));
+      }, (tool) => {
+        setMessages((current) => current.map((message) => {
+          if (message.id !== placeholderId) return message;
+          const toolCalls = [...(message.toolCalls ?? [])];
+          const index = toolCalls.findIndex((call) => call.id === tool.id);
+          if (index === -1) toolCalls.push(tool);
+          else toolCalls[index] = { ...toolCalls[index], ...tool };
+          return { ...message, toolCalls, status: 'streaming' };
+        }));
+      }, (usage) => {
+        setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, usage } : message));
+      }, () => {
+        setWorkspaceRevision((value) => value + 1);
+        setWorkspaceOpen(true);
+      });
+      const thoughts = streamedThoughts || result.thoughts;
+      await services.messages.appendAssistantMessage({ conversationId, text: result.text || streamedText, clientMessageId: placeholderId, thoughts, model: result.model, finishReason: result.finishReason, inputTokenCount: result.inputTokenCount, outputTokenCount: result.outputTokenCount });
+      setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, text: result.text || streamedText, thoughts: thoughts ?? message.thoughts, usage: result.usage ?? message.usage, status: 'complete' } : message));
+      if (selectedMode === 'plan') setPlanReadyMessageId(placeholderId);
+      retryRef.current = null;
+    } catch (reason) {
+      const stopped = isAbort(reason);
+      const text = streamedText || (stopped ? 'Generation stopped.' : 'I could not complete that response.');
+      setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, text, status: 'error' } : message));
+      if (!stopped) setError(errorMessage(reason, 'Could not send message'));
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      setStreaming(false);
+    }
+  };
+
+  const sendMessage = async (textOverride?: string, modeOverride: ChatMode = mode) => {
+    const text = (textOverride ?? draft).trim();
+    if (!text || !user || streaming) return;
+    setDraft('');
+    textareaRef.current?.focus();
+    setError(null);
+    let conversationId = activeConversationId;
+    let placeholderId: string | null = null;
+    try {
+      if (!conversationId) {
+        conversationId = await services.conversations.create({ title: text.slice(0, 48) });
+        await refreshConversations();
+        setActiveConversationId(conversationId);
+      }
+      const clientMessageId = crypto.randomUUID();
+      const userMessage: UiMessage = { id: clientMessageId, role: 'user', text, status: 'complete', clientMessageId };
+      const history = [...messagesRef.current.filter((message) => message.id !== 'welcome' && message.status !== 'error'), userMessage];
+      const assistantPlaceholderId = `assistant-${clientMessageId}`;
+      placeholderId = assistantPlaceholderId;
+      setMessages((current) => [...current.filter((message) => message.id !== 'welcome'), userMessage, { id: assistantPlaceholderId, role: 'assistant', text: '', status: 'streaming', replyToClientMessageId: clientMessageId }]);
+      await services.messages.appendUserMessage({ conversationId, text, clientMessageId });
+      await streamAssistant(conversationId, history, assistantPlaceholderId, modeOverride);
+    } catch (reason) {
+      if (!isAbort(reason)) {
+        setError(errorMessage(reason, 'Could not send message'));
+        if (placeholderId) setMessages((current) => current.map((message) => message.id === placeholderId ? { ...message, text: 'Message could not be saved.', status: 'error' } : message));
+      }
+    }
+  };
+
+  const stopStreaming = () => abortRef.current?.abort();
+  const enableNotifications = async () => {
+    setNotificationsBusy(true);
+    setError(null);
+    try {
+      const enabled = await services.notifications.enable((message) => {
+        setNotice(message);
+        window.setTimeout(() => setNotice((current) => (current === message ? null : current)), 6000);
+      });
+      setNotificationsEnabled(enabled);
+      if (enabled) {
+        await services.notifications.showEnabledConfirmation();
+      } else if (typeof Notification !== 'undefined' && Notification.permission === 'denied') {
+        setError('Notifications are blocked for localhost. Allow them in Chrome site settings, then reload.');
+      } else if (!enabled) {
+        setError('Notifications are unavailable in this browser.');
+      }
+    } catch (reason) {
+      setError(errorMessage(reason, 'Could not enable notifications'));
+    } finally {
+      setNotificationsBusy(false);
+    }
+  };
+  const signIn = async () => { setError(null); try { await services.auth.signIn(); } catch (reason) { setError(errorMessage(reason, 'Could not sign in')); } };
+  const signOut = async () => {
+    abortRef.current?.abort();
+    setUser(null);
+    setNotificationsEnabled(false);
+    try { await services.auth.signOut(); } catch (reason) { setError(errorMessage(reason, 'Could not sign out')); }
+  };
+
+  return (
+    <main className="relative flex h-svh overflow-hidden bg-background text-foreground">
+      {sidebarOpen && <button type="button" aria-label="Close conversation sidebar" className="fixed inset-0 z-10 bg-black/25 sm:hidden" onClick={() => setSidebarOpen(false)} />}
+      <aside className={`${sidebarOpen ? 'w-72' : 'w-0'} absolute inset-y-0 start-0 z-20 flex shrink-0 flex-col overflow-hidden border-e bg-card shadow-xl transition-[width] duration-200 sm:relative sm:inset-auto sm:z-auto sm:shadow-none`}>
+        <div className="flex h-16 items-center justify-between border-b px-4"><div><p className="text-sm font-semibold tracking-tight">PyChat</p><p className="text-xs text-muted-foreground">Private AI workspace</p></div><Button variant="ghost" size="icon" aria-label="Close conversation sidebar" onClick={() => setSidebarOpen(false)}><PanelLeftClose /></Button></div>
+        <div className="p-3"><Button className="w-full justify-start gap-2" variant="outline" onClick={() => void startConversation()} disabled={!user || streaming}><MessageSquarePlus /> New conversation</Button></div>
+        <nav aria-label="Conversations" className="flex-1 space-y-1 overflow-y-auto px-2">{conversations.map((conversation) => <div key={conversation.id} className={`group flex items-center gap-1 rounded-lg text-sm transition-colors ${conversation.id === activeConversationId ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}><button className="min-w-0 flex-1 px-3 py-2 text-start" onClick={() => selectConversation(conversation.id)}><span className="block truncate font-medium">{conversation.title}</span><span className="mt-0.5 block text-xs opacity-70">{conversation.updatedAt ? formatTime(conversation.updatedAt) : 'Just now'}</span></button><Button variant="ghost" size="icon" className="me-1 size-8 shrink-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100 focus-visible:opacity-100" aria-label={`Delete conversation ${conversation.title}`} disabled={deletingConversationId !== null} onClick={() => void deleteConversation(conversation.id)}><Trash2 /></Button></div>)}{!conversations.length && !conversationLoading && <p className="px-3 py-8 text-center text-xs text-muted-foreground">No conversations yet. Start one to develop an idea.</p>}</nav>
+        <div className="border-t p-3">{user ? <div className="flex items-center gap-2"><div className="relative shrink-0"><div className="grid size-8 place-items-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">{initials(user)}</div><span className="absolute -end-0.5 -bottom-0.5 size-2.5 rounded-full border-2 border-card bg-emerald-500" aria-hidden="true" /></div><div className="min-w-0 flex-1"><p className="truncate text-sm font-medium">{user.displayName ?? 'Signed in'}</p><p className="truncate text-xs text-muted-foreground">{online.length} online · {user.email}</p></div><Button variant="ghost" size="icon" aria-label="Sign out" onClick={() => void signOut()}><LogOut /></Button></div> : <Button className="w-full gap-2" onClick={() => void signIn()} disabled={authLoading}><LogIn /> Sign in to continue</Button>}</div>
+      </aside>
+      <section className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-16 shrink-0 items-center gap-3 border-b px-4 sm:px-6">{!sidebarOpen && <Button variant="ghost" size="icon" aria-label="Open conversation sidebar" onClick={() => setSidebarOpen(true)}><PanelLeftOpen /></Button>}<div className="min-w-0 flex-1"><p className="truncate text-sm font-semibold">{activeConversation?.title ?? 'New conversation'}</p><p className="text-xs text-muted-foreground">Private thinking space · {modeOptions.find((option) => option.id === mode)?.label}</p></div><Button variant={notificationsEnabled ? 'secondary' : 'ghost'} size="icon" aria-label={notificationsEnabled ? 'Send test notification' : 'Enable notifications'} title={notificationsEnabled ? 'Send test notification' : 'Enable notifications'} disabled={!user || notificationsBusy} onClick={() => void enableNotifications()}>{notificationsBusy ? <LoaderCircle className="animate-spin" /> : <Bell />}</Button><Button variant={workspaceOpen ? 'secondary' : 'ghost'} size="icon" aria-label={workspaceOpen ? 'Workspace open' : 'Open workspace'} title="Open workspace" onClick={() => setWorkspaceOpen((open) => !open)}><Code2 /></Button></header>
+        {notice && <div role="status" className="chat-message-in border-b bg-primary/5 px-4 py-2.5 sm:px-6"><div className="mx-auto flex max-w-3xl items-start gap-3"><Bell className="mt-0.5 size-4 shrink-0 text-primary" /><div className="min-w-0 flex-1"><p className="truncate text-sm font-medium">{notice.title}</p>{notice.body && <p className="truncate text-xs text-muted-foreground">{notice.body}</p>}</div><Button variant="ghost" size="icon-xs" aria-label="Dismiss notification" onClick={() => setNotice(null)}><XCircle /></Button></div></div>}
+        <MessageScrollerProvider autoScroll><MessageScroller className="min-h-0 flex-1"><StreamingFollow revision={messageRevision} streaming={streaming} /><MessageScrollerViewport className="px-4 py-8 sm:px-8"><MessageScrollerContent className="mx-auto w-full max-w-3xl gap-8"><MessageScrollerItem messageId="intro" scrollAnchor={messages.length <= 1}><div className="mx-auto max-w-xl py-16 text-center"><div className="mx-auto mb-5 grid size-12 place-items-center rounded-2xl bg-primary text-primary-foreground shadow-sm"><span className="text-lg">✦</span></div><h1 className="text-2xl font-semibold tracking-tight">A clearer place to think.</h1><p className="mt-2 text-sm leading-6 text-muted-foreground">Explore possibilities, turn ideas into plans, or pressure-test a direction. Your context stays with you across conversations.</p></div></MessageScrollerItem><MessageGroup className="gap-8">{messages.map((message, index) => <MessageScrollerItem key={message.id} messageId={message.id} scrollAnchor={message.role === 'user'} className="chat-message-in" style={{ animationDelay: `${Math.min(index * 35, 350)}ms` }}><Message align={message.role === 'user' ? 'end' : 'start'}><MessageAvatar className={message.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}><span className="grid size-8 place-items-center text-xs font-semibold">{message.role === 'user' ? initials(user) : '✦'}</span></MessageAvatar><MessageContent className={message.role === 'assistant' ? 'w-full max-w-[min(42rem,78%)]' : 'w-fit max-w-[min(42rem,78%)]'}><MessageHeader>{message.role === 'user' ? 'You' : 'PyChat'}</MessageHeader>{message.role === 'assistant' && message.toolCalls && <ToolActivity calls={message.toolCalls} />}{message.role === 'assistant' && message.thoughts && <ThoughtsDisclosure thoughts={message.thoughts} streaming={message.status === 'streaming'} />}<div className={`w-fit max-w-full rounded-xl px-4 py-3 leading-7 shadow-sm ${message.role === 'user' ? 'bg-primary text-primary-foreground' : 'border-transparent bg-muted text-foreground'}`}>{message.text ? message.role === 'assistant' ? <MarkdownMessage content={message.text} /> : <p className="whitespace-pre-wrap text-sm">{message.text}</p> : <span className="inline-flex gap-1 text-muted-foreground"><i className="size-1.5 animate-pulse rounded-full bg-current" /><i className="size-1.5 animate-pulse rounded-full bg-current [animation-delay:150ms]" /><i className="size-1.5 animate-pulse rounded-full bg-current [animation-delay:300ms]" /></span>}</div>{message.status === 'streaming' && <MessageFooter>Thinking…</MessageFooter>}{message.status === 'error' && <MessageFooter><span role="alert">Response unavailable.</span><Button variant="ghost" size="sm" onClick={() => retryRef.current?.()}>Retry</Button></MessageFooter>}{message.role === 'assistant' && message.usage && <MessageFooter><UsageSummary usage={message.usage} /></MessageFooter>}<div className={message.role === 'user' ? 'self-end' : 'self-start'}><CopyMessageButton text={message.text} /></div>{message.role === 'assistant' && planReadyMessageId && (message.id === planReadyMessageId || message.clientMessageId === planReadyMessageId) && <StartPlanCard onStart={() => { setPlanReadyMessageId(null); void sendMessage('Start the plan above. Begin with the first actionable step.', 'plan'); }} onDecline={() => setPlanReadyMessageId(null)} onSendDirection={(direction) => { setPlanReadyMessageId(null); void sendMessage(direction, 'plan'); }} />}</MessageContent></Message></MessageScrollerItem>)}</MessageGroup></MessageScrollerContent></MessageScrollerViewport><MessageScrollerButton /></MessageScroller></MessageScrollerProvider>
+        <div className="border-t bg-background/90 p-4 backdrop-blur sm:px-8"><div className="mx-auto max-w-3xl">{error && <p role="alert" className="mb-2 text-xs text-destructive">{error}</p>}<div className="mb-2 flex flex-wrap items-center gap-1" role="tablist" aria-label="Thinking mode">{modeOptions.map((option) => <button key={option.id} type="button" role="tab" aria-selected={mode === option.id} title={option.description} disabled={!user || streaming} onClick={() => { setMode(option.id); setPlanReadyMessageId(null); }} className={`rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring ${mode === option.id ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}>{option.label}</button>)}</div><div className="relative rounded-xl border bg-card shadow-sm focus-within:ring-2 focus-within:ring-ring/30"><textarea ref={textareaRef} value={draft} onChange={(event) => setDraft(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); void sendMessage(); } }} disabled={!user || streaming} rows={3} placeholder={user ? modeOptions.find((option) => option.id === mode)?.placeholder : 'Sign in to start a private conversation'} aria-label="Message" className="min-h-24 w-full resize-none bg-transparent px-4 pb-12 pt-4 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed" /><div className="absolute inset-x-3 bottom-3 flex items-center justify-between"><span className="text-xs text-muted-foreground">Enter to send · Shift + Enter for a new line</span>{streaming ? <Button variant="secondary" size="icon" aria-label="Stop generating" onClick={stopStreaming}><Square /></Button> : <Button size="icon" aria-label="Send message" disabled={!user || !draft.trim() || messageLoading} onClick={() => void sendMessage()}><ArrowUp /></Button>}</div></div><p className="mt-2 text-center text-[11px] text-muted-foreground">PyChat helps you explore, plan, and refine. Check important information.</p></div></div>
+      </section>
+      {workspaceOpen && <PreviewErrorBoundary><WorkspacePreview services={services} revision={workspaceRevision} onClose={() => setWorkspaceOpen(false)} /></PreviewErrorBoundary>}
+    </main>
+  );
+}

--- a/packages/create-pyric/templates/chat/src/ui/chat/chat-types.ts
+++ b/packages/create-pyric/templates/chat/src/ui/chat/chat-types.ts
@@ -1,0 +1,100 @@
+import type { ChatMode } from '../../chat-mode';
+
+export type UiMessageRole = 'user' | 'assistant' | 'system';
+
+export type UiMessage = {
+  id: string;
+  role: UiMessageRole;
+  text: string;
+  createdAt?: Date;
+  status?: 'sending' | 'streaming' | 'complete' | 'error';
+  clientMessageId?: string;
+  thoughts?: string;
+  replyToClientMessageId?: string;
+  toolCalls?: UiToolCall[];
+  usage?: UiUsage;
+};
+
+export type UiConversation = {
+  id: string;
+  title: string;
+  updatedAt?: Date;
+};
+
+export type UiUser = {
+  displayName: string | null;
+  email: string | null;
+  photoURL: string | null;
+};
+
+export type UiPresence = {
+  uid: string;
+  displayName: string | null;
+};
+
+export type UiNotification = {
+  title: string;
+  body: string | null;
+};
+
+export type UiFinishReason = 'stop' | 'length' | 'safety' | 'error' | null;
+
+export type UiUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens?: number;
+  cachedTokens?: number;
+  costUsd?: number;
+};
+
+export type UiToolCall = {
+  id: string;
+  name: string;
+  args: unknown;
+  status: 'running' | 'complete' | 'error';
+  summary?: string;
+};
+
+export type ChatPageServices = {
+  auth: {
+    currentUser(): UiUser | null;
+    observe(callback: (user: UiUser | null) => void): () => void;
+    signIn(): Promise<UiUser>;
+    signOut(): Promise<void>;
+  };
+  conversations: {
+    list(): Promise<UiConversation[]>;
+    create(input?: { title?: string }): Promise<string>;
+    delete(id: string): Promise<void>;
+    observe(id: string, callback: (conversation: UiConversation) => void): () => void;
+    observeList(callback: (conversations: UiConversation[]) => void): () => void;
+  };
+  messages: {
+    list(conversationId: string): Promise<UiMessage[]>;
+    appendUserMessage(input: { conversationId: string; text: string; clientMessageId: string }): Promise<string>;
+    appendAssistantMessage(input: { conversationId: string; text: string; clientMessageId: string; thoughts?: string; model?: string; finishReason?: UiFinishReason; inputTokenCount?: number | null; outputTokenCount?: number | null }): Promise<string>;
+    observeRecent(conversationId: string, callback: (messages: UiMessage[]) => void): () => void;
+  };
+  ai: {
+    stream(
+      input: { conversationId: string; messages: Pick<UiMessage, 'role' | 'text'>[]; mode?: ChatMode; signal?: AbortSignal },
+      onChunk: (chunk: string) => void,
+      onThought?: (thought: string) => void,
+      onTool?: (tool: UiToolCall) => void,
+      onUsage?: (usage: UiUsage) => void,
+      onWorkspaceChanged?: () => void,
+    ): Promise<{ text: string; thoughts?: string; model?: string; finishReason?: UiFinishReason; inputTokenCount?: number | null; outputTokenCount?: number | null; usage?: UiUsage }>;
+  };
+  presence: {
+    observe(callback: (online: UiPresence[]) => void): () => void;
+  };
+  notifications: {
+    enable(onMessage: (message: UiNotification) => void): Promise<boolean>;
+    showEnabledConfirmation(): Promise<void>;
+  };
+  workspace: {
+    readAppSource(): Promise<string>;
+    previewApp(source: string, hostModules: { react: Record<string, unknown>; jsxRuntime: Record<string, unknown>; jsxDevRuntime: Record<string, unknown> }): Promise<{ ok: true; component: unknown } | { ok: false; diagnostics: Array<{ message: string; line?: number; column?: number }> }>;
+    subscribe(callback: () => void): () => void;
+  };
+};

--- a/packages/create-pyric/templates/chat/src/ui/chat/firebase-chat-gateway.ts
+++ b/packages/create-pyric/templates/chat/src/ui/chat/firebase-chat-gateway.ts
@@ -1,0 +1,113 @@
+import { FirebaseAuthService } from '@/services/auth-service';
+import { ConversationService } from '@/services/conversation-service';
+import { MessageService } from '@/services/message-service';
+import { UserService } from '@/services/user-service';
+import { PresenceService } from '@/services/presence-service';
+import { NotificationService } from '@/services/notification-service';
+import { BrowserAgentService } from '@/services/browser-agent-service';
+import { asConversationId, type AuthUser, type Conversation, type Message, type PresenceEntry } from '@/firebase/types';
+import type { ChatPageServices, UiConversation, UiMessage, UiPresence, UiUser } from './chat-types';
+
+const toUiUser = (user: AuthUser | null): UiUser | null =>
+  user
+    ? { displayName: user.displayName, email: user.email, photoURL: user.photoURL }
+    : null;
+
+const toUiPresence = (entry: PresenceEntry): UiPresence => ({ uid: entry.uid, displayName: entry.displayName });
+
+const toUiConversation = (conversation: Conversation): UiConversation => ({
+  id: conversation.id,
+  title: conversation.title,
+  updatedAt: conversation.updatedAt?.toDate(),
+});
+
+const toUiMessage = (message: Message): UiMessage => ({
+  id: message.id,
+  role: message.role,
+  text: message.text,
+  createdAt: message.createdAt?.toDate(),
+  status: 'complete',
+  clientMessageId: message.clientMessageId ?? undefined,
+  thoughts: message.thoughts ?? undefined,
+  usage: message.inputTokenCount !== null || message.outputTokenCount !== null
+    ? { inputTokens: message.inputTokenCount ?? 0, outputTokens: message.outputTokenCount ?? 0 }
+    : undefined,
+});
+
+export const createFirebaseChatGateway = (): ChatPageServices => {
+  const auth = new FirebaseAuthService();
+  const conversations = new ConversationService();
+  const messages = new MessageService();
+  const ai = new BrowserAgentService();
+  const users = new UserService();
+  const presence = new PresenceService();
+  const notifications = new NotificationService();
+  const provisioned = new Set<string>();
+
+  const provision = async (user: AuthUser): Promise<void> => {
+    if (provisioned.has(user.uid)) return;
+    provisioned.add(user.uid);
+    try {
+      await users.provision(user);
+      await presence.goOnline(user);
+    } catch (error) {
+      provisioned.delete(user.uid);
+      throw error;
+    }
+  };
+
+  return {
+    auth: {
+      currentUser: () => toUiUser(auth.currentUser()),
+      observe: (callback) => auth.observe((user) => {
+        if (!user) {
+          callback(null);
+          return;
+        }
+        void provision(user).then(() => callback(toUiUser(user))).catch(() => callback(null));
+      }),
+      signIn: async () => {
+        const signedIn = await auth.signIn();
+        await provision(signedIn);
+        const user = toUiUser(signedIn);
+        if (!user) throw new Error('Unable to sign in');
+        return user;
+      },
+      signOut: async () => {
+        await presence.goOffline().catch(() => undefined);
+        await auth.signOut();
+      },
+    },
+    presence: {
+      observe: (callback) => presence.observe((entries) => callback(entries.map(toUiPresence))),
+    },
+    notifications: {
+      enable: async (onMessage) => (await notifications.enable((message) => onMessage({ title: message.title, body: message.body }))) !== null,
+      showEnabledConfirmation: () => notifications.showEnabledConfirmation(),
+    },
+    conversations: {
+      list: async () => (await conversations.list()).items.map(toUiConversation),
+      create: (input) => conversations.create(input),
+      delete: (id) => conversations.delete(id as Conversation['id']),
+      observe: (id, callback) => conversations.observe(id as Conversation['id'], (value) => callback(toUiConversation(value))),
+      observeList: (callback) => conversations.observeList((values) => callback(values.map(toUiConversation))),
+    },
+    messages: {
+      list: async (conversationId) => (await messages.list(conversationId)).items.map(toUiMessage),
+      appendUserMessage: (input) => messages.appendUserMessage({ ...input, conversationId: asConversationId(input.conversationId) }),
+      appendAssistantMessage: (input) => messages.appendAssistantMessage({ ...input, conversationId: asConversationId(input.conversationId) }),
+      observeRecent: (conversationId, callback) => messages.observeRecent(conversationId, (value) => callback(value.map(toUiMessage))),
+    },
+    ai: {
+      stream: async (input, onChunk, onThought, onTool, onUsage, onWorkspaceChanged) => {
+        const result = await ai.stream(input, { onChunk, onThought, onTool, onUsage, onWorkspaceChanged });
+        return { text: result.text, thoughts: result.thoughts, model: 'gemini-2.5-flash', finishReason: 'stop', usage: result.usage, inputTokenCount: result.usage?.inputTokens ?? null, outputTokenCount: result.usage?.outputTokens ?? null };
+      },
+    },
+    workspace: {
+      readAppSource: () => ai.readAppSource(),
+      previewApp: (source, hostModules) => ai.previewApp(source, hostModules),
+      subscribe: (callback) => ai.subscribe(callback),
+    },
+  };
+};

--- a/packages/create-pyric/templates/chat/src/ui/chat/markdown-message.tsx
+++ b/packages/create-pyric/templates/chat/src/ui/chat/markdown-message.tsx
@@ -1,0 +1,16 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { cn } from '@/lib/utils';
+
+type MarkdownMessageProps = {
+  content: string;
+  className?: string;
+};
+
+export function MarkdownMessage({ content, className }: MarkdownMessageProps) {
+  return (
+    <div className={cn('typeset typeset-chat max-w-[37em]', className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/create-pyric/templates/chat/src/ui/chat/preview-component-state.ts
+++ b/packages/create-pyric/templates/chat/src/ui/chat/preview-component-state.ts
@@ -1,0 +1,12 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+/** Store the generated preview export for React to render later. */
+export function storePreviewComponent(
+  setComponent: Dispatch<SetStateAction<unknown>>,
+  component: unknown,
+): void {
+  // React treats a function passed directly to a state setter as an updater.
+  // Preview exports are often function components, so wrap the value to keep
+  // React from executing the generated component against the host's hook list.
+  setComponent(() => component);
+}

--- a/packages/create-pyric/templates/chat/src/vite-env.d.ts
+++ b/packages/create-pyric/templates/chat/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/create-pyric/templates/chat/storage.rules
+++ b/packages/create-pyric/templates/chat/storage.rules
@@ -1,0 +1,23 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /users/{uid}/conversations/{conversationId}/attachments/{attachmentId}/{fileName} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow write: if request.auth != null
+                   && request.auth.uid == uid
+                   && firestore.get(/databases/(default)/documents/conversations/$(conversationId)).data.ownerUid == request.auth.uid
+                   && request.resource.size > 0
+                   && request.resource.size <= 10 * 1024 * 1024
+                   && (request.resource.contentType == 'image/jpeg'
+                       || request.resource.contentType == 'image/png'
+                       || request.resource.contentType == 'image/webp'
+                       || request.resource.contentType == 'application/pdf'
+                       || request.resource.contentType == 'text/plain');
+      allow delete: if request.auth != null && request.auth.uid == uid;
+    }
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/packages/create-pyric/templates/chat/test/notification-display.test.ts
+++ b/packages/create-pyric/templates/chat/test/notification-display.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { showPersistentNotification } from '../src/services/notification-display.ts';
+
+test('uses the persistent service-worker display surface when available', async () => {
+  const shown: Array<{ title: string; options?: NotificationOptions }> = [];
+  let usedPageConstructor = false;
+  const registration = {
+    showNotification: async (title: string, options?: NotificationOptions) => {
+      shown.push({ title, options });
+    },
+  };
+  class PageNotification {
+    constructor() {
+      usedPageConstructor = true;
+    }
+  }
+
+  await showPersistentNotification(
+    registration,
+    'PyChat',
+    { body: 'Assistant reply', tag: 'conversation-1' },
+    PageNotification as unknown as typeof Notification,
+  );
+
+  assert.deepEqual(shown, [{ title: 'PyChat', options: { body: 'Assistant reply', tag: 'conversation-1' } }]);
+  assert.equal(usedPageConstructor, false);
+});

--- a/packages/create-pyric/templates/chat/test/notification-permission.test.ts
+++ b/packages/create-pyric/templates/chat/test/notification-permission.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { requestNotificationPermission } from '../src/services/notification-permission.ts';
+
+test('does not enable notifications when the browser permission is denied', async () => {
+  let requested = false;
+  const enabled = await requestNotificationPermission({
+    permission: 'denied',
+    requestPermission: async () => {
+      requested = true;
+      return 'granted';
+    },
+  });
+
+  assert.equal(enabled, false);
+  assert.equal(requested, false);
+});

--- a/packages/create-pyric/templates/chat/test/preview-component-state.test.js
+++ b/packages/create-pyric/templates/chat/test/preview-component-state.test.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { act, create } from 'react-test-renderer';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { storePreviewComponent } from '../src/ui/chat/preview-component-state.ts';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+test('stores a generated function component and renders its hooks in its own component', async () => {
+  let generatedRenders = 0;
+
+  function GeneratedTodoApp() {
+    generatedRenders += 1;
+    useState([]);
+    return React.createElement('main', null, 'Todo app');
+  }
+
+  function PreviewHarness() {
+    const [component, setComponent] = useState(null);
+    useEffect(() => storePreviewComponent(setComponent, GeneratedTodoApp), []);
+    return component
+      ? React.createElement(component)
+      : React.createElement('output', null, 'Compiling');
+  }
+
+  let renderer;
+  await act(async () => {
+    renderer = create(React.createElement(PreviewHarness));
+  });
+
+  assert.equal(generatedRenders, 1);
+  assert.deepEqual(renderer.toJSON().children, ['Todo app']);
+});

--- a/packages/create-pyric/templates/chat/tsconfig.json
+++ b/packages/create-pyric/templates/chat/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/create-pyric/templates/chat/vite.config.ts
+++ b/packages/create-pyric/templates/chat/vite.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { pyric } from '@pyric/cli/vite';
+import path from 'node:path';
+
+// Under `vite dev` pyric() swaps firebase/* to the in-process pyric
+// sandbox and deploys + hot-reloads the rules — no Firebase project,
+// credentials, or emulators. `vite build` (mode production) ships the real
+// firebase package; the swap never reaches the deployed artifact. For a
+// self-contained sandbox preview you can serve under `pyric dev`, build with a
+// non-production mode: `vite build --mode development` (see the `build:sandbox`
+// script). That output is marked and can never be deployed.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const proxyUpstream = env.PYRIC_AI_PROXY_UPSTREAM;
+  const model = env.PYRIC_AI_MODEL;
+  if (Boolean(proxyUpstream) !== Boolean(model)) {
+    throw new Error(
+      'PyChat local AI configuration requires both PYRIC_AI_PROXY_UPSTREAM and PYRIC_AI_MODEL.',
+    );
+  }
+
+  return {
+    plugins: [
+      react(),
+      tailwindcss(),
+      pyric({
+        bridge: true,
+        // The authored 2+modules source is the source of truth; the plugin
+        // resolves it in-memory, so no vendored firestore.rules is needed in
+        // dev. `npm run rules:resolve` still generates it for Firebase deploy.
+        rules: 'firestore.modules.rules',
+        ...(proxyUpstream && model
+          ? {
+              ai: {
+                proxyUpstream,
+                engine: {
+                  kind: 'openai' as const,
+                  model,
+                  modelMap: { 'gemini-2.5-flash': model },
+                },
+              },
+            }
+          : {}),
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+  };
+});

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, it, mock } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { parseCreateArgs } from '../src/parse-args.js';
 import { runScaffold, applyDepsMode, TEMPLATES } from '../src/scaffold.js';
+import { loadAssetTemplate } from '../src/templates.js';
+
+function treeBytes(root: string): number {
+  return readdirSync(root, { withFileTypes: true }).reduce((total, entry) => {
+    const path = join(root, entry.name);
+    return total + (entry.isDirectory() ? treeBytes(path) : statSync(path).size);
+  }, 0);
+}
 
 function bufferIo() {
   let out = '';
@@ -29,6 +46,12 @@ describe('parseCreateArgs', () => {
     const args = parseCreateArgs(['app', '--', '--template', 'static']);
     expect(args.positional).toEqual(['app']);
     expect(args.flags.get('template')).toBe('static');
+  });
+
+  it('accepts chat as a named template value', () => {
+    const args = parseCreateArgs(['my-chat', '--template', 'chat']);
+    expect(args.positional).toEqual(['my-chat']);
+    expect(args.flags.get('template')).toBe('chat');
   });
 });
 
@@ -102,5 +125,91 @@ describe('runScaffold', () => {
     );
     expect(code).toBe(0);
     expect(writeFn.mock.calls.some((c) => c[0] === '/tmp/cwd-scaffold/package.json')).toBe(true);
+  });
+
+  it('scaffolds the full chat template quickly from one allowlisted source tree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'create-pyric-chat-'));
+    const project = join(root, 'thinking-room');
+    const io = bufferIo();
+    try {
+      const started = performance.now();
+      const code = await runScaffold(
+        {
+          dir: project,
+          template: 'chat',
+          name: 'thinking-room',
+          effectiveTemplate: applyDepsMode(TEMPLATES.chat, 'npm', { version: '1.2.3' }),
+        },
+        io,
+      );
+      const elapsedMs = performance.now() - started;
+
+      expect(code).toBe(0);
+      expect(elapsedMs).toBeLessThan(2_000);
+      expect(treeBytes(project)).toBeLessThan(750_000);
+      const generated = JSON.parse(readFileSync(join(project, 'package.json'), 'utf8')) as {
+        name: string;
+        devDependencies: Record<string, string>;
+      };
+      expect(generated.name).toBe('thinking-room');
+      expect(generated.devDependencies['@pyric/cli']).toBe('^1.2.3');
+      expect(generated.devDependencies.pyric).toBe('^1.2.3');
+      expect(readFileSync(join(project, 'README.md'), 'utf8')).toContain('# thinking-room');
+      expect(readFileSync(join(project, 'index.html'), 'utf8')).toContain('<title>thinking-room');
+      expect(readFileSync(join(project, '.gitignore'), 'utf8')).toContain('node_modules/');
+      expect(readdirSync(project)).not.toContain('scaffold.json');
+      expect(readdirSync(project)).not.toContain('bun.lock');
+      expect(readFileSync(join(project, 'vite.config.ts'), 'utf8')).not.toContain('node_modules/');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps every top-level chat source entry classified by the manifest', () => {
+    const root = fileURLToPath(new URL('../templates/chat/', import.meta.url));
+    const manifest = JSON.parse(readFileSync(join(root, 'scaffold.json'), 'utf8')) as {
+      include: string[];
+    };
+    const runtimeEntries = new Set(['.agents', '.codex', '.npmignore', 'dist', 'node_modules']);
+    expect(readdirSync(root).filter((entry) => !runtimeEntries.has(entry)).sort()).toEqual(
+      [...manifest.include, 'package.json', 'scaffold.json'].sort(),
+    );
+  });
+
+  it('rejects an asset manifest entry that escapes the template root', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'create-pyric-unsafe-'));
+    const root = join(parent, 'chat');
+    try {
+      mkdirSync(root);
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ scripts: {}, dependencies: {}, devDependencies: {} }),
+      );
+      writeFileSync(join(root, 'scaffold.json'), JSON.stringify({ include: ['../outside.txt'] }));
+      writeFileSync(join(parent, 'outside.txt'), 'not part of the template');
+      expect(() => loadAssetTemplate('chat', root)).toThrow('unsafe include');
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinks instead of copying outside the source tree', () => {
+    const root = mkdtempSync(join(tmpdir(), 'create-pyric-symlink-'));
+    try {
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ scripts: {}, dependencies: {}, devDependencies: {} }),
+      );
+      writeFileSync(join(root, 'target.txt'), 'target');
+      writeFileSync(join(root, 'scaffold.json'), JSON.stringify({ include: ['linked.txt'] }));
+      try {
+        symlinkSync(join(root, 'target.txt'), join(root, 'linked.txt'));
+      } catch {
+        return; // Windows may not grant symlink creation to an unprivileged test process.
+      }
+      expect(() => loadAssetTemplate('chat', root)).toThrow('contains a symlink');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -197,6 +197,15 @@ assert_tar_has() {
     exit 1
   fi
 }
+assert_tar_lacks() {
+  local tb="$1" pattern="$2" desc="$3" listing
+  listing=$(tar -tzf "$tb")
+  if grep -qE "$pattern" <<<"$listing"; then
+    echo "  ✗ UNEXPECTED in tarball: $desc (matched pattern: $pattern)" >&2
+    exit 1
+  fi
+  echo "  ✓ $desc"
+}
 packset_check packages/pyric pyric
 packset_check packages/pyric-admin pyric-admin
 packset_check packages/create-pyric create-pyric
@@ -207,6 +216,9 @@ assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/grammar/FirestoreRules\.ohm$
 assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/rtdb/grammar/RtdbExpr\.ohm$' "pyric ships the RTDB rules grammar (.ohm)"
 assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/modules/stdlib/.*\.rules$' "pyric ships the rules stdlib modules (.rules)"
 assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/dist/bin\.js$' "create-pyric ships the create-pyric bin"
+assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/src/ui/chat/chat-page\.tsx$' "create-pyric ships the canonical chat app source"
+assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/src/firebase-messaging-sw\.ts$' "create-pyric ships the chat notification worker"
+assert_tar_lacks "$TARBALL_CREATE_PYRIC" 'package/templates/chat/dist/' "create-pyric excludes the built chat dist/ tree"
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/cli/index\.js$' "@pyric/cli ships the pyric CLI bin"
 # The Vite plugin's `ui` option + `pyric dev --ui` resolve the Studio app from
 # dist/serve/studio-ui (build-embedded). The plugin's firebase swap resolves the
@@ -563,6 +575,27 @@ grep -q "pyricSandbox" "$CREATE_OUT/vite.config.ts"
 test -f "$CREATE_OUT/package.json"
 grep -q '"dev": "vite"' "$CREATE_OUT/package.json"
 echo "  ✓ create-pyric scaffolds Vite + @pyric/cli/vite"
+
+# Named chat smoke: prove the packaged asset tree is available to the installed
+# bin and stays free of repo/install artifacts and internal package paths.
+echo "▸ create-pyric chat smoke"
+CREATE_CHAT_OUT="$WORK/create-chat-smoke-app"
+rm -rf "$CREATE_CHAT_OUT"
+"$CREATE_PYRIC_BIN" "$CREATE_CHAT_OUT" --template chat --name packed-chat
+test -f "$CREATE_CHAT_OUT/src/ui/chat/chat-page.tsx"
+test -f "$CREATE_CHAT_OUT/src/firebase-messaging-sw.ts"
+test -f "$CREATE_CHAT_OUT/functions/index.js"
+test -f "$CREATE_CHAT_OUT/test/notification-display.test.ts"
+grep -q '"name": "packed-chat"' "$CREATE_CHAT_OUT/package.json"
+grep -q '# packed-chat' "$CREATE_CHAT_OUT/README.md"
+test ! -e "$CREATE_CHAT_OUT/bun.lock"
+test ! -e "$CREATE_CHAT_OUT/scaffold.json"
+test ! -e "$CREATE_CHAT_OUT/.pyric"
+if grep -R -qE '@inbrowser-(workspace|resumable|firebase)-|node_modules/@inbrowser' "$CREATE_CHAT_OUT/src"; then
+  echo "  ✗ chat scaffold contains an internal @inbrowser alias or node_modules import" >&2
+  exit 1
+fi
+echo "  ✓ create-pyric scaffolds the portable chat app"
 
 # ─── Phase 5.5: serve smoke (init + serve from the packed bin) ─────────
 # The subpath + bin checks above prove imports resolve, but they never boot


### PR DESCRIPTION
Adds `chat`, an opt-in create-pyric template for scaffolding the full PyChat React, Firebase, browser-agent, Functions, and Messaging reference app.

```bash
npm create pyric my-chat -- --template chat
cd my-chat
npm install
npm run dev
```

The generated app starts with Pyric's scripted AI engine, so the command above needs no model server or Firebase project. An OpenAI-compatible MiniMax server is an environment-only switch:

```dotenv
PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
PYRIC_AI_MODEL=minimax-m2.7
```

The same template is available through the existing CLI entry point:

```bash
npx pyric init my-chat --template chat
cd my-chat
npm install
npm run dev
```

## The runnable chat tree is the scaffold source of truth

`packages/create-pyric/templates/chat` is both a buildable workspace app and the packaged scaffold asset. `scaffold.json` allowlists generated paths; the loader rejects traversal, symlinks, binary assets, duplicate outputs, install directories, build output, local environment files, and lockfiles. Project-name tokens are replaced while the files are written.

The default `web` template is unchanged. Template validation is centralized through `TEMPLATE_NAMES` and `isTemplateName`, which are shared by `create-pyric` and `pyric init` instead of maintaining separate unions.

The app imports public package exports such as `@inbrowser/workspace/fs`, `@inbrowser/resumable`, and `@inbrowser/model`. It does not depend on aliases into `node_modules/*/dist`.

## Risk

The create-pyric package now owns a substantially larger source tree, and importing its scaffold registry synchronously reads the chat manifest and assets. The packed package remains 69 KB compressed, but reviewers should judge whether keeping a full reference app in create-pyric is the right long-term ownership boundary.

The explicit scaffold allowlist prevents accidental files from shipping to generated apps, but a newly added top-level template path must also be added to `scaffold.json`. A regression test fails when an unclassified source entry appears.

The production app build emits the browser compiler's 12 MB `esbuild-wasm` asset and a large application chunk. Those are generated-app build outputs and are excluded from the create-pyric tarball; this PR does not attempt application code splitting.

<details>
<summary>Implementation notes and verification</summary>

- `bash scripts/build.sh --packages-only` passed.
- `bun test --cwd packages/cli`: 1,252 passed, 20 gated/skipped, 0 failed.
- create-pyric typecheck and tests: 13 passed, 0 failed, including the chat app tests.
- Chat typecheck, production build, and notification bundle checks passed.
- The scaffold performance test completed in about 22 ms and generated less than 750 KB of source.
- A real packed-package install and `create-pyric --template chat` smoke test produced the complete app with no lockfile, `.pyric`, internal `@inbrowser` alias, or `node_modules` import.
- `npm pack --dry-run`: 69,184 bytes compressed, 262,451 bytes unpacked, with no chat `dist` or `node_modules` tree.
- Packaging coverage asserts that the tarball contains the canonical chat source and Messaging worker, excludes chat build output, and can scaffold the named template from the installed bin.

</details>
