### PR TITLE
fix(admin-firestore): add DocumentSnapshot.get parity

### DIFF
--- a/packages/conformance/exceptions/admin-firestore-document-snapshot-get.ts
+++ b/packages/conformance/exceptions/admin-firestore-document-snapshot-get.ts
@@ -1,0 +1,6 @@
+import type { ObservationException } from './types.ts';
+
+export const exception: ObservationException = {
+  reason:
+    'focused admin Firestore bootstrap capture; the full firebase-admin/firestore surface registry and census are not admitted yet',
+};

--- a/packages/conformance/observations/firestore/admin-firestore-document-snapshot-get.json
+++ b/packages/conformance/observations/firestore/admin-firestore-document-snapshot-get.json
@@ -1,0 +1,119 @@
+{
+  "name": "admin-firestore-document-snapshot-get",
+  "matrixRow": "",
+  "rowIds": [],
+  "description": "firebase-admin DocumentSnapshot.get(fieldPath) behavior across one-shot document/query reads, transaction document/query reads, and document/query listeners, including missing fields/documents, dotted strings, literal-dot FieldPath segments, and invalid path validation.",
+  "observedAt": "2026-07-21T00:14:49.250Z",
+  "adminSdkVersion": "13.10.0",
+  "behavior": {
+    "oneShotDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "oneShotQueryDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "transactionDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "transactionQueryDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "listenerDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "listenerQueryDocument": {
+      "getType": "function",
+      "topLevel": "top-level",
+      "dottedString": "nested-value",
+      "dottedFieldPath": "nested-value",
+      "literalDotFieldPath": "literal-dot-value",
+      "literalDotAsStringTraverses": "nested-dot-value",
+      "missingFieldIsUndefined": true,
+      "scalarIntermediateIsUndefined": true
+    },
+    "missingDocument": {
+      "exists": false,
+      "dataIsUndefined": true,
+      "getIsUndefined": true
+    },
+    "invalidPaths": {
+      "empty": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths can't be empty and must not contain\n    \"*~/[]\"."
+      },
+      "leadingDot": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths must not start or end with \".\"."
+      },
+      "trailingDot": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths must not start or end with \".\"."
+      },
+      "doubleDot": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths must not contain \"..\" in them."
+      },
+      "forbiddenCharacter": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths can't be empty and must not contain\n    \"*~/[]\"."
+      },
+      "omitted": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. The path cannot be omitted."
+      },
+      "wrongType": {
+        "threw": true,
+        "name": "Error",
+        "code": null,
+        "message": "Value for argument \"field\" is not a valid field path. Paths can only be specified as strings or via a FieldPath object."
+      }
+    }
+  }
+}

--- a/packages/conformance/probes/firestore/admin-firestore-document-snapshot-get.ts
+++ b/packages/conformance/probes/firestore/admin-firestore-document-snapshot-get.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+import { cert, deleteApp, initializeApp, type ServiceAccount } from 'firebase-admin/app';
+import {
+  FieldPath,
+  getFirestore,
+  type DocumentSnapshot,
+  type QueryDocumentSnapshot,
+} from 'firebase-admin/firestore';
+import type { Probe } from '../../rigs/types.ts';
+
+type SnapshotWithGet = Pick<DocumentSnapshot, 'get'> | Pick<QueryDocumentSnapshot, 'get'>;
+
+function view(snapshot: SnapshotWithGet): Record<string, unknown> {
+  return {
+    getType: typeof snapshot.get,
+    topLevel: snapshot.get('topLevel'),
+    dottedString: snapshot.get('nested.value'),
+    dottedFieldPath: snapshot.get(new FieldPath('nested', 'value')),
+    literalDotFieldPath: snapshot.get(new FieldPath('literal.with.dot')),
+    literalDotAsStringTraverses: snapshot.get('literal.with.dot'),
+    missingFieldIsUndefined: snapshot.get('nested.missing') === undefined,
+    scalarIntermediateIsUndefined: snapshot.get('topLevel.child') === undefined,
+  };
+}
+
+function captureThrow(fn: () => unknown): Record<string, unknown> {
+  try {
+    fn();
+    return { threw: false };
+  } catch (error) {
+    const value = error as { name?: unknown; code?: unknown; message?: unknown };
+    return {
+      threw: true,
+      name: typeof value.name === 'string' ? value.name : null,
+      code: typeof value.code === 'string' ? value.code : null,
+      message: typeof value.message === 'string' ? value.message : String(error),
+    };
+  }
+}
+
+async function firstSnapshot<T>(
+  subscribe: (
+    next: (snapshot: T) => void,
+    error: (error: unknown) => void,
+  ) => () => void,
+): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    let unsubscribe = (): void => {};
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error('timed out waiting for the initial Firestore listener snapshot'));
+    }, 15_000);
+    unsubscribe = subscribe(
+      (snapshot) => {
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve(snapshot);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        unsubscribe();
+        reject(error);
+      },
+    );
+  });
+}
+
+export const probe: Probe = {
+  description:
+    'firebase-admin DocumentSnapshot.get(fieldPath) behavior across one-shot document/query reads, transaction document/query reads, and document/query listeners, including missing fields/documents, dotted strings, literal-dot FieldPath segments, and invalid path validation.',
+  matrixRow: '',
+  rowIds: [],
+  async observe() {
+    const serviceAccountPath = process.env.PYRIC_ORACLE_SA_PATH;
+    if (!serviceAccountPath) {
+      throw new Error('PYRIC_ORACLE_SA_PATH is required for the admin Firestore oracle probe');
+    }
+    const serviceAccount = JSON.parse(readFileSync(serviceAccountPath, 'utf8')) as ServiceAccount;
+    const app = initializeApp(
+      { credential: cert(serviceAccount) },
+      `admin-firestore-get-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const db = getFirestore(app);
+    const collection = db.collection(`pyric_oracle/admin_snapshot_get_${Date.now()}/documents`);
+    const doc = collection.doc('present');
+    const missing = collection.doc('missing');
+    const data = {
+      topLevel: 'top-level',
+      nested: { value: 'nested-value' },
+      literal: { with: { dot: 'nested-dot-value' } },
+      'literal.with.dot': 'literal-dot-value',
+      probeKind: 'document-snapshot-get',
+    };
+
+    try {
+      await doc.set(data);
+
+      const oneShotDocument = await doc.get();
+      const oneShotQuery = await collection.where('probeKind', '==', data.probeKind).get();
+      const transaction = await db.runTransaction(async (tx) => {
+        const transactionDocument = await tx.get(doc);
+        const transactionQuery = await tx.get(
+          collection.where('probeKind', '==', data.probeKind),
+        );
+        return {
+          document: view(transactionDocument),
+          queryDocument: view(transactionQuery.docs[0]!),
+        };
+      });
+      const listenerDocument = await firstSnapshot<DocumentSnapshot>((next, error) =>
+        doc.onSnapshot(next, error),
+      );
+      const listenerQuery = await firstSnapshot<
+        FirebaseFirestore.QuerySnapshot
+      >((next, error) => collection.where('probeKind', '==', data.probeKind).onSnapshot(next, error));
+      const missingDocument = await missing.get();
+
+      return {
+        oneShotDocument: view(oneShotDocument),
+        oneShotQueryDocument: view(oneShotQuery.docs[0]!),
+        transactionDocument: transaction.document,
+        transactionQueryDocument: transaction.queryDocument,
+        listenerDocument: view(listenerDocument),
+        listenerQueryDocument: view(listenerQuery.docs[0]!),
+        missingDocument: {
+          exists: missingDocument.exists,
+          dataIsUndefined: missingDocument.data() === undefined,
+          getIsUndefined: missingDocument.get('anything') === undefined,
+        },
+        invalidPaths: {
+          empty: captureThrow(() => oneShotDocument.get('')),
+          leadingDot: captureThrow(() => oneShotDocument.get('.nested')),
+          trailingDot: captureThrow(() => oneShotDocument.get('nested.')),
+          doubleDot: captureThrow(() => oneShotDocument.get('nested..value')),
+          forbiddenCharacter: captureThrow(() => oneShotDocument.get('nested[value]')),
+          omitted: captureThrow(() => oneShotDocument.get(undefined as never)),
+          wrongType: captureThrow(() => oneShotDocument.get(42 as never)),
+        },
+      };
+    } finally {
+      await doc.delete().catch(() => undefined);
+      await missing.delete().catch(() => undefined);
+      await deleteApp(app);
+    }
+  },
+};

--- a/packages/conformance/rigs/admin-firestore.ts
+++ b/packages/conformance/rigs/admin-firestore.ts
@@ -1,0 +1,32 @@
+import type { RigManifestRecord } from './types.ts';
+
+export const rig: RigManifestRecord = {
+  description:
+    'Credentialed firebase-admin Firestore behavior probes against the dedicated production oracle project.',
+  script: 'packages/conformance/src/admin-firestore-probes.ts',
+  observationPrefixes: ['admin-firestore-'],
+  automation: 'credentialed',
+  network: 'firebase-production',
+  requires: {
+    env: [
+      {
+        name: 'PYRIC_ORACLE_SA_PATH',
+        description: 'Path to the dedicated oracle project service-account JSON.',
+      },
+    ],
+    projectFeatures: ['Cloud Firestore provisioned in the dedicated oracle project.'],
+    local: ['Installed firebase-admin package.'],
+  },
+  safety: {
+    writes:
+      'One run-scoped document under pyric_oracle, written through the Admin SDK in the dedicated oracle project.',
+    cleanup:
+      'The run-scoped document is deleted in a finally block and the temporary Admin app is deleted.',
+    unattendedSafe: true,
+  },
+  freshness: {
+    versionField: 'adminSdkVersion',
+    policy:
+      'Checked against the installed firebase-admin package; live behavior drift is detected by verify-mode replay.',
+  },
+};

--- a/packages/conformance/src/admin-firestore-probes.ts
+++ b/packages/conformance/src/admin-firestore-probes.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Probe } from '../rigs/types.ts';
+import { probe } from '../probes/firestore/admin-firestore-document-snapshot-get.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ID = 'admin-firestore-document-snapshot-get';
+const OBSERVATION_PATH = join(HERE, '..', 'observations', 'firestore', `${ID}.json`);
+
+interface ObservationEnvelope {
+  name: string;
+  matrixRow: string;
+  rowIds: string[];
+  description: string;
+  observedAt: string;
+  adminSdkVersion: string;
+  behavior: Record<string, unknown>;
+}
+
+function installedAdminVersion(): string {
+  const packagePath = fileURLToPath(import.meta.resolve('firebase-admin/package.json'));
+  return (JSON.parse(readFileSync(packagePath, 'utf8')) as { version: string }).version;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return Array.isArray(a) && Array.isArray(b) && a.length === b.length &&
+      a.every((value, index) => deepEqual(value, b[index]));
+  }
+  if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null) {
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+    const aKeys = Object.keys(aRecord).sort();
+    const bKeys = Object.keys(bRecord).sort();
+    return deepEqual(aKeys, bKeys) && aKeys.every((key) => deepEqual(aRecord[key], bRecord[key]));
+  }
+  return false;
+}
+
+async function capture(record: Probe, adminSdkVersion: string): Promise<ObservationEnvelope> {
+  return {
+    name: ID,
+    matrixRow: record.matrixRow,
+    rowIds: record.rowIds,
+    description: record.description,
+    observedAt: new Date().toISOString(),
+    adminSdkVersion,
+    behavior: await record.observe(),
+  };
+}
+
+const adminSdkVersion = installedAdminVersion();
+const actual = await capture(probe, adminSdkVersion);
+
+if (process.argv.includes('--write')) {
+  writeFileSync(OBSERVATION_PATH, `${JSON.stringify(actual, null, 2)}\n`);
+  console.log(`wrote ${ID}.json against firebase-admin ${adminSdkVersion}`);
+} else {
+  const expected = JSON.parse(readFileSync(OBSERVATION_PATH, 'utf8')) as ObservationEnvelope;
+  const matches = expected.adminSdkVersion === adminSdkVersion &&
+    deepEqual(expected.behavior, actual.behavior);
+  console.log(
+    `${matches ? 'MATCH' : 'MISMATCH'} ${ID} ` +
+      `(captured ${expected.adminSdkVersion}, installed ${adminSdkVersion})`,
+  );
+  process.exit(matches ? 0 : 1);
+}

--- a/packages/conformance/surfaces/firestore.json
+++ b/packages/conformance/surfaces/firestore.json
@@ -25,11 +25,13 @@
     "_validateIsNotUsedTogether"
   ],
   "observationPrefixes": [
-    "firestore-"
+    "firestore-",
+    "admin-firestore-"
   ],
   "coverage": true,
   "captureRigs": [
-    "oracle-run"
+    "oracle-run",
+    "admin-firestore"
   ],
   "registry": "firestore",
   "dispositions": [

--- a/packages/pyric-admin/test/firestore/firestore/document-snapshot-get.test.ts
+++ b/packages/pyric-admin/test/firestore/firestore/document-snapshot-get.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getInternalEnv } from 'pyric/sandbox/internal';
+import {
+  FieldPath,
+  getAdminFirestore,
+  onSnapshot,
+  type AdminDocumentSnapshot,
+  type AdminQueryDocumentSnapshot,
+  type DocumentSnapshot,
+  type QueryDocumentSnapshot,
+} from '../../../src/firestore/index.js';
+
+const observation = (
+  JSON.parse(
+    readFileSync(
+      join(
+        import.meta.dir,
+        '..',
+        '..',
+        '..',
+        '..',
+        'conformance',
+        'observations',
+        'firestore',
+        'admin-firestore-document-snapshot-get.json',
+      ),
+      'utf8',
+    ),
+  ) as { behavior: Record<string, Record<string, unknown>> }
+).behavior;
+
+type SnapshotWithGet =
+  | AdminDocumentSnapshot
+  | AdminQueryDocumentSnapshot
+  | DocumentSnapshot
+  | QueryDocumentSnapshot;
+
+function view(snapshot: SnapshotWithGet): Record<string, unknown> {
+  return {
+    getType: typeof snapshot.get,
+    topLevel: snapshot.get('topLevel'),
+    dottedString: snapshot.get('nested.value'),
+    dottedFieldPath: snapshot.get(new FieldPath('nested', 'value')),
+    literalDotFieldPath: snapshot.get(new FieldPath('literal.with.dot')),
+    literalDotAsStringTraverses: snapshot.get('literal.with.dot'),
+    missingFieldIsUndefined: snapshot.get('nested.missing') === undefined,
+    scalarIntermediateIsUndefined: snapshot.get('topLevel.child') === undefined,
+  };
+}
+
+describe('firebase-admin DocumentSnapshot.get(fieldPath) oracle parity — local arm', () => {
+  it('replays one-shot, query, transaction, and listener snapshot behavior', async () => {
+    const sandbox = initializeSandbox();
+    const db = getAdminFirestore(sandbox);
+    const doc = db.doc('snapshot-get/present');
+    await doc.set({
+      topLevel: 'top-level',
+      nested: { value: 'nested-value' },
+      literal: { with: { dot: 'nested-dot-value' } },
+      'literal.with.dot': 'literal-dot-value',
+      probeKind: 'document-snapshot-get',
+    });
+
+    const oneShotDocument = await doc.get();
+    const oneShotQuery = await db
+      .collection('snapshot-get')
+      .where('probeKind', '==', 'document-snapshot-get')
+      .get();
+    expect(view(oneShotDocument)).toEqual(observation.oneShotDocument);
+    expect(view(oneShotQuery.docs[0]!)).toEqual(observation.oneShotQueryDocument);
+
+    await db.runTransaction(async (tx) => {
+      const transactionDocument = await tx.get(doc);
+      const transactionQuery = await tx.get(
+        db.collection('snapshot-get').where('probeKind', '==', 'document-snapshot-get'),
+      );
+      expect(view(transactionDocument)).toEqual(observation.transactionDocument);
+      expect(view(transactionQuery.docs[0]!)).toEqual(observation.transactionQueryDocument);
+    });
+
+    const documentFires: DocumentSnapshot[] = [];
+    const queryFires: QueryDocumentSnapshot[] = [];
+    const unsubscribeDocument = onSnapshot(doc, (snapshot) => documentFires.push(snapshot));
+    const unsubscribeQuery = onSnapshot(
+      db.collection('snapshot-get').where('probeKind', '==', 'document-snapshot-get'),
+      (snapshot) => queryFires.push(snapshot.docs[0]!),
+    );
+    getInternalEnv(sandbox).flushListeners();
+    unsubscribeDocument();
+    unsubscribeQuery();
+    expect(view(documentFires[0]!)).toEqual(observation.listenerDocument);
+    expect(view(queryFires[0]!)).toEqual(observation.listenerQueryDocument);
+  });
+
+  it('returns undefined for missing documents and replays path validation', async () => {
+    const sandbox = initializeSandbox();
+    const db = getAdminFirestore(sandbox);
+    const missing = await db.doc('snapshot-get/missing').get();
+    expect({
+      exists: missing.exists,
+      dataIsUndefined: missing.data() === undefined,
+      getIsUndefined: missing.get('anything') === undefined,
+    }).toEqual(observation.missingDocument);
+
+    await db.doc('snapshot-get/present').set({ nested: { value: 1 } });
+    const present = await db.doc('snapshot-get/present').get();
+    const invalid = observation.invalidPaths as Record<
+      string,
+      { threw: boolean; name: string; code: null; message: string }
+    >;
+    const cases: Record<string, () => unknown> = {
+      empty: () => present.get(''),
+      leadingDot: () => present.get('.nested'),
+      trailingDot: () => present.get('nested.'),
+      doubleDot: () => present.get('nested..value'),
+      forbiddenCharacter: () => present.get('nested[value]'),
+      omitted: () => present.get(undefined as never),
+      wrongType: () => present.get(42 as never),
+    };
+    for (const [name, call] of Object.entries(cases)) {
+      expect(call).toThrow(invalid[name]!.message);
+    }
+  });
+});

--- a/packages/pyric-admin/test/remote/remote-firestore.test.ts
+++ b/packages/pyric-admin/test/remote/remote-firestore.test.ts
@@ -72,6 +72,7 @@ import {
   getFirestore,
   getAdminFirestore,
   onSnapshot,
+  FieldPath,
   FieldValue,
   Timestamp,
   type SandboxFirestore,
@@ -234,6 +235,30 @@ function makeStack(opts: { rules?: string } = {}) {
 }
 
 type WireError = Error & { code?: string; denialContext?: unknown };
+
+function snapshotGetView(snapshot: { get(fieldPath: string | FieldPath): unknown }): Record<string, unknown> {
+  return {
+    getType: typeof snapshot.get,
+    topLevel: snapshot.get('topLevel'),
+    dottedString: snapshot.get('nested.value'),
+    dottedFieldPath: snapshot.get(new FieldPath('nested', 'value')),
+    literalDotFieldPath: snapshot.get(new FieldPath('literal.with.dot')),
+    literalDotAsStringTraverses: snapshot.get('literal.with.dot'),
+    missingFieldIsUndefined: snapshot.get('nested.missing') === undefined,
+    scalarIntermediateIsUndefined: snapshot.get('topLevel.child') === undefined,
+  };
+}
+
+const SNAPSHOT_GET_EXPECTED = {
+  getType: 'function',
+  topLevel: 'top-level',
+  dottedString: 'nested-value',
+  dottedFieldPath: 'nested-value',
+  literalDotFieldPath: 'literal-dot-value',
+  literalDotAsStringTraverses: 'nested-dot-value',
+  missingFieldIsUndefined: true,
+  scalarIntermediateIsUndefined: true,
+};
 
 // ─── Dispatch selection ─────────────────────────────────────────────────────
 
@@ -777,6 +802,52 @@ describe('pyric-admin remote Firestore — batch + transactions', () => {
 // ─── onSnapshot ────────────────────────────────────────────────────────────
 
 describe('pyric-admin remote Firestore — onSnapshot', () => {
+  it('DocumentSnapshot.get(fieldPath) is consistent across every remote snapshot producer', async () => {
+    const { remote } = makeStack();
+    const db = getAdminFirestore(remote);
+    const doc = db.doc('snapshot-get/present');
+    await doc.set({
+      topLevel: 'top-level',
+      nested: { value: 'nested-value' },
+      literal: { with: { dot: 'nested-dot-value' } },
+      'literal.with.dot': 'literal-dot-value',
+      probeKind: 'document-snapshot-get',
+    });
+
+    const oneShotDocument = await doc.get();
+    const oneShotQuery = await db
+      .collection('snapshot-get')
+      .where('probeKind', '==', 'document-snapshot-get')
+      .get();
+    expect(snapshotGetView(oneShotDocument)).toEqual(SNAPSHOT_GET_EXPECTED);
+    expect(snapshotGetView(oneShotQuery.docs[0]!)).toEqual(SNAPSHOT_GET_EXPECTED);
+
+    await db.runTransaction(async (tx) => {
+      const transactionDocument = await tx.get(doc);
+      const transactionQuery = await tx.get(
+        db.collection('snapshot-get').where('probeKind', '==', 'document-snapshot-get'),
+      );
+      expect(snapshotGetView(transactionDocument)).toEqual(SNAPSHOT_GET_EXPECTED);
+      expect(snapshotGetView(transactionQuery.docs[0]!)).toEqual(SNAPSHOT_GET_EXPECTED);
+    });
+
+    const documentFires: Array<{ get(fieldPath: string | FieldPath): unknown }> = [];
+    const queryFires: Array<{ get(fieldPath: string | FieldPath): unknown }> = [];
+    const unsubscribeDocument = onSnapshot(doc, (snapshot) => documentFires.push(snapshot));
+    const unsubscribeQuery = onSnapshot(
+      db.collection('snapshot-get').where('probeKind', '==', 'document-snapshot-get'),
+      (snapshot) => queryFires.push(snapshot.docs[0]!),
+    );
+    await tick();
+    unsubscribeDocument();
+    unsubscribeQuery();
+    expect(snapshotGetView(documentFires[0]!)).toEqual(SNAPSHOT_GET_EXPECTED);
+    expect(snapshotGetView(queryFires[0]!)).toEqual(SNAPSHOT_GET_EXPECTED);
+
+    const missing = await db.doc('snapshot-get/missing').get();
+    expect(missing.get('anything')).toBeUndefined();
+  });
+
   it('doc listener: initial + updates (incl. browser-side writes) + unsubscribe', async () => {
     const { ctx, remote } = makeStack();
     const db = getAdminFirestore(remote);

--- a/packages/pyric/src/firestore/sandbox/admin-compat/field-path.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/field-path.ts
@@ -1,0 +1,124 @@
+/**
+ * Firebase Admin-compatible field paths and DocumentSnapshot field lookup.
+ *
+ * Every local/remote snapshot producer delegates here so validation, dotted
+ * string traversal, literal-dot FieldPath segments, and missing-value behavior
+ * cannot drift between one-shot, query, transaction, and listener reads.
+ */
+
+const FORBIDDEN_STRING_FIELD_PATH = /[*~/[\]]/;
+const SIMPLE_FIELD_NAME = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+
+export class FieldPath {
+  /**
+   * Structural compatibility with Pyric's Web-SDK FieldPath. Keeping the
+   * segment vector available under the same internal shape also lets the
+   * shared listener builder accept either mapped SDK's FieldPath instance.
+   */
+  readonly _internalPath: { segments: string[]; offset: number; len: number };
+
+  constructor(...segments: string[]) {
+    if (Array.isArray(segments[0])) {
+      throw new Error(
+        'The FieldPath constructor no longer supports an array as its first argument. ' +
+          'Please unpack your array and call FieldPath() with individual arguments.',
+      );
+    }
+    if (segments.length === 0) {
+      throw new Error('Function "FieldPath()" requires at least 1 argument.');
+    }
+    segments.forEach((segment, index) => {
+      if (typeof segment !== 'string') {
+        throw new Error(`Element at index ${index} is not a valid string.`);
+      }
+      if (segment.length === 0) {
+        throw new Error(`Element at index ${index} should not be an empty string.`);
+      }
+    });
+    this._internalPath = {
+      segments: [...segments],
+      offset: 0,
+      len: segments.length,
+    };
+  }
+
+  private static readonly DOCUMENT_ID = new FieldPath('__name__');
+
+  static documentId(): FieldPath {
+    return FieldPath.DOCUMENT_ID;
+  }
+
+  isEqual(other: FieldPath): boolean {
+    const theirs = fieldPathSegments(other);
+    const ours = this._internalPath.segments;
+    return ours.length === theirs.length && ours.every((segment, index) => segment === theirs[index]);
+  }
+
+  toString(): string {
+    return this._internalPath.segments
+      .map((segment) => SIMPLE_FIELD_NAME.test(segment)
+        ? segment
+        : `\`${segment.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}\``)
+      .join('.');
+  }
+}
+
+export type SnapshotFieldPath = string | FieldPath;
+
+function invalidFieldPath(message: string): Error {
+  return new Error(`Value for argument "field" is not a valid field path. ${message}`);
+}
+
+/** Convert a validated string/FieldPath argument to literal path segments. */
+export function fieldPathSegments(fieldPath: SnapshotFieldPath): readonly string[] {
+  if (fieldPath instanceof FieldPath) {
+    return fieldPath._internalPath.segments;
+  }
+  // The Web-SDK-shaped listener surface has its own FieldPath class. It uses
+  // this exact internal segment vector; accepting it keeps the shared listener
+  // snapshot compatible on both canonical import paths.
+  if (typeof fieldPath === 'object' && fieldPath !== null) {
+    const internal = (fieldPath as { _internalPath?: { segments?: unknown } })._internalPath;
+    if (Array.isArray(internal?.segments) && internal.segments.every((part) => typeof part === 'string')) {
+      return [...internal.segments];
+    }
+  }
+  if (fieldPath === undefined) {
+    throw invalidFieldPath('The path cannot be omitted.');
+  }
+  if (typeof fieldPath !== 'string') {
+    throw invalidFieldPath('Paths can only be specified as strings or via a FieldPath object.');
+  }
+  if (fieldPath.includes('..')) {
+    throw invalidFieldPath('Paths must not contain ".." in them.');
+  }
+  if (fieldPath.startsWith('.') || fieldPath.endsWith('.')) {
+    throw invalidFieldPath('Paths must not start or end with ".".');
+  }
+  if (fieldPath.length === 0 || FORBIDDEN_STRING_FIELD_PATH.test(fieldPath)) {
+    throw invalidFieldPath('Paths can\'t be empty and must not contain\n    "*~/[]".');
+  }
+  return fieldPath.split('.');
+}
+
+function isMap(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/** Firebase Admin DocumentSnapshot.get(fieldPath) over decoded document data. */
+export function getSnapshotField(
+  data: Record<string, unknown> | undefined,
+  fieldPath: SnapshotFieldPath,
+): unknown {
+  const segments = fieldPathSegments(fieldPath);
+  let current: unknown = data;
+  for (const segment of segments) {
+    if (!isMap(current)) return undefined;
+    current = Object.prototype.hasOwnProperty.call(current, segment)
+      ? current[segment]
+      : undefined;
+  }
+  return current;
+}

--- a/packages/pyric/src/firestore/sandbox/admin-compat/index.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/index.ts
@@ -27,6 +27,8 @@ export {
   FieldValue,
   Timestamp,
 } from './types.js';
+export { FieldPath } from './field-path.js';
+export type { SnapshotFieldPath } from './field-path.js';
 
 export type {
   AggregateField,

--- a/packages/pyric/src/firestore/sandbox/admin-compat/query.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/query.ts
@@ -35,6 +35,7 @@ import type { LocalEnvironment } from 'pyric/sandbox/internal';
 import { generateAutoId } from 'pyric/sandbox/internal';
 import { lastSegment } from './paths.js';
 import { translateReadData } from './snapshots.js';
+import { getSnapshotField } from './field-path.js';
 import { DocumentRefImpl } from './doc-ref.js';
 import { activityValue } from '../../../firestore/sandbox/activity-query-value.js';
 // Canonical Firestore value comparison (FS-B3) — type-order-aware,
@@ -786,6 +787,7 @@ export class QueryImpl implements Query {
         ref,
         exists: true,
         data: () => translated,
+        get: (fieldPath) => getSnapshotField(translated, fieldPath),
       };
     });
     return {

--- a/packages/pyric/src/firestore/sandbox/admin-compat/snapshots.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/snapshots.ts
@@ -42,6 +42,7 @@ import {
 // pass-through) lives in its own module so the `onSnapshot` listener path
 // can share it without pulling the snapshot builders in (FS-B10).
 import { translateReadData } from './read-translation.js';
+import { getSnapshotField } from './field-path.js';
 
 export { translateReadData };
 
@@ -56,5 +57,6 @@ export function makeDocSnapshot(
     ref,
     exists,
     data: () => (exists ? translated : undefined),
+    get: (fieldPath) => getSnapshotField(translated, fieldPath),
   };
 }

--- a/packages/pyric/src/firestore/sandbox/admin-compat/transaction.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/transaction.ts
@@ -23,7 +23,7 @@
  */
 
 import type { Transaction as SimTransaction } from 'pyric/sandbox/internal';
-import { translateReadData } from './snapshots.js';
+import { makeDocSnapshot } from './snapshots.js';
 import {
   type DocumentData,
   type DocumentReference,
@@ -68,21 +68,7 @@ export class TransactionImpl implements Transaction {
     }
     const txSnap = this.simTx.get(refOrQuery.path);
     const data = txSnap.data();
-    if (data === undefined) {
-      return {
-        id: refOrQuery.id,
-        ref: refOrQuery,
-        exists: false,
-        data: () => undefined,
-      };
-    }
-    const translated = translateReadData(data);
-    return {
-      id: refOrQuery.id,
-      ref: refOrQuery,
-      exists: true,
-      data: () => translated,
-    };
+    return makeDocSnapshot(refOrQuery, data);
   }
 
   set(ref: DocumentReference, data: DocumentData): Transaction {

--- a/packages/pyric/src/firestore/sandbox/admin-compat/types.ts
+++ b/packages/pyric/src/firestore/sandbox/admin-compat/types.ts
@@ -20,6 +20,7 @@ import {
   boundedActivityIdentity,
   registerActivityValue,
 } from '../../../firestore/sandbox/activity-value-registry.js';
+import type { SnapshotFieldPath } from './field-path.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Public surface — what agent code calls.
@@ -74,6 +75,7 @@ export interface DocumentSnapshot {
   readonly ref: DocumentReference;
   readonly exists: boolean;
   data(): DocumentData | undefined;
+  get(fieldPath: SnapshotFieldPath): unknown;
 }
 
 export interface QueryDocumentSnapshot extends DocumentSnapshot {

--- a/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
+++ b/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
@@ -19,6 +19,10 @@ import type { Operation } from './local-environment.js';
 // `typeName` field and no `nanoseconds`). `read-translation.ts` carries no
 // admin-compat-surface dependency, so importing it here is cycle-free.
 import { translateReadData } from './admin-compat/read-translation.js';
+import {
+  getSnapshotField,
+  type SnapshotFieldPath,
+} from './admin-compat/field-path.js';
 // RULES-B11 — structured `where`/`limit`/`orderBy` view of a query, consumed
 // by the listener path's query-proof gate ("rules are not filters").
 import type { QueryConstraints } from '../../rules/simulator/query-proof.js';
@@ -224,7 +228,7 @@ export interface DocumentSnapshot {
    * Dotted paths supported. Missing intermediate keys yield `undefined`
    * — production behavior; agents commonly chain optional reads.
    */
-  get(fieldPath: string): unknown;
+  get(fieldPath: SnapshotFieldPath): unknown;
 }
 
 /**
@@ -292,22 +296,6 @@ export const SANDBOX_METADATA_PENDING: SnapshotMetadata = Object.freeze({
 
 // ─── Snapshot construction helpers ───────────────────────────────────
 
-/**
- * Walk a dotted path against a data tree. Returns `undefined` on any
- * missing intermediate or non-object node — matching production's
- * forgiving accessor (Web SDK `DocumentSnapshot.get`).
- */
-function getByPath(data: DocumentData | undefined, fieldPath: string): unknown {
-  if (data === undefined) return undefined;
-  const parts = fieldPath.split('.');
-  let cur: unknown = data;
-  for (const p of parts) {
-    if (cur === null || cur === undefined || typeof cur !== 'object') return undefined;
-    cur = (cur as Record<string, unknown>)[p];
-  }
-  return cur;
-}
-
 function lastSegment(path: string): string {
   const i = path.lastIndexOf('/');
   return i === -1 ? path : path.slice(i + 1);
@@ -335,7 +323,7 @@ export function buildDocumentSnapshot(
     metadata,
     exists: () => exists,
     data: () => translated,
-    get: (fieldPath: string) => getByPath(translated, fieldPath),
+    get: (fieldPath) => getSnapshotField(translated, fieldPath),
   };
 }
 
@@ -353,7 +341,7 @@ function buildQueryDocumentSnapshot(
     metadata,
     exists: () => true,
     data: () => translated,
-    get: (fieldPath: string) => getByPath(translated, fieldPath),
+    get: (fieldPath) => getSnapshotField(translated, fieldPath),
   };
 }
 

--- a/packages/pyric/src/sandbox/admin-firestore/index.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/index.ts
@@ -63,7 +63,8 @@ export type {
   WriteBatch,
 } from 'pyric/sandbox/admin-compat';
 export type { LintResult, LintWarning, RulesMetrics } from 'pyric/rules/internal';
-export { FieldValue, Timestamp } from 'pyric/sandbox/admin-compat';
+export { FieldPath, FieldValue, Timestamp } from 'pyric/sandbox/admin-compat';
+export type { SnapshotFieldPath } from 'pyric/sandbox/admin-compat';
 
 // Web-SDK-shaped snapshot types — what `onSnapshot` callbacks receive.
 // Spelled with the conventional Web SDK names so consumers can type

--- a/packages/pyric/src/sandbox/admin-firestore/remote/snapshots.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/remote/snapshots.ts
@@ -13,6 +13,7 @@ import type { RemoteArm } from './channel.js';
 import { decodeDocData } from './value-codec.js';
 import { makeDocRef } from './doc-ref.js';
 import type { WireDocSnap, WireQuerySnap } from './wire-types.js';
+import { getSnapshotField } from '../../../firestore/sandbox/admin-compat/field-path.js';
 
 export function makeDocumentSnapshot(ref: DocumentReference, wire: WireDocSnap): DocumentSnapshot {
   const data = wire.exists && wire.data ? decodeDocData(wire.data) : undefined;
@@ -21,6 +22,7 @@ export function makeDocumentSnapshot(ref: DocumentReference, wire: WireDocSnap):
     ref,
     exists: wire.exists,
     data: () => data,
+    get: (fieldPath) => getSnapshotField(data, fieldPath),
   };
 }
 
@@ -37,6 +39,7 @@ export function makeQuerySnapshot(
       ref,
       exists: true,
       data: () => data,
+      get: (fieldPath) => getSnapshotField(data, fieldPath),
     };
   });
   return {


### PR DESCRIPTION
Adds Firebase Admin-compatible `DocumentSnapshot.get(fieldPath)` across every local and bridged snapshot producer.

```ts
import { FieldPath, getFirestore } from 'firebase-admin/firestore';

const profile = await getFirestore().doc('profiles/alice').get();

profile.get('settings.theme');
// Reads the nested `settings.theme` value.

profile.get(new FieldPath('settings.theme'));
// Reads a top-level field whose name literally contains a dot.
```

> [!IMPORTANT]
> Review-only draft. This PR is explicitly **not part of the alpha.13 release cut**.

## Every Admin snapshot producer exposes the same field lookup

The same accessor now appears on document snapshots returned by one-shot reads, query reads, transactions, and listeners. Both the in-process Admin implementation and the WebSocket-bridged implementation delegate to one field-path reader, including missing documents, missing fields, scalar intermediate values, dotted strings, and literal-dot `FieldPath` segments.

```ts
const db = getFirestore();
const ref = db.doc('profiles/alice');

const direct = await ref.get();
direct.get('displayName');

const query = await db.collection('profiles').where('active', '==', true).get();
query.docs[0]?.get('displayName');

await db.runTransaction(async (transaction) => {
  const transactional = await transaction.get(ref);
  transactional.get('displayName');
});

const unsubscribe = ref.onSnapshot((listened) => {
  listened.get('displayName');
});
unsubscribe();
```

## Firebase supplies the expected behavior

A credentialed `firebase-admin` 13.10.0 probe records the production result for all six snapshot contexts and invalid field paths. The local parity test replays that captured behavior; the remote test exercises every bridged producer.

This evidence does not raise a published compatibility score. Admin Firestore snapshots are not yet part of the formal score checklist, so the observation carries a temporary pre-admission exception and receives no coverage credit.

## Risk

The new field-path helper is also used by Web-shaped listener snapshots that previously had a small dotted-string-only reader. Review should decide whether sharing the Admin validator across that boundary is desirable or whether the lookup mechanism should be shared while validation remains surface-specific.

The PR also introduces a Pyric-owned `FieldPath` implementation on the Admin surface. Its constructor errors, `documentId()`, `isEqual()`, and string rendering should be reviewed as public compatibility behavior even though this probe concentrates on snapshot lookup.

The oracle runner writes one run-scoped document to the dedicated Firebase project and deletes it in `finally`. The checked-in observation has no registry row linkage until the full Admin Firestore surface is admitted.

<details>
<summary>Verification and coverage-adversary finding</summary>

- Focused local and remote tests: 42 passed, 0 failed.
- Conformance workspace: 233 passed, 0 failed; typecheck passed.
- `pyric` and `pyric-admin` typechecks passed.
- Registry validation: 823 rows, 276 observations, 0 problems.
- Census gate: no new public gaps.
- Generated conformance projections are unchanged and current.
- All observations match the installed Firebase SDK versions.
- Compatibility audit: 0 orphan observations.
- `git diff --check` passed.
- The focused remote suite continues to print the existing best-effort persistence warnings; the suite exits successfully.

Coverage-adversary verdict: **EARNED**. The PR adds a production capture and an implementation that passes against it. It changes no registry row status, credits no new numerator, removes nothing from the denominator, and therefore moves no published score.

</details>
