### PR TITLE
feat(ui): add the Pyric runtime chip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "@types/ws": "^8.5.0",
         "firebase": "^12.12.0",
         "firebase-admin": "^13.0.0",
+        "jsdom": "^29.1.1",
         "typescript": "^5.7.0",
         "vite": "^5.0.0",
       },
@@ -3075,7 +3076,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -3313,8 +3314,6 @@
 
     "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
-    "@dotenvx/dotenvx/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
-
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@dotenvx/dotenvx/yocto-spinner": ["yocto-spinner@1.2.2", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng=="],
@@ -3493,6 +3492,8 @@
 
     "firebase-tools/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "firebase-tools/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
+
     "firebase-tools/ws": ["ws@7.5.12", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg=="],
 
     "firebase-tools/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
@@ -3526,8 +3527,6 @@
     "is-ci/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "isomorphic-git/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "jsdom/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "just-bash/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -3618,8 +3617,6 @@
     "shadcn/ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
     "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
-
-    "shadcn/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -129,6 +129,7 @@
     "@types/ws": "^8.5.0",
     "firebase": "^12.12.0",
     "firebase-admin": "^13.0.0",
+    "jsdom": "^29.1.1",
     "typescript": "^5.7.0",
     "vite": "^5.0.0"
   },

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -1,0 +1,275 @@
+import type {
+  PyricRuntimeError,
+  PyricRuntimeSnapshot,
+  PyricRuntimeStatus,
+} from './status.js';
+
+export interface PyricRuntimeChipOptions {
+  runtime: PyricRuntimeStatus;
+  document?: Document;
+  clipboard?: Pick<Clipboard, 'writeText'>;
+  initiallyOpen?: boolean;
+}
+
+export interface PyricRuntimeChip {
+  element: HTMLElement;
+  dispose(): void;
+}
+
+const styles = `
+  :host {
+    --pyric-bg: #1e1e24;
+    --pyric-content: #16161a;
+    --pyric-border: #33333f;
+    --pyric-border-soft: #2a2a35;
+    --pyric-text: #fbfbfe;
+    --pyric-muted: #89899f;
+    --pyric-accent: #19cc61;
+    --pyric-warning: #e6c79c;
+    --pyric-error: #f0a0a0;
+    all: initial;
+    position: fixed;
+    right: max(20px, env(safe-area-inset-right));
+    bottom: max(20px, env(safe-area-inset-bottom));
+    z-index: 2147483000;
+    color: var(--pyric-text);
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-synthesis: none;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  .announcer { height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; clip: rect(0 0 0 0); white-space: nowrap; }
+  button, a { font: inherit; }
+  button { margin: 0; }
+  .chip {
+    align-items: center;
+    background: var(--pyric-bg);
+    border: 1px solid var(--pyric-border);
+    border-radius: 999px;
+    box-shadow: 0 12px 34px rgba(0, 0, 0, .38);
+    color: var(--pyric-text);
+    cursor: pointer;
+    display: flex;
+    gap: 10px;
+    height: 36px;
+    padding: 0 12px;
+  }
+  .chip:hover { border-color: #4a4a58; }
+  .brand, .signals, .signal, .panel-title, .worker-state { align-items: center; display: flex; }
+  .brand { gap: 8px; }
+  .brand-mark { color: rgba(251, 251, 254, .78); font: 600 11px/1 ui-monospace, monospace; }
+  .brand-label, .signals, .worker-state, code, .button { font-family: "JetBrains Mono", ui-monospace, monospace; }
+  .brand-label { font-size: 11px; }
+  .signals { color: var(--pyric-muted); font-size: 10px; gap: 8px; }
+  .signal { gap: 4px; white-space: nowrap; }
+  .dot { background: var(--pyric-accent); border-radius: 50%; height: 8px; width: 8px; }
+  .dot.error { background: var(--pyric-error); box-shadow: 0 0 0 3px rgba(240,160,160,.12); }
+  .signal.update { color: var(--pyric-warning); }
+  .chevron { color: var(--pyric-muted); height: 14px; width: 14px; }
+  .panel {
+    background: var(--pyric-bg);
+    border: 1px solid var(--pyric-border);
+    border-radius: 8px;
+    box-shadow: 0 18px 60px rgba(0, 0, 0, .48);
+    max-width: calc(100vw - 40px);
+    overflow: hidden;
+    width: 380px;
+  }
+  .panel-header { align-items: center; display: flex; height: 44px; justify-content: space-between; padding: 0 12px; }
+  .panel-title { gap: 8px; min-width: 0; }
+  .panel-title strong { font: 500 12px/1 ui-monospace, monospace; }
+  .count { background: rgba(58,42,42,.3); border: 1px solid #3a2a2a; border-radius: 999px; color: var(--pyric-error); font: 9px/1 ui-monospace, monospace; padding: 4px 6px; }
+  .icon-button { align-items: center; background: transparent; border: 0; border-radius: 4px; color: var(--pyric-muted); cursor: pointer; display: inline-flex; height: 28px; justify-content: center; padding: 0; width: 28px; }
+  .icon-button:hover { background: rgba(255,255,255,.05); color: var(--pyric-text); }
+  .icon-button:disabled { cursor: not-allowed; opacity: .42; }
+  .icon-button[data-copy-failed] { color: var(--pyric-error); }
+  .icon { height: 15px; width: 15px; }
+  .worker-state { border-top: 1px solid var(--pyric-border-soft); color: var(--pyric-muted); font-size: 10px; justify-content: space-between; min-height: 34px; padding: 7px 12px; }
+  .worker-state .available { color: var(--pyric-warning); }
+  .worker-state .state-label { align-items: center; display: flex; gap: 7px; }
+  .mini-dot { background: var(--pyric-accent); border-radius: 50%; height: 6px; width: 6px; }
+  .available .mini-dot { background: var(--pyric-warning); }
+  .epochs { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .errors { background: var(--pyric-content); border-bottom: 1px solid var(--pyric-border-soft); border-top: 1px solid var(--pyric-border-soft); max-height: 184px; min-height: 58px; overflow-y: auto; }
+  .errors::-webkit-scrollbar { width: 8px; }
+  .errors::-webkit-scrollbar-thumb { background: #33333f; border-radius: 4px; }
+  .error-row { align-items: flex-start; border-bottom: 1px solid rgba(42,42,53,.7); display: grid; gap: 8px; grid-template-columns: 18px minmax(0,1fr) 28px; padding: 10px 8px 10px 12px; }
+  .error-row:last-child { border-bottom: 0; }
+  .error-number { color: var(--pyric-error); font: 10px/20px ui-monospace, monospace; }
+  .error-body { min-width: 0; }
+  .error-body code { color: #d7d7df; display: block; font-size: 11px; line-height: 1.55; overflow-wrap: anywhere; white-space: pre-wrap; }
+  .error-meta { color: var(--pyric-muted); font: 9px/1.4 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; }
+  .empty { align-items: center; color: var(--pyric-muted); display: flex; font: 11px/1.5 ui-monospace, monospace; min-height: 57px; padding: 12px; }
+  .actions { display: grid; gap: 8px; grid-template-columns: 1fr 1fr; min-height: 56px; padding: 10px 12px; }
+  .button { align-items: center; background: transparent; border: 1px solid var(--pyric-border-soft); border-radius: 4px; color: var(--pyric-muted); display: inline-flex; font-size: 10px; justify-content: center; letter-spacing: .06em; min-height: 34px; padding: 6px 8px; text-decoration: none; text-transform: uppercase; }
+  button.button { cursor: pointer; }
+  .button:hover:not(:disabled):not([aria-disabled="true"]), a.button:hover { border-color: #3a3a48; color: var(--pyric-text); }
+  .button.update:not(:disabled):not([aria-disabled="true"]) { background: rgba(230,199,156,.1); border-color: rgba(230,199,156,.4); color: var(--pyric-warning); }
+  .button.update:not(:disabled):not([aria-disabled="true"]):hover { background: rgba(230,199,156,.15); }
+  .button:disabled, .button[aria-disabled="true"] { cursor: not-allowed; opacity: .42; }
+  .button svg { height: 14px; margin-left: 6px; width: 14px; }
+  @media (max-width: 460px) {
+    :host { bottom: max(12px, env(safe-area-inset-bottom)); right: 12px; }
+    .panel { max-width: calc(100vw - 24px); }
+    .worker-state { align-items: flex-start; flex-direction: column; gap: 4px; }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .chip, .panel { animation: pyric-enter 120ms ease-out; transform-origin: bottom right; }
+    @keyframes pyric-enter { from { opacity: 0; transform: translateY(4px) scale(.98); } }
+  }
+`;
+
+const icons = {
+  close: '<svg class="icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m6 6 12 12M18 6 6 18"/></svg>',
+  copy: '<svg class="icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="8" y="8" width="11" height="11" rx="1"/><path d="M16 8V5H5v11h3"/></svg>',
+  chevron: '<svg class="chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m6 15 6-6 6 6"/></svg>',
+  external: '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 5h5v5M19 5l-8 8"/><path d="M19 13v6H5V5h6"/></svg>',
+};
+
+function escapeAttribute(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+}
+
+export function formatPyricRuntimeError(error: PyricRuntimeError): string {
+  const context = [
+    error.source,
+    error.service && error.method ? `${error.service}.${error.method}` : error.service ?? error.method,
+    error.path,
+    error.code,
+  ].filter(Boolean).join(' · ');
+  return `${error.message}${context ? `\n${context}` : ''}${error.stack ? `\n${error.stack}` : ''}`;
+}
+
+function renderErrors(snapshot: PyricRuntimeSnapshot, canCopy: boolean): string {
+  if (snapshot.errors.length === 0) return '<div class="empty">No sandbox errors.</div>';
+  return snapshot.errors.map((error, index) => `
+    <div class="error-row" data-error-id="${escapeAttribute(error.id)}">
+      <span class="error-number">${String(index + 1).padStart(2, '0')}</span>
+      <div class="error-body"><code></code><div class="error-meta"></div></div>
+      <button class="icon-button" type="button" data-copy-error="${escapeAttribute(error.id)}" aria-label="${canCopy ? `Copy error ${index + 1}` : 'Copy unavailable'}" title="${canCopy ? 'Copy error' : 'Clipboard unavailable'}" ${canCopy ? '' : 'disabled'}>${icons.copy}</button>
+    </div>
+  `).join('');
+}
+
+/** Mount the framework-independent runtime chip in an isolated shadow root. */
+export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRuntimeChip {
+  const documentLike = options.document ?? document;
+  const host = documentLike.createElement('div');
+  host.setAttribute('data-pyric-runtime-chip-host', '');
+  const root = host.attachShadow({ mode: 'open' });
+  root.innerHTML = `<style>${styles}</style><div class="announcer" role="status" aria-live="polite" aria-atomic="true"></div><div data-view></div>`;
+  const view = root.querySelector<HTMLElement>('[data-view]')!;
+  const announcer = root.querySelector<HTMLElement>('.announcer')!;
+  const clipboard = options.clipboard
+    ?? documentLike.defaultView?.navigator.clipboard;
+  let open = options.initiallyOpen ?? false;
+  let snapshot = options.runtime.getSnapshot();
+
+  const render = (next = snapshot): void => {
+    const active = root.activeElement;
+    const oldViewport = view.querySelector<HTMLElement>('[data-error-viewport]');
+    const oldScroll = oldViewport
+      ? {
+          top: oldViewport.scrollTop,
+          atBottom: oldViewport.scrollHeight - oldViewport.scrollTop - oldViewport.clientHeight <= 8,
+        }
+      : null;
+    const activeCopyId = active?.getAttribute('data-copy-error');
+    const activeControl = ['data-expand', 'data-collapse', 'data-update-worker', 'data-open-studio']
+      .find((attribute) => active?.hasAttribute(attribute));
+    const focusToken = activeCopyId !== null && activeCopyId !== undefined
+      ? { attribute: 'data-copy-error', value: activeCopyId }
+      : activeControl
+        ? { attribute: activeControl, value: null }
+        : null;
+    snapshot = next;
+    const errorCount = snapshot.errors.length;
+    const workerLabel = snapshot.updateAvailable
+      ? 'New worker available'
+      : snapshot.mode === 'starting'
+        ? 'Sandbox starting'
+        : snapshot.mode === 'in-page'
+          ? 'In-page sandbox'
+          : 'Worker current';
+    const epochs = snapshot.updateAvailable
+      ? `${snapshot.runningEpoch?.slice(0, 8) ?? 'unknown'} → ${snapshot.servedEpoch?.slice(0, 8) ?? 'unknown'}`
+      : snapshot.runningEpoch?.slice(0, 8) ?? '';
+
+    view.innerHTML = `${open ? `
+      <section class="panel" role="dialog" aria-label="Pyric runtime">
+        <header class="panel-header">
+          <div class="panel-title"><span class="brand-mark">&gt;_</span><strong>Pyric runtime</strong>${errorCount > 0 ? `<span class="count">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span>` : ''}</div>
+          <button class="icon-button" type="button" data-collapse aria-label="Collapse Pyric runtime">${icons.close}</button>
+        </header>
+        <div class="worker-state"><span class="state-label${snapshot.updateAvailable ? ' available' : ''}"><span class="mini-dot"></span>${workerLabel}</span><span class="epochs">${epochs}</span></div>
+        <div class="errors" data-error-viewport>${renderErrors(snapshot, Boolean(clipboard))}</div>
+        <div class="actions">
+          <button class="button update" type="button" data-update-worker ${snapshot.updateAvailable ? '' : 'disabled'} aria-disabled="${snapshot.updateAvailable && !snapshot.updatingWorker ? 'false' : 'true'}">${snapshot.updatingWorker ? 'Updating…' : 'Update worker'}</button>
+          <a class="button" data-open-studio href="${escapeAttribute(snapshot.manifest.studioUrl)}" target="_blank" rel="noopener noreferrer">Studio${icons.external}</a>
+        </div>
+      </section>
+    ` : `
+      <button class="chip" type="button" data-expand aria-label="Open Pyric runtime" aria-expanded="false">
+        <span class="brand"><span class="dot${errorCount > 0 ? ' error' : ''}"></span><span class="brand-label">Pyric</span></span>
+        <span class="signals">${snapshot.updateAvailable ? '<span class="signal update">update</span>' : ''}${errorCount > 0 ? `<span class="signal">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span>` : '<span class="signal">ready</span>'}${icons.chevron}</span>
+      </button>
+    `}`;
+
+    const announcement = `${workerLabel}. ${errorCount === 0 ? 'No runtime errors' : `${errorCount} runtime ${errorCount === 1 ? 'error' : 'errors'}`}.`;
+    if (announcer.textContent !== announcement) announcer.textContent = announcement;
+    const newViewport = view.querySelector<HTMLElement>('[data-error-viewport]');
+    if (oldScroll && newViewport) {
+      newViewport.scrollTop = oldScroll.atBottom ? newViewport.scrollHeight : oldScroll.top;
+    }
+
+    for (const error of snapshot.errors) {
+      const row = [...root.querySelectorAll('[data-error-id]')]
+        .find((candidate) => candidate.getAttribute('data-error-id') === error.id);
+      const code = row?.querySelector('code');
+      const meta = row?.querySelector('.error-meta');
+      if (code) code.textContent = error.message;
+      if (meta) meta.textContent = [error.source, error.service && error.method ? `${error.service}.${error.method}` : error.service ?? error.method, error.path, error.code].filter(Boolean).join(' · ');
+    }
+
+    root.querySelector('[data-expand]')?.addEventListener('click', () => {
+      open = true;
+      render();
+      root.querySelector<HTMLButtonElement>('[data-collapse]')?.focus();
+    });
+    root.querySelector('[data-collapse]')?.addEventListener('click', () => {
+      open = false;
+      render();
+      root.querySelector<HTMLButtonElement>('[data-expand]')?.focus();
+    });
+    root.querySelector('[data-update-worker]')?.addEventListener('click', () => {
+      if (!snapshot.updateAvailable || snapshot.updatingWorker) return;
+      void options.runtime.updateWorker().catch(() => { /* status records and renders the failure */ });
+    });
+    for (const button of root.querySelectorAll<HTMLButtonElement>('[data-copy-error]')) {
+      button.addEventListener('click', () => {
+        const error = snapshot.errors.find((item) => item.id === button.dataset.copyError);
+        if (!error || !clipboard) return;
+        void clipboard.writeText(formatPyricRuntimeError(error)).catch(() => {
+          button.setAttribute('data-copy-failed', '');
+          button.setAttribute('aria-label', 'Copy failed');
+          button.title = 'Copy failed';
+        });
+      });
+    }
+    if (focusToken) {
+      const candidates = root.querySelectorAll<HTMLElement>(`[${focusToken.attribute}]`);
+      const replacement = [...candidates].find((candidate) =>
+        focusToken.value === null || candidate.getAttribute(focusToken.attribute) === focusToken.value);
+      replacement?.focus();
+    }
+  };
+
+  documentLike.body.append(host);
+  const unsubscribe = options.runtime.subscribe(render);
+  return {
+    element: host,
+    dispose() {
+      unsubscribe();
+      host.remove();
+    },
+  };
+}

--- a/packages/cli/test/serve/runtime/chip.test.ts
+++ b/packages/cli/test/serve/runtime/chip.test.ts
@@ -1,0 +1,146 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, mock } from 'bun:test';
+import { mountPyricRuntimeChip } from '../../../src/serve/runtime/chip.js';
+import { createPyricRuntimeStatus } from '../../../src/serve/runtime/status.js';
+import type { PyricRuntimeManifest } from '../../../src/serve/runtime/manifest.js';
+
+const manifest: PyricRuntimeManifest = {
+  studioUrl: '/__pyric/ui/',
+  worker: { url: '/__pyric/sdk/worker.js', name: 'pyric-shared-worker', servedEpoch: 'bbbbbbbbbbbbbbbb' },
+};
+
+function setup(options: {
+  initiallyOpen?: boolean;
+  clipboard?: Pick<Clipboard, 'writeText'> | null;
+} = {}) {
+  const dom = new JSDOM('<!doctype html><body></body>', { url: 'http://localhost/' });
+  const runtime = createPyricRuntimeStatus(manifest);
+  const writeText = mock(() => Promise.resolve());
+  const clipboard = options.clipboard === null
+    ? undefined
+    : options.clipboard ?? { writeText };
+  const chip = mountPyricRuntimeChip({
+    runtime,
+    document: dom.window.document,
+    ...(clipboard ? { clipboard } : {}),
+    ...(options.initiallyOpen === undefined ? {} : { initiallyOpen: options.initiallyOpen }),
+  });
+  const root = chip.element.shadowRoot!;
+  return { dom, runtime, chip, root, writeText };
+}
+
+describe('PyricRuntimeChip', () => {
+  it('is collapsed by default and surfaces errors and worker updates compactly', () => {
+    const { runtime, root } = setup();
+    expect(root.querySelector('[data-expand]')).not.toBeNull();
+    expect(root.textContent).toContain('ready');
+
+    runtime.reportError('write denied', 'sandbox');
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
+
+    expect(root.textContent).toContain('update');
+    expect(root.textContent).toContain('1 error');
+  });
+
+  it('keeps worker and Studio controls stable while update availability changes', () => {
+    const { runtime, root } = setup({ initiallyOpen: true });
+    const initialUpdate = root.querySelector<HTMLButtonElement>('[data-update-worker]')!;
+    expect(initialUpdate.disabled).toBe(true);
+    expect(root.querySelector('[data-open-studio]')?.getAttribute('href')).toBe('/__pyric/ui/');
+    expect(root.querySelector('[data-open-studio]')?.getAttribute('target')).toBe('_blank');
+
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
+    expect(root.querySelector<HTMLButtonElement>('[data-update-worker]')!.disabled).toBe(false);
+  });
+
+  it('moves focus with the compact and expanded controls', () => {
+    const { root } = setup();
+    root.querySelector<HTMLButtonElement>('[data-expand]')!.click();
+    expect(root.activeElement?.hasAttribute('data-collapse')).toBe(true);
+
+    root.querySelector<HTMLButtonElement>('[data-collapse]')!.click();
+    expect(root.activeElement?.hasAttribute('data-expand')).toBe(true);
+  });
+
+  it('preserves the focused control across runtime publications', () => {
+    const { runtime, root } = setup({ initiallyOpen: true });
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
+    const announcer = root.querySelector('.announcer');
+    const update = root.querySelector<HTMLButtonElement>('[data-update-worker]')!;
+    update.focus();
+
+    runtime.reportError('a new sandbox error', 'sandbox');
+
+    expect(root.activeElement?.hasAttribute('data-update-worker')).toBe(true);
+    expect(root.querySelector('.announcer')).toBe(announcer);
+    expect(announcer?.textContent).toContain('1 runtime error');
+  });
+
+  it('preserves the error viewport position across runtime publications', () => {
+    const { runtime, root } = setup({ initiallyOpen: true });
+    runtime.reportError('first', 'sandbox');
+    const viewport = root.querySelector<HTMLElement>('[data-error-viewport]')!;
+    Object.defineProperties(viewport, {
+      scrollHeight: { value: 300 },
+      clientHeight: { value: 100 },
+    });
+    viewport.scrollTop = 40;
+
+    runtime.reportError('second', 'sandbox');
+
+    expect(root.querySelector<HTMLElement>('[data-error-viewport]')!.scrollTop).toBe(40);
+  });
+
+  it('renders a scrollable error viewport and copies the selected error', async () => {
+    const { runtime, root, writeText } = setup({ initiallyOpen: true });
+    runtime.reportError(Object.assign(new Error('listener failed'), { code: 'permission-denied' }), 'sandbox');
+
+    expect(root.querySelector('[data-error-viewport]')).not.toBeNull();
+    expect(root.querySelector('.error-body')?.textContent).toContain('listener failed');
+    root.querySelector<HTMLButtonElement>('[data-copy-error]')!.click();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0]?.[0]).toContain('listener failed');
+    expect(writeText.mock.calls[0]?.[0]).toContain('permission-denied');
+  });
+
+  it('disables copy when the Clipboard API is unavailable', () => {
+    const { runtime, root } = setup({ initiallyOpen: true, clipboard: null });
+    runtime.reportError('listener failed', 'sandbox');
+
+    const copy = root.querySelector<HTMLButtonElement>('[data-copy-error]')!;
+    expect(copy.disabled).toBe(true);
+    expect(copy.getAttribute('aria-label')).toBe('Copy unavailable');
+  });
+
+  it('handles a rejected clipboard write and exposes failure on the control', async () => {
+    const writeText = mock(() => Promise.reject(new Error('permission denied')));
+    const { runtime, root } = setup({ initiallyOpen: true, clipboard: { writeText } });
+    runtime.reportError('listener failed', 'sandbox');
+    const copy = root.querySelector<HTMLButtonElement>('[data-copy-error]')!;
+    copy.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(copy.hasAttribute('data-copy-failed')).toBe(true);
+    expect(copy.getAttribute('aria-label')).toBe('Copy failed');
+  });
+
+  it('invokes the runtime updater and disposes its host', async () => {
+    const { runtime, root, chip, dom } = setup({ initiallyOpen: true });
+    const update = mock(() => Promise.resolve());
+    runtime.setWorkerUpdater(update);
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
+    const button = root.querySelector<HTMLButtonElement>('[data-update-worker]')!;
+    button.focus();
+    button.click();
+    await Promise.resolve();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(root.activeElement?.hasAttribute('data-update-worker')).toBe(true);
+    expect(root.querySelector('[data-update-worker]')?.getAttribute('aria-disabled')).toBe('true');
+    chip.dispose();
+    expect(dom.window.document.querySelector('[data-pyric-runtime-chip-host]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds `PyricRuntimeChip`, the framework-independent runtime UI that keeps sandbox health compact until a developer opens it.

```ts
const chip = mountPyricRuntimeChip({
  runtime: getPyricRuntimeStatus(),
});

// The collapsed chip shows worker-update and error signals. Opening it reveals
// copyable runtime errors, a stable update-worker control, and a Studio link.
chip.dispose();
```

## Runtime state stays visible without taking over the app

The component mounts in an isolated shadow root and uses the playground palette, typography, density, and status semantics. It is collapsed by default. Its compact face distinguishes a healthy runtime, retained errors, and a newer served worker without requiring the developer to open Studio.

The expanded panel gives retained runtime errors a bounded scroll port and a copy button per error. The update-worker control always occupies the same action slot, but remains disabled until the runtime reports a newer worker epoch. Studio opens at the runtime manifest's URL in a new tab.

This PR deliberately stops at the component boundary. The next stacked PR injects and configures it through `pyric()`; keeping mounting separate makes the UI contract reviewable before it becomes automatic behavior.

## Risk

The chip uses a very high fixed stacking layer and isolated styling so host applications cannot accidentally erase its diagnostics. Review should judge whether that overlay behavior, bottom-right placement, keyboard focus handoff, and retained-error disclosure are appropriate for a development-only surface.

<details>
<summary>Implementation notes</summary>

- The UI question was tested as three real-playground variants on `prototype/runtime-chip` at `0ee5444b`: anchored chip, bottom console, and sidecar. The anchored chip won because it preserves working width and reads as a transient runtime signal rather than app chrome.
- Runtime/component and dependency suites: 32 passed.
- CLI build and TypeScript check: passed.
- Publish manifest lint (`publint`, `attw`, exports-to-dist drift): passed for all four packages.
- `git diff --check`: passed.
- This PR is stacked on #412 and should merge after it.

</details>
