### PR TITLE
feat(runtime): replace stale workers gracefully

### DIFF
--- a/packages/cli/src/serve/entries/worker-runtime.ts
+++ b/packages/cli/src/serve/entries/worker-runtime.ts
@@ -15,6 +15,16 @@ import {
 } from '../runtime/manifest.js';
 import { getPyricRuntimeStatus } from '../runtime/status.js';
 import { connectRuntimeWorker } from '../runtime/worker-connection.js';
+import { createWorkerReplacement } from '../runtime/worker-replacement.js';
+import {
+  preflightWorkerEpochStorage,
+  rememberWorkerEpoch,
+  workerNameForEpoch,
+} from '../runtime/worker-generation.js';
+import {
+  onWorkerRuntimeReload,
+  retireWorkerRuntime,
+} from '../worker/client/runtime-control.js';
 
 const hasSharedWorker = typeof SharedWorker !== 'undefined';
 const runtimeStatus = getPyricRuntimeStatus();
@@ -24,7 +34,16 @@ const workerRequested =
   && !(globalThis as { __PYRIC_FORCE_INPAGE__?: boolean }).__PYRIC_FORCE_INPAGE__;
 
 export const WORKER_URL = PYRIC_WORKER_URL;
-export const WORKER_NAME = PYRIC_WORKER_NAME;
+let epochStorage: Storage | undefined;
+try {
+  epochStorage = typeof localStorage === 'undefined' ? undefined : localStorage;
+} catch {
+  epochStorage = undefined;
+}
+export const WORKER_NAME = workerNameForEpoch(
+  runtimeStatus.getSnapshot().servedEpoch,
+  epochStorage,
+);
 
 /** Control traffic only; Firebase apps receive independent app-owned ports. */
 export const workerDb: ClientDb | null = workerRequested
@@ -54,6 +73,24 @@ runtimeStatus.setWorker({
   mode: useWorker ? 'shared-worker' : 'in-page',
   runningEpoch: null,
 });
+
+const workerReplacement = useWorker && workerDb && typeof window !== 'undefined'
+  ? createWorkerReplacement({
+      targetEpoch: runtimeStatus.getSnapshot().servedEpoch!,
+      retire: () => retireWorkerRuntime(
+        workerDb,
+        runtimeStatus.getSnapshot().servedEpoch!,
+      ),
+      subscribeReload: onWorkerRuntimeReload,
+      preflight: () => preflightWorkerEpochStorage(epochStorage),
+      commitGeneration: (epoch) => rememberWorkerEpoch(epoch, epochStorage),
+      onPreparationError: (error) => runtimeStatus.reportError(error, 'worker'),
+      reload: () => window.location.reload(),
+    })
+  : null;
+runtimeStatus.setWorkerUpdater(
+  workerReplacement ? () => workerReplacement.request() : null,
+);
 
 if (useWorker && workerDb) {
   subscribeEvents(workerDb, (events) => runtimeStatus.recordSandboxEvents(events));

--- a/packages/cli/src/serve/runtime/status.ts
+++ b/packages/cli/src/serve/runtime/status.ts
@@ -23,6 +23,7 @@ export interface PyricRuntimeSnapshot {
   servedEpoch: string | null;
   runningEpoch: string | null;
   updateAvailable: boolean;
+  updatingWorker: boolean;
   errors: readonly PyricRuntimeError[];
 }
 
@@ -30,6 +31,8 @@ export interface PyricRuntimeStatus {
   getSnapshot(): PyricRuntimeSnapshot;
   subscribe(listener: (snapshot: PyricRuntimeSnapshot) => void): () => void;
   setWorker(input: { mode: Exclude<PyricRuntimeMode, 'starting'>; runningEpoch?: string | null }): void;
+  setWorkerUpdater(update: (() => Promise<void>) | null): void;
+  updateWorker(): Promise<void>;
   reportError(error: unknown, source: PyricRuntimeErrorSource): void;
   recordSandboxEvents(events: readonly SandboxEvent[]): void;
   clearErrors(): void;
@@ -128,8 +131,10 @@ export function createPyricRuntimeStatus(
     servedEpoch: manifest.worker.servedEpoch,
     runningEpoch: null,
     updateAvailable: false,
+    updatingWorker: false,
     errors: [],
   };
+  let workerUpdater: (() => Promise<void>) | null = null;
 
   const publish = (next: PyricRuntimeSnapshot): void => {
     snapshot = next;
@@ -164,7 +169,24 @@ export function createPyricRuntimeStatus(
           && runningEpoch !== 'dev'
           && servedEpoch !== runningEpoch,
         ),
+        updatingWorker: false,
       });
+    },
+    setWorkerUpdater(update) {
+      workerUpdater = update;
+    },
+    async updateWorker() {
+      if (!snapshot.updateAvailable || snapshot.updatingWorker || !workerUpdater) {
+        throw new Error('No Pyric worker update is available.');
+      }
+      publish({ ...snapshot, updatingWorker: true });
+      try {
+        await workerUpdater();
+      } catch (error) {
+        publish({ ...snapshot, updatingWorker: false });
+        appendError(normalizePyricRuntimeError(error, 'worker'));
+        throw error;
+      }
     },
     reportError(error, source) {
       appendError(normalizePyricRuntimeError(error, source));

--- a/packages/cli/src/serve/runtime/worker-generation.ts
+++ b/packages/cli/src/serve/runtime/worker-generation.ts
@@ -1,0 +1,75 @@
+import { PYRIC_WORKER_NAME } from './manifest.js';
+
+export const PYRIC_WORKER_GENERATION_KEY = 'pyric:worker-generation';
+const PYRIC_WORKER_GENERATION_PROBE_KEY = 'pyric:worker-generation-probe';
+
+interface EpochStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+/** Select the replacement generation only after this page was told to move. */
+export function workerNameForEpoch(
+  _servedEpoch: string | null,
+  storage: EpochStorage | undefined,
+): string {
+  if (!storage) return PYRIC_WORKER_NAME;
+  try {
+    const generation = storage.getItem(PYRIC_WORKER_GENERATION_KEY);
+    return generation && /^[a-f0-9]{16}$/.test(generation)
+      ? `${PYRIC_WORKER_NAME}:${generation}`
+      : PYRIC_WORKER_NAME;
+  } catch {
+    return PYRIC_WORKER_NAME;
+  }
+}
+
+/** Persist the generation boundary before a page reloads. */
+export function rememberWorkerEpoch(
+  epoch: string,
+  storage: EpochStorage | undefined,
+): void {
+  if (!/^[a-f0-9]{16}$/.test(epoch)) {
+    throw new Error('Pyric cannot replace the worker: invalid served worker epoch.');
+  }
+  if (!storage) {
+    throw new Error(
+      'Pyric cannot replace the worker because origin storage is unavailable. Close all tabs for this origin and reopen the app.',
+    );
+  }
+  try {
+    storage.setItem(PYRIC_WORKER_GENERATION_KEY, epoch);
+    if (storage.getItem(PYRIC_WORKER_GENERATION_KEY) !== epoch) {
+      throw new Error('the worker generation could not be read back');
+    }
+  } catch (cause) {
+    throw new Error(
+      'Pyric cannot replace the worker because origin storage is unavailable. Close all tabs for this origin and reopen the app.',
+      { cause },
+    );
+  }
+}
+
+/** Prove origin storage works without publishing a successor generation. */
+export function preflightWorkerEpochStorage(storage: EpochStorage | undefined): void {
+  if (!storage?.removeItem) {
+    throw new Error(
+      'Pyric cannot replace the worker because origin storage is unavailable. Close all tabs for this origin and reopen the app.',
+    );
+  }
+  try {
+    const previousProbe = storage.getItem(PYRIC_WORKER_GENERATION_PROBE_KEY);
+    storage.setItem(PYRIC_WORKER_GENERATION_PROBE_KEY, 'ok');
+    if (storage.getItem(PYRIC_WORKER_GENERATION_PROBE_KEY) !== 'ok') {
+      throw new Error('the worker generation probe could not be read back');
+    }
+    if (previousProbe === null) storage.removeItem(PYRIC_WORKER_GENERATION_PROBE_KEY);
+    else storage.setItem(PYRIC_WORKER_GENERATION_PROBE_KEY, previousProbe);
+  } catch (cause) {
+    throw new Error(
+      'Pyric cannot replace the worker because origin storage is unavailable. Close all tabs for this origin and reopen the app.',
+      { cause },
+    );
+  }
+}

--- a/packages/cli/src/serve/runtime/worker-replacement.ts
+++ b/packages/cli/src/serve/runtime/worker-replacement.ts
@@ -1,0 +1,42 @@
+interface WorkerReplacementOptions {
+  targetEpoch: string;
+  retire(): Promise<void>;
+  subscribeReload(listener: (epoch: string) => void): () => void;
+  preflight(): void;
+  commitGeneration(epoch: string): void;
+  onPreparationError?(error: unknown): void;
+  reload(): void;
+  schedule?: (run: () => void) => void;
+}
+
+export interface WorkerReplacement {
+  request(): Promise<void>;
+  dispose(): void;
+}
+
+/** Coordinate one reload per page after the old SharedWorker announces retirement. */
+export function createWorkerReplacement(options: WorkerReplacementOptions): WorkerReplacement {
+  const schedule = options.schedule ?? ((run) => { setTimeout(run, 100); });
+  let reloadScheduled = false;
+  const unsubscribe = options.subscribeReload((epoch) => {
+    if (reloadScheduled) return;
+    try {
+      options.commitGeneration(epoch);
+    } catch (error) {
+      options.onPreparationError?.(error);
+      return;
+    }
+    reloadScheduled = true;
+    schedule(options.reload);
+  });
+  return {
+    async request() {
+      // Verify that this page can persist the successor before asking the old
+      // worker to retire, but do not publish that successor until the worker
+      // announces that its drain and capture barrier completed.
+      options.preflight();
+      await options.retire();
+    },
+    dispose: unsubscribe,
+  };
+}

--- a/packages/cli/src/serve/worker/client/connection.ts
+++ b/packages/cli/src/serve/worker/client/connection.ts
@@ -57,8 +57,8 @@ export function getFirestore(
     });
   }
   const port = worker.port;
-  port.start();
   wirePort(port);
+  port.start();
   return { __kind: 'client-db', port };
 }
 

--- a/packages/cli/src/serve/worker/client/core.ts
+++ b/packages/cli/src/serve/worker/client/core.ts
@@ -10,6 +10,7 @@
  * they did when all of this lived inline in `client.ts`.
  */
 import type { InboundMessage, OutboundMessage } from '../protocol.js';
+import type { RuntimeReloadMessage } from '../protocol.js';
 // TYPE-ONLY — the auth-lens contract + the cross-service event envelope, shared
 // with the worker host + the sandbox's event provenance. Erased at build, so the
 // leaf client bundle stays engine-free.
@@ -58,6 +59,14 @@ export const _eventSubs = new Map<string, {
   next: (events: readonly SandboxEvent[]) => void;
 }>();
 const disconnectedPorts = new WeakSet<ClientPort>();
+const runtimeReloadListeners = new Set<(message: RuntimeReloadMessage) => void>();
+
+export function subscribeRuntimeReload(
+  listener: (message: RuntimeReloadMessage) => void,
+): () => void {
+  runtimeReloadListeners.add(listener);
+  return () => runtimeReloadListeners.delete(listener);
+}
 
 function appDeletedError(): Error & { code: string } {
   return Object.assign(new Error('Firebase App was deleted'), { code: 'app/app-deleted' });
@@ -231,6 +240,8 @@ export function wirePort(port: ClientPort): void {
       // no rehydration. Deliver the whole batch to the registered subscriber.
       const subscription = _eventSubs.get(msg.subId);
       if (subscription) subscription.next(msg.events);
+    } else if (msg.t === 'runtime-reload') {
+      for (const listener of runtimeReloadListeners) listener(msg);
     }
   };
 }

--- a/packages/cli/src/serve/worker/client/runtime-control.ts
+++ b/packages/cli/src/serve/worker/client/runtime-control.ts
@@ -1,0 +1,22 @@
+import { nextId, rpcWithTimeout, subscribeRuntimeReload } from './core.js';
+import type { ClientDb } from './handles.js';
+
+/** Ask the current SharedWorker to drain accepted work and retire. */
+export async function retireWorkerRuntime(
+  db: ClientDb,
+  targetEpoch: string,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 12_000;
+  await rpcWithTimeout(
+    db.port,
+    { t: 'op', id: nextId(), method: 'retireRuntime', targetEpoch },
+    timeoutMs,
+    `Timed out waiting for the Pyric worker to retire after ${timeoutMs}ms.`,
+  );
+}
+
+/** Observe the worker's all-pages reload signal. */
+export function onWorkerRuntimeReload(listener: (epoch: string) => void): () => void {
+  return subscribeRuntimeReload((message) => listener(message.epoch));
+}

--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -48,6 +48,7 @@
 // without enabling the full webworker lib.
 interface SharedWorkerGlobalScope {
   onconnect: ((e: MessageEvent) => void) | null;
+  close(): void;
 }
 
 import { createIndexedDBBackend } from 'pyric/sandbox';
@@ -65,8 +66,17 @@ import {
   type ServiceWorkerChannelMessage,
 } from './service-worker-channel.js';
 import { createServiceWorkerRelay } from './service-worker-relay.js';
+import { createWorkerRetirement } from './retirement.js';
 
 declare const __PYRIC_WORKER_VERSION__: string;
+const workerEpoch = typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
+  ? __PYRIC_WORKER_VERSION__
+  : 'dev';
+const workerScope = self as unknown as SharedWorkerGlobalScope;
+const retirement = createWorkerRetirement({
+  closeWorker: () => workerScope.close(),
+  beforeAnnounce: async () => { await _ctx?.captureFlush?.(); },
+});
 
 // ─── Singleton context ────────────────────────────────────────────────────
 
@@ -127,9 +137,10 @@ async function buildCtx(): Promise<HostCtx> {
  * Each tab gets its own `MessagePort`; we start() it (required for
  * classic-mode workers to un-pause the message queue) and wire onmessage.
  */
-(self as unknown as SharedWorkerGlobalScope).onconnect = (e: MessageEvent) => {
+workerScope.onconnect = (e: MessageEvent) => {
   const port = e.ports[0];
   port.start();
+  retirement.connect(port);
 
   let messageQueue = Promise.resolve();
   port.onmessage = (ev: MessageEvent<InboundMessage>) => {
@@ -139,11 +150,22 @@ async function buildCtx(): Promise<HostCtx> {
         id: ev.data.id,
         ok: true,
         value: {
-          version: typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
-            ? __PYRIC_WORKER_VERSION__
-            : 'dev',
+          version: workerEpoch,
         },
       });
+      return;
+    }
+    if (ev.data.t === 'op' && ev.data.method === 'retireRuntime') {
+      void retirement.retire(port, ev.data.id, ev.data.targetEpoch);
+      return;
+    }
+    if (!retirement.accepting()) {
+      if ('id' in ev.data) {
+        port.postMessage({
+          t: 'res', id: ev.data.id, ok: false,
+          error: { code: 'pyric/worker-retiring', message: 'The Pyric worker is restarting.' },
+        });
+      }
       return;
     }
     // Serialize each port's frames. A disconnect acknowledgement therefore
@@ -158,12 +180,14 @@ async function buildCtx(): Promise<HostCtx> {
         console.error('[pyric worker] message handler error:', (e as Error)?.stack ?? e, 'msg:', ev.data);
       }
     });
+    retirement.track(port, messageQueue);
   };
 
   // Best-effort port cleanup on tab close/navigation.
   // Chrome doesn't reliably fire 'close' on MessagePort — handled as
   // best-effort; subscriptions also GC when the worker itself dies.
   port.addEventListener('close', () => {
+    retirement.disconnect(port);
     if (_ctx) cleanupPort(_ctx, port as unknown as PortLike);
   });
 };
@@ -189,6 +213,11 @@ if (typeof BroadcastChannel !== 'undefined') {
   channel.onmessage = (event: MessageEvent<ServiceWorkerChannelMessage>) => {
     const envelope = event.data;
     if (envelope.direction !== 'host') return;
-    void relay.handle(envelope);
+    // A generation-targeted replacement can briefly overlap this old worker
+    // with its successor. Only the accepting generation may answer the shared
+    // service-worker relay channel, otherwise both workers would reply.
+    if (!retirement.accepting()) return;
+    const work = relay.handle(envelope);
+    retirement.trackDetached(work);
   };
 }

--- a/packages/cli/src/serve/worker/host-context.ts
+++ b/packages/cli/src/serve/worker/host-context.ts
@@ -169,7 +169,7 @@ export interface HostCtx {
    * worker would otherwise re-prime via `hydrateEventHistory` (issue #359
    * extension). Absent when capture is off.
    */
-  captureFlush?: () => void;
+  captureFlush?: () => Promise<void>;
   /**
    * Per-uid impersonation Firestore handles (Pyric Studio auth lens, T2).
    * Keyed by the impersonated uid. Each is a FROZEN-identity

--- a/packages/cli/src/serve/worker/host/studio.ts
+++ b/packages/cli/src/serve/worker/host/studio.ts
@@ -60,7 +60,7 @@ export async function handleStudioOp(
         // reset just emptied `sandbox.history()`, and waiting out the
         // capture debounce leaves a window where a worker death resurrects
         // the wiped session's events on the next boot.
-        ctx.captureFlush?.();
+        await ctx.captureFlush?.();
         ok(port, msg.id, { errors });
       } catch (e) {
         fail(port, msg.id, e instanceof Error ? e : new Error(String(e)));

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -483,6 +483,7 @@ export type OpMessage = (
   // Staleness guard: report the worker's baked build version so the page can
   // warn when a still-running OLD worker serves code older than what's served.
   | { t: 'op'; id: string; method: 'getRuntimeEpoch' }
+  | { t: 'op'; id: string; method: 'retireRuntime'; targetEpoch: string }
   | { t: 'op'; id: string; method: 'getVersion' }
   // ── Phase 2 (transfer): export/import the FULL sandbox state as a bundle
   // string (the chunk format the persist layer uses). importState CLOBBERS. ──
@@ -915,7 +916,17 @@ export interface EventStreamMessage {
   events: readonly SandboxEvent[];
 }
 
-export type OutboundMessage = ResMessage | SnapMessage | EventStreamMessage;
+/** The retiring worker tells every connected page to reload after it drains. */
+export interface RuntimeReloadMessage {
+  t: 'runtime-reload';
+  epoch: string;
+}
+
+export type OutboundMessage =
+  | ResMessage
+  | SnapMessage
+  | EventStreamMessage
+  | RuntimeReloadMessage;
 
 // ─── Serialized document data ─────────────────────────────────────────────
 

--- a/packages/cli/src/serve/worker/retirement.ts
+++ b/packages/cli/src/serve/worker/retirement.ts
@@ -1,0 +1,125 @@
+interface RetirementPort {
+  postMessage(message: unknown): void;
+}
+
+interface WorkerRetirementOptions {
+  closeWorker(): void;
+  beforeAnnounce?(): Promise<void>;
+  drainTimeoutMs?: number;
+  schedule?: (run: () => void) => void;
+}
+
+export interface WorkerRetirement {
+  connect(port: RetirementPort): void;
+  disconnect(port: RetirementPort): void;
+  track(port: RetirementPort, work: Promise<void>): void;
+  trackDetached(work: Promise<void>): void;
+  accepting(): boolean;
+  retire(requester: RetirementPort, requestId: string, targetEpoch: string): Promise<void>;
+}
+
+/** Drain already-accepted port work before every page reloads onto a new worker. */
+export function createWorkerRetirement(options: WorkerRetirementOptions): WorkerRetirement {
+  const ports = new Set<RetirementPort>();
+  const workByPort = new Map<RetirementPort, Promise<void>>();
+  const detachedWork = new Set<Promise<void>>();
+  const requests: Array<{ requester: RetirementPort; requestId: string }> = [];
+  const schedule = options.schedule ?? ((run) => { setTimeout(run, 50); });
+  const drainTimeoutMs = options.drainTimeoutMs ?? 10_000;
+  let retiring = false;
+  let announced = false;
+  let announcedEpoch: string | null = null;
+  let retirement: Promise<void> | null = null;
+
+  const timeout = (work: Promise<void>): Promise<void> => new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Worker retirement drain timed out after ${drainTimeoutMs}ms.`)),
+      drainTimeoutMs,
+    );
+    void work.then(
+      () => { clearTimeout(timer); resolve(); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+
+  const failRequests = (error: Error): void => {
+    for (const request of requests.splice(0)) {
+      request.requester.postMessage({
+        t: 'res', id: request.requestId, ok: false,
+        error: { code: 'pyric/worker-retirement-timeout', message: error.message },
+      });
+    }
+  };
+
+  return {
+    connect(port) {
+      ports.add(port);
+      if (announcedEpoch) {
+        port.postMessage({ t: 'runtime-reload', epoch: announcedEpoch });
+      }
+    },
+    disconnect(port) {
+      ports.delete(port);
+    },
+    track(port, work) {
+      workByPort.set(port, work);
+      const settled = (): void => {
+        if (workByPort.get(port) === work) workByPort.delete(port);
+      };
+      void work.then(settled, settled);
+    },
+    trackDetached(work) {
+      detachedWork.add(work);
+      void work.then(
+        () => { detachedWork.delete(work); },
+        () => { detachedWork.delete(work); },
+      );
+    },
+    accepting: () => !retiring,
+    async retire(requester, requestId, targetEpoch) {
+      if (!/^[a-f0-9]{16}$/.test(targetEpoch)) {
+        requester.postMessage({
+          t: 'res', id: requestId, ok: false,
+          error: { code: 'pyric/invalid-worker-epoch', message: 'Invalid replacement worker epoch.' },
+        });
+        return;
+      }
+      if (announced) {
+        requester.postMessage({
+          t: 'res', id: requestId, ok: true, value: { retiring: true },
+        });
+        requester.postMessage({ t: 'runtime-reload', epoch: announcedEpoch! });
+        return;
+      }
+      requests.push({ requester, requestId });
+      if (!retirement) {
+        retiring = true;
+        const acceptedWork = [...workByPort.values(), ...detachedWork];
+        const attempt = { cancelled: false };
+        retirement = timeout((async () => {
+          await Promise.allSettled(acceptedWork);
+          if (attempt.cancelled) return;
+          await options.beforeAnnounce?.();
+          if (attempt.cancelled) return;
+          for (const request of requests.splice(0)) {
+            request.requester.postMessage({
+              t: 'res', id: request.requestId, ok: true, value: { retiring: true },
+            });
+          }
+          announced = true;
+          announcedEpoch = targetEpoch;
+          for (const port of ports) {
+            port.postMessage({ t: 'runtime-reload', epoch: targetEpoch });
+          }
+          schedule(options.closeWorker);
+        })()).catch((error: unknown) => {
+          attempt.cancelled = true;
+          retiring = false;
+          retirement = null;
+          failRequests(error instanceof Error ? error : new Error(String(error)));
+        });
+      }
+      await retirement;
+    },
+  };
+}

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -263,7 +263,7 @@ export function applyServeInit(
     const debounceMs = payload.capture ? (env.captureDebounceMs ?? 400) : 0;
     let timer: ReturnType<typeof setTimeout> | null = null;
 
-    const flush = (): void => {
+    const flush = async (): Promise<void> => {
       const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
       const rtdbState =
         payload.databaseRules || ctx.sandbox.history().some((event) => event.service === 'rtdb')
@@ -286,8 +286,7 @@ export function applyServeInit(
       }));
       // Relative URL resolves against the worker script's origin (same origin
       // as the page). Fire-and-forget — capture failures never break ops.
-      env
-        .fetch('/__pyric/capture', {
+      await env.fetch('/__pyric/capture', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body,
@@ -297,7 +296,7 @@ export function applyServeInit(
 
     const unsub = ctx.sandbox.onEvent(() => {
       if (timer) clearTimeout(timer);
-      timer = setTimeout(flush, debounceMs);
+      timer = setTimeout(() => { void flush(); }, debounceMs);
     });
 
     result.captureEnabled = true;
@@ -308,12 +307,12 @@ export function applyServeInit(
     // the next boot's `hydrateEventHistory` would prime them straight back
     // into Traffic. Bypasses the debounce; cancels any pending flush (it
     // would only re-write the same post-reset history).
-    ctx.captureFlush = (): void => {
+    ctx.captureFlush = async (): Promise<void> => {
       if (timer) {
         clearTimeout(timer);
         timer = null;
       }
-      flush();
+      await flush();
     };
     result.dispose = (): void => {
       if (timer) clearTimeout(timer);

--- a/packages/cli/test/serve/runtime/status.test.ts
+++ b/packages/cli/test/serve/runtime/status.test.ts
@@ -126,6 +126,36 @@ describe('Pyric runtime status', () => {
     runtime.clearErrors();
     expect(runtime.getSnapshot()).toMatchObject({ errors: [], updateAvailable: true });
   });
+
+  it('runs the configured worker update only when a new epoch is available', async () => {
+    const status = createPyricRuntimeStatus({
+      ...manifest,
+      worker: { ...manifest.worker, servedEpoch: 'served-new' },
+    });
+    let updates = 0;
+    status.setWorkerUpdater(async () => { updates += 1; });
+
+    await expect(status.updateWorker()).rejects.toThrow('No Pyric worker update is available');
+    status.setWorker({ mode: 'shared-worker', runningEpoch: 'running-old' });
+    await status.updateWorker();
+
+    expect(updates).toBe(1);
+    expect(status.getSnapshot().updatingWorker).toBe(true);
+  });
+
+  it('returns to an actionable error state when worker replacement fails', async () => {
+    const status = createPyricRuntimeStatus(manifest);
+    status.setWorker({ mode: 'shared-worker', runningEpoch: 'running-old' });
+    status.setWorkerUpdater(async () => { throw new Error('retirement timed out'); });
+
+    await expect(status.updateWorker()).rejects.toThrow('retirement timed out');
+
+    expect(status.getSnapshot()).toMatchObject({
+      updateAvailable: true,
+      updatingWorker: false,
+      errors: [{ source: 'worker', message: 'retirement timed out' }],
+    });
+  });
 });
 
 describe('normalizePyricRuntimeError', () => {

--- a/packages/cli/test/serve/runtime/worker-generation.test.ts
+++ b/packages/cli/test/serve/runtime/worker-generation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  PYRIC_WORKER_GENERATION_KEY,
+  preflightWorkerEpochStorage,
+  rememberWorkerEpoch,
+  workerNameForEpoch,
+} from '../../../src/serve/runtime/worker-generation.js';
+
+describe('worker generation identity', () => {
+  it('uses a new name only after the page remembers the served epoch', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => { values.set(key, value); },
+      removeItem: (key: string) => { values.delete(key); },
+    };
+
+    expect(workerNameForEpoch('0123456789abcdef', storage)).toBe('pyric-shared-worker');
+    rememberWorkerEpoch('0123456789abcdef', storage);
+    expect(values.get(PYRIC_WORKER_GENERATION_KEY)).toBe('0123456789abcdef');
+    expect(workerNameForEpoch('0123456789abcdef', storage)).toBe(
+      'pyric-shared-worker:0123456789abcdef',
+    );
+  });
+
+  it('keeps the origin on its remembered generation when a newer epoch is served', () => {
+    const storage = {
+      getItem: () => '0123456789abcdef',
+      setItem() {},
+    };
+    expect(workerNameForEpoch('fedcba9876543210', storage)).toBe(
+      'pyric-shared-worker:0123456789abcdef',
+    );
+  });
+
+  it('lets a fresh tab join the origin-wide remembered generation', () => {
+    const originValues = new Map([[PYRIC_WORKER_GENERATION_KEY, '0123456789abcdef']]);
+    const freshTabStorage = {
+      getItem: (key: string) => originValues.get(key) ?? null,
+      setItem: (key: string, value: string) => { originValues.set(key, value); },
+    };
+
+    expect(workerNameForEpoch('0123456789abcdef', freshTabStorage)).toBe(
+      'pyric-shared-worker:0123456789abcdef',
+    );
+  });
+
+  it('fails before retirement when origin storage cannot persist the successor', () => {
+    expect(() => rememberWorkerEpoch('0123456789abcdef', undefined)).toThrow(
+      'origin storage is unavailable',
+    );
+  });
+
+  it('preflights storage without publishing a successor generation', () => {
+    const values = new Map([[PYRIC_WORKER_GENERATION_KEY, '0123456789abcdef']]);
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => { values.set(key, value); },
+      removeItem: (key: string) => { values.delete(key); },
+    };
+
+    preflightWorkerEpochStorage(storage);
+    expect(workerNameForEpoch(null, storage)).toBe('pyric-shared-worker:0123456789abcdef');
+  });
+});

--- a/packages/cli/test/serve/runtime/worker-replacement.test.ts
+++ b/packages/cli/test/serve/runtime/worker-replacement.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  PYRIC_WORKER_GENERATION_KEY,
+  preflightWorkerEpochStorage,
+  rememberWorkerEpoch,
+  workerNameForEpoch,
+} from '../../../src/serve/runtime/worker-generation.js';
+import { createWorkerReplacement } from '../../../src/serve/runtime/worker-replacement.js';
+
+describe('page worker replacement', () => {
+  it('requests retirement and reloads once when the worker broadcasts replacement', async () => {
+    let notify: ((epoch: string) => void) | undefined;
+    let retireCalls = 0;
+    let reloads = 0;
+    const scheduled: Array<() => void> = [];
+    const prepared: string[] = [];
+    let preflights = 0;
+    const replacement = createWorkerReplacement({
+      targetEpoch: '0123456789abcdef',
+      retire: async () => { retireCalls += 1; },
+      subscribeReload: (listener) => {
+        notify = listener;
+        return () => { notify = undefined; };
+      },
+      preflight: () => { preflights += 1; },
+      commitGeneration: (epoch) => { prepared.push(epoch); },
+      reload: () => { reloads += 1; },
+      schedule: (run) => { scheduled.push(run); },
+    });
+
+    await replacement.request();
+    notify?.('0123456789abcdef');
+    notify?.('0123456789abcdef');
+
+    expect(retireCalls).toBe(1);
+    expect(preflights).toBe(1);
+    expect(scheduled).toHaveLength(1);
+    expect(prepared).toEqual(['0123456789abcdef']);
+    scheduled[0]?.();
+    expect(reloads).toBe(1);
+    replacement.dispose();
+  });
+
+  it('does not retire the live worker when successor identity cannot be prepared', async () => {
+    let retireCalls = 0;
+    const replacement = createWorkerReplacement({
+      targetEpoch: '0123456789abcdef',
+      retire: async () => { retireCalls += 1; },
+      subscribeReload: () => () => {},
+      preflight: () => { throw new Error('origin storage unavailable'); },
+      commitGeneration() {},
+      reload() {},
+    });
+
+    await expect(replacement.request()).rejects.toThrow('origin storage unavailable');
+    expect(retireCalls).toBe(0);
+  });
+
+  it('does not publish successor identity when retirement fails', async () => {
+    let commits = 0;
+    const replacement = createWorkerReplacement({
+      targetEpoch: '0123456789abcdef',
+      retire: async () => { throw new Error('drain timed out'); },
+      subscribeReload: () => () => {},
+      preflight() {},
+      commitGeneration: () => { commits += 1; },
+      reload() {},
+    });
+
+    await expect(replacement.request()).rejects.toThrow('drain timed out');
+    expect(commits).toBe(0);
+  });
+
+  it('keeps tabs opened during drain on the active generation', async () => {
+    const values = new Map([[PYRIC_WORKER_GENERATION_KEY, 'aaaaaaaaaaaaaaaa']]);
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => { values.set(key, value); },
+      removeItem: (key: string) => { values.delete(key); },
+    };
+    let finishRetirement: (() => void) | undefined;
+    const retirement = new Promise<void>((resolve) => { finishRetirement = resolve; });
+    const replacement = createWorkerReplacement({
+      targetEpoch: 'bbbbbbbbbbbbbbbb',
+      retire: () => retirement,
+      subscribeReload: () => () => {},
+      preflight: () => preflightWorkerEpochStorage(storage),
+      commitGeneration: (epoch) => rememberWorkerEpoch(epoch, storage),
+      reload() {},
+    });
+
+    const request = replacement.request();
+    expect(workerNameForEpoch('bbbbbbbbbbbbbbbb', storage)).toBe(
+      'pyric-shared-worker:aaaaaaaaaaaaaaaa',
+    );
+
+    finishRetirement?.();
+    await request;
+  });
+});

--- a/packages/cli/test/serve/worker/bundle-realm.test.ts
+++ b/packages/cli/test/serve/worker/bundle-realm.test.ts
@@ -68,6 +68,7 @@ import type { OutboundMessage, ResMessage, SnapMessage } from '../../../src/serv
 interface Realm {
   send(msg: unknown): void;
   replies: OutboundMessage[];
+  closed(): boolean;
   close(): void;
 }
 
@@ -81,7 +82,13 @@ async function bootBundledWorker(): Promise<Realm> {
   const src = readFileSync(file, 'utf8');
 
   // The SharedWorkerGlobalScope the bundle installs its `onconnect` on.
-  const workerSelf: { onconnect?: (e: { ports: unknown[] }) => void } = {};
+  let workerClosed = false;
+  const workerSelf: {
+    onconnect?: (e: { ports: unknown[] }) => void;
+    close(): void;
+  } = {
+    close() { workerClosed = true; },
+  };
 
   // Standalone boot: no `pyric dev` behind the worker, so /__pyric/init.json
   // 404s and buildWorkerCtx falls back to plain IDB.
@@ -115,6 +122,7 @@ async function bootBundledWorker(): Promise<Realm> {
 
   return {
     replies,
+    closed: () => workerClosed,
     send: (msg) => channel.port1.postMessage(msg),
     close: () => {
       channel.port1.close();
@@ -225,5 +233,18 @@ describe('bundle realm — the shipped SharedWorker artifact executes', () => {
     });
     await settle();
     expect(snapsFor(realm, SUB).length).toBe(countAtUnsub);
+  }, 30_000);
+
+  it('retires the shipped worker only after acknowledging and notifying the page', async () => {
+    const response = await sendOp(realm, {
+      id: 'realm-retire', method: 'retireRuntime', targetEpoch: 'fedcba9876543210',
+    });
+    expect(response.ok).toBe(true);
+    await settle(100);
+
+    expect(realm.replies).toContainEqual({
+      t: 'runtime-reload', epoch: 'fedcba9876543210',
+    });
+    expect(realm.closed()).toBe(true);
   }, 30_000);
 });

--- a/packages/cli/test/serve/worker/client/connection.test.ts
+++ b/packages/cli/test/serve/worker/client/connection.test.ts
@@ -27,10 +27,11 @@ describe('SharedWorker connection', () => {
 
   it('surfaces the SharedWorker script error event', () => {
     let emitError: ((event: { message?: string }) => void) | undefined;
+    let wiredBeforeStart = false;
     const port: ClientPort = {
       onmessage: null,
       postMessage() {},
-      start() {},
+      start() { wiredBeforeStart = port.onmessage !== null; },
       close() {},
     };
     (globalThis as { SharedWorker?: unknown }).SharedWorker = class {
@@ -48,5 +49,6 @@ describe('SharedWorker connection', () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0]?.message).toContain('worker script failed');
+    expect(wiredBeforeStart).toBe(true);
   });
 });

--- a/packages/cli/test/serve/worker/client/runtime-control.test.ts
+++ b/packages/cli/test/serve/worker/client/runtime-control.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  onWorkerRuntimeReload,
+  retireWorkerRuntime,
+} from '../../../../src/serve/worker/client/runtime-control.js';
+import { wirePort } from '../../../../src/serve/worker/client/core.js';
+import type { ClientDb, ClientPort } from '../../../../src/serve/worker/client/handles.js';
+
+describe('worker runtime control', () => {
+  it('requests retirement and relays the all-pages reload signal', async () => {
+    const sent: Array<{ id?: string; method?: string }> = [];
+    const port: ClientPort = {
+      onmessage: null,
+      postMessage(message) { sent.push(message as { id?: string; method?: string }); },
+      start() {},
+      close() {},
+    };
+    wirePort(port);
+    const db: ClientDb = { __kind: 'client-db', port };
+    let reloads = 0;
+    const epochs: string[] = [];
+    const unsubscribe = onWorkerRuntimeReload((epoch) => {
+      reloads += 1;
+      epochs.push(epoch);
+    });
+
+    const retiring = retireWorkerRuntime(db, '0123456789abcdef');
+    const id = sent[0]?.id;
+    expect(sent[0]?.method).toBe('retireRuntime');
+    expect(sent[0]).toMatchObject({ targetEpoch: '0123456789abcdef' });
+    port.onmessage?.({
+      data: { t: 'res', id, ok: true, value: { retiring: true } },
+    } as MessageEvent);
+    await retiring;
+    port.onmessage?.({
+      data: { t: 'runtime-reload', epoch: '0123456789abcdef' },
+    } as MessageEvent);
+
+    expect(reloads).toBe(1);
+    expect(epochs).toEqual(['0123456789abcdef']);
+    unsubscribe();
+  });
+
+  it('bounds a retirement request when the worker cannot reply', async () => {
+    const port: ClientPort = {
+      onmessage: null,
+      postMessage() {},
+      start() {},
+      close() {},
+    };
+    const db: ClientDb = { __kind: 'client-db', port };
+
+    await expect(retireWorkerRuntime(
+      db, '0123456789abcdef', { timeoutMs: 5 },
+    )).rejects.toThrow('Timed out waiting for the Pyric worker to retire');
+  });
+});

--- a/packages/cli/test/serve/worker/retirement.test.ts
+++ b/packages/cli/test/serve/worker/retirement.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'bun:test';
+import { createWorkerRetirement } from '../../../src/serve/worker/retirement.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  return { promise: new Promise<void>((done) => { resolve = done; }), resolve };
+}
+
+describe('SharedWorker retirement', () => {
+  it('drains accepted work, acknowledges the requester, notifies every page, then closes', async () => {
+    const firstMessages: unknown[] = [];
+    const secondMessages: unknown[] = [];
+    const first = { postMessage: (message: unknown) => firstMessages.push(message) };
+    const second = { postMessage: (message: unknown) => secondMessages.push(message) };
+    const work = deferred();
+    const scheduled: Array<() => void> = [];
+    let closed = false;
+    const retirement = createWorkerRetirement({
+      closeWorker: () => { closed = true; },
+      schedule: (run) => { scheduled.push(run); },
+    });
+    retirement.connect(first);
+    retirement.connect(second);
+    retirement.track(first, work.promise);
+
+    const retiring = retirement.retire(first, 'replace-1', '0123456789abcdef');
+    const alsoRetiring = retirement.retire(second, 'replace-2', '0123456789abcdef');
+    await Promise.resolve();
+    expect(firstMessages).toEqual([]);
+    expect(retirement.accepting()).toBe(false);
+
+    work.resolve();
+    await Promise.all([retiring, alsoRetiring]);
+
+    expect(firstMessages).toEqual([
+      { t: 'res', id: 'replace-1', ok: true, value: { retiring: true } },
+      { t: 'runtime-reload', epoch: '0123456789abcdef' },
+    ]);
+    expect(secondMessages).toEqual([
+      { t: 'res', id: 'replace-2', ok: true, value: { retiring: true } },
+      { t: 'runtime-reload', epoch: '0123456789abcdef' },
+    ]);
+    expect(closed).toBe(false);
+    scheduled[0]?.();
+    expect(closed).toBe(true);
+  });
+
+  it('still drains accepted work after its page disconnects', async () => {
+    const disconnected = { postMessage() {} };
+    const requesterMessages: unknown[] = [];
+    const requester = { postMessage: (message: unknown) => requesterMessages.push(message) };
+    const work = deferred();
+    let closed = false;
+    const retirement = createWorkerRetirement({
+      closeWorker: () => { closed = true; },
+      schedule: (run) => { run(); },
+    });
+    retirement.connect(disconnected);
+    retirement.connect(requester);
+    retirement.track(disconnected, work.promise);
+    retirement.disconnect(disconnected);
+
+    const retiring = retirement.retire(
+      requester, 'replace-after-disconnect', '0123456789abcdef',
+    );
+    await Promise.resolve();
+    expect(requesterMessages).toEqual([]);
+    expect(closed).toBe(false);
+
+    work.resolve();
+    await retiring;
+    expect(closed).toBe(true);
+  });
+
+  it('drains accepted ServiceWorker relay work outside direct page ports', async () => {
+    const requesterMessages: unknown[] = [];
+    const requester = { postMessage: (message: unknown) => requesterMessages.push(message) };
+    const relayWork = deferred();
+    let closed = false;
+    const retirement = createWorkerRetirement({
+      closeWorker: () => { closed = true; },
+      schedule: (run) => { run(); },
+    });
+    retirement.connect(requester);
+    retirement.trackDetached(relayWork.promise);
+
+    const retiring = retirement.retire(
+      requester, 'replace-with-relay', '0123456789abcdef',
+    );
+    await Promise.resolve();
+    expect(requesterMessages).toEqual([]);
+    expect(closed).toBe(false);
+
+    relayWork.resolve();
+    await retiring;
+    expect(closed).toBe(true);
+  });
+
+  it('flushes capture before notifying pages and immediately redirects a late connection', async () => {
+    const order: string[] = [];
+    const scheduled: Array<() => void> = [];
+    const requester = { postMessage: (message: unknown) => {
+      const typed = message as { t?: string };
+      order.push(typed.t === 'runtime-reload' ? 'reload' : 'ack');
+    } };
+    const retirement = createWorkerRetirement({
+      beforeAnnounce: async () => { order.push('capture'); },
+      closeWorker: () => { order.push('close'); },
+      schedule: (run) => { scheduled.push(run); },
+    });
+    retirement.connect(requester);
+
+    await retirement.retire(requester, 'replace-capture', '0123456789abcdef');
+    expect(order).toEqual(['capture', 'ack', 'reload']);
+
+    const lateMessages: unknown[] = [];
+    retirement.connect({ postMessage: (message) => lateMessages.push(message) });
+    expect(lateMessages).toEqual([
+      { t: 'runtime-reload', epoch: '0123456789abcdef' },
+    ]);
+    scheduled[0]?.();
+    expect(order).toEqual(['capture', 'ack', 'reload', 'close']);
+  });
+
+  it('rolls back retirement and reports an error when accepted work never drains', async () => {
+    const messages: unknown[] = [];
+    const requester = { postMessage: (message: unknown) => messages.push(message) };
+    const work = deferred();
+    let closes = 0;
+    const retirement = createWorkerRetirement({
+      closeWorker() { closes += 1; },
+      drainTimeoutMs: 5,
+    });
+    retirement.connect(requester);
+    retirement.track(requester, work.promise);
+
+    await retirement.retire(requester, 'replace-timeout', '0123456789abcdef');
+
+    expect(retirement.accepting()).toBe(true);
+    expect(messages).toContainEqual({
+      t: 'res', id: 'replace-timeout', ok: false,
+      error: {
+        code: 'pyric/worker-retirement-timeout',
+        message: 'Worker retirement drain timed out after 5ms.',
+      },
+    });
+
+    messages.length = 0;
+    work.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(messages).toEqual([]);
+    expect(closes).toBe(0);
+  });
+});

--- a/packages/cli/test/serve/worker/serve-init.test.ts
+++ b/packages/cli/test/serve/worker/serve-init.test.ts
@@ -378,6 +378,28 @@ describe('applyServeInit — capture (the verify loop)', () => {
     await tick(20);
     expect(fetchSpy.calls.length).toBe(0);
   });
+
+  it('exposes an immediate capture flush that resolves only after its POST settles', async () => {
+    const ctx = await makeCtx();
+    let resolvePost!: (response: Response) => void;
+    const pendingFetch = (() => new Promise<Response>((resolve) => {
+      resolvePost = resolve;
+    })) as typeof fetch;
+    applyServeInit(
+      ctx,
+      { ...basePayload, capture: true },
+      { fetch: pendingFetch, captureDebounceMs: 5 },
+    );
+
+    let settled = false;
+    const flushing = ctx.captureFlush!().then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolvePost({ ok: true, status: 204 } as Response);
+    await flushing;
+    expect(settled).toBe(true);
+  });
 });
 
 describe('setupWorkerHotReload — the worker owns the single SSE', () => {


### PR DESCRIPTION
Adds coordinated SharedWorker replacement so one runtime action retires stale code and reloads every page sharing it.

```ts
const runtime = globalThis.__pyricRuntime;

if (runtime?.getSnapshot().updateAvailable) {
  await runtime.updateWorker();
  // The old worker drains accepted operations, tells every connected page to
  // move to the successor generation, then closes.
}
```

## One update request replaces the worker for every tab

The named SharedWorker stops accepting new operations, drains work accepted from direct page ports and the ServiceWorker relay, flushes capture state, acknowledges concurrent update requesters, and broadcasts one `runtime-reload` message to every page.

Before requesting retirement, the page probes origin storage with a separate reversible key. It does not publish the successor while the old worker is draining, so tabs opened during that window keep joining the active generation. Only the successful reload broadcast commits the successor generation; reloaded pages then connect under its epoch-bound worker name and cannot reattach to the retired instance.

Each page deduplicates the broadcast before scheduling its reload. The runtime status keeps `updatingWorker` true during the handoff and records an actionable worker error if storage is unavailable or retirement times out. A failed/timed-out retirement resumes the old worker without changing the active generation.

## Risk

This introduces an intentional multi-page reload and a worker-level close. Review should focus on drain ordering, generation publication, concurrent requests, message delivery before close, and ensuring ordinary runtime traffic cannot enter after retirement begins.

<details>
<summary>Implementation notes</summary>

- Focused replacement/status/retirement suites: 25 passed.
- Bundler suite: 21 passed.
- Shipped SharedWorker bundle realm: 4 passed, including acknowledgement → broadcast → close.
- Vite integration: 75 passed, 5 explicitly gated bridge E2E tests skipped.
- CLI build and TypeScript check: passed.
- `git diff --check`: passed.
- This PR is stacked on #411 and should merge after it.

</details>
