### PR TITLE
test(conformance): refresh model snapshots for messaging behavior-class rows

### DIFF
--- a/packages/conformance/test/src/conformance-model.test.ts
+++ b/packages/conformance/test/src/conformance-model.test.ts
@@ -17,7 +17,7 @@ function one(query: string): FeatureSupport {
 
 describe('multi-axis conformance model', () => {
   it('supplies the shared assurance and rules-report projections in memory', () => {
-    expect(Object.keys(model.assuranceNodeVerdicts)).toHaveLength(1107);
+    expect(Object.keys(model.assuranceNodeVerdicts)).toHaveLength(1114);
     expect(Object.keys(model.nodeVerdicts).length).toBeGreaterThan(Object.keys(model.assuranceNodeVerdicts).length);
     expect(model.rulesLanguage.capability.engines).toHaveLength(3);
     expect(model.rulesLanguage.coverage.engines).toHaveLength(3);
@@ -221,7 +221,10 @@ describe('multi-axis conformance model', () => {
     expect(result.surface).toBe('messaging');
     expect(result.claims.map(({ id }) => id)).toEqual([
       'messaging:runtime:getToken',
+      'messaging#19',
       'messaging#2',
+      'messaging#20',
+      'messaging#21',
       'messaging#7',
     ]);
   });
@@ -229,7 +232,12 @@ describe('multi-axis conformance model', () => {
   it('does not contaminate features with unrelated family-row divergences', () => {
     expect(one('firestore/and').claims.map(({ id }) => id)).not.toContain('firestore#61');
     expect(one('storage/getMetadata').claims.map(({ id }) => id)).not.toContain('storage#86');
-    expect(one('messaging-admin/send').claims.map(({ id }) => id)).toEqual(['messaging-admin#4']);
+    expect(one('messaging-admin/send').claims.map(({ id }) => id)).toEqual([
+      'messaging-admin#4',
+      'messaging-admin#40',
+      'messaging-admin#41',
+      'messaging-admin#42',
+    ]);
   });
 
   it('cannot silently drop a feature-bearing divergence from the query model', () => {


### PR DESCRIPTION
## What

Fixes main, which is red after the conformance merge train. The `multi-axis conformance model` test (`packages/conformance/test/src/conformance-model.test.ts`) hardcodes three exact snapshots that #453's seven messaging behavior-class rows legitimately changed:

- `assuranceNodeVerdicts` count: 1107 -> 1114 (+7, exactly the seven new rows)
- `getToken` claims gain `messaging#19` (multi-device), `#20` (token rotation), `#21` (inactivity expiry) — all reference the getToken-minted token
- `messaging-admin/send` claims gain `messaging-admin#40` (quota), `#41` (retry), `#42` (offline) — all `send()` behaviors

The rows' `featureKeys` are correct, so the model joins them correctly; the assertions were stale, not wrong. Test-only change; no production or model code touched. Full conformance test package is green with this fix.

## Why it escaped CI

The messaging stack (#445, #452, #449, #453) was merged in rapid succession. CI's cancel-in-progress concurrency cancelled every intermediate main run; the first run to complete on the accumulated main was the #451 merge run, which surfaced the drift. No individual PR's CI saw the full accumulation.

## Forward note

The count assertion is an exact snapshot by design (a canary for unexpected model-size drift). Any future row-adding PR — including #446 once it rebases — must bump it again.