### PR TITLE
feat(vite): inject the runtime chip

### DIFF
--- a/packages/cli/src/serve/entries/init.ts
+++ b/packages/cli/src/serve/entries/init.ts
@@ -14,6 +14,8 @@ import { useWorker, workerDb } from './worker-runtime.js';
 import { ServeAuthHelper } from './auth-helper-core.js';
 import { installServeAuthResolver } from './auth-helper-runtime.js';
 import { mountAuthHelperDialog } from './auth-helper-dom.js';
+import { installPyricRuntimeChip } from '../runtime/chip-install.js';
+import { getPyricRuntimeStatus } from '../runtime/status.js';
 
 const localAuth = useWorker ? null : getAuth(sandbox);
 const workerAuth = useWorker && workerDb ? getWorkerAuth(workerDb) : null;
@@ -42,5 +44,6 @@ const resolver = helper.resolver();
 installServeAuthResolver(resolver);
 if (localAuth) authSandbox.setAuthFlowResolver(localAuth, resolver);
 mountAuthHelperDialog(helper);
+installPyricRuntimeChip({ runtime: getPyricRuntimeStatus(), document });
 
 export {};

--- a/packages/cli/src/serve/runtime/chip-config.ts
+++ b/packages/cli/src/serve/runtime/chip-config.ts
@@ -1,0 +1,30 @@
+export type PyricRuntimeChipOption = boolean | { initiallyOpen?: boolean };
+
+export interface PyricRuntimeChipConfig {
+  initiallyOpen: boolean;
+  studioEnabled: boolean;
+}
+
+export const PYRIC_RUNTIME_CHIP_META = 'pyric-runtime-chip';
+
+/** Encode the Vite option as declarative HTML consumed by the init entry. */
+export function runtimeChipMetaValue(option: PyricRuntimeChipOption | undefined): string {
+  if (option === false) return 'off';
+  return typeof option === 'object' && option.initiallyOpen ? 'expanded' : 'collapsed';
+}
+
+interface RuntimeChipDocument {
+  querySelector(selector: string): { getAttribute(name: string): string | null } | null;
+}
+
+/** Read only plugin-authored values; absent/unknown metadata keeps the UI off. */
+export function readPyricRuntimeChipConfig(
+  documentLike: RuntimeChipDocument,
+): PyricRuntimeChipConfig | null {
+  const meta = documentLike.querySelector(`meta[name="${PYRIC_RUNTIME_CHIP_META}"]`);
+  const value = meta?.getAttribute('content');
+  const studioEnabled = meta?.getAttribute('data-studio') !== 'off';
+  if (value === 'collapsed') return { initiallyOpen: false, studioEnabled };
+  if (value === 'expanded') return { initiallyOpen: true, studioEnabled };
+  return null;
+}

--- a/packages/cli/src/serve/runtime/chip-install.ts
+++ b/packages/cli/src/serve/runtime/chip-install.ts
@@ -1,0 +1,27 @@
+import {
+  mountPyricRuntimeChip,
+  type PyricRuntimeChip,
+  type PyricRuntimeChipOptions,
+} from './chip.js';
+import { readPyricRuntimeChipConfig } from './chip-config.js';
+import type { PyricRuntimeStatus } from './status.js';
+
+export interface InstallPyricRuntimeChipOptions {
+  runtime: PyricRuntimeStatus;
+  document: Document;
+  mount?: (options: PyricRuntimeChipOptions) => PyricRuntimeChip;
+}
+
+/** Mount once when the Vite plugin opted this page into runtime UI. */
+export function installPyricRuntimeChip(
+  options: InstallPyricRuntimeChipOptions,
+): PyricRuntimeChip | null {
+  const config = readPyricRuntimeChipConfig(options.document);
+  if (!config || options.document.querySelector('[data-pyric-runtime-chip-host]')) return null;
+  return (options.mount ?? mountPyricRuntimeChip)({
+    runtime: options.runtime,
+    document: options.document,
+    initiallyOpen: config.initiallyOpen,
+    ...(config.studioEnabled ? {} : { studioUrl: null }),
+  });
+}

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -9,6 +9,8 @@ export interface PyricRuntimeChipOptions {
   document?: Document;
   clipboard?: Pick<Clipboard, 'writeText'>;
   initiallyOpen?: boolean;
+  /** Override Studio availability. Omitted uses the runtime manifest URL. */
+  studioUrl?: string | null;
 }
 
 export interface PyricRuntimeChip {
@@ -161,6 +163,9 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
   const announcer = root.querySelector<HTMLElement>('.announcer')!;
   const clipboard = options.clipboard
     ?? documentLike.defaultView?.navigator.clipboard;
+  const studioUrl = 'studioUrl' in options
+    ? options.studioUrl
+    : options.runtime.getSnapshot().manifest.studioUrl;
   let open = options.initiallyOpen ?? false;
   let snapshot = options.runtime.getSnapshot();
 
@@ -204,7 +209,9 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
         <div class="errors" data-error-viewport>${renderErrors(snapshot, Boolean(clipboard))}</div>
         <div class="actions">
           <button class="button update" type="button" data-update-worker ${snapshot.updateAvailable ? '' : 'disabled'} aria-disabled="${snapshot.updateAvailable && !snapshot.updatingWorker ? 'false' : 'true'}">${snapshot.updatingWorker ? 'Updating…' : 'Update worker'}</button>
-          <a class="button" data-open-studio href="${escapeAttribute(snapshot.manifest.studioUrl)}" target="_blank" rel="noopener noreferrer">Studio${icons.external}</a>
+          ${studioUrl
+            ? `<a class="button" data-open-studio href="${escapeAttribute(studioUrl)}" target="_blank" rel="noopener noreferrer">Studio${icons.external}</a>`
+            : `<span class="button" data-open-studio aria-disabled="true" title="Pyric Studio is disabled">Studio${icons.external}</span>`}
         </div>
       </section>
     ` : `

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -93,6 +93,11 @@ import {
   type PyricAiOptions,
 } from './vite-ai-config.js';
 import { resolveViteRulesConfig } from './vite-rules-source.js';
+import {
+  PYRIC_RUNTIME_CHIP_META,
+  runtimeChipMetaValue,
+  type PyricRuntimeChipOption,
+} from './runtime/chip-config.js';
 
 /**
  * Whether a `vite build` should run the firebase→pyric swap (produce a SANDBOX
@@ -161,6 +166,10 @@ export interface PyricOptions {
    *  so app, Studio, and agent all observe the one sandbox); pass `ui: false`
    *  to disable. */
   ui?: boolean;
+  /** Inject the collapsed Pyric runtime chip into the app during sandbox Vite
+   *  dev/builds. On by default. Pass `false` to hide it, or
+   *  `{ initiallyOpen: true }` when actively debugging runtime errors. */
+  runtimeChip?: PyricRuntimeChipOption;
   /** RTDB-triggered Cloud Functions under this dev server (the `pyric dev`
    *  parity fold). By default a `functions` block in `firebase.json` is
    *  discovered automatically: its `onValueCreated` triggers run in an isolated
@@ -1012,6 +1021,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
     },
 
     transformIndexHtml(html) {
+      const runtimeChipTag = `<meta name="${PYRIC_RUNTIME_CHIP_META}" content="${runtimeChipMetaValue(options.runtimeChip)}" data-studio="${options.ui === false ? 'off' : 'on'}" data-pyric-sandbox>`;
       // Sandbox BUILD: the app's own `firebase/*` imports were already swapped
       // (resolveId, above) to pyric's in-page adapters and BUNDLED into the app
       // chunk, and the emitted init chunk (script-tagged here) carries the
@@ -1028,7 +1038,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
         const initTag = initChunkFile
           ? `<script type="module" crossorigin src="/${initChunkFile}" data-pyric-sandbox-init></script>`
           : '';
-        const tags = SANDBOX_BUILD_META + initTag;
+        const tags = SANDBOX_BUILD_META + runtimeChipTag + initTag;
         return html.includes('</head>')
           ? html.replace('</head>', `${tags}</head>`)
           : tags + html;
@@ -1058,7 +1068,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // Boot the sandbox by loading the real init entry as a module (Vite
       // serves + transforms it). The init module's top-level await deploys rules
       // before app code runs. Mirrors serve's injectServeTags.
-      const tag = head + aiEngineTag + `<script type="module" src="/@fs/${entries.init}" ${MARKER}></script>`;
+      const tag = head + aiEngineTag + runtimeChipTag + `<script type="module" src="/@fs/${entries.init}" ${MARKER}></script>`;
       return html.includes('</head>') ? html.replace('</head>', `${tag}</head>`) : tag + html;
     },
   };

--- a/packages/cli/src/vite.ts
+++ b/packages/cli/src/vite.ts
@@ -8,6 +8,7 @@
  */
 export { pyric } from './serve/vite-plugin.js';
 export type { PyricOptions } from './serve/vite-plugin.js';
+export type { PyricRuntimeChipOption } from './serve/runtime/chip-config.js';
 
 // The benign node-builtin shims serve's bundler and this plugin apply when
 // bundling pyric's browser graph (`fs`/`path`/`url` reached via the rules

--- a/packages/cli/test/serve/runtime/chip-config.test.ts
+++ b/packages/cli/test/serve/runtime/chip-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  readPyricRuntimeChipConfig,
+  runtimeChipMetaValue,
+} from '../../../src/serve/runtime/chip-config.js';
+
+describe('Pyric runtime chip configuration', () => {
+  it('defaults to collapsed and supports the small explicit option surface', () => {
+    expect(runtimeChipMetaValue(undefined)).toBe('collapsed');
+    expect(runtimeChipMetaValue(true)).toBe('collapsed');
+    expect(runtimeChipMetaValue(false)).toBe('off');
+    expect(runtimeChipMetaValue({ initiallyOpen: true })).toBe('expanded');
+  });
+
+  it('reads only known plugin-authored metadata values', () => {
+    const documentWith = (content: string | null, studio = 'on') => ({
+      querySelector: () => content === null ? null : {
+        getAttribute: (name: string) => name === 'content' ? content : studio,
+      },
+    });
+    expect(readPyricRuntimeChipConfig(documentWith('collapsed'))).toEqual({ initiallyOpen: false, studioEnabled: true });
+    expect(readPyricRuntimeChipConfig(documentWith('expanded', 'off'))).toEqual({ initiallyOpen: true, studioEnabled: false });
+    expect(readPyricRuntimeChipConfig(documentWith('off'))).toBeNull();
+    expect(readPyricRuntimeChipConfig(documentWith('unexpected'))).toBeNull();
+    expect(readPyricRuntimeChipConfig(documentWith(null))).toBeNull();
+  });
+});

--- a/packages/cli/test/serve/runtime/chip-install.test.ts
+++ b/packages/cli/test/serve/runtime/chip-install.test.ts
@@ -1,0 +1,53 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, mock } from 'bun:test';
+import { installPyricRuntimeChip } from '../../../src/serve/runtime/chip-install.js';
+import { createPyricRuntimeStatus } from '../../../src/serve/runtime/status.js';
+import type { PyricRuntimeChip } from '../../../src/serve/runtime/chip.js';
+
+function setup(content?: string, studio = 'on') {
+  const meta = content === undefined ? '' : `<meta name="pyric-runtime-chip" content="${content}" data-studio="${studio}">`;
+  const dom = new JSDOM(`<!doctype html><head>${meta}</head><body></body>`, { url: 'http://localhost/' });
+  const runtime = createPyricRuntimeStatus({
+    studioUrl: '/__pyric/ui/',
+    worker: { url: '/__pyric/sdk/worker.js', name: 'pyric-shared-worker', servedEpoch: null },
+  });
+  const mounted = { element: dom.window.document.createElement('div'), dispose() {} };
+  const mount = mock((): PyricRuntimeChip => mounted);
+  return { dom, runtime, mount, mounted };
+}
+
+describe('installPyricRuntimeChip', () => {
+  it('mounts the configured chip once with its initial state', () => {
+    const { dom, runtime, mount, mounted } = setup('expanded');
+    const installed = installPyricRuntimeChip({ runtime, document: dom.window.document, mount });
+
+    expect(installed).toBe(mounted);
+    expect(mount).toHaveBeenCalledTimes(1);
+    expect(mount.mock.calls[0]?.[0]).toMatchObject({ runtime, initiallyOpen: true });
+  });
+
+  it('does not mount without opt-in metadata or when explicitly off', () => {
+    for (const content of [undefined, 'off']) {
+      const { dom, runtime, mount } = setup(content);
+      expect(installPyricRuntimeChip({ runtime, document: dom.window.document, mount })).toBeNull();
+      expect(mount).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not duplicate an existing runtime chip host', () => {
+    const { dom, runtime, mount } = setup('collapsed');
+    const existing = dom.window.document.createElement('div');
+    existing.setAttribute('data-pyric-runtime-chip-host', '');
+    dom.window.document.body.append(existing);
+
+    expect(installPyricRuntimeChip({ runtime, document: dom.window.document, mount })).toBeNull();
+    expect(mount).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Studio action present but disabled when Vite UI is off', () => {
+    const { dom, runtime, mount } = setup('collapsed', 'off');
+    installPyricRuntimeChip({ runtime, document: dom.window.document, mount });
+
+    expect(mount.mock.calls[0]?.[0]).toMatchObject({ studioUrl: null });
+  });
+});

--- a/packages/cli/test/serve/runtime/chip.test.ts
+++ b/packages/cli/test/serve/runtime/chip.test.ts
@@ -12,6 +12,7 @@ const manifest: PyricRuntimeManifest = {
 function setup(options: {
   initiallyOpen?: boolean;
   clipboard?: Pick<Clipboard, 'writeText'> | null;
+  studioUrl?: string | null;
 } = {}) {
   const dom = new JSDOM('<!doctype html><body></body>', { url: 'http://localhost/' });
   const runtime = createPyricRuntimeStatus(manifest);
@@ -24,6 +25,7 @@ function setup(options: {
     document: dom.window.document,
     ...(clipboard ? { clipboard } : {}),
     ...(options.initiallyOpen === undefined ? {} : { initiallyOpen: options.initiallyOpen }),
+    ...('studioUrl' in options ? { studioUrl: options.studioUrl } : {}),
   });
   const root = chip.element.shadowRoot!;
   return { dom, runtime, chip, root, writeText };
@@ -51,6 +53,13 @@ describe('PyricRuntimeChip', () => {
 
     runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
     expect(root.querySelector<HTMLButtonElement>('[data-update-worker]')!.disabled).toBe(false);
+  });
+
+  it('keeps a disabled Studio action in place when Studio is unavailable', () => {
+    const { root } = setup({ initiallyOpen: true, studioUrl: null });
+    const studio = root.querySelector('[data-open-studio]');
+    expect(studio?.tagName).toBe('SPAN');
+    expect(studio?.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('moves focus with the compact and expanded controls', () => {

--- a/packages/cli/test/serve/vite-plugin-runtime-chip.test.ts
+++ b/packages/cli/test/serve/vite-plugin-runtime-chip.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import { pyric } from '../../src/serve/vite-plugin.js';
+
+type PyricPlugin = ReturnType<typeof pyric>;
+
+function transform(plugin: PyricPlugin): string {
+  return (plugin.transformIndexHtml as (html: string) => string)(
+    '<html><head></head><body></body></html>',
+  );
+}
+
+describe('pyric() runtime chip injection', () => {
+  it('injects the collapsed chip configuration by default before the init module', () => {
+    const html = transform(pyric());
+    const meta = 'name="pyric-runtime-chip" content="collapsed"';
+
+    expect(html).toContain(meta);
+    expect(html.indexOf(meta)).toBeLessThan(html.indexOf('/@fs/'));
+  });
+
+  it('supports the opt-out and initially-open configuration without another plugin', () => {
+    expect(transform(pyric({ runtimeChip: false }))).toContain(
+      'name="pyric-runtime-chip" content="off"',
+    );
+    expect(transform(pyric({ runtimeChip: { initiallyOpen: true } }))).toContain(
+      'name="pyric-runtime-chip" content="expanded"',
+    );
+  });
+
+  it('disables the stable Studio action when the Vite Studio mount is off', () => {
+    expect(transform(pyric({ ui: false }))).toContain('data-studio="off"');
+  });
+
+  it('carries the same configuration into sandbox builds only when the plugin applies', () => {
+    const plugin = pyric();
+    const applies = plugin.apply as (
+      config: unknown,
+      env: { command: 'build'; mode: string },
+    ) => boolean;
+    expect(applies({}, { command: 'build', mode: 'production' })).toBe(false);
+    expect(applies({}, { command: 'build', mode: 'development' })).toBe(true);
+
+    (plugin.config as (config: unknown, env: unknown) => unknown)(
+      {},
+      { command: 'build', mode: 'development' },
+    );
+    const html = transform(plugin);
+    expect(html).toContain('data-pyric-sandbox-build');
+    expect(html).toContain('name="pyric-runtime-chip" content="collapsed"');
+  });
+});

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -69,7 +69,7 @@ describe('pyric — plugin shape', () => {
     expect(applies(forcedOff, 'serve', 'production')).toBe(true); // dev still always on
   });
 
-  it('sandbox build: transformIndexHtml stamps ONLY the marker (no init/@fs, no force-in-page)', () => {
+  it('sandbox build: transformIndexHtml stamps sandbox metadata (no init/@fs or force-in-page)', () => {
     const p = pyric();
     // Flag the plugin as a build (apply already gated it upstream).
     (p.config as (c: unknown, env: unknown) => unknown)({}, { command: 'build', mode: 'development' });
@@ -196,6 +196,7 @@ describe('transformIndexHtml — sandbox boot injection', () => {
   it('omits the AI global when no plugin engine is configured', () => {
     expect(xform('<html><head></head></html>')).not.toContain('__PYRIC_AI_ENGINE__');
   });
+
 });
 
 // ── integration: the plugin works inside a REAL Vite dev server ───────────────


### PR DESCRIPTION
Makes `pyric()` mount the collapsed runtime chip automatically in Vite sandbox pages, with no new setup in the hero path.

```ts
import { defineConfig } from 'vite';
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [pyric()], // collapsed runtime health, errors, updates, and Studio
});
```

## The default stays simple and the escape hatches stay local

```ts
pyric({ runtimeChip: false });

pyric({
  runtimeChip: { initiallyOpen: true },
});
```

The plugin writes a declarative `pyric-runtime-chip` meta value before its existing init module. The init entry reads only the known `collapsed`, `expanded`, and `off` states, mounts once, and ignores absent or unknown metadata. A normal production-mode Vite build still does not apply the sandbox plugin, so neither the sandbox runtime nor the chip reaches production output.

When `ui: false` disables Studio, the Studio action remains in its stable panel slot but is disabled instead of opening a known 404. The default `ui` behavior still opens Studio in a new tab.

## Risk

This changes the visible default of every Vite sandbox page from no runtime chrome to one collapsed bottom-right chip. Review should judge that default, confirm opt-out behavior, and verify the metadata/init ordering across dev and sandbox-build paths.

<details>
<summary>Implementation notes</summary>

- Full Vite/runtime-chip matrix: 95 passed, 5 explicitly gated bridge E2E tests skipped.
- Browser bundler/init graph: 21 passed.
- CLI build and TypeScript check: passed.
- `git diff --check`: passed.
- Configuration is HTML metadata, not executable inline configuration.
- This PR is stacked on #413 and should merge after it.

</details>
