### PR TITLE
fix(auth): give in-page OAuth users Google provider metadata

### DIFF
--- a/packages/cli/src/serve/entries/auth-helper-core.ts
+++ b/packages/cli/src/serve/entries/auth-helper-core.ts
@@ -5,8 +5,9 @@
  * directory and returns a Firebase-shaped credential; it never constructs an
  * Auth handle or mutates a Sandbox. In SharedWorker mode the directory reads
  * the worker's user pool and the picked credential is committed by
- * `auth.acceptIdentity`. The in-page fallback supplies a small adapter over its
- * local auth user store.
+ * `auth.acceptIdentity`. The in-page fallback supplies a mint that calls
+ * `sandbox.createSignInCredential` so the resolved User carries real
+ * provider metadata.
  */
 import type {
   AuthFlowRequest,
@@ -31,9 +32,21 @@ export interface HelperIdentity {
 
 export interface HelperIdentityDirectory {
   list(): HelperIdentity[] | Promise<HelperIdentity[]>;
-  /** Optional on the worker path: `auth.acceptIdentity` performs the write. */
+  /** Optional on the worker path: `auth.acceptIdentity` performs the write.
+   *  Unused when a custom {@link HelperCredentialMint} owns creation. */
   add?(identity: HelperIdentity): void | Promise<void>;
 }
+
+/**
+ * Mint a Firebase-shaped credential for a picker pick/add. The default mint
+ * builds a bare helper User (worker path → discarded by `acceptIdentity`).
+ * The in-page fallback injects `sandbox.createSignInCredential`.
+ */
+export type HelperCredentialMint = (
+  request:
+    | { kind: 'pick'; identity: HelperIdentity; providerId: string }
+    | { kind: 'add'; spec: NewIdentitySpec; providerId: string },
+) => UserCredential | Promise<UserCredential>;
 
 export interface HelperSnapshot {
   /** The in-flight request, or null when no popup/redirect is pending. */
@@ -52,8 +65,13 @@ export class ServeAuthHelper {
   private readonly listeners = new Set<() => void>();
   private cached: HelperSnapshot | null = null;
   private identities: HelperIdentity[] = [];
+  private readonly mint: HelperCredentialMint;
 
-  constructor(private readonly directory: HelperIdentityDirectory) {
+  constructor(
+    private readonly directory: HelperIdentityDirectory,
+    mint?: HelperCredentialMint,
+  ) {
+    this.mint = mint ?? ((request) => this.defaultMint(request));
     this.refreshIdentities();
   }
 
@@ -118,22 +136,17 @@ export class ServeAuthHelper {
       pending.reject(authError('auth/internal-error', `unknown identity ${uid}`));
       return;
     }
-    pending.resolve(this.credential(identity, pending.req.providerId));
+    void Promise.resolve(
+      this.mint({ kind: 'pick', identity, providerId: pending.req.providerId }),
+    ).then(pending.resolve, pending.reject);
   }
 
   add(spec: NewIdentitySpec): void {
     const pending = this.take();
     if (!pending) return;
-    const identity: HelperIdentity = {
-      uid: `${pending.req.providerId}:${spec.email}`,
-      email: spec.email,
-      displayName: spec.displayName ?? null,
-      customClaims: spec.customClaims ?? {},
-    };
-    void Promise.resolve(this.directory.add?.(identity)).then(
-      () => pending.resolve(this.credential(identity, pending.req.providerId)),
-      pending.reject,
-    );
+    void Promise.resolve(
+      this.mint({ kind: 'add', spec, providerId: pending.req.providerId }),
+    ).then(pending.resolve, pending.reject);
   }
 
   cancel(): void {
@@ -154,23 +167,63 @@ export class ServeAuthHelper {
     return pending;
   }
 
-  private credential(identity: HelperIdentity, providerId: string): UserCredential {
-    const user: User = {
-      uid: identity.uid,
-      email: identity.email,
-      displayName: identity.displayName,
-      isAnonymous: false,
-      getIdToken: async () => `pyric-serve-${identity.uid}`,
-      getIdTokenResult: async () => ({
-        token: `pyric-serve-${identity.uid}`,
-        claims: { sub: identity.uid, ...identity.customClaims },
-        expirationTime: new Date(Date.now() + 3600_000).toISOString(),
-        issuedAtTime: new Date().toISOString(),
-        authTime: new Date().toISOString(),
-      }),
+  private async defaultMint(
+    request:
+      | { kind: 'pick'; identity: HelperIdentity; providerId: string }
+      | { kind: 'add'; spec: NewIdentitySpec; providerId: string },
+  ): Promise<UserCredential> {
+    if (request.kind === 'pick') {
+      return bareCredential(request.identity, request.providerId);
+    }
+    const identity: HelperIdentity = {
+      uid: `${request.providerId}:${request.spec.email}`,
+      email: request.spec.email,
+      displayName: request.spec.displayName ?? null,
+      customClaims: request.spec.customClaims ?? {},
     };
-    return { user, providerId, operationType: 'signIn' };
+    await Promise.resolve(this.directory.add?.(identity));
+    return bareCredential(identity, request.providerId);
   }
+}
+
+/** Bare helper User — worker path discards this in favor of `acceptIdentity`. */
+function bareCredential(identity: HelperIdentity, providerId: string): UserCredential {
+  const issuedAtTime = new Date().toISOString();
+  const expirationTime = new Date(Date.now() + 3600_000).toISOString();
+  const user: User = {
+    uid: identity.uid,
+    email: identity.email,
+    displayName: identity.displayName,
+    isAnonymous: false,
+    emailVerified: false,
+    photoURL: null,
+    phoneNumber: null,
+    providerId: 'firebase',
+    providerData: [
+      {
+        uid: identity.uid,
+        displayName: identity.displayName,
+        email: identity.email,
+        phoneNumber: null,
+        photoURL: null,
+        providerId,
+      },
+    ],
+    getIdToken: async () => `pyric-serve-${identity.uid}`,
+    getIdTokenResult: async () => ({
+      token: `pyric-serve-${identity.uid}`,
+      claims: {
+        sub: identity.uid,
+        ...identity.customClaims,
+        firebase: { sign_in_provider: providerId },
+      },
+      signInProvider: providerId,
+      expirationTime,
+      issuedAtTime,
+      authTime: issuedAtTime,
+    }),
+  };
+  return { user, providerId, operationType: 'signIn' };
 }
 
 function authError(code: string, message: string): Error & { code: string } {

--- a/packages/cli/src/serve/entries/init.ts
+++ b/packages/cli/src/serve/entries/init.ts
@@ -2,7 +2,8 @@
  * `/__pyric/sdk/init.js` — the script tag `pyric dev` injects into every
  * served HTML page. Pulls the shared runtime and mounts the sign-in helper.
  * In worker mode the helper reads the worker user directory and owns UI state
- * only; in fallback mode it adapts the page sandbox's Auth store.
+ * only; in fallback mode it mints credentials via `createSignInCredential`
+ * so OAuth users carry real provider metadata.
  */
 import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 import {
@@ -19,27 +20,36 @@ import { getPyricRuntimeStatus } from '../runtime/status.js';
 
 const localAuth = useWorker ? null : getAuth(sandbox);
 const workerAuth = useWorker && workerDb ? getWorkerAuth(workerDb) : null;
-const helper = new ServeAuthHelper(
-  workerAuth
-    ? {
-        list: async () => (await listUsers(workerAuth)).map((user) => ({
-          uid: user.uid,
-          email: user.email,
-          displayName: user.displayName,
-          customClaims: user.customClaims,
-        })),
-      }
-    : {
+const helper = workerAuth
+  ? new ServeAuthHelper({
+      list: async () => (await listUsers(workerAuth)).map((user) => ({
+        uid: user.uid,
+        email: user.email,
+        displayName: user.displayName,
+        customClaims: user.customClaims,
+      })),
+    })
+  : new ServeAuthHelper(
+      {
         list: () => authSandbox.listIdentities(localAuth!),
-        add: (identity) => authSandbox.seedUsers(localAuth!, [{
-          uid: identity.uid,
-          email: identity.email ?? '',
-          password: '__pyric_popup_no_password__',
-          displayName: identity.displayName ?? undefined,
-          customClaims: identity.customClaims,
-        }]),
       },
-);
+      (request) => {
+        if (request.kind === 'pick') {
+          return authSandbox.createSignInCredential(localAuth!, {
+            providerId: request.providerId,
+            uid: request.identity.uid,
+          });
+        }
+        return authSandbox.createSignInCredential(localAuth!, {
+          providerId: request.providerId,
+          spec: {
+            email: request.spec.email,
+            displayName: request.spec.displayName,
+            customClaims: request.spec.customClaims,
+          },
+        });
+      },
+    );
 const resolver = helper.resolver();
 installServeAuthResolver(resolver);
 if (localAuth) authSandbox.setAuthFlowResolver(localAuth, resolver);

--- a/packages/cli/test/serve/auth-helper.test.ts
+++ b/packages/cli/test/serve/auth-helper.test.ts
@@ -12,17 +12,29 @@ import {
 } from 'pyric/auth';
 import { ServeAuthHelper } from '../../src/serve/entries/auth-helper-core.js';
 
+/** Mirror served in-page wiring: mint via createSignInCredential. */
 function helperForLocalAuth(auth: ReturnType<typeof getAuth>): ServeAuthHelper {
-  const helper = new ServeAuthHelper({
-    list: () => authSandbox.listIdentities(auth),
-    add: (identity) => authSandbox.seedUsers(auth, [{
-      uid: identity.uid,
-      email: identity.email ?? '',
-      password: '__pyric_popup_no_password__',
-      displayName: identity.displayName ?? undefined,
-      customClaims: identity.customClaims,
-    }]),
-  });
+  const helper = new ServeAuthHelper(
+    {
+      list: () => authSandbox.listIdentities(auth),
+    },
+    (request) => {
+      if (request.kind === 'pick') {
+        return authSandbox.createSignInCredential(auth, {
+          providerId: request.providerId,
+          uid: request.identity.uid,
+        });
+      }
+      return authSandbox.createSignInCredential(auth, {
+        providerId: request.providerId,
+        spec: {
+          email: request.spec.email,
+          displayName: request.spec.displayName,
+          customClaims: request.spec.customClaims,
+        },
+      });
+    },
+  );
   authSandbox.setAuthFlowResolver(auth, helper.resolver());
   return helper;
 }
@@ -39,6 +51,14 @@ function wire() {
   authSandbox.delegateProviderEnforcement(auth, true);
   const helper = helperForLocalAuth(auth);
   return { auth, helper };
+}
+
+function expectGoogleProviderMetadata(
+  user: NonNullable<ReturnType<typeof getAuth>['currentUser']>,
+  identityProviderId = 'google.com',
+): void {
+  expect(user.providerId).toBe('firebase');
+  expect(user.providerData?.map((p) => p.providerId)).toContain(identityProviderId);
 }
 
 describe('ServeAuthHelper', () => {
@@ -63,8 +83,12 @@ describe('ServeAuthHelper', () => {
       user: {
         uid: 'google.com:worker@example.com',
         email: 'worker@example.com',
+        providerId: 'firebase',
+        providerData: [{ providerId: 'google.com' }],
       },
     });
+    const cred = await pending;
+    expect((await cred.user.getIdTokenResult()).signInProvider).toBe('google.com');
   });
 
   it('non-delegated (in-page fallback): a disabled google.com popup throws operation-not-allowed', async () => {
@@ -89,13 +113,23 @@ describe('ServeAuthHelper', () => {
     expect(cred.user.email).toBe('new@example.com');
     expect(cred.providerId).toBe('google.com');
     expect(auth.currentUser?.uid).toBe(cred.user.uid);
-    expect((await cred.user.getIdTokenResult()).claims.role).toBe('admin');
+    expectGoogleProviderMetadata(cred.user);
+    expectGoogleProviderMetadata(auth.currentUser!);
+    const token = await cred.user.getIdTokenResult();
+    expect(token.claims.role).toBe('admin');
+    expect(token.signInProvider).toBe('google.com');
+    expect(
+      (token.claims as { firebase?: { sign_in_provider?: string } }).firebase?.sign_in_provider,
+    ).toBe('google.com');
     // seeded → claims visible to rules via the sandbox user DB
     const ids = authSandbox.listIdentities(auth);
-    expect(ids.find((i) => i.email === 'new@example.com')?.customClaims).toEqual({ role: 'admin' });
+    const created = ids.find((i) => i.email === 'new@example.com');
+    expect(created?.customClaims).toEqual({ role: 'admin' });
+    expect(created?.providerId).toBe('google.com');
+    expect(created?.providerUserInfo.map((p) => p.providerId)).toEqual(['google.com']);
   });
 
-  it('created identity appears in the picker and is pickable next time', async () => {
+  it('created identity appears in the picker and is pickable next time with Google metadata', async () => {
     const { auth, helper } = wire();
     const p1 = signInWithPopup(auth, new GoogleAuthProvider());
     helper.add({ email: 'a@example.com' });
@@ -103,7 +137,14 @@ describe('ServeAuthHelper', () => {
     const p2 = signInWithPopup(auth, new GoogleAuthProvider());
     const uid = helper.snapshot().identities.find((i) => i.email === 'a@example.com')!.uid;
     helper.pick(uid);
-    expect((await p2).user.email).toBe('a@example.com');
+    const cred = await p2;
+    expect(cred.user.email).toBe('a@example.com');
+    expectGoogleProviderMetadata(cred.user);
+    expectGoogleProviderMetadata(auth.currentUser!);
+    expect((await cred.user.getIdTokenResult()).signInProvider).toBe('google.com');
+    expect(authSandbox.listIdentities(auth).find((i) => i.uid === uid)?.providerId).toBe(
+      'google.com',
+    );
   });
 
   it('cancel rejects auth/popup-closed-by-user; no user set', async () => {
@@ -114,12 +155,19 @@ describe('ServeAuthHelper', () => {
     expect(auth.currentUser).toBeNull();
   });
 
-  it('redirect flows through the same helper + getRedirectResult', async () => {
+  it('redirect flows through the same helper + getRedirectResult with Google metadata', async () => {
     const { auth, helper } = wire();
     const p = signInWithRedirect(auth, new GoogleAuthProvider());
     helper.add({ email: 'redir@example.com' });
     await p;
-    expect((await getRedirectResult(auth))?.user.email).toBe('redir@example.com');
+    const result = await getRedirectResult(auth);
+    expect(result?.user.email).toBe('redir@example.com');
+    expectGoogleProviderMetadata(result!.user);
+    expectGoogleProviderMetadata(auth.currentUser!);
+    expect((await result!.user.getIdTokenResult()).signInProvider).toBe('google.com');
+    expect(
+      authSandbox.listIdentities(auth).find((i) => i.email === 'redir@example.com')?.providerId,
+    ).toBe('google.com');
   });
 
   it('snapshot is referentially stable between emits (view-layer contract)', async () => {

--- a/packages/pyric/src/auth/sign-in.ts
+++ b/packages/pyric/src/auth/sign-in.ts
@@ -9,6 +9,7 @@ import type {
   AuthFlowRequest,
   AuthFlowResolver,
   Persistence,
+  User,
   UserCredential,
 } from './types.js';
 
@@ -118,6 +119,51 @@ async function resolveFlow(
   );
 }
 
+/**
+ * After a resolver/mock hands back a User, ensure `providerData` reflects the
+ * linked provider recorded by {@link SandboxBackend.recordProviderSignIn}.
+ * Bare helper Users (no `providerData`) are patched in place when possible so
+ * `cred.user === auth.currentUser` still holds; otherwise the store-built User
+ * replaces them.
+ */
+function ensureProviderUser(
+  backend: SandboxTarget['backend'],
+  user: User,
+  providerId: string,
+): User {
+  if (user.providerData?.some((entry) => entry.providerId === providerId)) {
+    return user;
+  }
+  const stored = backend.findByUid(user.uid);
+  if (!stored) return user;
+  const rebuilt = backend.buildUserFromStored(stored);
+  const mutable = user as { -readonly [K in keyof User]: User[K] };
+  try {
+    mutable.providerId = rebuilt.providerId ?? 'firebase';
+    mutable.providerData = rebuilt.providerData;
+    mutable.emailVerified = rebuilt.emailVerified;
+    mutable.photoURL = rebuilt.photoURL;
+    mutable.phoneNumber = rebuilt.phoneNumber;
+    mutable.getIdToken = (forceRefresh?: boolean) => rebuilt.getIdToken(forceRefresh);
+    mutable.getIdTokenResult = (forceRefresh?: boolean) => rebuilt.getIdTokenResult(forceRefresh);
+    return user;
+  } catch {
+    return rebuilt;
+  }
+}
+
+async function commitProviderSignIn(
+  backend: SandboxTarget['backend'],
+  credential: UserCredential,
+  providerId: string,
+): Promise<UserCredential> {
+  backend.assertSignInAllowed(credential.user.uid);
+  backend.recordProviderSignIn(credential.user, providerId);
+  const user = ensureProviderUser(backend, credential.user, providerId);
+  await backend.transitionCurrentUser(user, providerId);
+  return user === credential.user ? credential : { ...credential, user };
+}
+
 export async function signInWithPopup(
   auth: Auth,
   provider: AuthProvider,
@@ -126,10 +172,7 @@ export async function signInWithPopup(
   const { backend } = targetOf(auth);
   const credential = await resolveFlow(backend, provider, 'signIn', resolver, 'popup');
   const providerId = credential.providerId ?? provider.providerId;
-  backend.assertSignInAllowed(credential.user.uid);
-  backend.recordProviderSignIn(credential.user, providerId);
-  await backend.transitionCurrentUser(credential.user, providerId);
-  return credential;
+  return commitProviderSignIn(backend, credential, providerId);
 }
 
 export async function signInWithRedirect(
@@ -140,10 +183,8 @@ export async function signInWithRedirect(
   const { backend } = targetOf(auth);
   const credential = await resolveFlow(backend, provider, 'signIn', resolver, 'redirect');
   const providerId = credential.providerId ?? provider.providerId;
-  backend.assertSignInAllowed(credential.user.uid);
-  backend.recordProviderSignIn(credential.user, providerId);
-  await backend.transitionCurrentUser(credential.user, providerId);
-  backend.setRedirectResult(credential);
+  const committed = await commitProviderSignIn(backend, credential, providerId);
+  backend.setRedirectResult(committed);
 }
 
 export async function getRedirectResult(

--- a/packages/pyric/test/auth/sandbox-user-identity.test.ts
+++ b/packages/pyric/test/auth/sandbox-user-identity.test.ts
@@ -110,4 +110,15 @@ describe('rich User preservation (sandbox)', () => {
     expect(auth.currentUser?.email).toBe('manual@example.com');
     expect(auth.currentUser?.displayName).toBe('Display manual');
   });
+
+  it('bare resolver without providerData: popup patches google.com onto currentUser', async () => {
+    const auth = getAuth(initializeSandbox());
+    authSandbox.setAuthProviderConfig(auth, 'google.com', true);
+    authSandbox.setAuthFlowResolver(auth, richResolver('bare-google'));
+    const cred = await signInWithPopup(auth, new GoogleAuthProvider());
+    expect(cred.user).toBe(auth.currentUser!);
+    expect(cred.user.providerData?.map((p) => p.providerId)).toContain('google.com');
+    expect(cred.user.providerId).toBe('firebase');
+    expect((await cred.user.getIdTokenResult()).signInProvider).toBe('google.com');
+  });
 });


### PR DESCRIPTION
```ts
import { getAuth, GoogleAuthProvider, signInWithPopup, sandbox as authSandbox } from 'pyric/auth';

authSandbox.setAuthProviderConfig(auth, 'google.com', true);
// In-page pyric dev helper resolves the picker, then:
const { user } = await signInWithPopup(auth, new GoogleAuthProvider());

user.providerId; // 'firebase' — aggregate, same as production
user.providerData.map((p) => p.providerId); // ['google.com']
(await user.getIdTokenResult()).signInProvider; // 'google.com'
authSandbox.listIdentities(auth)[0].providerId; // 'google.com' (not 'password')
```

## In-page Google popup users no longer look like password accounts

On the no-SharedWorker fallback, `ServeAuthHelper` used to seed new OAuth identities without `providerId` and keep a bare `User` (no `providerData`) as `currentUser`. The SharedWorker path already rebuilt a correct user via `auth.acceptIdentity`; the in-page path now mints through `sandbox.createSignInCredential`, and `signInWithPopup` / `signInWithRedirect` patch any bare resolver user from the store so `providerData` and `firebase.sign_in_provider` match the provider that signed in.

## Risk

- In-page OAuth only. SharedWorker `acceptIdentity` is unchanged.
- Custom `AuthFlowResolver`s that return Users without `providerData` now get that array (and token methods) filled from the store after sign-in; reference identity (`cred.user === currentUser`) is preserved when the object is mutable.
- `User.metadata` remains unmodeled.

<details>
<summary>Implementation notes</summary>

- `ServeAuthHelper` takes an optional `HelperCredentialMint`; worker keeps the default bare mint (discarded by `acceptIdentity`).
- In-page `init.ts` injects `createSignInCredential` for pick/add; drops password-default `seedUsers`.
- `commitProviderSignIn` in `sign-in.ts` runs `recordProviderSignIn` then `ensureProviderUser`.
- Verification: `bun test test/serve/auth-helper.test.ts` (7 pass); `bun test test/auth/sandbox-user-identity.test.ts` (6 pass); related provider/resolver suites (55 pass).

</details>