### PR TITLE
fix: make provider UIDs RTDB-safe and isolate browser rules dispatch

### DIFF
--- a/packages/cli/src/bridge/client/dispatch.ts
+++ b/packages/cli/src/bridge/client/dispatch.ts
@@ -15,7 +15,7 @@
  * pinned by `test/bridge/tool-parity.test.ts`.
  */
 
-import { createFirestoreSimulatorTools } from 'pyric/rules/internal/node';
+import { createFirestoreSimulatorTools } from 'pyric/rules/internal';
 import {
   createFirestoreDataTools,
   createFirestoreInspectTools,

--- a/packages/cli/src/serve/entries/auth-helper-core.ts
+++ b/packages/cli/src/serve/entries/auth-helper-core.ts
@@ -176,7 +176,7 @@ export class ServeAuthHelper {
       return bareCredential(request.identity, request.providerId);
     }
     const identity: HelperIdentity = {
-      uid: `${request.providerId}:${request.spec.email}`,
+      uid: mintProviderUid(),
       email: request.spec.email,
       displayName: request.spec.displayName ?? null,
       customClaims: request.spec.customClaims ?? {},
@@ -184,6 +184,11 @@ export class ServeAuthHelper {
     await Promise.resolve(this.directory.add?.(identity));
     return bareCredential(identity, request.providerId);
   }
+}
+
+/** Provider UIDs are opaque Firebase identifiers, not encoded credentials. */
+function mintProviderUid(): string {
+  return `provider-${globalThis.crypto.randomUUID()}`;
 }
 
 /** Bare helper User — worker path discards this in favor of `acceptIdentity`. */

--- a/packages/cli/test/serve/auth-helper.test.ts
+++ b/packages/cli/test/serve/auth-helper.test.ts
@@ -10,6 +10,7 @@ import {
   GoogleAuthProvider,
   sandbox as authSandbox,
 } from 'pyric/auth';
+import { child, getDatabase, ref } from 'pyric/database';
 import { ServeAuthHelper } from '../../src/serve/entries/auth-helper-core.js';
 
 /** Mirror served in-page wiring: mint via createSignInCredential. */
@@ -50,7 +51,7 @@ function wire() {
   // (covered in test/serve/worker/auth.test.ts).
   authSandbox.delegateProviderEnforcement(auth, true);
   const helper = helperForLocalAuth(auth);
-  return { auth, helper };
+  return { auth, helper, sandbox };
 }
 
 function expectGoogleProviderMetadata(
@@ -105,7 +106,7 @@ describe('ServeAuthHelper', () => {
   });
 
   it('add → popup resolves, signs in, claims land in the token', async () => {
-    const { auth, helper } = wire();
+    const { auth, helper, sandbox } = wire();
     const p = signInWithPopup(auth, new GoogleAuthProvider());
     expect(helper.snapshot().request?.providerId).toBe('google.com');
     helper.add({ email: 'new@example.com', displayName: 'New', customClaims: { role: 'admin' } });
@@ -127,6 +128,21 @@ describe('ServeAuthHelper', () => {
     expect(created?.customClaims).toEqual({ role: 'admin' });
     expect(created?.providerId).toBe('google.com');
     expect(created?.providerUserInfo.map((p) => p.providerId)).toEqual(['google.com']);
+    expect(() => child(ref(getDatabase(sandbox), 'users'), cred.user.uid)).not.toThrow();
+  });
+
+  it('default worker mint produces a UID that is safe in an RTDB child path', async () => {
+    const sandbox = initializeSandbox();
+    const helper = new ServeAuthHelper({ list: () => [] });
+    const pending = helper.resolver().openPopup({
+      providerId: 'google.com',
+      authType: 'signIn',
+    });
+
+    helper.add({ email: 'dceast@gmail.com' });
+
+    const credential = await pending;
+    expect(() => child(ref(getDatabase(sandbox), 'users'), credential.user.uid)).not.toThrow();
   });
 
   it('created identity appears in the picker and is pickable next time with Google metadata', async () => {

--- a/packages/cli/test/serve/bundler.test.ts
+++ b/packages/cli/test/serve/bundler.test.ts
@@ -476,6 +476,10 @@ describe('bundleWorker — the SharedWorker script (Phase 3c.A)', () => {
     // Browser-standalone: no bare firebase/* or node: specifiers survive.
     expect(src).not.toMatch(/from\s*["']firebase\//);
     expect(src).not.toMatch(/from\s*["']node:/);
+    // Browser tool dispatch uses the in-memory modules resolver. Pulling the
+    // disk-backed resolver into this graph makes Vite request an `fs` shim and
+    // can fail at module evaluation before the worker connects.
+    expect(src).not.toContain('readFileSync');
     // Provenance banner + the connect wiring that makes it a SharedWorker host.
     expect(src).toContain('NOT the real Firebase SDK');
     expect(src).toContain('onconnect');

--- a/packages/pyric/src/auth/sandbox-backend-types.ts
+++ b/packages/pyric/src/auth/sandbox-backend-types.ts
@@ -101,7 +101,7 @@ export interface ProviderUserInfo {
  *  — mirrors the emulator's add-user form (`customAttributes` →
  *  `customClaims`). */
 export interface SignInIdentitySpec {
-  /** Defaults to `'<providerId>:<email>'`. */
+  /** Defaults to an opaque generated uid. */
   uid?: string;
   email: string;
   displayName?: string;

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -1350,7 +1350,7 @@ export class SandboxBackend {
    *     "add account"). If `spec.email` already belongs to a stored
    *     user, that identity is reused and the provider linked
    *     (Google-style same-email account reuse); otherwise a fresh
-   *     record is created with uid `spec.uid ?? '<providerId>:<email>'`
+   *     record is created with the supplied uid or an opaque generated uid
    *     and NO password (provider identities can't sign in via
    *     `signInWithEmailAndPassword`).
    *
@@ -1382,7 +1382,7 @@ export class SandboxBackend {
         stored = byEmail;
       } else {
         stored = this.makeStored({
-          uid: spec.uid ?? `${providerId}:${spec.email}`,
+          uid: spec.uid ?? mintProviderUid(),
           email: spec.email,
           displayName: spec.displayName ?? null,
           customClaims: spec.customClaims ?? {},
@@ -2252,6 +2252,11 @@ export class SandboxBackend {
     }
     return stored;
   }
+}
+
+/** Provider UIDs are opaque Firebase identifiers, not encoded credentials. */
+function mintProviderUid(): string {
+  return `provider-${globalThis.crypto.randomUUID()}`;
 }
 
 /** Re-exported from {@link ./auth-errors.ts} so consumers importing

--- a/packages/pyric/src/rules/internal/index.ts
+++ b/packages/pyric/src/rules/internal/index.ts
@@ -141,6 +141,7 @@ export type {
   FirestoreRulesToolDeps,
   FirestoreSimulatorToolDeps,
 } from '../tools.js';
+export { createFirestoreSimulatorTools } from '../simulator.js';
 
 // ─── Stdlib reference (browser-safe — pure data) ─────────────────────
 // Module-organized reference an agent can call before writing rules.

--- a/packages/pyric/test/auth/sandbox-user-admin.test.ts
+++ b/packages/pyric/test/auth/sandbox-user-admin.test.ts
@@ -26,6 +26,14 @@ function freshAuth(): Auth {
   return getAuth(initializeSandbox());
 }
 
+function expectGeneratedProviderUid(uid: string): void {
+  expect(uid).toStartWith('provider-');
+  expect(uid).not.toContain('@');
+  for (const reservedRtdbCharacter of ['.', '#', '$', '[', ']', '/']) {
+    expect(uid).not.toContain(reservedRtdbCharacter);
+  }
+}
+
 function mockUser(uid: string, email: string | null = null): User {
   return {
     uid,
@@ -209,13 +217,13 @@ describe('sandbox.createSignInCredential (A2)', () => {
     );
   });
 
-  it('{spec} creates the identity with the default uid and no password', () => {
+  it('{spec} creates the identity with an opaque RTDB-safe uid and no password', () => {
     const auth = freshAuth();
     const cred = authSandbox.createSignInCredential(auth, {
       providerId: 'google.com',
       spec: { email: 'new@x.com', displayName: 'New', customClaims: { plan: 'pro' } },
     });
-    expect(cred.user.uid).toBe('google.com:new@x.com');
+    expectGeneratedProviderUid(cred.user.uid);
     const id = authSandbox.listIdentities(auth).find((i) => i.uid === cred.user.uid);
     expect(id!.providerUserInfo).toEqual([{ providerId: 'google.com' }]);
     expect(id!.customClaims).toEqual({ plan: 'pro' });
@@ -260,8 +268,9 @@ describe('sandbox.createSignInCredential (A2)', () => {
       openRedirect: async () => cred,
     });
     const result = await signInWithPopup(auth, new GoogleAuthProvider());
-    expect(result.user.uid).toBe('google.com:flow@x.com');
-    expect(auth.currentUser?.uid).toBe('google.com:flow@x.com');
+    expectGeneratedProviderUid(result.user.uid);
+    expect(result.user.uid).toBe(cred.user.uid);
+    expect(auth.currentUser?.uid).toBe(cred.user.uid);
   });
 });
 

--- a/packages/pyric/test/rules/internal/index.test.ts
+++ b/packages/pyric/test/rules/internal/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test';
+import { initializeSandbox } from '../../../src/sandbox/index.js';
+import { getInternalEnv } from '../../../src/sandbox/internal/index.js';
+import { createFirestoreSimulatorTools } from '../../../src/rules/internal/index.js';
+
+describe('browser-safe rules internals', () => {
+  it('exposes the simulator tools without the disk-backed resolver entry', () => {
+    const sandbox = initializeSandbox();
+    const tools = createFirestoreSimulatorTools({
+      resolveSandbox: () => getInternalEnv(sandbox),
+    });
+
+    expect(tools.map((tool) => tool.name)).toContain('firestore_simulator_create');
+  });
+});


### PR DESCRIPTION
Provider sign-in now yields an opaque RTDB-safe UID, and browser tool dispatch no longer loads the disk-backed rules resolver.

```ts
import { GoogleAuthProvider, getAuth, signInWithPopup } from 'firebase/auth';
import { child, getDatabase, ref } from 'firebase/database';

const credential = await signInWithPopup(
  getAuth(),
  new GoogleAuthProvider(),
);
const userDocument = child(
  ref(getDatabase(), 'users'),
  credential.user.uid,
);

// The generated UID is an opaque value such as
// provider-28984d60-18f0-49e2-8e9c-be7f61c8e853, so constructing the
// RTDB child reference does not reject characters from an email address.
console.log(userDocument.toString());
```

## Generated provider identities no longer encode credentials into their UID

Both provider-account creation paths previously generated values such as
`google.com:dceast@gmail.com`. The Auth result was accepted, but using its UID
as an RTDB child key failed because RTDB paths reject `.`.

The in-page Auth backend and the served account picker now mint opaque
`provider-<uuid>` identifiers. Existing identities and callers that explicitly
supply a UID keep that UID unchanged.

## Browser tool dispatch stays on the browser rules entry

The page-side bridge dispatcher imported `pyric/rules/internal/node`, bringing
the `readFileSync`-based modules resolver into a browser bundle. It now imports
the simulator factory from `pyric/rules/internal`, where the factory is wired
to the in-memory browser resolver. Server-side tool metadata retains the
Node-backed resolver.

## Risk

Persisted provider identities created by an earlier release retain their old
UID; this change does not rewrite stored identities or user data keyed by them.

The browser simulator now reads the generated inline rules stdlib rather than
the filesystem. The package prebuild already regenerates that inline source,
and the Node tool surface remains disk-backed.

<details>
<summary>Implementation notes and verification</summary>

- `bun test packages/pyric/test/auth`: 320 passed.
- Focused Auth, bridge, and browser-internal regressions: 51 passed.
- `bun test --timeout 30000 packages/cli/test/serve/bundler.test.ts`: 22 passed.
- Pyric and CLI TypeScript checks passed.
- A forced Vite optimization followed by a real headless-browser chat sign-in
  completed successfully, displayed the signed-in state, created RTDB presence
  under the generated provider UID, and produced no console or page errors.
- The reported Vite exception was conditional and did not reproduce on the
  fresh chat landing route before the fix. The invalid static boundary was
  nevertheless present; the worker-bundle regression now proves that
  `readFileSync` cannot re-enter that browser graph.

</details>
