### PR TITLE
release: v0.1.0-alpha.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.11",
+      "version": "0.1.0-alpha.12",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -111,7 +111,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.11",
+      "version": "0.1.0-alpha.12",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -231,7 +231,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.11",
+      "version": "0.1.0-alpha.12",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -249,7 +249,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.11",
+      "version": "0.1.0-alpha.12",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -313,7 +313,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.11",
+      "version": "0.1.0-alpha.12",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.12`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.11

- fix(release): publish admin messaging with valid source maps (#408) (24b102fc)
- refactor(firestore): internalize value codec (74f01328)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.12` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.12` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.12 && git push origin v0.1.0-alpha.12` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
