### PR TITLE
fix(runtime): replace stale SharedWorkers safely

### DIFF
--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -320,7 +320,7 @@ export async function startServe(opts: {
   let bundle: { outDir: string; cached: boolean; dispose?: () => void };
   // The worker executable epoch: stamped into the page (`<meta name="pyric-worker-v">`)
   // so the page can WARN when a still-running worker is older than the served
-  // bundle. The worker NAME is stable (`pyric-shared-worker`) — all tabs share
+  // bundle. The worker NAME is origin-generation scoped — all tabs share
   // one backend — so a SharedWorker (which can't hot-update) is detected as
   // stale, not auto-replaced; the user closes all tabs to load the new worker.
   let workerVersion: string;

--- a/packages/cli/src/serve/bundler.ts
+++ b/packages/cli/src/serve/bundler.ts
@@ -384,6 +384,8 @@ export interface WorkerBundleOptions {
   minify?: boolean;
   /** Test seam for proving epoch identity from an isolated executable graph. */
   entryPath?: string;
+  /** Restart-required boot identity mixed into the baked worker epoch. */
+  epochSalt?: string;
 }
 
 const WORKER_EPOCH_PLACEHOLDER = 'PYRIC_EPOCH_HERE';
@@ -470,7 +472,10 @@ export interface WorkerBundleResult {
 export async function bundleWorker(opts: WorkerBundleOptions): Promise<WorkerBundleResult> {
   const outFile = join(opts.outDir, 'worker.js');
   const marker = join(opts.outDir, '.worker-complete');
-  const hash = workerSourceHash();
+  const sourceHash = workerSourceHash();
+  const hash = opts.epochSalt
+    ? createHash('sha256').update(sourceHash).update('\0').update(opts.epochSalt).digest('hex')
+    : sourceHash;
   if (
     !opts.noCache &&
     existsSync(outFile) &&
@@ -511,7 +516,9 @@ export async function bundleWorker(opts: WorkerBundleOptions): Promise<WorkerBun
   if (!canonicalSource.includes(WORKER_EPOCH_PLACEHOLDER)) {
     throw new Error('pyric dev: SharedWorker bundle omitted its epoch placeholder');
   }
-  const epoch = createHash('sha256').update(canonicalSource).digest('hex').slice(0, 16);
+  const epochHash = createHash('sha256').update(canonicalSource);
+  if (opts.epochSalt) epochHash.update('\0').update(opts.epochSalt);
+  const epoch = epochHash.digest('hex').slice(0, 16);
   writeFileSync(outFile, canonicalSource.replaceAll(WORKER_EPOCH_PLACEHOLDER, epoch));
   writeFileSync(join(opts.outDir, WORKER_EPOCH_FILE), epoch);
   writeFileSync(marker, hash);

--- a/packages/cli/src/serve/runtime/worker-generation.ts
+++ b/packages/cli/src/serve/runtime/worker-generation.ts
@@ -9,19 +9,41 @@ interface EpochStorage {
   removeItem?(key: string): void;
 }
 
-/** Select the replacement generation only after this page was told to move. */
+/**
+ * Select the origin's active worker generation.
+ *
+ * A browser that predates generation-aware workers has no stored epoch but may
+ * still have the legacy `pyric-shared-worker` alive. Seed the first served
+ * epoch before connecting so a new client never attaches to that incompatible
+ * worker. Later releases keep using the stored generation until replacement
+ * is explicitly committed.
+ */
 export function workerNameForEpoch(
-  _servedEpoch: string | null,
+  servedEpoch: string | null,
   storage: EpochStorage | undefined,
 ): string {
-  if (!storage) return PYRIC_WORKER_NAME;
+  const validServedEpoch = servedEpoch && /^[a-f0-9]{16}$/.test(servedEpoch)
+    ? servedEpoch
+    : null;
+  if (!storage) {
+    return validServedEpoch
+      ? `${PYRIC_WORKER_NAME}:${validServedEpoch}`
+      : PYRIC_WORKER_NAME;
+  }
   try {
     const generation = storage.getItem(PYRIC_WORKER_GENERATION_KEY);
-    return generation && /^[a-f0-9]{16}$/.test(generation)
-      ? `${PYRIC_WORKER_NAME}:${generation}`
-      : PYRIC_WORKER_NAME;
-  } catch {
+    if (generation && /^[a-f0-9]{16}$/.test(generation)) {
+      return `${PYRIC_WORKER_NAME}:${generation}`;
+    }
+    if (validServedEpoch) {
+      storage.setItem(PYRIC_WORKER_GENERATION_KEY, validServedEpoch);
+      return `${PYRIC_WORKER_NAME}:${validServedEpoch}`;
+    }
     return PYRIC_WORKER_NAME;
+  } catch {
+    return validServedEpoch
+      ? `${PYRIC_WORKER_NAME}:${validServedEpoch}`
+      : PYRIC_WORKER_NAME;
   }
 }
 

--- a/packages/cli/src/serve/vite-ai-config.ts
+++ b/packages/cli/src/serve/vite-ai-config.ts
@@ -22,6 +22,14 @@ export interface ResolvedViteAiConfig {
   proxyUpstream: string | undefined;
 }
 
+/** Values captured once by a SharedWorker and therefore requiring replacement. */
+export function viteWorkerEpochSalt(
+  projectKey: string,
+  engineWire: AiEngineConfigWire | undefined,
+): string {
+  return JSON.stringify({ projectKey, aiEngine: engineWire ?? null });
+}
+
 /** Load env using Vite's `envDir`-relative-to-root convention. */
 export function loadViteAiEnv(
   mode: string,

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -90,6 +90,7 @@ import {
 import {
   loadViteAiEnv,
   resolveViteAiConfig,
+  viteWorkerEpochSalt,
   type PyricAiOptions,
 } from './vite-ai-config.js';
 import { resolveViteRulesConfig } from './vite-rules-source.js';
@@ -508,7 +509,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // On bundle failure, the collaborator stays unready and its HTML tag
       // forces the in-page sandbox.
       try {
-        await workerRuntime.prepare();
+        await workerRuntime.prepare(viteWorkerEpochSalt(cwd, resolvedAi.engineWire));
       } catch (e) {
         server.config.logger.warn(
           `  ⚠ [pyric] SharedWorker bundle failed — using the in-page sandbox (single-tab, ephemeral): ${e instanceof Error ? e.message : String(e)}`,

--- a/packages/cli/src/serve/vite-worker-runtime.ts
+++ b/packages/cli/src/serve/vite-worker-runtime.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import {
   bundleWorker,
   workerSourceHash,
@@ -14,7 +15,7 @@ export interface ViteWorkerRuntimeStatus {
 }
 
 export interface ViteWorkerRuntime {
-  prepare(): Promise<void>;
+  prepare(epochSalt?: string): Promise<void>;
   status(): ViteWorkerRuntimeStatus;
   headTag(marker: string): string;
 }
@@ -31,14 +32,20 @@ export function createViteWorkerRuntime(
 ): ViteWorkerRuntime {
   const cacheRoot = options.cacheRoot ?? join(homedir(), '.pyric', 'vite-worker');
   const cacheKey = options.cacheKey ?? workerSourceHash();
-  const sdkDir = join(cacheRoot, cacheKey);
+  const defaultSdkDir = join(cacheRoot, cacheKey);
   const bundle = options.bundle ?? bundleWorker;
-  let current: ViteWorkerRuntimeStatus = { sdkDir, ready: false, epoch: null };
+  let current: ViteWorkerRuntimeStatus = { sdkDir: defaultSdkDir, ready: false, epoch: null };
 
   return {
-    async prepare() {
+    async prepare(epochSalt) {
+      const sdkDir = epochSalt
+        ? join(
+            cacheRoot,
+            `${cacheKey}-${createHash('sha256').update(epochSalt).digest('hex').slice(0, 12)}`,
+          )
+        : defaultSdkDir;
       current = { sdkDir, ready: false, epoch: null };
-      const result = await bundle({ outDir: sdkDir });
+      const result = await bundle({ outDir: sdkDir, ...(epochSalt ? { epochSalt } : {}) });
       current = { sdkDir, ready: true, epoch: result.epoch };
     },
     status: () => current,

--- a/packages/cli/test/e2e/ai-worker-boundary.pw.ts
+++ b/packages/cli/test/e2e/ai-worker-boundary.pw.ts
@@ -6,9 +6,10 @@ test('served AI uses only the SharedWorker broker and emits one authoritative ev
 
   const actual = await page.evaluate(async () => {
     const events: Array<{ service?: string; op?: string }> = [];
+    const generation = localStorage.getItem('pyric:worker-generation');
     const worker = new SharedWorker('/__pyric/sdk/worker.js', {
       type: 'classic',
-      name: 'pyric-shared-worker',
+      name: generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker',
     });
     worker.port.start();
     let notify: (() => void) | undefined;

--- a/packages/cli/test/e2e/auth-popup.pw.ts
+++ b/packages/cli/test/e2e/auth-popup.pw.ts
@@ -14,9 +14,10 @@ test('Google popup sign-in fires onAuthStateChanged with the user', async ({ pag
   // OAuth providers are disabled by default. Enable Google on the authoritative
   // worker backend (the same control operation Studio's provider toggle uses).
   await page.evaluate(() => new Promise<void>((resolve, reject) => {
+    const generation = localStorage.getItem('pyric:worker-generation');
     const worker = new SharedWorker('/__pyric/sdk/worker.js', {
       type: 'classic',
-      name: 'pyric-shared-worker',
+      name: generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker',
     });
     const id = `enable-google-${Date.now()}`;
     worker.port.onmessage = (event) => {

--- a/packages/cli/test/e2e/messaging-app-boundary.pw.ts
+++ b/packages/cli/test/e2e/messaging-app-boundary.pw.ts
@@ -18,9 +18,10 @@ test('served canonical Messaging imports stay app-owned over the SharedWorker', 
 
     const primaryToken = await messagingModule.getToken(primaryMessaging);
     const siblingToken = await messagingModule.getToken(siblingMessaging);
+    const generation = localStorage.getItem('pyric:worker-generation');
     const worker = new SharedWorker('/__pyric/sdk/worker.js', {
       type: 'classic',
-      name: 'pyric-shared-worker',
+      name: generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker',
     });
     worker.port.start();
     const workerToken = await new Promise<string>((resolve, reject) => {
@@ -158,9 +159,10 @@ test('firebase/messaging/sw receives the shared broker from a real module Servic
       source: string,
       notification = false,
     ): Promise<{ route?: string; handlerCount?: number; payload?: unknown }> => {
+      const generation = localStorage.getItem('pyric:worker-generation');
       const worker = new SharedWorker('/__pyric/sdk/worker.js', {
         type: 'classic',
-        name: 'pyric-shared-worker',
+        name: generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker',
       });
       worker.port.start();
       return new Promise((resolve, reject) => {

--- a/packages/cli/test/e2e/site-static/static-site.pw.ts
+++ b/packages/cli/test/e2e/site-static/static-site.pw.ts
@@ -101,7 +101,9 @@ test('a Firestore write via the worker port is visible to a second, independent 
         worker: SharedWorker,
         msg: Record<string, unknown>,
       ) => Promise<{ ok: boolean; value?: unknown }>;
-      const workerA = new SharedWorker('/__pyric/sdk/worker.js', { name: 'pyric-shared-worker' });
+      const generation = localStorage.getItem('pyric:worker-generation');
+      const workerName = generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker';
+      const workerA = new SharedWorker('/__pyric/sdk/worker.js', { name: workerName });
       const write = await workerOp(workerA, {
         t: 'op',
         id: 'w1',
@@ -109,7 +111,7 @@ test('a Firestore write via the worker port is visible to a second, independent 
         path: 'notes/e2e-check',
         data: { marker },
       });
-      const workerB = new SharedWorker('/__pyric/sdk/worker.js', { name: 'pyric-shared-worker' });
+      const workerB = new SharedWorker('/__pyric/sdk/worker.js', { name: workerName });
       const read = await workerOp(workerB, { t: 'op', id: 'r1', method: 'admin.getDocument', path: 'notes/e2e-check' });
       return { write, read };
     },
@@ -140,7 +142,9 @@ test(
           worker: SharedWorker,
           msg: Record<string, unknown>,
         ) => Promise<{ ok: boolean; value?: unknown }>;
-        const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: 'pyric-shared-worker' });
+        const generation = localStorage.getItem('pyric:worker-generation');
+        const workerName = generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker';
+        const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: workerName });
         await workerOp(worker, {
           t: 'op',
           id: 'w1',
@@ -162,7 +166,9 @@ test(
           worker: SharedWorker,
           msg: Record<string, unknown>,
         ) => Promise<{ ok: boolean; value?: unknown }>;
-        const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: 'pyric-shared-worker' });
+        const generation = localStorage.getItem('pyric:worker-generation');
+        const workerName = generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker';
+        const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: workerName });
         return await workerOp(worker, { t: 'op', id: 'r1', method: 'admin.getDocument', path: 'notes/reload-check' });
       },
       { helper: WORKER_OP_HELPER },
@@ -177,7 +183,9 @@ test('the curated demo seed (__pyric/init.json) is applied on first worker boot'
   await page.waitForTimeout(1000);
 
   const seeded = await page.evaluate(async () => {
-    const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: 'pyric-shared-worker' });
+    const generation = localStorage.getItem('pyric:worker-generation');
+    const workerName = generation ? `pyric-shared-worker:${generation}` : 'pyric-shared-worker';
+    const worker = new SharedWorker('/__pyric/sdk/worker.js', { name: workerName });
     worker.port.start();
     const res = await new Promise<{ ok: boolean; value?: Record<string, unknown> | null }>((resolve) => {
       worker.port.onmessage = (ev) => {

--- a/packages/cli/test/serve/bundler.test.ts
+++ b/packages/cli/test/serve/bundler.test.ts
@@ -495,4 +495,26 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
     expect(second.epoch).toBe(first.epoch);
     expect(readFileSync(join(firstDir, 'worker.js'), 'utf8')).toContain(first.epoch);
   }, 30_000);
+
+  it('includes restart-required configuration in the baked worker epoch', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'pyric-worker-config-epoch-'));
+    const entry = join(root, 'worker.ts');
+    writeFileSync(entry, 'globalThis.workerEpoch = __PYRIC_WORKER_VERSION__;');
+
+    const scripted = await bundleWorker({
+      outDir: join(root, 'scripted'),
+      noCache: true,
+      entryPath: entry,
+      epochSalt: 'project=/app;ai=scripted',
+    });
+    const openai = await bundleWorker({
+      outDir: join(root, 'openai'),
+      noCache: true,
+      entryPath: entry,
+      epochSalt: 'project=/app;ai=openai:qwen3',
+    });
+
+    expect(openai.epoch).not.toBe(scripted.epoch);
+    expect(readFileSync(join(root, 'openai', 'worker.js'), 'utf8')).toContain(openai.epoch);
+  }, 30_000);
 });

--- a/packages/cli/test/serve/runtime/worker-generation.test.ts
+++ b/packages/cli/test/serve/runtime/worker-generation.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../src/serve/runtime/worker-generation.js';
 
 describe('worker generation identity', () => {
-  it('uses a new name only after the page remembers the served epoch', () => {
+  it('seeds a versioned name instead of reconnecting to a legacy unversioned worker', () => {
     const values = new Map<string, string>();
     const storage = {
       getItem: (key: string) => values.get(key) ?? null,
@@ -15,8 +15,9 @@ describe('worker generation identity', () => {
       removeItem: (key: string) => { values.delete(key); },
     };
 
-    expect(workerNameForEpoch('0123456789abcdef', storage)).toBe('pyric-shared-worker');
-    rememberWorkerEpoch('0123456789abcdef', storage);
+    expect(workerNameForEpoch('0123456789abcdef', storage)).toBe(
+      'pyric-shared-worker:0123456789abcdef',
+    );
     expect(values.get(PYRIC_WORKER_GENERATION_KEY)).toBe('0123456789abcdef');
     expect(workerNameForEpoch('0123456789abcdef', storage)).toBe(
       'pyric-shared-worker:0123456789abcdef',
@@ -43,6 +44,13 @@ describe('worker generation identity', () => {
     expect(workerNameForEpoch('0123456789abcdef', freshTabStorage)).toBe(
       'pyric-shared-worker:0123456789abcdef',
     );
+  });
+
+  it('still avoids the legacy worker when origin storage is unavailable', () => {
+    expect(workerNameForEpoch('0123456789abcdef', undefined)).toBe(
+      'pyric-shared-worker:0123456789abcdef',
+    );
+    expect(workerNameForEpoch('dev', undefined)).toBe('pyric-shared-worker');
   });
 
   it('fails before retirement when origin storage cannot persist the successor', () => {

--- a/packages/cli/test/serve/vite-ai-config.test.ts
+++ b/packages/cli/test/serve/vite-ai-config.test.ts
@@ -6,6 +6,7 @@ import {
   engineConfigToWire,
   loadViteAiEnv,
   resolveViteAiConfig,
+  viteWorkerEpochSalt,
 } from '../../src/serve/vite-ai-config.js';
 
 describe('Vite AI configuration', () => {
@@ -113,5 +114,17 @@ describe('Vite AI configuration', () => {
       model: 'qwen3:4b',
       engine: { kind: 'scripted' },
     }, {})).toThrow('Choose either ai.model or ai.engine');
+  });
+
+  it('changes worker boot identity when the project or AI engine changes', () => {
+    const scripted = viteWorkerEpochSalt('/app', undefined);
+    const openai = viteWorkerEpochSalt('/app', {
+      kind: 'openai',
+      baseUrl: '/__pyric/ai-proxy',
+      model: 'qwen3:4b',
+    });
+
+    expect(openai).not.toBe(scripted);
+    expect(viteWorkerEpochSalt('/other-app', undefined)).not.toBe(scripted);
   });
 });

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -304,8 +304,12 @@ type PyricMiddleware = (req: PyricReq, res: MockRes, next: () => void) => void;
  *  `/__pyric` middleware. This runs the FULL M2 prelude — rules load, capture,
  *  state eager-load (the fail-fast), seed orchestration, worker-bundle cache-hit,
  *  namespace mount — minus a real http server. */
-async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<PyricMiddleware> {
+async function bootPluginInstance(
+  opts: Record<string, unknown>,
+  root: string,
+): Promise<{ handler: PyricMiddleware; plugin: ReturnType<typeof pyric> }> {
   let handler: PyricMiddleware | undefined;
+  const plugin = pyric(opts);
   const stub = {
     config: { root, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
     middlewares: { use(p: string, h: PyricMiddleware) { if (p === '/__pyric') handler = h; } },
@@ -315,9 +319,13 @@ async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<
     // port; `on` is a no-op here (the attachUpgrade spy test uses its own stub).
     httpServer: { address: () => ({ port: 5173 }), on() {}, once() {} },
   };
-  await (pyric(opts).configureServer as (s: unknown) => Promise<void>)(stub);
+  await (plugin.configureServer as (s: unknown) => Promise<void>)(stub);
   if (!handler) throw new Error('plugin did not mount the /__pyric middleware');
-  return handler;
+  return { handler, plugin };
+}
+
+async function bootPlugin(opts: Record<string, unknown>, root: string): Promise<PyricMiddleware> {
+  return (await bootPluginInstance(opts, root)).handler;
 }
 /** Invoke the captured middleware; resolve when it responds (res 'finish') OR
  *  passes through (next()). Returns the recorded response + whether it next()ed. */
@@ -446,6 +454,26 @@ describe('M2 — worker bundle + persist (via the /__pyric middleware)', () => {
     expect(html).toContain('pyric-worker-v'); // staleness stamp ⇒ worker path active
     expect(html).not.toContain('__PYRIC_FORCE_INPAGE__'); // NOT the in-page fallback
     expect(html).toContain(entries.init); // boots the sandbox
+  });
+
+  it('changes the worker version when the configured AI model changes', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-ai-epoch-'));
+    const first = await bootPluginInstance({ ai: { model: 'model-a' } }, tmp);
+    const second = await bootPluginInstance({ ai: { model: 'model-b' } }, tmp);
+
+    expect((await initJson(first.handler)).ai.engine.model).toBe('model-a');
+    expect((await initJson(second.handler)).ai.engine.model).toBe('model-b');
+
+    const htmlFor = (p: ReturnType<typeof pyric>): string =>
+      (p.transformIndexHtml as (h: string) => string)('<html><head></head></html>');
+    const epochFrom = (html: string): string | undefined =>
+      html.match(/name="pyric-worker-v" content="([^"]+)"/)?.[1];
+
+    const firstEpoch = epochFrom(htmlFor(first.plugin));
+    const secondEpoch = epochFrom(htmlFor(second.plugin));
+    expect(firstEpoch).toBeTruthy();
+    expect(secondEpoch).toBeTruthy();
+    expect(secondEpoch).not.toBe(firstEpoch);
   });
 
   it('persist mounts the /__pyric/state channel and sets persist in the payload', async () => {

--- a/packages/cli/test/serve/vite-worker-runtime.test.ts
+++ b/packages/cli/test/serve/vite-worker-runtime.test.ts
@@ -10,6 +10,31 @@ describe('Vite worker runtime', () => {
   });
 
   it('atomically projects the epoch returned by a successful bundle', async () => {
+    const calls: Array<{ outDir: string; epochSalt?: string }> = [];
+    const runtime = createViteWorkerRuntime({
+      cacheRoot: '/cache',
+      cacheKey: 'key',
+      bundle: async ({ outDir, epochSalt }) => {
+        calls.push({ outDir, epochSalt });
+        return { outFile: `${outDir}/worker.js`, epoch: '0123456789abcdef' };
+      },
+    });
+
+    await runtime.prepare('project=/app;ai=openai:qwen3');
+
+    expect(calls).toEqual([{
+      outDir: expect.stringMatching(/^\/cache\/key-[a-f0-9]{12}$/),
+      epochSalt: 'project=/app;ai=openai:qwen3',
+    }]);
+    expect(runtime.status()).toEqual({
+      sdkDir: calls[0]!.outDir, ready: true, epoch: '0123456789abcdef',
+    });
+    expect(runtime.headTag('data-pyric-sandbox')).toBe(
+      '<meta name="pyric-worker-v" content="0123456789abcdef" data-pyric-sandbox>',
+    );
+  });
+
+  it('isolates worker artifacts when restart-required configuration changes', async () => {
     const calls: string[] = [];
     const runtime = createViteWorkerRuntime({
       cacheRoot: '/cache',
@@ -20,15 +45,10 @@ describe('Vite worker runtime', () => {
       },
     });
 
-    await runtime.prepare();
+    await runtime.prepare('ai=scripted');
+    await runtime.prepare('ai=openai:qwen3');
 
-    expect(calls).toEqual(['/cache/key']);
-    expect(runtime.status()).toEqual({
-      sdkDir: '/cache/key', ready: true, epoch: '0123456789abcdef',
-    });
-    expect(runtime.headTag('data-pyric-sandbox')).toBe(
-      '<meta name="pyric-worker-v" content="0123456789abcdef" data-pyric-sandbox>',
-    );
+    expect(calls[0]).not.toBe(calls[1]);
   });
 
   it('remains on the in-page fallback when bundling fails', async () => {


### PR DESCRIPTION
Prevents Vite apps from silently reusing a SharedWorker whose code or AI boot configuration is stale.

```ts
import { defineConfig } from 'vite';
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [
    pyric({
      ai: {
        model: 'qwen3:4b',
        proxyUpstream: 'http://localhost:11434/v1',
      },
    }),
  ],
});

// After changing model and restarting Vite, the Pyric runtime chip reports
// that a worker update is available. Its update action moves every new tab to
// the worker containing the new AI configuration.
```

## Worker identity now includes the configuration the worker keeps

The SharedWorker reads its AI engine once when it starts. Its epoch previously described only the bundled code, so changing `ai.model` could leave the chip green while the old scripted engine kept answering requests.

The Vite worker epoch now combines the executable bundle with the project path and AI engine. A model or engine change therefore produces a different served epoch and the existing chip presents its worker-update action. `proxyUpstream` remains outside the epoch because Vite's same-origin proxy reads that server-side value after restart; changing it does not require a browser worker replacement.

## The first generation-aware load cannot attach to an older worker

An origin with no saved generation previously connected to the unversioned `pyric-shared-worker`. If that worker came from alpha.12, alpha.13 sent `getRuntimeEpoch` to code that did not implement it and then encountered the Firebase configuration already bound to that worker.

The first generation-aware load now records the served epoch and opens its epoch-qualified worker. Later changes stay on the active generation until the chip's update action retires it and commits the successor.

## Risk

The first load after this upgrade starts a separate worker instead of reusing an unversioned worker. An already-open old tab can retain the old worker until it closes, while new tabs share the new generation. Direct browser conformance probes now resolve the active generation rather than accidentally creating a second unversioned backend.

<details>
<summary>Implementation notes</summary>

- The worker bundle cache and baked epoch include restart-required configuration.
- Vite uses separate immutable bundle directories for distinct worker boot identities.
- Relevant runtime, Vite, bundler, chip, and shipped-worker tests: 127 passed, 2 skipped.
- The exact CI browser-conformance command that previously failed: 7 passed.
- `@pyric/cli` typecheck and build passed.
- No conformance numbers or evidence changed.

</details>
