### PR TITLE
fix(chat): reconcile persisted messages once

### DIFF
--- a/packages/create-pyric/templates/chat/src/ui/chat/chat-page.tsx
+++ b/packages/create-pyric/templates/chat/src/ui/chat/chat-page.tsx
@@ -13,8 +13,7 @@ import type { ChatPageServices, UiConversation, UiMessage, UiNotification, UiPre
 import type { ChatMode } from '../../chat-mode';
 import { MarkdownMessage } from './markdown-message';
 import { storePreviewComponent } from './preview-component-state';
-
-const starterMessages: UiMessage[] = [{ id: 'welcome', role: 'assistant', text: 'Good morning. What would you like to work through?', status: 'complete' }];
+import { reconcileMessages, starterMessages } from './message-reconciliation';
 
 const initials = (user: UiUser | null): string =>
   (user?.displayName ?? user?.email ?? 'You').split(' ').map((part) => part[0]).join('').slice(0, 2).toUpperCase();
@@ -27,11 +26,6 @@ const modeOptions: Array<{ id: ChatMode; label: string; description: string; pla
   { id: 'plan', label: 'Plan', description: 'Make it actionable', placeholder: 'Turn an idea into a plan…' },
   { id: 'refine', label: 'Refine', description: 'Pressure-test a direction', placeholder: 'Pressure-test a direction…' },
 ];
-const chronological = (items: UiMessage[]): UiMessage[] => [...items].sort((a, b) => {
-  if (!a.createdAt || !b.createdAt) return 0;
-  return a.createdAt.getTime() - b.createdAt.getTime();
-});
-
 const conversationIdFromUrl = (): string | null => new URLSearchParams(window.location.search).get('conversation');
 
 const writeConversationUrl = (conversationId: string | null, replace = false): void => {
@@ -39,65 +33,6 @@ const writeConversationUrl = (conversationId: string | null, replace = false): v
   if (conversationId) url.searchParams.set('conversation', conversationId);
   else url.searchParams.delete('conversation');
   window.history[replace ? 'replaceState' : 'pushState']({}, '', `${url.pathname}${url.search}${url.hash}`);
-};
-
-const reconcileMessages = (serverMessages: UiMessage[], currentMessages: UiMessage[]): UiMessage[] => {
-  const seenServerMessages = new Set<string>();
-  const server = chronological(serverMessages).filter((message) => {
-    if (!message.clientMessageId) return true;
-    const key = `${message.role}:${message.clientMessageId}`;
-    if (seenServerMessages.has(key)) return false;
-    seenServerMessages.add(key);
-    return true;
-  });
-  const serverClientIds = new Set(server.map((message) => message.clientMessageId).filter(Boolean));
-  const localAssistants = currentMessages.filter((message) => message.role === 'assistant' && message.id !== 'welcome');
-  const persistedAssistantIds = new Set(server.filter((message) => message.role === 'assistant').map((message) => message.clientMessageId).filter(Boolean));
-  const linkedAssistants = new Set<string>();
-  const result: UiMessage[] = [];
-
-  const addReply = (message: UiMessage) => {
-    for (const assistant of localAssistants) {
-      if (assistant.replyToClientMessageId === message.clientMessageId && !persistedAssistantIds.has(assistant.id)) {
-        result.push(assistant);
-        linkedAssistants.add(assistant.id);
-      }
-    }
-  };
-
-  for (const message of server) {
-    result.push(message);
-    if (message.role === 'user') addReply(message);
-  }
-
-  for (const message of currentMessages) {
-    if (message.role === 'user' && message.clientMessageId && !serverClientIds.has(message.clientMessageId)) {
-      result.push(message);
-      addReply(message);
-    }
-  }
-
-  result.push(...localAssistants.filter((message) => !linkedAssistants.has(message.id) && !message.replyToClientMessageId));
-
-  const turnKey = (message: UiMessage): string => {
-    if (message.role === 'assistant') {
-      if (message.replyToClientMessageId) return message.replyToClientMessageId;
-      if (message.clientMessageId?.startsWith('assistant-')) return message.clientMessageId.slice('assistant-'.length);
-    }
-    return message.clientMessageId ?? message.id;
-  };
-  const turnOrder = new Map<string, number>();
-  result.forEach((message, index) => {
-    const key = turnKey(message);
-    if (!turnOrder.has(key)) turnOrder.set(key, index);
-  });
-  return result.length ? [...result].sort((a, b) => {
-    const orderDifference = (turnOrder.get(turnKey(a)) ?? 0) - (turnOrder.get(turnKey(b)) ?? 0);
-    if (orderDifference !== 0) return orderDifference;
-    if (a.role === 'user' && b.role !== 'user') return -1;
-    if (a.role !== 'user' && b.role === 'user') return 1;
-    return 0;
-  }) : starterMessages;
 };
 
 function CopyMessageButton({ text }: { text: string }) {

--- a/packages/create-pyric/templates/chat/src/ui/chat/message-reconciliation.ts
+++ b/packages/create-pyric/templates/chat/src/ui/chat/message-reconciliation.ts
@@ -1,0 +1,81 @@
+import type { UiMessage } from './chat-types';
+
+export const starterMessages: UiMessage[] = [{
+  id: 'welcome',
+  role: 'assistant',
+  text: 'Good morning. What would you like to work through?',
+  status: 'complete',
+}];
+
+const chronological = (items: UiMessage[]): UiMessage[] => [...items].sort((a, b) => {
+  if (!a.createdAt || !b.createdAt) return 0;
+  return a.createdAt.getTime() - b.createdAt.getTime();
+});
+
+export const reconcileMessages = (
+  serverMessages: UiMessage[],
+  currentMessages: UiMessage[],
+): UiMessage[] => {
+  const seenServerMessages = new Set<string>();
+  const server = chronological(serverMessages).filter((message) => {
+    if (!message.clientMessageId) return true;
+    const key = `${message.role}:${message.clientMessageId}`;
+    if (seenServerMessages.has(key)) return false;
+    seenServerMessages.add(key);
+    return true;
+  });
+  const serverIds = new Set(server.map((message) => message.id));
+  const serverClientIds = new Set(server.map((message) => message.clientMessageId).filter(Boolean));
+  const localAssistants = currentMessages.filter((message) => message.role === 'assistant' && message.id !== 'welcome');
+  const persistedAssistantIds = new Set(server.filter((message) => message.role === 'assistant').map((message) => message.clientMessageId).filter(Boolean));
+  const linkedAssistants = new Set<string>();
+  const result: UiMessage[] = [];
+
+  const addReply = (message: UiMessage) => {
+    for (const assistant of localAssistants) {
+      if (assistant.replyToClientMessageId === message.clientMessageId && !persistedAssistantIds.has(assistant.id)) {
+        result.push(assistant);
+        linkedAssistants.add(assistant.id);
+      }
+    }
+  };
+
+  for (const message of server) {
+    result.push(message);
+    if (message.role === 'user') addReply(message);
+  }
+
+  for (const message of currentMessages) {
+    if (message.role === 'user' && message.clientMessageId && !serverClientIds.has(message.clientMessageId)) {
+      result.push(message);
+      addReply(message);
+    }
+  }
+
+  // React state contains both optimistic assistants and the previous listener
+  // result. Keep only assistants that are genuinely absent from this snapshot.
+  result.push(...localAssistants.filter((message) =>
+    !serverIds.has(message.id)
+    && !linkedAssistants.has(message.id)
+    && !message.replyToClientMessageId));
+
+  const turnKey = (message: UiMessage): string => {
+    if (message.role === 'assistant') {
+      if (message.replyToClientMessageId) return message.replyToClientMessageId;
+      if (message.clientMessageId?.startsWith('assistant-')) return message.clientMessageId.slice('assistant-'.length);
+    }
+    return message.clientMessageId ?? message.id;
+  };
+  const turnOrder = new Map<string, number>();
+  result.forEach((message, index) => {
+    const key = turnKey(message);
+    if (!turnOrder.has(key)) turnOrder.set(key, index);
+  });
+  return result.length ? [...result].sort((a, b) => {
+    const orderDifference = (turnOrder.get(turnKey(a)) ?? 0) - (turnOrder.get(turnKey(b)) ?? 0);
+    if (orderDifference !== 0) return orderDifference;
+    if (a.role === 'user' && b.role !== 'user') return -1;
+    if (a.role !== 'user' && b.role === 'user') return 1;
+    return 0;
+  }) : starterMessages;
+};

--- a/packages/create-pyric/templates/chat/test/message-reconciliation.test.ts
+++ b/packages/create-pyric/templates/chat/test/message-reconciliation.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { reconcileMessages } from '../src/ui/chat/message-reconciliation.ts';
+import type { UiMessage } from '../src/ui/chat/chat-types.ts';
+
+test('does not duplicate a persisted assistant when Firestore publishes again', () => {
+  const persistedAssistant: UiMessage = {
+    id: 'OK6MzPx25jG9GY9FwRA3',
+    role: 'assistant',
+    text: 'Persisted reply',
+    status: 'complete',
+    clientMessageId: 'assistant-client-message-1',
+  };
+
+  const firstSnapshot = reconcileMessages([persistedAssistant], []);
+  const secondSnapshot = reconcileMessages([persistedAssistant], firstSnapshot);
+
+  assert.deepEqual(secondSnapshot.map((message) => message.id), ['OK6MzPx25jG9GY9FwRA3']);
+});
+
+test('keeps a streaming assistant until its persisted replacement arrives', () => {
+  const user: UiMessage = {
+    id: 'server-user-1',
+    role: 'user',
+    text: 'Hello',
+    status: 'complete',
+    clientMessageId: 'client-message-1',
+  };
+  const streamingAssistant: UiMessage = {
+    id: 'assistant-client-message-1',
+    role: 'assistant',
+    text: 'Streaming',
+    status: 'streaming',
+    replyToClientMessageId: 'client-message-1',
+  };
+
+  const whileStreaming = reconcileMessages([user], [user, streamingAssistant]);
+  assert.deepEqual(whileStreaming.map((message) => message.id), [
+    'server-user-1',
+    'assistant-client-message-1',
+  ]);
+
+  const persistedAssistant: UiMessage = {
+    id: 'server-assistant-1',
+    role: 'assistant',
+    text: 'Complete',
+    status: 'complete',
+    clientMessageId: 'assistant-client-message-1',
+  };
+  const afterPersistence = reconcileMessages(
+    [user, persistedAssistant],
+    whileStreaming,
+  );
+  assert.deepEqual(afterPersistence.map((message) => message.id), [
+    'server-user-1',
+    'server-assistant-1',
+  ]);
+});


### PR DESCRIPTION
Prevents a Firestore assistant message from appearing twice when the chat listener publishes another snapshot.

```ts
const persistedAssistant = {
  id: 'OK6MzPx25jG9GY9FwRA3',
  role: 'assistant' as const,
  text: 'Persisted reply',
  status: 'complete' as const,
  clientMessageId: 'assistant-client-message-1',
};

const first = reconcileMessages([persistedAssistant], []);
const second = reconcileMessages([persistedAssistant], first);

second.map((message) => message.id);
// => ['OK6MzPx25jG9GY9FwRA3']
// Previously returned the same ID twice, causing React's duplicate-key warning.
```

## Previous listener results are no longer mistaken for optimistic messages

`currentMessages` contains two kinds of state: local streaming placeholders and messages retained from the previous Firestore snapshot. The reconciliation step previously collected every assistant from that array, added the latest server messages, and then appended prior assistants without checking whether their document IDs were already present.

The latest snapshot's document IDs now form the boundary. A prior assistant is retained only when it is absent from the server snapshot, while a genuine streaming placeholder remains beside its user message until Firestore publishes the persisted assistant that replaces it.

The reconciliation algorithm now lives in `message-reconciliation.ts`, giving this state transition a direct test seam instead of requiring the complete chat page to render.

## Risk

This changes only the generated chat template's in-memory message merge. Incorrect matching could remove a streaming placeholder too early or retain it after persistence; the regression test covers both sides of that transition.

<details>
<summary>Implementation notes</summary>

- The minimal reproduction failed before the fix with `['OK6MzPx25jG9GY9FwRA3', 'OK6MzPx25jG9GY9FwRA3']`.
- Reconciliation tests cover repeated snapshots and streaming-placeholder replacement.
- Full chat-template test suite: passed.
- Chat-template type-check: passed.
- Production and notification build checks: passed.

</details>
