### PR TITLE
fix(chat-template): read presence data compatibly

### DIFF
--- a/packages/create-pyric/templates/chat/functions/index.js
+++ b/packages/create-pyric/templates/chat/functions/index.js
@@ -24,7 +24,7 @@ export const onPresenceOnline = onValueCreated('/presence/{uid}', async (event) 
   const profile = getFirestore().collection('users').doc(uid);
   const snapshot = await profile.get();
   const now = FieldValue.serverTimestamp();
-  const seen = snapshot.exists && snapshot.get('firstSeenAt')
+  const seen = snapshot.exists && snapshot.data()?.firstSeenAt
     ? { lastSeenAt: now }
     : { firstSeenAt: now, lastSeenAt: now };
   await profile.set(seen, { merge: true });

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -169,6 +169,9 @@ describe('runScaffold', () => {
       expect(viteConfig).not.toContain('loadEnv');
       expect(viteConfig).not.toContain('bridge: true');
       expect(viteConfig).not.toContain('modelMap');
+      const functions = readFileSync(join(project, 'functions/index.js'), 'utf8');
+      expect(functions).toContain('snapshot.data()?.firstSeenAt');
+      expect(functions).not.toContain("snapshot.get('firstSeenAt')");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Keeps the generated chat Function running when its local Admin snapshot does not implement `get(fieldPath)`.

```js
const snapshot = await profile.get();
const now = FieldValue.serverTimestamp();
const seen = snapshot.exists && snapshot.data()?.firstSeenAt
  ? { lastSeenAt: now }
  : { firstSeenAt: now, lastSeenAt: now };
await profile.set(seen, { merge: true });
```

## Presence startup no longer depends on the pending parity work

The generated `onPresenceOnline` Function reads the existing top-level field through the standard `data()` snapshot API. This preserves the intended first-seen/last-seen behavior and removes the `snapshot.get is not a function` startup failure without pulling the broader Admin `DocumentSnapshot.get(fieldPath)` implementation into this release.

The scaffold test fixes this choice in the generated output so the incompatible accessor cannot return unnoticed.

## Risk

For the top-level `firstSeenAt` field, `snapshot.data()?.firstSeenAt` and `snapshot.get('firstSeenAt')` have the same missing-field result. This PR deliberately does not implement or claim broader `FieldPath` parity.

<details>
<summary>Verification and scope</summary>

- `bun test test/scaffold.test.ts` in `packages/create-pyric`: 10 passed, 0 failed.
- `git diff --check` passed.
- Only the chat Function and its scaffold assertion are included.
- The separate Admin snapshot parity implementation remains uncommitted and outside this PR.

</details>
