### PR TITLE
fix: surface chat provisioning failures and dedupe helper sign-in identities

### DIFF
--- a/packages/cli/src/serve/entries/auth-helper-core.ts
+++ b/packages/cli/src/serve/entries/auth-helper-core.ts
@@ -175,6 +175,14 @@ export class ServeAuthHelper {
     if (request.kind === 'pick') {
       return bareCredential(request.identity, request.providerId);
     }
+    // Same-email add resolves to the existing identity (Google-style account
+    // reuse) — mirrors `createSignInCredential`'s in-page policy, and keeps a
+    // repeated add idempotent instead of seeding a second account whose email
+    // mapping orphans the first.
+    const existing = this.findIdentityByEmail(request.spec.email);
+    if (existing) {
+      return bareCredential(existing, request.providerId);
+    }
     const identity: HelperIdentity = {
       uid: `${request.providerId}:${request.spec.email}`,
       email: request.spec.email,
@@ -184,6 +192,27 @@ export class ServeAuthHelper {
     await Promise.resolve(this.directory.add?.(identity));
     return bareCredential(identity, request.providerId);
   }
+
+  private findIdentityByEmail(email: string): HelperIdentity | undefined {
+    const normalized = email.toLowerCase();
+    return this.identities.find(
+      (identity) => identity.email?.toLowerCase() === normalized,
+    );
+  }
+}
+
+/**
+ * Recover the original custom claims from a helper credential's token claims.
+ * `bareCredential` (and the in-page backend mint) seed `sub` and the
+ * synthesized `firebase` envelope alongside the custom claims; neither is a
+ * custom claim, and seeding them back into the worker would persist
+ * synthesized metadata as user data.
+ */
+export function customClaimsFromTokenClaims(
+  claims: Record<string, unknown>,
+): Record<string, unknown> {
+  const { sub: _sub, firebase: _firebase, ...customClaims } = claims;
+  return customClaims;
 }
 
 /** Bare helper User — worker path discards this in favor of `acceptIdentity`. */

--- a/packages/cli/src/serve/entries/auth.ts
+++ b/packages/cli/src/serve/entries/auth.ts
@@ -19,6 +19,7 @@ import * as wcRaw from '../worker/client.js';
 import { acceptProviderCredential, restorePortSession } from '../worker/client.js';
 import { useWorker } from './worker-runtime.js';
 import { sessionStoreForApp } from './app-session-store.js';
+import { customClaimsFromTokenClaims } from './auth-helper-core.js';
 import { resolveServeAuthFlow } from './auth-helper-runtime.js';
 import type { SessionMode } from './session-store.js';
 import { getApp, type FirebaseApp } from 'pyric/app';
@@ -153,9 +154,10 @@ export const setPersistence = (
 
 /**
  * Resolve a provider identity through the backend-free ServeAuthHelper, then
- * hand it to the worker. The
- * helper seeds `{ sub, ...claims }` into the resolved credential's token, so we
- * strip `sub` to recover the original custom claims for the worker seed.
+ * hand it to the worker. The helper seeds `{ sub, ...claims, firebase }` into
+ * the resolved credential's token, so we strip the synthesized `sub` and
+ * `firebase` entries to recover the original custom claims for the worker
+ * seed (see `customClaimsFromTokenClaims`).
  *
  * Enforcement lives at the hand-off: `auth.acceptIdentity` gates against the
  * WORKER's provider config and rejects `auth/operation-not-allowed` for a
@@ -173,7 +175,9 @@ async function bridgeProviderSignIn(
     kind,
   );
   const tokenResult = await cred.user.getIdTokenResult();
-  const { sub: _sub, ...customClaims } = (tokenResult.claims ?? {}) as Record<string, unknown>;
+  const customClaims = customClaimsFromTokenClaims(
+    (tokenResult.claims ?? {}) as Record<string, unknown>,
+  );
   return acceptProviderCredential(auth as never, {
     uid: cred.user.uid,
     email: cred.user.email,

--- a/packages/cli/test/serve/auth-helper.test.ts
+++ b/packages/cli/test/serve/auth-helper.test.ts
@@ -10,7 +10,11 @@ import {
   GoogleAuthProvider,
   sandbox as authSandbox,
 } from 'pyric/auth';
-import { ServeAuthHelper } from '../../src/serve/entries/auth-helper-core.js';
+import {
+  customClaimsFromTokenClaims,
+  ServeAuthHelper,
+  type HelperIdentity,
+} from '../../src/serve/entries/auth-helper-core.js';
 
 /** Mirror served in-page wiring: mint via createSignInCredential. */
 function helperForLocalAuth(auth: ReturnType<typeof getAuth>): ServeAuthHelper {
@@ -89,6 +93,40 @@ describe('ServeAuthHelper', () => {
     });
     const cred = await pending;
     expect((await cred.user.getIdTokenResult()).signInProvider).toBe('google.com');
+  });
+
+  it('worker-path add with an existing email reuses that identity instead of seeding a duplicate', async () => {
+    const existing: HelperIdentity = {
+      uid: 'google.com:worker@example.com',
+      email: 'worker@example.com',
+      displayName: 'Worker User',
+      customClaims: { role: 'reviewer' },
+    };
+    const added: HelperIdentity[] = [];
+    const helper = new ServeAuthHelper({
+      list: () => [existing],
+      add: (identity) => { added.push(identity); },
+    });
+    const pending = helper.resolver().openPopup({
+      providerId: 'google.com',
+      authType: 'signIn',
+    });
+
+    helper.add({ email: 'Worker@Example.com', displayName: 'Renamed' });
+
+    const cred = await pending;
+    expect(cred.user.uid).toBe(existing.uid);
+    expect(cred.user.email).toBe('worker@example.com');
+    expect(added).toEqual([]); // no second account for the same email
+  });
+
+  it('customClaimsFromTokenClaims strips the synthesized sub and firebase entries only', () => {
+    expect(customClaimsFromTokenClaims({
+      sub: 'uid-1',
+      firebase: { sign_in_provider: 'google.com' },
+      role: 'admin',
+      plan: 'pro',
+    })).toEqual({ role: 'admin', plan: 'pro' });
   });
 
   it('non-delegated (in-page fallback): a disabled google.com popup throws operation-not-allowed', async () => {

--- a/packages/create-pyric/templates/chat/src/services/provisioning.ts
+++ b/packages/create-pyric/templates/chat/src/services/provisioning.ts
@@ -1,0 +1,23 @@
+/**
+ * Deduplicates post-sign-in provisioning per user while keeping failures
+ * observable. Concurrent callers share one in-flight attempt, so a failure
+ * reaches every caller instead of being masked by an "already started"
+ * short-circuit. A failed attempt is forgotten, letting the next sign-in
+ * retry from scratch; a successful attempt stays cached so provisioning
+ * runs once per user.
+ */
+export const createProvisioner = <TUser extends { uid: string }>(
+  provision: (user: TUser) => Promise<void>,
+): ((user: TUser) => Promise<void>) => {
+  const attempts = new Map<string, Promise<void>>();
+  return (user) => {
+    const inFlight = attempts.get(user.uid);
+    if (inFlight) return inFlight;
+    const attempt = provision(user).catch((error: unknown) => {
+      attempts.delete(user.uid);
+      throw error;
+    });
+    attempts.set(user.uid, attempt);
+    return attempt;
+  };
+};

--- a/packages/create-pyric/templates/chat/src/ui/chat/firebase-chat-gateway.ts
+++ b/packages/create-pyric/templates/chat/src/ui/chat/firebase-chat-gateway.ts
@@ -1,4 +1,5 @@
 import { FirebaseAuthService } from '@/services/auth-service';
+import { createProvisioner } from '@/services/provisioning';
 import { ConversationService } from '@/services/conversation-service';
 import { MessageService } from '@/services/message-service';
 import { UserService } from '@/services/user-service';
@@ -42,29 +43,27 @@ export const createFirebaseChatGateway = (): ChatPageServices => {
   const users = new UserService();
   const presence = new PresenceService();
   const notifications = new NotificationService();
-  const provisioned = new Set<string>();
-
-  const provision = async (user: AuthUser): Promise<void> => {
-    if (provisioned.has(user.uid)) return;
-    provisioned.add(user.uid);
-    try {
-      await users.provision(user);
-      await presence.goOnline(user);
-    } catch (error) {
-      provisioned.delete(user.uid);
-      throw error;
-    }
-  };
+  const provision = createProvisioner(async (user: AuthUser) => {
+    await users.provision(user);
+    await presence.goOnline(user);
+  });
 
   return {
     auth: {
       currentUser: () => toUiUser(auth.currentUser()),
+      // Auth state reports the signed-in user as soon as Firebase does; a
+      // provisioning failure must not masquerade as "signed out". The signIn
+      // path awaits the same shared attempt, so its failure surfaces in the
+      // sign-in error UI rather than only here.
       observe: (callback) => auth.observe((user) => {
         if (!user) {
           callback(null);
           return;
         }
-        void provision(user).then(() => callback(toUiUser(user))).catch(() => callback(null));
+        callback(toUiUser(user));
+        provision(user).catch((error: unknown) => {
+          console.error('Post-sign-in provisioning failed; the user profile or presence may be missing.', error);
+        });
       }),
       signIn: async () => {
         const signedIn = await auth.signIn();

--- a/packages/create-pyric/templates/chat/test/provisioning.test.ts
+++ b/packages/create-pyric/templates/chat/test/provisioning.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createProvisioner } from '../src/services/provisioning.ts';
+
+const user = { uid: 'user-1' };
+
+test('concurrent callers share one attempt and both observe its failure', async () => {
+  let runs = 0;
+  let reject: (reason: Error) => void = () => undefined;
+  const provision = createProvisioner(() => {
+    runs += 1;
+    return new Promise<void>((_resolve, nextReject) => {
+      reject = nextReject;
+    });
+  });
+
+  const observerAttempt = provision(user);
+  const signInAttempt = provision(user);
+  assert.equal(runs, 1);
+
+  reject(new Error('presence write denied'));
+  await assert.rejects(observerAttempt, /presence write denied/);
+  await assert.rejects(signInAttempt, /presence write denied/);
+});
+
+test('a failed attempt is forgotten so the next sign-in retries', async () => {
+  let runs = 0;
+  const provision = createProvisioner(() => {
+    runs += 1;
+    return runs === 1 ? Promise.reject(new Error('offline')) : Promise.resolve();
+  });
+
+  await assert.rejects(provision(user), /offline/);
+  await provision(user);
+  assert.equal(runs, 2);
+});
+
+test('a successful attempt is cached per user', async () => {
+  let runs = 0;
+  const provision = createProvisioner(() => {
+    runs += 1;
+    return Promise.resolve();
+  });
+
+  await provision(user);
+  await provision(user);
+  await provision({ uid: 'user-2' });
+  assert.equal(runs, 2);
+});


### PR DESCRIPTION
Closes the remaining gaps behind "mock Google sign-in creates the user but never signs in" in the chat template: the gateway no longer converts a post-sign-in provisioning failure into a signed-out callback, and the served sign-in bridge stops seeding duplicate accounts and synthesized claims.

```ts
// templates/chat: a provisioning failure now reaches the sign-in UI.
const services = createFirebaseChatGateway();

services.auth.observe((user) => {
  // Fires with the signed-in user as soon as Firebase reports it —
  // even if the users/{uid} doc write or the RTDB presence write fails.
  render(user);
});

await services.auth.signIn();
// Rejects with the real provisioning error (for example the RTDB
// permission failure), which chat-page shows in its error banner.
// Previously the observer's in-flight attempt swallowed it and the app
// silently stayed on the signed-out screen.
```

## The chat gateway no longer maps a provisioning failure to signed-out

The gateway ran `users.provision` + `presence.goOnline` before reporting auth state, mapped any failure to `callback(null)`, and deduped attempts with a `Set<string>` of uids. That set raced the sign-in click: the observer registered the uid first, so `signIn()`'s own provision call short-circuited as success and no error surfaced anywhere.

`createProvisioner` (new, `templates/chat/src/services/provisioning.ts`) shares one in-flight promise per uid, so every caller observes the same outcome, and forgets a failed attempt so the next sign-in retries:

```ts
const provision = createProvisioner(async (user: AuthUser) => {
  await users.provision(user);
  await presence.goOnline(user);
});

const a = provision(user); // starts the attempt
const b = provision(user); // same promise — a failure rejects both
```

## Same-email picker adds reuse the account

The worker-path helper mint seeded a fresh record on every "add", even for an email the directory already lists. Because the worker's `seedUsers` re-points the email mapping at the new uid, a repeated add orphaned the original record and showed duplicates in the picker. The mint now resolves a same-email add to the existing identity — the policy `createSignInCredential` already applies in-page:

```ts
helper.add({ email: 'Worker@Example.com' }); // worker@example.com exists
const cred = await pending;
cred.user.uid; // the existing identity's uid — no second account seeded
```

## Synthesized token claims stay out of the worker seed

`bridgeProviderSignIn` stripped only `sub` from the helper token before seeding custom claims, so the synthesized `firebase: { sign_in_provider }` envelope was persisted as a user custom claim. `customClaimsFromTokenClaims` now strips both.

## Risk

- The gateway observer now reports the signed-in user before provisioning completes, so the chat UI can render signed-in before the `users/{uid}` doc or presence node exists. Downstream reads already tolerate missing docs; presence simply appears when the write lands.
- The helper's email-reuse check reads the identity list captured when the picker opened; an account added from another tab in that window would still seed by uid, which `seedUsers` upserts idempotently.
- Composes with #457 (opaque provider uids). The reuse guard touches lines adjacent to its `defaultMint` change, so whichever merges second has a one-hunk conflict in `auth-helper-core.ts`.

<details>
<summary>Implementation notes</summary>

- `packages/cli` serve suite: 629 pass; the 18 failures are the pre-existing missing `.generated/can-i-use.js` conformance modules (worktree without a full `bun run build`), all in vite-plugin/bridge infrastructure files this PR does not touch. `test/serve/auth-helper.test.ts`: 9 pass.
- Chat template: `bun run test` 8 pass (3 new provisioner tests), `bun run typecheck` clean.
- Migration for previously persisted `providerId:email` uids was considered and dropped — unreleased library.

</details>
