### PR TITLE
fix(cli): serve Studio through Vite mount

### DIFF
--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -94,10 +94,20 @@ Rule.
 - Do not select a fallback and transform it in the same expression. Select the
   value first, then validate or transform it in a separate statement or named
   helper.
+- Keep a condition inline when it expresses one obvious fact. Extract a
+  positively named predicate when a compound or negated condition encodes a
+  domain boundary, policy, eligibility rule, or state classification.
+- The call site states the decision. The predicate contains the boolean
+  mechanics and uses domain vocabulary rather than a generic name such as
+  `isValid`.
 
 The review test: can a reader identify every fallback, its precedence, and the
 reason for it without mentally evaluating operators? If not, replace the
 shorthand with explicit control flow.
+
+The condition review test: can the condition be stated as one domain question?
+If it can, the call site should ask that question through a named predicate
+rather than restating its boolean algebra.
 
 ## 3c. Configuration assembly is explicit
 

--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -77,7 +77,7 @@ The God-object rule. A single class longer than 400 lines is a design smell, not
 - Authored pages link each other by relative `.md` path; the site's remark
   plugin resolves those to routes and fails the build on a broken link.
 
-## 3b. Conditional expressions stay simple
+## 3b. Conditional and fallback logic states its policy
 
 Rule.
 
@@ -87,6 +87,17 @@ Rule.
   and both outcomes are short, simple values.
 - If a ternary needs to wrap, performs work in either branch, or introduces a
   second condition, replace it with explicit control flow.
+- Nullish-coalescing and logical-operator chains may express one obvious default.
+  They must not encode precedence among values with different semantic roles.
+- When fallback order is part of the behaviour, write one explicit branch per
+  fallback and give each value a domain-specific name.
+- Do not select a fallback and transform it in the same expression. Select the
+  value first, then validate or transform it in a separate statement or named
+  helper.
+
+The review test: can a reader identify every fallback, its precedence, and the
+reason for it without mentally evaluating operators? If not, replace the
+shorthand with explicit control flow.
 
 ## 3c. Configuration assembly is explicit
 

--- a/packages/cli/src/serve/site-tree.ts
+++ b/packages/cli/src/serve/site-tree.ts
@@ -48,8 +48,11 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
     // encoded traversal cannot cross from Studio into docs or static assets.
     // Connect preserves that target in `originalUrl` after stripping a mount
     // prefix from `url`.
-    const rawPathname =
-      (req.originalUrl ?? req.url ?? url.pathname).split('?', 1)[0] ?? url.pathname;
+    const rawRequestTarget = req.originalUrl ?? req.url ?? url.pathname;
+    const queryStart = rawRequestTarget.indexOf('?');
+    const rawPathname = queryStart === -1
+      ? rawRequestTarget
+      : rawRequestTarget.slice(0, queryStart);
     if (rawPathname !== '/__pyric/ui' && !rawPathname.startsWith('/__pyric/ui/')) {
       return false;
     }

--- a/packages/cli/src/serve/site-tree.ts
+++ b/packages/cli/src/serve/site-tree.ts
@@ -13,6 +13,10 @@ interface StudioRoutesManifest {
   routes: string[];
 }
 
+interface RequestWithOriginalUrl extends IncomingMessage {
+  originalUrl?: string;
+}
+
 function studioRoutesFromSite(root: string): ReadonlySet<string> {
   const manifestPath = join(root, 'studio-routes.json');
   const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as StudioRoutesManifest;
@@ -20,6 +24,26 @@ function studioRoutesFromSite(root: string): ReadonlySet<string> {
     throw new Error(`pyric: invalid Studio route manifest at ${manifestPath}`);
   }
   return new Set(parsed.routes);
+}
+
+function rawRequestPathname(request: RequestWithOriginalUrl, parsedUrl: URL): string {
+  let requestTarget = request.originalUrl;
+
+  if (requestTarget === undefined) {
+    requestTarget = request.url;
+  }
+
+  if (requestTarget === undefined) {
+    return parsedUrl.pathname;
+  }
+
+  const queryStringStart = requestTarget.indexOf('?');
+
+  if (queryStringStart === -1) {
+    return requestTarget;
+  }
+
+  return requestTarget.slice(0, queryStringStart);
 }
 
 function withWorkerVersion(html: string, workerVersion: string | undefined): string {
@@ -39,7 +63,7 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
   const studioRoutes = studioRoutesFromSite(root);
 
   return (
-    req: IncomingMessage & { originalUrl?: string },
+    req: RequestWithOriginalUrl,
     res: ServerResponse,
     url: URL,
   ): boolean => {
@@ -48,11 +72,7 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
     // encoded traversal cannot cross from Studio into docs or static assets.
     // Connect preserves that target in `originalUrl` after stripping a mount
     // prefix from `url`.
-    const rawRequestTarget = req.originalUrl ?? req.url ?? url.pathname;
-    const queryStart = rawRequestTarget.indexOf('?');
-    const rawPathname = queryStart === -1
-      ? rawRequestTarget
-      : rawRequestTarget.slice(0, queryStart);
+    const rawPathname = rawRequestPathname(req, url);
     if (rawPathname !== '/__pyric/ui' && !rawPathname.startsWith('/__pyric/ui/')) {
       return false;
     }

--- a/packages/cli/src/serve/site-tree.ts
+++ b/packages/cli/src/serve/site-tree.ts
@@ -17,6 +17,9 @@ interface RequestWithOriginalUrl extends IncomingMessage {
   originalUrl?: string;
 }
 
+const SITE_TREE_MOUNT_PATH = '/__pyric/ui';
+const SITE_TREE_DESCENDANT_PREFIX = `${SITE_TREE_MOUNT_PATH}/`;
+
 function studioRoutesFromSite(root: string): ReadonlySet<string> {
   const manifestPath = join(root, 'studio-routes.json');
   const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as StudioRoutesManifest;
@@ -46,6 +49,14 @@ function rawRequestPathname(request: RequestWithOriginalUrl, parsedUrl: URL): st
   return requestTarget.slice(0, queryStringStart);
 }
 
+function isSiteTreePath(pathname: string): boolean {
+  if (pathname === SITE_TREE_MOUNT_PATH) {
+    return true;
+  }
+
+  return pathname.startsWith(SITE_TREE_DESCENDANT_PREFIX);
+}
+
 function withWorkerVersion(html: string, workerVersion: string | undefined): string {
   if (!workerVersion || html.includes('name="pyric-worker-v"')) return html;
   if (!/^[a-f0-9]{16}$/.test(workerVersion)) {
@@ -73,16 +84,21 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
     // Connect preserves that target in `originalUrl` after stripping a mount
     // prefix from `url`.
     const rawPathname = rawRequestPathname(req, url);
-    if (rawPathname !== '/__pyric/ui' && !rawPathname.startsWith('/__pyric/ui/')) {
+    if (!isSiteTreePath(rawPathname)) {
       return false;
     }
-    if (rawPathname === '/__pyric/ui') {
-      res.writeHead(301, { location: '/__pyric/ui/' }).end();
+    if (rawPathname === SITE_TREE_MOUNT_PATH) {
+      res.writeHead(301, { location: SITE_TREE_DESCENDANT_PREFIX }).end();
       return true;
     }
 
-    const rel = rawPathname.slice('/__pyric/ui'.length) || '/';
-    const decodedRel = decodeStaticPathname(rel);
+    let relativePath = rawPathname.slice(SITE_TREE_MOUNT_PATH.length);
+
+    if (relativePath === '') {
+      relativePath = '/';
+    }
+
+    const decodedRel = decodeStaticPathname(relativePath);
     if (decodedRel === null || decodedRel.includes('\\')) {
       res.writeHead(404).end('not found');
       return true;
@@ -92,8 +108,8 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
       res.writeHead(404).end('not found');
       return true;
     }
-    if (!rel.endsWith('/') && !extname(rel)) {
-      const dir = resolveStaticPath(root, rel);
+    if (!relativePath.endsWith('/') && !extname(relativePath)) {
+      const dir = resolveStaticPath(root, relativePath);
       if (dir && existsSync(dir) && statSync(dir).isDirectory()) {
         res.writeHead(301, { location: `${rawPathname}/` }).end();
         return true;
@@ -102,7 +118,7 @@ export function createSiteTreeHandler(root: string, workerVersion?: string) {
 
     const first = decodedSegments[0];
     const studioRequest = first === undefined || studioRoutes.has(first);
-    let file = resolveStaticFile(root, rel);
+    let file = resolveStaticFile(root, relativePath);
     // Storage object names commonly contain extensions (logo.png), while the
     // other Studio routes reserve extension-bearing misses for static assets.
     const allowsDottedState = first === 'storage';

--- a/packages/cli/src/serve/site-tree.ts
+++ b/packages/cli/src/serve/site-tree.ts
@@ -38,11 +38,18 @@ function withWorkerVersion(html: string, workerVersion: string | undefined): str
 export function createSiteTreeHandler(root: string, workerVersion?: string) {
   const studioRoutes = studioRoutesFromSite(root);
 
-  return (req: IncomingMessage, res: ServerResponse, url: URL): boolean => {
+  return (
+    req: IncomingMessage & { originalUrl?: string },
+    res: ServerResponse,
+    url: URL,
+  ): boolean => {
     // URL parsing normalizes encoded dot segments before `url.pathname`
     // reaches us. Route and validate against the raw request target so an
     // encoded traversal cannot cross from Studio into docs or static assets.
-    const rawPathname = (req.url ?? url.pathname).split('?', 1)[0] ?? url.pathname;
+    // Connect preserves that target in `originalUrl` after stripping a mount
+    // prefix from `url`.
+    const rawPathname =
+      (req.originalUrl ?? req.url ?? url.pathname).split('?', 1)[0] ?? url.pathname;
     if (rawPathname !== '/__pyric/ui' && !rawPathname.startsWith('/__pyric/ui/')) {
       return false;
     }

--- a/packages/cli/test/serve/vite-plugin-generation.test.ts
+++ b/packages/cli/test/serve/vite-plugin-generation.test.ts
@@ -289,6 +289,18 @@ describe('ui: Pyric Studio mount (parity with dev --ui)', () => {
     expect(index.body.toLowerCase()).toContain('<!doctype html');
   });
 
+  it.skipIf(!studioBuilt)('serves Studio after Connect strips the /__pyric mount prefix', async () => {
+    const tmp = mkTmp('pyric-vite-ui-mounted-');
+    const handler = await bootPlugin({ ui: true }, tmp);
+    const index = await callPyric(handler, {
+      path: '/__pyric/ui/',
+      mountedPath: '/ui/',
+    });
+    expect(index.nexted).toBe(false);
+    expect(index.statusCode).toBe(200);
+    expect(String(index.headers['content-type'])).toContain('text/html');
+  });
+
   // The workspace/project routes mount whenever `ui` is on (they need only the
   // disk-backed stores, not the built assets), so this runs regardless of the build.
   it('ui:true → mounts the Studio local-mode workspace route (handled, not passed through)', async () => {

--- a/packages/cli/test/serve/vite-plugin-harness.ts
+++ b/packages/cli/test/serve/vite-plugin-harness.ts
@@ -98,11 +98,17 @@ export async function bootPlugin(
 
 export async function callPyric(
   handler: PyricMiddleware,
-  options: { method?: string; path: string; host?: string; headers?: Record<string, string> },
+  options: {
+    method?: string;
+    path: string;
+    mountedPath?: string;
+    host?: string;
+    headers?: Record<string, string>;
+  },
 ): Promise<{ statusCode: number; headers: Record<string, unknown>; body: string; nexted: boolean }> {
   const request: PyricReq = {
     method: options.method ?? 'GET',
-    url: options.path,
+    url: options.mountedPath ?? options.path,
     originalUrl: options.path,
     headers: { host: options.host ?? 'localhost', ...(options.headers ?? {}) },
   };


### PR DESCRIPTION
Vite applications using `pyric()` now serve Pyric Studio from the documented same-origin URL instead of falling through to the application SPA.

```ts
// vite.config.ts
import { defineConfig } from 'vite';
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [pyric()],
});

// GET /                   → the application
// GET /__pyric/ui/        → Pyric Studio
// GET /__pyric/ui/rtdb/   → Pyric Studio's RTDB page
```

## Connect's stripped mount path no longer bypasses Studio

The Vite adapter mounts its namespace at `/__pyric`. Connect preserves the full request target in `req.originalUrl` while stripping that prefix from `req.url`, so the Studio tree previously saw `/ui/`, declined the request, and let Vite's SPA fallback return the application.

The site-tree handler now prefers the preserved raw target and retains `req.url` as the fallback used by `pyric dev`. A named `rawRequestPathname` helper states each fallback and query-string decision with explicit control flow, while `isSiteTreePath` names the namespace policy at the routing call site. The regression harness represents both request values independently, matching Connect's mounted-middleware behavior.

The maintainer code convention now requires explicit branches when fallback order is behaviour, prohibits selecting a fallback and transforming it in the same expression, and requires positive domain predicates for compound conditions that encode boundaries or policy.

## Risk

This changes raw-path selection for the unified documentation and Studio tree. The existing traversal, finite-route, asset, documentation, and CLI-hosted site tests continue to pass; requests outside `/__pyric/ui` still fall through.

<details>
<summary>Implementation notes</summary>

- Based on `origin/main` at `a782d2a1`.
- The regression failed before the implementation with `Expected: false, Received: true` because the middleware called `next()`.
- `bun run build:cli` — passed.
- Focused Vite generation suite — 27 passed, 0 failed.
- Adjacent site-tree and Vite integration suites — 39 passed, 0 failed.
- Full CLI suite — 1,390 passed, 18 intentionally skipped, 0 failed.
- Live chat-template verification:
  - `/` returned the chat application title.
  - `/__pyric/ui/` returned `Pyric Studio`.
  - `/__pyric/ui/firestore/` returned `Pyric Studio`.

</details>
