### PR TITLE
feat(vite): make pyric() convention-first

### DIFF
--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -66,6 +66,11 @@ The God-object rule. A single class longer than 400 lines is a design smell, not
 - Repository-maintainer runbooks live under root `docs/`. They document
   contributor-only operations such as publishing and local package testing and
   are not duplicated into the user-facing product documentation.
+- A generated project template may include a README containing only the
+  artifact-local commands and configuration needed to run that generated
+  project. Canonical product concepts, explanations, and reference material
+  remain under `packages/site-docs/src/content/`; template READMEs link there
+  rather than becoming a second documentation set.
 - Generated documentation is never committed: the conformance matrices and the
   TypeDoc API reference are written into `packages/site-docs/src/content/_generated/`
   (gitignored) by `bun run generate` immediately before `astro build`.

--- a/packages/cli/src/serve/vite-ai-config.ts
+++ b/packages/cli/src/serve/vite-ai-config.ts
@@ -1,0 +1,62 @@
+import type { AIOptions } from 'pyric/ai';
+import type { AiEngineConfigWire } from './worker/protocol.js';
+
+const AI_PROXY_PATH = '/__pyric/ai-proxy';
+
+/** Declarative AI engines that can cross Vite's page/SharedWorker boundary. */
+export type PyricAiEngineConfig = Extract<NonNullable<AIOptions['engine']>, { kind: string }>;
+
+export interface PyricAiOptions {
+  /** Simple OpenAI-compatible model selection through Pyric's same-origin proxy. */
+  model?: string;
+  /** Advanced declarative engine configuration. */
+  engine?: PyricAiEngineConfig;
+  /** OpenAI-compatible upstream used by the same-origin proxy. */
+  proxyUpstream?: string;
+}
+
+export interface ResolvedViteAiConfig {
+  engineWire: AiEngineConfigWire | undefined;
+  proxyUpstream: string | undefined;
+}
+
+/** Convert a public declarative engine into the JSON-safe worker wire shape. */
+export function engineConfigToWire(engine: PyricAiEngineConfig): AiEngineConfigWire {
+  if (engine.kind === 'openai') {
+    return {
+      kind: 'openai',
+      baseUrl: engine.baseUrl ?? AI_PROXY_PATH,
+      ...(engine.model !== undefined ? { model: engine.model } : {}),
+      ...(engine.modelMap !== undefined ? { modelMap: engine.modelMap } : {}),
+    };
+  }
+  return {
+    kind: 'scripted',
+    ...(engine.script !== undefined
+      ? { script: engine.script as unknown as Array<Record<string, unknown>> }
+      : {}),
+  };
+}
+
+/** Resolve the plugin's explicit-options-over-Vite-env AI convention. */
+export function resolveViteAiConfig(
+  options: PyricAiOptions | undefined,
+  env: Record<string, string | undefined>,
+): ResolvedViteAiConfig {
+  if (options?.model !== undefined && options.engine !== undefined) {
+    throw new Error('@pyric/cli/vite: Choose either ai.model or ai.engine, not both.');
+  }
+
+  const model = options?.model?.trim() || env.PYRIC_AI_MODEL?.trim();
+  const engineWire = options?.engine
+    ? engineConfigToWire(options.engine)
+    : model
+      ? engineConfigToWire({ kind: 'openai', baseUrl: AI_PROXY_PATH, model })
+      : undefined;
+
+  return {
+    engineWire,
+    proxyUpstream:
+      options?.proxyUpstream?.trim() || env.PYRIC_AI_PROXY_UPSTREAM?.trim() || undefined,
+  };
+}

--- a/packages/cli/src/serve/vite-ai-config.ts
+++ b/packages/cli/src/serve/vite-ai-config.ts
@@ -1,4 +1,6 @@
 import type { AIOptions } from 'pyric/ai';
+import path from 'node:path';
+import { loadEnv } from 'vite';
 import type { AiEngineConfigWire } from './worker/protocol.js';
 
 const AI_PROXY_PATH = '/__pyric/ai-proxy';
@@ -18,6 +20,19 @@ export interface PyricAiOptions {
 export interface ResolvedViteAiConfig {
   engineWire: AiEngineConfigWire | undefined;
   proxyUpstream: string | undefined;
+}
+
+/** Load env using Vite's `envDir`-relative-to-root convention. */
+export function loadViteAiEnv(
+  mode: string,
+  root: string | undefined,
+  envDir: string | undefined,
+): Record<string, string> {
+  const resolvedRoot = path.resolve(root ?? process.cwd());
+  const resolvedEnvDir = envDir === undefined
+    ? resolvedRoot
+    : path.resolve(resolvedRoot, envDir);
+  return loadEnv(mode, resolvedEnvDir, '');
 }
 
 /** Convert a public declarative engine into the JSON-safe worker wire shape. */

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -44,7 +44,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node
 import { homedir } from 'node:os';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
-import { loadEnv, type Plugin, type UserConfig, type ConfigEnv } from 'vite';
+import type { Plugin, UserConfig, ConfigEnv } from 'vite';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 import {
   SDK_MODULES,
@@ -90,6 +90,7 @@ import {
   registerModuleUrl,
 } from '../cli/dev-runner.js';
 import {
+  loadViteAiEnv,
   resolveViteAiConfig,
   type PyricAiOptions,
 } from './vite-ai-config.js';
@@ -351,8 +352,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
 
     config(config, env) {
       sandboxBuild = env.command === 'build';
-      const envRoot = options.root ?? config.root ?? process.cwd();
-      const loadedEnv = loadEnv(env.mode, envRoot, '');
+      const loadedEnv = loadViteAiEnv(env.mode, config.root, config.envDir);
       resolvedAi = resolveViteAiConfig(options.ai, loadedEnv);
       // Cast: the `esbuild` package's `Plugin` type skews slightly from Vite's
       // bundled esbuild types (benign — the Plugin shape is stable across the

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -44,7 +44,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node
 import { homedir } from 'node:os';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
-import type { Plugin, UserConfig, ConfigEnv } from 'vite';
+import { loadEnv, type Plugin, type UserConfig, type ConfigEnv } from 'vite';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 import {
   SDK_MODULES,
@@ -159,8 +159,9 @@ function packageRootOf(file: string): string {
 }
 
 export interface PyricOptions {
-  /** firestore.rules path (relative to `root`). Default: `firebase.json`'s
-   *  `firestore.rules`, else `firestore.rules` in the project root. */
+  /** Firestore rules path (relative to `root`). Default discovery prefers an
+   *  authored `firestore.modules.rules`, then `firebase.json`, then
+   *  `firestore.rules` in the project root. */
   rules?: string;
   /** Project dir for `firebase.json` / rules discovery. Default: Vite's `root`. */
   root?: string;
@@ -229,11 +230,14 @@ export interface PyricOptions {
    *
    *   pyric({
    *     ai: {
-   *       engine: { kind: 'openai', model: 'llama3.2', baseUrl: '/__pyric/ai-proxy' },
+   *       model: 'llama3.2',
    *       proxyUpstream: 'http://localhost:11434/v1', // your Ollama
    *     },
    *   })
    *
+   * - `model` is the simple OpenAI-compatible path. It uses the same-origin
+   *   proxy and becomes the catch-all upstream model. `PYRIC_AI_MODEL` selects
+   *   the same path when neither `model` nor `engine` is explicit.
    * - `engine` is `pyric/ai`'s `EngineConfig` (scripted | openai), applied on
    *   both the SharedWorker and in-page paths. An openai `baseUrl` of
    *   `/__pyric/ai-proxy` (or omitted) routes through the same-origin proxy so a
@@ -241,13 +245,14 @@ export interface PyricOptions {
    * - `proxyUpstream` sets what `/__pyric/ai-proxy` forwards to (beats the
    *   `PYRIC_AI_PROXY_UPSTREAM` env var; default `http://localhost:11434/v1`).
    *
-   * Precedence: a plugin-level `engine`, when set, always wins over an engine an
-   * app's own `getAI()` passes (host-side via `ctx.aiEngine` on the worker path,
-   * page-side via an injected global on the in-page fallback); with no plugin
-   * engine the first `getAI()` call's engine is honored (first-call-wins), and
-   * with neither the zero-config scripted default applies.
+   * Precedence: explicit `engine` or `model`, then `PYRIC_AI_MODEL`, then an
+   * engine passed by the app's first `getAI()` call; with none, the zero-config
+   * scripted default applies. `model` and `engine` are mutually exclusive.
    */
   ai?: {
+    /** Simple OpenAI-compatible model selection. Uses Pyric's same-origin AI
+     * proxy and treats this model as the catch-all for Firebase model ids. */
+    model?: string;
     /** Engine config (scripted | openai). Custom `AnswerEngine` objects are not
      *  supported at the plugin level — they can't cross to the worker/page. */
     engine?: PyricAiEngineConfig;
@@ -264,6 +269,9 @@ export interface PyricOptions {
  *   export default defineConfig({ plugins: [pyric()] });
  */
 export function pyric(options: PyricOptions = {}): Plugin {
+  if (options.ai?.model !== undefined && options.ai.engine !== undefined) {
+    throw new Error('@pyric/cli/vite: Choose either ai.model or ai.engine, not both.');
+  }
   // Resolved once. `defaultSdkEntries()` prefers compiled dist `.js` and falls
   // back to source `.ts` in the workspace.
   const entries = defaultSdkEntries(); // { app, auth, firestore, init } → abs paths
@@ -364,11 +372,20 @@ export function pyric(options: PyricOptions = {}): Plugin {
   // so multi-tab is disabled under bridge to keep agent + app on one backend.
   const bridgeOpts = options.bridge === true ? {} : options.bridge || null;
 
-  // Plugin-level AI engine, normalized once to the JSON-safe wire shape. Travels
+  // Plugin-level AI engine, normalized to the JSON-safe wire shape. Travels
   // to the worker host via the init payload (→ ctx.aiEngine) AND to the in-page
-  // fallback via an injected synchronous global (see transformIndexHtml). Undefined
-  // when the `ai.engine` option is unset.
-  const aiEngineWire = options.ai?.engine ? engineConfigToWire(options.ai.engine) : undefined;
+  // fallback via an injected synchronous global (see transformIndexHtml).
+  // An explicit engine is available immediately (some hook tests call the HTML
+  // transform directly); Vite's config hook may otherwise select the simple
+  // PYRIC_AI_MODEL environment path for the active mode/root.
+  const explicitModel = options.ai?.model?.trim();
+  const explicitAiEngineWire = options.ai?.engine
+    ? engineConfigToWire(options.ai.engine)
+    : explicitModel
+      ? engineConfigToWire({ kind: 'openai', baseUrl: AI_PROXY_PATH, model: explicitModel })
+      : undefined;
+  let aiEngineWire = explicitAiEngineWire;
+  let aiProxyUpstream = options.ai?.proxyUpstream?.trim() || undefined;
 
   return {
     name: 'pyric:sandbox',
@@ -386,6 +403,15 @@ export function pyric(options: PyricOptions = {}): Plugin {
 
     config(_config, env) {
       sandboxBuild = env.command === 'build';
+      const envRoot = options.root ?? _config.root ?? process.cwd();
+      const loadedEnv = loadEnv(env.mode, envRoot, '');
+      const model = loadedEnv.PYRIC_AI_MODEL?.trim();
+      aiEngineWire = explicitAiEngineWire ?? (model
+        ? engineConfigToWire({ kind: 'openai', baseUrl: AI_PROXY_PATH, model })
+        : undefined);
+      aiProxyUpstream = options.ai?.proxyUpstream?.trim()
+        || loadedEnv.PYRIC_AI_PROXY_UPSTREAM?.trim()
+        || undefined;
       // Cast: the `esbuild` package's `Plugin` type skews slightly from Vite's
       // bundled esbuild types (benign — the Plugin shape is stable across the
       // versions in range).
@@ -457,9 +483,14 @@ export function pyric(options: PyricOptions = {}): Plugin {
       } catch {
         /* optional — serve without a firebase.json */
       }
-      // Honor an explicit `rules` option by overriding the resolved config.
-      const config: FirebaseJson | null = options.rules
-        ? { ...(fbJson ?? {}), firestore: { ...(fbJson?.firestore ?? {}), rules: options.rules } }
+      // Convention-first development source: an explicit option wins; otherwise
+      // an authored 2+modules file wins over firebase.json's generated deployment
+      // target. Projects without that convention retain the normal Firebase
+      // discovery path.
+      const rulesSource = options.rules
+        ?? (existsSync(path.join(cwd, 'firestore.modules.rules')) ? 'firestore.modules.rules' : undefined);
+      const config: FirebaseJson | null = rulesSource
+        ? { ...(fbJson ?? {}), firestore: { ...(fbJson?.firestore ?? {}), rules: rulesSource } }
         : fbJson;
       const loaded = await loadProjectRules(cwd, config);
       const loadedDatabase = await loadProjectDatabaseRules(cwd, config);
@@ -668,7 +699,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
         studioUiDir,
         // `ai.proxyUpstream`: what `/__pyric/ai-proxy` forwards to (beats the
         // PYRIC_AI_PROXY_UPSTREAM env var; falls back to the default when unset).
-        aiProxyUpstream: options.ai?.proxyUpstream,
+        aiProxyUpstream,
         // Adapt Vite's logger to the plain info/note shape the namespace's
         // diagnostics (denial relay, future hot-reload lines) expect —
         // matches the `↻`/`⚠ [pyric]` lines already logged elsewhere in this

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -62,8 +62,6 @@ import {
   type InitPayload,
 } from './namespace.js';
 import { formatActivityWarning } from './activity-warning.js';
-import type { AiEngineConfigWire } from './worker/protocol.js';
-import type { AIOptions } from 'pyric/ai';
 import { diskWorkspace, diskProjectStore } from './studio/index.js';
 import { createBridgeMount } from './bridge-mount.js';
 import {
@@ -91,6 +89,11 @@ import {
   createLinePrefixer,
   registerModuleUrl,
 } from '../cli/dev-runner.js';
+import {
+  resolveViteAiConfig,
+  type PyricAiOptions,
+} from './vite-ai-config.js';
+import { resolveViteRulesConfig } from './vite-rules-source.js';
 
 /**
  * Whether a `vite build` should run the firebase→pyric swap (produce a SANDBOX
@@ -109,41 +112,6 @@ function swapsInBuild(env: ConfigEnv, swapInBuild: boolean | undefined): boolean
 /** Any `firebase/<sub>` specifier. */
 const FB_ANY = /^firebase\/([a-z-]+(?:\/[a-z-]+)*)$/;
 
-/** The serve proxy route the browser openai engine defaults to (#98.2). */
-const AI_PROXY_PATH = '/__pyric/ai-proxy';
-
-/**
- * The plugin-level engine config surface = `pyric/ai`'s `EngineConfig` (what an
- * app passes to `getAI`), minus the custom `AnswerEngine` object variant — a
- * live object cannot cross to the SharedWorker host or serialize into the page,
- * so the plugin's declarative surface is the JSON-able `scripted` / `openai`
- * configs only (the same restriction the worker path already enforces).
- */
-export type PyricAiEngineConfig = Extract<NonNullable<AIOptions['engine']>, { kind: string }>;
-
-/**
- * Node-side `EngineConfig` → JSON-safe {@link AiEngineConfigWire}. Mirrors the
- * browser `toEngineWire` (entries/ai.ts): an openai config with no `baseUrl`
- * targets the same-origin proxy; scripted `script` entries pass through (plain
- * authoring shapes — function/RegExp matchers can't survive JSON and are not a
- * plugin-config use case).
- */
-export function engineConfigToWire(engine: PyricAiEngineConfig): AiEngineConfigWire {
-  if (engine.kind === 'openai') {
-    return {
-      kind: 'openai',
-      baseUrl: engine.baseUrl ?? AI_PROXY_PATH,
-      ...(engine.model !== undefined ? { model: engine.model } : {}),
-      ...(engine.modelMap !== undefined ? { modelMap: engine.modelMap } : {}),
-    };
-  }
-  return {
-    kind: 'scripted',
-    ...(engine.script !== undefined
-      ? { script: engine.script as unknown as Array<Record<string, unknown>> }
-      : {}),
-  };
-}
 /** The firebase subpaths with swap entries. */
 const SERVED = new Set(SDK_MODULES.map((specifier) => specifier.slice('firebase/'.length)));
 const entryKey = (subpath: string): string => subpath.replaceAll('/', '-');
@@ -249,17 +217,7 @@ export interface PyricOptions {
    * engine passed by the app's first `getAI()` call; with none, the zero-config
    * scripted default applies. `model` and `engine` are mutually exclusive.
    */
-  ai?: {
-    /** Simple OpenAI-compatible model selection. Uses Pyric's same-origin AI
-     * proxy and treats this model as the catch-all for Firebase model ids. */
-    model?: string;
-    /** Engine config (scripted | openai). Custom `AnswerEngine` objects are not
-     *  supported at the plugin level — they can't cross to the worker/page. */
-    engine?: PyricAiEngineConfig;
-    /** OpenAI-compatible upstream `/__pyric/ai-proxy` forwards to. Beats
-     *  `PYRIC_AI_PROXY_UPSTREAM`; default `http://localhost:11434/v1`. */
-    proxyUpstream?: string;
-  };
+  ai?: PyricAiOptions;
 }
 
 /**
@@ -269,9 +227,7 @@ export interface PyricOptions {
  *   export default defineConfig({ plugins: [pyric()] });
  */
 export function pyric(options: PyricOptions = {}): Plugin {
-  if (options.ai?.model !== undefined && options.ai.engine !== undefined) {
-    throw new Error('@pyric/cli/vite: Choose either ai.model or ai.engine, not both.');
-  }
+  let resolvedAi = resolveViteAiConfig(options.ai, {});
   // Resolved once. `defaultSdkEntries()` prefers compiled dist `.js` and falls
   // back to source `.ts` in the workspace.
   const entries = defaultSdkEntries(); // { app, auth, firestore, init } → abs paths
@@ -378,15 +334,6 @@ export function pyric(options: PyricOptions = {}): Plugin {
   // An explicit engine is available immediately (some hook tests call the HTML
   // transform directly); Vite's config hook may otherwise select the simple
   // PYRIC_AI_MODEL environment path for the active mode/root.
-  const explicitModel = options.ai?.model?.trim();
-  const explicitAiEngineWire = options.ai?.engine
-    ? engineConfigToWire(options.ai.engine)
-    : explicitModel
-      ? engineConfigToWire({ kind: 'openai', baseUrl: AI_PROXY_PATH, model: explicitModel })
-      : undefined;
-  let aiEngineWire = explicitAiEngineWire;
-  let aiProxyUpstream = options.ai?.proxyUpstream?.trim() || undefined;
-
   return {
     name: 'pyric:sandbox',
     // Active for `vite dev` ALWAYS, and for `vite build` only when it is a
@@ -395,23 +342,18 @@ export function pyric(options: PyricOptions = {}): Plugin {
     // production output. A sandbox build applies the same swap so the output
     // bundles pyric's in-page adapters (self-contained; preview it under
     // `pyric dev`, never deploy it).
-    apply(_config, env) {
+    apply(config, env) {
+      void config;
       if (env.command === 'serve') return true;
       return swapsInBuild(env, options.swapInBuild);
     },
     enforce: 'pre',
 
-    config(_config, env) {
+    config(config, env) {
       sandboxBuild = env.command === 'build';
-      const envRoot = options.root ?? _config.root ?? process.cwd();
+      const envRoot = options.root ?? config.root ?? process.cwd();
       const loadedEnv = loadEnv(env.mode, envRoot, '');
-      const model = loadedEnv.PYRIC_AI_MODEL?.trim();
-      aiEngineWire = explicitAiEngineWire ?? (model
-        ? engineConfigToWire({ kind: 'openai', baseUrl: AI_PROXY_PATH, model })
-        : undefined);
-      aiProxyUpstream = options.ai?.proxyUpstream?.trim()
-        || loadedEnv.PYRIC_AI_PROXY_UPSTREAM?.trim()
-        || undefined;
+      resolvedAi = resolveViteAiConfig(options.ai, loadedEnv);
       // Cast: the `esbuild` package's `Plugin` type skews slightly from Vite's
       // bundled esbuild types (benign — the Plugin shape is stable across the
       // versions in range).
@@ -487,11 +429,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // an authored 2+modules file wins over firebase.json's generated deployment
       // target. Projects without that convention retain the normal Firebase
       // discovery path.
-      const rulesSource = options.rules
-        ?? (existsSync(path.join(cwd, 'firestore.modules.rules')) ? 'firestore.modules.rules' : undefined);
-      const config: FirebaseJson | null = rulesSource
-        ? { ...(fbJson ?? {}), firestore: { ...(fbJson?.firestore ?? {}), rules: rulesSource } }
-        : fbJson;
+      const config = resolveViteRulesConfig(cwd, options.rules, fbJson);
       const loaded = await loadProjectRules(cwd, config);
       const loadedDatabase = await loadProjectDatabaseRules(cwd, config);
       const loadedStorage = await loadProjectStorageRules(cwd, config);
@@ -660,7 +598,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
         messaging: true,
         // Plugin-level engine → the worker host's ctx.aiEngine (host-ai.ts),
         // which wins over any op-carried engine. Null when unset.
-        ai: aiEngineWire ? { engine: aiEngineWire } : null,
+        ai: resolvedAi.engineWire ? { engine: resolvedAi.engineWire } : null,
       });
       // Pyric Studio: mount the disk-backed workspace/project routes that
       // Studio's `local` mode talks to + serve the built Studio app at
@@ -699,7 +637,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
         studioUiDir,
         // `ai.proxyUpstream`: what `/__pyric/ai-proxy` forwards to (beats the
         // PYRIC_AI_PROXY_UPSTREAM env var; falls back to the default when unset).
-        aiProxyUpstream,
+        aiProxyUpstream: resolvedAi.proxyUpstream,
         // Adapt Vite's logger to the plain info/note shape the namespace's
         // diagnostics (denial relay, future hot-reload lines) expect —
         // matches the `↻`/`⚠ [pyric]` lines already logged elsewhere in this
@@ -1120,8 +1058,8 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // be awaited there. Harmless on the worker path (that branch ignores the
       // global; the worker reads ctx.aiEngine from init.json). `<` is escaped so
       // an engine value can never break out of the script tag.
-      const aiEngineTag = aiEngineWire
-        ? `<script ${MARKER}>globalThis.__PYRIC_AI_ENGINE__=${JSON.stringify(aiEngineWire).replace(/</g, '\\u003c')};</script>`
+      const aiEngineTag = resolvedAi.engineWire
+        ? `<script ${MARKER}>globalThis.__PYRIC_AI_ENGINE__=${JSON.stringify(resolvedAi.engineWire).replace(/</g, '\\u003c')};</script>`
         : '';
       // Boot the sandbox by loading the real init entry as a module (Vite
       // serves + transforms it). The init module's top-level await deploys rules

--- a/packages/cli/src/serve/vite-rules-source.ts
+++ b/packages/cli/src/serve/vite-rules-source.ts
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import type { FirebaseJson } from '../cli/firebase-json.js';
+
+/**
+ * Apply the Vite authoring convention without replacing unrelated Firebase
+ * configuration. The normal rules loader retains responsibility for its
+ * `firebase.json` and root `firestore.rules` fallbacks.
+ */
+export function resolveViteRulesConfig(
+  root: string,
+  explicitRules: string | undefined,
+  firebaseConfig: FirebaseJson | null,
+): FirebaseJson | null {
+  const rulesSource = explicitRules
+    ?? (existsSync(path.join(root, 'firestore.modules.rules'))
+      ? 'firestore.modules.rules'
+      : undefined);
+
+  if (!rulesSource) return firebaseConfig;
+  return {
+    ...(firebaseConfig ?? {}),
+    firestore: {
+      ...(firebaseConfig?.firestore ?? {}),
+      rules: rulesSource,
+    },
+  };
+}

--- a/packages/cli/test/serve/ai-proxy.test.ts
+++ b/packages/cli/test/serve/ai-proxy.test.ts
@@ -31,7 +31,7 @@ afterEach(async () => {
   while (upstreams.length) upstreams.pop()!.stop();
 });
 
-async function startServe(aiProxyUpstream: string): Promise<ServeHandle> {
+async function startServe(aiProxyUpstream?: string): Promise<ServeHandle> {
   const { site, sdk } = fixture();
   const ns = createPyricNamespace({
     sdkDir: sdk,
@@ -62,6 +62,31 @@ function closedLoopbackUrl(path = ''): string {
 }
 
 describe('/__pyric/ai-proxy', () => {
+  it('defaults to Ollama\'s OpenAI-compatible endpoint', async () => {
+    const h = await startServe();
+    const nativeFetch = globalThis.fetch;
+    const priorEnv = process.env.PYRIC_AI_PROXY_UPSTREAM;
+    let target = '';
+    delete process.env.PYRIC_AI_PROXY_UPSTREAM;
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      target = String(input);
+      return Response.json({ choices: [] });
+    }) as typeof fetch;
+    try {
+      const res = await nativeFetch(`${h.url}/__pyric/ai-proxy/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(res.status).toBe(200);
+      expect(target).toBe('http://localhost:11434/v1/chat/completions');
+    } finally {
+      globalThis.fetch = nativeFetch;
+      if (priorEnv === undefined) delete process.env.PYRIC_AI_PROXY_UPSTREAM;
+      else process.env.PYRIC_AI_PROXY_UPSTREAM = priorEnv;
+    }
+  });
+
   it('forwards POST path suffix + query + body, keeps authorization, strips origin-sensitive headers', async () => {
     const seen: Array<{ method: string; url: string; body: string; headers: Headers }> = [];
     const upstream = Bun.serve({

--- a/packages/cli/test/serve/vite-ai-config.test.ts
+++ b/packages/cli/test/serve/vite-ai-config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import {
   engineConfigToWire,
+  loadViteAiEnv,
   resolveViteAiConfig,
 } from '../../src/serve/vite-ai-config.js';
 
@@ -49,6 +53,20 @@ describe('Vite AI configuration', () => {
         model: 'llama3.2',
       },
       proxyUpstream: 'http://model.test:8080/v1',
+    });
+  });
+
+  it('loads AI variables from a custom Vite envDir relative to the Vite root', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-env-dir-'));
+    mkdirSync(path.join(root, 'config'));
+    writeFileSync(
+      path.join(root, 'config', '.env.local'),
+      'PYRIC_AI_MODEL=custom-env-model\nPYRIC_AI_PROXY_UPSTREAM=http://custom.test/v1\n',
+    );
+
+    expect(loadViteAiEnv('development', root, 'config')).toMatchObject({
+      PYRIC_AI_MODEL: 'custom-env-model',
+      PYRIC_AI_PROXY_UPSTREAM: 'http://custom.test/v1',
     });
   });
 

--- a/packages/cli/test/serve/vite-ai-config.test.ts
+++ b/packages/cli/test/serve/vite-ai-config.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  engineConfigToWire,
+  resolveViteAiConfig,
+} from '../../src/serve/vite-ai-config.js';
+
+describe('Vite AI configuration', () => {
+  it('converts declarative engine configs to worker-safe wire values', () => {
+    expect(
+      engineConfigToWire({
+        kind: 'openai',
+        baseUrl: 'http://host/v1',
+        model: 'm',
+        modelMap: { a: 'b' },
+      }),
+    ).toEqual({
+      kind: 'openai',
+      baseUrl: 'http://host/v1',
+      model: 'm',
+      modelMap: { a: 'b' },
+    });
+    expect(
+      engineConfigToWire({ kind: 'scripted', script: [{ respond: { text: 'hi' } }] }),
+    ).toEqual({
+      kind: 'scripted',
+      script: [{ respond: { text: 'hi' } }],
+    });
+  });
+
+  it('turns a model into an OpenAI engine through Pyric\'s same-origin proxy', () => {
+    expect(resolveViteAiConfig({ model: ' qwen3:4b ' }, {})).toEqual({
+      engineWire: {
+        kind: 'openai',
+        baseUrl: '/__pyric/ai-proxy',
+        model: 'qwen3:4b',
+      },
+      proxyUpstream: undefined,
+    });
+  });
+
+  it('uses Vite env when plugin options do not select a model or upstream', () => {
+    expect(resolveViteAiConfig(undefined, {
+      PYRIC_AI_MODEL: ' llama3.2 ',
+      PYRIC_AI_PROXY_UPSTREAM: ' http://model.test:8080/v1 ',
+    })).toEqual({
+      engineWire: {
+        kind: 'openai',
+        baseUrl: '/__pyric/ai-proxy',
+        model: 'llama3.2',
+      },
+      proxyUpstream: 'http://model.test:8080/v1',
+    });
+  });
+
+  it('gives explicit model and upstream precedence over conflicting env', () => {
+    expect(resolveViteAiConfig({
+      model: 'explicit-model',
+      proxyUpstream: 'http://explicit.test/v1',
+    }, {
+      PYRIC_AI_MODEL: 'env-model',
+      PYRIC_AI_PROXY_UPSTREAM: 'http://env.test/v1',
+    })).toEqual({
+      engineWire: {
+        kind: 'openai',
+        baseUrl: '/__pyric/ai-proxy',
+        model: 'explicit-model',
+      },
+      proxyUpstream: 'http://explicit.test/v1',
+    });
+  });
+
+  it('gives an explicit engine precedence over a conflicting env model', () => {
+    expect(resolveViteAiConfig({
+      engine: { kind: 'scripted', script: [{ respond: { text: 'explicit' } }] },
+    }, {
+      PYRIC_AI_MODEL: 'env-model',
+    })).toEqual({
+      engineWire: {
+        kind: 'scripted',
+        script: [{ respond: { text: 'explicit' } }],
+      },
+      proxyUpstream: undefined,
+    });
+  });
+
+  it('leaves the engine unset so the app\'s first getAI() call keeps control', () => {
+    expect(resolveViteAiConfig(undefined, {})).toEqual({
+      engineWire: undefined,
+      proxyUpstream: undefined,
+    });
+  });
+
+  it('rejects ambiguous model and engine options', () => {
+    expect(() => resolveViteAiConfig({
+      model: 'qwen3:4b',
+      engine: { kind: 'scripted' },
+    }, {})).toThrow('Choose either ai.model or ai.engine');
+  });
+});

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -6,11 +6,10 @@
  *  header for why). The full browser e2e lives in the M1 spike (plans/pyric-vite-plugin.md section 7b). */
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import path, { join } from 'node:path';
-import { Readable, Writable } from 'node:stream';
+import { Writable } from 'node:stream';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import type { ConfigEnv } from 'vite';
-import { pyric, engineConfigToWire } from '../../src/serve/vite-plugin.js';
+import { pyric } from '../../src/serve/vite-plugin.js';
 import {
   SDK_MODULES,
   defaultSdkEntries,
@@ -68,28 +67,6 @@ describe('pyric — plugin shape', () => {
     const forcedOff = pyric({ swapInBuild: false });
     expect(applies(forcedOff, 'build', 'development')).toBe(false); // never swap in build
     expect(applies(forcedOff, 'serve', 'production')).toBe(true); // dev still always on
-  });
-
-  it('engineConfigToWire: openai passes model/modelMap and keeps baseUrl', () => {
-    expect(
-      engineConfigToWire({ kind: 'openai', baseUrl: 'http://host/v1', model: 'm', modelMap: { a: 'b' } }),
-    ).toEqual({ kind: 'openai', baseUrl: 'http://host/v1', model: 'm', modelMap: { a: 'b' } });
-  });
-
-  it('engineConfigToWire: scripted script passes through as plain JSON entries', () => {
-    expect(engineConfigToWire({ kind: 'scripted', script: [{ respond: { text: 'hi' } }] })).toEqual({
-      kind: 'scripted',
-      script: [{ respond: { text: 'hi' } }],
-    });
-  });
-
-  it('rejects configuring both ai.model and ai.engine', () => {
-    expect(() => pyric({
-      ai: {
-        model: 'qwen3:4b',
-        engine: { kind: 'scripted' },
-      },
-    })).toThrow('Choose either ai.model or ai.engine');
   });
 
   it('sandbox build: transformIndexHtml stamps ONLY the marker (no init/@fs, no force-in-page)', () => {
@@ -328,11 +305,6 @@ type PyricMiddleware = (req: PyricReq, res: MockRes, next: () => void) => void;
  *  namespace mount — minus a real http server. */
 async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<PyricMiddleware> {
   let handler: PyricMiddleware | undefined;
-  const instance = pyric(opts);
-  (instance.config as (config: unknown, env: ConfigEnv) => unknown)(
-    { root },
-    { command: 'serve', mode: 'development' },
-  );
   const stub = {
     config: { root, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
     middlewares: { use(p: string, h: PyricMiddleware) { if (p === '/__pyric') handler = h; } },
@@ -342,7 +314,7 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
     // port; `on` is a no-op here (the attachUpgrade spy test uses its own stub).
     httpServer: { address: () => ({ port: 5173 }), on() {}, once() {} },
   };
-  await (instance.configureServer as (s: unknown) => Promise<void>)(stub);
+  await (pyric(opts).configureServer as (s: unknown) => Promise<void>)(stub);
   if (!handler) throw new Error('plugin did not mount the /__pyric middleware');
   return handler;
 }
@@ -350,14 +322,14 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
  *  passes through (next()). Returns the recorded response + whether it next()ed. */
 async function callPyric(
   handler: PyricMiddleware,
-  opts: { method?: string; path: string; host?: string; headers?: Record<string, string>; body?: string },
+  opts: { method?: string; path: string; host?: string; headers?: Record<string, string> },
 ): Promise<{ statusCode: number; headers: Record<string, unknown>; body: string; nexted: boolean }> {
-  const req = Object.assign(Readable.from(opts.body === undefined ? [] : [Buffer.from(opts.body)]), {
+  const req: PyricReq = {
     method: opts.method ?? 'GET',
     url: opts.path,
     originalUrl: opts.path,
     headers: { host: opts.host ?? 'localhost', ...(opts.headers ?? {}) },
-  }) as unknown as PyricReq;
+  };
   const res = new MockRes();
   let nexted = false;
   await new Promise<void>((resolve, reject) => {
@@ -395,26 +367,6 @@ describe('integration — configureServer rules prelude + the /__pyric middlewar
     expect((await initJson(await bootPlugin({}, tmp))).rules).toBeNull();
   });
 
-  it('prefers authored firestore.modules.rules over firebase.json generated rules', async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-module-rules-'));
-    writeFileSync(path.join(tmp, 'firebase.json'), JSON.stringify({
-      firestore: { rules: 'firestore.rules' },
-    }));
-    writeFileSync(
-      path.join(tmp, 'firestore.rules'),
-      RULES.replace('allow read: if true', 'allow read: if false'),
-    );
-    writeFileSync(
-      path.join(tmp, 'firestore.modules.rules'),
-      RULES.replace("rules_version = '2'", "rules_version = '2+modules'"),
-    );
-
-    const init = await initJson(await bootPlugin({}, tmp));
-
-    expect(init.rules).toContain('allow read: if true');
-    expect(init.rules).not.toContain('allow read: if false');
-  });
-
   it('carries the plugin AI engine into /__pyric/init.json (→ worker ctx.aiEngine)', async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-'));
     const init = await initJson(
@@ -424,64 +376,6 @@ describe('integration — configureServer rules prelude + the /__pyric middlewar
       ),
     );
     expect(init.ai).toEqual({ engine: { kind: 'openai', baseUrl: '/__pyric/ai-proxy', model: 'llama3.2' } });
-  });
-
-  it('uses PYRIC_AI_MODEL from Vite env as the openai catch-all model', async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-env-'));
-    writeFileSync(path.join(tmp, '.env.local'), 'PYRIC_AI_MODEL=qwen3:4b\n');
-
-    const init = await initJson(await bootPlugin({}, tmp));
-
-    expect(init.ai).toEqual({
-      engine: {
-        kind: 'openai',
-        baseUrl: '/__pyric/ai-proxy',
-        model: 'qwen3:4b',
-      },
-    });
-  });
-
-  it('uses PYRIC_AI_PROXY_UPSTREAM from Vite env as the server-side proxy destination', async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-upstream-env-'));
-    writeFileSync(
-      path.join(tmp, '.env.local'),
-      'PYRIC_AI_MODEL=qwen3:4b\nPYRIC_AI_PROXY_UPSTREAM=http://model.test:8080/v1\n',
-    );
-    const handler = await bootPlugin({}, tmp);
-    const originalFetch = globalThis.fetch;
-    let target = '';
-    globalThis.fetch = (async (input: string | URL | Request) => {
-      target = String(input);
-      return Response.json({ choices: [] });
-    }) as typeof fetch;
-    try {
-      const response = await callPyric(handler, {
-        method: 'POST',
-        path: '/__pyric/ai-proxy/chat/completions',
-        headers: { 'content-type': 'application/json' },
-        body: '{}',
-      });
-      expect(response.statusCode).toBe(200);
-      expect(target).toBe('http://model.test:8080/v1/chat/completions');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('accepts ai.model as the simple explicit openai configuration', async () => {
-    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-model-'));
-
-    const init = await initJson(
-      await bootPlugin({ ai: { model: 'llama3.2' } }, tmp),
-    );
-
-    expect(init.ai).toEqual({
-      engine: {
-        kind: 'openai',
-        baseUrl: '/__pyric/ai-proxy',
-        model: 'llama3.2',
-      },
-    });
   });
 
   it('serves ai: null in init.json when no plugin engine is configured', async () => {

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -6,9 +6,10 @@
  *  header for why). The full browser e2e lives in the M1 spike (plans/pyric-vite-plugin.md section 7b). */
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import path, { join } from 'node:path';
-import { Writable } from 'node:stream';
+import { Readable, Writable } from 'node:stream';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
+import type { ConfigEnv } from 'vite';
 import { pyric, engineConfigToWire } from '../../src/serve/vite-plugin.js';
 import {
   SDK_MODULES,
@@ -80,6 +81,15 @@ describe('pyric — plugin shape', () => {
       kind: 'scripted',
       script: [{ respond: { text: 'hi' } }],
     });
+  });
+
+  it('rejects configuring both ai.model and ai.engine', () => {
+    expect(() => pyric({
+      ai: {
+        model: 'qwen3:4b',
+        engine: { kind: 'scripted' },
+      },
+    })).toThrow('Choose either ai.model or ai.engine');
   });
 
   it('sandbox build: transformIndexHtml stamps ONLY the marker (no init/@fs, no force-in-page)', () => {
@@ -318,6 +328,11 @@ type PyricMiddleware = (req: PyricReq, res: MockRes, next: () => void) => void;
  *  namespace mount — minus a real http server. */
 async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<PyricMiddleware> {
   let handler: PyricMiddleware | undefined;
+  const instance = pyric(opts);
+  (instance.config as (config: unknown, env: ConfigEnv) => unknown)(
+    { root },
+    { command: 'serve', mode: 'development' },
+  );
   const stub = {
     config: { root, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
     middlewares: { use(p: string, h: PyricMiddleware) { if (p === '/__pyric') handler = h; } },
@@ -327,7 +342,7 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
     // port; `on` is a no-op here (the attachUpgrade spy test uses its own stub).
     httpServer: { address: () => ({ port: 5173 }), on() {}, once() {} },
   };
-  await (pyric(opts).configureServer as (s: unknown) => Promise<void>)(stub);
+  await (instance.configureServer as (s: unknown) => Promise<void>)(stub);
   if (!handler) throw new Error('plugin did not mount the /__pyric middleware');
   return handler;
 }
@@ -335,14 +350,14 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
  *  passes through (next()). Returns the recorded response + whether it next()ed. */
 async function callPyric(
   handler: PyricMiddleware,
-  opts: { method?: string; path: string; host?: string; headers?: Record<string, string> },
+  opts: { method?: string; path: string; host?: string; headers?: Record<string, string>; body?: string },
 ): Promise<{ statusCode: number; headers: Record<string, unknown>; body: string; nexted: boolean }> {
-  const req: PyricReq = {
+  const req = Object.assign(Readable.from(opts.body === undefined ? [] : [Buffer.from(opts.body)]), {
     method: opts.method ?? 'GET',
     url: opts.path,
     originalUrl: opts.path,
     headers: { host: opts.host ?? 'localhost', ...(opts.headers ?? {}) },
-  };
+  }) as unknown as PyricReq;
   const res = new MockRes();
   let nexted = false;
   await new Promise<void>((resolve, reject) => {
@@ -380,6 +395,26 @@ describe('integration — configureServer rules prelude + the /__pyric middlewar
     expect((await initJson(await bootPlugin({}, tmp))).rules).toBeNull();
   });
 
+  it('prefers authored firestore.modules.rules over firebase.json generated rules', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-module-rules-'));
+    writeFileSync(path.join(tmp, 'firebase.json'), JSON.stringify({
+      firestore: { rules: 'firestore.rules' },
+    }));
+    writeFileSync(
+      path.join(tmp, 'firestore.rules'),
+      RULES.replace('allow read: if true', 'allow read: if false'),
+    );
+    writeFileSync(
+      path.join(tmp, 'firestore.modules.rules'),
+      RULES.replace("rules_version = '2'", "rules_version = '2+modules'"),
+    );
+
+    const init = await initJson(await bootPlugin({}, tmp));
+
+    expect(init.rules).toContain('allow read: if true');
+    expect(init.rules).not.toContain('allow read: if false');
+  });
+
   it('carries the plugin AI engine into /__pyric/init.json (→ worker ctx.aiEngine)', async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-'));
     const init = await initJson(
@@ -389,6 +424,64 @@ describe('integration — configureServer rules prelude + the /__pyric middlewar
       ),
     );
     expect(init.ai).toEqual({ engine: { kind: 'openai', baseUrl: '/__pyric/ai-proxy', model: 'llama3.2' } });
+  });
+
+  it('uses PYRIC_AI_MODEL from Vite env as the openai catch-all model', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-env-'));
+    writeFileSync(path.join(tmp, '.env.local'), 'PYRIC_AI_MODEL=qwen3:4b\n');
+
+    const init = await initJson(await bootPlugin({}, tmp));
+
+    expect(init.ai).toEqual({
+      engine: {
+        kind: 'openai',
+        baseUrl: '/__pyric/ai-proxy',
+        model: 'qwen3:4b',
+      },
+    });
+  });
+
+  it('uses PYRIC_AI_PROXY_UPSTREAM from Vite env as the server-side proxy destination', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-upstream-env-'));
+    writeFileSync(
+      path.join(tmp, '.env.local'),
+      'PYRIC_AI_MODEL=qwen3:4b\nPYRIC_AI_PROXY_UPSTREAM=http://model.test:8080/v1\n',
+    );
+    const handler = await bootPlugin({}, tmp);
+    const originalFetch = globalThis.fetch;
+    let target = '';
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      target = String(input);
+      return Response.json({ choices: [] });
+    }) as typeof fetch;
+    try {
+      const response = await callPyric(handler, {
+        method: 'POST',
+        path: '/__pyric/ai-proxy/chat/completions',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(target).toBe('http://model.test:8080/v1/chat/completions');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('accepts ai.model as the simple explicit openai configuration', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-model-'));
+
+    const init = await initJson(
+      await bootPlugin({ ai: { model: 'llama3.2' } }, tmp),
+    );
+
+    expect(init.ai).toEqual({
+      engine: {
+        kind: 'openai',
+        baseUrl: '/__pyric/ai-proxy',
+        model: 'llama3.2',
+      },
+    });
   });
 
   it('serves ai: null in init.json when no plugin engine is configured', async () => {

--- a/packages/cli/test/serve/vite-rules-source.test.ts
+++ b/packages/cli/test/serve/vite-rules-source.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveViteRulesConfig } from '../../src/serve/vite-rules-source.js';
+
+function project(): string {
+  return mkdtempSync(path.join(tmpdir(), 'pyric-vite-rules-source-'));
+}
+
+describe('Vite rules source convention', () => {
+  it('gives an explicit rules path precedence over the modules convention', () => {
+    const root = project();
+    writeFileSync(path.join(root, 'firestore.modules.rules'), 'modules');
+    expect(resolveViteRulesConfig(root, 'custom.rules', {
+      firestore: { rules: 'firebase.rules' },
+    })).toEqual({ firestore: { rules: 'custom.rules' } });
+  });
+
+  it('prefers firestore.modules.rules over firebase.json', () => {
+    const root = project();
+    writeFileSync(path.join(root, 'firestore.modules.rules'), 'modules');
+    expect(resolveViteRulesConfig(root, undefined, {
+      firestore: { rules: 'firebase.rules' },
+      storage: { rules: 'storage.rules' },
+    })).toEqual({
+      firestore: { rules: 'firestore.modules.rules' },
+      storage: { rules: 'storage.rules' },
+    });
+  });
+
+  it('preserves firebase.json when no explicit or modules source exists', () => {
+    const root = project();
+    const firebase = { firestore: { rules: 'firestore.rules' } };
+    expect(resolveViteRulesConfig(root, undefined, firebase)).toBe(firebase);
+  });
+
+  it('leaves discovery open for the firestore.rules fallback', () => {
+    const root = project();
+    writeFileSync(path.join(root, 'firestore.rules'), 'fallback');
+    expect(resolveViteRulesConfig(root, undefined, null)).toBeNull();
+  });
+});

--- a/packages/create-pyric/templates/chat/.env.example
+++ b/packages/create-pyric/templates/chat/.env.example
@@ -12,9 +12,9 @@ VITE_FIREBASE_DATABASE_URL=
 # production FCM token registration; the dev sandbox mints tokens without it.
 VITE_FIREBASE_VAPID_KEY=
 
-# Optional local OpenAI-compatible model. Leave both unset to use Pyric's
-# built-in scripted AI. MiniMax example:
-# PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
-# PYRIC_AI_MODEL=minimax-m2.7
-PYRIC_AI_PROXY_UPSTREAM=
+# Optional local model. Leave unset to use Pyric's built-in scripted AI.
+# This model-only path uses Ollama at http://localhost:11434/v1 by default.
+# Example: ollama pull qwen3:4b
 PYRIC_AI_MODEL=
+# Override only when using another OpenAI-compatible model server.
+PYRIC_AI_PROXY_UPSTREAM=

--- a/packages/create-pyric/templates/chat/README.md
+++ b/packages/create-pyric/templates/chat/README.md
@@ -33,7 +33,7 @@ PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
 ```
 
 Start the model server separately, then restart Vite.
-See the [Pyric AI Logic guide](https://pyric.dev/docs/ai-logic/) for the full
+See the [Pyric AI Logic guide](https://pyric.dev/docs/build/ai-logic/) for the full
 engine and proxy behavior.
 
 ## What runs in the sandbox

--- a/packages/create-pyric/templates/chat/README.md
+++ b/packages/create-pyric/templates/chat/README.md
@@ -33,6 +33,8 @@ PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
 ```
 
 Start the model server separately, then restart Vite.
+See the [Pyric AI Logic guide](https://pyric.dev/docs/ai-logic/) for the full
+engine and proxy behavior.
 
 ## What runs in the sandbox
 

--- a/packages/create-pyric/templates/chat/README.md
+++ b/packages/create-pyric/templates/chat/README.md
@@ -13,16 +13,26 @@ npm run dev
 ```
 
 With no model configuration, Pyric's built-in scripted engine answers locally.
-To use MiniMax or another OpenAI-compatible server, copy `.env.example` to
-`.env.local` and set both:
+To use Ollama, pull a model, copy `.env.example` to `.env.local`, and select it:
 
-```dotenv
-PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
-PYRIC_AI_MODEL=minimax-m2.7
+```bash
+ollama pull qwen3:4b
 ```
 
-Start that server separately, then restart Vite. The scaffold deliberately does
-not assume an operating system or a particular model launcher.
+```dotenv
+PYRIC_AI_MODEL=qwen3:4b
+```
+
+Pyric forwards the unchanged `firebase/ai` calls to Ollama's default
+OpenAI-compatible endpoint at `http://localhost:11434/v1`. For another model
+server, also set its base URL (including `/v1` when required):
+
+```dotenv
+PYRIC_AI_MODEL=minimax-m2.7
+PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
+```
+
+Start the model server separately, then restart Vite.
 
 ## What runs in the sandbox
 

--- a/packages/create-pyric/templates/chat/vite.config.ts
+++ b/packages/create-pyric/templates/chat/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { pyric } from '@pyric/cli/vite';
@@ -11,44 +11,11 @@ import path from 'node:path';
 // self-contained sandbox preview you can serve under `pyric dev`, build with a
 // non-production mode: `vite build --mode development` (see the `build:sandbox`
 // script). That output is marked and can never be deployed.
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-  const proxyUpstream = env.PYRIC_AI_PROXY_UPSTREAM;
-  const model = env.PYRIC_AI_MODEL;
-  if (Boolean(proxyUpstream) !== Boolean(model)) {
-    throw new Error(
-      'PyChat local AI configuration requires both PYRIC_AI_PROXY_UPSTREAM and PYRIC_AI_MODEL.',
-    );
-  }
-
-  return {
-    plugins: [
-      react(),
-      tailwindcss(),
-      pyric({
-        bridge: true,
-        // The authored 2+modules source is the source of truth; the plugin
-        // resolves it in-memory, so no vendored firestore.rules is needed in
-        // dev. `npm run rules:resolve` still generates it for Firebase deploy.
-        rules: 'firestore.modules.rules',
-        ...(proxyUpstream && model
-          ? {
-              ai: {
-                proxyUpstream,
-                engine: {
-                  kind: 'openai' as const,
-                  model,
-                  modelMap: { 'gemini-2.5-flash': model },
-                },
-              },
-            }
-          : {}),
-      }),
-    ],
-    resolve: {
-      alias: {
-        '@': path.resolve(__dirname, './src'),
-      },
+export default defineConfig({
+  plugins: [react(), tailwindcss(), pyric()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
     },
-  };
+  },
 });

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -159,7 +159,12 @@ describe('runScaffold', () => {
       expect(readFileSync(join(project, '.gitignore'), 'utf8')).toContain('node_modules/');
       expect(readdirSync(project)).not.toContain('scaffold.json');
       expect(readdirSync(project)).not.toContain('bun.lock');
-      expect(readFileSync(join(project, 'vite.config.ts'), 'utf8')).not.toContain('node_modules/');
+      const viteConfig = readFileSync(join(project, 'vite.config.ts'), 'utf8');
+      expect(viteConfig).not.toContain('node_modules/');
+      expect(viteConfig).toContain('pyric()');
+      expect(viteConfig).not.toContain('loadEnv');
+      expect(viteConfig).not.toContain('bridge: true');
+      expect(viteConfig).not.toContain('modelMap');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -170,7 +175,7 @@ describe('runScaffold', () => {
     const manifest = JSON.parse(readFileSync(join(root, 'scaffold.json'), 'utf8')) as {
       include: string[];
     };
-    const runtimeEntries = new Set(['.agents', '.codex', '.npmignore', 'dist', 'node_modules']);
+    const runtimeEntries = new Set(['.agents', '.codex', '.npmignore', '.pyric', 'dist', 'node_modules']);
     expect(readdirSync(root).filter((entry) => !runtimeEntries.has(entry)).sort()).toEqual(
       [...manifest.include, 'package.json', 'scaffold.json'].sort(),
     );


### PR DESCRIPTION
Makes `pyric()` convention-first so the generated chat app keeps its Vite configuration small while rules and local-model settings are discovered by the plugin.

```ts
import { defineConfig } from 'vite';
import react from '@vitejs/plugin-react';
import tailwindcss from '@tailwindcss/vite';
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [react(), tailwindcss(), pyric()],
});
```

## `pyric()` now owns the development conventions the chat template used to spell out

The plugin resolves Firestore rules in this order: an explicit `rules` option, `firestore.modules.rules`, `firebase.json`, then the root `firestore.rules` fallback. This keeps the authored 2+modules file as the development source of truth without putting deployment-resolution mechanics in every app's Vite config.

The same bare plugin call reads local AI settings from Vite's active environment, including a custom `envDir`:

```dotenv
# Ollama's OpenAI-compatible endpoint at http://localhost:11434/v1 is the default.
PYRIC_AI_MODEL=qwen3:4b

# Set this only for a different OpenAI-compatible server.
PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
```

Explicit `ai.model`, `ai.engine`, and `ai.proxyUpstream` options still win over environment values. With no plugin or environment model, the app's first `getAI()` engine remains authoritative; with no engine anywhere, Pyric keeps its scripted default.

## Risk

This changes default rules discovery only when a project contains `firestore.modules.rules`; projects without that file retain the existing Firebase discovery path. It also makes `PYRIC_AI_MODEL` active at plugin level, so an accidentally inherited variable can intentionally select a real local-model engine instead of the scripted engine. The new precedence tests are the primary review surface.

<details>
<summary>Implementation notes</summary>

- AI option/environment precedence is isolated in `vite-ai-config.ts`; rules discovery is isolated in `vite-rules-source.ts` rather than extending the already-large plugin module.
- Generated-template README guidance is limited to commands and configuration for that generated app and links to the canonical AI Logic guide.
- This is PR 1 of the runtime-chip sequence. It establishes the convention-first plugin surface before runtime status/epoch and UI work build on it.

Verification:

- `bun test packages/cli/test/serve/vite-plugin.test.ts` — 51 passed
- focused AI/rules/scaffold suites — 22 passed
- CLI and create-pyric TypeScript checks — passed
- CLI and create-pyric builds — passed
- cold standards review — no findings
- cold spec/behavior review — no findings
- `git diff --check` — passed

</details>
