### PR TITLE
fix(conformance): strengthen observation completeness gate and extend to messaging

### DIFF
--- a/packages/conformance/src/observation-gate.ts
+++ b/packages/conformance/src/observation-gate.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared observation completeness gate for the oracle-conformance suites.
+ *
+ * ─── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ * Before this helper, every surface's completeness test asked only whether each
+ * committed observation's filename appeared as a SUBSTRING of the test file's own
+ * source text (`source.includes(f.replace('.json',''))`). A filename sitting in a
+ * comment satisfied that check, and nothing verified the observation's recorded
+ * behavior fields were ever driven against the mirror. The messaging suites did
+ * not scan the observations directory at all — they gated only on a row partition
+ * — so the committed `messaging-*` captures were wholly unguarded despite cdd.md
+ * step 3 claiming prefix completeness.
+ *
+ * ─── MECHANISM: an instrumented loader ──────────────────────────────────────
+ * `load(name)` returns the observation's `behavior` block wrapped in a `Proxy`
+ * whose get-trap records every top-level field read, keyed to that observation
+ * file. `report()` then requires each committed observation under the prefix to
+ * be EITHER listed in `notApplicable` (with a written reason) OR loaded AND have
+ * had at least one behavior field read at runtime. Consequences:
+ *   - A filename mentioned only in a comment is never loaded  → uncovered → fail.
+ *   - A bare `load(name)` whose result is never read (zero field reads) is
+ *     `loadedButUnused` → uncovered → fail.
+ * This is strictly stronger than the old substring gate: a comment or an unused
+ * `load()` no longer passes.
+ *
+ * ─── CROSS-FILE ASSERTIONS (`siblingSources`) ───────────────────────────────
+ * A surface may split its assertions across sibling test files (rtdb-modular
+ * asserts its `onDisconnect` captures in `on-disconnect.test.ts`). Runtime
+ * instrumentation cannot see a sibling's `load()` calls, so `report()` falls back
+ * to a STATIC check for any committed observation not loaded in-process: it counts
+ * the observation covered only if a sibling source contains an actual
+ * `load('<stem>')` / `obs('<stem>')` CALL for it (`assertedInSibling`). A bare
+ * comment mention in the sibling — the exact hole this gate closes in-file — does
+ * NOT satisfy it. This is a documented, weaker tier than in-file instrumentation:
+ * it proves the sibling loads the observation, not that the loaded value reaches
+ * an assertion (see limit 5).
+ *
+ * ─── HONEST LIMITS (read before trusting the green) ─────────────────────────
+ *  1. In-file, it records that a field was READ, not that the read value reached
+ *     an `expect()`. A handler that reads `o.foo` into a variable and never
+ *     asserts it still marks the file asserted. The gate proves the observation's
+ *     data flowed into the suite, not that every field's comparison outcome is
+ *     checked — full data-flow-to-assertion tracking is out of scope.
+ *  2. Only top-level `behavior` keys are tracked. A deep read
+ *     (`o.routing.visibleClient`) counts via its top-level parent (`routing`);
+ *     the gate does not require every nested leaf to be touched.
+ *  3. It relies on `report()` running AFTER every assertion set in the same
+ *     process — call it from a single `it(...)` declared last in the file, so
+ *     bun's in-file sequential execution has populated the read log by then.
+ *  4. An observation whose `behavior` block is empty (`{}`) can never be marked
+ *     asserted by a field read; such a capture must be listed in `notApplicable`.
+ *  5. `siblingSources` matching is static (a `load(`/`obs(` call for the stem),
+ *     not runtime — the gate trusts that the sibling suite, which runs in the
+ *     same CI, actually drives what it loads. It is stricter than the old
+ *     substring gate (a comment no longer counts) but weaker than instrumentation.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ObservationGateConfig {
+  /** Absolute path to the surface's observation directory. */
+  dir: string;
+  /**
+   * Selects which files in `dir` belong to this surface's prefix. Receives the
+   * bare filename (e.g. `rtdb-set-then-get-roundtrip.json`).
+   */
+  match: (filename: string) => boolean;
+  /**
+   * Observations genuinely not replayable in-process, each mapped to a written
+   * reason. Keys may be given with or without the `.json` suffix.
+   */
+  notApplicable?: Record<string, string>;
+  /**
+   * Absolute paths to sibling test files that assert observations under this
+   * prefix. An observation not loaded in-process is still counted covered if a
+   * sibling source contains a `load('<stem>')` / `obs('<stem>')` call for it.
+   */
+  siblingSources?: string[];
+}
+
+export interface ObservationGateReport {
+  /** All committed observation stems under the prefix (no `.json`). */
+  committed: string[];
+  /** Committed stems that were loaded in-process AND had ≥1 behavior field read. */
+  asserted: string[];
+  /** Committed stems loaded (via a `load`/`obs` call) by a sibling source. */
+  assertedInSibling: string[];
+  /** Stems in `notApplicable`, intersected with what is committed. */
+  notApplicable: string[];
+  /** Stems that were `load()`-ed in-process but had zero behavior fields read. */
+  loadedButUnused: string[];
+  /**
+   * Committed stems that are neither asserted (here or in a sibling) nor listed
+   * N/A — the gate-failing set. Includes never-loaded comment-only mentions and
+   * loadedButUnused.
+   */
+  uncovered: string[];
+}
+
+export interface ObservationGate {
+  /**
+   * Instrumented loader. Returns the observation's `behavior` block wrapped so
+   * every top-level field read is recorded against `name`. Accepts a name with
+   * or without the `.json` suffix. Use it exactly where the suite loads an
+   * observation to drive assertions.
+   */
+  load<T = Record<string, any>>(name: string): T;
+  /** Compute the completeness report. Call from a single `it()` declared last. */
+  report(): ObservationGateReport;
+}
+
+const stem = (name: string): string => (name.endsWith('.json') ? name.slice(0, -5) : name);
+
+/** True if `source` contains an actual `load('<stem>')` / `obs('<stem>')` call
+ *  (single/double/back-quoted, with or without a `.json` suffix). A bare comment
+ *  mention of the stem does NOT match. */
+function siblingLoadsStem(source: string, id: string): boolean {
+  const esc = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`\\b(?:load|obs)\\(\\s*['"\`]${esc}(?:\\.json)?['"\`]`);
+  return re.test(source);
+}
+
+export function createObservationGate(config: ObservationGateConfig): ObservationGate {
+  const naStems = new Set(Object.keys(config.notApplicable ?? {}).map(stem));
+  /** stem → set of top-level behavior keys read through the proxy. */
+  const reads = new Map<string, Set<string>>();
+
+  function record(name: string, key: string): void {
+    let set = reads.get(name);
+    if (!set) {
+      set = new Set<string>();
+      reads.set(name, set);
+    }
+    set.add(key);
+  }
+
+  function load<T = Record<string, any>>(name: string): T {
+    const id = stem(name);
+    // Registering an empty read-set marks the file loaded even before any field
+    // read, so a bare load() surfaces as loadedButUnused rather than never-loaded.
+    if (!reads.has(id)) reads.set(id, new Set<string>());
+    const json = JSON.parse(readFileSync(join(config.dir, `${id}.json`), 'utf8')) as {
+      behavior: Record<string, any>;
+    };
+    const behavior = json.behavior ?? {};
+    return new Proxy(behavior, {
+      get(target, prop, receiver) {
+        // Only count real string-keyed data reads. Symbols (Symbol.iterator,
+        // then/toJSON probes from test frameworks) never mark a file asserted.
+        if (typeof prop === 'string' && prop in target) {
+          record(id, prop);
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as T;
+  }
+
+  function report(): ObservationGateReport {
+    const committed = readdirSync(config.dir)
+      .filter((f) => f.endsWith('.json') && config.match(f))
+      .map(stem)
+      .sort();
+
+    const siblingText =
+      (config.siblingSources ?? []).map((p) => readFileSync(p, 'utf8')).join('\n') || '';
+
+    const asserted: string[] = [];
+    const assertedInSibling: string[] = [];
+    const loadedButUnused: string[] = [];
+    const notApplicable: string[] = [];
+    const uncovered: string[] = [];
+
+    for (const id of committed) {
+      if (naStems.has(id)) {
+        notApplicable.push(id);
+        continue;
+      }
+      const fields = reads.get(id);
+      if (fields && fields.size > 0) {
+        asserted.push(id);
+      } else if (!fields && siblingText && siblingLoadsStem(siblingText, id)) {
+        // Not loaded in-process, but a sibling suite loads it with a real call.
+        assertedInSibling.push(id);
+      } else {
+        if (fields) loadedButUnused.push(id); // loaded in-process, but zero field reads
+        uncovered.push(id);
+      }
+    }
+
+    return { committed, asserted, assertedInSibling, notApplicable, loadedButUnused, uncovered };
+  }
+
+  return { load, report };
+}

--- a/packages/conformance/test/src/observation-gate.test.ts
+++ b/packages/conformance/test/src/observation-gate.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the shared observation completeness gate. These pin the
+ * ratchet the surface suites rely on: a comment-only mention or an unused
+ * `load()` must NOT count an observation as asserted.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createObservationGate } from '../../src/observation-gate.ts';
+
+const dir = mkdtempSync(join(tmpdir(), 'obs-gate-'));
+
+beforeAll(() => {
+  const write = (name: string, behavior: Record<string, unknown>) =>
+    writeFileSync(join(dir, name), JSON.stringify({ behavior }));
+  write('demo-alpha.json', { count: 3, colonSeparated: true });
+  write('demo-beta.json', { ok: true });
+  write('demo-gamma.json', { fired: true });
+  write('demo-empty.json', {}); // no fields to read
+});
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const match = (f: string) => f.startsWith('demo-');
+
+describe('observation completeness gate', () => {
+  it('marks a file asserted only when a behavior field is actually read', () => {
+    const gate = createObservationGate({ dir, match });
+    const alpha = gate.load('demo-alpha');
+    expect(alpha.count).toBe(3); // real read → asserted
+
+    // demo-beta is loaded but never read → loadedButUnused, and demo-gamma is
+    // only mentioned in this comment (demo-gamma) → never loaded.
+    gate.load('demo-beta');
+
+    const r = gate.report();
+    expect(r.asserted).toEqual(['demo-alpha']);
+    expect(r.loadedButUnused).toEqual(['demo-beta']);
+    // Both the unused load and the comment-only mention fail the gate; the empty
+    // observation is uncovered too (no field can ever be read).
+    expect(r.uncovered.sort()).toEqual(['demo-beta', 'demo-empty', 'demo-gamma']);
+  });
+
+  it('a comment-only mention does not satisfy the gate (the core ratchet)', () => {
+    const gate = createObservationGate({ dir, match });
+    // demo-alpha, demo-beta, demo-gamma, demo-empty are named here — a substring
+    // gate would pass all four. This one asserts none, so all are uncovered.
+    const r = gate.report();
+    expect(r.asserted).toEqual([]);
+    expect(r.uncovered).toEqual(['demo-alpha', 'demo-beta', 'demo-empty', 'demo-gamma']);
+  });
+
+  it('siblingSources: a real load() call in a sibling covers a file, a comment does not', () => {
+    const goodSibling = join(dir, 'sibling-good.ts');
+    const commentSibling = join(dir, 'sibling-comment.ts');
+    writeFileSync(goodSibling, `const o = load('demo-gamma'); expect(o.fired).toBe(true);\n`);
+    // demo-empty is only NAMED in a comment here — no load() call.
+    writeFileSync(commentSibling, `// demo-empty is covered elsewhere (it is not)\n`);
+
+    const gate = createObservationGate({
+      dir,
+      match,
+      siblingSources: [goodSibling, commentSibling],
+    });
+    gate.load('demo-alpha').count;
+    gate.load('demo-beta').ok;
+    const r = gate.report();
+    expect(r.assertedInSibling).toEqual(['demo-gamma']); // real load() in sibling
+    expect(r.uncovered).toEqual(['demo-empty']); // comment-only in sibling still fails
+  });
+
+  it('NOT_APPLICABLE entries (with reasons) cover a file without a read', () => {
+    const gate = createObservationGate({
+      dir,
+      match,
+      notApplicable: {
+        'demo-empty.json': 'empty behavior block — nothing to replay',
+        'demo-gamma': 'not replayable in-process',
+      },
+    });
+    gate.load('demo-alpha').count;
+    gate.load('demo-beta').ok;
+    const r = gate.report();
+    expect(r.notApplicable.sort()).toEqual(['demo-empty', 'demo-gamma']);
+    expect(r.uncovered).toEqual([]);
+    expect(r.committed.length).toBe(4);
+  });
+});

--- a/packages/pyric-admin/test/app/oracle-conformance.test.ts
+++ b/packages/pyric-admin/test/app/oracle-conformance.test.ts
@@ -20,8 +20,8 @@
  * AppStore), so each case resets it first via the test-only reset helper.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   initializeApp,
@@ -45,11 +45,18 @@ const NOT_APPLICABLE: Record<string, string> = {
     'prod-only: getDatabase() requires a configured databaseURL and throws database/invalid-argument without one. The pyric-admin sandbox has no notion of a databaseURL (getDatabase() resolves the default sandbox app directly), so this capture documents prod behavior only.',
 };
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('admin-app-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, `${name}.json`), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 /** Run `fn`, assert it threw with the given `.code`, and return the error so
@@ -250,14 +257,9 @@ describe('oracle conformance (admin app registry)', () => {
   // ── completeness: every admin-app observation is asserted or explicitly N/A ─
 
   it('every admin-app observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter(
-      (f) => f.startsWith('admin-app-') && f.endsWith('.json'),
-    );
-    expect(all.length).toBeGreaterThanOrEqual(11);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBeGreaterThanOrEqual(11);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });

--- a/packages/pyric-admin/test/messaging/oracle-conformance.test.ts
+++ b/packages/pyric-admin/test/messaging/oracle-conformance.test.ts
@@ -33,9 +33,9 @@
  * every row in the registry file.
  */
 import { afterAll, describe, expect, it } from 'bun:test';
-import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { messagingRows } from '../../../../packages/conformance/registry/messaging.ts';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 
 // Enable the mirror's climb-only implicit-app path for this file's lifetime,
 // then restore, so sibling files' flag-off contract tests (e.g. dispatch's
@@ -52,12 +52,39 @@ afterAll(() => {
  *  subdirectory. */
 const OBS_DIR = join(import.meta.dir, '..', '..', '..', '..', 'packages', 'conformance', 'observations', 'messaging-admin');
 
+/**
+ * Observations under `observations/messaging-admin/` that cannot be replayed
+ * against the in-process admin mirror, each with a written reason.
+ *
+ * Intentionally EMPTY: all ten committed `messaging-send-*` captures — the five
+ * accept-path resource-name shapes and the five `google.rpc` error envelopes —
+ * are driven against the mirror's `send`/`dryRun` below and their behavior
+ * fields asserted. Nothing here is a send-plane reality the mirror cannot
+ * exhibit. Type-only shapes such as messaging-admin#10 (`Message` union) have NO
+ * committed observation file and are closed by the tier-2 assignability census
+ * (see #440), so they never surface in this prefix gate. Add an entry here only
+ * for a committed capture that genuinely cannot be replayed in-process.
+ */
+const NOT_APPLICABLE_OBS: Record<string, string> = {};
+
+/**
+ * Instrumented observation gate: `obs(name)` returns the frozen `behavior` block
+ * wrapped so every field read is recorded, and `messagingObsGate.report()`
+ * enforces prefix completeness over `observations/messaging-admin/` — a filename
+ * in a comment or an unused `load()` no longer counts as asserted. See
+ * `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+ */
+const messagingObsGate = createObservationGate({
+  dir: OBS_DIR,
+  // Committed admin captures use the `messaging-send-` prefix today; matching the
+  // broader stem also guards any future `messaging-admin-` capture.
+  match: (f) => f.startsWith('messaging-send-') || f.startsWith('messaging-admin-'),
+  notApplicable: NOT_APPLICABLE_OBS,
+});
+
 /** Load the frozen `behavior` block of a committed observation by name. */
 function obs(name: string): Record<string, any> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, `${name}.json`), 'utf8')) as {
-    behavior: Record<string, any>;
-  };
-  return json.behavior;
+  return messagingObsGate.load(name);
 }
 
 /** The FCM resource name shape returned by an accepted send / dryRun. */
@@ -355,6 +382,18 @@ describe('oracle conformance (messaging-admin send plane)', () => {
       await handler();
     });
   }
+
+  // ── completeness: every committed messaging-admin observation is meaningfully asserted ──
+  // cdd.md step 3 claims every `messaging-` prefixed observation is asserted or
+  // listed N/A. This gate makes that true over `observations/messaging-admin/`:
+  // each committed capture must have been loaded AND had a behavior field driven
+  // above (a comment mention or an unused load() does not count).
+  it('completeness: every observations/messaging-admin/ capture is asserted (prefix gate)', () => {
+    const r = messagingObsGate.report();
+    expect(r.committed.length).toBe(10);
+    expect(r.loadedButUnused).toEqual([]);
+    expect(r.uncovered).toEqual([]);
+  });
 
   // ── completeness: this suite owns EXACTLY the messaging-admin partition ──
   it('completeness: covers exactly the messaging-admin rows (partition gate)', () => {

--- a/packages/pyric/test/app/oracle-conformance.test.ts
+++ b/packages/pyric/test/app/oracle-conformance.test.ts
@@ -20,8 +20,8 @@
  * so each case resets it first via getApps()/deleteApp().
  */
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import 'fake-indexeddb/auto';
 import {
   initializeApp,
@@ -52,11 +52,18 @@ const OPTS = {
   appId: '1:0:web:0',
 };
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('app-registry-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, `${name}.json`), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 /** Run `fn`, assert it threw with the given `.code`, and return the error so
@@ -424,10 +431,9 @@ describe('oracle conformance (client app registry)', () => {
   // ── completeness: every app-registry observation is asserted or explicitly N/A ─
 
   it('every app-registry observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter((f) => f.startsWith('app-registry-') && f.endsWith('.json'));
-    expect(all.length).toBeGreaterThanOrEqual(14);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter((f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE));
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBeGreaterThanOrEqual(14);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });

--- a/packages/pyric/test/auth/oracle-conformance.test.ts
+++ b/packages/pyric/test/auth/oracle-conformance.test.ts
@@ -17,8 +17,8 @@
  * the bottom enforces that, so a new capture can't silently go un-checked.
  */
 import { describe, expect, it } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   ActionCodeOperation,
@@ -90,11 +90,18 @@ const NOT_APPLICABLE: Record<string, string> = {
     'BLOCKED: same disabled Email/Password provider — the probe could not create the user whose email it would change.',
 };
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('auth-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, name), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 /** Drain the microtask queue a few times — the shim's initial listener fire is
@@ -769,12 +776,9 @@ describe('oracle conformance (auth)', () => {
   // ── completeness: every observation is asserted or explicitly N/A ─────
 
   it('every auth observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter((f) => f.startsWith('auth-') && f.endsWith('.json'));
-    expect(all.length).toBeGreaterThanOrEqual(26);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBeGreaterThanOrEqual(26);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });

--- a/packages/pyric/test/database/modular/oracle-conformance.test.ts
+++ b/packages/pyric/test/database/modular/oracle-conformance.test.ts
@@ -49,8 +49,8 @@
  *     already does this, so the warm-client contract conforms.
  */
 import { describe, it, expect } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   getDatabase,
@@ -92,11 +92,21 @@ const NOT_APPLICABLE: Record<string, string> = {
     'requires terminating the writer process; the sandbox boundary is pinned as a documented divergence in M84',
 };
 
+// Instrumented completeness gate. `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. The onDisconnect captures are asserted
+// in the sibling `on-disconnect.test.ts`; the gate covers those via a static
+// `siblingSources` load-call check (stricter than a bare mention). See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('rtdb-modular-'),
+  notApplicable: NOT_APPLICABLE,
+  siblingSources: [join(import.meta.dir, '..', 'on-disconnect.test.ts')],
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, name), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 function setup() {
@@ -959,17 +969,16 @@ describe('oracle conformance (rtdb-modular)', () => {
   // ── completeness: every `rtdb-modular-*` observation is covered ────────
 
   it('every rtdb-modular observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter(
-      (f) => f.startsWith('rtdb-modular-') && f.endsWith('.json'),
-    );
-    expect(all.length).toBe(44);
-    const source = [
-      readFileSync(import.meta.path, 'utf8'),
-      readFileSync(join(import.meta.dir, '..', 'on-disconnect.test.ts'), 'utf8'),
-    ].join('\n');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBe(44);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    // The onDisconnect captures are asserted in on-disconnect.test.ts.
+    expect(r.assertedInSibling.sort()).toEqual([
+      'rtdb-modular-ondisconnect-clean-set',
+      'rtdb-modular-ondisconnect-operations-cancel',
+      'rtdb-modular-ondisconnect-registration',
+      'rtdb-modular-ondisconnect-rules',
+    ]);
+    expect(r.uncovered).toEqual([]); // every capture is asserted (here or sibling) or N/A
   });
 });

--- a/packages/pyric/test/database/oracle-conformance.test.ts
+++ b/packages/pyric/test/database/oracle-conformance.test.ts
@@ -36,8 +36,8 @@
  *     KNOWN DIVERGENCE comment — never weakened to pass.
  */
 import { describe, it, expect } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   getDatabase,
@@ -67,11 +67,18 @@ const NOT_APPLICABLE: Record<string, string> = {
     'REST `/.settings/rules.json` PUT/GET round-trip (path-variable segments, `.indexOn`, `.read`/`.write`/`.validate` keys preserved verbatim). The sandbox exposes `sandbox.setRules` (write) but no rules read-back API, so the round-trip structural-preservation fact cannot be observed in-process.',
 };
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('rtdb-') && !f.startsWith('rtdb-modular-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, name), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 function setup() {
@@ -419,14 +426,9 @@ describe('oracle conformance (rtdb)', () => {
   // ── completeness: every `rtdb-*` (non-modular) observation is covered ──
 
   it('every rtdb (non-modular) observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter(
-      (f) => f.startsWith('rtdb-') && !f.startsWith('rtdb-modular-') && f.endsWith('.json'),
-    );
-    expect(all.length).toBe(14);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBe(14);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });

--- a/packages/pyric/test/firestore/oracle-conformance.test.ts
+++ b/packages/pyric/test/firestore/oracle-conformance.test.ts
@@ -27,8 +27,8 @@
  * un-checked.
  */
 import { describe, it, expect } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox, type Sandbox } from 'pyric/sandbox';
 import { FirebaseError } from '../../src/app/index.js';
 import { seedDocuments, setRules } from 'pyric/sandbox/firestore';
@@ -85,11 +85,18 @@ const NOT_APPLICABLE: Record<string, string> = {
     "exercises the prod fallthrough (getFirestore() with no argument and no default Firebase App) — the app/no-app FirebaseError is a firebase-app concern of the prod path, not modeled by the sandbox target (which always takes an explicit Sandbox/ctx). Mirrors the auth suite's NOT_APPLICABLE for auth-bare-getauth-no-default-app.",
 };
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('firestore-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, name), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 /** Drain the microtask queue a few times so listener fan-out settles. The
@@ -1468,12 +1475,9 @@ describe('oracle conformance (firestore)', () => {
   // ── completeness: every observation is asserted or explicitly N/A ─────
 
   it('every firestore observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter((f) => f.startsWith('firestore-') && f.endsWith('.json'));
-    expect(all.length).toBeGreaterThanOrEqual(40);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBeGreaterThanOrEqual(40);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });

--- a/packages/pyric/test/messaging/oracle-conformance.test.ts
+++ b/packages/pyric/test/messaging/oracle-conformance.test.ts
@@ -30,9 +30,9 @@
  * cover every row in the registry file.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { messagingRows } from '../../../../packages/conformance/registry/messaging.ts';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeApp } from 'pyric/app';
 import { createAppForSandbox } from 'pyric/app/internal';
 import { initializeSandbox } from 'pyric/sandbox';
@@ -52,12 +52,37 @@ afterAll(async () => {
  *  subdirectory. */
 const OBS_DIR = join(import.meta.dir, '..', '..', '..', '..', 'packages', 'conformance', 'observations', 'messaging');
 
+/**
+ * Observations under `observations/messaging/` that cannot be replayed against
+ * the in-process broker, each with a written reason.
+ *
+ * Intentionally EMPTY: all seven committed `messaging-web-*` captures — including
+ * the service-worker receive-plane ones (onBackgroundMessage, data-only
+ * background) — are driven against the sandbox broker below and their behavior
+ * fields asserted. Nothing here is a service-worker-only reality the broker
+ * cannot exhibit. Type-only shapes such as messaging#10 (`FcmOptions`) have NO
+ * committed observation file, so they are closed by the tier-2 assignability
+ * census (see #440) and never surface in this prefix gate. Add an entry here
+ * only for a committed capture that genuinely cannot be replayed in-process.
+ */
+const NOT_APPLICABLE_OBS: Record<string, string> = {};
+
+/**
+ * Instrumented observation gate: `obs(name)` returns the frozen `behavior` block
+ * wrapped so every field read is recorded, and `messagingObsGate.report()`
+ * enforces prefix completeness over `observations/messaging/` — a filename in a
+ * comment or an unused `load()` no longer counts as asserted. See
+ * `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+ */
+const messagingObsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('messaging-'),
+  notApplicable: NOT_APPLICABLE_OBS,
+});
+
 /** Load the frozen `behavior` block of a committed observation by name. */
 function obs(name: string): Record<string, any> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, `${name}.json`), 'utf8')) as {
-    behavior: Record<string, any>;
-  };
-  return json.behavior;
+  return messagingObsGate.load(name);
 }
 
 /**
@@ -436,6 +461,18 @@ describe('oracle conformance (messaging client + sw)', () => {
       await handler();
     });
   }
+
+  // ── completeness: every committed messaging observation is meaningfully asserted ──
+  // cdd.md step 3 claims every `messaging-` prefixed observation is asserted or
+  // listed N/A. This gate makes that true over `observations/messaging/`: each
+  // committed capture must have been loaded AND had a behavior field driven above
+  // (a comment mention or an unused load() does not count).
+  it('completeness: every observations/messaging/ capture is asserted (prefix gate)', () => {
+    const r = messagingObsGate.report();
+    expect(r.committed.length).toBe(7);
+    expect(r.loadedButUnused).toEqual([]);
+    expect(r.uncovered).toEqual([]);
+  });
 
   // ── completeness: this suite owns EXACTLY the client + sw row partition ──
   it('completeness: covers exactly the messaging client + sw rows (partition gate)', () => {

--- a/packages/pyric/test/storage/oracle-conformance.test.ts
+++ b/packages/pyric/test/storage/oracle-conformance.test.ts
@@ -22,8 +22,8 @@
  */
 import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'bun:test';
-import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { createObservationGate } from '../../../../packages/conformance/src/observation-gate.ts';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   getStorageSandbox,
@@ -43,11 +43,18 @@ const OBS_DIR = join(import.meta.dir, '..', '..', '..', '..', 'packages', 'confo
 /** Observations that cannot be replayed against the sandbox, with the reason. */
 const NOT_APPLICABLE: Record<string, string> = {};
 
+// Instrumented completeness gate: `load(name)` records which behavior fields are
+// read so the completeness test can fail an observation that is only mentioned in
+// a comment or loaded but never asserted. See
+// `packages/conformance/src/observation-gate.ts` for the mechanism and its limits.
+const obsGate = createObservationGate({
+  dir: OBS_DIR,
+  match: (f) => f.startsWith('storage-'),
+  notApplicable: NOT_APPLICABLE,
+});
+
 function load(name: string): Record<string, unknown> {
-  const json = JSON.parse(readFileSync(join(OBS_DIR, name), 'utf8')) as {
-    behavior: Record<string, unknown>;
-  };
-  return json.behavior;
+  return obsGate.load(name);
 }
 
 function uniqueDbName(label: string): string {
@@ -262,12 +269,9 @@ describe('oracle conformance (storage)', () => {
   // ── completeness: every observation is asserted or explicitly N/A ─────
 
   it('every storage observation is covered (no silent gaps)', () => {
-    const all = readdirSync(OBS_DIR).filter((f) => f.startsWith('storage-') && f.endsWith('.json'));
-    expect(all.length).toBeGreaterThanOrEqual(9);
-    const source = readFileSync(import.meta.path, 'utf8');
-    const uncovered = all.filter(
-      (f) => !source.includes(f.replace('.json', '')) && !(f in NOT_APPLICABLE),
-    );
-    expect(uncovered).toEqual([]);
+    const r = obsGate.report();
+    expect(r.committed.length).toBeGreaterThanOrEqual(9);
+    expect(r.loadedButUnused).toEqual([]); // a bare load() with no field read fails
+    expect(r.uncovered).toEqual([]); // every capture is asserted or explicitly N/A
   });
 });


### PR DESCRIPTION
```ts
// packages/conformance/src/observation-gate.ts — the completeness gate a suite now uses.
const obsGate = createObservationGate({
  dir: OBS_DIR,                              // observations/messaging/
  match: (f) => f.startsWith('messaging-'),  // the surface prefix
  notApplicable: NOT_APPLICABLE_OBS,         // committed captures not replayable in-process
});
function obs(name) { return obsGate.load(name); } // instrumented loader

// messaging#2 drives the mirror and reads the observation's fields:
const stability = obs('messaging-web-token-stability');
expect(token2 === token).toBe(stability.tokensEqual);   // <-- the read the gate records

// At the bottom, the completeness test now demands a REAL assertion, not a mention:
const r = obsGate.report();
expect(r.loadedButUnused).toEqual([]);  // a bare load() with no field read fails
expect(r.uncovered).toEqual([]);        // a filename in a comment fails
```

## The completeness gate now checks that observations are asserted, not merely mentioned

The old per-surface gate asked only whether each committed observation's filename appeared as a **substring of the test file's own source** (`source.includes(f.replace('.json',''))`). A filename in a comment satisfied it, and nothing verified the observation's behavior fields were driven against the mirror. The messaging suites did not scan the observations directory at all — they gated on a row partition only — so the 17 committed `messaging-*` / `messaging-send-*` captures were unguarded, despite cdd.md step 3 claiming prefix completeness.

`createObservationGate` returns an instrumented `load(name)` that wraps the observation's `behavior` block in a `Proxy` recording every top-level field read, keyed to the file. `report()` requires each committed observation under the prefix to be **loaded AND have ≥1 field read** at runtime, or be listed in `NOT_APPLICABLE` with a written reason. A comment-only mention (never loaded → `uncovered`) and a bare `load()` with no read (`loadedButUnused`) both fail.

## The ratchet, demonstrated red-then-green

Temporarily replacing messaging#2's real stability assertion with a comment that only name-drops the observation — the exact thing the old substring gate accepted:

```
const shape = obs('messaging-web-token-shape');
// RATCHET DEMO: merely name-drop messaging-web-token-stability in a comment
// instead of loading and asserting it. The old substring gate passed on this.
```

The strengthened prefix gate goes **red**:

```
470 |   it('completeness: every observations/messaging/ capture is asserted (prefix gate)', () => {
473 |     expect(r.loadedButUnused).toEqual([]);
474 |     expect(r.uncovered).toEqual([]);
error: expect(received).toEqual(expected)
- []
+ [ "messaging-web-token-stability" ]
(fail) oracle conformance (messaging client + sw) > completeness: every observations/messaging/ capture is asserted (prefix gate)
 18 pass, 1 fail
```

Restoring the real `expect(token2 === token).toBe(stability.tokensEqual)` returns it to **green** (19 pass). The same ratchet is pinned as a unit test in `packages/conformance/test/src/observation-gate.test.ts` (a comment-only mention and an unused `load()` are both flagged `uncovered`).

## Both messaging suites now enforce prefix completeness; existing surfaces migrated verbatim

- `packages/pyric/test/messaging` gates over `observations/messaging/` (7 captures); `packages/pyric-admin/test/messaging` over `observations/messaging-admin/` (10 captures). Both keep their existing row-partition gate — the new prefix gate is additive, so #448's broker-replay assertion sets and #445's ledger worklists are untouched.
- auth, firestore, storage, app, database, database/modular, and admin-app moved to the shared helper with their `NOT_APPLICABLE` maps and reasons preserved verbatim.

## Cross-file assertions (`siblingSources`)

rtdb-modular asserts its `onDisconnect` captures in the sibling `on-disconnect.test.ts`, which runtime instrumentation cannot see. The gate covers those via a documented `siblingSources` **static** check: it counts an observation covered only if a sibling source contains an actual `load('<stem>')` / `obs('<stem>')` call — a bare comment in the sibling does not qualify. This is stricter than the old any-substring match but weaker than in-file instrumentation, and is called out in the helper's honest-limits header.

## NOT_APPLICABLE entries added

None invented. The messaging and messaging-admin `NOT_APPLICABLE_OBS` maps are **intentionally empty and documented**: all 17 committed captures (including the service-worker receive-plane ones) are driven in-process and asserted. Type-only shapes such as messaging#10 (`FcmOptions`) and messaging-admin#10 (`Message` union) have no committed observation file, so they are closed by the tier-2 assignability census and never enter a prefix gate. Every migrated surface kept its prior map unchanged (auth 6, firestore 1, database 3, admin-app 1; storage/app empty).

## Risk

- Additive to the messaging suites (new `it`, shared loader) — no assertion weakened, both partition gates retained, so #448/#445 do not regress.
- The gate keys on committed observation **files**, not registry rows, so #442/#447's `it.skip` born-unverified rows (whose classes have no observations) impose no demand: the gate never asks for an assertion for an observation that does not exist.
- Honest limit: the loader records a field **read**, not that the read value reached an `expect()`. It proves the observation's data flowed into the suite, not that every field's comparison outcome is checked. Documented in the helper header alongside the sibling-check and empty-behavior caveats.

<details>
<summary>Verification (worktree on top of fix/messaging-suite-replay)</summary>

```
bun run compat:validate                          → Rows: 842, Observations: 298, Problems: 0
bun run packages/conformance/src/audit-gate.ts   → 45 tolerated (5 high-risk + 40 evidence-tier gap), no new rows, exit 0
bun run compat:check                             → exit 0 (typecheck, validate, census, entry-path, projections, coverage)
bun test --cwd packages/conformance             → 340 pass, 0 fail
bun test packages/pyric/test/messaging packages/pyric-admin/test/messaging  → 137 pass, 0 fail
migrated oracle suites + gate unit test          → 192 pass, 0 fail
```

Build prerequisites run first: `bun install`, then `pyric`/`pyric-admin` dists built.

</details>

Closes #441.
