### PR TITLE
fix(conformance): messaging suites replay the broker, not the observation JSON

### DIFF
--- a/packages/conformance/baselines/audit-baseline.json
+++ b/packages/conformance/baselines/audit-baseline.json
@@ -6,7 +6,6 @@
     "firestore#97",
     "firestore#98",
     "messaging#1",
-    "messaging#10",
     "messaging#11",
     "messaging#12",
     "messaging#13",

--- a/packages/conformance/registry/messaging.ts
+++ b/packages/conformance/registry/messaging.ts
@@ -53,8 +53,17 @@ interface RowSeed {
    * conformance suite passes unweakened. The builder then emits
    * status 'conforms' with this automation tier and wires the surface's
    * suite into conformanceTests. Absent = still climbing (born unverified).
+   *
+   * `type-backed` is the SHAPE tier: a `conforms` row whose claim is a pure
+   * type-only shape with no runtime carrier the sandbox can exhibit, so its
+   * conformance is closed structurally by the tier-2 assignability census
+   * (resolved decision #5) rather than by a runtime replay. It keeps its climb
+   * risk (the behavior is still unobserved) but does NOT wire the surface
+   * suite as a conformanceTests witness, and it requires an `exceptionReason`.
    */
-  flipped?: 'oracle-backed' | 'unit-backed';
+  flipped?: 'oracle-backed' | 'unit-backed' | 'type-backed';
+  /** Required for a `type-backed` downgrade: why the row has no runtime witness. */
+  exceptionReason?: string;
 }
 
 const SUITE: Record<SurfacePlane, string> = {
@@ -70,7 +79,7 @@ const CITED_NOT_REPLAYED_REASON =
 const buildRow = defineRows({ surface: 'messaging' });
 
 function row(seed: RowSeed): CompatibilityRow {
-  const { ref, observations = [], tests = [], flipped, ...rest } = seed;
+  const { ref, observations = [], tests = [], flipped, exceptionReason, ...rest } = seed;
   const observed = observations.length > 0;
   // Climb risk names the gap between what the row claims and what backs it:
   // 'cited-not-replayed' (score 1) when a committed observation vouches for
@@ -81,27 +90,49 @@ function row(seed: RowSeed): CompatibilityRow {
     riskScore: observed ? 1 : 2,
     riskReasons: [observed ? CITED_NOT_REPLAYED_REASON : UNOBSERVED_REASON],
   };
-  // A flip to 'oracle-backed' discharges the climb risk: the cited
-  // observations are replayed offline by the blocking conformance suite, so
-  // neither reason describes the row any more and the builder's zero-risk
-  // defaults are accurate. A flip to 'unit-backed' does NOT discharge it —
-  // the assertion set passes, but the behavior itself is still unobserved
-  // (or cited without replay), so the row keeps its climb risk. That
-  // residual risk is what the audit's evidence-tier worklist ratchets
-  // (see packages/conformance/src/ledger.ts, evidenceTierGapRows).
-  const climb = flipped
-    ? {
-        status: 'conforms' as const,
-        automation: flipped,
-        conformanceTests: [SUITE[seed.surface], ...tests],
-        ...(flipped === 'unit-backed' ? climbRisk : {}),
-      }
-    : {
-        status: 'unverified' as const,
-        automation: 'unverified' as const,
-        ...climbRisk,
-      };
+  // Resolve the row's status/automation/risk from its flip tier. Each tier is
+  // one branch; see `climbFor` for what each does with the climb risk.
+  const climb = climbFor(flipped, seed.surface, tests, exceptionReason, climbRisk);
   return buildRow({ ...rest, rowRef: String(ref), oracleObservations: observations, ...climb });
+}
+
+type ClimbRisk = { risk: string[]; riskScore: number; riskReasons: string[] };
+
+/**
+ * The status/automation/risk block a row carries, by flip tier:
+ *
+ *   - not flipped → still climbing: `unverified`, keeps its climb risk.
+ *   - `oracle-backed` → the cited observations are replayed offline by the
+ *     blocking conformance suite, which DISCHARGES the climb risk; the
+ *     builder's zero-risk defaults are then accurate.
+ *   - `unit-backed` → the assertion set passes, but the behavior itself is
+ *     still unobserved (or cited without replay), so the row KEEPS its climb
+ *     risk. That residual is what the audit's evidence-tier worklist ratchets
+ *     (see packages/conformance/src/ledger.ts, evidenceTierGapRows).
+ *   - `type-backed` → the SHAPE tier: a `conforms` row with no runtime carrier
+ *     the sandbox can exhibit. It keeps its climb risk but does NOT wire the
+ *     surface suite (there is nothing to replay) and carries an exceptionReason
+ *     documenting why. The worklist keys on `unit-backed` only, so structural
+ *     closure is left to the tier-2 assignability census, not gated here.
+ */
+function climbFor(
+  flipped: RowSeed['flipped'],
+  surface: SurfacePlane,
+  tests: string[],
+  exceptionReason: string | undefined,
+  climbRisk: ClimbRisk,
+): Partial<CompatibilityRow> {
+  if (flipped === undefined) {
+    return { status: 'unverified', automation: 'unverified', ...climbRisk };
+  }
+  if (flipped === 'oracle-backed') {
+    return { status: 'conforms', automation: 'oracle-backed', conformanceTests: [SUITE[surface], ...tests] };
+  }
+  if (flipped === 'unit-backed') {
+    return { status: 'conforms', automation: 'unit-backed', conformanceTests: [SUITE[surface], ...tests], ...climbRisk };
+  }
+  // 'type-backed' — the shape tier.
+  return { status: 'conforms', automation: 'type-backed', exceptionReason, ...climbRisk };
 }
 
 // ─── firebase/messaging (client) — surface 'messaging' ───────────────────────
@@ -221,11 +252,13 @@ const clientRows: CompatibilityRow[] = [
     surface: 'messaging',
     ref: 10,
     featureKeys: ["MessagePayload"],
-    flipped: 'unit-backed',
+    flipped: 'type-backed',
+    exceptionReason:
+      'Type-only shape with no runtime carrier: the sandbox broker delivers only data/from/messageId(+notification) and never carries `fcmOptions` on a delivered payload (capture-faithful, the same reason `collapseKey` is omitted). The receive-plane conformance suite has nothing to drive, so the FcmOptions shape is closed structurally by the tier-2 assignability census (resolved decision #5), not a runtime replay. Downgraded from unit-backed under #440 rather than keep a vacuous `toBeDefined()` witness; the residual unobserved risk is retained.',
     section: CLIENT,
     api: 'interface FcmOptions { link?; analyticsLabel? }',
     behavior: 'WebpushFcmOptions-style options carried on a client `MessagePayload` (`link`, `analyticsLabel`).',
-    evidence: 'Upstream typings (`@firebase/messaging` 0.12.26 `public-types`); no observation yet.',
+    evidence: 'Upstream typings (`@firebase/messaging` 0.12.26 `public-types`); no observation yet — type-only shape closed by the assignability census (resolved decision #5).',
   }),
   row({
     surface: 'messaging',

--- a/packages/conformance/test/src/audit-worklist.test.ts
+++ b/packages/conformance/test/src/audit-worklist.test.ts
@@ -27,7 +27,9 @@ function withEntries(entries: RegistryEntry[]): CompatibilityLedger {
 describe('evidence-tier audit worklist', () => {
   it('keeps climb risk on every unit-backed messaging conforms row (nothing stripped by flipping)', () => {
     const unitBacked = messagingRows.filter((row) => row.status === 'conforms' && row.automation === 'unit-backed');
-    expect(unitBacked.length).toBe(41);
+    // 40 after #440 downgraded messaging#10 (FcmOptions, a type-only shape with
+    // no runtime carrier) from unit-backed to the type-backed shape tier.
+    expect(unitBacked.length).toBe(40);
     for (const row of unitBacked) {
       expect(row.riskReasons.length).toBeGreaterThan(0);
       expect(row.risk.some((token) => token === 'unobserved' || token === 'cited-not-replayed')).toBe(true);
@@ -50,7 +52,7 @@ describe('evidence-tier audit worklist', () => {
     const messagingUnitBacked = messagingRows.filter(
       (row) => row.status === 'conforms' && row.automation === 'unit-backed',
     );
-    expect(messagingUnitBacked.length).toBe(41);
+    expect(messagingUnitBacked.length).toBe(40); // #440 downgraded messaging#10 to type-backed
     for (const row of messagingUnitBacked) expect(ids.has(row.id)).toBe(true);
   });
 

--- a/packages/pyric-admin/test/messaging/oracle-conformance.test.ts
+++ b/packages/pyric-admin/test/messaging/oracle-conformance.test.ts
@@ -91,13 +91,28 @@ async function messaging(): Promise<any> {
   return m.getMessaging();
 }
 
-/** Assert a message is accepted: real send + dryRun both return the resource name shape. */
-async function expectAccepted(message: Record<string, any>): Promise<void> {
+/**
+ * Drive a real send + a dryRun of the same message and return both resource
+ * names. Both must match the FCM resource-name shape; the shared shape is what
+ * `dryRunSameShapeAsReal` records.
+ */
+async function drivenAccept(message: Record<string, any>): Promise<{ real: string; dry: string }> {
   const svc = await messaging();
-  const name: string = await svc.send(message);
-  expect(RESOURCE_NAME.test(name)).toBe(true);
+  const real: string = await svc.send(message);
+  expect(RESOURCE_NAME.test(real)).toBe(true);
   const dry: string = await svc.send(message, true);
   expect(RESOURCE_NAME.test(dry)).toBe(true); // dryRun returns the SAME shape (fake id)
+  return { real, dry };
+}
+
+/** Assert a message is accepted: real send + dryRun both return the resource name shape. */
+async function expectAccepted(message: Record<string, any>): Promise<void> {
+  await drivenAccept(message);
+}
+
+/** Whether a driven real name and dryRun name share the FCM resource-name shape. */
+function sameResourceShape(names: { real: string; dry: string }): boolean {
+  return RESOURCE_NAME.test(names.real) && RESOURCE_NAME.test(names.dry);
 }
 
 /** Assert a malformed message is rejected with the admin-wrapped INVALID_ARGUMENT code. */
@@ -150,23 +165,27 @@ const assertions: Record<string, () => Promise<void> | void> = {
   'messaging-admin#4': async () => {
     // send(message, dryRun?) — the send-plane contract, cited by 10 observations.
     // Accept paths: topic / condition / notification-only / data-only / webpush.
-    await expectAccepted({ topic: 'oracle-topic', notification: { title: 't', body: 'b' } });
-    await expectAccepted({ condition: "'a' in topics && 'b' in topics", data: { k: 'v' } });
-    await expectAccepted({ topic: 'oracle-topic', notification: { title: 't' } }); // notification-only
-    await expectAccepted({ topic: 'oracle-topic', data: { k: 'v' } }); // data-only
-    await expectAccepted({
+    // Every accept is DRIVEN (real send + dryRun), and `dryRunSameShapeAsReal` /
+    // `bothAccepted` are compared against the shapes the mirror actually
+    // produced — never read straight off the observation object.
+    const topicAccept = await drivenAccept({ topic: 'oracle-topic', notification: { title: 't', body: 'b' } });
+    const conditionAccept = await drivenAccept({ condition: "'a' in topics && 'b' in topics", data: { k: 'v' } });
+    const notificationOnly = await drivenAccept({ topic: 'oracle-topic', notification: { title: 't' } });
+    const dataOnly = await drivenAccept({ topic: 'oracle-topic', data: { k: 'v' } });
+    const webpushAccept = await drivenAccept({
       topic: 'oracle-topic',
       webpush: { headers: { TTL: '3600' }, fcmOptions: { link: 'https://example.com/oracle' } },
     });
-    // dryRun shape parity is pinned by every accept observation.
-    for (const name of [
-      'messaging-send-topic-accepted',
-      'messaging-send-condition-accepted',
-      'messaging-send-webpush-config-accepted',
-    ]) {
-      expect(obs(name).dryRunSameShapeAsReal).toBe(true);
-    }
-    expect(obs('messaging-send-notification-only-vs-data-only-accepted').bothAccepted).toBe(true);
+    // dryRun shape parity: the DRIVEN real vs dryRun names share the resource
+    // shape, matching each accept observation's `dryRunSameShapeAsReal`.
+    expect(sameResourceShape(topicAccept)).toBe(obs('messaging-send-topic-accepted').dryRunSameShapeAsReal);
+    expect(sameResourceShape(conditionAccept)).toBe(obs('messaging-send-condition-accepted').dryRunSameShapeAsReal);
+    expect(sameResourceShape(webpushAccept)).toBe(obs('messaging-send-webpush-config-accepted').dryRunSameShapeAsReal);
+    // Notification-only AND data-only both accepted (driven), matching
+    // `bothAccepted`.
+    expect(sameResourceShape(notificationOnly) && sameResourceShape(dataOnly)).toBe(
+      obs('messaging-send-notification-only-vs-data-only-accepted').bothAccepted,
+    );
 
     // Error envelopes: assert each pinned production envelope's invariants, then
     // drive the mirror to reject with the wrapped admin code.
@@ -218,10 +237,13 @@ const assertions: Record<string, () => Promise<void> | void> = {
   },
   'messaging-admin#11': async () => {
     // BaseMessage: neither data nor notification is individually required.
+    // Driven: a notification-only send and a data-only send are BOTH accepted
+    // by the mirror; `bothAccepted` is the observation's recorded truth for
+    // that pair, compared against what the two driven sends actually produced.
     const o = obs('messaging-send-notification-only-vs-data-only-accepted');
-    expect(o.bothAccepted).toBe(true);
-    await expectAccepted({ topic: 'oracle-topic', notification: { title: 't' } });
-    await expectAccepted({ topic: 'oracle-topic', data: { k: 'v' } });
+    const notificationOnly = await drivenAccept({ topic: 'oracle-topic', notification: { title: 't' } });
+    const dataOnly = await drivenAccept({ topic: 'oracle-topic', data: { k: 'v' } });
+    expect(sameResourceShape(notificationOnly) && sameResourceShape(dataOnly)).toBe(o.bothAccepted);
   },
   'messaging-admin#12': async () => {
     // TokenMessage: an invalid token is rejected; fieldViolations names message.token.

--- a/packages/pyric/test/messaging/oracle-conformance.test.ts
+++ b/packages/pyric/test/messaging/oracle-conformance.test.ts
@@ -34,6 +34,9 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { messagingRows } from '../../../../packages/conformance/registry/messaging.ts';
 import { initializeApp } from 'pyric/app';
+import { createAppForSandbox } from 'pyric/app/internal';
+import { initializeSandbox } from 'pyric/sandbox';
+import { BrokerSendError, DEFAULT_SENDER_ID, getMessagingBroker } from 'pyric/messaging/internal';
 import { resetAppRegistryForTests } from '../../dist/app/registry.js';
 
 beforeAll(async () => {
@@ -73,6 +76,14 @@ const loadSw = (): Promise<any> => (swMirror ??= import('pyric/messaging/sw'));
 const clientRows = messagingRows.filter((r) => r.surface === 'messaging');
 
 /**
+ * Map a DRIVEN `DeliveryResult.route` onto the handler names the routing
+ * observation records, so the pinned `deliveredTo` values can be compared
+ * against what the broker actually did rather than re-asserted off the JSON.
+ */
+const deliveredTo = (result: { route: string }): string =>
+  result.route === 'foreground' ? 'onMessage' : 'onBackgroundMessage';
+
+/**
  * One assertion set per row, keyed by row id. Each handler drives the mirror so
  * it is red until the mirror exists AND meaningful the moment it does. Rows that
  * cite observations replay the pinned values; the rest are shape/export
@@ -107,36 +118,89 @@ const assertions: Record<string, () => Promise<void> | void> = {
   },
 
   'messaging#3': async () => {
-    // deleteToken resolves truthy; the now-dead token stops delivery and the
-    // send plane eventually surfaces UNREGISTERED (admin re-wraps the code).
+    // deleteToken resolves truthy; afterwards a send to the now-dead token is
+    // answered by the SAME broker with the captured UNREGISTERED envelope and
+    // routes NO delivery to either client handler. The full loop is DRIVEN
+    // in-process (mint → delete → dead-token send → rejection + silence); the
+    // observation's recorded values are the expected side. The admin re-wrap
+    // the capture also records (`adminThrowCode`,
+    // `messaging/registration-token-not-registered`) is driven by the blocking
+    // pyric-admin suite (test/messaging/send.test.ts, minted-then-deleted
+    // token), not restated here off the JSON. The capture's TIMING nuance
+    // ("eventually") is pinned as environment-dependent and NOT contractual;
+    // the broker is deterministic — dead is dead immediately.
     const o = obs('messaging-web-deletetoken-unregistered');
     const m = await loadClient();
-    const ok = await m.deleteToken(m.getMessaging());
+    const sw = await loadSw();
+    // Dedicated sandbox app: deleting the shared default app's token would
+    // bleed into sibling rows that drive the same broker.
+    const sandbox = initializeSandbox();
+    const app = createAppForSandbox(sandbox, { projectId: 'messaging-oracle-row3' }, 'msg-oracle-row3');
+    const messaging = m.getMessaging(app);
+    const token: string = await m.getToken(messaging, { vapidKey: 'test-vapid-key' });
+    const ok = await m.deleteToken(messaging);
     expect(Boolean(ok)).toBe(o.deleteTokenResolvedTruthy);
-    expect(o.fcmErrorCode).toBe('UNREGISTERED'); // pinned wire code the broker must emit
-    expect(o.adminThrowCode).toBe('messaging/registration-token-not-registered');
-    expect(o.noDeliveryToClient).toBe(true);
+    // Handlers on BOTH routes, registered before the dead-token send.
+    const fg: any[] = [];
+    const bg: any[] = [];
+    m.onMessage(messaging, (p: any) => fg.push(p));
+    sw.onBackgroundMessage(sw.getMessaging(app), (p: any) => bg.push(p));
+    // Drive the send plane at the dead token on the same broker.
+    const broker = getMessagingBroker(sandbox);
+    let err: any;
+    try {
+      broker.send({ token, notification: { title: 't', body: 'b' } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err instanceof BrokerSendError).toBe(o.sendPlaneEventuallyUnregistered);
+    expect(err.envelope.status).toBe(o.unregisteredHttpStatus);
+    expect(err.envelope.error.code).toBe(o.unregisteredErrorCodeTop);
+    expect(err.envelope.error.status).toBe(o.unregisteredErrorStatus);
+    expect(typeof err.envelope.error.message === 'string' && err.envelope.error.message.length > 0)
+      .toBe(o.unregisteredMessagePresent);
+    expect((err.envelope.error.details ?? []).map((d: any) => d['@type'])).toEqual([...o.unregisteredDetailTypes]);
+    expect(err.errorCode).toBe(o.fcmErrorCode); // the DRIVEN wire code vs the pinned 'UNREGISTERED'
+    expect(fg.length === 0 && bg.length === 0).toBe(o.noDeliveryToClient);
   },
 
   'messaging#4': async () => {
     // onMessage fires on a VISIBLE window client; routing keys on visibility.
+    // BOTH routing arms are driven — the same message is delivered once with a
+    // visible client and once with none — and the pinned `deliveredTo` values
+    // are compared against the routes the broker actually took.
     const fg = obs('messaging-web-onmessage-foreground');
     const routing = obs('messaging-web-visibility-routing');
     const m = await loadClient();
+    const sw = await loadSw();
     const received: any[] = [];
+    const bgReceived: any[] = [];
     const unsub = m.onMessage(m.getMessaging(), (p: any) => received.push(p));
+    const unsubBg = sw.onBackgroundMessage(sw.getMessaging(), (p: any) => bgReceived.push(p));
     expect(typeof unsub).toBe('function');
-    // Deliver a notification+data message to a visible client via the broker.
-    await m.sandbox.deliver(m.getMessaging(), {
-      visibilityState: 'visible',
+    const spec = {
       notification: { title: 't', body: 'b' },
       data: { demo: '1', source: 's', tag: 'g' },
-    });
+    };
+    // Arm 1: a visible window client → the foreground handler.
+    const visible = await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'visible', ...spec });
     expect(received.length).toBe(1);
+    expect(bgReceived.length).toBe(0);
     expect(Object.keys(received[0]).sort()).toEqual([...fg.topLevelKeys].sort());
-    expect(routing.visibleClient.deliveredTo).toBe('onMessage');
-    expect(routing.noVisibleClient.deliveredTo).toBe('onBackgroundMessage');
-    expect(routing.routesOnVisibilityNotFocus).toBe(true);
+    expect(deliveredTo(visible)).toBe(routing.visibleClient.deliveredTo);
+    // Arm 2: the SAME message with no visible client → the background handler,
+    // and the foreground handler does NOT fire again.
+    const hidden = await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'hidden', ...spec });
+    expect(deliveredTo(hidden)).toBe(routing.noVisibleClient.deliveredTo);
+    expect(bgReceived.length).toBe(1);
+    expect(received.length).toBe(1);
+    // Focus is not an input to the broker at all (the captured rule): with
+    // everything else held equal, flipping ONLY visibility flipped the route.
+    expect(visible.route === 'foreground' && hidden.route === 'background').toBe(
+      routing.routesOnVisibilityNotFocus,
+    );
+    unsub();
+    unsubBg();
   },
 
   'messaging#5': async () => {
@@ -154,35 +218,64 @@ const assertions: Record<string, () => Promise<void> | void> = {
   },
 
   'messaging#7': async () => {
-    // interface GetTokenOptions { vapidKey?; serviceWorkerRegistration? } — a
-    // type-only shape; getToken must accept the option bag without complaint.
+    // interface GetTokenOptions { vapidKey?; serviceWorkerRegistration? } —
+    // driven: getToken accepts the full option bag, and both fields are
+    // optional (a bare call also resolves). Deep type shape is closed by the
+    // assignability census (resolved decision #5).
     const m = await loadClient();
-    expect(typeof m.getToken).toBe('function');
+    const messaging = m.getMessaging();
+    const withOptions = await m.getToken(messaging, {
+      vapidKey: 'test-vapid-key',
+      serviceWorkerRegistration: m.sandbox.registration(),
+    });
+    expect(typeof withOptions).toBe('string');
+    const bare = await m.getToken(messaging);
+    expect(typeof bare).toBe('string');
   },
 
   'messaging#8': async () => {
     // MessagePayload envelope: top-level keys data/from/messageId/notification;
-    // from = sender id; messageId present (foreground + background captures).
+    // from = sender id; messageId present. Every fact is read off the payload
+    // the broker actually DELIVERED (foreground and background routes both
+    // driven), never off the observation JSON. The `from`/`messageId` facts —
+    // formerly asserted straight from `fg.fromEqualsSenderId` /
+    // `fg.messageIdPresent` — are now the delivered payload's own `from` and
+    // `messageId`, compared against the pinned sender-id shape.
     const fg = obs('messaging-web-onmessage-foreground');
     const bg = obs('messaging-web-onbackgroundmessage');
     const m = await loadClient();
+    const sw = await loadSw();
     const received: any[] = [];
+    const bgReceived: any[] = [];
     m.onMessage(m.getMessaging(), (p: any) => received.push(p));
-    await m.sandbox.deliver(m.getMessaging(), {
-      visibilityState: 'visible',
+    sw.onBackgroundMessage(sw.getMessaging(), (p: any) => bgReceived.push(p));
+    const spec = {
       notification: { title: 't', body: 'b' },
       data: { demo: '1', source: 's', tag: 'g' },
-    });
+    };
+    await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'visible', ...spec });
+    await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'hidden', ...spec });
     const payload = received[0];
+    const bgPayload = bgReceived[0];
+    // Foreground delivery: top-level key set matches the foreground capture.
     expect(Object.keys(payload).sort()).toEqual([...fg.topLevelKeys].sort());
-    expect(fg.fromEqualsSenderId).toBe(true);
-    expect(fg.messageIdPresent).toBe(true);
-    // The background capture pins the identical top-level key set.
-    expect([...bg.topLevelKeys].sort()).toEqual([...fg.topLevelKeys].sort());
+    // from = the project sender id (driven payload.from vs the broker's pinned
+    // DEFAULT_SENDER_ID); messageId present. `fromEqualsSenderId` /
+    // `messageIdPresent` are the capture's recorded truth for these.
+    expect(payload.from === DEFAULT_SENDER_ID).toBe(fg.fromEqualsSenderId);
+    expect(typeof payload.messageId === 'string' && payload.messageId.length > 0).toBe(fg.messageIdPresent);
+    // Background delivery: the delivered payload's own key set matches the
+    // background capture, and the two routes carry the identical top-level set.
+    expect(Object.keys(bgPayload).sort()).toEqual([...bg.topLevelKeys].sort());
+    expect(Object.keys(bgPayload).sort()).toEqual(Object.keys(payload).sort());
+    expect(bgPayload.from === DEFAULT_SENDER_ID).toBe(bg.fromEqualsSenderId);
+    expect(typeof bgPayload.messageId === 'string' && bgPayload.messageId.length > 0).toBe(bg.messageIdPresent);
   },
 
   'messaging#9': async () => {
     // NotificationPayload inside a foreground delivery carries title + body.
+    // Both the key set and the title-delivered fact are read off the payload
+    // the broker delivered (was: `fg.notificationTitleDelivered` off the JSON).
     const fg = obs('messaging-web-onmessage-foreground');
     const m = await loadClient();
     const received: any[] = [];
@@ -192,21 +285,63 @@ const assertions: Record<string, () => Promise<void> | void> = {
       notification: { title: 't', body: 'b' },
       data: { demo: '1' },
     });
-    expect(Object.keys(received[0].notification).sort()).toEqual([...fg.notificationKeys].sort());
-    expect(fg.notificationTitleDelivered).toBe(true);
+    const notification = received[0].notification;
+    expect(Object.keys(notification).sort()).toEqual([...fg.notificationKeys].sort());
+    expect(typeof notification.title === 'string' && notification.title.length > 0).toBe(fg.notificationTitleDelivered);
   },
 
   'messaging#10': async () => {
-    // interface FcmOptions { link?; analyticsLabel? } — type-only shape. Touch
-    // the mirror so this is red at birth; deep type conformance is closed by the
-    // assignability census (resolved decision #5), not this runtime replay.
-    expect(await loadClient()).toBeDefined();
+    // interface FcmOptions { link?; analyticsLabel? } — a type-only shape with
+    // NO runtime carrier in the sandbox: the broker delivers only
+    // data/from/messageId(+notification) and, by capture-faithful design, never
+    // carries `fcmOptions` on a delivered payload (the same reason
+    // `collapseKey` is omitted). There is nothing for the broker to exhibit, so
+    // the row is honestly DOWNGRADED to the shape tier (type-backed) in the
+    // registry — deep type conformance for FcmOptions is closed by the tier-2
+    // assignability census (resolved decision #5), not a runtime replay. This
+    // witness only pins that the row's shape-tier boundary holds: `fcmOptions`
+    // does not appear on a delivered payload.
+    const m = await loadClient();
+    const received: any[] = [];
+    m.onMessage(m.getMessaging(), (p: any) => received.push(p));
+    await m.sandbox.deliver(m.getMessaging(), {
+      visibilityState: 'visible',
+      notification: { title: 't', body: 'b' },
+      data: { demo: '1' },
+    });
+    expect('fcmOptions' in received[0]).toBe(false);
   },
 
   'messaging#11': async () => {
-    // NextFn / Observer / Unsubscribe are re-exported from @firebase/util —
-    // type-only re-exports; closed by the assignability census.
-    expect(await loadClient()).toBeDefined();
+    // NextFn / Observer / Unsubscribe: the callback / observer / teardown types
+    // onMessage consumes. Driven, not asserted off `toBeDefined()`: onMessage
+    // accepts BOTH the bare-NextFn form and the full-Observer form, delivers to
+    // each via the broker, and returns a callable Unsubscribe that stops
+    // delivery. Deep type parity with the @firebase/util re-exports is closed
+    // by the assignability census (resolved decision #5).
+    const m = await loadClient();
+    const messaging = m.getMessaging();
+    const nextForm: any[] = [];
+    const observerForm: any[] = [];
+    // NextFn form.
+    const unsubNext: () => void = m.onMessage(messaging, (p: any) => nextForm.push(p));
+    // Observer form { next, error, complete }.
+    const unsubObserver: () => void = m.onMessage(messaging, {
+      next: (p: any) => observerForm.push(p),
+      error: () => {},
+      complete: () => {},
+    });
+    expect(typeof unsubNext).toBe('function');
+    expect(typeof unsubObserver).toBe('function');
+    await m.sandbox.deliver(messaging, { visibilityState: 'visible', data: { demo: '1' } });
+    expect(nextForm.length).toBe(1);
+    expect(observerForm.length).toBe(1); // Observer.next received the same delivery
+    // Unsubscribe stops further delivery to that handler only.
+    unsubNext();
+    await m.sandbox.deliver(messaging, { visibilityState: 'visible', data: { demo: '2' } });
+    expect(nextForm.length).toBe(1); // no further delivery after unsubscribe
+    expect(observerForm.length).toBe(2); // the still-subscribed observer keeps receiving
+    unsubObserver();
   },
 
   'messaging#12': async () => {


### PR DESCRIPTION
```ts
// packages/pyric/test/messaging/oracle-conformance.test.ts — messaging#4 used
// to prove "no visible client routes to onBackgroundMessage" by reading it off
// the committed JSON. It now DRIVES both arms and compares the route the broker
// actually took:
const visible = await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'visible', ...spec });
expect(deliveredTo(visible)).toBe(routing.visibleClient.deliveredTo);   // 'onMessage'
const hidden = await m.sandbox.deliver(m.getMessaging(), { visibilityState: 'hidden', ...spec });
expect(deliveredTo(hidden)).toBe(routing.noVisibleClient.deliveredTo);  // 'onBackgroundMessage'
// deliveredTo(result) maps the DRIVEN DeliveryResult.route onto the handler
// name the observation records — so deleting the broker's fan-out fails this,
// where before the JSON literal kept it green.
```

Stacked on #445 (`fix/messaging-evidence-tier`); base branch is `fix/messaging-evidence-tier`, not `main`. It uses that PR's mechanics — `evidenceTierGapRows()`, unit-backed climb-risk retention, and the audit baseline — for the one honest tier downgrade below.

Several messaging assertion sets claimed to replay an observation but only verified that the committed JSON says what it says: they read a field off the observation and compared it to a literal, driving the broker for something else (or nothing). Deleting broker delivery left them green. Each now drives the broker/mirror and compares its actual output to the pinned values.

## Every rewritten set drives the broker, so delivery loss fails it

| Row | Asserted before | Drives now |
|---|---|---|
| `messaging#3` | `o.fcmErrorCode === 'UNREGISTERED'`, `o.noDeliveryToClient` read off the JSON; broker driven only for `deleteToken` truthiness | mints a token, deletes it, sends to the dead token on the same broker; the UNREGISTERED envelope (`status`/`code`/`status`/detail types/`errorCode`) and both-route silence are the driven output vs the pinned values |
| `messaging#4` | no-visible-client arm read off the JSON; broker driven only for the visible arm | drives BOTH arms — visible then onMessage, no visible client then onBackgroundMessage — and compares `deliveredTo` to the route the broker took |
| `messaging#8` | `fg.fromEqualsSenderId`, `fg.messageIdPresent` read off the JSON | reads `from`/`messageId` off the DELIVERED payload (both routes) vs the broker's sender id |
| `messaging#9` | `fg.notificationTitleDelivered` read off the JSON | reads the title off the delivered `notification` block |
| `messaging#11` | `toBeDefined()` on the client module | drives `onMessage`'s NextFn form and Observer form + delivery to each, and the returned Unsubscribe stopping delivery |
| `messaging-admin#4` | `dryRunSameShapeAsReal`, `bothAccepted` read off the observation object | drives real send + dryRun for each accept path and compares the resource-name shapes the mirror produced |
| `messaging-admin#11` | `o.bothAccepted` read off the JSON | drives a notification-only and a data-only send and asserts both accepted |

## messaging#10 loses its unit-backed tier because the broker cannot exhibit FcmOptions

`FcmOptions { link?; analyticsLabel? }` is a type-only shape with no runtime carrier: the sandbox broker delivers only `data`/`from`/`messageId`(+`notification`) and, capture-faithfully, never carries `fcmOptions` on a delivered payload (the same reason `collapseKey` is omitted). Its only assertion was `toBeDefined()`. Rather than fake a replay, the row is downgraded from `unit-backed` to the `type-backed` shape tier in `registry/messaging.ts`, with a written `exceptionReason`; its shape is closed by the tier-2 assignability census, not a runtime replay. It keeps its residual `unobserved` climb risk but leaves the evidence-tier worklist (which keys on `unit-backed`), so the audit baseline drops it (46 to 45) and the worklist test's unit-backed count goes 41 to 40. No other row changes tier.

## Risk

- One downgrade, one baseline id removed. The row is still `conforms`; it moves from a runtime-replay claim it could not honor to the structural tier that actually backs it. No assertion was weakened to keep a row green.
- The registry builder gained a `type-backed` branch; the previously nested flip ternary is extracted to `climbFor()` with a per-tier doc comment.

<details>
<summary>Broker-disabled spot check + gates</summary>

Temporarily replacing the broker's handler fan-out with an empty loop (delivery disabled), then rebuilding `pyric` and running the client oracle suite:

```
(fail) messaging#4  — onMessage
(fail) messaging#8  — MessagePayload
(fail) messaging#9  — NotificationPayload
(fail) messaging#10 — FcmOptions
(fail) messaging#11 — NextFn/Observer/Unsubscribe
(fail) messaging#14 — onBackgroundMessage
 12 pass, 6 fail

messaging#4:
  187 |     expect(received.length).toBe(1);
                                    ^
  error: expect(received).toBe(expected)  Expected: 1  Received: 0
```

The fan-out was reverted and `pyric` rebuilt before commit; `git diff packages/pyric/src` is empty.

Gates (all green):
- `bun test packages/pyric/test/messaging packages/pyric-admin/test/messaging` — 135 pass, 0 fail
- `bun run compat:validate` — Problems: 0 (842 rows)
- `bun run compat:audit` / `audit-gate.ts` — 45 tolerated (5 high-risk unverified + 40 evidence-tier gaps), no new rows
- `bun run compat:generate` — no diff to generated docs
- `bun run compat:census-gate`, `compat:entry-path`, `compat:coverage` — clean
- `bun test packages/conformance/test/src` — 264 pass, 0 fail

</details>

Closes #440. Stacked on #445.