### PR TITLE
ci: weekly oracle re-capture lane for production drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,10 @@ jobs:
 
       - name: Oracle conformance gate (observations × probes)
         # Loads every observations/*.json, protects their captured values, then
-        # runs each live probe. A contradiction fails the build.
+        # replays each registered conformance probe against the local shim and
+        # the frozen record — it contacts nothing live. A contradiction between
+        # the shim and the committed observation fails the build. Live
+        # re-capture is a separate scheduled lane (oracle-recapture.yml).
         run: bun run packages/conformance/src/check-observations.ts
 
       - name: Conformance graph integrity

--- a/.github/workflows/oracle-recapture.yml
+++ b/.github/workflows/oracle-recapture.yml
@@ -1,0 +1,135 @@
+# Oracle re-capture lane — weekly production drift detection.
+#
+# Nothing else in CI re-consults production: build.yml only checks committed
+# observations against the offline model and the version guard, so a `conforms`
+# claim can silently outlive the behavior it was captured against. This lane
+# re-runs the schedulable capture rigs against live Firebase, overwriting the
+# observation files in place, then reports any change to the observations tree
+# as drift — the same "the diff is the drift report" mechanism a human uses
+# locally (see packages/conformance/docs/how-to-run-the-conformance-system.md).
+# The comparison ignores the per-run `observedAt` timestamp every capture
+# stamps, so it fires only on a real change to a captured fact.
+#
+# Two tiers of rig run here (the guide's rig fleet section is the map):
+#   1. unattended — admin-app + app-registry: pure in-process probes of the
+#      installed firebase / firebase-admin packages. No secret, no network;
+#      they always run.
+#   2. credentialed — oracle-run, messaging-send, rules-firestore,
+#      rules-storage: each reaches a real Firebase project and needs a
+#      provisioned secret. Each matrix leg gates on its own secret and skips
+#      cleanly (a warning, a green run) when it is absent — the same
+#      secret-absent pattern simulator-parity.yml uses so a fork or an
+#      unconfigured repo never sees a red run.
+#
+# Deliberately excluded:
+#   - rtdb-rules      — the one rig that MUTATES a live project (deploys a
+#                       ruleset, then restores). Its deploy/capture/restore/
+#                       read-back invariant is a human-witnessed correctness
+#                       contract; it is not run unattended here.
+#   - messaging-web   — human-witnessed, headed Chromium with a persistent
+#                       profile. Cannot run on a CI worker by nature.
+#   - ai-logic        — credentialed, but every run consumes paid model quota
+#                       and it sits outside this lane's scoped rig set. It can
+#                       be added as another credentialed matrix leg (guard
+#                       PYRIC_AI_FIREBASE_CONFIG) when that trade is accepted.
+#
+# SAFETY: this lane never commits, pushes, or otherwise persists a changed
+# observation. On drift it fails loudly with the diff in the job summary; a
+# human reviews the affected rows and re-captures deliberately on a branch.
+
+name: Oracle re-capture
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC — off-peak and clear of the daily build (09:17)
+    # and playground (10:43) crons.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Read-only: drift surfaces as a red run with the diff in the summary. The lane
+# writes nothing back to the repository.
+permissions:
+  contents: read
+
+concurrency:
+  # One re-capture at a time; a manual dispatch supersedes an in-flight run.
+  group: oracle-recapture
+  cancel-in-progress: false
+
+jobs:
+  unattended:
+    name: Unattended rigs (installed-SDK probes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+      - name: Install
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
+      - name: Re-capture admin-app observations
+        # In-process probes of the installed firebase-admin app registry.
+        # --write overwrites the admin-app-* observation files in place so the
+        # drift step can diff them (verify mode, the default, would not rewrite).
+        run: bun run packages/conformance/src/admin-app-probes.ts --write
+      - name: Re-capture app-registry observations
+        # In-process probes of the installed firebase/app client registry.
+        run: bun run packages/conformance/src/app-registry-probes.ts --write
+      - name: Detect observation drift
+        run: bun scripts/ci/oracle-drift-report.ts "unattended rigs (admin-app, app-registry)"
+
+  credentialed:
+    name: Credentialed rig (${{ matrix.rig }})
+    runs-on: ubuntu-latest
+    strategy:
+      # One rig's drift or absent secret must not cancel the others.
+      fail-fast: false
+      matrix:
+        include:
+          - rig: oracle-run
+            script: packages/conformance/src/run.ts
+            guard: PYRIC_ORACLE_FIREBASE_CONFIG
+          - rig: messaging-send
+            script: packages/conformance/src/messaging-send-probes.ts
+            guard: PYRIC_MESSAGING_SA_BASE64
+          - rig: rules-firestore
+            script: packages/conformance/src/run-rules.ts
+            guard: PARITY_SA_BASE64
+          - rig: rules-storage
+            script: packages/conformance/src/run-rules-storage.ts
+            guard: PARITY_SA_BASE64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+      - name: Check credential availability
+        id: secret-check
+        # Skip cleanly when this rig's secret is absent (fork / unconfigured
+        # repo), exactly like simulator-parity's parity-stress job. The guard
+        # var name is per-rig; ${!GUARD} reads whichever one this leg needs.
+        env:
+          GUARD: ${{ matrix.guard }}
+          PYRIC_ORACLE_FIREBASE_CONFIG: ${{ secrets.PYRIC_ORACLE_FIREBASE_CONFIG }}
+          PYRIC_MESSAGING_SA_BASE64: ${{ secrets.PYRIC_MESSAGING_SA_BASE64 }}
+          PARITY_SA_BASE64: ${{ secrets.PARITY_SA_BASE64 }}
+        run: |
+          if [ -z "${!GUARD}" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::$GUARD not configured — ${{ matrix.rig }} re-capture skipped. Add the oracle secret to enable production drift detection for this rig."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install
+        if: steps.secret-check.outputs.available == 'true'
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
+      - name: Re-capture ${{ matrix.rig }} against production
+        if: steps.secret-check.outputs.available == 'true'
+        env:
+          PYRIC_ORACLE_FIREBASE_CONFIG: ${{ secrets.PYRIC_ORACLE_FIREBASE_CONFIG }}
+          PYRIC_MESSAGING_SA_BASE64: ${{ secrets.PYRIC_MESSAGING_SA_BASE64 }}
+          PARITY_SA_BASE64: ${{ secrets.PARITY_SA_BASE64 }}
+        run: bun run ${{ matrix.script }}
+      - name: Detect observation drift
+        if: steps.secret-check.outputs.available == 'true'
+        run: bun scripts/ci/oracle-drift-report.ts "${{ matrix.rig }}"

--- a/packages/conformance/docs/how-to-run-the-conformance-system.md
+++ b/packages/conformance/docs/how-to-run-the-conformance-system.md
@@ -889,6 +889,69 @@ behaves as pinned. A changed file means cloud behavior MOVED, and the affected
 rows need review before you commit. Never commit a changed observation without
 reading what changed.
 
+### The scheduled re-capture lane
+
+A manual re-run is the only thing that keeps a capture honest, and nobody
+re-runs a rig on a schedule by hand. `.github/workflows/oracle-recapture.yml`
+does it automatically. It runs **weekly** (Monday 06:00 UTC) and on manual
+dispatch, re-executes the schedulable rigs against live Firebase, and applies
+the same drift report — `git diff` over the observations tree — as a gate. The
+offline gates in `build.yml` cannot catch this class of change: server-side
+facts such as the send-plane error envelopes, the oversized-payload byte
+boundary, and batch limits can move with no client SDK release, so only a fresh
+capture sees them.
+
+The lane runs two of the three tiers from
+[the fleet, by automation tier](#the-fleet-by-automation-tier):
+
+- The **unattended** rigs (`admin-app`, `app-registry`) always run — they need
+  no secret.
+- The **credentialed** rigs `oracle-run`, `messaging-send`, `rules-firestore`,
+  and `rules-storage` each run only when their secret is present. When a secret
+  is absent (a fork, or a repo that has not provisioned the oracle project) that
+  rig's leg skips cleanly with a warning and the run stays green, the same
+  secret-absent contract `simulator-parity.yml` uses. `messaging-send` carries
+  the highest-drift-risk records, the purely server-side `messaging-admin`
+  facts, so it is the one to prioritize provisioning.
+
+Three rigs are deliberately left out. `messaging-web` is human-witnessed
+(headed Chromium, persistent profile) and cannot run on a CI worker. `ai-logic`
+is credentialed but every run consumes paid model quota, so it stays a manual
+capture; it can be added as another credentialed leg when that trade is
+accepted. `rtdb-rules` is the one rig that mutates a live project — its
+[deploy, capture, restore, read-back invariant](#the-safety-invariant-deploy-capture-restore-read-back)
+is a witnessed correctness contract, not something to run unattended, so the
+lane never touches it.
+
+The comparison ignores the `observedAt` stamp every capture rewrites (and any
+pure reformatting), so the lane fires only on a real change to a captured fact,
+not on the timestamp. It never commits, pushes, or otherwise persists a changed
+observation: the observations tree is read-only to CI.
+
+### When the drift report fires
+
+A red re-capture run means a fact you had pinned no longer matches production.
+The changed observations are not in the repository — the lane refuses to write
+them — so the recovery is deliberate, on a branch, by a person:
+
+1. **Read the diff** in the failed run's job summary. Each drifted file is shown
+   with the `observedAt` noise already stripped, so what is left is the behavior
+   that moved. If the summary lists nothing and the run is still red, the failure
+   is the rig itself, not drift — read the step log.
+2. **Reproduce it locally.** Point the same rig's env vars at the oracle project
+   and run its `script` on a branch, then `git diff` the observations tree. The
+   local diff should match the summary.
+3. **Decide what the change is.** Either production genuinely moved and the new
+   capture is the truth, or the affected rows now describe a real difference from
+   production. Re-capture the observation, then follow
+   [record a divergence](#record-a-divergence) for every row the moved fact now
+   contradicts: pin both sides in the surface's conformance suite, flip the row
+   to `diverged-documented`, regenerate, and re-run `compat:validate`. Never
+   weaken an assertion or hand-edit a capture to make the report go green.
+4. **Commit the re-capture with its row changes together**, so the observation
+   and the claims it backs move in one reviewed step. The next scheduled run then
+   passes because the pinned facts match production again.
+
 ## Add to the system
 
 ### The rule that outranks the rest

--- a/scripts/ci/oracle-drift-report.ts
+++ b/scripts/ci/oracle-drift-report.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * Oracle drift report.
+ *
+ * Used by .github/workflows/oracle-recapture.yml after a capture rig has
+ * re-run against production and overwritten its observation files in place.
+ * The observations tree is committed, so a change to it IS the drift report:
+ * an unchanged fact means production still behaves as pinned; a changed fact
+ * means cloud behavior moved and the affected registry rows need human review
+ * (see packages/conformance/docs/how-to-run-the-conformance-system.md).
+ *
+ * Why not a bare `git diff --exit-code`: every observation envelope stamps a
+ * fresh `observedAt` timestamp on every write, and short arrays can serialize
+ * differently across writer versions. Those are noise, not drift. This report
+ * strips `observedAt` and re-canonicalizes both sides before comparing, so it
+ * fires ONLY on a real change to a captured fact — anything other than the
+ * timestamp. That is the same judgement a human applies reading the diff
+ * locally, made mechanical so the scheduled lane can gate on it.
+ *
+ * It NEVER commits, pushes, or otherwise persists the change. On drift it
+ * writes the (timestamp-free) diff into the GitHub Actions job summary and
+ * exits non-zero so the run goes red — a visible, reviewable artifact.
+ *
+ * Usage: bun scripts/ci/oracle-drift-report.ts <rig-label>
+ * Exit:  0 = no drift; 1 = drift detected; 2 = usage error.
+ */
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const OBS_TREE = 'packages/conformance/observations';
+const DOC = 'packages/conformance/docs/how-to-run-the-conformance-system.md';
+
+const label = process.argv[2];
+if (!label) {
+  console.error('usage: bun scripts/ci/oracle-drift-report.ts <rig-label>');
+  process.exit(2);
+}
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/** Content of a path at HEAD, or null if it did not exist there. */
+function headContent(path: string): string | null {
+  try {
+    return git(['show', `HEAD:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+/** Content of a path in the working tree, or null if it was deleted. */
+function workingContent(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** Parse an observation, drop the volatile `observedAt` stamp wherever it
+ *  appears, and re-serialize with sorted keys so formatting never registers
+ *  as drift. Non-JSON content is returned verbatim so a malformed capture
+ *  still surfaces as a difference rather than being silently swallowed. */
+function canonicalize(content: string | null): string | null {
+  if (content === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  const stripped = strip(parsed);
+  return JSON.stringify(stripped, sortedReplacer(), 2) + '\n';
+}
+
+function strip(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(strip);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (k === 'observedAt') continue;
+      out[k] = strip(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Stable key order so re-serialization is deterministic. */
+function sortedReplacer() {
+  return function (this: unknown, _key: string, value: unknown): unknown {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const record = value as Record<string, unknown>;
+      return Object.fromEntries(Object.keys(record).sort().map((k) => [k, record[k]]));
+    }
+    return value;
+  };
+}
+
+/** Changed observation paths (modified, added, or deleted) vs HEAD. */
+function changedObservationPaths(): string[] {
+  const out = git(['status', '--porcelain', '--', OBS_TREE]);
+  const paths: string[] = [];
+  for (const line of out.split('\n')) {
+    if (!line.trim()) continue;
+    // Porcelain: 2 status chars, a space, then the path (possibly "old -> new").
+    const path = line.slice(3).split(' -> ').pop()!.trim().replace(/^"|"$/g, '');
+    if (path.endsWith('.json')) paths.push(path);
+  }
+  return paths.sort();
+}
+
+/** A timestamp-free unified diff between HEAD and working versions of one
+ *  file, or '' when the only difference was the stamp / formatting. */
+function normalizedDiff(path: string, tmp: string): string {
+  const head = canonicalize(headContent(path));
+  const work = canonicalize(workingContent(path));
+  if (head === work) return '';
+
+  const headFile = join(tmp, 'HEAD', path);
+  const workFile = join(tmp, 'CURRENT', path);
+  mkdirSync(dirname(headFile), { recursive: true });
+  mkdirSync(dirname(workFile), { recursive: true });
+  writeFileSync(headFile, head ?? '');
+  writeFileSync(workFile, work ?? '');
+
+  let raw: string;
+  try {
+    // --no-index diff; exits 1 when the files differ, which execFileSync
+    // throws on — the diff text is on the thrown error's stdout.
+    raw = git(['--no-pager', 'diff', '--no-index', '--unified=3', '--', headFile, workFile]);
+  } catch (err) {
+    raw = (err as { stdout?: string }).stdout ?? '';
+  }
+  // Relabel the temp file headers back to the real observation path.
+  return raw
+    .split('\n')
+    .filter((l) => !l.startsWith('index ') && !l.startsWith('diff --git '))
+    .map((l) => {
+      if (l.startsWith('--- ')) return `--- a/${path}`;
+      if (l.startsWith('+++ ')) return `+++ b/${path}`;
+      return l;
+    })
+    .join('\n')
+    .trim();
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'oracle-drift-'));
+const drifted: { path: string; diff: string }[] = [];
+for (const path of changedObservationPaths()) {
+  const diff = normalizedDiff(path, tmp);
+  if (diff) drifted.push({ path, diff });
+}
+
+if (drifted.length === 0) {
+  console.log(`[oracle-drift] ${label}: no drift — production still matches the pinned observations.`);
+  process.exit(0);
+}
+
+const lines: string[] = [];
+lines.push(`## Oracle drift detected — ${label}`);
+lines.push('');
+lines.push(
+  `The re-capture changed **${drifted.length}** committed observation(s) under \`${OBS_TREE}\` ` +
+    '(beyond the per-run `observedAt` timestamp). Production behavior moved since these facts were ' +
+    'last pinned. Nothing was committed.',
+);
+lines.push('');
+lines.push(`Review the diff below and follow the drift-response procedure in \`${DOC}\` before ` + 're-capturing deliberately on a branch.');
+lines.push('');
+for (const { path, diff } of drifted) {
+  lines.push(`### \`${path}\``);
+  lines.push('');
+  lines.push('```diff');
+  lines.push(diff);
+  lines.push('```');
+  lines.push('');
+}
+const report = lines.join('\n');
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+  appendFileSync(summaryPath, report + '\n');
+} else {
+  console.log(report);
+}
+
+console.error(`::error::Oracle observation drift detected for ${label} — see the job summary for the diff.`);
+process.exit(1);


### PR DESCRIPTION
Adds `.github/workflows/oracle-recapture.yml`, a scheduled lane that re-runs the schedulable oracle capture rigs against live Firebase every week and fails visibly when a captured production fact has moved. Here is what an operator sees on a run where the FCM send plane changed an error envelope:

```
Credentialed rig (messaging-send)  x failed
  Re-capture messaging-send against production   ok (10 observations rewritten)
  Detect observation drift                        x exit 1

# Job summary
## Oracle drift detected - messaging-send

The re-capture changed 1 committed observation(s) under
`packages/conformance/observations` (beyond the per-run `observedAt` timestamp).
Production behavior moved since these facts were last pinned. Nothing was committed.

### .../messaging-admin/messaging-send-oversized-payload-error-envelope.json
    "behavior": {
      "status": 400,
-     "errorCode": "INVALID_ARGUMENT",
+     "errorCode": "PAYLOAD_TOO_LARGE",
```

Nothing else in CI re-consults production: `build.yml` only checks committed observations against the offline model and the version guard, so a `conforms` claim can silently outlive the behavior it was captured against. Server-side facts (send-plane error envelopes, the oversized-payload byte boundary, batch limits) move with no client SDK release, so only a fresh capture sees them.

## The lane runs the two schedulable tiers and gates on the diff

Weekly (Mon 06:00 UTC) and on manual dispatch. Two jobs:

- **unattended** — `admin-app` + `app-registry`, pure in-process probes of the installed `firebase` / `firebase-admin` packages. No secret; they always run.
- **credentialed** (matrix, `fail-fast: false`) — `oracle-run`, `messaging-send`, `rules-firestore`, `rules-storage`. Each leg gates on its own secret and, when it is absent, skips cleanly with a warning and stays green — the same secret-absent contract `simulator-parity.yml` uses, so a fork or an unconfigured repo never goes red:

```yaml
- name: Check credential availability
  id: secret-check
  env:
    GUARD: ${{ matrix.guard }}          # e.g. PARITY_SA_BASE64
    PARITY_SA_BASE64: ${{ secrets.PARITY_SA_BASE64 }}
    # ...the other rig secrets...
  run: |
    if [ -z "${!GUARD}" ]; then
      echo "available=false" >> "$GITHUB_OUTPUT"
      echo "::warning::$GUARD not configured - ${{ matrix.rig }} re-capture skipped."
    else
      echo "available=true" >> "$GITHUB_OUTPUT"
    fi
```

Every capture rewrites a fresh `observedAt` stamp, so a bare `git diff --exit-code` would be red on every run. `scripts/ci/oracle-drift-report.ts` strips `observedAt` (and any pure reformatting) and structurally compares each changed observation against `HEAD`, so it fires only on a real change to a captured fact. It writes the timestamp-free diff to the job summary and exits 1. It never commits, pushes, or otherwise persists the changed observations — the tree is read-only to CI.

## Three rigs are deliberately excluded

- `rtdb-rules` — the one rig that mutates a live project (deploy ruleset, capture, restore, read-back verify). That invariant is a witnessed correctness contract; the lane never runs it unattended.
- `messaging-web` — human-witnessed, headed Chromium with a persistent profile. Cannot run on a CI worker by nature.
- `ai-logic` — credentialed, but every run consumes paid model quota. It stays a manual capture and can be added as another credentialed leg (guard `PYRIC_AI_FIREBASE_CONFIG`) when that trade is accepted.

`build.yml`'s oracle-gate comment claimed the step "runs each live probe"; it contacts nothing live. Corrected to say it replays the local shim against the frozen records.

## Risk

Low. No existing job changes behavior — `build.yml`'s only edit is a comment. The new workflow is scheduled + dispatch, so it never runs on PRs. If oracle secrets are unset the whole lane is a clean green skip. The one behavioral judgement is the drift comparison ignoring `observedAt`; if a rig ever moved a real fact into a field named `observedAt` it would be missed, but that field is reserved for the capture timestamp across every rig.

<details>
<summary>What was and was not executable in validation</summary>

No credentials here, so the live capture paths could not be exercised. Validated by structure and by the non-credentialed logic paths:

- `actionlint` 1.7.12 — clean on `oracle-recapture.yml` and `build.yml` (exit 0).
- `tsc --noEmit --strict` on `scripts/ci/oracle-drift-report.ts` — clean.
- **No-drift path**: ran `admin-app` + `app-registry` with `--write` (34 observation files rewritten, all `observedAt`/formatting noise). Drift report -> `no drift`, exit 0.
- **Drift path**: injected a behavioral change into one observation's `behavior` block -> report flagged exactly that one file (the other 33 timestamp-only changes ignored), timestamp-free diff in the summary, `::error::` annotation, exit 1.
- **Secret-absent skip**: `run-rules.ts` and `run-rules-storage.ts` run inert (exit 0, no writes) with no secret; `messaging-send-probes.ts` and `run.ts` exit non-zero with no secret, which is why every credentialed leg is gated behind the `if: available == 'true'` guard rather than relying on the rig's own behavior.
- Could not run: live rig captures against Firebase (`oracle-run`, `messaging-send`, `rules-firestore`, `rules-storage`) require the oracle project secrets, which are not present in this environment.

</details>

Closes #439
