### PR TITLE
release: v0.1.0-alpha.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.12",
+      "version": "0.1.0-alpha.13",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -112,7 +112,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.12",
+      "version": "0.1.0-alpha.13",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -232,7 +232,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.12",
+      "version": "0.1.0-alpha.13",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -250,7 +250,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.12",
+      "version": "0.1.0-alpha.13",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -314,7 +314,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.12",
+      "version": "0.1.0-alpha.13",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.13`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.12

- fix(chat-template): read presence data compatibly (0818faa3)
- docs: teach Pyric through the chat app (9034894f)
- docs: explain local AI and runtime recovery (0fafa017)
- feat(vite): inject the runtime chip (79e3fe43)
- feat(ui): add the Pyric runtime chip (3aab2618)
- feat(runtime): replace stale workers gracefully (3a595ecb)
- fix(runtime): survive worker startup failures (c62e42a4)
- refactor(vite): isolate worker runtime state (33686ab1)
- fix(runtime): make worker status trustworthy (07812f51)
- feat(runtime): expose worker status and sandbox errors (bc167f92)
- fix(vite): honor custom env directories (4002d5d0)
- refactor(vite): isolate convention policy (124d93a1)
- feat(vite): make pyric convention-first (2421ed1e)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.13` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.13` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.13 && git push origin v0.1.0-alpha.13` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
