### PR TITLE
feat(runtime): expose worker status and sandbox errors

### DIFF
--- a/packages/cli/scripts/compile.ts
+++ b/packages/cli/scripts/compile.ts
@@ -86,7 +86,7 @@ const bundler = (await import(pathToFileURL(bundlerMod).href)) as {
   bundleSdk: (o: { entries: Record<string, string>; noCache: boolean; cacheRoot: string }) => Promise<{ outDir: string }>;
   bundleWorker: (o: { outDir: string; noCache: boolean }) => Promise<string>;
   defaultSdkEntries: () => Record<string, string>;
-  workerSourceHash: () => string;
+  workerBundleEpoch: (outDir: string) => string;
   pyricVersion: () => string;
 };
 
@@ -98,7 +98,7 @@ const { outDir } = await bundler.bundleSdk({
 });
 await bundler.bundleWorker({ outDir, noCache: true });
 const version = bundler.pyricVersion();
-const workerVersion = bundler.workerSourceHash();
+const workerVersion = bundler.workerBundleEpoch(outDir);
 
 // ── 2. Collect bytes → base64 maps ────────────────────────────────────
 /** SDK dir is flat. Embed `.js` only (sourcemaps are 4× the bytes and only

--- a/packages/cli/scripts/compile.ts
+++ b/packages/cli/scripts/compile.ts
@@ -84,9 +84,8 @@ mkdirSync(BUILD, { recursive: true });
 
 const bundler = (await import(pathToFileURL(bundlerMod).href)) as {
   bundleSdk: (o: { entries: Record<string, string>; noCache: boolean; cacheRoot: string }) => Promise<{ outDir: string }>;
-  bundleWorker: (o: { outDir: string; noCache: boolean }) => Promise<string>;
+  bundleWorker: (o: { outDir: string; noCache: boolean }) => Promise<{ outFile: string; epoch: string }>;
   defaultSdkEntries: () => Record<string, string>;
-  workerBundleEpoch: (outDir: string) => string;
   pyricVersion: () => string;
 };
 
@@ -96,9 +95,9 @@ const { outDir } = await bundler.bundleSdk({
   noCache: true,
   cacheRoot: STAGE,
 });
-await bundler.bundleWorker({ outDir, noCache: true });
+const worker = await bundler.bundleWorker({ outDir, noCache: true });
 const version = bundler.pyricVersion();
-const workerVersion = bundler.workerBundleEpoch(outDir);
+const workerVersion = worker.epoch;
 
 // ── 2. Collect bytes → base64 maps ────────────────────────────────────
 /** SDK dir is flat. Embed `.js` only (sourcemaps are 4× the bytes and only

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -14,7 +14,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import type { ParsedArgs } from './parse-args.js';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from './firebase-json.js';
-import { bundleSdk, bundleWorker, defaultSdkEntries, resolveDocsUiDir, resolveStudioUiDir, workerBundleEpoch } from '../serve/bundler.js';
+import { bundleSdk, bundleWorker, defaultSdkEntries, resolveDocsUiDir, resolveStudioUiDir } from '../serve/bundler.js';
 import {
   isStandalone,
   materializeDocsUi,
@@ -335,12 +335,12 @@ export async function startServe(opts: {
     // fall back to the in-page sandbox. Built alongside the SDK so a warm
     // start skips both.
     try {
-      await bundleWorker({ outDir: bundle.outDir, noCache: opts.noCache });
+      const worker = await bundleWorker({ outDir: bundle.outDir, noCache: opts.noCache });
+      workerVersion = worker.epoch;
     } catch (error) {
       bundle.dispose?.();
       throw error;
     }
-    workerVersion = workerBundleEpoch(bundle.outDir);
   }
   const bundleMs = Math.round(performance.now() - t0);
 

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -14,7 +14,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import type { ParsedArgs } from './parse-args.js';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from './firebase-json.js';
-import { bundleSdk, bundleWorker, defaultSdkEntries, resolveDocsUiDir, resolveStudioUiDir, workerSourceHash } from '../serve/bundler.js';
+import { bundleSdk, bundleWorker, defaultSdkEntries, resolveDocsUiDir, resolveStudioUiDir, workerBundleEpoch } from '../serve/bundler.js';
 import {
   isStandalone,
   materializeDocsUi,
@@ -318,7 +318,7 @@ export async function startServe(opts: {
   // and is identical either way.
   const t0 = performance.now();
   let bundle: { outDir: string; cached: boolean; dispose?: () => void };
-  // The worker content hash: stamped into the page (`<meta name="pyric-worker-v">`)
+  // The worker executable epoch: stamped into the page (`<meta name="pyric-worker-v">`)
   // so the page can WARN when a still-running worker is older than the served
   // bundle. The worker NAME is stable (`pyric-shared-worker`) — all tabs share
   // one backend — so a SharedWorker (which can't hot-update) is detected as
@@ -340,7 +340,7 @@ export async function startServe(opts: {
       bundle.dispose?.();
       throw error;
     }
-    workerVersion = workerSourceHash();
+    workerVersion = workerBundleEpoch(bundle.outDir);
   }
   const bundleMs = Math.round(performance.now() - t0);
 

--- a/packages/cli/src/serve/bundler.ts
+++ b/packages/cli/src/serve/bundler.ts
@@ -390,7 +390,7 @@ const WORKER_EPOCH_PLACEHOLDER = 'PYRIC_EPOCH_HERE';
 const WORKER_EPOCH_FILE = '.worker-epoch';
 
 /** Read the executable epoch written alongside a completed worker bundle. */
-export function workerBundleEpoch(outDir: string): string {
+function readWorkerBundleEpoch(outDir: string): string {
   const epoch = readFileSync(join(outDir, WORKER_EPOCH_FILE), 'utf8').trim();
   if (!/^[a-f0-9]{16}$/.test(epoch)) {
     throw new Error(`pyric dev: invalid SharedWorker epoch in ${join(outDir, WORKER_EPOCH_FILE)}`);
@@ -403,7 +403,7 @@ export function workerBundleEpoch(outDir: string): string {
  * (keyed by SDK entries), which does not cover its host graph, so this broad
  * source-tree hash decides when esbuild must run again. It is intentionally NOT
  * the user-facing worker epoch: unrelated CLI changes may invalidate this cache,
- * while {@link workerBundleEpoch} is derived from the executable output and only
+ * while the epoch returned by {@link bundleWorker} is derived from the executable output and only
  * then decides whether a running SharedWorker needs replacement.
  */
 export function workerSourceHash(
@@ -462,7 +462,12 @@ export function sourceTreeHash(root: string): string {
  * or protocol edit therefore invalidates the shared SDK generation too, so
  * the page and worker halves cannot come from different source generations.
  */
-export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
+export interface WorkerBundleResult {
+  outFile: string;
+  epoch: string;
+}
+
+export async function bundleWorker(opts: WorkerBundleOptions): Promise<WorkerBundleResult> {
   const outFile = join(opts.outDir, 'worker.js');
   const marker = join(opts.outDir, '.worker-complete');
   const hash = workerSourceHash();
@@ -473,7 +478,7 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
     existsSync(join(opts.outDir, WORKER_EPOCH_FILE)) &&
     readFileSync(marker, 'utf8') === hash
   ) {
-    return outFile;
+    return { outFile, epoch: readWorkerBundleEpoch(opts.outDir) };
   }
 
   mkdirSync(opts.outDir, { recursive: true });
@@ -510,5 +515,5 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
   writeFileSync(outFile, canonicalSource.replaceAll(WORKER_EPOCH_PLACEHOLDER, epoch));
   writeFileSync(join(opts.outDir, WORKER_EPOCH_FILE), epoch);
   writeFileSync(marker, hash);
-  return outFile;
+  return { outFile, epoch };
 }

--- a/packages/cli/src/serve/bundler.ts
+++ b/packages/cli/src/serve/bundler.ts
@@ -382,16 +382,29 @@ export interface WorkerBundleOptions {
   /** Bypass + overwrite the cached worker bundle. */
   noCache?: boolean;
   minify?: boolean;
+  /** Test seam for proving epoch identity from an isolated executable graph. */
+  entryPath?: string;
+}
+
+const WORKER_EPOCH_PLACEHOLDER = 'PYRIC_EPOCH_HERE';
+const WORKER_EPOCH_FILE = '.worker-epoch';
+
+/** Read the executable epoch written alongside a completed worker bundle. */
+export function workerBundleEpoch(outDir: string): string {
+  const epoch = readFileSync(join(outDir, WORKER_EPOCH_FILE), 'utf8').trim();
+  if (!/^[a-f0-9]{16}$/.test(epoch)) {
+    throw new Error(`pyric dev: invalid SharedWorker epoch in ${join(outDir, WORKER_EPOCH_FILE)}`);
+  }
+  return epoch;
 }
 
 /**
- * Content hash of the worker's executable CLI graph + pyric version. The worker bundle
- * shares the SDK `outDir` (keyed by the SDK entries), which does NOT cover the
- * worker graph — so the worker bundle carries its OWN content marker. Hash the
- * full CLI source/dist tree because the worker imports bridge and verify leaves
- * outside `serve/worker`; an allowlist would silently miss future dependencies.
- * Installed pyric dist bytes are also hashed because workspace and prerelease
- * builds can change implementation without a version bump.
+ * Conservative worker CACHE key. The worker bundle shares the SDK `outDir`
+ * (keyed by SDK entries), which does not cover its host graph, so this broad
+ * source-tree hash decides when esbuild must run again. It is intentionally NOT
+ * the user-facing worker epoch: unrelated CLI changes may invalidate this cache,
+ * while {@link workerBundleEpoch} is derived from the executable output and only
+ * then decides whether a running SharedWorker needs replacement.
  */
 export function workerSourceHash(
   pyricRoot = pyricPackageRoot(),
@@ -457,6 +470,7 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
     !opts.noCache &&
     existsSync(outFile) &&
     existsSync(marker) &&
+    existsSync(join(opts.outDir, WORKER_EPOCH_FILE)) &&
     readFileSync(marker, 'utf8') === hash
   ) {
     return outFile;
@@ -465,7 +479,7 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
   mkdirSync(opts.outDir, { recursive: true });
   const root = pyricPackageRoot();
   const result = await esbuild.build({
-    entryPoints: [workerEntryPath()],
+    entryPoints: [opts.entryPath ?? workerEntryPath()],
     outfile: outFile,
     bundle: true,
     format: 'iife',
@@ -474,10 +488,10 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
     sourcemap: 'linked',
     minify: opts.minify ?? true,
     logLevel: 'silent',
-    // Bake the build hash so the worker can report its version (staleness
-    // guard): the page warns when a still-running OLD worker is older than the
-    // served bundle. Matches the `<meta name="pyric-worker-v">` value.
-    define: { __PYRIC_WORKER_VERSION__: JSON.stringify(hash) },
+    // Reserve a fixed-width self-version slot. After esbuild writes the actual
+    // executable graph, we hash that canonical output and replace this token
+    // with the resulting epoch (same width, so the sourcemap stays aligned).
+    define: { __PYRIC_WORKER_VERSION__: JSON.stringify(WORKER_EPOCH_PLACEHOLDER) },
     banner: {
       js: '/* pyric dev: SharedWorker sandbox host serving firebase/* — NOT the real Firebase SDK */',
     },
@@ -488,6 +502,13 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<string> {
       `pyric dev: SharedWorker bundle failed:\n${result.errors.map((e) => e.text).join('\n')}`,
     );
   }
+  const canonicalSource = readFileSync(outFile, 'utf8');
+  if (!canonicalSource.includes(WORKER_EPOCH_PLACEHOLDER)) {
+    throw new Error('pyric dev: SharedWorker bundle omitted its epoch placeholder');
+  }
+  const epoch = createHash('sha256').update(canonicalSource).digest('hex').slice(0, 16);
+  writeFileSync(outFile, canonicalSource.replaceAll(WORKER_EPOCH_PLACEHOLDER, epoch));
+  writeFileSync(join(opts.outDir, WORKER_EPOCH_FILE), epoch);
   writeFileSync(marker, hash);
   return outFile;
 }

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -412,16 +412,15 @@ function explainSandboxFrame(stackOrUrl: string | undefined): boolean {
   return true;
 }
 if (typeof window !== 'undefined') {
-  window.addEventListener('error', (e) => {
-    if (explainSandboxFrame(e.error instanceof Error ? (e.error.stack ?? e.filename) : e.filename)) {
-      runtimeStatus.reportError(e.error ?? e.message, 'sandbox');
-    }
-  });
-  window.addEventListener('unhandledrejection', (e) => {
-    if (explainSandboxFrame(e.reason instanceof Error ? e.reason.stack : undefined)) {
-      runtimeStatus.reportError(e.reason, 'sandbox');
-    }
-  });
+  // Stack containment is useful provenance context, but it is NOT an ownership
+  // boundary: an app callback thrown from an SDK caller also contains an SDK
+  // frame. Explicit sandbox events and runtime catches feed the status model.
+  window.addEventListener('error', (e) =>
+    explainSandboxFrame(e.error instanceof Error ? (e.error.stack ?? e.filename) : e.filename),
+  );
+  window.addEventListener('unhandledrejection', (e) =>
+    explainSandboxFrame(e.reason instanceof Error ? e.reason.stack : undefined),
+  );
 }
 
 // ── bridge peer (only when `pyric dev --bridge` put a URL in the payload;
@@ -461,6 +460,7 @@ if (bridgeUrlFromPayload) {
   try {
     await connectBridgePeer(bridgeUrlFromPayload);
   } catch (e) {
+    runtimeStatus.reportError(e, 'runtime');
     console.error('[pyric dev] bridge connect failed:', e instanceof Error ? e.message : String(e));
   }
 } else if (useWorker) {
@@ -475,6 +475,7 @@ if (bridgeUrlFromPayload) {
       const url = res.ok ? ((await res.json()) as InitPayload).bridgeUrl : null;
       if (url) await connectBridgePeer(url);
     } catch (e) {
+      runtimeStatus.reportError(e, 'runtime');
       console.error('[pyric dev] bridge connect failed:', e instanceof Error ? e.message : String(e));
     }
   })();
@@ -548,6 +549,7 @@ if (!useWorker && typeof EventSource !== 'undefined') {
       diagnostics.rulesHash = rulesHash;
       console.info(`[pyric dev] firestore.rules hot-reloaded (hash ${rulesHash})`);
     } catch (err) {
+      runtimeStatus.reportError(err, 'runtime');
       console.error('[pyric dev] rules hot-reload failed:', err instanceof Error ? err.message : String(err));
     }
   });

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -34,6 +34,7 @@ import { toPageOriginWsUrl } from './bridge-url.js';
 import { buildVerifyFixture } from '../../verify/fixture.js';
 import type { InitPayload } from '../init-payload.js';
 import { setupFirebaseActivityGuard } from '../activity-guard.js';
+import { getPyricRuntimeStatus } from '../runtime/status.js';
 export { sandbox } from './app-backend.js';
 import { sandbox } from './app-backend.js';
 
@@ -102,6 +103,11 @@ const diagnostics: ServeDiagnostics = {
   seedSkipped: false,
 };
 globalThis.__pyricServe = diagnostics;
+const runtimeStatus = getPyricRuntimeStatus();
+
+if (!useWorker) {
+  sandbox.onEvent((event) => runtimeStatus.recordSandboxEvents([event]));
+}
 
 let bridgeUrlFromPayload: string | null = null;
 let activityTokenFromPayload: string | null = null;
@@ -359,6 +365,7 @@ if (!useWorker) try {
   }
 } catch (e) {
   diagnostics.initError = e instanceof Error ? e.message : String(e);
+  runtimeStatus.reportError(e, 'runtime');
   console.error(
     '[pyric dev] init failed — the sandbox is running WITHOUT your project rules:',
     diagnostics.initError,
@@ -393,21 +400,28 @@ console.info(
 );
 
 let provenanceHintShown = false;
-function explainSandboxFrame(stackOrUrl: string | undefined): void {
-  if (provenanceHintShown || !stackOrUrl || !stackOrUrl.includes('/__pyric/sdk/')) return;
-  provenanceHintShown = true;
-  console.info(
-    '[pyric dev] the error above originates in the pyric sandbox shim serving firebase/*, ' +
-      'not the real Firebase SDK — behavior can differ where COMPAT coverage is incomplete.',
-  );
+function explainSandboxFrame(stackOrUrl: string | undefined): boolean {
+  if (!stackOrUrl || !stackOrUrl.includes('/__pyric/sdk/')) return false;
+  if (!provenanceHintShown) {
+    provenanceHintShown = true;
+    console.info(
+      '[pyric dev] the error above originates in the pyric sandbox shim serving firebase/*, ' +
+        'not the real Firebase SDK — behavior can differ where COMPAT coverage is incomplete.',
+    );
+  }
+  return true;
 }
 if (typeof window !== 'undefined') {
-  window.addEventListener('error', (e) =>
-    explainSandboxFrame(e.error instanceof Error ? (e.error.stack ?? e.filename) : e.filename),
-  );
-  window.addEventListener('unhandledrejection', (e) =>
-    explainSandboxFrame(e.reason instanceof Error ? e.reason.stack : undefined),
-  );
+  window.addEventListener('error', (e) => {
+    if (explainSandboxFrame(e.error instanceof Error ? (e.error.stack ?? e.filename) : e.filename)) {
+      runtimeStatus.reportError(e.error ?? e.message, 'sandbox');
+    }
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    if (explainSandboxFrame(e.reason instanceof Error ? e.reason.stack : undefined)) {
+      runtimeStatus.reportError(e.reason, 'sandbox');
+    }
+  });
 }
 
 // ── bridge peer (only when `pyric dev --bridge` put a URL in the payload;

--- a/packages/cli/src/serve/entries/worker-runtime.ts
+++ b/packages/cli/src/serve/entries/worker-runtime.ts
@@ -16,6 +16,7 @@ import {
 import { getPyricRuntimeStatus } from '../runtime/status.js';
 
 const hasSharedWorker = typeof SharedWorker !== 'undefined';
+const runtimeStatus = getPyricRuntimeStatus();
 
 export const useWorker =
   (hasSharedWorker || (isServiceWorkerRealm() && typeof BroadcastChannel !== 'undefined'))
@@ -27,7 +28,9 @@ export const WORKER_NAME = PYRIC_WORKER_NAME;
 /** Control traffic only; Firebase apps receive independent app-owned ports. */
 export const workerDb: ClientDb | null = useWorker
   ? hasSharedWorker
-    ? getFirestore(WORKER_URL, WORKER_NAME)
+    ? getFirestore(WORKER_URL, WORKER_NAME, {
+        onError: (error) => runtimeStatus.reportError(error, 'worker'),
+      })
     : null
   : null;
 
@@ -41,7 +44,6 @@ export const presenceSession = useWorker && workerDb
   ? startPresence({ db: workerDb, kind: 'app' })
   : null;
 
-const runtimeStatus = getPyricRuntimeStatus();
 runtimeStatus.setWorker({
   mode: useWorker ? 'shared-worker' : 'in-page',
   runningEpoch: null,

--- a/packages/cli/src/serve/entries/worker-runtime.ts
+++ b/packages/cli/src/serve/entries/worker-runtime.ts
@@ -3,11 +3,17 @@ import {
   getFirestore,
   getWorkerVersion,
   startPresence,
+  subscribeEvents,
   subscribePresence,
   type ClientDb,
 } from '../worker/client.js';
 import { getServiceWorkerFirestore } from '../worker/client/service-worker-connection.js';
 import { isServiceWorkerRealm } from '../worker/service-worker-channel.js';
+import {
+  PYRIC_WORKER_NAME,
+  PYRIC_WORKER_URL,
+} from '../runtime/manifest.js';
+import { getPyricRuntimeStatus } from '../runtime/status.js';
 
 const hasSharedWorker = typeof SharedWorker !== 'undefined';
 
@@ -15,8 +21,8 @@ export const useWorker =
   (hasSharedWorker || (isServiceWorkerRealm() && typeof BroadcastChannel !== 'undefined'))
   && !(globalThis as { __PYRIC_FORCE_INPAGE__?: boolean }).__PYRIC_FORCE_INPAGE__;
 
-export const WORKER_URL = '/__pyric/sdk/worker.js';
-export const WORKER_NAME = 'pyric-shared-worker';
+export const WORKER_URL = PYRIC_WORKER_URL;
+export const WORKER_NAME = PYRIC_WORKER_NAME;
 
 /** Control traffic only; Firebase apps receive independent app-owned ports. */
 export const workerDb: ClientDb | null = useWorker
@@ -35,12 +41,21 @@ export const presenceSession = useWorker && workerDb
   ? startPresence({ db: workerDb, kind: 'app' })
   : null;
 
+const runtimeStatus = getPyricRuntimeStatus();
+runtimeStatus.setWorker({
+  mode: useWorker ? 'shared-worker' : 'in-page',
+  runningEpoch: null,
+});
+
+if (useWorker && workerDb) {
+  subscribeEvents(workerDb, (events) => runtimeStatus.recordSandboxEvents(events));
+}
+
 if (useWorker && typeof document !== 'undefined') {
-  const servedVersion = document
-    .querySelector('meta[name="pyric-worker-v"]')
-    ?.getAttribute('content');
+  const servedVersion = runtimeStatus.getSnapshot().servedEpoch;
   void getWorkerVersion(workerDb!)
     .then(async (runningVersion) => {
+      runtimeStatus.setWorker({ mode: 'shared-worker', runningEpoch: runningVersion });
       if (
         !servedVersion
         || !runningVersion
@@ -71,5 +86,5 @@ if (useWorker && typeof document !== 'undefined') {
           + `the old code running for everyone.)${othersHint}`,
       );
     })
-    .catch(() => {});
+    .catch((error) => runtimeStatus.reportError(error, 'worker'));
 }

--- a/packages/cli/src/serve/entries/worker-runtime.ts
+++ b/packages/cli/src/serve/entries/worker-runtime.ts
@@ -14,11 +14,12 @@ import {
   PYRIC_WORKER_URL,
 } from '../runtime/manifest.js';
 import { getPyricRuntimeStatus } from '../runtime/status.js';
+import { connectRuntimeWorker } from '../runtime/worker-connection.js';
 
 const hasSharedWorker = typeof SharedWorker !== 'undefined';
 const runtimeStatus = getPyricRuntimeStatus();
 
-export const useWorker =
+const workerRequested =
   (hasSharedWorker || (isServiceWorkerRealm() && typeof BroadcastChannel !== 'undefined'))
   && !(globalThis as { __PYRIC_FORCE_INPAGE__?: boolean }).__PYRIC_FORCE_INPAGE__;
 
@@ -26,13 +27,18 @@ export const WORKER_URL = PYRIC_WORKER_URL;
 export const WORKER_NAME = PYRIC_WORKER_NAME;
 
 /** Control traffic only; Firebase apps receive independent app-owned ports. */
-export const workerDb: ClientDb | null = useWorker
+export const workerDb: ClientDb | null = workerRequested
   ? hasSharedWorker
-    ? getFirestore(WORKER_URL, WORKER_NAME, {
-        onError: (error) => runtimeStatus.reportError(error, 'worker'),
-      })
+    ? connectRuntimeWorker(
+        () => getFirestore(WORKER_URL, WORKER_NAME, {
+          onError: (error) => runtimeStatus.reportError(error, 'worker'),
+        }),
+        (error) => runtimeStatus.reportError(error, 'worker'),
+      )
     : null
   : null;
+
+export const useWorker = workerRequested && (!hasSharedWorker || workerDb !== null);
 
 export function openWorkerDb(appName: string): ClientDb {
   if (hasSharedWorker) return getFirestore(WORKER_URL, WORKER_NAME);

--- a/packages/cli/src/serve/runtime/manifest.ts
+++ b/packages/cli/src/serve/runtime/manifest.ts
@@ -1,0 +1,37 @@
+/** Stable routes and identity used by the served runtime and its UI. */
+export const PYRIC_WORKER_URL = '/__pyric/sdk/worker.js';
+export const PYRIC_WORKER_NAME = 'pyric-shared-worker';
+export const PYRIC_STUDIO_URL = '/__pyric/ui/';
+
+export interface PyricRuntimeManifest {
+  studioUrl: string;
+  worker: {
+    url: string;
+    name: string;
+    /** Content epoch served by the current dev server; null in in-page mode. */
+    servedEpoch: string | null;
+  };
+}
+
+interface RuntimeDocument {
+  querySelector(selector: string): { getAttribute(name: string): string | null } | null;
+}
+
+/** Read the server-stamped worker epoch before application code starts. */
+export function readPyricRuntimeManifest(
+  documentLike: RuntimeDocument | undefined = typeof document === 'undefined' ? undefined : document,
+): PyricRuntimeManifest {
+  const servedEpoch = documentLike
+    ?.querySelector('meta[name="pyric-worker-v"]')
+    ?.getAttribute('content')
+    ?.trim() || null;
+
+  return {
+    studioUrl: PYRIC_STUDIO_URL,
+    worker: {
+      url: PYRIC_WORKER_URL,
+      name: PYRIC_WORKER_NAME,
+      servedEpoch,
+    },
+  };
+}

--- a/packages/cli/src/serve/runtime/status.ts
+++ b/packages/cli/src/serve/runtime/status.ts
@@ -87,6 +87,18 @@ function sandboxError(event: SandboxEvent): PyricRuntimeError | null {
       message: event.error.message,
     };
   }
+  if (event.kind === 'listener_errored' && event.error) {
+    return {
+      id: event.id,
+      source: 'sandbox',
+      at: event.at,
+      service: 'firestore',
+      method: 'listener',
+      ...('path' in event.target ? { path: event.target.path } : {}),
+      code: event.error.code,
+      message: event.error.message,
+    };
+  }
   if (event.kind === 'listener' && event.phase === 'errored' && event.error) {
     return {
       id: event.id,

--- a/packages/cli/src/serve/runtime/status.ts
+++ b/packages/cli/src/serve/runtime/status.ts
@@ -1,0 +1,182 @@
+import type { SandboxEvent } from 'pyric/sandbox';
+import type { PyricRuntimeManifest } from './manifest.js';
+import { readPyricRuntimeManifest } from './manifest.js';
+
+export type PyricRuntimeMode = 'starting' | 'shared-worker' | 'in-page';
+export type PyricRuntimeErrorSource = 'sandbox' | 'worker' | 'runtime';
+
+export interface PyricRuntimeError {
+  id: string;
+  source: PyricRuntimeErrorSource;
+  at: number;
+  message: string;
+  code?: string;
+  stack?: string;
+  service?: string;
+  method?: string;
+  path?: string;
+}
+
+export interface PyricRuntimeSnapshot {
+  manifest: PyricRuntimeManifest;
+  mode: PyricRuntimeMode;
+  servedEpoch: string | null;
+  runningEpoch: string | null;
+  updateAvailable: boolean;
+  errors: readonly PyricRuntimeError[];
+}
+
+export interface PyricRuntimeStatus {
+  getSnapshot(): PyricRuntimeSnapshot;
+  subscribe(listener: (snapshot: PyricRuntimeSnapshot) => void): () => void;
+  setWorker(input: { mode: Exclude<PyricRuntimeMode, 'starting'>; runningEpoch?: string | null }): void;
+  reportError(error: unknown, source: PyricRuntimeErrorSource): void;
+  recordSandboxEvents(events: readonly SandboxEvent[]): void;
+  clearErrors(): void;
+}
+
+let nextErrorId = 0;
+
+function errorCode(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const code = (value as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+/** Convert thrown values into a serializable, copyable runtime error. */
+export function normalizePyricRuntimeError(
+  value: unknown,
+  source: PyricRuntimeErrorSource,
+  at = Date.now(),
+  id = `runtime-error-${++nextErrorId}`,
+): PyricRuntimeError {
+  if (value instanceof Error) {
+    return {
+      id,
+      source,
+      at,
+      message: value.message,
+      ...(errorCode(value) ? { code: errorCode(value) } : {}),
+      ...(value.stack ? { stack: value.stack } : {}),
+    };
+  }
+  if (typeof value === 'string') return { id, source, at, message: value };
+  if (value && typeof value === 'object') {
+    const message = (value as { message?: unknown }).message;
+    return {
+      id,
+      source,
+      at,
+      message: typeof message === 'string' ? message : String(value),
+      ...(errorCode(value) ? { code: errorCode(value) } : {}),
+    };
+  }
+  return { id, source, at, message: String(value) };
+}
+
+function sandboxError(event: SandboxEvent): PyricRuntimeError | null {
+  if (event.kind === 'runtime_error') {
+    return {
+      id: event.id,
+      source: 'sandbox',
+      at: event.at,
+      service: event.service,
+      method: event.method,
+      ...(event.path ? { path: event.path } : {}),
+      ...(event.error.code ? { code: event.error.code } : {}),
+      message: event.error.message,
+    };
+  }
+  if (event.kind === 'listener' && event.phase === 'errored' && event.error) {
+    return {
+      id: event.id,
+      source: 'sandbox',
+      at: event.at,
+      service: event.service,
+      method: 'listener',
+      ...(event.target.path ? { path: event.target.path } : {}),
+      ...(event.error.code ? { code: event.error.code } : {}),
+      message: event.error.message,
+    };
+  }
+  return null;
+}
+
+/** Observable, bounded status model shared by the runtime and injected UI. */
+export function createPyricRuntimeStatus(
+  manifest: PyricRuntimeManifest,
+  options: { maxErrors?: number } = {},
+): PyricRuntimeStatus {
+  const maxErrors = Math.max(1, options.maxErrors ?? 50);
+  const listeners = new Set<(snapshot: PyricRuntimeSnapshot) => void>();
+  const errorIds = new Set<string>();
+  let snapshot: PyricRuntimeSnapshot = {
+    manifest,
+    mode: 'starting',
+    servedEpoch: manifest.worker.servedEpoch,
+    runningEpoch: null,
+    updateAvailable: false,
+    errors: [],
+  };
+
+  const publish = (next: PyricRuntimeSnapshot): void => {
+    snapshot = next;
+    for (const listener of listeners) listener(snapshot);
+  };
+  const appendError = (error: PyricRuntimeError): void => {
+    if (errorIds.has(error.id)) return;
+    errorIds.add(error.id);
+    const errors = [...snapshot.errors, error].slice(-maxErrors);
+    const retained = new Set(errors.map((item) => item.id));
+    for (const id of errorIds) if (!retained.has(id)) errorIds.delete(id);
+    publish({ ...snapshot, errors });
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(snapshot);
+      return () => listeners.delete(listener);
+    },
+    setWorker({ mode, runningEpoch = null }) {
+      const servedEpoch = manifest.worker.servedEpoch;
+      publish({
+        ...snapshot,
+        mode,
+        runningEpoch,
+        updateAvailable: Boolean(
+          mode === 'shared-worker'
+          && servedEpoch
+          && runningEpoch
+          && runningEpoch !== 'dev'
+          && servedEpoch !== runningEpoch,
+        ),
+      });
+    },
+    reportError(error, source) {
+      appendError(normalizePyricRuntimeError(error, source));
+    },
+    recordSandboxEvents(events) {
+      for (const event of events) {
+        const normalized = sandboxError(event);
+        if (normalized) appendError(normalized);
+      }
+    },
+    clearErrors() {
+      errorIds.clear();
+      publish({ ...snapshot, errors: [] });
+    },
+  };
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __pyricRuntime: PyricRuntimeStatus | undefined;
+}
+
+/** One global status source even when the runtime and UI are separate bundles. */
+export function getPyricRuntimeStatus(): PyricRuntimeStatus {
+  return globalThis.__pyricRuntime
+    ??= createPyricRuntimeStatus(readPyricRuntimeManifest());
+}

--- a/packages/cli/src/serve/runtime/worker-connection.ts
+++ b/packages/cli/src/serve/runtime/worker-connection.ts
@@ -1,0 +1,14 @@
+import type { ClientDb } from '../worker/client/handles.js';
+
+/** Construct the control connection without letting a browser policy failure abort runtime boot. */
+export function connectRuntimeWorker(
+  connect: () => ClientDb,
+  reportError: (error: unknown) => void,
+): ClientDb | null {
+  try {
+    return connect();
+  } catch (error) {
+    reportError(error);
+    return null;
+  }
+}

--- a/packages/cli/src/serve/standalone-assets.ts
+++ b/packages/cli/src/serve/standalone-assets.ts
@@ -31,7 +31,7 @@ export interface EmbeddedAssets {
    * materialization cache. Optional so older compiled binaries still boot.
    */
   assetVersion?: string;
-  /** Worker source hash stamped into the page (`<meta name="pyric-worker-v">`). */
+  /** Worker executable epoch stamped into the page (`<meta name="pyric-worker-v">`). */
   workerVersion: string;
   /** Lazy: flat map of SDK filename -> base64 bytes (app.js, worker.js, chunks). */
   sdk: () => Promise<Record<string, string>>;
@@ -68,7 +68,7 @@ function embedded(): EmbeddedAssets {
   return e;
 }
 
-/** The worker content hash baked in at compile time (see serve.ts). */
+/** The worker executable epoch baked in at compile time (see serve.ts). */
 export function embeddedWorkerVersion(): string {
   return embedded().workerVersion;
 }

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -52,6 +52,7 @@ import {
   resolveStudioUiDir,
   pyricPackageRoot,
   bundleWorker,
+  workerBundleEpoch,
   workerSourceHash,
   NODE_BUILTIN_RE,
   NODE_BUILTIN_SHIMS,
@@ -303,7 +304,8 @@ export function pyric(options: PyricOptions = {}): Plugin {
   // a still-running OLD worker is detected as stale. `workerReady` flips true once
   // `bundleWorker` succeeds in configureServer; until then (or on bundle failure)
   // the page is forced onto the in-page sandbox path. transformIndexHtml reads it.
-  const workerVersion = workerSourceHash();
+  const workerCacheKey = workerSourceHash();
+  let workerVersion: string | null = null;
   let workerReady = false;
 
   // Set by the `config` hook. When the plugin runs under `vite build` at all it
@@ -501,9 +503,10 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // /__pyric/sdk/worker.js. This is what flips runtime.ts to the worker path.
       // On bundle failure, fall back to the in-page sandbox (workerReady stays
       // false → transformIndexHtml forces in-page).
-      const sdkDir = path.join(homedir(), '.pyric', 'vite-worker', workerVersion);
+      const sdkDir = path.join(homedir(), '.pyric', 'vite-worker', workerCacheKey);
       try {
         await bundleWorker({ outDir: sdkDir });
+        workerVersion = workerBundleEpoch(sdkDir);
         workerReady = true;
       } catch (e) {
         server.config.logger.warn(
@@ -1049,7 +1052,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // forces in-page: the bridge peer routes agent tool-calls THROUGH the
       // worker (see `connectBridgePeer`), so the agent shares the one sandbox the
       // app + Studio use.
-      const head = workerReady
+      const head = workerReady && workerVersion
         ? `<meta name="pyric-worker-v" content="${workerVersion}" ${MARKER}>`
         : `<script ${MARKER}>globalThis.__PYRIC_FORCE_INPAGE__=true;</script>`;
       // Plugin-level engine for the IN-PAGE path: a classic inline script runs

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -41,7 +41,6 @@
  */
 import { readFile } from 'node:fs/promises';
 import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
 import type { Plugin, UserConfig, ConfigEnv } from 'vite';
@@ -51,12 +50,10 @@ import {
   defaultSdkEntries,
   resolveStudioUiDir,
   pyricPackageRoot,
-  bundleWorker,
-  workerBundleEpoch,
-  workerSourceHash,
   NODE_BUILTIN_RE,
   NODE_BUILTIN_SHIMS,
 } from './bundler.js';
+import { createViteWorkerRuntime } from './vite-worker-runtime.js';
 import {
   createEventHub,
   createPyricNamespace,
@@ -301,12 +298,10 @@ export function pyric(options: PyricOptions = {}): Plugin {
   };
 
   // M2: the SharedWorker bundle's content hash (sync) — stamped into the page so
-  // a still-running OLD worker is detected as stale. `workerReady` flips true once
-  // `bundleWorker` succeeds in configureServer; until then (or on bundle failure)
-  // the page is forced onto the in-page sandbox path. transformIndexHtml reads it.
-  const workerCacheKey = workerSourceHash();
-  let workerVersion: string | null = null;
-  let workerReady = false;
+  // a still-running OLD worker is detected as stale. The collaborator becomes
+  // ready once its bundle succeeds; until then (or on bundle failure) the page
+  // is forced onto the in-page sandbox path. transformIndexHtml reads its tag.
+  const workerRuntime = createViteWorkerRuntime();
 
   // Set by the `config` hook. When the plugin runs under `vite build` at all it
   // is a SANDBOX build (the `apply` gate below only lets build through under the
@@ -501,13 +496,10 @@ export function pyric(options: PyricOptions = {}): Plugin {
 
       // ── M2 SharedWorker host: bundle it (cached per version) and serve it at
       // /__pyric/sdk/worker.js. This is what flips runtime.ts to the worker path.
-      // On bundle failure, fall back to the in-page sandbox (workerReady stays
-      // false → transformIndexHtml forces in-page).
-      const sdkDir = path.join(homedir(), '.pyric', 'vite-worker', workerCacheKey);
+      // On bundle failure, the collaborator stays unready and its HTML tag
+      // forces the in-page sandbox.
       try {
-        await bundleWorker({ outDir: sdkDir });
-        workerVersion = workerBundleEpoch(sdkDir);
-        workerReady = true;
+        await workerRuntime.prepare();
       } catch (e) {
         server.config.logger.warn(
           `  ⚠ [pyric] SharedWorker bundle failed — using the in-page sandbox (single-tab, ephemeral): ${e instanceof Error ? e.message : String(e)}`,
@@ -629,6 +621,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
           );
         }
       }
+      const { sdkDir } = workerRuntime.status();
       const namespace = createPyricNamespace({
         sdkDir,
         initPayload,
@@ -1048,13 +1041,11 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // module evaluates — a classic inline script runs before the deferred module.
       // The flag (not nulling `window.SharedWorker`) leaves the user's own
       // SharedWorker usage intact. We force in-page ONLY when the worker bundle
-      // failed (workerReady false) — the ephemeral fallback. `bridge` no longer
+      // failed (worker runtime unready) — the ephemeral fallback. `bridge` no longer
       // forces in-page: the bridge peer routes agent tool-calls THROUGH the
       // worker (see `connectBridgePeer`), so the agent shares the one sandbox the
       // app + Studio use.
-      const head = workerReady && workerVersion
-        ? `<meta name="pyric-worker-v" content="${workerVersion}" ${MARKER}>`
-        : `<script ${MARKER}>globalThis.__PYRIC_FORCE_INPAGE__=true;</script>`;
+      const head = workerRuntime.headTag(MARKER);
       // Plugin-level engine for the IN-PAGE path: a classic inline script runs
       // before the deferred init module AND before app code's `getAI`, so the
       // served `getAI` (entries/ai.ts) reads it synchronously — init.json can't

--- a/packages/cli/src/serve/vite-worker-runtime.ts
+++ b/packages/cli/src/serve/vite-worker-runtime.ts
@@ -1,0 +1,51 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  bundleWorker,
+  workerSourceHash,
+  type WorkerBundleOptions,
+  type WorkerBundleResult,
+} from './bundler.js';
+
+export interface ViteWorkerRuntimeStatus {
+  sdkDir: string;
+  ready: boolean;
+  epoch: string | null;
+}
+
+export interface ViteWorkerRuntime {
+  prepare(): Promise<void>;
+  status(): ViteWorkerRuntimeStatus;
+  headTag(marker: string): string;
+}
+
+interface ViteWorkerRuntimeOptions {
+  cacheRoot?: string;
+  cacheKey?: string;
+  bundle?: (options: WorkerBundleOptions) => Promise<WorkerBundleResult>;
+}
+
+/** Own the Vite plugin's worker build state and its one HTML projection. */
+export function createViteWorkerRuntime(
+  options: ViteWorkerRuntimeOptions = {},
+): ViteWorkerRuntime {
+  const cacheRoot = options.cacheRoot ?? join(homedir(), '.pyric', 'vite-worker');
+  const cacheKey = options.cacheKey ?? workerSourceHash();
+  const sdkDir = join(cacheRoot, cacheKey);
+  const bundle = options.bundle ?? bundleWorker;
+  let current: ViteWorkerRuntimeStatus = { sdkDir, ready: false, epoch: null };
+
+  return {
+    async prepare() {
+      current = { sdkDir, ready: false, epoch: null };
+      const result = await bundle({ outDir: sdkDir });
+      current = { sdkDir, ready: true, epoch: result.epoch };
+    },
+    status: () => current,
+    headTag(marker) {
+      return current.ready && current.epoch
+        ? `<meta name="pyric-worker-v" content="${current.epoch}" ${marker}>`
+        : `<script ${marker}>globalThis.__PYRIC_FORCE_INPAGE__=true;</script>`;
+    },
+  };
+}

--- a/packages/cli/src/serve/worker/client/connection.ts
+++ b/packages/cli/src/serve/worker/client/connection.ts
@@ -75,7 +75,7 @@ export async function getWorkerVersion(
   const timeoutMs = options.timeoutMs ?? 2_000;
   const r = (await rpcWithTimeout(
     db.port,
-    { t: 'op', id, method: 'getVersion' },
+    { t: 'op', id, method: 'getRuntimeEpoch' },
     timeoutMs,
     `Timed out waiting for the Pyric SharedWorker version handshake after ${timeoutMs}ms.`,
   )) as { version: string };

--- a/packages/cli/src/serve/worker/client/connection.ts
+++ b/packages/cli/src/serve/worker/client/connection.ts
@@ -11,6 +11,7 @@ import {
   nextSubId,
   wirePort,
   rpc,
+  rpcWithTimeout,
   rawRpc,
   openSnapshotSubscription,
   closeSubscription,
@@ -29,7 +30,15 @@ import type { ClientDb } from './handles.js';
  * `getFirestore` mirrors `pyric/firestore`'s `getFirestore(sandbox)` shape
  * but returns a `ClientDb` backed by a `MessagePort` instead of a sandbox.
  */
-export function getFirestore(workerUrl: string | URL, name?: string): ClientDb {
+export interface SharedWorkerConnectionOptions {
+  onError?: (error: Error) => void;
+}
+
+export function getFirestore(
+  workerUrl: string | URL,
+  name?: string,
+  options: SharedWorkerConnectionOptions = {},
+): ClientDb {
   if (typeof SharedWorker === 'undefined') {
     throw new Error(
       'SharedWorker is not available. ' +
@@ -41,6 +50,12 @@ export function getFirestore(workerUrl: string | URL, name?: string): ClientDb {
     type: 'classic',
     name: name ?? 'pyric-shared-worker',
   });
+  if (options.onError) {
+    worker.addEventListener('error', (event) => {
+      const detail = event.message || `failed to load ${String(workerUrl)}`;
+      options.onError?.(new Error(`Pyric SharedWorker error: ${detail}`));
+    });
+  }
   const port = worker.port;
   port.start();
   wirePort(port);
@@ -52,8 +67,18 @@ export function getFirestore(workerUrl: string | URL, name?: string): ClientDb {
  * compares it to the served bundle version and warns when a still-running OLD
  * worker is older than what's served (a SharedWorker can't hot-update).
  */
-export async function getWorkerVersion(db: ClientDb): Promise<string> {
-  const r = (await rpc(db.port, { t: 'op', id: nextId(), method: 'getVersion' })) as { version: string };
+export async function getWorkerVersion(
+  db: ClientDb,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const id = nextId();
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const r = (await rpcWithTimeout(
+    db.port,
+    { t: 'op', id, method: 'getVersion' },
+    timeoutMs,
+    `Timed out waiting for the Pyric SharedWorker version handshake after ${timeoutMs}ms.`,
+  )) as { version: string };
   return r.version;
 }
 

--- a/packages/cli/src/serve/worker/client/core.ts
+++ b/packages/cli/src/serve/worker/client/core.ts
@@ -331,6 +331,29 @@ export function rpc(port: ClientPort, msg: InboundMessage): Promise<unknown> {
 }
 
 /**
+ * Send a client RPC with a bounded wait, while keeping correlation cleanup
+ * inside the transport module that owns the pending-request registry.
+ */
+export function rpcWithTimeout(
+  port: ClientPort,
+  msg: InboundMessage,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<unknown> {
+  const id = (msg as { id: string }).id;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      if (!_pending.delete(id)) return;
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+  });
+  return Promise.race([rpc(port, msg), timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
  * Like {@link rpc} but stamps the active default auth lens onto the op message
  * (Pyric Studio). Used by data-service ops so a `setLens(...)` choice
  * carries per op without every call site threading `actAs`. Auth ops + version

--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -66,6 +66,8 @@ import {
 } from './service-worker-channel.js';
 import { createServiceWorkerRelay } from './service-worker-relay.js';
 
+declare const __PYRIC_WORKER_VERSION__: string;
+
 // ─── Singleton context ────────────────────────────────────────────────────
 
 // `_ctx` is the RESOLVED context, kept for the synchronous `close` handler.
@@ -131,6 +133,19 @@ async function buildCtx(): Promise<HostCtx> {
 
   let messageQueue = Promise.resolve();
   port.onmessage = (ev: MessageEvent<InboundMessage>) => {
+    if (ev.data.t === 'op' && ev.data.method === 'getRuntimeEpoch') {
+      port.postMessage({
+        t: 'res',
+        id: ev.data.id,
+        ok: true,
+        value: {
+          version: typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
+            ? __PYRIC_WORKER_VERSION__
+            : 'dev',
+        },
+      });
+      return;
+    }
     // Serialize each port's frames. A disconnect acknowledgement therefore
     // cannot overtake an already-posted mutation, and later frames see the
     // disconnected-port tombstone instead of touching the shared backend.

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -482,6 +482,7 @@ export type OpMessage = (
   | { t: 'op'; id: string; method: 'ai.countTokens'; model: string; request: Record<string, unknown>; engine?: AiEngineConfigWire }
   // Staleness guard: report the worker's baked build version so the page can
   // warn when a still-running OLD worker serves code older than what's served.
+  | { t: 'op'; id: string; method: 'getRuntimeEpoch' }
   | { t: 'op'; id: string; method: 'getVersion' }
   // ── Phase 2 (transfer): export/import the FULL sandbox state as a bundle
   // string (the chunk format the persist layer uses). importState CLOBBERS. ──

--- a/packages/cli/test/serve/bundler.test.ts
+++ b/packages/cli/test/serve/bundler.test.ts
@@ -13,6 +13,7 @@ import {
   resolveDocsUiDir,
   sourceTreeHash,
   workerEntryPath,
+  workerBundleEpoch,
   workerSourceHash,
 } from '../../src/serve/bundler.js';
 
@@ -476,5 +477,24 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
     // Marker cache: a second call without noCache returns the same file fast.
     const again = await bundleWorker({ outDir: dir });
     expect(again).toBe(file);
+  }, 30_000);
+
+  it('derives the worker epoch from executable output, not unrelated files', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'pyric-worker-epoch-'));
+    const entry = join(root, 'worker.ts');
+    const unrelated = join(root, 'runtime-chip.ts');
+    writeFileSync(entry, 'globalThis.workerEpoch = __PYRIC_WORKER_VERSION__;');
+    writeFileSync(unrelated, 'export const chip = 1;');
+
+    const firstDir = join(root, 'first');
+    await bundleWorker({ outDir: firstDir, noCache: true, entryPath: entry });
+    const first = workerBundleEpoch(firstDir);
+
+    writeFileSync(unrelated, 'export const chip = 2;');
+    const secondDir = join(root, 'second');
+    await bundleWorker({ outDir: secondDir, noCache: true, entryPath: entry });
+
+    expect(workerBundleEpoch(secondDir)).toBe(first);
+    expect(readFileSync(join(firstDir, 'worker.js'), 'utf8')).toContain(first);
   }, 30_000);
 });

--- a/packages/cli/test/serve/bundler.test.ts
+++ b/packages/cli/test/serve/bundler.test.ts
@@ -13,7 +13,6 @@ import {
   resolveDocsUiDir,
   sourceTreeHash,
   workerEntryPath,
-  workerBundleEpoch,
   workerSourceHash,
 } from '../../src/serve/bundler.js';
 
@@ -452,7 +451,7 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
 
   it('bundles the real worker entry as a classic-worker iife; marker caches', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'pyric-worker-bundle-'));
-    const file = await bundleWorker({ outDir: dir, noCache: true, minify: false });
+    const { outFile: file } = await bundleWorker({ outDir: dir, noCache: true, minify: false });
     expect(file.endsWith('/worker.js')).toBe(true);
     const src = readFileSync(file, 'utf8');
 
@@ -476,7 +475,7 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
 
     // Marker cache: a second call without noCache returns the same file fast.
     const again = await bundleWorker({ outDir: dir });
-    expect(again).toBe(file);
+    expect(again.outFile).toBe(file);
   }, 30_000);
 
   it('derives the worker epoch from executable output, not unrelated files', async () => {
@@ -487,14 +486,13 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
     writeFileSync(unrelated, 'export const chip = 1;');
 
     const firstDir = join(root, 'first');
-    await bundleWorker({ outDir: firstDir, noCache: true, entryPath: entry });
-    const first = workerBundleEpoch(firstDir);
+    const first = await bundleWorker({ outDir: firstDir, noCache: true, entryPath: entry });
 
     writeFileSync(unrelated, 'export const chip = 2;');
     const secondDir = join(root, 'second');
-    await bundleWorker({ outDir: secondDir, noCache: true, entryPath: entry });
+    const second = await bundleWorker({ outDir: secondDir, noCache: true, entryPath: entry });
 
-    expect(workerBundleEpoch(secondDir)).toBe(first);
-    expect(readFileSync(join(firstDir, 'worker.js'), 'utf8')).toContain(first);
+    expect(second.epoch).toBe(first.epoch);
+    expect(readFileSync(join(firstDir, 'worker.js'), 'utf8')).toContain(first.epoch);
   }, 30_000);
 });

--- a/packages/cli/test/serve/runtime/manifest.test.ts
+++ b/packages/cli/test/serve/runtime/manifest.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  PYRIC_STUDIO_URL,
+  PYRIC_WORKER_NAME,
+  PYRIC_WORKER_URL,
+  readPyricRuntimeManifest,
+} from '../../../src/serve/runtime/manifest.js';
+
+describe('Pyric runtime manifest', () => {
+  it('describes the served worker epoch and stable runtime routes', () => {
+    const documentLike = {
+      querySelector(selector: string) {
+        expect(selector).toBe('meta[name="pyric-worker-v"]');
+        return { getAttribute: (name: string) => name === 'content' ? 'epoch-123' : null };
+      },
+    };
+
+    expect(readPyricRuntimeManifest(documentLike)).toEqual({
+      studioUrl: PYRIC_STUDIO_URL,
+      worker: {
+        url: PYRIC_WORKER_URL,
+        name: PYRIC_WORKER_NAME,
+        servedEpoch: 'epoch-123',
+      },
+    });
+  });
+
+  it('reports no served epoch on the in-page fallback', () => {
+    expect(readPyricRuntimeManifest({ querySelector: () => null }).worker.servedEpoch).toBeNull();
+  });
+});

--- a/packages/cli/test/serve/runtime/status.test.ts
+++ b/packages/cli/test/serve/runtime/status.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  createPyricRuntimeStatus,
+  normalizePyricRuntimeError,
+} from '../../../src/serve/runtime/status.js';
+import type { PyricRuntimeManifest } from '../../../src/serve/runtime/manifest.js';
+
+const manifest: PyricRuntimeManifest = {
+  studioUrl: '/__pyric/ui/',
+  worker: {
+    url: '/__pyric/sdk/worker.js',
+    name: 'pyric-shared-worker',
+    servedEpoch: 'served-2',
+  },
+};
+
+describe('Pyric runtime status', () => {
+  it('marks a different running worker epoch as an available update', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'running-1' });
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      mode: 'shared-worker',
+      servedEpoch: 'served-2',
+      runningEpoch: 'running-1',
+      updateAvailable: true,
+    });
+
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'served-2' });
+    expect(runtime.getSnapshot().updateAvailable).toBe(false);
+  });
+
+  it('publishes the current snapshot immediately and after changes', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    const seen: boolean[] = [];
+    const unsubscribe = runtime.subscribe((snapshot) => seen.push(snapshot.updateAvailable));
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'running-1' });
+    unsubscribe();
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'served-2' });
+
+    expect(seen).toEqual([false, true]);
+  });
+
+  it('normalizes and deduplicates sandbox runtime-error events', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    const event = {
+      kind: 'runtime_error' as const,
+      id: 'sandbox-error-1',
+      at: 123,
+      service: 'firestore' as const,
+      method: 'setDoc',
+      path: 'posts/a',
+      auth: { uid: null, token: null },
+      error: { code: 'permission-denied', message: 'write denied' },
+    };
+
+    runtime.recordSandboxEvents([event, event]);
+
+    expect(runtime.getSnapshot().errors).toEqual([{
+      id: 'sandbox-error-1',
+      source: 'sandbox',
+      at: 123,
+      service: 'firestore',
+      method: 'setDoc',
+      path: 'posts/a',
+      code: 'permission-denied',
+      message: 'write denied',
+    }]);
+  });
+
+  it('normalizes errored listeners into the same error shape', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    runtime.recordSandboxEvents([{
+      kind: 'listener',
+      id: 'listener-error-1',
+      at: 456,
+      service: 'database',
+      phase: 'errored',
+      listenerId: 'listener-1',
+      target: { kind: 'value', path: 'messages' },
+      auth: { uid: null, token: null },
+      error: { code: 'database/error', message: 'listener failed' },
+    }]);
+
+    expect(runtime.getSnapshot().errors[0]).toMatchObject({
+      id: 'listener-error-1',
+      source: 'sandbox',
+      service: 'database',
+      path: 'messages',
+      code: 'database/error',
+      message: 'listener failed',
+    });
+  });
+
+  it('bounds retained errors and clears them without changing worker status', () => {
+    const runtime = createPyricRuntimeStatus(manifest, { maxErrors: 2 });
+    runtime.reportError('first', 'runtime');
+    runtime.reportError('second', 'runtime');
+    runtime.reportError('third', 'runtime');
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'running-1' });
+
+    expect(runtime.getSnapshot().errors.map((error) => error.message)).toEqual(['second', 'third']);
+    runtime.clearErrors();
+    expect(runtime.getSnapshot()).toMatchObject({ errors: [], updateAvailable: true });
+  });
+});
+
+describe('normalizePyricRuntimeError', () => {
+  it('preserves useful Error fields without retaining the original object', () => {
+    const error = Object.assign(new Error('worker failed'), { code: 'worker/crashed' });
+    const normalized = normalizePyricRuntimeError(error, 'worker', 99, 'error-1');
+    expect(normalized).toMatchObject({
+      id: 'error-1',
+      source: 'worker',
+      at: 99,
+      code: 'worker/crashed',
+      message: 'worker failed',
+    });
+    expect(normalized.stack).toContain('worker failed');
+  });
+});

--- a/packages/cli/test/serve/runtime/status.test.ts
+++ b/packages/cli/test/serve/runtime/status.test.ts
@@ -92,6 +92,29 @@ describe('Pyric runtime status', () => {
     });
   });
 
+  it('normalizes Firestore listener_errored events', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    runtime.recordSandboxEvents([{
+      kind: 'listener_errored',
+      id: 'firestore-listener-error-1',
+      at: 789,
+      listenerId: 'listener-2',
+      target: { kind: 'doc', path: 'posts/a' },
+      auth: null,
+      error: { code: 'permission-denied', message: 'read denied' },
+    }]);
+
+    expect(runtime.getSnapshot().errors[0]).toMatchObject({
+      id: 'firestore-listener-error-1',
+      source: 'sandbox',
+      service: 'firestore',
+      method: 'listener',
+      path: 'posts/a',
+      code: 'permission-denied',
+      message: 'read denied',
+    });
+  });
+
   it('bounds retained errors and clears them without changing worker status', () => {
     const runtime = createPyricRuntimeStatus(manifest, { maxErrors: 2 });
     runtime.reportError('first', 'runtime');

--- a/packages/cli/test/serve/runtime/worker-connection.test.ts
+++ b/packages/cli/test/serve/runtime/worker-connection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { connectRuntimeWorker } from '../../../src/serve/runtime/worker-connection.js';
+
+describe('runtime worker connection', () => {
+  it('reports a synchronous SharedWorker construction failure and permits fallback', () => {
+    const errors: unknown[] = [];
+
+    const db = connectRuntimeWorker(
+      () => { throw new DOMException('blocked by policy', 'SecurityError'); },
+      (error) => errors.push(error),
+    );
+
+    expect(db).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(DOMException);
+  });
+});

--- a/packages/cli/test/serve/vite-worker-runtime.test.ts
+++ b/packages/cli/test/serve/vite-worker-runtime.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import { createViteWorkerRuntime } from '../../src/serve/vite-worker-runtime.js';
+
+describe('Vite worker runtime', () => {
+  it('forces the in-page runtime until a worker bundle is ready', () => {
+    const runtime = createViteWorkerRuntime({ cacheRoot: '/cache', cacheKey: 'key' });
+
+    expect(runtime.status()).toEqual({ sdkDir: '/cache/key', ready: false, epoch: null });
+    expect(runtime.headTag('data-pyric-sandbox')).toContain('__PYRIC_FORCE_INPAGE__');
+  });
+
+  it('atomically projects the epoch returned by a successful bundle', async () => {
+    const calls: string[] = [];
+    const runtime = createViteWorkerRuntime({
+      cacheRoot: '/cache',
+      cacheKey: 'key',
+      bundle: async ({ outDir }) => {
+        calls.push(outDir);
+        return { outFile: `${outDir}/worker.js`, epoch: '0123456789abcdef' };
+      },
+    });
+
+    await runtime.prepare();
+
+    expect(calls).toEqual(['/cache/key']);
+    expect(runtime.status()).toEqual({
+      sdkDir: '/cache/key', ready: true, epoch: '0123456789abcdef',
+    });
+    expect(runtime.headTag('data-pyric-sandbox')).toBe(
+      '<meta name="pyric-worker-v" content="0123456789abcdef" data-pyric-sandbox>',
+    );
+  });
+
+  it('remains on the in-page fallback when bundling fails', async () => {
+    const runtime = createViteWorkerRuntime({
+      cacheRoot: '/cache',
+      cacheKey: 'key',
+      bundle: async () => { throw new Error('bundle failed'); },
+    });
+
+    await expect(runtime.prepare()).rejects.toThrow('bundle failed');
+    expect(runtime.status()).toEqual({ sdkDir: '/cache/key', ready: false, epoch: null });
+    expect(runtime.headTag('data-pyric-sandbox')).toContain('__PYRIC_FORCE_INPAGE__');
+  });
+});

--- a/packages/cli/test/serve/worker/bundle-realm.test.ts
+++ b/packages/cli/test/serve/worker/bundle-realm.test.ts
@@ -48,7 +48,7 @@
  *
  * WHAT PROVES THE BUNDLE (not the source) IS UNDER TEST
  * ----------------------------------------------------
- * `getVersion` reports the build hash esbuild baked in via `define`. Imported
+ * `getRuntimeEpoch` reports the build hash esbuild baked in via `define`. Imported
  * from source that value is the literal `'dev'` (see host.test.ts). Asserting
  * it is a real hash — NOT `'dev'` — is what pins this test to the artifact.
  */
@@ -77,7 +77,7 @@ interface Realm {
  */
 async function bootBundledWorker(): Promise<Realm> {
   const dir = mkdtempSync(join(tmpdir(), 'pyric-bundle-realm-'));
-  const file = await bundleWorker({ outDir: dir, noCache: true, minify: false });
+  const { outFile: file } = await bundleWorker({ outDir: dir, noCache: true, minify: false });
   const src = readFileSync(file, 'utf8');
 
   // The SharedWorkerGlobalScope the bundle installs its `onconnect` on.
@@ -170,8 +170,8 @@ describe('bundle realm — the shipped SharedWorker artifact executes', () => {
 
   afterAll(() => realm?.close());
 
-  it('boots, wires onconnect, and answers an op with the BAKED build hash', async () => {
-    const res = await sendOp(realm, { id: 'realm-version', method: 'getVersion' });
+  it('answers the BAKED epoch before the sandbox context has to initialize', async () => {
+    const res = await sendOp(realm, { id: 'realm-version', method: 'getRuntimeEpoch' });
     const value = okValue<{ version: string }>(res);
 
     // A real esbuild-injected hash — NOT the 'dev' the source-imported host

--- a/packages/cli/test/serve/worker/client/connection.test.ts
+++ b/packages/cli/test/serve/worker/client/connection.test.ts
@@ -2,17 +2,15 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import {
   getFirestore,
   getWorkerVersion,
-} from '../../../src/serve/worker/client/connection.js';
-import { _pending } from '../../../src/serve/worker/client/core.js';
-import type { ClientDb, ClientPort } from '../../../src/serve/worker/client/handles.js';
+} from '../../../../src/serve/worker/client/connection.js';
+import type { ClientDb, ClientPort } from '../../../../src/serve/worker/client/handles.js';
 
 const priorSharedWorker = globalThis.SharedWorker;
 afterEach(() => {
   (globalThis as { SharedWorker?: typeof SharedWorker }).SharedWorker = priorSharedWorker;
-  _pending.clear();
 });
 
-describe('SharedWorker connection status', () => {
+describe('SharedWorker connection', () => {
   it('rejects a version handshake that never receives a worker reply', async () => {
     const port: ClientPort = {
       onmessage: null,
@@ -25,7 +23,6 @@ describe('SharedWorker connection status', () => {
     await expect(getWorkerVersion(db, { timeoutMs: 5 })).rejects.toThrow(
       'Timed out waiting for the Pyric SharedWorker version handshake',
     );
-    expect(_pending.size).toBe(0);
   });
 
   it('surfaces the SharedWorker script error event', () => {

--- a/packages/cli/test/serve/worker/client/core.test.ts
+++ b/packages/cli/test/serve/worker/client/core.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import { rpcWithTimeout, wirePort } from '../../../../src/serve/worker/client/core.js';
+import type { ClientPort } from '../../../../src/serve/worker/client/handles.js';
+
+describe('worker client RPC timeout', () => {
+  it('rejects a bounded RPC and ignores its late response', async () => {
+    const port: ClientPort = {
+      onmessage: null,
+      postMessage() {},
+      start() {},
+      close() {},
+    };
+    wirePort(port);
+
+    const request = rpcWithTimeout(
+      port,
+      { t: 'op', id: 'slow-operation', method: 'getRuntimeEpoch' },
+      5,
+      'worker did not answer',
+    );
+    await expect(request).rejects.toThrow('worker did not answer');
+
+    expect(() => port.onmessage?.({
+      data: { t: 'res', id: 'slow-operation', ok: true, value: { version: 'late' } },
+    } as MessageEvent)).not.toThrow();
+  });
+});

--- a/packages/cli/test/serve/worker/connection-status.test.ts
+++ b/packages/cli/test/serve/worker/connection-status.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  getFirestore,
+  getWorkerVersion,
+} from '../../../src/serve/worker/client/connection.js';
+import { _pending } from '../../../src/serve/worker/client/core.js';
+import type { ClientDb, ClientPort } from '../../../src/serve/worker/client/handles.js';
+
+const priorSharedWorker = globalThis.SharedWorker;
+afterEach(() => {
+  (globalThis as { SharedWorker?: typeof SharedWorker }).SharedWorker = priorSharedWorker;
+  _pending.clear();
+});
+
+describe('SharedWorker connection status', () => {
+  it('rejects a version handshake that never receives a worker reply', async () => {
+    const port: ClientPort = {
+      onmessage: null,
+      postMessage() {},
+      start() {},
+      close() {},
+    };
+    const db: ClientDb = { __kind: 'client-db', port };
+
+    await expect(getWorkerVersion(db, { timeoutMs: 5 })).rejects.toThrow(
+      'Timed out waiting for the Pyric SharedWorker version handshake',
+    );
+    expect(_pending.size).toBe(0);
+  });
+
+  it('surfaces the SharedWorker script error event', () => {
+    let emitError: ((event: { message?: string }) => void) | undefined;
+    const port: ClientPort = {
+      onmessage: null,
+      postMessage() {},
+      start() {},
+      close() {},
+    };
+    (globalThis as { SharedWorker?: unknown }).SharedWorker = class {
+      port = port;
+      addEventListener(type: string, listener: (event: { message?: string }) => void) {
+        if (type === 'error') emitError = listener;
+      }
+    };
+    const errors: Error[] = [];
+
+    getFirestore('/worker.js', 'test-worker', {
+      onError: (error) => errors.push(error),
+    });
+    emitError?.({ message: 'worker script failed' });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain('worker script failed');
+  });
+});

--- a/packages/conformance/src/capture/messaging-web/e2e-sandbox.ts
+++ b/packages/conformance/src/capture/messaging-web/e2e-sandbox.ts
@@ -94,7 +94,7 @@ if (!built.success) {
 const pageJs = await built.outputs[0]!.text();
 
 const workerOutDir = mkdtempSync(join(tmpdir(), 'pyric-msg-e2e-worker-'));
-const workerFile = await bundleWorker({ outDir: workerOutDir, noCache: true });
+const { outFile: workerFile } = await bundleWorker({ outDir: workerOutDir, noCache: true });
 const workerJs = readFileSync(workerFile, 'utf8');
 const workerMap = existsSync(`${workerFile}.map`) ? readFileSync(`${workerFile}.map`, 'utf8') : null;
 console.log(`worker bundle: ${workerFile} (${(workerJs.length / 1024 / 1024).toFixed(1)} MB)`);


### PR DESCRIPTION
Adds an observable Pyric runtime status that distinguishes the served worker bundle from the worker actually running in the browser and collects sandbox-owned failures.

```ts
const runtime = globalThis.__pyricRuntime;

const unsubscribe = runtime?.subscribe((status) => {
  console.log(status.mode);            // 'starting' | 'shared-worker' | 'in-page'
  console.log(status.updateAvailable); // true only when executable worker epochs differ
  console.log(status.errors);          // normalized sandbox/runtime/worker failures
});

// Later, when this observer is no longer needed:
unsubscribe?.();
```

## Worker updates now follow executable identity

The served page carries an epoch derived from the emitted `worker.js`, and the running SharedWorker reports the same baked epoch. Unrelated CLI or future chip-only changes may invalidate the conservative build cache, but they no longer tell the user to replace an unchanged worker.

The version handshake is bounded, SharedWorker script errors are observable, and correlation cleanup remains owned by the worker-client transport.

## Sandbox failures share one copyable shape

Canonical runtime errors, current listener errors, and legacy Firestore `listener_errored` events enter a bounded, deduplicated status stream. Explicit bridge, initialization, and rules-reload catches are also reported. Ordinary application exceptions are not classified as Pyric failures merely because their stack includes an SDK caller frame.

## Risk

This changes the worker version stamped by the CLI, compiled standalone assets, and Vite plugin from a broad source-tree hash to an executable-bundle epoch. Review should focus on cache/epoch separation and on whether the explicit error capture points cover Pyric-owned failures without capturing application errors.

<details>
<summary>Implementation notes</summary>

- Runtime manifest/status tests: 42 passed across the focused runtime, connection, and worker-init set.
- Bundler tests: 21 passed, including executable epoch stability.
- Shipped SharedWorker bundle-realm test: 3 passed outside the restricted sandbox. The same test's esbuild child stalls only under the restricted process sandbox.
- Vite integration: 76 passed, 5 explicitly gated bridge E2E tests skipped.
- Package/client surface: 6 passed.
- CLI TypeScript check and `bun run build:cli`: passed.
- `git diff --check feat/vite-convention-config...HEAD`: passed.
- Two independent cold rereviews found no remaining high- or medium-severity behavior or standards findings.
- This PR is stacked on #410 and should merge after it.

</details>
