### PR TITLE
refactor(cli): share sandbox session across serve adapters

### DIFF
--- a/docs/vite-plugin-serve-architecture-research.md
+++ b/docs/vite-plugin-serve-architecture-research.md
@@ -1,0 +1,159 @@
+# Vite plugin / serve architecture research
+
+**Investigated:** 2026-07-21 at `3011b4ccd62cad949deba0cd96871d91f9759fbd`
+
+**Question:** What first-party evidence should constrain a maintainability refactor of `packages/cli/src/serve/vite-plugin.ts`, especially one intended to share code with `pyric dev`?
+
+**Primary sources:** Vite's official documentation and source, this repository's source, ADRs, priorities, tests, and Git history.
+
+## Conclusion
+
+Keep the Vite plugin as the Vite **adapter**, but move construction and ownership of a running Pyric sandbox session behind one shared, host-neutral **module** used by both the Vite adapter and the `pyric dev` adapter.
+
+The evidence does **not** support merging the two hosts or wrapping one in the other. Vite owns module resolution, dependency optimization, HTML transformation, its watcher, middleware ordering, and sometimes the HTTP server. `pyric dev` owns static hosting, import-map injection, port scanning, CLI output, process signals, and child-command orchestration. Those are real separate adapters. The duplicated middle is the session: project/rules loading, seed and persistent-state preparation, capture, Studio storage, `/__pyric` namespace, bridge, activity reporting, runtime payload, and owned-resource disposal.
+
+This passes the repository's Refactoring and Tech Debt test in [`PRIORITIES.md`](../PRIORITIES.md): the maintenance friction is demonstrated by repeated parallel edits and by comments that explicitly describe copied behavior. It also executes the accepted direction in [ADR-0008](decisions/0008-cli-serve-structure-cleanup-follow-up.md), which requires resource owners for configuration/fixtures, SDK assets, HTTP/bridge/UI startup, and shutdown while leaving the command as lifecycle orchestration.
+
+## Vite contracts that constrain the adapter
+
+The package supports Vite 5, 6, and 7, rather than one implementation version ([CLI manifest](../packages/cli/package.json#L127-L143)). The refactor should therefore stay on documented plugin and dev-server contracts rather than Vite internals.
+
+1. `config` is the pre-resolution hook for returning a partial configuration; `configResolved` receives the final configuration. That matches the current optimizer, build-target, environment, and `server.fs.allow` work and argues for leaving it in the Vite adapter. [Vite 6 Plugin API — `config` and `configResolved`](https://v6.vite.dev/guide/api-plugin#config)
+2. `resolveId` and `load` are request-time plugin hooks, and Vite warns that an importer's shape is not always uniform. Pyric's Firebase swap and importer-scoped Node shims therefore belong to the adapter and should continue to be tested through Vite. [Vite 6 Plugin API — universal hooks](https://v6.vite.dev/guide/api-plugin#universal-hooks)
+3. `configureServer` is an async, sequential hook intended for attaching Connect middleware. A returned function means “install post middleware”; it is **not** a disposer. The current plugin correctly mounts its guarded `/__pyric` middleware directly because it must run independently of Vite's internal middleware ordering. [Vite 6 Plugin API — `configureServer`](https://v6.vite.dev/guide/api-plugin#configureserver)
+4. `transformIndexHtml` can return tag descriptors, and `order: 'pre'` is the supported way to send injected scripts through Vite's pipeline. Pyric's sandbox marker, init entry, runtime chip, and build chunk integration remain Vite-adapter work. [Vite 6 Plugin API — `transformIndexHtml`](https://v6.vite.dev/guide/api-plugin#transformindexhtml)
+5. `ViteDevServer.httpServer` is explicitly null in middleware mode, while `middlewares`, `watcher`, and `close()` remain dev-server contracts. A shared session cannot assume it owns a Node HTTP server; bridge upgrades and listen-address-dependent functions must be optional host capabilities. [Vite 6 JavaScript API — `ViteDevServer`](https://v6.vite.dev/guide/api-javascript#vitedevserver)
+6. Vite documents that `buildEnd` and `closeBundle` run when the dev server closes. Vite 5.4.21 source shows `server.close()` concurrently closing the watcher, hot channel, plugin container, dependency optimizers, and HTTP server; closing the plugin container is what drives plugin close hooks even in middleware mode. This is a stronger lifecycle signal than listening only to `httpServer.close`. [Vite 6 Plugin API — dev lifecycle](https://v6.vite.dev/guide/api-plugin#universal-hooks), [Vite 5.4.21 server source](https://github.com/vitejs/vite/blob/v5.4.21/packages/vite/src/node/server/index.ts)
+
+### Lifecycle implication
+
+The Vite adapter should own one idempotent session disposer and invoke it from `closeBundle`; an `httpServer.close` listener may remain only as a defensive compatibility path if tests prove it necessary. Resource cleanup must not depend exclusively on `httpServer`, because official Vite types make it null in middleware mode. Any Vite watcher handlers registered for rules or Functions hot reload need matching removal in that disposer.
+
+## Repository evidence: the duplicated middle
+
+Both public entry points already call the same low-level modules, but each still assembles the session independently:
+
+| Session concern | `pyric dev` | Vite plugin |
+|---|---|---|
+| Firestore/RTDB/Storage rules | [`startServe`](../packages/cli/src/cli/serve.ts#L166-L232) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L425-L449) |
+| Capture, persistence, fresh-state validation | [`startServe`](../packages/cli/src/cli/serve.ts#L240-L257) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L451-L471) |
+| Seed/state-envelope decoding | [`startServe`](../packages/cli/src/cli/serve.ts#L259-L310) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L473-L510) |
+| Bridge mount and project identity | [`startServe`](../packages/cli/src/cli/serve.ts#L340-L379) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L524-L569) |
+| Event hub, Studio stores, site tree, namespace | [`startServe`](../packages/cli/src/cli/serve.ts#L382-L432) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L571-L657) |
+| Functions discovery/child lifecycle | [`runServe`](../packages/cli/src/cli/serve.ts#L650-L840) | [`configureServer`](../packages/cli/src/serve/vite-plugin.ts#L524-L545) and its later child block |
+
+This is more than shared imports. The plugin's comments say “Reproduce serve's rules prelude,” “mirrors serve's startServe orchestration,” “Ported from serve.ts,” and “mirrors serve.ts.” Those are first-party admissions that the interface is too low-level: callers reuse primitives but must still know the same ordering and precedence rules.
+
+At the investigation commit:
+
+- `vite-plugin.ts` is 1,077 lines and `serve.ts` is 984 lines.
+- `configureServer` begins at line 425 and the HTML/build hooks resume at line 1,010: roughly 585 lines of the plugin are dev-session assembly.
+- Since 2026-07-13, Git history shows at least 17 commits touching the Vite plugin; several cross-cutting behavior changes edited both adapters (Studio/docs, worker status, storage project scope, activity guard, and app registry), while Functions support landed once in `serve.ts` and later required two substantial Vite-plugin folds. Reproduce with:
+
+```bash
+git log --since=2026-07-13 --numstat --format='commit %h %ad %s' --date=short -- \
+  packages/cli/src/serve/vite-plugin.ts packages/cli/src/cli/serve.ts
+```
+
+The deletion test points at the orchestration, not the existing low-level modules: deleting `state-store.ts`, `capture-store.ts`, `namespace.ts`, or `bridge-mount.ts` would concentrate real complexity. Deleting the duplicated assembly from either adapter would mostly move it to the other. The deepening opportunity is one module that owns assembly order and resource lifetime. This research stops short of designing that module's interface; the architecture review's grilling step comes first.
+
+## Where sharing should stop
+
+The following Vite responsibilities should remain local to `vite-plugin.ts`:
+
+- `apply`, `config`, and `configResolved` policy;
+- Firebase resolution and Node-shim `resolveId`/`load` hooks;
+- dependency-optimizer esbuild integration;
+- SharedWorker bundle preparation through the existing `vite-worker-runtime` module;
+- adaptation of Vite's Connect request shape and DNS-rebinding inputs;
+- adaptation of `server.watcher` changes into shared reload operations;
+- optional upgrade/listening capabilities from `server.httpServer`; and
+- build-only chunk emission plus `transformIndexHtml` tags.
+
+The following `pyric dev` responsibilities should remain local to the CLI/static-server adapter:
+
+- hosting/public-directory selection and inlined-Firebase scan;
+- SDK/static asset materialization and import-map HTML injection;
+- port scan, standalone packaging behavior, and terminal banner/JSON output;
+- signal handling, auto-open, developer child-command orchestration, and process guard; and
+- static-server shutdown.
+
+Trying to share these would create a shallow abstraction full of Vite-or-static conditionals. One adapter per host is a real seam because two hosts already exist; the shared module should contain only the session semantics both adapters currently duplicate.
+
+## Recommended architecture direction
+
+Use three layers:
+
+```text
+Vite adapter                           static/CLI adapter
+resolution, optimizer, HTML,          assets, hosting, import map,
+Connect + watcher adaptation          ports, process + child lifecycle
+              \                         /
+               \                       /
+                shared sandbox-session module
+                project configuration + fixtures
+                rules/live payload + stores + Studio
+                namespace + bridge + resource disposal
+                           |
+                 existing focused modules
+```
+
+The shared module should be deep and own the ordering invariants that currently leak into both adapters:
+
+- validate `fresh` against persistence and eagerly validate existing state;
+- decode seed fixtures once, with “lived state wins” precedence;
+- load the three rules families and construct the live init payload;
+- decide whether Functions require a bridge and resolve project identity once;
+- construct capture/state/Studio/event/namespace resources together; and
+- dispose bridge pointers, child processes, subscriptions, and other owned resources once.
+
+Keep watcher selection outside: the CLI adapter uses `watchProjectRules`; the Vite adapter uses Vite's watcher. Share the last-good rules behavior, not the mechanism that observes the filesystem. Keep host attachment and listen-dependent behavior in each adapter.
+
+## Implementation outcome
+
+The subsequent design pass kept the recommended three-layer shape and narrowed
+the shared boundary where the host contracts demanded it. The implemented
+`sandbox-session` module owns rules loading and last-good replacement, seed and
+persistence precedence, capture, Studio stores, the live init payload, the
+`/__pyric` namespace, SSE clients, and idempotent session cleanup. Both the
+static/CLI adapter and the Vite adapter construct that same module.
+
+Bridge construction and Functions lifecycle remain adapter-owned. They need
+host facts that are intentionally absent from the session interface: bound HTTP
+servers and upgrade attachment, discovery pointers, Vite's watcher, child
+processes, and the bridge's live `sandboxConnected` state. Moving them into the
+session would widen the interface into a host abstraction and make the module
+shallower. The session instead accepts only the late-bound bridge URL needed by
+the init payload; each adapter composes the bridge handler ahead of the shared
+namespace handler.
+
+Vite cleanup is explicit in its hooks: each transition captures the current
+session, clears the configured reference, removes adapter-owned watcher
+listeners, and closes the captured session. There is deliberately no
+mutation-hiding `closeActiveSession()` helper. `closeBundle` provides the
+middleware-mode lifecycle signal, where `httpServer` is null, while the shared
+session's idempotent `close()` ends its owned SSE streams.
+
+## Verification implications
+
+The current tests are already organized around observable adapter behavior (`packages/cli/test/serve/vite-plugin*.test.ts`, `server.test.ts`, bridge tests, rules tests, persistence tests). Preserve them as characterization tests. Add a smaller shared-session suite for ordering and cleanup invariants, then keep at least these adapter-level checks:
+
+- Vite 5/6/7 type/build compatibility and a real dev-server smoke;
+- middleware mode with `httpServer === null`, including cleanup through `server.close()`;
+- normal Vite close and restart do not retain watcher listeners, discovery pointers, bridge upgrades, or Functions children;
+- `/__pyric` middleware remains before Vite internals and independently host-guarded;
+- sandbox build versus production build behavior and HTML tags remain unchanged; and
+- `pyric dev` and Vite produce equivalent init payload semantics for the same rules, seed, persist, capture, Studio, bridge, and AI inputs.
+
+## Sources
+
+- [Repository priorities](../PRIORITIES.md)
+- [Repository context](../CONTEXT.md)
+- [ADR-0008: CLI serve structure cleanup](decisions/0008-cli-serve-structure-cleanup-follow-up.md)
+- [`vite-plugin.ts`](../packages/cli/src/serve/vite-plugin.ts)
+- [`serve.ts`](../packages/cli/src/cli/serve.ts)
+- [`server.ts`](../packages/cli/src/serve/server.ts)
+- [Vite 6 Plugin API](https://v6.vite.dev/guide/api-plugin)
+- [Vite 6 JavaScript API](https://v6.vite.dev/guide/api-javascript)
+- [Vite 5.4.21 dev-server source](https://github.com/vitejs/vite/blob/v5.4.21/packages/vite/src/node/server/index.ts)
+- [Vite 5.4.21 plugin types/source](https://github.com/vitejs/vite/blob/v5.4.21/packages/vite/src/node/plugin.ts)

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -11,7 +11,7 @@
  * version) → static server with the `/__pyric/` namespace + HTML injection.
  */
 import { dirname, join, relative, resolve } from 'node:path';
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, watch as watchFile, writeFileSync } from 'node:fs';
 import type { ParsedArgs } from './parse-args.js';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from './firebase-json.js';
 import { bundleSdk, bundleWorker, defaultSdkEntries, resolveSiteUiDir } from '../serve/bundler.js';
@@ -21,18 +21,10 @@ import {
   materializeSiteUi,
   embeddedWorkerVersion,
 } from '../serve/standalone-assets.js';
-import { loadProjectDatabaseRules, loadProjectRules, loadProjectStorageRules, watchProjectRules } from '../serve/rules.js';
 import { hasSandboxBuildMarker } from '../serve/sandbox-marker.js';
-import {
-  createEventHub,
-  createPyricNamespace,
-  type InitPayload,
-} from '../serve/namespace.js';
+import type { InitPayload } from '../serve/namespace.js';
 import { injectServeTags } from '../serve/html-injection.js';
 import { formatActivityWarning } from '../serve/activity-warning.js';
-import { createStateStore, STATE_FILE_VERSION, type PyricStateFile } from '../serve/state-store.js';
-import { diskProjectStore, diskWorkspace } from '../serve/studio/index.js';
-import { createCaptureStore } from '../serve/capture-store.js';
 import { consoleServeLogger, startStaticServer, stderrServeLogger, type ServeHandle } from '../serve/server.js';
 import { createBridgeMount } from '../serve/bridge-mount.js';
 import { openBrowser, shouldAutoOpen } from '../serve/open-browser.js';
@@ -55,6 +47,11 @@ import {
   discoverFunctionsRtdbProject,
   type FunctionsRtdbProject,
 } from '../functions-rtdb/project.js';
+import {
+  createSandboxSession,
+  SandboxSeedError,
+  type SandboxSession,
+} from '../serve/sandbox-session.js';
 
 interface HostingConfig {
   public?: string;
@@ -215,100 +212,6 @@ export async function startServe(opts: {
     }
   }
 
-  // Rules: fail fast on broken rules; serve rule-less only when genuinely absent.
-  // Held in a mutable box — the watcher swaps it and the payload producer
-  // always serves the live version.
-  const loaded = await loadProjectRules(opts.cwd, config);
-  const loadedDatabase = await loadProjectDatabaseRules(opts.cwd, config);
-  // Storage rules deploy ONCE at boot — see the `storageRules` doc on
-  // `InitPayload`: `pyric/storage` only honors rules on the FIRST storage
-  // call per Sandbox, so unlike firestore/database rules there is no live
-  // "live" box to swap here; a storage.rules edit needs a restart.
-  const loadedStorage = await loadProjectStorageRules(opts.cwd, config);
-  const live = {
-    rules: loaded.rules,
-    rulesHash: loaded.rulesHash,
-    databaseRules: loadedDatabase.rules,
-    databaseRulesHash: loadedDatabase.rulesHash,
-    databaseUrl: loadedDatabase.databaseUrl,
-  };
-
-  // --capture (default on): the capture store writes .pyric/last-session.json
-  // whenever the page pushes its session fixture via POST /__pyric/capture.
-  // pyric verify (no-arg) reads that file. Independent of --persist — capture
-  // records for the verify loop, persist is for cross-reload durability.
-  const capture = (opts.capture ?? true) ? createCaptureStore(opts.cwd) : null;
-
-  // --persist: the state store IS the durable sandbox (section 3c). Load eagerly so
-  // a corrupt/mismatched file fails the start (inspect-or-delete message)
-  // instead of silently serving ephemeral.
-  const state = opts.persist ? createStateStore(opts.cwd) : null;
-  // --fresh: the escape hatch from "state wins after the first run" — drop
-  // the existing state (+ its backup) so this run re-seeds from scratch.
-  if (state && opts.fresh) {
-    for (const p of [state.path, state.backupPath]) if (existsSync(p)) rmSync(p);
-    logger.note('  ⓘ --fresh: discarded the existing state file; re-seeding');
-    // Half-reset warning: --fresh only deletes the SERVER file. The worker's
-    // durable store is browser IndexedDB, and prime-once only fills an EMPTY
-    // IDB (createWorkerDurableBackend) — a browser that already holds sandbox
-    // data KEEPS it and its next flush repopulates the supposedly-fresh file.
-    // The reset handshake (making --fresh actually clear the browser store) is
-    // future work; until then, say so loudly rather than let the file quietly
-    // refill.
-    logger.note(
-      '  ⚠ --fresh only resets the server-side state file — a browser tab that already has ' +
-        'sandbox data in IndexedDB keeps it and will write it straight back on its next flush. ' +
-        'For a full reset, also clear the browser store: Studio → Settings → Reset, or open an ' +
-        'incognito/private window.',
-    );
-  }
-  let persistedEnvelope = state?.load() ?? null;
-
-  // --seed accepts BOTH shapes: a bare path→fields map, or a PyricStateFile
-  // envelope (detected by its `version` key — what `pyric snapshot` emits).
-  let seed: Record<string, Record<string, unknown>> | null = null;
-  /** Ephemeral fixture restore: the controller blob from a state-file seed,
-   *  restored in-page through the persistence deserializer (wrapper
-   *  re-hydration) via a read-only backend. */
-  let seedState: unknown | null = null;
-  let seedUsers: Record<string, unknown>[] | null = null;
-  let seedLabel = '';
-  if (opts.seed) {
-    const seedPath = resolve(opts.cwd, opts.seed);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(readFileSync(seedPath, 'utf8'));
-    } catch (e) {
-      throw new Error(`pyric dev: failed to read --seed ${seedPath}: ${e instanceof Error ? e.message : String(e)}`);
-    }
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new Error(`pyric dev: --seed must be a JSON object of "collection/doc" → fields, got ${Array.isArray(parsed) ? 'array' : typeof parsed}`);
-    }
-    const obj = parsed as Record<string, unknown>;
-    if (obj.version === STATE_FILE_VERSION && ('firestore' in obj || 'auth' in obj)) {
-      const fixture = obj as unknown as PyricStateFile;
-      const docCount = Object.keys(
-        ((fixture.firestore as { firestore?: Record<string, unknown> } | null)?.firestore) ?? {},
-      ).length;
-      const userCount = fixture.auth?.users?.length ?? 0;
-      seedLabel = `${docCount} doc(s) + ${userCount} user(s) from state fixture`;
-      if (state && !state.exists()) {
-        // Persist first run seeded from a fixture: prime the store, then the
-        // normal persist path restores it like any lived state.
-        if (fixture.firestore != null) state.writeSection('firestore', fixture.firestore);
-        if (fixture.auth != null) state.writeSection('auth', fixture.auth);
-        persistedEnvelope = state.load();
-      } else if (!state) {
-        seedState = fixture.firestore ?? null;
-        seedUsers = (fixture.auth?.users as Record<string, unknown>[] | undefined) ?? null;
-      }
-      // persist + existing state: the lived state wins; the fixture is inert.
-    } else {
-      seed = parsed as Record<string, Record<string, unknown>>;
-      seedLabel = `${Object.keys(seed).length} document(s)`;
-    }
-  }
-
   // SDK bundles (cached per pyric version + entry hash). In a standalone
   // binary the runtime esbuild bundler is unavailable, so the deterministic
   // bundles were built at compile time and embedded; materialize them to a
@@ -353,43 +256,6 @@ export async function startServe(opts: {
 
   // bridgeUrl needs the BOUND port; resolved after listen via this box.
   const origin = { host: opts.host ?? 'localhost', port: 0 };
-  const payload = (): InitPayload => ({
-    rules: live.rules,
-    rulesHash: live.rulesHash,
-    databaseRules: live.databaseRules,
-    databaseRulesHash: live.databaseRulesHash,
-    databaseUrl: live.databaseUrl,
-    storageRules: loadedStorage.rules,
-    storageRulesHash: loadedStorage.rulesHash,
-    // Project identity: scopes the storage IDB name per served project
-    // (issue #359). Local-only — a dev path never leaves the machine.
-    projectKey: opts.cwd,
-    bridgeUrl: mount && origin.port > 0 ? mount.wsUrl(origin) : null,
-    // Precedence: once a state file exists, the lived state is the truth —
-    // --seed applies only on the first (state-less) run.
-    seed: state?.exists() ? null : seed,
-    seedState,
-    persist: Boolean(state),
-    capture: Boolean(capture),
-    authUsers: state
-      ? ((state.readSection('auth') as { users?: Record<string, unknown>[] } | null)?.users ?? null)
-      : seedUsers,
-    // Served firebase/messaging is part of the canonical swap, so the worker
-    // broker must be available whenever the SDK entries are served.
-    messaging: true,
-  });
-
-  const events = createEventHub();
-  // --ui (Pyric Studio): serve the disk-backed workspace + project routes.
-  // Single-project mode: the served `cwd` IS the one project's file tree; the
-  // project store roots at `.pyric/projects` (multi-project ready) but the
-  // current served tree is also reachable directly via /__pyric/workspace.
-  const studio = opts.ui
-    ? {
-        workspace: diskWorkspace(opts.cwd),
-        projects: diskProjectStore(join(opts.cwd, '.pyric', 'projects')),
-      }
-    : undefined;
   // --ui also serves the unified Astro site under /__pyric/ui/. The dir is
   // resolved by file path (never imported), so a missing build is a clear
   // warning rather than a crash; the data routes still mount.
@@ -405,18 +271,40 @@ export async function startServe(opts: {
       );
     }
   }
-  const sdkNamespace = createPyricNamespace({
-    sdkDir: bundle.outDir,
-    initPayload: payload,
-    events,
-    activity: (incident) => logger.note(formatActivityWarning(incident)),
-    state: state ?? undefined,
-    capture: capture ?? undefined,
-    studio,
-    siteUiDir,
-    workerVersion,
-    logger,
-  });
+  let session: SandboxSession;
+  try {
+    session = await createSandboxSession({
+      projectDir: opts.cwd,
+      firebaseConfig: config,
+      sdk: { dir: bundle.outDir, workerVersion },
+      seedFile: opts.seed,
+      persistence: opts.persist ? { fresh: opts.fresh } : undefined,
+      capture: opts.capture,
+      studio: opts.ui ? { siteUiDir } : false,
+      bridgeUrl: () => mount && origin.port > 0 ? mount.wsUrl(origin) : null,
+      activity: (incident) => logger.note(formatActivityWarning(incident)),
+      logger,
+    });
+  } catch (error) {
+    bundle.dispose?.();
+    if (error instanceof SandboxSeedError) {
+      if (error.kind === 'read') {
+        throw new Error(`pyric dev: failed to read --seed ${error.path}: ${error.detail}`);
+      }
+      throw new Error(`pyric dev: --seed must be a JSON object of "collection/doc" → fields, ${error.detail}`);
+    }
+    throw error;
+  }
+  if (opts.persist && opts.fresh) {
+    logger.note('  ⓘ --fresh: discarded the existing state file; re-seeding');
+    logger.note(
+      '  ⚠ --fresh only resets the server-side state file — a browser tab that already has ' +
+        'sandbox data in IndexedDB keeps it and will write it straight back on its next flush. ' +
+        'For a full reset, also clear the browser store: Studio → Settings → Reset, or open an ' +
+        'incognito/private window.',
+    );
+  }
+  const payload = session.payload;
   let handle: Awaited<ReturnType<typeof startStaticServer>>;
   try {
     handle = await startStaticServer({
@@ -425,8 +313,8 @@ export async function startServe(opts: {
       host: opts.host ?? 'localhost',
       spaRewrite: wantsSpaRewrite(hosting),
       namespaceHandler: mount
-        ? async (req, res, url) => (await mount.handler(req, res, url)) || sdkNamespace(req, res, url)
-        : sdkNamespace,
+        ? async (req, res, url) => (await mount.handler(req, res, url)) || session.handle(req, res, url)
+        : session.handle,
       // Never force in-page: serve always serves the worker, and the bridge peer
       // routes agent tool-calls THROUGH the worker (see connectBridgePeer), so app
       // + Studio + agent share the one sandbox even under --bridge.
@@ -435,10 +323,12 @@ export async function startServe(opts: {
       logger,
     });
   } catch (error) {
+    await session.close();
     bundle.dispose?.();
     throw error;
   }
   if (bundle.dispose) handle.server.once('close', bundle.dispose);
+  handle.server.once('close', () => void session.close());
   origin.port = handle.port;
   // Attach the WS upgrade to EVERY bound server so the sandbox peer connects on
   // whichever loopback family the page resolved (localhost binds both now).
@@ -465,20 +355,31 @@ export async function startServe(opts: {
     } catch { /* best-effort: discovery falls back to a port scan */ }
   }
 
-  // Hot-reload: watch the rules file, swap the live ruleset, broadcast.
-  const watching = (opts.watch ?? true) && loaded.sourcePath !== null;
+  // Hot-reload: the static adapter observes the filesystem; the session owns
+  // read/prepare/last-good replacement and event broadcast.
+  const rulesSourcePath = session.summary.rules.firestore.sourcePath;
+  const watching = (opts.watch ?? true) && rulesSourcePath !== null;
   if (watching) {
-    const watcher = watchProjectRules(
-      loaded.sourcePath!,
-      (next) => {
-        live.rules = next.rules;
-        live.rulesHash = next.rulesHash;
-        events.broadcast('rules-changed', next);
-        logger.note(`  ↻ rules reloaded (hash ${next.rulesHash}) → ${events.clientCount()} page(s)`);
-      },
-      (message) => logger.note(`  ⚠ rules NOT reloaded (last-good stays live): ${message}`),
-    );
-    handle.server.once('close', () => watcher.close());
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const watcher = watchFile(rulesSourcePath!, () => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        void session.reloadFirestoreRules().then((result) => {
+          if (result.kind === 'reloaded') {
+            logger.note(`  ↻ rules reloaded (hash ${result.rulesHash}) → ${result.clients} page(s)`);
+          } else if (result.kind === 'rejected') {
+            logger.note(`  ⚠ rules NOT reloaded (last-good stays live): ${result.error.message}`);
+          }
+        });
+      }, 150);
+    });
+    watcher.on('error', (error) => {
+      logger.note(`  ⚠ rules watcher failed (hot reload off): ${error instanceof Error ? error.message : String(error)}`);
+    });
+    handle.server.once('close', () => {
+      if (debounce) clearTimeout(debounce);
+      watcher.close();
+    });
   }
 
   logger.info(`=== Serving from '${opts.cwd}'...`);
@@ -493,18 +394,18 @@ export async function startServe(opts: {
         : `✔ sandbox  pyric SDK bundles built in ${bundleMs}ms`,
   );
   logger.info(
-    loaded.rules
-      ? `✔ rules    ${loaded.sourcePath} → deployed to the in-page sandbox (hash ${loaded.rulesHash})`
+    session.payload().rules
+      ? `✔ rules    ${session.summary.rules.firestore.sourcePath} → deployed to the in-page sandbox (hash ${session.summary.rules.firestore.hash})`
       : `• rules    no firestore.rules — sandbox runs with default rules`,
   );
   logger.info(
-    loadedDatabase.rules
-      ? `✔ rules    ${loadedDatabase.sourcePath} → deployed to the RTDB sandbox (hash ${loadedDatabase.rulesHash})`
+    session.payload().databaseRules
+      ? `✔ rules    ${session.summary.rules.database.sourcePath} → deployed to the RTDB sandbox (hash ${session.summary.rules.database.hash})`
       : `• rules    no database.rules — RTDB sandbox runs with default rules`,
   );
   logger.info(
-    loadedStorage.rules
-      ? `✔ rules    ${loadedStorage.sourcePath} → deployed to the storage sandbox (hash ${loadedStorage.rulesHash}; ` +
+    session.payload().storageRules
+      ? `✔ rules    ${session.summary.rules.storage.sourcePath} → deployed to the storage sandbox (hash ${session.summary.rules.storage.hash}; ` +
         `edits require a restart — storage rules do not hot-reload)`
       : `• rules    no storage.rules — storage sandbox runs open (no rules configured)`,
   );
@@ -518,20 +419,19 @@ export async function startServe(opts: {
     logger.info(`✔ bridge   MCP endpoint: ${mount.mcpUrl(origin)} (sandbox peers over ws at /__pyric/sandbox)`);
   }
   let persistSummary: ServeRuntime['persist'] = null;
-  if (state) {
-    const fsDocs = persistedEnvelope?.firestore
-      ? Object.keys((persistedEnvelope.firestore as { firestore?: Record<string, unknown> }).firestore ?? {}).length
-      : 0;
-    const users = (persistedEnvelope?.auth as { users?: unknown[] } | null)?.users?.length ?? 0;
+  const persistence = session.summary.persistence;
+  if (persistence) {
+    const fsDocs = persistence.restoredDocs;
+    const users = persistence.restoredUsers;
     persistSummary = { restoredDocs: fsDocs, restoredUsers: users };
     logger.info(
-      persistedEnvelope
-        ? `✔ persist  ${state.path} (${fsDocs} doc(s), ${users} user(s) restored; --seed skipped)`
-        : `✔ persist  new state file at ${state.path} (first run — seed applies)`,
+      persistence.restored
+        ? `✔ persist  ${persistence.path} (${fsDocs} doc(s), ${users} user(s) restored; --seed skipped)`
+        : `✔ persist  new state file at ${persistence.path} (first run — seed applies)`,
     );
-    if (existsSync(state.backupPath)) {
+    if (existsSync(persistence.backupPath)) {
       logger.note(
-        `  ⓘ a recovery backup exists at ${state.backupPath} (prior non-empty state was ` +
+        `  ⓘ a recovery backup exists at ${persistence.backupPath} (prior non-empty state was ` +
           'replaced by an empty one — e.g. a reset). Restore: mv it back over state.json.',
       );
     }
@@ -547,13 +447,13 @@ export async function startServe(opts: {
   // (A fixture that primed the persist store is reported by the persist
   // line; a fixture ignored because lived state exists is intentionally
   // silent about staging.)
-  if ((seed && !state?.exists()) || seedState || seedUsers) {
-    logger.info(`✔ seed     ${seedLabel} staged for page init`);
+  if (session.summary.seedStaged) {
+    logger.info(`✔ seed     ${session.summary.seedLabel} staged for page init`);
   }
-  if (capture) {
-    logger.info(`✔ capture  session → ${capture.path} (run \`pyric verify\` to replay it)`);
+  if (session.summary.capturePath) {
+    logger.info(`✔ capture  session → ${session.summary.capturePath} (run \`pyric verify\` to replay it)`);
   }
-  if (watching) logger.info(`✔ watch    hot-reloading ${loaded.sourcePath} over /__pyric/events`);
+  if (watching) logger.info(`✔ watch    hot-reloading ${rulesSourcePath} over /__pyric/events`);
   // Browser-honesty: the sandbox is browser-resident — firestore/auth and
   // persistence run IN the served page. With no page open, data ops silently
   // no-op. This warning (paired with auto-open in runServe) is the fix for the

--- a/packages/cli/src/serve/namespace.ts
+++ b/packages/cli/src/serve/namespace.ts
@@ -34,12 +34,19 @@ export interface ServeEventHub {
   handle(req: IncomingMessage, res: ServerResponse): void;
   broadcast(event: string, data: unknown): void;
   clientCount(): number;
+  /** End all open streams. Idempotent; used by host-neutral session cleanup. */
+  close(): void;
 }
 
 export function createEventHub(): ServeEventHub {
   const clients = new Set<ServerResponse>();
+  let closed = false;
   return {
     handle(req, res) {
+      if (closed) {
+        res.writeHead(503, { 'content-type': 'text/plain' }).end('sandbox session closed');
+        return;
+      }
       res.writeHead(200, {
         'content-type': 'text/event-stream',
         'cache-control': 'no-store',
@@ -53,6 +60,7 @@ export function createEventHub(): ServeEventHub {
       res.on('error', () => clients.delete(res));
     },
     broadcast(event, data) {
+      if (closed) return;
       const frame = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
       for (const res of clients) {
         try {
@@ -63,6 +71,12 @@ export function createEventHub(): ServeEventHub {
       }
     },
     clientCount: () => clients.size,
+    close() {
+      if (closed) return;
+      closed = true;
+      for (const res of clients) res.end();
+      clients.clear();
+    },
   };
 }
 

--- a/packages/cli/src/serve/sandbox-session.ts
+++ b/packages/cli/src/serve/sandbox-session.ts
@@ -1,0 +1,233 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ActivityIncident } from 'pyric/firestore/internal';
+import type { FirebaseJson } from '../cli/firebase-json.js';
+import { createCaptureStore, type CaptureStore } from './capture-store.js';
+import type { InitPayload } from './init-payload.js';
+import {
+  loadProjectDatabaseRules,
+  loadProjectRules,
+  loadProjectStorageRules,
+  prepareRulesSource,
+  rulesHashOf,
+} from './rules.js';
+import { createEventHub, createPyricNamespace } from './namespace.js';
+import { diskProjectStore, diskWorkspace } from './studio/index.js';
+import type { ServeLogger } from './server.js';
+import {
+  createStateStore,
+  firestoreDocCount,
+  STATE_FILE_VERSION,
+  type PyricStateFile,
+  type StateStore,
+} from './state-store.js';
+
+export interface SandboxSessionOptions {
+  projectDir: string;
+  firebaseConfig: FirebaseJson | null;
+  sdk: { dir: string; workerVersion?: string };
+  seedFile?: string;
+  capture?: boolean;
+  persistence?: { fresh?: boolean };
+  studio?: false | { siteUiDir?: string };
+  bridgeUrl?: () => string | null;
+  ai?: InitPayload['ai'];
+  aiProxyUpstream?: string;
+  logger?: ServeLogger;
+  activity?: (incident: ActivityIncident) => void;
+}
+
+export interface SandboxSessionSummary {
+  rules: {
+    firestore: { sourcePath: string | null; hash: string | null };
+    database: { sourcePath: string | null; hash: string | null };
+    storage: { sourcePath: string | null; hash: string | null };
+  };
+  persistence: null | {
+    path: string;
+    backupPath: string;
+    restoredDocs: number;
+    restoredUsers: number;
+    restored: boolean;
+  };
+  capturePath: string | null;
+  seedLabel: string | null;
+  seedStaged: boolean;
+  studioMounted: boolean;
+}
+
+export interface SandboxSession {
+  readonly summary: SandboxSessionSummary;
+  payload(): InitPayload;
+  handle(req: IncomingMessage, res: ServerResponse, url: URL): boolean | Promise<boolean>;
+  reloadFirestoreRules(): Promise<RulesReloadResult>;
+  close(): Promise<void>;
+}
+
+export class SandboxSeedError extends Error {
+  constructor(
+    readonly kind: 'read' | 'shape',
+    readonly path: string,
+    readonly detail: string,
+  ) {
+    super(kind === 'read' ? `failed to read seed ${path}: ${detail}` : `seed must be a JSON object (${detail})`);
+    this.name = 'SandboxSeedError';
+  }
+}
+
+export type RulesReloadResult =
+  | { kind: 'not-configured' }
+  | { kind: 'reloaded'; rulesHash: string; clients: number }
+  | { kind: 'rejected'; error: Error };
+
+export async function createSandboxSession(
+  options: SandboxSessionOptions,
+): Promise<SandboxSession> {
+  // Preserve the established fail-fast order: Firestore, then RTDB, then
+  // Storage. Callers historically surfaced the first error in this sequence.
+  const firestore = await loadProjectRules(options.projectDir, options.firebaseConfig);
+  const database = await loadProjectDatabaseRules(options.projectDir, options.firebaseConfig);
+  const storage = await loadProjectStorageRules(options.projectDir, options.firebaseConfig);
+  const live = {
+    rules: firestore.rules,
+    rulesHash: firestore.rulesHash,
+  };
+  const events = createEventHub();
+  const capture: CaptureStore | undefined = (options.capture ?? true)
+    ? createCaptureStore(options.projectDir)
+    : undefined;
+  const state: StateStore | undefined = options.persistence
+    ? createStateStore(options.projectDir)
+    : undefined;
+  if (state && options.persistence?.fresh) {
+    for (const file of [state.path, state.backupPath]) {
+      if (existsSync(file)) rmSync(file);
+    }
+  }
+  let persisted = state?.load() ?? null;
+  let seed: Record<string, Record<string, unknown>> | null = null;
+  let seedState: unknown | null = null;
+  let seedUsers: Record<string, unknown>[] | null = null;
+  let seedLabel: string | null = null;
+  if (options.seedFile) {
+    const seedPath = resolve(options.projectDir, options.seedFile);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(seedPath, 'utf8')) as unknown;
+    } catch (error) {
+      throw new SandboxSeedError('read', seedPath, error instanceof Error ? error.message : String(error));
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new SandboxSeedError('shape', seedPath, `got ${Array.isArray(parsed) ? 'array' : typeof parsed}`);
+    }
+    const record = parsed as Record<string, unknown>;
+    if (record.version === STATE_FILE_VERSION && ('firestore' in record || 'auth' in record)) {
+      const fixture = record as unknown as PyricStateFile;
+      const restoredDocs = firestoreDocCount(fixture.firestore);
+      const restoredUsers = fixture.auth?.users?.length ?? 0;
+      seedLabel = `${restoredDocs} doc(s) + ${restoredUsers} user(s) from state fixture`;
+      if (state && !state.exists()) {
+        if (fixture.firestore != null) state.writeSection('firestore', fixture.firestore);
+        if (fixture.auth != null) state.writeSection('auth', fixture.auth);
+        persisted = state.load();
+      } else if (!state) {
+        seedState = fixture.firestore ?? null;
+        seedUsers = (fixture.auth?.users as Record<string, unknown>[] | undefined) ?? null;
+      }
+    } else {
+      seed = record as Record<string, Record<string, unknown>>;
+      seedLabel = `${Object.keys(seed).length} document(s)`;
+    }
+  }
+
+  const payload = (): InitPayload => ({
+    rules: live.rules,
+    rulesHash: live.rulesHash,
+    databaseRules: database.rules,
+    databaseRulesHash: database.rulesHash,
+    databaseUrl: database.databaseUrl,
+    storageRules: storage.rules,
+    storageRulesHash: storage.rulesHash,
+    projectKey: options.projectDir,
+    bridgeUrl: options.bridgeUrl?.() ?? null,
+    seed: state?.exists() ? null : seed,
+    seedState,
+    persist: Boolean(state),
+    capture: Boolean(capture),
+    authUsers: state
+      ? ((state.readSection('auth') as { users?: Record<string, unknown>[] } | null)?.users ?? null)
+      : seedUsers,
+    messaging: true,
+    ai: options.ai ?? null,
+  });
+
+  const summary: SandboxSessionSummary = {
+    rules: {
+      firestore: { sourcePath: firestore.sourcePath, hash: firestore.rulesHash },
+      database: { sourcePath: database.sourcePath, hash: database.rulesHash },
+      storage: { sourcePath: storage.sourcePath, hash: storage.rulesHash },
+    },
+    persistence: state
+      ? {
+          path: state.path,
+          backupPath: state.backupPath,
+          restoredDocs: firestoreDocCount(persisted?.firestore),
+          restoredUsers: persisted?.auth?.users?.length ?? 0,
+          restored: persisted !== null,
+        }
+      : null,
+    capturePath: capture?.path ?? null,
+    seedLabel,
+    seedStaged: Boolean((seed && !state?.exists()) || seedState || seedUsers),
+    studioMounted: Boolean(options.studio),
+  };
+
+  const namespace = createPyricNamespace({
+    sdkDir: options.sdk.dir,
+    initPayload: payload,
+    events,
+    state,
+    capture,
+    studio: options.studio
+      ? {
+          workspace: diskWorkspace(options.projectDir),
+          projects: diskProjectStore(join(options.projectDir, '.pyric', 'projects')),
+        }
+      : undefined,
+    siteUiDir: options.studio ? options.studio.siteUiDir : undefined,
+    workerVersion: options.sdk.workerVersion,
+    aiProxyUpstream: options.aiProxyUpstream,
+    activity: options.activity,
+    logger: options.logger,
+  });
+
+  const reloadFirestoreRules = async (): Promise<RulesReloadResult> => {
+    if (!firestore.sourcePath) return { kind: 'not-configured' };
+    try {
+      const raw = await readFile(firestore.sourcePath, 'utf8');
+      const rules = prepareRulesSource(raw, firestore.sourcePath);
+      const rulesHash = rulesHashOf(rules);
+      live.rules = rules;
+      live.rulesHash = rulesHash;
+      events.broadcast('rules-changed', { rules, rulesHash });
+      return { kind: 'reloaded', rulesHash, clients: events.clientCount() };
+    } catch (error) {
+      return { kind: 'rejected', error: error instanceof Error ? error : new Error(String(error)) };
+    }
+  };
+  let closePromise: Promise<void> | null = null;
+  const close = (): Promise<void> => {
+    closePromise ??= Promise.resolve().then(() => events.close());
+    return closePromise;
+  };
+
+  return {
+    summary,
+    payload,
+    handle: namespace,
+    reloadFirestoreRules,
+    close,
+  };
+}

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -17,15 +17,14 @@
  * deploy hosting` refuses it). `pyric({ swapInBuild })` forces the build
  * behavior on/off regardless of mode. See `sandbox-marker.ts`.
  *
- * This is a thin adapter over serve's proven machinery. It REUSES, not reimplements:
+ * This is the Vite adapter over serve's proven machinery. It reuses:
  *   - the node-builtin shims — `NODE_BUILTIN_SHIMS`;
  *   - the swap targets — `defaultSdkEntries()` (the `serve/entries/*` wrappers,
  *     compiled-dist preferred, src fallback);
- *   - the `/__pyric/*` namespace — `createPyricNamespace` mounted verbatim behind
- *     a connect-middleware adapter;
- *   - rules load + prepare — `loadProjectRules` / `prepareRulesSource`;
+ *   - the host-neutral sandbox session — rules, fixtures, stores, live payload,
+ *     Studio routes, `/__pyric/*` namespace, and owned cleanup;
  *   - the SharedWorker host — `bundleWorker` served at `/__pyric/sdk/worker.js`;
- *   - durable stores — `createStateStore` (persist) / `createCaptureStore`.
+ *   - the bridge mount shared with `pyric dev --bridge`.
  *
  * Scope = M1 (swap + rules) + M2 (SharedWorker multi-tab + persist/capture/seed)
  * + M3 (the MCP bridge fold — `{ bridge }`). M3 reuses `createBridgeMount` (the
@@ -39,8 +38,7 @@
  * the same `/__pyric/*` routes. If the worker bundle fails, the plugin falls back
  * to the in-page sandbox (single-tab, ephemeral).
  */
-import { readFile } from 'node:fs/promises';
-import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
 import type { Plugin, UserConfig, ConfigEnv } from 'vite';
@@ -54,23 +52,8 @@ import {
   NODE_BUILTIN_SHIMS,
 } from './bundler.js';
 import { createViteWorkerRuntime } from './vite-worker-runtime.js';
-import {
-  createEventHub,
-  createPyricNamespace,
-  type InitPayload,
-} from './namespace.js';
 import { formatActivityWarning } from './activity-warning.js';
-import { diskWorkspace, diskProjectStore } from './studio/index.js';
 import { createBridgeMount } from './bridge-mount.js';
-import {
-  loadProjectDatabaseRules,
-  loadProjectRules,
-  loadProjectStorageRules,
-  prepareRulesSource,
-  rulesHashOf,
-} from './rules.js';
-import { createStateStore, STATE_FILE_VERSION, type PyricStateFile } from './state-store.js';
-import { createCaptureStore } from './capture-store.js';
 import { isAllowedHost } from './server.js';
 import { SANDBOX_BUILD_META } from './sandbox-marker.js';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from '../cli/firebase-json.js';
@@ -99,6 +82,11 @@ import {
   runtimeChipMetaValue,
   type PyricRuntimeChipOption,
 } from './runtime/chip-config.js';
+import {
+  createSandboxSession,
+  SandboxSeedError,
+  type SandboxSession,
+} from './sandbox-session.js';
 
 /**
  * Whether a `vite build` should run the firebase→pyric swap (produce a SANDBOX
@@ -287,26 +275,6 @@ export function pyric(options: PyricOptions = {}): Plugin {
     },
   };
 
-  // Live rules box — the watcher swaps it; the init payload always serves the
-  // current version.
-  const live: {
-    rules: string | null;
-    rulesHash: string | null;
-    databaseRules: { rules: Record<string, unknown> } | null;
-    databaseRulesHash: string | null;
-    databaseUrl: string | null;
-    storageRules: string | null;
-    storageRulesHash: string | null;
-  } = {
-    rules: null,
-    rulesHash: null,
-    databaseRules: null,
-    databaseRulesHash: null,
-    databaseUrl: null,
-    storageRules: null,
-    storageRulesHash: null,
-  };
-
   // M2: the SharedWorker bundle's content hash (sync) — stamped into the page so
   // a still-running OLD worker is detected as stale. The collaborator becomes
   // ready once its bundle succeeds; until then (or on bundle failure) the page
@@ -335,6 +303,8 @@ export function pyric(options: PyricOptions = {}): Plugin {
   // sandbox path — the bridge peer is the in-page sandbox, never the SharedWorker,
   // so multi-tab is disabled under bridge to keep agent + app on one backend.
   const bridgeOpts = options.bridge === true ? {} : options.bridge || null;
+  let configuredSession: SandboxSession | null = null;
+  const configuredListenerDisposers: Array<() => void> = [];
 
   // Plugin-level AI engine, normalized to the JSON-safe wire shape. Travels
   // to the worker host via the init payload (→ ctx.aiEngine) AND to the in-page
@@ -423,9 +393,14 @@ export function pyric(options: PyricOptions = {}): Plugin {
     },
 
     async configureServer(server) {
+      const priorSession = configuredSession;
+      configuredSession = null;
+      for (const dispose of configuredListenerDisposers.splice(0).reverse()) dispose();
+      await priorSession?.close();
       const cwd = options.root ?? server.config.root;
 
-      // Reproduce serve's rules prelude: firebase.json (optional) → loadProjectRules.
+      // Resolve the optional Firebase configuration before the shared session
+      // loads and prepares the project's rules.
       let fbJson: FirebaseJson | null = null;
       try {
         fbJson = await readFirebaseJson(cwd);
@@ -437,72 +412,6 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // target. Projects without that convention retain the normal Firebase
       // discovery path.
       const config = resolveViteRulesConfig(cwd, options.rules, fbJson);
-      const loaded = await loadProjectRules(cwd, config);
-      const loadedDatabase = await loadProjectDatabaseRules(cwd, config);
-      const loadedStorage = await loadProjectStorageRules(cwd, config);
-      live.rules = loaded.rules;
-      live.rulesHash = loaded.rulesHash;
-      live.databaseRules = loadedDatabase.rules;
-      live.databaseRulesHash = loadedDatabase.rulesHash;
-      live.databaseUrl = loadedDatabase.databaseUrl;
-      live.storageRules = loadedStorage.rules;
-      live.storageRulesHash = loadedStorage.rulesHash;
-
-      // ── M2 durable stores (mirrors serve's startServe orchestration) ──────
-      // Capture (default-on): the worker/page pushes its session fixture to
-      // /__pyric/capture; the store writes .pyric/last-session.json for `pyric verify`.
-      const capture = (options.capture ?? true) ? createCaptureStore(cwd) : undefined;
-      // Persist: createStateStore IS the durable sandbox. Load eagerly so a
-      // corrupt/mismatched file fails the start (not silently ephemeral).
-      const state = options.persist ? createStateStore(cwd) : undefined;
-      if (state && options.fresh) {
-        for (const p of [state.path, state.backupPath]) if (existsSync(p)) rmSync(p);
-        server.config.logger.info('  ⓘ [pyric] fresh: discarded the existing state file; re-seeding');
-      }
-      // Eager load (mirrors serve.ts:158) — parse the file NOW so a corrupt or
-      // version-mismatched state file throws StateFileError and FAILS THE START
-      // with the actionable inspect-or-delete message. Without this the first
-      // parse is deferred into initPayload() at request time, where it throws
-      // synchronously AFTER namespace.ts has committed `writeHead(200)`: the
-      // client gets a 200 with an empty body, the page/worker swallow the JSON
-      // error, and the sandbox silently runs WITHOUT the persisted data + rules.
-      // (No-op on first run: load() returns null for a missing file.)
-      // configureServer is async, so an uncaught throw aborts the dev start.
-      if (state) state.load();
-
-      // Seed: a "collection/doc" → fields map, OR a `pyric snapshot` state-file
-      // envelope (detected by its `version` key). Ported from serve.ts.
-      let seed: Record<string, Record<string, unknown>> | null = null;
-      let seedState: unknown | null = null;
-      let seedUsers: Record<string, unknown>[] | null = null;
-      if (options.seed) {
-        const seedPath = path.resolve(cwd, options.seed);
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(readFileSync(seedPath, 'utf8'));
-        } catch (e) {
-          throw new Error(`@pyric/cli/vite: failed to read seed ${seedPath}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          throw new Error('@pyric/cli/vite: seed must be a JSON object of "collection/doc" → fields');
-        }
-        const obj = parsed as Record<string, unknown>;
-        if (obj.version === STATE_FILE_VERSION && ('firestore' in obj || 'auth' in obj)) {
-          const fixture = obj as unknown as PyricStateFile;
-          if (state && !state.exists()) {
-            // persist first run from a fixture: prime the store, then the normal
-            // persist path restores it like any lived state.
-            if (fixture.firestore != null) state.writeSection('firestore', fixture.firestore);
-            if (fixture.auth != null) state.writeSection('auth', fixture.auth);
-          } else if (!state) {
-            seedState = fixture.firestore ?? null;
-            seedUsers = (fixture.auth?.users as Record<string, unknown>[] | undefined) ?? null;
-          }
-          // persist + existing state: lived state wins; the fixture is inert.
-        } else {
-          seed = parsed as Record<string, Record<string, unknown>>;
-        }
-      }
 
       // ── M2 SharedWorker host: bundle it (cached per version) and serve it at
       // /__pyric/sdk/worker.js. This is what flips runtime.ts to the worker path.
@@ -566,45 +475,6 @@ export function pyric(options: PyricOptions = {}): Plugin {
           })
         : null;
 
-      // The /__pyric/* namespace, reused VERBATIM (now with the sdk dir + state +
-      // capture routes live).
-      const events = createEventHub();
-      const initPayload = (): InitPayload => ({
-        rules: live.rules,
-        rulesHash: live.rulesHash,
-        databaseRules: live.databaseRules,
-        databaseRulesHash: live.databaseRulesHash,
-        databaseUrl: live.databaseUrl,
-        storageRules: live.storageRules,
-        storageRulesHash: live.storageRulesHash,
-        // Project identity: scopes the storage IDB name per served project
-        // (issue #359). Local-only — a dev path never leaves the machine.
-        projectKey: cwd,
-        // The bound port is known only after `listen`; initPayload runs per
-        // request (after listen), so resolve it lazily here. Absolute ws://host:port
-        // mirrors serve (the browser reads this as the bridge peer URL).
-        bridgeUrl: (() => {
-          if (!mount) return null;
-          const addr = server.httpServer?.address();
-          const port = addr && typeof addr === 'object' ? addr.port : 0;
-          const host = (typeof server.config.server.host === 'string' && server.config.server.host) || 'localhost';
-          return port > 0 ? mount.wsUrl({ host, port }) : null;
-        })(),
-        // Precedence: once a state file exists, lived state is the truth — seed
-        // applies only on the first (state-less) run.
-        seed: state?.exists() ? null : seed,
-        seedState,
-        persist: Boolean(state),
-        capture: Boolean(capture),
-        authUsers: state
-          ? ((state.readSection('auth') as { users?: Record<string, unknown>[] } | null)?.users ?? null)
-          : seedUsers,
-        // Messaging is part of the canonical firebase/* sandbox swap.
-        messaging: true,
-        // Plugin-level engine → the worker host's ctx.aiEngine (host-ai.ts),
-        // which wins over any op-carried engine. Null when unset.
-        ai: resolvedAi.engineWire ? { engine: resolvedAi.engineWire } : null,
-      });
       // Pyric Studio: mount the disk-backed workspace/project routes that
       // Studio's `local` mode talks to + serve the built Studio app at
       // /__pyric/ui/. Mirrors `pyric dev --ui`; the unified Astro site is
@@ -615,12 +485,6 @@ export function pyric(options: PyricOptions = {}): Plugin {
       // app, Studio, and agent all observe the ONE sandbox. Explicit `ui: false`
       // still wins.
       const uiEnabled = options.ui ?? true;
-      const studio = uiEnabled
-        ? {
-            workspace: diskWorkspace(cwd),
-            projects: diskProjectStore(path.join(cwd, '.pyric', 'projects')),
-          }
-        : undefined;
       let siteUiDir: string | undefined;
       if (uiEnabled) {
         siteUiDir = resolveSiteUiDir() ?? undefined;
@@ -632,28 +496,44 @@ export function pyric(options: PyricOptions = {}): Plugin {
         }
       }
       const { sdkDir, epoch: workerVersion } = workerRuntime.status();
-      const namespace = createPyricNamespace({
-        sdkDir,
-        initPayload,
-        events,
-        activity: (incident) => server.config.logger.warn(formatActivityWarning(incident)),
-        state,
-        capture,
-        studio,
-        siteUiDir,
-        workerVersion: workerVersion ?? undefined,
-        // `ai.proxyUpstream`: what `/__pyric/ai-proxy` forwards to (beats the
-        // PYRIC_AI_PROXY_UPSTREAM env var; falls back to the default when unset).
-        aiProxyUpstream: resolvedAi.proxyUpstream,
-        // Adapt Vite's logger to the plain info/note shape the namespace's
-        // diagnostics (denial relay, future hot-reload lines) expect —
-        // matches the `↻`/`⚠ [pyric]` lines already logged elsewhere in this
-        // plugin via `server.config.logger` directly.
-        logger: {
-          info: (m) => server.config.logger.info(m),
-          note: (m) => server.config.logger.warn(m),
-        },
-      });
+      let session: SandboxSession;
+      try {
+        session = await createSandboxSession({
+          projectDir: cwd,
+          firebaseConfig: config,
+          sdk: { dir: sdkDir, workerVersion: workerVersion ?? undefined },
+          seedFile: options.seed,
+          persistence: options.persist ? { fresh: options.fresh } : undefined,
+          capture: options.capture,
+          studio: uiEnabled ? { siteUiDir } : false,
+          bridgeUrl: () => {
+            if (!mount) return null;
+            const addr = server.httpServer?.address();
+            const port = addr && typeof addr === 'object' ? addr.port : 0;
+            const host = (typeof server.config.server.host === 'string' && server.config.server.host) || 'localhost';
+            return port > 0 ? mount.wsUrl({ host, port }) : null;
+          },
+          ai: resolvedAi.engineWire ? { engine: resolvedAi.engineWire } : null,
+          aiProxyUpstream: resolvedAi.proxyUpstream,
+          activity: (incident) => server.config.logger.warn(formatActivityWarning(incident)),
+          logger: {
+            info: (message) => server.config.logger.info(message),
+            note: (message) => server.config.logger.warn(message),
+          },
+        });
+      } catch (error) {
+        if (error instanceof SandboxSeedError) {
+          if (error.kind === 'read') {
+            throw new Error(`@pyric/cli/vite: failed to read seed ${error.path}: ${error.detail}`);
+          }
+          throw new Error('@pyric/cli/vite: seed must be a JSON object of "collection/doc" → fields');
+        }
+        throw error;
+      }
+      configuredSession = session;
+      if (options.persist && options.fresh) {
+        server.config.logger.info('  ⓘ [pyric] fresh: discarded the existing state file; re-seeding');
+      }
 
       // DNS-rebinding guard for the /__pyric/* surface. Vite has its own host
       // check, but a `configureServer` hook that doesn't return a function mounts
@@ -680,7 +560,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
         // handled by the mount, not 404 through the namespace. Falls through to the
         // namespace when the mount returns false (every non-bridge route).
         Promise.resolve(mount ? mount.handler(req, res, url) : false)
-          .then((bridged) => (bridged ? true : Promise.resolve(namespace(req, res, url))))
+          .then((bridged) => (bridged ? true : Promise.resolve(session.handle(req, res, url))))
           .then((handled) => {
             if (!handled) next();
           })
@@ -967,41 +847,49 @@ export function pyric(options: PyricOptions = {}): Plugin {
           server.watcher.on('change', onFunctionsFsEvent);
           server.watcher.on('add', onFunctionsFsEvent);
           server.watcher.on('unlink', onFunctionsFsEvent);
+          configuredListenerDisposers.push(() => {
+            if (reloadDebounce) clearTimeout(reloadDebounce);
+            server.watcher.off('change', onFunctionsFsEvent);
+            server.watcher.off('add', onFunctionsFsEvent);
+            server.watcher.off('unlink', onFunctionsFsEvent);
+          });
         }
       }
 
-      // Rules hot-reload from Vite's OWN watcher (no second fs watcher). Reuse
-      // prepareRulesSource (resolve + lint); last-good stays live on a broken save.
-      // Debounced (editors emit several change events per save) — matches
-      // watchProjectRules' 150ms cadence, which we can't reuse here (it opens its
-      // own fs watcher).
-      if (loaded.sourcePath) {
-        const rulesFile = loaded.sourcePath;
+      // Vite owns filesystem observation; the session owns read/prepare/hash,
+      // last-good replacement, live payload mutation, and SSE broadcast.
+      const rulesFile = session.summary.rules.firestore.sourcePath;
+      if (rulesFile) {
         let debounce: ReturnType<typeof setTimeout> | null = null;
         server.watcher.add(rulesFile);
-        server.watcher.on('change', (file) => {
+        const onRulesChange = (file: string): void => {
           if (path.resolve(file) !== path.resolve(rulesFile)) return;
           if (debounce) clearTimeout(debounce);
           debounce = setTimeout(() => {
-          void readFile(rulesFile, 'utf8').then(
-            (raw) => {
-              try {
-                const rules = prepareRulesSource(raw, rulesFile);
-                live.rules = rules;
-                live.rulesHash = rulesHashOf(rules);
-                events.broadcast('rules-changed', { rules, rulesHash: live.rulesHash });
-                server.config.logger.info(`  ↻ [pyric] rules reloaded (${live.rulesHash})`);
-              } catch (e) {
+            void session.reloadFirestoreRules().then((result) => {
+              if (result.kind === 'reloaded') {
+                server.config.logger.info(`  ↻ [pyric] rules reloaded (${result.rulesHash})`);
+              } else if (result.kind === 'rejected') {
                 server.config.logger.warn(
-                  `  ⚠ [pyric] rules NOT reloaded (last-good stays live): ${e instanceof Error ? e.message : String(e)}`,
+                  `  ⚠ [pyric] rules NOT reloaded (last-good stays live): ${result.error.message}`,
                 );
               }
-            },
-            () => {},
-          );
+            });
           }, 150);
+        };
+        server.watcher.on('change', onRulesChange);
+        configuredListenerDisposers.push(() => {
+          if (debounce) clearTimeout(debounce);
+          server.watcher.off('change', onRulesChange);
         });
       }
+    },
+
+    async closeBundle() {
+      const session = configuredSession;
+      configuredSession = null;
+      for (const dispose of configuredListenerDisposers.splice(0).reverse()) dispose();
+      await session?.close();
     },
 
     // Sandbox build only: emit the serve init entry as its own chunk. Emitted in

--- a/packages/cli/test/serve/sandbox-session.test.ts
+++ b/packages/cli/test/serve/sandbox-session.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { createSandboxSession } from '../../src/serve/sandbox-session.js';
+
+const projects: string[] = [];
+
+function project(): string {
+  const root = mkdtempSync(join(tmpdir(), 'pyric-sandbox-session-'));
+  projects.push(root);
+  mkdirSync(join(root, 'sdk'));
+  return root;
+}
+
+class ResponseRecorder extends EventEmitter {
+  statusCode = 200;
+  body = '';
+  headers: Record<string, string> = {};
+  ended = false;
+
+  writeHead(status: number, headers: Record<string, string> = {}): this {
+    this.statusCode = status;
+    this.headers = headers;
+    return this;
+  }
+
+  end(body = ''): this {
+    this.body += String(body);
+    this.ended = true;
+    this.emit('finish');
+    return this;
+  }
+
+  write(body: string): boolean {
+    this.body += String(body);
+    return true;
+  }
+}
+
+afterEach(() => {
+  for (const root of projects.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('sandbox session', () => {
+  it('stages a bare seed and shared defaults in the live payload', async () => {
+    const root = project();
+    writeFileSync(join(root, 'seed.json'), JSON.stringify({
+      'tasks/first': { title: 'Ship the deep module', done: false },
+    }));
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+      seedFile: 'seed.json',
+    });
+
+    expect(session.payload()).toMatchObject({
+      rules: null,
+      databaseRules: null,
+      storageRules: null,
+      projectKey: root,
+      bridgeUrl: null,
+      seed: {
+        'tasks/first': { title: 'Ship the deep module', done: false },
+      },
+      persist: false,
+      capture: true,
+      messaging: true,
+    });
+
+    await session.close();
+  });
+
+  it('primes empty file persistence from a state fixture and exposes restored state', async () => {
+    const root = project();
+    writeFileSync(join(root, 'fixture.json'), JSON.stringify({
+      version: 1,
+      firestore: {
+        version: 1,
+        savedAt: 42,
+        firestore: { 'tasks/lived': { title: 'Persisted' } },
+      },
+      auth: { users: [{ uid: 'reader', email: 'reader@example.com', password: 'secret' }] },
+    }));
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+      seedFile: 'fixture.json',
+      persistence: { fresh: false },
+    });
+
+    expect(session.payload()).toMatchObject({
+      seed: null,
+      persist: true,
+      authUsers: [{ uid: 'reader', email: 'reader@example.com', password: 'secret' }],
+    });
+    expect(session.summary.persistence).toMatchObject({
+      restoredDocs: 1,
+      restoredUsers: 1,
+    });
+
+    await session.close();
+  });
+
+  it('replaces valid Firestore rules and retains last-good rules after a broken edit', async () => {
+    const root = project();
+    const sourcePath = join(root, 'firestore.rules');
+    writeFileSync(sourcePath, `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents { match /before/{id} { allow read: if true; } }
+}`);
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: { firestore: { rules: 'firestore.rules' } },
+      sdk: { dir: join(root, 'sdk') },
+    });
+    const beforeHash = session.payload().rulesHash;
+
+    writeFileSync(sourcePath, `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents { match /after/{id} { allow read: if true; } }
+}`);
+    const reloaded = await session.reloadFirestoreRules();
+    expect(reloaded.kind).toBe('reloaded');
+    expect(session.payload().rules).toContain('/after/{id}');
+    expect(session.payload().rulesHash).not.toBe(beforeHash);
+
+    const lastGoodHash = session.payload().rulesHash;
+    writeFileSync(sourcePath, 'rules_version = ;;; broken');
+    const rejected = await session.reloadFirestoreRules();
+    expect(rejected.kind).toBe('rejected');
+    expect(session.payload().rulesHash).toBe(lastGoodHash);
+    expect(session.payload().rules).toContain('/after/{id}');
+
+    await session.close();
+  });
+
+  it('serves one live init payload with late-bound host facts', async () => {
+    const root = project();
+    let bridgeUrl: string | null = null;
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk'), workerVersion: 'worker-v1' },
+      bridgeUrl: () => bridgeUrl,
+      ai: { engine: { kind: 'scripted' } },
+    });
+
+    bridgeUrl = 'ws://localhost:5173/__pyric/sandbox';
+    const response = new ResponseRecorder();
+    const handled = await session.handle(
+      { headers: { host: 'localhost' } } as IncomingMessage,
+      response as unknown as ServerResponse,
+      new URL('http://localhost/__pyric/init.json'),
+    );
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      projectKey: root,
+      bridgeUrl,
+      ai: { engine: { kind: 'scripted' } },
+    });
+
+    await session.close();
+  });
+
+  it('closes owned event streams exactly once', async () => {
+    const root = project();
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+    });
+    const request = new EventEmitter() as IncomingMessage;
+    const response = new ResponseRecorder();
+
+    expect(await session.handle(
+      request,
+      response as unknown as ServerResponse,
+      new URL('http://localhost/__pyric/events'),
+    )).toBe(true);
+    expect(response.ended).toBe(false);
+
+    await session.close();
+    await session.close();
+    expect(response.ended).toBe(true);
+  });
+});

--- a/packages/cli/test/serve/vite-plugin.test.ts
+++ b/packages/cli/test/serve/vite-plugin.test.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import path, { join } from 'node:path';
 import { Writable } from 'node:stream';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { pyric } from '../../src/serve/vite-plugin.js';
@@ -412,6 +413,36 @@ describe('integration — configureServer rules prelude + the /__pyric middlewar
     try { await bootPlugin({ rules: 'does-not-exist.rules' }, tmp); } catch { threw = true; }
     expect(threw).toBe(true);
   });
+
+  it('closeBundle disposes the session in Vite middleware mode', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-close-'));
+    let handler: PyricMiddleware | undefined;
+    const p = pyric({ ui: false });
+    const watcher = { add() {}, on() {}, off() {} };
+    await (p.configureServer as (server: unknown) => Promise<void>)({
+      config: { root: tmp, logger: { info() {}, warn() {} }, server: { allowedHosts: [], host: 'localhost' } },
+      middlewares: { use(route: string, candidate: PyricMiddleware) { if (route === '/__pyric') handler = candidate; } },
+      watcher,
+      httpServer: null,
+    });
+    if (!handler) throw new Error('plugin did not mount middleware');
+
+    const request = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      url: '/__pyric/events',
+      originalUrl: '/__pyric/events',
+      headers: { host: 'localhost' },
+    }) as unknown as PyricReq;
+    const response = new MockRes();
+    handler(request, response, () => {});
+    await Bun.sleep(0);
+    expect(response.body).toContain(': connected');
+    expect(response.writableEnded).toBe(false);
+
+    await (p.closeBundle as () => Promise<void>)();
+    await (p.closeBundle as () => Promise<void>)();
+    expect(response.writableEnded).toBe(true);
+  });
 });
 
 // NOTE (unit): asserts the workerReady===false → in-page output in ISOLATION
@@ -507,6 +538,12 @@ describe('M2 — seed precedence + persist validation', () => {
     return 'seed.json';
   };
   afterAll(() => { if (tmp) rmSync(tmp, { recursive: true, force: true }); });
+
+  it('keeps the existing Vite policy where fresh without persist is inert', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-fresh-inert-'));
+    const init = await initJson(await bootPlugin({ fresh: true }, tmp));
+    expect(init.persist).toBe(false);
+  });
 
   it('seed as a bare "collection/doc" map (no persist) → payload.seed IS the map', async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-seedmap-'));


### PR DESCRIPTION
Shares one host-neutral sandbox session between `pyric dev` and the Vite plugin while preserving each host's existing behavior.

```ts
const session = await createSandboxSession({
  projectDir: cwd,
  firebaseConfig: config,
  sdk: { dir: sdkDir, workerVersion },
  seedFile: options.seed,
  persistence: options.persist ? { fresh: options.fresh } : undefined,
  capture: options.capture,
  studio: uiEnabled ? { siteUiDir } : false,
  bridgeUrl: () => boundBridgeUrl(),
});

// The host composes its own bridge before the shared namespace.
const handled = (await bridge.handle(req, res, url)) ||
  (await session.handle(req, res, url));

// Session-owned event streams close once; host-owned listeners stay explicit.
await session.close();
```

## Session semantics now live below both host adapters

`sandbox-session.ts` owns the ordering and precedence that had been duplicated in `serve.ts` and `vite-plugin.ts`: Firestore, RTDB, and Storage rules loading; state validation; seed-envelope decoding; lived-state precedence; capture; Studio stores; the live init payload; namespace routes; last-good rules replacement; and SSE cleanup.

The adapters retain the responsibilities that genuinely differ. Vite still owns resolution, optimization, HTML transforms, its watcher, Connect middleware, and optional HTTP upgrade attachment. The static CLI still owns asset materialization, static hosting, port selection, terminal output, and process orchestration. Bridge and Functions lifecycle remain adapter-owned because they require those host-specific capabilities.

Vite lifecycle transitions are intentionally visible in `configureServer` and `closeBundle`: capture the configured session, clear the reference, remove adapter-owned listeners, then close the captured session. This also closes sessions in middleware mode, where Vite exposes no HTTP server.

## Risk

The main risk is behavior drift in seed/persist precedence, rules reload, or shutdown ordering while moving construction below the adapters. The full CLI suite and packed-runtime smoke exercise both hosts, including Vite middleware-mode cleanup and static `pyric dev` startup. Bridge construction and Vite resolution were left outside the new module to avoid changing ADR-0001 package-selection behavior or introducing a shallow host abstraction.

<details>
<summary>Implementation notes</summary>

- Added focused shared-session coverage for bare seeds, state fixtures, live rules replacement, late-bound payload values, and idempotent SSE cleanup.
- Added a Vite middleware-mode characterization proving `closeBundle` ends an open event stream and remains idempotent.
- Preserved Vite's existing policy that `fresh` without persistence is inert.
- Recorded the first-party Vite and repository constraints in `docs/vite-plugin-serve-architecture-research.md`.

Verification:

- `bun test --cwd packages/cli`: 1,335 passed, 20 gated skips, 0 failed.
- `bun x tsc -p packages/cli/tsconfig.json --noEmit`: passed.
- `bun run build:cli`: passed.
- `bun run test:packaging` under an isolated temporary cache: all five packages packed and installed; packed `pyric dev` served `/__pyric/init.json`; runtime smoke passed.
- `git diff --check`: passed.

</details>
