### PR TITLE
fix(release): publish admin messaging with valid source maps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ service and sandbox fronts.
 
 ### `pyric-admin`
 
-`pyric-admin/{app,auth,firestore,database,storage}` provides Admin-shaped
+`pyric-admin/{app,auth,firestore,database,storage,messaging}` provides Admin-shaped
 handles for the sandbox. Production server code should import
 `firebase-admin/*` directly. During activated development, the CLI resolver can
 map those canonical imports to the sandbox mirrors without changing source.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,6 +93,7 @@
   },
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],

--- a/packages/conformance/src/conformance-model.ts
+++ b/packages/conformance/src/conformance-model.ts
@@ -260,6 +260,7 @@ async function buildConformanceModel(enforceCensusPolicy: boolean): Promise<Conf
   const developerSurfaceByContract = new Map(surfaceContracts.map(({ key, record }) =>
     [key, record.developerSurface] as const,
   ));
+  const contractByKey = new Map(surfaceContracts.map(({ key, record }) => [key, record] as const));
   const importsByContract = new Map<string, readonly string[]>();
   const runtimeExportsByContract = new Map<string, ReadonlySet<string>>();
   for (const { key, record } of surfaceContracts) {
@@ -267,7 +268,9 @@ async function buildConformanceModel(enforceCensusPolicy: boolean): Promise<Conf
       ? record.mirrors
       : record.kind === 'native'
         ? [record.symbolSource]
-        : [];
+        : record.kind === 'registry-only'
+          ? record.evidenceImports ?? []
+          : [];
     for (const importPath of imports) {
       const entry = workspaceEntryPaths(importPath);
       if (!entry) {
@@ -401,7 +404,12 @@ async function buildConformanceModel(enforceCensusPolicy: boolean): Promise<Conf
     const rowVerdict = verdicts[row.id];
     for (const name of featureKeys) {
       const feature = ensure(name, developerSurfaceFor(row.surface));
-      if (runtimeExportsByContract.get(row.surface)?.has(name)) addImportPaths(feature, row.surface);
+      if (
+        runtimeExportsByContract.get(row.surface)?.has(name)
+        || contractByKey.get(row.surface)?.kind === 'registry-only'
+      ) {
+        addImportPaths(feature, row.surface);
+      }
       classify(feature, 'declared', 'available');
       feature.registryStatuses.push(row.status);
       if (rowVerdict) feature.assuranceVerdicts.push(rowVerdict);

--- a/packages/conformance/surfaces/messaging-admin.json
+++ b/packages/conformance/surfaces/messaging-admin.json
@@ -2,6 +2,9 @@
   "schema": "pyric.conformance.surface.v2",
   "kind": "registry-only",
   "developerSurface": "messaging-admin",
+  "evidenceImports": [
+    "pyric-admin/messaging"
+  ],
   "observationPrefixes": [
     "messaging-send-"
   ],

--- a/packages/conformance/test/src/conformance-model.test.ts
+++ b/packages/conformance/test/src/conformance-model.test.ts
@@ -64,11 +64,12 @@ describe('multi-axis conformance model', () => {
     expect(siblingEntry.supports.map(({ feature }) => feature)).not.toContain('getToken');
   });
 
-  it('scopes real native exports without scoping rules constructs or unreleased registry-only APIs', () => {
+  it('scopes published native and registry-only APIs without scoping rules constructs', () => {
     expect(canIUse(model, 'evaluateStorageRules', { importPath: 'pyric/storage' }).match).toBe('exact');
-    // Messaging Admin remains explicitly unreleased, so it cannot be used as
-    // a published import scope until it graduates from pyricUnreleasedExports.
-    expect(canIUse(model, 'send', { importPath: 'pyric-admin/messaging' }).match).toBe('none');
+    expect(canIUse(model, 'send', { importPath: 'pyric-admin/messaging' })).toMatchObject({
+      match: 'exact',
+      supports: [expect.objectContaining({ surface: 'messaging-admin', availability: 'available' })],
+    });
     expect(canIUse(model, 'getAfter', { importPath: 'pyric/rules' }).match).toBe('none');
   });
 

--- a/packages/conformance/test/src/workspace-entry.test.ts
+++ b/packages/conformance/test/src/workspace-entry.test.ts
@@ -5,7 +5,9 @@ describe('workspace entry resolution', () => {
   it('maps published workspace exports back to source for clean-checkout generation', () => {
     expect(workspaceSourceEntry('pyric/ai')).toEndWith('packages/pyric/src/ai/index.ts');
     expect(workspaceSourceEntry('pyric/messaging/sw')).toEndWith('packages/pyric/src/messaging/sw.ts');
-    expect(workspaceSourceEntry('pyric-admin/messaging')).toBeNull();
+    expect(workspaceSourceEntry('pyric-admin/messaging')).toEndWith(
+      'packages/pyric-admin/src/messaging/index.ts',
+    );
     expect(workspaceSourceEntry('@pyric/conformance/docs')).toBeNull();
     expect(workspaceSourceEntry('firebase/ai')).toBeNull();
   });

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "src",
     "templates",
     "README.md",
     "LICENSE"

--- a/packages/pyric-admin/README.md
+++ b/packages/pyric-admin/README.md
@@ -21,6 +21,7 @@ loads `firebase-admin` directly.
 | `pyric-admin/auth` | Admin Auth shape |
 | `pyric-admin/database` | Admin Realtime Database shape |
 | `pyric-admin/storage` | Admin Storage shape |
+| `pyric-admin/messaging` | Admin Cloud Messaging send plane |
 
 ## Explicit sandbox setup
 
@@ -46,3 +47,4 @@ without sandbox activation and therefore resolves Firebase Admin directly.
 - [Auth API](https://pyric.dev/docs/pyric-admin-auth-reference-api/)
 - [Realtime Database API](https://pyric.dev/docs/pyric-admin-database-reference-api/)
 - [Storage API](https://pyric.dev/docs/pyric-admin-storage-reference-api/)
+- [Messaging API](https://pyric.dev/docs/pyric-admin-messaging-reference-api/)

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],
@@ -63,8 +64,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "pyricUnreleasedExports": [
-    "./messaging"
-  ]
+  }
 }

--- a/packages/pyric-admin/test/published-manifest.test.ts
+++ b/packages/pyric-admin/test/published-manifest.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dir, '../../..');
+const workDirs: string[] = [];
+
+afterEach(() => {
+  for (const directory of workDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('published pyric-admin manifest', () => {
+  test('exports the messaging mirror required by the shipped chat template', () => {
+    const work = mkdtempSync(join(tmpdir(), 'pyric-admin-published-manifest-'));
+    workDirs.push(work);
+    const manifestPath = join(work, 'package.json');
+    writeFileSync(
+      manifestPath,
+      readFileSync(join(root, 'packages/pyric-admin/package.json'), 'utf8'),
+    );
+
+    const rewrite = spawnSync(
+      process.execPath,
+      [join(root, 'scripts/lib/rewrite-workspace-deps.mjs'), manifestPath, root],
+      { encoding: 'utf8' },
+    );
+    expect(rewrite.status).toBe(0);
+
+    const published = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      exports?: Record<string, unknown>;
+    };
+    expect(Object.keys(published.exports ?? {})).toContain('./messaging');
+  });
+});

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -125,6 +125,7 @@
   },
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],

--- a/packages/site-docs/test/api-reference.test.ts
+++ b/packages/site-docs/test/api-reference.test.ts
@@ -47,9 +47,9 @@ describe('generated API reference inventory', () => {
   });
 
   test('uses unique stable routes backed by declaration entries', () => {
-    expect(descriptors).toHaveLength(49);
-    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(49);
-    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(49);
+    expect(descriptors).toHaveLength(50);
+    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(50);
+    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(50);
     for (const descriptor of descriptors) {
       expect(existsSync(descriptor.typesPath), descriptor.importPath).toBeTrue();
       expect(descriptor.slug).toMatch(/^[a-z0-9-]+-reference-api$/);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,6 +77,7 @@
   },
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/lib/package-artifact-manifest.mjs
+++ b/scripts/lib/package-artifact-manifest.mjs
@@ -1,0 +1,75 @@
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+function readTarEntry(tarballPath, entryPath) {
+  const archive = gunzipSync(readFileSync(tarballPath));
+  for (let offset = 0; offset + 512 <= archive.length; ) {
+    const header = archive.subarray(offset, offset + 512);
+    const name = header.subarray(0, 100).toString('utf8').replace(/\0.*$/, '');
+    const prefix = header.subarray(345, 500).toString('utf8').replace(/\0.*$/, '');
+    const path = prefix ? `${prefix}/${name}` : name;
+    const sizeText = header.subarray(124, 136).toString('ascii').replace(/\0.*$/, '').trim();
+    const size = sizeText ? Number.parseInt(sizeText, 8) : 0;
+    const contentsOffset = offset + 512;
+    if (path === entryPath) {
+      return archive.subarray(contentsOffset, contentsOffset + size).toString('utf8');
+    }
+    offset = contentsOffset + Math.ceil(size / 512) * 512;
+  }
+  throw new Error(`${entryPath} not found in ${tarballPath}`);
+}
+
+/**
+ * Build the release manifest from the package manifests inside the tarballs.
+ * Source manifests are used only to locate each artifact.
+ */
+export function createPackageArtifactManifest({
+  root,
+  outDir,
+  packageDirs,
+  generatedAt = new Date().toISOString(),
+}) {
+  return {
+    generated: generatedAt,
+    packages: packageDirs.map((sourceDir) => {
+      const sourceManifest = JSON.parse(
+        readFileSync(join(root, sourceDir, 'package.json'), 'utf8'),
+      );
+      const flatName = sourceManifest.name.replace(/^@/, '').replace(/\//g, '-');
+      const file = `${flatName}-${sourceManifest.version}.tgz`;
+      const fullPath = join(outDir, file);
+      const packedManifest = JSON.parse(readTarEntry(fullPath, 'package/package.json'));
+
+      return {
+        name: packedManifest.name,
+        version: packedManifest.version,
+        tarball: `dist/packages/${file}`,
+        bytes: statSync(fullPath).size,
+        sourceDir,
+        subpaths: packedManifest.exports ? Object.keys(packedManifest.exports).sort() : [],
+        bin: packedManifest.bin ? Object.keys(packedManifest.bin) : [],
+      };
+    }),
+  };
+}
+
+export function writePackageArtifactManifest(options) {
+  const manifest = createPackageArtifactManifest(options);
+  writeFileSync(join(options.outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [, , root, outDir, ...packageDirs] = process.argv;
+  if (!root || !outDir || packageDirs.length === 0) {
+    throw new Error(
+      'usage: node package-artifact-manifest.mjs <root> <out-dir> <package-dir>...',
+    );
+  }
+  const manifest = writePackageArtifactManifest({ root, outDir, packageDirs });
+  console.log(
+    `    → dist/packages/manifest.json (${manifest.packages.length} packages)`,
+  );
+}

--- a/scripts/lib/package-artifact-manifest.test.ts
+++ b/scripts/lib/package-artifact-manifest.test.ts
@@ -1,13 +1,22 @@
-import { describe, expect, test } from 'bun:test';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createPackageArtifactManifest } from './package-artifact-manifest.mjs';
 
+const workDirs: string[] = [];
+
+afterEach(() => {
+  for (const directory of workDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 describe('package artifact manifest', () => {
   test('reports exports from the packed manifest, not the source manifest', () => {
     const root = mkdtempSync(join(tmpdir(), 'pyric-artifact-manifest-'));
+    workDirs.push(root);
     const packageDir = join(root, 'packages/example');
     const packedDir = join(root, 'packed/package');
     const outDir = join(root, 'dist/packages');

--- a/scripts/lib/package-artifact-manifest.test.ts
+++ b/scripts/lib/package-artifact-manifest.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createPackageArtifactManifest } from './package-artifact-manifest.mjs';
+
+describe('package artifact manifest', () => {
+  test('reports exports from the packed manifest, not the source manifest', () => {
+    const root = mkdtempSync(join(tmpdir(), 'pyric-artifact-manifest-'));
+    const packageDir = join(root, 'packages/example');
+    const packedDir = join(root, 'packed/package');
+    const outDir = join(root, 'dist/packages');
+    mkdirSync(packageDir, { recursive: true });
+    mkdirSync(packedDir, { recursive: true });
+    mkdirSync(outDir, { recursive: true });
+
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: '@example/pkg',
+        version: '1.2.3',
+        exports: { './public': './dist/public.js', './removed': './dist/removed.js' },
+      }),
+    );
+    writeFileSync(
+      join(packedDir, 'package.json'),
+      JSON.stringify({
+        name: '@example/pkg',
+        version: '1.2.3',
+        exports: { './public': './dist/public.js' },
+      }),
+    );
+
+    const tarball = join(outDir, 'example-pkg-1.2.3.tgz');
+    const packed = spawnSync('tar', ['-czf', tarball, '-C', join(root, 'packed'), 'package']);
+    expect(packed.status).toBe(0);
+
+    const manifest = createPackageArtifactManifest({
+      root,
+      outDir,
+      packageDirs: ['packages/example'],
+      generatedAt: '2026-07-19T00:00:00.000Z',
+    });
+
+    expect(manifest.packages[0]?.subpaths).toEqual(['./public']);
+    const sourceExports = JSON.parse(
+      readFileSync(join(packageDir, 'package.json'), 'utf8'),
+    ).exports;
+    expect(Object.keys(sourceExports)).toContain('./removed');
+  });
+});

--- a/scripts/lib/verify-published-sourcemaps.mjs
+++ b/scripts/lib/verify-published-sourcemaps.mjs
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function* filesBelow(directory) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) yield* filesBelow(path);
+    else yield path;
+  }
+}
+
+export function findBrokenPublishedSourceMaps(packageRoot) {
+  const dist = join(packageRoot, 'dist');
+  if (!existsSync(dist)) return [];
+
+  const broken = [];
+  for (const mapPath of filesBelow(dist)) {
+    if (!mapPath.endsWith('.map')) continue;
+    const map = JSON.parse(readFileSync(mapPath, 'utf8'));
+    for (const [index, source] of (map.sources ?? []).entries()) {
+      if (/^(?:data:|https?:|webpack:)/.test(source)) continue;
+      if (map.sourcesContent?.[index] != null) continue;
+      const sourcePath = resolve(dirname(mapPath), map.sourceRoot ?? '', source);
+      if (!existsSync(sourcePath)) {
+        broken.push({ mapPath, source, sourcePath });
+      }
+    }
+  }
+  return broken;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const packageRoot = process.argv[2];
+  if (!packageRoot) throw new Error('usage: node verify-published-sourcemaps.mjs <package-root>');
+  const broken = findBrokenPublishedSourceMaps(packageRoot);
+  if (broken.length > 0) {
+    console.error(`published source maps reference ${broken.length} missing source file(s)`);
+    for (const issue of broken.slice(0, 10)) {
+      console.error(`  ${issue.mapPath}: ${issue.source}`);
+    }
+    if (broken.length > 10) console.error(`  …and ${broken.length - 10} more`);
+    process.exit(1);
+  }
+}

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -143,33 +143,8 @@ done
 echo ""
 echo "━━━ Phase 3: manifest ━━━"
 
-node -e "
-const fs = require('fs');
-const path = require('path');
-const root = '$ROOT';
-const out = '$OUT_DIR';
-const packages = $(printf '%s\n' "${PACKAGES[@]}" | jq -R . | jq -s .);
-const manifest = {
-  generated: new Date().toISOString(),
-  packages: packages.map((dir) => {
-    const pj = JSON.parse(fs.readFileSync(path.join(root, dir, 'package.json'), 'utf-8'));
-    const flat = pj.name.replace(/^@/, '').replace(/\//g, '-');
-    const file = flat + '-' + pj.version + '.tgz';
-    const fullPath = path.join(out, file);
-    return {
-      name: pj.name,
-      version: pj.version,
-      tarball: 'dist/packages/' + file,
-      bytes: fs.statSync(fullPath).size,
-      sourceDir: dir,
-      subpaths: pj.exports ? Object.keys(pj.exports).sort() : [],
-      bin: pj.bin ? Object.keys(pj.bin) : [],
-    };
-  }),
-};
-fs.writeFileSync(path.join(out, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
-console.log('    → dist/packages/manifest.json (' + manifest.packages.length + ' packages)');
-"
+node "$ROOT/scripts/lib/package-artifact-manifest.mjs" \
+  "$ROOT" "$OUT_DIR" "${PACKAGES[@]}"
 
 # ─── Phase 4: report ───────────────────────────────────────────────────
 echo ""

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -124,6 +124,7 @@ pack_one() {
       "$tmp/package/package.json" "$ROOT"
     (cd "$tmp" && tar -czf "$full" package)
   fi
+  node "$ROOT/scripts/lib/verify-published-sourcemaps.mjs" "$tmp/package"
   rm -rf "$tmp"
 
   # Verification: the published tarball MUST NOT contain workspace: deps.
@@ -259,6 +260,7 @@ cat > package.json <<JSON
     "@pyric/ui": "file:${TARBALL_UI}",
     "firebase": "^12.12.0",
     "firebase-admin": "^13.0.0",
+    "firebase-functions": "^6.0.0",
     "vite": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -596,6 +598,19 @@ if grep -R -qE '@inbrowser-(workspace|resumable|firebase)-|node_modules/@inbrows
   exit 1
 fi
 echo "  ✓ create-pyric scaffolds the portable chat app"
+
+# Execute the unchanged Functions module through the same packed register
+# loader that the Vite plugin injects into its child. The chat template imports
+# firebase-admin/messaging, so this catches a packed pyric-admin manifest that
+# strips the mapped pyric-admin/messaging subpath even when workspace tests pass.
+ln -s "$WORK/consumer/node_modules" "$CREATE_CHAT_OUT/node_modules"
+(
+  cd "$CREATE_CHAT_OUT"
+  PYRIC_SANDBOX="remote:http://127.0.0.1:1" \
+    NODE_OPTIONS="--import @pyric/cli/register" \
+    node functions/index.js
+)
+echo "  ✓ packed chat Functions module boots through @pyric/cli/register"
 
 # ─── Phase 5.5: serve smoke (init + serve from the packed bin) ─────────
 # The subpath + bin checks above prove imports resolve, but they never boot


### PR DESCRIPTION
Makes the published chat template boot by shipping `pyric-admin/messaging` and resolvable TypeScript sources for every emitted sourcemap.

```sh
npm create pyric@0.1.0-alpha.11 my-chat -- --template chat
cd my-chat
npm run dev
# The unchanged functions/index.js import of firebase-admin/messaging now maps
# to the published pyric-admin/messaging export and the Functions child starts.
```

## The packed chat Functions module now resolves every mapped Admin import

The release rewrite no longer removes `pyric-admin/messaging`, which the shipped chat template reaches through `@pyric/cli/register`. The packaging gate now installs `firebase-functions`, scaffolds the real chat template, and executes its unchanged Functions module through that register loader.

The artifact manifest is now derived from each tarball's own `package.json`, so release metadata cannot claim an export that the publish rewrite removed. A package-level regression test also applies the real rewrite and asserts that `./messaging` survives.

## Published sourcemaps now resolve to shipped source files

Each publishable package includes `src`, matching the relative source paths already recorded in its emitted maps. The packaging gate checks every packed map and fails if a referenced source is neither shipped nor embedded.

## Risk

This graduates `pyric-admin/messaging` into the public npm contract and increases tarball sizes by including TypeScript sources. The largest packed artifacts are `@pyric/cli` at 3.6 MB and `pyric` at 1.8 MB. No compatibility percentage or Firebase census denominator changes; the existing registry-only messaging evidence is now correctly attached to its published import.

<details>
<summary>Implementation notes and verification</summary>

- `bun run test`: pass, full repository build and test suite.
- `bun run test:packaging`: pass; all five tarballs install, all subpaths resolve, the chat Functions module boots, and the Vite/serve smoke tests pass.
- `bash scripts/pack-packages.sh --skip-build`: pass; the generated artifact manifest includes `pyric-admin/messaging` from the tarball itself.
- `bun run lint:manifest`: pass for all four library manifests.
- `bun run compat:census-gate`, `compat:entry-path`, `compat:conformance:check`, `compat:coverage`, and `compat:validate`: pass with 0 new runtime gaps, 0 coverage regression, and 0 model problems.
- Coverage audit verdict: EARNED. This exposes an already implemented and tested Admin Messaging surface that the released chat template requires; it does not manufacture improvement by changing a denominator or reclassifying evidence.
- No package was published.

</details>
