### PR TITLE
docs: explain local AI and runtime recovery

### DIFF
--- a/packages/create-pyric/templates/chat/.env.example
+++ b/packages/create-pyric/templates/chat/.env.example
@@ -12,9 +12,11 @@ VITE_FIREBASE_DATABASE_URL=
 # production FCM token registration; the dev sandbox mints tokens without it.
 VITE_FIREBASE_VAPID_KEY=
 
-# Optional local model. Leave unset to use Pyric's built-in scripted AI.
-# This model-only path uses Ollama at http://localhost:11434/v1 by default.
+# Optional local model. Setting this switches from Pyric's scripted AI to its
+# OpenAI-compatible engine and supplies the model name sent upstream.
+# The model-only path uses Ollama at http://localhost:11434/v1 by default.
 # Example: ollama pull qwen3:4b
 PYRIC_AI_MODEL=
-# Override only when using another OpenAI-compatible model server.
+# Override only for another OpenAI-compatible model server. This is the
+# server-side base URL, not the browser proxy path; include /v1 when required.
 PYRIC_AI_PROXY_UPSTREAM=

--- a/packages/create-pyric/templates/chat/README.md
+++ b/packages/create-pyric/templates/chat/README.md
@@ -34,7 +34,20 @@ PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
 
 Start the model server separately, then restart Vite.
 See the [Pyric AI Logic guide](https://pyric.dev/docs/build/ai-logic/) for the full
-engine and proxy behavior.
+engine and proxy behaviour.
+
+For a one-off run on macOS, Linux, or another POSIX shell, prefix the same
+command with the variables:
+
+```bash
+PYRIC_AI_MODEL=qwen3:4b \
+PYRIC_AI_PROXY_UPSTREAM=http://localhost:11434/v1 \
+npm run dev
+```
+
+Do not put `&&` before `npm run dev`: that makes the values unexported shell
+variables instead of environment variables for Vite. Use `.env.local` for the
+normal, persistent setup.
 
 ## What runs in the sandbox
 
@@ -49,6 +62,15 @@ For native notifications, sign in and use the bell once to grant permission.
 The same bundled module service worker handles `onBackgroundMessage` in local
 development and production. Local delivery still requires an open page to keep
 the Pyric sandbox alive.
+
+## Runtime status
+
+Pyric adds a collapsed runtime chip to the bottom-right corner during Vite
+development. It signals sandbox errors and tells you when the long-lived worker
+needs an update. Open it to copy an error, activate the new worker safely,
+or open Pyric Studio in a new tab. Updating finishes accepted sandbox work and
+then reloads every connected tab onto the new worker. The chip is not included
+in a normal production build.
 
 ## Test and build
 

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -154,7 +154,11 @@ describe('runScaffold', () => {
       expect(generated.name).toBe('thinking-room');
       expect(generated.devDependencies['@pyric/cli']).toBe('^1.2.3');
       expect(generated.devDependencies.pyric).toBe('^1.2.3');
-      expect(readFileSync(join(project, 'README.md'), 'utf8')).toContain('# thinking-room');
+      const readme = readFileSync(join(project, 'README.md'), 'utf8');
+      expect(readme).toContain('# thinking-room');
+      expect(readme).toContain('PYRIC_AI_MODEL=qwen3:4b \\');
+      expect(readme).toContain('Do not put `&&` before `npm run dev`');
+      expect(readme).toContain('## Runtime status');
       expect(readFileSync(join(project, 'index.html'), 'utf8')).toContain('<title>thinking-room');
       expect(readFileSync(join(project, '.gitignore'), 'utf8')).toContain('node_modules/');
       expect(readdirSync(project)).not.toContain('scaffold.json');

--- a/packages/site-docs/src/content/build/ai-logic.md
+++ b/packages/site-docs/src/content/build/ai-logic.md
@@ -10,6 +10,7 @@ description: "Keep Firebase AI Logic application code unchanged while model resp
 # Run Firebase AI Logic locally
 
 Keep using the Firebase AI Logic Web API:
+
 ```ts
 import { getAI, getGenerativeModel } from 'firebase/ai';
 
@@ -17,13 +18,15 @@ const ai = getAI(app);
 const model = getGenerativeModel(ai, {
   model: 'gemini-flash-lite-latest',
 });
-const result = await model.generateContent('Summarize this report.');
+const result = await model.generateContent('Summarise this report.');
 ```
-During development, Pyric answers through a local engine instead of a Google AI endpoint. A production build runs the same application code through Firebase. Use the [Firebase AI Logic Web guide](https://firebase.google.com/docs/ai-logic/get-started?platform=web) for normal model, prompt, chat, streaming, schema, and function-calling APIs.
 
-## Choose how the sandbox answers
+During development, Pyric answers through a local engine instead of a Google AI endpoint. A normal production build runs the same application code through Firebase. Use the [Firebase AI Logic Web guide](https://firebase.google.com/docs/ai-logic/get-started?platform=web) for the application API.
 
-The default scripted engine is deterministic and makes no network requests. Test setup can queue an exact response through the sandbox-only scripting entry point:
+## Start with deterministic responses
+
+With no AI configuration, Pyric uses its built-in scripted engine. It makes no network requests and gives deterministic responses. Tests can queue an exact response through the sandbox-only scripting entry point:
+
 ```ts
 import { getAI } from 'pyric/ai';
 import { script } from 'pyric/ai/scripting';
@@ -31,42 +34,87 @@ import { script } from 'pyric/ai/scripting';
 const ai = getAI(app);
 script(ai, [
   {
-    match: 'Summarize this report.',
+    match: 'Summarise this report.',
     respond: { text: 'The report is ready for review.' },
   },
 ]);
 ```
+
 Keep scripted setup outside application code that ships.
 
-## Answer with a real local model (Ollama)
+## Use a local model
 
-The sandbox can answer through any OpenAI-compatible server — a local [Ollama](https://ollama.com), llama.cpp, anything speaking `/v1/chat/completions` — while your application keeps making unchanged Firebase AI Logic calls. Pass the `engine` option on the app's own `getAI` call from `firebase/ai`, the handle the application actually queries, so the setting reaches the code that answers:
+For Ollama, put the model identifier in `.env.local` at the Vite project root:
 
-```ts
-import { getAI, type AIOptions } from 'firebase/ai';
-
-const ai = getAI(app, {
-  engine: { kind: 'openai', model: 'llama3.2' },
-} as AIOptions);
+```bash
+ollama pull qwen3:4b
 ```
 
-The first `getAI` call for an app decides its engine; later calls with different options are ignored, so configure it where the app first creates its AI handle.
-
-`engine` is a pyric extension that only the sandbox reads. At runtime, production `firebase/ai` ignores the extra option; in TypeScript, `AIOptions` has no `engine` member, so a typed build needs the options object cast — the `as AIOptions` above — or the engine kept in a development-only branch.
-
-With no `baseUrl`, answering routes through `pyric dev`'s same-origin AI proxy at `/__pyric/ai-proxy`, which forwards to `http://localhost:11434/v1` — a locally running Ollama works with zero CORS setup, no `OLLAMA_ORIGINS`, nothing. Point the proxy at a different server with the `PYRIC_AI_PROXY_UPSTREAM` environment variable on `pyric dev`.
-
-Use `modelMap` to send specific Gemini model ids to specific upstream models; `model` stays the catch-all for anything unmatched.
-
-```ts
-engine: { kind: 'openai', modelMap: { 'gemini-2.5-flash': 'llama3.2' } }
+```dotenv
+PYRIC_AI_MODEL=qwen3:4b
 ```
 
-`maxOutputTokens`, `temperature`, `topP`, `stopSequences`, and JSON response formatting carry over to the OpenAI request. `topK` and `thinkingConfig` have no equivalent and are dropped in development, though production still honors them. When a local thinking model returns its reasoning, it surfaces as thought parts.
+Then restart Vite:
 
-Gemini-shaped requests go out as OpenAI-compatible ones and come back Gemini-shaped, so streaming, chat history, and function calling all flow through. The [AI chat example](https://github.com/davideast/pyric/tree/main/examples/ai-chat) runs both engines side by side.
+```bash
+npm run dev
+```
 
-Local engines do not reproduce model quality, safety policy, latency, quotas, billing, or service availability. Verify model-dependent behavior against the production backend before release.
+That one variable switches Pyric from the scripted engine to its OpenAI-compatible engine. `PYRIC_AI_MODEL` is the model name Pyric sends to the upstream server. It is also the catch-all mapping when the application requests a Firebase model name such as `gemini-flash-lite-latest`.
+
+Ollama's default OpenAI-compatible base URL is already Pyric's default: `http://localhost:11434/v1`. Start Ollama separately and make sure the selected model is installed.
+
+## Point Pyric at another model server
+
+Set `PYRIC_AI_PROXY_UPSTREAM` only when the model server is somewhere other than the default Ollama URL:
+
+```dotenv
+PYRIC_AI_MODEL=minimax-m2.7
+PYRIC_AI_PROXY_UPSTREAM=http://localhost:8080/v1
+```
+
+The two settings have different jobs:
+
+- `PYRIC_AI_MODEL` selects the model and activates the OpenAI-compatible engine.
+- `PYRIC_AI_PROXY_UPSTREAM` selects the server to which Pyric forwards requests. It is an OpenAI-compatible server base URL, not a Firebase endpoint and not a browser URL. Include `/v1` when that server expects it.
+
+Your browser still calls Pyric on the same origin at `/__pyric/ai-proxy`. The Vite server forwards that request to the upstream server's `/chat/completions` endpoint. This server-side hop avoids browser CORS configuration. An upstream URL alone does not select a model or replace the scripted engine, which is why `PYRIC_AI_MODEL` is still required.
+
+## Set the variables for one command
+
+On macOS, Linux, and other POSIX shells, prefix the same command with both variables:
+
+```bash
+PYRIC_AI_MODEL=qwen3:4b \
+PYRIC_AI_PROXY_UPSTREAM=http://localhost:11434/v1 \
+npm run dev
+```
+
+Do not put `&&` before `npm run dev` like this:
+
+```bash
+# Wrong: these are unexported shell variables, so Vite does not receive them.
+PYRIC_AI_MODEL=qwen3:4b PYRIC_AI_PROXY_UPSTREAM=http://localhost:11434/v1 && npm run dev
+```
+
+The prefix form adds the variables to the environment of that `npm run dev` process. The `&&` form completes a shell-only assignment first, then starts npm as a separate command without exporting those values. Use `.env.local` for a durable project configuration; Vite loads it automatically, and it remains ignored by the template's Git configuration.
+
+## Configure the Vite plugin explicitly
+
+Environment variables keep the default `pyric()` configuration small. If a project needs configuration in code, use the equivalent plugin options:
+
+```ts
+pyric({
+  ai: {
+    model: 'qwen3:4b',
+    proxyUpstream: 'http://localhost:11434/v1',
+  },
+})
+```
+
+For model-specific routing or a scripted configuration shared by the whole dev server, the advanced `ai.engine` option accepts Pyric's declarative engine configuration. Choose either `ai.model` or `ai.engine`, not both. Explicit plugin options take precedence over Vite-loaded environment variables.
+
+Generation settings such as `maxOutputTokens`, `temperature`, `topP`, `stopSequences`, and JSON response formatting carry over to the OpenAI request. `topK` and `thinkingConfig` have no equivalent and are dropped locally. Local models do not reproduce production model quality, safety policy, latency, quotas, billing, or service availability, so verify model-dependent behaviour against the production backend before release.
 
 ## Check the supported boundary
 

--- a/packages/site-docs/src/content/get-started/how-the-swap-works.md
+++ b/packages/site-docs/src/content/get-started/how-the-swap-works.md
@@ -49,6 +49,8 @@ In development the sandbox runs in a SharedWorker, which has three consequences 
 
 This is also why Pyric Studio and an MCP-connected agent see exactly what your app sees: they route into the same worker.
 
+A SharedWorker can outlive a Vite module update, so a refreshed page may otherwise reconnect to an older sandbox runtime. Pyric compares the running worker's build identity with the one the dev server is currently serving. When they differ, the runtime chip offers an update. Activating it lets the old worker finish accepted work and flush captured state before it tells every connected tab to reload onto the new generation. See [Resolve runtime errors and stale workers](../observe/resolve-runtime-status.md) for the recovery steps and configuration.
+
 ## Node processes
 
 For a Node child process, `pyric dev` sets `PYRIC_SANDBOX` and preloads `@pyric/cli/register`, which maps `firebase/*` to `pyric/*` and `firebase-admin/*` to `pyric-admin/*` for that process. Same rule as the browser: activation present, sandbox; activation absent, Firebase.

--- a/packages/site-docs/src/content/get-started/start-building.md
+++ b/packages/site-docs/src/content/get-started/start-building.md
@@ -23,6 +23,8 @@ npm run dev
 
 Open the local URL printed by Vite. The application and Pyric Studio use the same local backend. Studio is mounted at `/__pyric/ui/` on that origin.
 
+Pyric also adds a small, collapsed runtime chip in the bottom-right corner. It stays quiet while the sandbox is healthy and signals when there is an error to inspect or a newer worker to activate. [Resolve runtime errors and stale workers](../observe/resolve-runtime-status.md) covers both actions.
+
 ## Add Pyric to an existing Vite application
 
 Install the development plugin:
@@ -43,7 +45,7 @@ Start the normal development server:
 ```bash
 npm run dev
 ```
-No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. The plugin discovers Firestore rules from `firebase.json`, or uses `firestore.rules` when no path is configured.
+No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. The plugin uses an explicit `rules` option first, then discovers `firestore.modules.rules`, the path in `firebase.json`, or `firestore.rules`, in that order.
 
 ## Use a static application or Node process
 

--- a/packages/site-docs/src/content/observe/resolve-runtime-status.md
+++ b/packages/site-docs/src/content/observe/resolve-runtime-status.md
@@ -1,0 +1,55 @@
+---
+title: "Resolve runtime errors and stale workers"
+navLabel: "Runtime status"
+group: "Observe & shape"
+section: ""
+order: 15
+description: "Use the Pyric runtime chip to inspect sandbox errors, activate a new worker, and open Studio."
+---
+
+# Resolve runtime errors and stale workers
+
+During Vite development, Pyric adds a compact runtime chip to the bottom-right corner of the application. It is collapsed by default and reports `ready` while the sandbox is healthy. Open it when the chip reports errors or an update.
+
+## Inspect a sandbox error
+
+1. Select the chip to open the runtime panel.
+2. Read the error in the scrollable error area.
+3. Use the copy button beside that error to paste the complete message and context into an issue, terminal, or agent conversation.
+4. Select **Studio** to open Pyric Studio in a new tab when you need to inspect the sandbox's data, rules, or traffic.
+
+The chip reports errors from the Pyric sandbox. Errors produced only by application UI code remain in the browser's normal developer tools.
+
+## Activate a new worker
+
+Vite can serve a newer Pyric worker while an older SharedWorker is still running for the origin. When that happens, the collapsed chip shows `update` and the panel labels the worker as **New worker available**.
+
+1. Save any unsaved, UI-only form input. Updating reloads every connected tab for this origin.
+2. Open the chip.
+3. Select **Update worker**.
+
+The old worker stops taking new work, finishes operations it already accepted, flushes captured state, and then reloads its connected tabs onto the new worker generation. The update control always occupies the same place in the panel, but remains disabled when the running worker is current.
+
+If replacement fails, the panel records the failure as a copyable error and leaves the update available so you can try again. Resolve the reported cause first. If a stale worker remains after a failed recovery, close every tab for that development origin and reopen the application.
+
+## Configure the chip
+
+The default configuration is the recommended one:
+
+```ts
+pyric()
+```
+
+To keep the panel open from the first load while actively debugging runtime failures:
+
+```ts
+pyric({ runtimeChip: { initiallyOpen: true } })
+```
+
+To hide the runtime surface entirely:
+
+```ts
+pyric({ runtimeChip: false })
+```
+
+The chip is a development surface. A normal production Vite build does not inject it. Disabling Pyric Studio with `ui: false` keeps the Studio action visible but unavailable, so the panel does not shift as its status changes.

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -219,6 +219,8 @@ assert_tar_has "$TARBALL_PYRIC" 'package/dist/rules/modules/stdlib/.*\.rules$' "
 assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/dist/bin\.js$' "create-pyric ships the create-pyric bin"
 assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/src/ui/chat/chat-page\.tsx$' "create-pyric ships the canonical chat app source"
 assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/src/firebase-messaging-sw\.ts$' "create-pyric ships the chat notification worker"
+assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/README\.md$' "create-pyric ships the chat setup guide"
+assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/\.env\.example$' "create-pyric ships the chat environment example"
 assert_tar_lacks "$TARBALL_CREATE_PYRIC" 'package/templates/chat/dist/' "create-pyric excludes the built chat dist/ tree"
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/cli/index\.js$' "@pyric/cli ships the pyric CLI bin"
 # The Vite plugin's `ui` option + `pyric dev --ui` resolve the Studio app from
@@ -239,6 +241,11 @@ assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/firestore\.js$' 
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/database\.js$' "@pyric/cli ships the firebase/database swap entry"
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/storage\.js$' "@pyric/cli ships the firebase/storage swap entry"
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/entries/init\.js$' "@pyric/cli ships the sandbox boot entry"
+# The boot entry imports these modules to expose runtime health and stale-worker
+# recovery. Missing files leave installed applications without their recovery UI.
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/runtime/chip\.js$' "@pyric/cli ships the runtime chip"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/runtime/chip-install\.js$' "@pyric/cli ships the runtime chip installer"
+assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/serve/runtime/chip-config\.js$' "@pyric/cli ships the runtime chip configuration"
 
 # ─── Phase 3: install all tarballs into a fresh consumer project ──────
 echo ""


### PR DESCRIPTION
Documents the zero-config Vite runtime surface and the model-server settings that turn unchanged `firebase/ai` calls into local-model requests.

```bash
ollama pull qwen3:4b
PYRIC_AI_MODEL=qwen3:4b npm run dev
```

## One model setting activates local AI; upstream only chooses its server

The AI Logic guide now starts with the built-in scripted engine, then teaches `PYRIC_AI_MODEL` as the one setting needed for Ollama. It defines `PYRIC_AI_PROXY_UPSTREAM` at first use as the server-side OpenAI-compatible base URL, shows why the browser still calls the same-origin `/__pyric/ai-proxy`, and documents both `.env.local` and correctly scoped POSIX command invocation.

The generated chat README carries the same runnable setup and explicitly shows why this does not pass variables to Vite:

```bash
# Wrong: the assignments finish before npm starts and are not exported.
PYRIC_AI_MODEL=qwen3:4b PYRIC_AI_PROXY_UPSTREAM=http://localhost:11434/v1 && npm run dev
```

## The collapsed runtime chip is the recovery path for errors and stale workers

The new Runtime status how-to shows how to copy sandbox errors, open Studio, and activate a newly served SharedWorker generation. It warns that connected tabs reload, explains the drain-and-capture boundary, gives the manual close-all-tabs fallback, and documents the complete Vite surface:

```ts
pyric() // collapsed by default
pyric({ runtimeChip: { initiallyOpen: true } })
pyric({ runtimeChip: false })
```

The quickstart introduces the chip without adding setup, while the import-swap explanation provides the worker-lifetime context. The quickstart also records the convention-first rules precedence introduced by the base PR.

## Risk

The main review risk is documentation drifting from the stacked implementation. The commands, option names, environment precedence, production exclusion, and worker-replacement behaviour were checked against the Vite and runtime sources. A second risk is publishing the docs while omitting their runtime or template assets; the packaging gate now asserts the three runtime-chip modules plus the chat README and `.env.example` in the actual tarballs.

<details>
<summary>Verification and review</summary>

- `bun run test:packaging` — PASS; all five packages built, packed, installed into fresh consumers, and resolved every advertised subpath
- `bun test --cwd packages/create-pyric` — 13 pass, 0 fail
- `bun run test:chat-template` — tests, typecheck, production build, and notification build checks pass
- `bun run --cwd packages/site-docs test` — 4 pass, 0 fail
- `bun run --cwd packages/site-docs build` — 91 pages built; the existing CSS minifier warning remains non-fatal
- `bun run lint:manifest` — publint, attw, and exports/dist drift pass for all published packages
- `git diff --check` — clean
- Independent documentation and release-readiness cold reviews — clean after correcting the one-off model name and worker wording
- `docs/site-rewrite/AI-MODEL-SERVER-PROPOSAL.md` is an unrelated, untracked user draft and is not part of this PR

</details>
