### PR TITLE
refactor(firestore): internalize the value codec

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,7 +50,7 @@ subpaths include:
 | `pyric/app` | Firebase-shaped client app registry: `initializeApp(options, settings?)`, `getApp`, `getApps`, `deleteApp`, local `FirebaseError`, pinned `SDK_VERSION`, `onLog`, `setLogLevel`, `registerVersion`. Default and named equal-config app containers share one managed sandbox backend; a second Firebase configuration in the same runtime is intentionally rejected. It has no `firebase/app` runtime dependency; production imports stay on `firebase/app`. |
 | `pyric/auth` | Sandbox-only modular Auth mirror, identity, providers, and popup/redirect resolver. It has no `firebase/auth` runtime dependency; production imports stay on `firebase/auth`. |
 | `pyric/firestore` | Sandbox-only modular Firestore mirror plus Firestore data/inspect tools. It has no `firebase/firestore` runtime dependency; production imports stay on `firebase/firestore`. |
-| `pyric/firestore-values` | Firestore value helpers/wrappers. |
+| `pyric/firestore/internal/value-codec` | Worker-only Firestore wire-value rehydration seam; not an application-facing surface. |
 | `pyric/database` | Sandbox-only modular Realtime Database mirror. It has no `firebase/database` runtime dependency; production imports stay on `firebase/database`. |
 | `pyric/sandbox/database` | Owner controls for installing RTDB rules, seeding data, and reading detached snapshots. |
 | `pyric/storage` | Modular Storage mirror and storage admin-style tools. |

--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -220,12 +220,11 @@ packages/pyric/src/
     sandbox/                THIS surface's no-network backend
       backend.ts            the service facade (wires collaborators, owns lifecycle)
       <concept>.ts          state, query, converters/, rules-eval, sentinels, ...
-    internal.ts             host-only seam (optional; published as ./internal)
+    internal.ts | internal/ host-only seam (optional; published below ./internal)
   sandbox/                  CROSS-SURFACE runtime only (whitelist above), including
     internal/client-app.ts  neutral FirebaseApp-to-runtime adapter seam
   app/                      FirebaseApp registry + app-owned runtime/lifecycle
   rules/                    native surface (no prod/sandbox split)
-  firestore-values/         native leaf codec (no prod/sandbox split)
 ```
 
 ### Alternatives considered
@@ -259,7 +258,7 @@ app registry  ->  app runtime  ->  sandbox/ runtime
               sandbox/internal/client-app  <-  surface service factories
 
 surface barrel  ->  X/ families  ->  X/sandbox/ backend
-                                      ->  sandbox/ runtime  ->  firestore-values (leaf)
+                                      ->  sandbox/ runtime  ->  firestore/internal/value-codec (leaf)
 ```
 
 A surface depends downward on its backend and the shared runtime. A surface
@@ -286,17 +285,17 @@ Today's sideways edges, enumerated:
    `rules/rtdb/expression-engine.ts`, so importing `pyric/rules` does not compile
    the RTDB grammar.
 
-2. **firestore-values -> rules/simulator/wrappers/*, deep leaf import.**
-   `firestore-values/index.ts` imports the seven wrapper value classes (Timestamp,
+2. **firestore/internal/value-codec -> rules/simulator/wrappers/*, deep leaf import.**
+   `firestore/internal/value-codec.ts` imports the seven wrapper value classes (Timestamp,
    Bytes, LatLng, Duration, Reference, Path, Vector) by their direct leaf paths,
    to avoid executing the `pyric/rules` barrel (which pulls the parser, linter,
    and simulator, roughly 10 MB) into every serve page. This is a real sideways
    deep import. It is tolerated today only because the imported files are
    zero-dependency leaves. Ruling: this is a misfiled shared primitive, not a
-   firestore-values-specific dependency. The wrapper value classes are a leaf
-   that both `rules` and `firestore-values` should depend on downward. Target
-   (low priority, no climb blocks on it): host the wrapper classes as a shared
-   leaf (fold them into `firestore-values`, or a new `values/` leaf) and have
+   value-codec-specific dependency. The wrapper value classes are a leaf that
+   both `rules` and the internal codec should depend on downward. Target (low
+   priority, no climb blocks on it): host the wrapper classes as a shared
+   `values/` leaf and have
    `rules/simulator` import them from there. That dissolves the sideways edge.
    Until then it is a whitelisted exception (8.7 check 2). `storage/rules.ts`
    became the wrapper leaf's SECOND sideways consumer when it adopted the
@@ -332,10 +331,11 @@ no `X/sandbox/`. It still obeys the barrel, family, size, and direction rules.
   reached by package-internal consumers through the published `rules/internal`
   subpaths. No prod/sandbox split. The database sandbox consumes the RTDB engine
   through the private adapter described in 8.3 case 1.
-- **firestore-values.** A leaf value codec with two consumers (the sandbox
-  persistence serializer and the serve worker client). It is a single-file
-  native surface by design: it must stay small so the per-page bundle does not
-  drag the rules engine. See 8.3 case 2 for its one sideways edge.
+- **Firestore's internal value codec.** A leaf module with two consumers (the
+  sandbox persistence serializer and the serve worker client). Its interface is
+  published only as `pyric/firestore/internal/value-codec`; it is not a native
+  product surface. It must stay small so the per-page bundle does not drag the
+  rules engine. See 8.3 case 2 for its one sideways edge.
 - **The `pyric/sandbox` public API** is itself a native surface: `sandbox/index.ts`
   is its barrel, `sandbox/types/` its types, and the whitelist in 8.2 its
   implementation. It is the runtime every mirror surface sits on, so it lives at
@@ -391,7 +391,7 @@ its own commit, export path unchanged).
 | messaging | `messaging/broker/*` | unchanged. reference example | no move | nothing |
 | ai | `ai/broker/*` + `ai/backend.ts` + `ai/sandbox-plane.ts` | conforms. optional tidy: fold `backend.ts` and `sandbox-plane.ts` under `ai/sandbox/` for symmetry | opportunistic, next time ai backend is touched | low priority; not blocking |
 | rules | Firestore engine under `rules/*`; RTDB engine historically under `database/{grammar,constraints,simulation}` | both native engines under `rules/`, with RTDB isolated in `rules/rtdb/` | RTDB pure-engine relocation | move the RTDB grammar, constraints compiler, compiled tree, simulator, and their tests under `rules/rtdb/`; keep `pyric/rules` and `pyric/rules/internal/rtdb` import paths stable |
-| firestore-values | leaf codec, deep-imports rules wrappers | unchanged near-term; long-term host the wrapper leaf here (8.3 case 2) | deferred, no climb blocks on it | eventually the wrapper value classes move to a shared leaf; not scheduled |
+| Firestore internal value codec | leaf codec, deep-imports rules wrappers | unchanged near-term; long-term depend on a shared wrapper leaf (8.3 case 2) | deferred, no climb blocks on it | eventually the wrapper value classes move to a shared leaf; not scheduled |
 
 New code rule, restated for the table: under this convention, any firestore
 backend concept a climb adds goes in `firestore/sandbox/` even before the bulk
@@ -412,7 +412,8 @@ every rule in this section mechanically.
    import that crosses into another surface `src/<B>/` fails, with four
    whitelisted exceptions: (a) `database/sandbox/rules-eval.ts` importing the
    private `rules/rtdb` engine described in 8.3; (b) the
-   `firestore-values -> rules/simulator/wrappers/*` leaf edge, listed explicitly
+   `firestore/internal/value-codec -> rules/simulator/wrappers/*` leaf edge,
+   listed explicitly
    so it is visible and removable; (c) `storage/rules.ts` importing the shared
    syntax layer `rules/grammar/{FirestoreParser,FirestoreAST}.js` (8.3 case 3,
    parse-only); (d) `storage/rules.ts` importing

--- a/packages/cli/src/serve/worker/host/core.ts
+++ b/packages/cli/src/serve/worker/host/core.ts
@@ -39,7 +39,7 @@ import {
   type CollectionReference,
   type Query,
 } from 'pyric/firestore';
-import { rehydrateDocValue } from 'pyric/firestore-values';
+import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
 import {
   getDatabase as pyricGetDatabase,
   getAdminDatabase as pyricGetAdminDatabase,

--- a/packages/cli/src/serve/worker/host/firestore-writes.ts
+++ b/packages/cli/src/serve/worker/host/firestore-writes.ts
@@ -29,7 +29,7 @@ import {
   type DocumentReference,
   type SetOptions,
 } from 'pyric/firestore';
-import { rehydrateDocValue } from 'pyric/firestore-values';
+import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
 
 import type { OpMessage, WriteDescriptor, TxnReadEntry, SentinelMarker } from '../protocol.js';
 import { serializeDocData, isSentinelMarker } from '../protocol.js';
@@ -293,7 +293,8 @@ export async function handleFirestoreWriteOp(
        * validation re-read comes through the admin-compat wrapper whose
        * `Timestamp.toJSON()` emits `{ type, seconds, nanoseconds }` — same
        * value, different key order, different string. Rehydrating both
-       * sides through the ONE shared codec (`pyric/firestore-values`)
+       * sides through the ONE shared codec
+       * (`pyric/firestore/internal/value-codec`)
        * collapses every marker family into the same wrapper classes with
        * deterministic `toJSON()` key order, so string equality ↔ value
        * equality again — an unmodified doc can never phantom-abort (which

--- a/packages/cli/src/serve/worker/index.ts
+++ b/packages/cli/src/serve/worker/index.ts
@@ -9,7 +9,8 @@
  *     the backend) — node/engine-heavy, never wanted in a page bundle.
  *   - `entry.ts` references `SharedWorkerGlobalScope` and is esbuild-only.
  *
- * `client.ts` imports only the value codec (`pyric/firestore-values`, a leaf)
+ * `client.ts` imports only the value codec
+ * (`pyric/firestore/internal/value-codec`, a leaf internal seam)
  * and type-only `pyric/sandbox` (erased at build), so this entry stays free of
  * the ~10 MB rules/sandbox engine — safe to import from any browser app.
  *

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -44,11 +44,11 @@
  */
 
 // LEAF import — the value codec only, NOT `pyric/sandbox`. Importing the
-// codec from the standalone `pyric/firestore-values` module keeps the
+// codec from `pyric/firestore/internal/value-codec` keeps the
 // SharedWorker CLIENT bundle (every serve page) free of the rules/sandbox
 // engine (~10 MB). The worker HOST (`entry.ts`/`host.ts`) still imports the
 // full library — it IS the backend — but the client path stays lean.
-import { rehydrateDocValue } from 'pyric/firestore-values';
+import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
 // TYPE-ONLY (erased at build, so the leaf client bundle stays engine-free).
 // The auth-lens contract and the cross-service event envelope are shared with
 // the sandbox's event provenance — Studio's Action Center folds these verbatim.

--- a/packages/pyric/README.md
+++ b/packages/pyric/README.md
@@ -17,7 +17,6 @@ Rules tooling and explicit sandbox controls.
 | `pyric/database` | Realtime Database modular mirror |
 | `pyric/storage` | Storage modular mirror and rules-aware sandbox tools |
 | `pyric/rules` | Firestore and RTDB rules lint, simulation, explanation, constraints, and standard library |
-| `pyric/firestore-values` | Firestore value helpers |
 | `pyric/sandbox` | Sandbox lifecycle, identity, events, persistence, and replay |
 
 The package manifest is the authority for public exports, including the

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/firestore/internal/index.d.ts",
       "import": "./dist/firestore/internal/index.js"
     },
+    "./firestore/internal/value-codec": {
+      "types": "./dist/firestore/internal/value-codec.d.ts",
+      "import": "./dist/firestore/internal/value-codec.js"
+    },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js"
@@ -77,10 +81,6 @@
     "./rules": {
       "types": "./dist/rules/index.d.ts",
       "import": "./dist/rules/index.js"
-    },
-    "./firestore-values": {
-      "types": "./dist/firestore-values/index.d.ts",
-      "import": "./dist/firestore-values/index.js"
     },
     "./rules/internal": {
       "types": "./dist/rules/internal/index.d.ts",

--- a/packages/pyric/src/firestore/internal/value-codec.ts
+++ b/packages/pyric/src/firestore/internal/value-codec.ts
@@ -1,5 +1,5 @@
 /**
- * Firestore value codec — the marker-based serialize/rehydrate of
+ * Internal Firestore value codec — the marker-based serialize/rehydrate of
  * Firestore special scalar types (Timestamp, Bytes, LatLng/GeoPoint,
  * Duration, Reference, Path, Vector).
  *
@@ -53,13 +53,13 @@
 
 // Direct leaf imports — NOT the `pyric/rules` barrel. Each of these modules
 // depends only on `./base.js` (no imports), so this stays engine-free.
-import { Bytes } from '../rules/simulator/wrappers/bytes.js';
-import { Duration } from '../rules/simulator/wrappers/duration.js';
-import { LatLng } from '../rules/simulator/wrappers/latlng.js';
-import { Path } from '../rules/simulator/wrappers/path.js';
-import { Reference } from '../rules/simulator/wrappers/reference.js';
-import { Timestamp } from '../rules/simulator/wrappers/timestamp.js';
-import { Vector } from '../rules/simulator/wrappers/vector.js';
+import { Bytes } from '../../rules/simulator/wrappers/bytes.js';
+import { Duration } from '../../rules/simulator/wrappers/duration.js';
+import { LatLng } from '../../rules/simulator/wrappers/latlng.js';
+import { Path } from '../../rules/simulator/wrappers/path.js';
+import { Reference } from '../../rules/simulator/wrappers/reference.js';
+import { Timestamp } from '../../rules/simulator/wrappers/timestamp.js';
+import { Vector } from '../../rules/simulator/wrappers/vector.js';
 // Sideways leaf import into the firestore surface (same character as the
 // wrapper imports above): the activity value registry is a zero-dependency
 // leaf owned by `firestore/sandbox/`, consumed here only to stamp trusted
@@ -67,7 +67,7 @@ import { Vector } from '../rules/simulator/wrappers/vector.js';
 import {
   registerActivityValue,
   trustedWireActivityValue,
-} from '../firestore/sandbox/activity-value-registry.js';
+} from '../sandbox/activity-value-registry.js';
 
 /**
  * Decode a base64url string (`-`/`_` alphabet, no padding) back into a

--- a/packages/pyric/src/sandbox/admin-firestore/remote/value-codec.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/remote/value-codec.ts
@@ -10,7 +10,8 @@
  * the worker STORES real typed values (rules comparisons and `orderBy`
  * see a Timestamp, not a map). Read payloads arrive as the
  * `SerializedDocData` JSON envelope and are rehydrated with the ONE shared
- * codec (`pyric/firestore-values`' `rehydrateDocValue`) then translated to
+ * codec (`pyric/firestore/internal/value-codec`'s `rehydrateDocValue`) then
+ * translated to
  * the compat field shapes (`translateReadData`) — the same shapes the
  * local arm's read path yields.
  *
@@ -27,7 +28,7 @@
  * vocabulary in this system.
  */
 
-import { rehydrateDocValue } from 'pyric/firestore-values';
+import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
 import {
   Timestamp as CompatTimestamp,
   type DocumentData,

--- a/packages/pyric/src/sandbox/persistence/chunk-format.ts
+++ b/packages/pyric/src/sandbox/persistence/chunk-format.ts
@@ -17,7 +17,7 @@
  * (Float32Array vector encoding is a later, backward-compatible refinement on the
  * per-bucket record shape.)
  */
-import { rehydrateDocValue } from '../../firestore-values/index.js';
+import { rehydrateDocValue } from '../../firestore/internal/value-codec.js';
 import { deserializeSnapshot } from './serialize.js';
 
 export const CHUNK_FORMAT_VERSION = 3 as const;

--- a/packages/pyric/src/sandbox/persistence/serialize.ts
+++ b/packages/pyric/src/sandbox/persistence/serialize.ts
@@ -19,12 +19,12 @@
  * be detected and reported (rather than corrupting silently).
  */
 
-// The marker-based value codec lives in a STANDALONE leaf module
-// (`firestore-values`) so the SharedWorker client can rehydrate doc values
-// WITHOUT pulling the rules engine. `serialize.ts` re-uses that same codec so
-// there is exactly one rehydrate implementation — the IDB persistence format
-// and the MessagePort wire format can't drift.
-import { rehydrateDocValue } from '../../firestore-values/index.js';
+// The marker-based value codec lives behind Firestore's leaf internal seam so
+// the SharedWorker client can rehydrate doc values WITHOUT pulling the rules
+// engine. `serialize.ts` re-uses that same codec so there is exactly one
+// rehydrate implementation — the IDB persistence format and the MessagePort
+// wire format can't drift.
+import { rehydrateDocValue } from '../../firestore/internal/value-codec.js';
 
 // Re-exported so existing consumers (`sandbox/persistence/index.ts` →
 // `pyric/sandbox`) keep their import path; the implementation now lives in the

--- a/packages/pyric/test/firestore/internal-value-codec-export.test.ts
+++ b/packages/pyric/test/firestore/internal-value-codec-export.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import manifest from '../../package.json';
+
+describe('Firestore internal value codec export', () => {
+  it('keeps the worker codec internal to Firestore instead of publishing a native surface', () => {
+    const exportedSubpaths = Object.keys(manifest.exports);
+    expect(exportedSubpaths).toContain('./firestore/internal/value-codec');
+    expect(exportedSubpaths).not.toContain('./firestore-values');
+  });
+});

--- a/packages/pyric/test/firestore/internal/value-codec.test.ts
+++ b/packages/pyric/test/firestore/internal/value-codec.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'bun:test';
 import {
   registeredActivityValue,
   trustedWireActivityValue,
-} from '../../src/firestore/sandbox/activity-value-registry.js';
-import { rehydrateDocValue } from '../../src/firestore-values/index.js';
-import { Bytes } from '../../src/rules/simulator/wrappers/bytes.js';
-import { Duration } from '../../src/rules/simulator/wrappers/duration.js';
-import { LatLng } from '../../src/rules/simulator/wrappers/latlng.js';
-import { Path } from '../../src/rules/simulator/wrappers/path.js';
-import { Reference } from '../../src/rules/simulator/wrappers/reference.js';
-import { Timestamp } from '../../src/rules/simulator/wrappers/timestamp.js';
-import { Vector } from '../../src/rules/simulator/wrappers/vector.js';
+} from '../../../src/firestore/sandbox/activity-value-registry.js';
+import { rehydrateDocValue } from '../../../src/firestore/internal/value-codec.js';
+import { Bytes } from '../../../src/rules/simulator/wrappers/bytes.js';
+import { Duration } from '../../../src/rules/simulator/wrappers/duration.js';
+import { LatLng } from '../../../src/rules/simulator/wrappers/latlng.js';
+import { Path } from '../../../src/rules/simulator/wrappers/path.js';
+import { Reference } from '../../../src/rules/simulator/wrappers/reference.js';
+import { Timestamp } from '../../../src/rules/simulator/wrappers/timestamp.js';
+import { Vector } from '../../../src/rules/simulator/wrappers/vector.js';
 
 describe('rehydrateDocValue', () => {
   it('rehydrates every Pyric marker into its wrapper type', () => {

--- a/packages/pyric/test/sandbox/persistence.test.ts
+++ b/packages/pyric/test/sandbox/persistence.test.ts
@@ -15,7 +15,7 @@
  */
 import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
 // Import wrappers from the same src module graph that `serialize.ts` (also
-// imported from src below) pulls in via the leaf `firestore-values` codec. In
+// imported from src below) pulls in via the leaf Firestore value codec. In
 // this monorepo, `pyric/rules` resolves to the *built* dist copy, which is a
 // DISTINCT class identity from the src wrappers — mixing the two would break
 // the `instanceof` checks. Production code is all-dist, so identity holds

--- a/packages/site-docs/test/api-reference.test.ts
+++ b/packages/site-docs/test/api-reference.test.ts
@@ -47,9 +47,9 @@ describe('generated API reference inventory', () => {
   });
 
   test('uses unique stable routes backed by declaration entries', () => {
-    expect(descriptors).toHaveLength(49);
-    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(49);
-    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(49);
+    expect(descriptors).toHaveLength(48);
+    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(48);
+    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(48);
     for (const descriptor of descriptors) {
       expect(existsSync(descriptor.typesPath), descriptor.importPath).toBeTrue();
       expect(descriptor.slug).toMatch(/^[a-z0-9-]+-reference-api$/);


### PR DESCRIPTION
Moves the worker wire-value codec from the product-looking `pyric/firestore-values` export to the explicit `pyric/firestore/internal/value-codec` seam.

```js
import { rehydrateDocValue } from "pyric/firestore/internal/value-codec";

const timestamp = rehydrateDocValue({
  type: "firestore/timestamp/1.0",
  seconds: 12,
  nanoseconds: 34,
});

console.log(timestamp.constructor.name); // Timestamp
console.log(timestamp.toMillis());       // 12000
```

## `firestore-values` is no longer presented as a product surface

The codec exists so the SharedWorker client can reconstruct Firestore scalar values without loading the full rules engine. Pyric itself is its only consumer. The previous top-level name made that implementation constraint look like a user-facing capability; the replacement keeps the same one-function leaf interface under Firestore ownership and marks it as internal.

Package-internal persistence code continues to share the same implementation, while `@pyric/cli` imports the new internal subpath. The codec behavior and serialized marker formats do not change.

## Risk

This removes an alpha package export. Any external code importing `pyric/firestore-values` will receive `ERR_PACKAGE_PATH_NOT_EXPORTED` and must change to `pyric/firestore/internal/value-codec`. Repository search found no non-Pyric consumers, but the reviewer should judge whether an alpha deprecation window is warranted.

The new path is intentionally internal: it supports Pyric adapters and is not a stability promise for application code.

<details>
<summary>Implementation notes and verification</summary>

- Moved the implementation and behavior tests under `firestore/internal`.
- Added a manifest regression that requires the new path and rejects `./firestore-values`.
- Updated the SharedWorker client and host, persistence serializer, remote Admin codec, package README, repository context, and architecture conventions.
- `bun run test:packaging` passed; the packed internal path resolves with exactly one export.
- `bun run lint:manifest` passed.
- `bun run compat:census-gate`, `compat:entry-path`, `compat:conformance:check`, and `compat:coverage` passed.
- Focused codec, persistence, workspace-entry, and conformance-model tests passed.
- The full suite passed through the pyric, pyric-admin, create-pyric, CLI, UI, and Studio packages. It exposed only the intended API-reference inventory ratchet, which was updated and then passed with the remaining suites.

Coverage-adversary verdict: **EARNED WITH RECLASSIFICATION**. Generated public API-reference routes move from 49 to 48 because this implementation seam is no longer classified as a product surface. No Firebase public-surface denominator, conformance percentage, assurance verdict, registry status, or observation changes; this PR claims no coverage improvement.

</details>