### PR TITLE
docs: publish RTDB compatibility as public API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,23 +213,6 @@ jobs:
           bun-version: '1.3.11'
       - run: bun test scripts/publish-alpha.test.ts
 
-  docs-only:
-    name: Authored documentation
-    runs-on: ubuntu-latest
-    needs: plan
-    if: contains(fromJSON('["docs-only", "full"]'), needs.plan.outputs.predicted-check-set)
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.11'
-      - run: bun install --frozen-lockfile --filter '!@pyric/playground'
-      - run: bash scripts/build.sh --packages-only
-      - name: Generate and build documentation
-        run: bun run --cwd packages/site-docs build
-      - name: Generated content must not dirty authored sources
-        run: git diff --exit-code
-
   packaging:
     name: Packaging gate (pack + install + subpath resolution)
     runs-on: ubuntu-latest
@@ -369,7 +352,7 @@ jobs:
     name: CI / required
     runs-on: ubuntu-latest
     if: always()
-    needs: [plan, build-and-test, library-tests, browser-conformance, release-contract, docs-only, packaging, install-matrix, standalone]
+    needs: [plan, build-and-test, library-tests, browser-conformance, release-contract, packaging, install-matrix, standalone]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/packages/cli/test/e2e/app-conformance-gate.test.ts
+++ b/packages/cli/test/e2e/app-conformance-gate.test.ts
@@ -24,16 +24,9 @@ const standaloneJobEnd = workflow.indexOf('\n  required:', standaloneJobStart);
 const standaloneJob = workflow.slice(standaloneJobStart, standaloneJobEnd);
 
 describe('served app conformance merge gate', () => {
-  test('required CI splits CLI and library tests; the docs build runs as its own job', () => {
+  test('required CI splits CLI and library tests without a standalone docs job', () => {
     expect(workflow).not.toContain('\n  documentation:');
-    // The test lanes only need package artifacts (--packages-only below), but the
-    // documentation build itself must be selected for BOTH docs-only and
-    // full runs — a full PR must not be able to break `site-docs build`
-    // undetected (regression: the selector originally gated it to
-    // docs-only, so full runs skipped the docs build entirely).
-    expect(workflow).toContain(
-      `contains(fromJSON('["docs-only", "full"]'), needs.plan.outputs.predicted-check-set)`,
-    );
+    expect(workflow).not.toContain('\n  docs-only:');
     expect(mainJobStart).toBeGreaterThanOrEqual(0);
     expect(mainJobEnd).toBeGreaterThan(mainJobStart);
     expect(mainJob).toContain('bash scripts/build.sh --packages-only');

--- a/packages/conformance/registry/rtdb.ts
+++ b/packages/conformance/registry/rtdb.ts
@@ -73,8 +73,8 @@ const row4 = defineRows({
 const row5 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface (Phase 3)",
-    api: "Modular SDK surface (Phase 3)",
+    section: "Public API",
+    api: "Public API",
   },
 });
 
@@ -82,8 +82,8 @@ const row6 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["getDatabase"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddLifecycleTests,
   },
 });
@@ -91,8 +91,8 @@ const row6 = defineRows({
 const row7 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddLifecycleTests,
   },
 });
@@ -101,8 +101,8 @@ const row8 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["get"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "conforms",
     automation: "oracle-backed",
     conformanceTests: cddLifecycleTests,
@@ -113,8 +113,8 @@ const row9 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["set"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -123,8 +123,8 @@ const row10 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["update"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -133,8 +133,8 @@ const row11 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["remove"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "conforms",
     automation: "oracle-backed",
     conformanceTests: cddPublicOperationTests,
@@ -145,8 +145,8 @@ const row12 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["push"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "conforms",
     automation: "oracle-backed",
     conformanceTests: cddPublicOperationTests,
@@ -157,8 +157,8 @@ const row13 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["onValue"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -166,8 +166,8 @@ const row13 = defineRows({
 const row14 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     automation: "oracle-backed",
     conformanceTests: cddPublicOperationTests,
   },
@@ -177,7 +177,7 @@ const row15 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["off"],
-    section: "Modular SDK surface",
+    section: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -185,8 +185,8 @@ const row15 = defineRows({
 const row16 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "conforms",
     automation: "oracle-backed",
     conformanceTests: cddPublicOperationTests,
@@ -196,8 +196,8 @@ const row16 = defineRows({
 const row17 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -206,8 +206,8 @@ const row18 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["runTransaction"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     conformanceTests: cddPublicOperationTests,
   },
 });
@@ -215,8 +215,8 @@ const row18 = defineRows({
 const row19 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "diverged-documented",
     statusNote: "logical disconnect lifecycle is modeled, but the in-memory data plane itself remains available",
     evidence: "`unit:database/on-disconnect.test.ts` + `unit:modular/fruit-aliases.test.ts`",
@@ -229,8 +229,8 @@ const row20 = defineRows({
   surface: "rtdb",
   defaults: {
     featureKeys: ["connectDatabaseEmulator"],
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "unsupported",
     evidence: "Phase 3",
     automation: "unsupported",
@@ -241,8 +241,8 @@ const row20 = defineRows({
 const row21 = defineRows({
   surface: "rtdb",
   defaults: {
-    section: "Modular SDK surface",
-    api: "Modular SDK surface",
+    section: "Public API",
+    api: "Public API",
     status: "diverged-documented",
     evidence: "`unit:modular/fruit-aliases.test.ts`",
     automation: "unit-backed",
@@ -258,6 +258,7 @@ export const rtdbRegistry = {
     { kind: 'markdown', markdown: "# `pyric/database` compatibility matrix\n\n## Status legend\n\n| Status | Meaning |\n|---|---|\n| ✓ | **Conforming** — observable behavior matches Firebase, locked by a passing probe |\n| ⚠ | **Diverged (documented)** — intentional difference with a written reason |\n| ✗ | **Bug** — should match Firebase but does not |\n| — | **Not implemented yet** — pending, or intentionally outside the mirror |\n| ? | **Unverified** — not yet backed by sufficient evidence |\n" },
     {
       kind: 'table',
+      publishInCompatibilityDocs: false,
       prefix: "## Archived production-toolkit observations\n\nThese unsupported tombstones preserve immutable oracle `rowIds` for the removed host, REST, data, crawl, generation, and deployment toolkit. They are historical evidence, not current API claims.\n",
       rows: [
         row1({
@@ -392,6 +393,7 @@ export const rtdbRegistry = {
     },
     {
       kind: 'table',
+      publishInCompatibilityDocs: false,
       prefix: "## `simulateRtdbRules(compiled, input)` — in-process rule evaluator\n",
       rows: [
         row2({
@@ -507,6 +509,7 @@ export const rtdbRegistry = {
     },
     {
       kind: 'table',
+      publishInCompatibilityDocs: false,
       prefix: "## Constraint authoring surface (`atoms` / `policies` / `compose` / `ruleset`)\n",
       rows: [
         row3({
@@ -548,6 +551,7 @@ export const rtdbRegistry = {
     },
     {
       kind: 'table',
+      publishInCompatibilityDocs: false,
       prefix: "## Compiled RTDB rules tree ↔ rules JSON\n",
       rows: [
         row4({
@@ -584,7 +588,7 @@ export const rtdbRegistry = {
     },
     {
       kind: 'table',
-      prefix: "## Modular SDK surface\n\n`pyric/database` is the sandbox-only mirror of `firebase/database`'s\ntree-shakable free-function shape (`getDatabase`, `ref`, `child`, `get`,\n`set`, `update`, `remove`, `push`, listeners, queries, transactions, and\nsentinels). Package resolution selects production or sandbox before either\nmodule loads; this mirror has no production target or runtime dependency on\n`firebase/database`.\n\nTwo sandbox identity modes are selected by the value passed to\n`getDatabase`:\n\n- **Sandbox** — `getDatabase(ctx: SandboxContext)`. Frozen identity baked into\n  the handle at construction.\n- **Sandbox-live** — `getDatabase(sandbox: Sandbox)`. Identity read per\n  operation from `sandbox.currentUser`.\n\nThe public implementation is split by API family under `packages/pyric/src/database/`; the\nin-process backend lives in `packages/pyric/src/database/sandbox/`. Rows below\nare scoped to the modular mirror. The pure rules-engine rows above are internal\ntooling coverage and are not exports of `pyric/database`.\n",
+      prefix: "## Public API\n\n`pyric/database` mirrors the public `firebase/database` API in the Pyric sandbox. The rows below compare its observable behaviour with Firebase.\n",
       rows: [
         row5({
           rowRef: "M1",
@@ -613,6 +617,7 @@ export const rtdbRegistry = {
           rowRef: "M3",
           surface: "rtdb-modular",
           featureKeys: ["getDatabase"],
+          publishInCompatibilityDocs: false,
           behavior: "An in-module production target is intentionally absent; direct calls with a real `FirebaseApp` reject with package-resolution guidance",
           status: "unsupported",
           evidence: "`unit:modular.test.ts`; production remains the responsibility of the unchanged `firebase/database` package",
@@ -2704,7 +2709,7 @@ export const rtdbRegistry = {
         row15({
           rowRef: "138",
           surface: "rtdb-modular",
-          api: "Modular SDK surface",
+          api: "Public API",
           behavior: "`off(ref)` removes ALL listeners at that ref (any event type, any callback)",
           status: "conforms",
           evidence: "oracle: `packages/conformance/observations/rtdb-modular/rtdb-modular-off-stops-child-fires.json` — after `off(ref)` with no eventType, a subsequent write produced `postOffFires: 0` against an `onChildAdded` registration.",
@@ -2718,7 +2723,7 @@ export const rtdbRegistry = {
         row15({
           rowRef: "139",
           surface: "rtdb-modular",
-          api: "Modular SDK surface",
+          api: "Public API",
           behavior: "`off(ref, 'value')` removes only `value` listeners at that ref",
           status: "conforms",
           evidence: "Sandbox aligned (M48); oracle: `packages/conformance/observations/rtdb/rtdb-off-eventtype-precision.json` — registered TWO `value` listeners + one `child_added` at the same ref; after `off(ref, 'value')` (no callback), `valueListenersStopped: true` (neither value cb fired on subsequent writes) AND `childListenerStillFiringAfterOffValue: true` (the child listener kept firing). `offValueClearsAllValueListeners: true` confirms the no-callback variant removes ALL value listeners at the ref.",
@@ -2732,7 +2737,7 @@ export const rtdbRegistry = {
         row15({
           rowRef: "140",
           surface: "rtdb-modular",
-          api: "Modular SDK surface",
+          api: "Public API",
           behavior: "`off(ref, 'value', cb)` removes only the specific callback",
           status: "conforms",
           evidence: "Sandbox aligned (M48); adjacent to #141 — the upstream `off` with the cb argument removes only the matching callback. Same probe (`rtdb-onvalue-unsub-equivalence.json` Case 2) confirms `off(ref, 'value', cb)` stops only that callback.",
@@ -2743,7 +2748,7 @@ export const rtdbRegistry = {
         row15({
           rowRef: "141",
           surface: "rtdb-modular",
-          api: "Modular SDK surface",
+          api: "Public API",
           behavior: "The returned unsubscribe function from `onValue(ref, cb)` is equivalent to `off(ref, 'value', cb)`",
           status: "conforms",
           evidence: "Sandbox aligned (M48); oracle: `packages/conformance/observations/rtdb/rtdb-onvalue-unsub-equivalence.json` — `unsubReturnType: 'function'`, `unsubReturnedFnStopsListener: true` (the captured return value halted fires on write), `offRefValueCbStopsListener: true` (the same effect via `off(ref, 'value', cb)`), `bothFormsEquivalent: true`.",
@@ -3084,6 +3089,7 @@ export const rtdbRegistry = {
     },
     {
       kind: 'table',
+      publishInCompatibilityDocs: false,
       prefix: "### `connectDatabaseEmulator` — emulator hook\n",
       rows: [
         row20({

--- a/packages/conformance/registry/types.ts
+++ b/packages/conformance/registry/types.ts
@@ -52,6 +52,9 @@ export interface CompatibilityRow {
    * participate in developer feature queries. Required when neither
    * featureKeys nor rules constructs provide an identity. */
   queryable?: false;
+  /** Keeps an internal or historical ledger row out of the reader-facing
+   * compatibility reference without deleting its evidence or stable id. */
+  publishInCompatibilityDocs?: false;
   rowRef: string;
   rowNumber: number | null;
   section: string;
@@ -106,6 +109,9 @@ export interface CompatibilityTableBlock {
   kind: 'table';
   prefix: string;
   rows: CompatibilityRow[];
+  /** Keeps an internal or historical ledger section out of the reader-facing
+   * compatibility reference without deleting its rows. */
+  publishInCompatibilityDocs?: false;
 }
 
 export type CompatibilityDocBlock = MarkdownBlock | CompatibilityTableBlock;

--- a/packages/conformance/src/generate-docs.ts
+++ b/packages/conformance/src/generate-docs.ts
@@ -400,17 +400,35 @@ function rewriteLegend(markdown: string, present: ReadonlySet<CompatStatus>): st
   return out.join('\n');
 }
 
-/** All of a surface's blocks with presentation derived from its own rows:
+/** The reader-facing subset of a registry. Internal and historical entries
+ * remain in the canonical ledger but do not become public compatibility
+ * claims, gap entries, or documentation links. */
+function publishedBlocks(surface: CompatibilitySurfaceRegistry): CompatibilitySurfaceRegistry['blocks'] {
+  const blocks: CompatibilitySurfaceRegistry['blocks'] = [];
+  for (const block of surface.blocks) {
+    if (block.kind === 'markdown') {
+      blocks.push(block);
+      continue;
+    }
+    if (block.publishInCompatibilityDocs === false) continue;
+    const rows = block.rows.filter((row) => row.publishInCompatibilityDocs !== false);
+    if (rows.length > 0) blocks.push({ ...block, rows });
+  }
+  return blocks;
+}
+
+/** All of a surface's published blocks with presentation derived from its own rows:
  * the score block (coverage figure + to-scale meters) lands under the first
  * heading, and every status legend keys only the statuses this surface
  * actually uses. */
 function scoredBlocks(surface: CompatibilitySurfaceRegistry, projection: DocumentationProjection) {
+  const blocks = publishedBlocks(surface);
   const present: ReadonlySet<CompatStatus> = new Set(
-    surface.blocks.flatMap((block) => (block.kind === 'table' ? block.rows.map((row) => row.status) : [])),
+    blocks.flatMap((block) => (block.kind === 'table' ? block.rows.map((row) => row.status) : [])),
   );
   const score = scoreBlock(surface, projection);
   let scorePlaced = score === null;
-  return surface.blocks.map((block) => {
+  return blocks.map((block) => {
     if (block.kind !== 'markdown') return block;
     let markdown = rewriteLegend(block.markdown, present);
     if (!scorePlaced) {

--- a/packages/conformance/test/src/generated-row-line-numbers.test.ts
+++ b/packages/conformance/test/src/generated-row-line-numbers.test.ts
@@ -28,12 +28,19 @@ function firstTableSurface(): CompatibilitySurfaceRegistry {
   return surface;
 }
 
+function publishedRows(surface: CompatibilitySurfaceRegistry) {
+  return surface.blocks.flatMap((block) => {
+    if (block.kind !== 'table' || block.publishInCompatibilityDocs === false) return [];
+    return block.rows.filter((row) => row.publishInCompatibilityDocs !== false);
+  });
+}
+
 describe('generatedRowLineNumbers ↔ rendered projection coupling', () => {
   it('every keyed row identity resolves to its own rendered table row', () => {
     for (const surface of projection.registries) {
       const lines = renderSurfaceMarkdown(surface, projection).split('\n');
       const rowLines = generatedRowLineNumbers(surface, projection);
-      const tableRows = surface.blocks.flatMap((b) => (b.kind === 'table' ? b.rows : []));
+      const tableRows = publishedRows(surface);
       for (const row of tableRows) {
         const line = rowLines.get(row.id);
         expect(line, `no line number keyed for ${row.id}`).toBeDefined();
@@ -42,6 +49,14 @@ describe('generatedRowLineNumbers ↔ rendered projection coupling', () => {
         // Resolves to a markdown table data row, and to the right one.
         expect(rendered!.startsWith('| ')).toBe(true);
         expect(rendered!.endsWith(rowRefCell(row.rowRef))).toBe(true);
+      }
+      const unpublishedRows = surface.blocks.flatMap((block) => {
+        if (block.kind !== 'table') return [];
+        if (block.publishInCompatibilityDocs === false) return block.rows;
+        return block.rows.filter((row) => row.publishInCompatibilityDocs === false);
+      });
+      for (const row of unpublishedRows) {
+        expect(rowLines.has(row.id), `${row.id} should not have a published documentation link`).toBe(false);
       }
     }
   });
@@ -72,7 +87,7 @@ describe('generatedRowLineNumbers ↔ rendered projection coupling', () => {
     const baseline = generatedRowLineNumbers(surface, projection);
     const afterEdit = generatedRowLineNumbers(shifted, projection);
     const lines = renderSurfaceMarkdown(shifted, projection).split('\n');
-    const tableRows = shifted.blocks.flatMap((b) => (b.kind === 'table' ? b.rows : []));
+    const tableRows = publishedRows(shifted);
 
     let anyShifted = false;
     for (const row of tableRows) {
@@ -85,5 +100,23 @@ describe('generatedRowLineNumbers ↔ rendered projection coupling', () => {
       if (before !== undefined && after! !== before) anyShifted = true;
     }
     expect(anyShifted, 'inserting a line should move the derived line numbers').toBe(true);
+  });
+
+  it('publishes the RTDB compatibility page as a concise public API reference', () => {
+    const surface = projection.registries.find(({ surface }) => surface === 'rtdb');
+    if (!surface) throw new Error('expected the RTDB compatibility registry');
+    const markdown = renderSurfaceMarkdown(surface, projection);
+
+    expect(markdown).toContain('## Public API');
+    expect(markdown).toContain('mirrors the public `firebase/database` API');
+    expect(markdown).not.toContain('## Modular SDK surface');
+    expect(markdown).not.toContain('Archived production-toolkit observations');
+    expect(markdown).not.toContain('simulateRtdbRules(compiled, input)');
+    expect(markdown).not.toContain('Constraint authoring surface');
+    expect(markdown).not.toContain('Compiled RTDB rules tree');
+    expect(markdown).not.toContain('An in-module production target is intentionally absent');
+    expect(markdown).not.toContain('A production target is intentionally absent');
+    expect(markdown).not.toContain('| — | **Not implemented yet**');
+    expect(markdown).not.toContain('packages/pyric/src/database');
   });
 });

--- a/scripts/ci/required.test.ts
+++ b/scripts/ci/required.test.ts
@@ -8,7 +8,6 @@ const success = {
   'library-tests': 'success',
   'browser-conformance': 'success',
   'release-contract': 'skipped',
-  'docs-only': 'success',
   packaging: 'skipped',
   'install-matrix': 'skipped',
   standalone: 'skipped',
@@ -29,7 +28,7 @@ describe('required CI result', () => {
     expect(requiredFailures({
       checkSet: 'release-only',
       requirePackaging: false,
-      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'docs-only': 'skipped', 'release-contract': 'success' },
+      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'browser-conformance': 'skipped', 'release-contract': 'success' },
     })).toEqual([]);
   });
 
@@ -46,16 +45,13 @@ describe('required CI result', () => {
     })).toEqual([]);
   });
 
-  test.each(['failure', 'cancelled', 'skipped', undefined])(
-    'rejects a required job with result %s',
-    (result) => {
-      expect(requiredFailures({
-        checkSet: 'docs-only',
-        requirePackaging: false,
-        results: { ...success, 'docs-only': result },
-      })).toEqual([`docs-only: ${result ?? 'missing'}`]);
-    },
-  );
+  test('does not require a build for authored-documentation-only changes', () => {
+    expect(requiredFailures({
+      checkSet: 'docs-only',
+      requirePackaging: false,
+      results: {},
+    })).toEqual([]);
+  });
 
   test('requires every packaging consumer (incl. the standalone smoke) when the packaging policy is active', () => {
     expect(requiredFailures({
@@ -64,12 +60,4 @@ describe('required CI result', () => {
       results: success,
     })).toEqual(['packaging: skipped', 'install-matrix: skipped', 'standalone: skipped']);
   });
-});
-
-test('full runs require the documentation build (regression: docs gap)', () => {
-  expect(requiredFailures({
-    checkSet: 'full',
-    requirePackaging: false,
-    results: { 'build-and-test': 'success', 'library-tests': 'success', 'browser-conformance': 'success', 'docs-only': 'skipped' },
-  })).toEqual(['docs-only: skipped']);
 });

--- a/scripts/ci/required.ts
+++ b/scripts/ci/required.ts
@@ -9,9 +9,9 @@ interface RequiredInput {
 }
 
 const CHECK_SET_JOBS: Record<PrCheckSet, readonly string[]> = {
-  full: ['build-and-test', 'library-tests', 'browser-conformance', 'docs-only'],
+  full: ['build-and-test', 'library-tests', 'browser-conformance'],
   'release-only': ['release-contract'],
-  'docs-only': ['docs-only'],
+  'docs-only': [],
 };
 
 export function requiredFailures(input: RequiredInput): string[] {


### PR DESCRIPTION
Publishes the RTDB compatibility page as a concise Firebase public-API reference and removes the redundant authored-documentation CI job.

```md
# pyric/database compatibility matrix

100% of the public API supported

## Public API

pyric/database mirrors the public firebase/database API in the Pyric sandbox.
The rows below compare its observable behaviour with Firebase.
```

## Internal RTDB tooling no longer reads as Firebase compatibility

Archived production-toolkit observations, the in-process rules evaluator, constraint authoring, compiled-rules conversion, and obsolete production-target rows remain in the canonical evidence ledger but are omitted from reader-facing compatibility docs.

`publishInCompatibilityDocs: false` gives table blocks and individual rows an explicit publication decision. The renderer applies that decision consistently to tables, status legends, gap summaries, and generated documentation links. The published score, denominator, registry statuses, and evidence remain unchanged.

The standalone `Authored documentation` workflow job and its aggregate required-job wiring are removed. Full browser-conformance runs still build and exercise the shipped Studio and documentation integration.

Evidence-to-GitHub links are intentionally held for #459 so they can be generated consistently for every compatibility surface.

## Risk

Rows marked as unpublished no longer receive a generated compatibility-page line number. They remain queryable and auditable through the conformance model, but consumers that incorrectly treated every ledger row as a public documentation claim could observe an empty documentation location.

The CI change removes the separate authored-Markdown build gate. Full runs retain the existing site build and browser integration coverage, while authored-documentation-only changes intentionally require no build job.

<details>
<summary>Implementation notes</summary>

- Rebased cleanly onto current `origin/main`.
- `bun test packages/conformance/test/src`: 274 passed.
- `bun test packages/conformance/test/src/generated-row-line-numbers.test.ts`: 4 passed after rebase.
- `bun test scripts/ci/check-set.test.ts scripts/ci/plan.test.ts scripts/ci/required.test.ts`: 16 passed after rebase.
- `bun run --cwd packages/site-docs test`: 43 passed.
- `bun run compat:validate`: 863 rows, 311 observations, 0 problems.
- `bun run --cwd packages/conformance typecheck`: passed.
- `bun run compat:conformance:check`: passed.
- `bun run build:cli` and `bun run --cwd packages/site-docs build`: passed.
- The built `/docs/database-compat/` HTML contains none of the unpublished headings or obsolete production-target language.

</details>
