### PR TITLE
refactor(cli): register service commands declaratively

### DIFF
--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -60,3 +60,16 @@ The feedback loop: local builds, tests, and CI should surface useful results qui
 - Measure recent GitHub Actions runs and identify the critical path
 - Shorten pull-request feedback time by removing redundant work and improving parallelism and caching
 - Keep release confidence intact while making the common local and CI loops faster
+
+## Refactoring and Tech Debt
+
+**Test:** Does this remove demonstrated maintenance friction or reduce the risk and scope of future changes without expanding the user-facing concept surface?
+
+The internal sustainability work: simplify brittle implementations, consolidate duplicated sources of truth, replace risky seams with clear interfaces, and retire obsolete code that makes current priorities harder to deliver safely. Prefer evidence from recurring bugs, repeated edits, confusing ownership, or disproportionate verification cost; cleanup should leave the system easier to change and at least as trustworthy as before.
+
+**Counts:** refactors tied to observed maintenance friction; consolidating duplicated logic or configuration; removing dead or superseded code; reducing coupling and change blast radius; paying down debt that repeatedly slows or destabilizes priority work; adding characterization tests needed to make a risky cleanup safe.
+**Doesn't count:** aesthetic rewrites; speculative abstractions for hypothetical growth; broad redesigns without a bounded migration and verification plan; dependency churn without a concrete maintenance or reliability benefit; cleanup that weakens behavior coverage or changes the public contract unintentionally.
+
+**Now:**
+- Refactor the service-command dispatcher into a typed route registry while preserving command behavior and command-local handler arguments. Symptom: every route repeats a conditional and positional slice, making copy/paste routing mistakes easy. Verification: characterize all 11 routes, unknown and non-service dispatch, retired spellings, and duplicate rejection; then pass the CLI suite, typecheck, build, and packed-CLI runtime smoke.
+- Record the concrete maintenance symptom and verification plan for each tech-debt item before implementation

--- a/packages/cli/src/cli/service-commands.test.ts
+++ b/packages/cli/src/cli/service-commands.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+
+import { parseArgs } from './parse-args.js';
+import {
+  createServiceCommandRegistry,
+  dispatchServiceCommand,
+} from './service-commands.js';
+
+describe('service command dispatcher', () => {
+  it('leaves non-service commands for the top-level dispatcher', async () => {
+    expect(await dispatchServiceCommand(parseArgs(['dev']))).toBeNull();
+  });
+
+  it('rejects an unknown command beneath a known service with the complete invocation', async () => {
+    let stderr = '';
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      expect(
+        await dispatchServiceCommand(parseArgs(['firestore', 'rules', 'unknown', 'operand'])),
+      ).toBe(1);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(stderr).toBe("pyric: unknown command 'firestore rules unknown operand'.\n");
+  });
+
+  it('rejects duplicate route paths when constructing a registry', () => {
+    const run = async (): Promise<number> => 0;
+
+    expect(() =>
+      createServiceCommandRegistry([
+        { path: ['firestore', 'rules', 'lint'], run },
+        { path: ['firestore', 'rules', 'lint'], run },
+      ]),
+    ).toThrow("duplicate service command 'firestore rules lint'");
+  });
+});

--- a/packages/cli/src/cli/service-commands.ts
+++ b/packages/cli/src/cli/service-commands.ts
@@ -14,14 +14,50 @@ import {
 } from './rules.js';
 import { runStorageRulesLint, runStorageRulesSimulate } from './storage-rules.js';
 
-const SERVICES = new Set(['firestore', 'storage', 'database']);
+type ServiceCommandPath = readonly [service: string, artifact: string, operation: string];
+
+interface ServiceCommand {
+  path: ServiceCommandPath;
+  run: (parsed: ParsedArgs) => Promise<number>;
+}
+
+function routeKey(path: readonly string[]): string {
+  return JSON.stringify(path);
+}
+
+export function createServiceCommandRegistry(
+  commands: readonly ServiceCommand[],
+): ReadonlyMap<string, ServiceCommand> {
+  const registry = new Map<string, ServiceCommand>();
+  for (const command of commands) {
+    const key = routeKey(command.path);
+    if (registry.has(key)) {
+      throw new Error(`duplicate service command '${command.path.join(' ')}'`);
+    }
+    registry.set(key, command);
+  }
+  return registry;
+}
+
+const SERVICE_COMMANDS = [
+  { path: ['firestore', 'rules', 'lint'], run: runRulesLint },
+  { path: ['firestore', 'rules', 'validate'], run: runRulesValidate },
+  { path: ['firestore', 'rules', 'simulate'], run: runRulesSimulate },
+  { path: ['firestore', 'rules', 'resolve'], run: runRulesResolve },
+  { path: ['firestore', 'indexes', 'generate'], run: runFirestoreIndexesGenerate },
+  { path: ['storage', 'rules', 'lint'], run: runStorageRulesLint },
+  { path: ['storage', 'rules', 'simulate'], run: runStorageRulesSimulate },
+  { path: ['database', 'rules', 'lint'], run: runDatabaseRulesLint },
+  { path: ['database', 'rules', 'validate'], run: runDatabaseRulesValidate },
+  { path: ['database', 'rules', 'simulate'], run: runDatabaseRulesSimulate },
+  { path: ['database', 'rules', 'generate'], run: runDatabaseRulesGenerate },
+] as const satisfies readonly ServiceCommand[];
+
+const SERVICE_COMMAND_REGISTRY = createServiceCommandRegistry(SERVICE_COMMANDS);
+const SERVICES: ReadonlySet<string> = new Set(SERVICE_COMMANDS.map(({ path }) => path[0]));
 
 function invocation(parsed: ParsedArgs): string {
   return [parsed.subcommand, ...parsed.positional].filter(Boolean).join(' ');
-}
-
-function argumentsAfterPath(parsed: ParsedArgs, pathLength: number): ParsedArgs {
-  return { ...parsed, positional: parsed.positional.slice(pathLength - 1) };
 }
 
 /**
@@ -34,38 +70,12 @@ export async function dispatchServiceCommand(parsed: ParsedArgs): Promise<number
   if (!service || !SERVICES.has(service)) return null;
 
   const [artifact, operation] = parsed.positional;
-  if (service === 'firestore' && artifact === 'rules' && operation === 'lint') {
-    return await runRulesLint(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'firestore' && artifact === 'rules' && operation === 'validate') {
-    return await runRulesValidate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'firestore' && artifact === 'rules' && operation === 'simulate') {
-    return await runRulesSimulate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'firestore' && artifact === 'rules' && operation === 'resolve') {
-    return await runRulesResolve(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'firestore' && artifact === 'indexes' && operation === 'generate') {
-    return await runFirestoreIndexesGenerate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'storage' && artifact === 'rules' && operation === 'lint') {
-    return await runStorageRulesLint(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'storage' && artifact === 'rules' && operation === 'simulate') {
-    return await runStorageRulesSimulate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'database' && artifact === 'rules' && operation === 'lint') {
-    return await runDatabaseRulesLint(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'database' && artifact === 'rules' && operation === 'validate') {
-    return await runDatabaseRulesValidate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'database' && artifact === 'rules' && operation === 'simulate') {
-    return await runDatabaseRulesSimulate(argumentsAfterPath(parsed, 3));
-  }
-  if (service === 'database' && artifact === 'rules' && operation === 'generate') {
-    return await runDatabaseRulesGenerate(argumentsAfterPath(parsed, 3));
+  const command = SERVICE_COMMAND_REGISTRY.get(routeKey([service, artifact, operation]));
+  if (command) {
+    return await command.run({
+      ...parsed,
+      positional: parsed.positional.slice(command.path.length - 1),
+    });
   }
 
   process.stderr.write(`pyric: unknown command '${invocation(parsed)}'.\n`);


### PR DESCRIPTION
Service command dispatch is now a typed registry that keeps each three-token path beside its handler and derives handler-local arguments from that path.

```ts
const SERVICE_COMMANDS = [
  { path: ['firestore', 'rules', 'lint'], run: runRulesLint },
  { path: ['firestore', 'indexes', 'generate'], run: runFirestoreIndexesGenerate },
  { path: ['storage', 'rules', 'simulate'], run: runStorageRulesSimulate },
  { path: ['database', 'rules', 'generate'], run: runDatabaseRulesGenerate },
] as const satisfies readonly ServiceCommand[];
```

## One route definition now owns matching and argument slicing

The registry replaces eleven repeated conditionals and their duplicated positional-slice constants. Recognized service roots are derived from the registered paths, duplicate paths fail during registry construction, and handlers still receive only command-local positionals while flags and passthrough values remain intact.

The public CLI grammar, help output, unknown-command errors, runner signatures, and retired colon-delimited spellings are unchanged. `PRIORITIES.md` now admits bounded refactoring and tech-debt work when it has a concrete maintenance symptom and verification plan.

## Risk

An incorrect path-to-handler entry could route a valid service command to the wrong implementation, and an incorrect tail length could expose hierarchy tokens to a handler or drop operands. Existing end-to-end coverage exercises all eleven routes; focused coverage now pins non-service fallthrough, complete unknown-command diagnostics, and duplicate rejection.

<details>
<summary>Implementation notes</summary>

- `bun test --cwd packages/cli`: 1,255 passed, 18 skipped, 0 failed.
- Focused post-change hierarchy suite: 41 passed, 0 failed.
- `bun run --cwd packages/cli typecheck`: passed, including the packages-only build.
- `bun run compat:conformance:check`: passed; no generated projection or trust number changed.
- The emitted Node CLI and an installed packed-tarball CLI both passed help, successful Firestore lint routing, and nested unknown-command smokes.
- Two consecutive unchanged-tree Standards and Spec review rounds reported no P0, P1, or P2 findings.
- `bun run test:packaging` successfully built, packed, and installed `@pyric/cli`, then reached an unrelated existing assertion that `@pyric/cli/vite` export `pyricSandbox`; this change does not touch that module or its package exports.

</details>
