### PR TITLE
release: v0.1.0-alpha.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.0-alpha.11",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -111,7 +111,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.0-alpha.11",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -231,7 +231,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.0-alpha.11",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -249,7 +249,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.0-alpha.11",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -313,7 +313,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.0-alpha.11",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.11`. Merging this PR marks the release; the changelog below is the record.

## Changes since the previous release

- Add a guarded npm publishing preflight and runbook (#391) (776f1b77)
- feat: add maintainable chat app scaffold (18db7316)
- fix(messaging): document native background notifications (4dd38fbc)
- fix(database): bypass rules for admin RTDB onValue listeners (b4e5fcd8)
- fix(pyric-admin): route admin-shape getFirestore to the rules-bypass lens (3d33ad55)
- fix(messaging): make sandbox.deliver reach the worker-backed broker (2fd95a17)
- fix(ai): map reasoning_content to thought parts in openai engine (897b2830)
- test(serve): acquire real ephemeral ports; finish the rename in functions tests (ea8cb516)
- docs(site): follow the plugin rename in the functions section (98d090f0)
- docs(site): functions under the Vite plugin — discovery, option precedence, hot reload (c233d622)
- feat(vite-plugin): hot-reload the functions child on source saves (34581471)
- feat(vite-plugin): `functions` option — off switch plus region/instance overrides (2a8a732a)
- docs(vite-plugin): correct stale bridge single-tab warning; pin worker-path topology (05757b9e)
- docs: follow the plugin rename in the local-build guide (2c941cfb)
- test(cli): ratify the vite.config.ts scaffold hash for the plugin rename (4858088a)
- feat(cli)!: rename the Vite plugin export from pyricSandbox to pyric (26116f41)
- docs: the Vite plugin swaps firebase/database and runs its triggers (8bdb58ef)
- feat(cli): run RTDB-triggered functions under the Vite plugin (e83f7d43)
- fix(serve): detach the worker boot fetch so capture and history hydration survive real browsers (21f5b703)
- test(cli): characterize issue #364 — worker capture/hydration dies on browser fetch (ff0136c5)
- docs: name all four vendored tarballs in local-build-testing (c955d2a2)
- test(cli): prove the vendored-consumer story and gate it in CI (361cf7d0)
- feat(cli): declarative AI engine + proxy upstream on the vite plugin (43adce87)
- feat(ai): surface silent engine gaps with diagnostics (dd87809f)
- docs: document rules-are-not-filters query provability for list queries (dafd4950)
- feat(serve): relay rules denials to the terminal for headless dev (04a1e65b)
- ci: make Playground contract non-blocking (e2c1fa27)
- fix(conformance): derive ledger line numbers from one render pass (5578b870)
- fix(site): make dead docs paths return real 404s (f800d513)
- fix(firestore): fail-closed doc-independence classifier for query proof (1f209dcb)
- fix(test): disable color output in RTDB expression-engine subprocess probe (02c4e3c2)
- fix(cli): pack and rewrite every runtime workspace dep for vendoring (a69fabf4)
- fix(cli): make the standalone binary invoke the CLI explicitly (a11e8d19)
- fix(firestore): require full doc-dependence accounting in query proof (032e7366)
- docs(ai-logic): fix Ollama engine setup to use firebase/ai handle (fd45ace7)
- fix(firestore): inline rules functions in query-proof and surface denial remediation (7c5e3b05)
- fix(serve): project-scope the worker sandbox persistence key (c941838a)
- fix(studio): clear the traffic/event history on resetAll (3b5260c7)
- docs: name the exact vendored tarball in verification commands (6d48ea16)
- docs: verify the local build by content, not version string (05bc46a6)
- test(studio): assign the fake IDB factory explicitly in the seed test (b642e9ca)
- fix(sandbox): report per-service reset failures; reattach seed doc comments (e8af6a31)
- fix(storage): project-scope the storage IndexedDB database name (dd4772a8)
- fix(sandbox): sandbox-owned resetAll so Studio reset clears storage and RTDB (56c7a6bb)
- docs: guide for packing and testing local builds in a real app (18e8ebe5)
- docs: document the Ollama engine; use the real vite plugin export (a3e90d49)
- fix(test): update activity-query-value imports to relocated admin-compat path (c3315111)
- fix(ci): restore the install step the matrix job needs (0bf09d6c)
- ci: retrigger with ci-packaging label for the new conformance/docs subpath (f85c64e7)
- fix(merge): reconcile loaders with build-fast main (c2cfa9b8)
- fix(ci): run the documentation build for full check-sets, not just docs-only (8827e285)
- fix(ci): honor main's script contract in the merge resolution (e4b0e4bc)
- test(firestore): repoint admin-query pins at the moved engine path (de8f9a56)
- chore(firestore): sweep review nits across the engine stack (19f7bf10)
- docs: 8.7 check 2 exception count two -> four (delta-review finding) (843391bc)
- fix(rules): validate operators loudly, revert interleave production rejects (d24ee1e5)
- refactor(activity): make the CLI formatter the single source of truth for warning text (f73639fa)
- refactor(sandbox): bundle activity provenance into one optional record (8cd5f24c)
- refactor(firestore-values): keep the native leaf single-file, move registry to the surface (434b3937)
- fix(activity): thread real source attribution into incidents (fb349f8c)
- feat(dev): warn on runaway Firebase activity (42a5c0be)
- refactor(cli): extract durable persistence from serve-init (ef520f79)
- feat(site-docs): render generated pages through Astro content loaders (3780552b)
- ci: shorten trustworthy PR feedback (1087d07b)
- test(firestore): pin admin-compat query semantics before engine absorption (200c1b58)
- fix(rules): simulator resolves global- and service-scope functions (ae31213f)
- feat(conformance): publish the docs projection at @pyric/cli/conformance/docs (4ef26d84)
- chore(release): script the tarball behavior smoke (2c18e037)
- fix(grammar): let import and function declarations interleave at top level (cbb8f0b0)
- chore(release): gate publishing on the full suite and packaging test (8aafa657)
- fix(storage): name the unresolved import in the call-time deny reason (e693a8b3)
- fix(storage): adopt the RULES-B5 float model — 1.0 is float, int ÷ int truncates (c690e5bd)
- test(conformance): capture production verdicts for the PR-333 syntax corpus (4703001c)
- revert: drop rules-subset.md edits (doc slated for deletion) (24cabfaf)
- refactor(firestore-sandbox): extract RulesReadEngine behind the facade (11753cb8)
- refactor(firestore-sandbox): extract RulesState holder for source + AST cache (33878c01)
- test(firestore-sandbox): unit-test ListenerDispatch against a fake host (e720145f)
- refactor(firestore-sandbox): extract ListenerDispatch behind the facade (acc8246d)
- refactor(firestore-sandbox): extract TriggerScope from currentTrigger field (320ec291)
- docs: regenerate rules API reference after merging main (01b6d93c)
- refactor(firestore): extract HistoryControls behind a narrow HistoryHost (82ffe02c)
- refactor(firestore): extract the engine EventBus internal seam (bcd8f663)
- refactor(firestore): extract listener-delivery and reads helpers (4b503963)
- refactor(firestore): extract rules-verdict helpers into rules-evaluation.ts (f1dbb85f)
- refactor(firestore): extract request-event payload builders into history.ts (477cabf8)
- refactor(firestore): extract write/batch operation shapes into writes.ts (785b72a0)
- refactor(firestore): move sandbox engine directory to ratified firestore/sandbox location (6ef473c6)
- refactor(conformance): author app registry rows as defineRows seeds (ae9239ab)
- refactor(conformance): author rules registry rows as defineRows seeds (8af51bab)
- refactor(conformance): author storage registry rows as defineRows seeds (87068774)
- refactor(conformance): author auth registry rows as defineRows seeds (d222e97f)
- refactor(conformance): author firestore registry rows as defineRows seeds (6ec32527)
- refactor(conformance): author rtdb registry rows as defineRows seeds (69b4eb11)
- refactor(conformance): assemble functions-rtdb rows through defineRows (2512a8fe)
- refactor(conformance): assemble messaging rows through defineRows (709e283f)
- refactor(conformance): author ai registry rows through defineRows (6d75fb2d)
- feat(conformance): add shared defineRows row-authoring adapter (a9070a30)
- test(firestore): pin engine delivery, attribution, ack, and rules-flip behavior (660266fa)
- docs: record the Firestore engine deepening plan (ADR-0009) (6095d0fb)
- test(conformance): corpus scenarios for PR-333 syntax + fix JS-semantics leaks (872c4fd1)
- Parse storage rules through the shared rules grammar (065fdd0d)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.11` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.11` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.11 && git push origin v0.1.0-alpha.11` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
