### PR TITLE
Support full-stack Vite monorepo interception with stateless tokens, ambient admin fallback, and .info system paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ packages/cli/build/
 ignored/
 
 # Editor and tool state.
+.jules/
+.jules.json
 .firebase/
 firebase-debug.log*
 packages/conformance/src/capture/functions-rtdb/fixture/runtime.cjs

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "pyric-monorepo",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
+        "@google/jules-cli": "https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media",
         "@pyric/cli": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
@@ -713,6 +714,8 @@
     "@google-cloud/pubsub": ["@google-cloud/pubsub@5.3.1", "", { "dependencies": { "@google-cloud/paginator": "^6.0.0", "@google-cloud/precise-date": "^5.0.0", "@google-cloud/projectify": "^5.0.0", "@google-cloud/promisify": "^5.0.0", "@opentelemetry/api": "~1.9.0", "@opentelemetry/core": "^1.30.1", "@opentelemetry/semantic-conventions": "~1.39.0", "arrify": "^2.0.0", "extend": "^3.0.2", "google-auth-library": "^10.5.0", "google-gax": "^5.0.5", "google-logging-utils": "^1.1.3", "heap-js": "^2.6.0", "is-stream-ended": "^0.1.4", "lodash.snakecase": "^4.1.1", "long": "^5.3.1", "p-defer": "^3.0.0" } }, "sha512-xXAQBVVrFviWz8L8yDKEqv1ziVw/gMSpYHt3IxSYRSY0fTyjis+xOrKJILj8dd8PAUHGnGiAIYuTprflkE9jsQ=="],
 
     "@google-cloud/storage": ["@google-cloud/storage@7.21.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0" } }, "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA=="],
+
+    "@google/jules-cli": ["@google/jules-cli@https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "citty": "^0.2.1", "handlebars": "^4.7.9", "zod": "^4.3.6" }, "peerDependencies": { "typescript": "^5" }, "bin": { "jules": "dist/jules.js", "jules-cli": "dist/jules.js", "jules-mcp": "dist/mcp.js" } }],
 
     "@googleapis/sqladmin": ["@googleapis/sqladmin@37.0.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-LBxSb3V+avoqsTHY/KsSR4/3FGnRfUw8yhGjx6ihTE5w7Y6l1EZkcx62aCCfCNkaigCQDvgiJG2Pq2jxN1sfag=="],
 
@@ -1504,6 +1507,8 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
+    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
     "cjson": ["cjson@0.3.3", "", { "dependencies": { "json-parse-helpfulerror": "^1.0.3" } }, "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg=="],
@@ -1941,6 +1946,8 @@
     "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2433,6 +2440,8 @@
     "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -3076,6 +3085,8 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultrahtml": ["ultrahtml@1.7.0", "", {}, "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g=="],
@@ -3234,6 +3245,8 @@
 
     "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
 
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -3343,6 +3356,8 @@
     "@google-cloud/storage/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "@google/jules-cli/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.3",
+    "@google/jules-cli": "https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media",
     "@types/bun": "latest",
     "bun-types": "latest",
     "firebase": "^12.12.0",

--- a/packages/cli/src/serve/discovery.ts
+++ b/packages/cli/src/serve/discovery.ts
@@ -20,11 +20,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Ports probed when the pointer is absent — serve's default scan window PLUS
- *  the vite-plugin default (5174), which the plain 3473+ window would miss (so a
- *  vite-only project was never found by scan). The standalone `pyric bridge`
- *  serves `/health` (not `/__pyric/health`) and writes no pointer, so it is
- *  registered directly via `claude mcp add`, not discovered here. */
-export const SCAN_PORTS = [3473, 3474, 3475, 3476, 3477, 5174];
+ *  the standard Vite dev ports (5173-5177), which the plain 3473+ window would miss
+ *  (so a vite-only or monorepo split-directory project is reliably found by scan).
+ *  The standalone `pyric bridge` serves `/health` (not `/__pyric/health`) and
+ *  writes no pointer, so it is registered directly via `claude mcp add`, not discovered here. */
+export const SCAN_PORTS = [3473, 3474, 3475, 3476, 3477, 5173, 5174, 5175, 5176, 5177];
 export const POINTER = join('.pyric', 'serve.json');
 
 export interface HealthLite {

--- a/packages/cli/src/serve/entries/auth-helper-core.ts
+++ b/packages/cli/src/serve/entries/auth-helper-core.ts
@@ -224,6 +224,12 @@ function mintProviderUid(): string {
 function bareCredential(identity: HelperIdentity, providerId: string): UserCredential {
   const issuedAtTime = new Date().toISOString();
   const expirationTime = new Date(Date.now() + 3600_000).toISOString();
+  const claims: Record<string, unknown> = {
+    sub: identity.uid,
+    ...identity.customClaims,
+    firebase: { sign_in_provider: providerId },
+  };
+  const token = `sandbox-id-token-${identity.uid}-0:${JSON.stringify(claims)}`;
   const user: User = {
     uid: identity.uid,
     email: identity.email,
@@ -243,14 +249,10 @@ function bareCredential(identity: HelperIdentity, providerId: string): UserCrede
         providerId,
       },
     ],
-    getIdToken: async () => `pyric-serve-${identity.uid}`,
+    getIdToken: async () => token,
     getIdTokenResult: async () => ({
-      token: `pyric-serve-${identity.uid}`,
-      claims: {
-        sub: identity.uid,
-        ...identity.customClaims,
-        firebase: { sign_in_provider: providerId },
-      },
+      token,
+      claims,
       signInProvider: providerId,
       expirationTime,
       issuedAtTime,

--- a/packages/cli/src/serve/worker/client/rtdb-references.ts
+++ b/packages/cli/src/serve/worker/client/rtdb-references.ts
@@ -51,7 +51,10 @@ export function makeRtdbRef(port: ClientPort, path: string): RtdbRefHandle {
 }
 
 function validateRtdbPath(path: string, allowEmpty: boolean): void {
-  if ((!allowEmpty && path.length === 0) || /[.#$[\]]/.test(path)) {
+  const normalized = path.replace(/^\/*\.info(\/|$)/, '/');
+  const isInvalidLength = !allowEmpty && path.length === 0;
+  const containsForbiddenChars = /[.#$[\]]/.test(normalized);
+  if (isInvalidLength || containsForbiddenChars) {
     throw new Error(
       `child failed: path argument was an invalid path = "${path}". Paths must be non-empty strings and can't contain ".", "#", "$", "[", or "]"`,
     );

--- a/packages/conformance/registry/auth.ts
+++ b/packages/conformance/registry/auth.ts
@@ -1009,7 +1009,7 @@ export const authRegistry = {
           api: "User` methods",
           behavior: "`user.getIdToken(true)` (forceRefresh) returns a NEW token; subsequent `getIdToken(false)` returns the cached new token",
           status: "conforms",
-          evidence: "`unit:sandbox-token-refresh.test.ts` — was ⚠ (documented divergence); aligned to prod in commit — sandbox now mints a fresh token on forceRefresh and fires `onIdTokenChanged`. Oracle: `packages/conformance/observations/auth/auth-getidtoken-force-refresh.json` defines the target shape (`forceRefreshReturnedDifferentString: true`, `token1EqualsToken2: true` against blockingfun — the refreshed token is cached, so a subsequent non-forced read returns it, not yet another fresh one). Sandbox tokens stay `sandbox-id-token-<uid>-<hash>` strings; prod's are real JWTs.",
+          evidence: "`unit:sandbox-token-refresh.test.ts` — was ⚠ (documented divergence); aligned to prod in commit — sandbox now mints a fresh token on forceRefresh and fires `onIdTokenChanged`. Oracle: `packages/conformance/observations/auth/auth-getidtoken-force-refresh.json` defines the target shape (`forceRefreshReturnedDifferentString: true`, `token1EqualsToken2: true` against blockingfun — the refreshed token is cached, so a subsequent non-forced read returns it, not yet another fresh one). Sandbox tokens stay `sandbox-id-token-<uid>-<serial>:<json>` strings; prod's are real JWTs.",
           risk: ["specific-value","specific-field","listener"],
           riskScore: 5,
           riskReasons: ["asserts 1 specific value(s)","asserts a specific field/property value","asserts listener semantics"],

--- a/packages/pyric-admin/src/app/index.ts
+++ b/packages/pyric-admin/src/app/index.ts
@@ -43,6 +43,15 @@ export function applicationDefault(): never {
   );
 }
 
+/**
+ * Link-compatible mirror of `firebase-admin/app`'s `cert(serviceAccountPathOrObject)`.
+ * Returns an inert sandbox credential token so unchanged application setup code
+ * can assign `appOptions.credential = cert(...)` under `@pyric/cli/register`.
+ */
+export function cert(serviceAccountPathOrObject: unknown): object {
+  return { [Symbol.for('pyric.admin.credential')]: 'cert' };
+}
+
 /** Local error with the observable firebase-admin app-error shape. */
 class FirebaseAppError extends Error {
   readonly code: string;
@@ -94,28 +103,25 @@ function alreadyExists(name: string, code: 'duplicate-app' | 'invalid-app-option
  * without Pyric activation instead of passing production options here.
  */
 export function initializeApp(
-  config?: InitializeAdminAppConfig,
+  config?: InitializeAdminAppConfig | Record<string, unknown>,
   name: string = DEFAULT_APP_NAME,
 ): PyricAdminApp {
   validateAppName(name);
   const existing = appRegistry.get(name);
 
-  if (config === undefined) {
+  const isBareOrAmbientConfig = config === undefined || !isSandboxConfig(config);
+  if (isBareOrAmbientConfig) {
     if (existing !== undefined) {
-      if (ambientApps.has(existing)) return existing;
+      const isExistingAmbient = ambientApps.has(existing);
+      if (isExistingAmbient) {
+        return existing;
+      }
       throw alreadyExists(name, 'invalid-app-options');
     }
     const app = initializeAmbientApp(name);
     appRegistry.set(name, app);
     ambientApps.add(app);
     return app;
-  }
-
-  if (!isSandboxConfig(config)) {
-    throw new TypeError(
-      'pyric-admin/app is a sandbox-only mirror. Production applications must ' +
-        'load firebase-admin/app without Pyric activation.',
-    );
   }
 
   if (existing !== undefined) {
@@ -208,7 +214,10 @@ function initializeAmbientApp(name: string): PyricAdminApp {
 
 function parsePyricSandboxEnv(env: string): RemoteSandboxFactoryOptions {
   const value = env.trim();
-  if (value === 'remote') return {};
+  const isRemoteOrBoolean = value === 'remote' || value === '1' || value === 'true';
+  if (isRemoteOrBoolean) {
+    return {};
+  }
   if (value.startsWith('remote:')) {
     const url = value.slice('remote:'.length).trim();
     if (url === '') {
@@ -222,11 +231,11 @@ function parsePyricSandboxEnv(env: string): RemoteSandboxFactoryOptions {
   }
   throw new Error(
     `pyric-admin: unrecognized PYRIC_SANDBOX value "${env}". Supported ` +
-      'values: "remote" (auto-discover the running `pyric dev`) or "remote:<url>".',
+      'values: "1", "true", "remote" (auto-discover the running `pyric dev`), or "remote:<url>".',
   );
 }
 
-function isSandboxConfig(config: InitializeAdminAppConfig): config is { sandbox: Sandbox } {
+function isSandboxConfig(config: unknown): config is { sandbox: Sandbox } {
   return typeof config === 'object' && config !== null && 'sandbox' in config;
 }
 

--- a/packages/pyric-admin/src/auth/auth.test.ts
+++ b/packages/pyric-admin/src/auth/auth.test.ts
@@ -120,7 +120,29 @@ describe('sandbox backend — createCustomToken / verifyIdToken roundtrip', () =
     const badToken = `${SANDBOX_TOKEN_PREFIX}:alice:not-json`;
     await expect(auth.verifyIdToken(badToken)).rejects.toThrow(/JSON/);
   });
+
+  it('verifies client ID tokens minted with sandbox-id-token prefix', async () => {
+    const sandbox = initializeSandbox();
+    const auth = getAuth(initializeApp({ sandbox }));
+    const clientClaims = { sub: 'bob', role: 'editor', firebase: { sign_in_provider: 'google.com' } };
+    const clientToken = `sandbox-id-token-bob-1:${JSON.stringify(clientClaims)}`;
+    const decoded = await auth.verifyIdToken(clientToken);
+    expect(decoded.uid).toBe('bob');
+    expect(decoded.sub).toBe('bob');
+    expect(decoded.role).toBe('editor');
+    expect(decoded.firebase.sign_in_provider).toBe('google.com');
+    expect(decoded.iss).toBe('https://sandbox.pyric.dev');
+    expect(decoded.aud).toBe('pyric-sandbox');
+  });
+
+  it('rejects client ID tokens with malformed claim JSON', async () => {
+    const sandbox = initializeSandbox();
+    const auth = getAuth(initializeApp({ sandbox }));
+    const badToken = 'sandbox-id-token-bob-1:not-json';
+    await expect(auth.verifyIdToken(badToken)).rejects.toThrow(/JSON/);
+  });
 });
+
 
 describe('sandbox backend — user CRUD', () => {
   it('createUser stores by uid; getUser retrieves it', async () => {
@@ -315,8 +337,9 @@ describe('sandbox backend — explicitly-not-implemented surface', () => {
   it('tenantManager getter throws the not-implemented message', () => {
     const sandbox = initializeSandbox();
     const auth = getAuth(initializeApp({ sandbox }));
-    expect(() => auth.tenantManager()).toThrow(
+    expect(() => (auth as Record<string, unknown>)['tenantManager']).toThrow(
       /not implemented in pyric-admin\/auth sandbox backend/,
     );
   });
 });
+

--- a/packages/pyric-admin/src/auth/index.ts
+++ b/packages/pyric-admin/src/auth/index.ts
@@ -78,85 +78,19 @@ import {
   type PyricAdminApp,
 } from '../app/index.js';
 import { assertAdminAppActive } from '../app/lifecycle.js';
+import type {
+  Auth,
+  CreateRequest,
+  DecodedIdToken,
+  ListUsersResult,
+  UpdateRequest,
+  UserRecord,
+} from './types.js';
+import { SANDBOX_TOKEN_PREFIX } from './token-decoders.js';
+import { verifySandboxIdToken } from './verify-token.js';
 
-export interface CreateRequest {
-  uid?: string;
-  email?: string;
-  emailVerified?: boolean;
-  displayName?: string | null;
-  photoURL?: string | null;
-  phoneNumber?: string | null;
-  disabled?: boolean;
-  password?: string;
-}
-
-export interface UpdateRequest extends Omit<CreateRequest, 'uid'> {
-  multiFactor?: unknown;
-  providerToLink?: unknown;
-  providersToUnlink?: unknown;
-}
-
-export interface DecodedIdToken extends Record<string, unknown> {
-  aud: string;
-  auth_time: number;
-  exp: number;
-  firebase: { identities: Record<string, unknown>; sign_in_provider: string };
-  iat: number;
-  iss: string;
-  sub: string;
-  uid: string;
-}
-
-export interface UserMetadata {
-  creationTime: string;
-  lastSignInTime: string;
-  toJSON(): Record<string, unknown>;
-}
-
-export interface UserInfo {
-  providerId: string;
-  uid: string;
-  displayName?: string;
-  email?: string;
-  photoURL?: string;
-  phoneNumber?: string;
-  toJSON(): Record<string, unknown>;
-}
-
-export interface UserRecord {
-  readonly uid: string;
-  readonly email?: string;
-  readonly emailVerified: boolean;
-  readonly displayName?: string;
-  readonly photoURL?: string;
-  readonly phoneNumber?: string;
-  readonly disabled: boolean;
-  readonly metadata: UserMetadata;
-  readonly providerData: UserInfo[];
-  readonly customClaims?: Record<string, unknown>;
-  readonly tenantId: string | null;
-  toJSON(): Record<string, unknown>;
-}
-
-export interface ListUsersResult {
-  users: UserRecord[];
-  pageToken?: string;
-}
-
-/** Sandbox Auth interface intentionally limited to implemented behavior. */
-export interface Auth {
-  readonly app: PyricAdminApp;
-  createCustomToken(uid: string, developerClaims?: object): Promise<string>;
-  verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
-  createUser(properties: CreateRequest): Promise<UserRecord>;
-  getUser(uid: string): Promise<UserRecord>;
-  getUserByEmail(email: string): Promise<UserRecord>;
-  deleteUser(uid: string): Promise<void>;
-  setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
-  updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord>;
-  listUsers(maxResults?: number, pageToken?: string): Promise<ListUsersResult>;
-  [key: string]: unknown;
-}
+export * from './types.js';
+export { SANDBOX_TOKEN_PREFIX } from './token-decoders.js';
 
 // ─── Sandbox backend ────────────────────────────────────────────────────
 
@@ -183,7 +117,7 @@ class AuthStore {
    * collision resistance — it needs a stable, debuggable identifier
    * that doesn't collide *within one sandbox session*. A counter plus
    * a constant prefix is enough; padding keeps the visual width
- * roughly consistent with Firebase Auth uids.
+   * roughly consistent with Firebase Auth uids.
    */
   mintUid(): string {
     const n = String(this.nextAutoUid++).padStart(20, '0');
@@ -239,102 +173,15 @@ function storeFor(sandbox: Sandbox): AuthStore {
 }
 
 /**
- * Token format minted by `createCustomToken` and parsed by
- * `verifyIdToken`. Exported as a constant so tests can lock the shape.
- *
- * Layout: `pyric-sandbox-custom:${uid}:${jsonClaims}`
- *
- * - The prefix lets `verifyIdToken` reject foreign tokens with a clear
- *   "not a sandbox token" error rather than NaN'ing out.
- * - `uid` is colon-free per the auto-uid format above.
- * - `jsonClaims` is the JSON-stringified developer claims (or `{}` when
- *   none were provided). Round-trips losslessly through `JSON.parse`.
- *
- * NOT a JWT. NOT signed. Do not use this token format to talk to any
- * real Firebase service — it only round-trips through this same
- * sandbox backend.
- */
-export const SANDBOX_TOKEN_PREFIX = 'pyric-sandbox-custom';
-
-/**
  * Mint a deterministic sandbox token (the {@link SANDBOX_TOKEN_PREFIX}
  * format). Stateless — shared verbatim by the local and remote sandbox
  * arms, so a token minted against either round-trips through
- * {@link verifySandboxIdToken} on the other.
+ * verifySandboxIdToken on the other.
  */
 function mintSandboxCustomToken(uid: string, developerClaims?: object): Promise<string> {
   const claims = developerClaims ?? {};
   const token = `${SANDBOX_TOKEN_PREFIX}:${uid}:${JSON.stringify(claims)}`;
   return Promise.resolve(token);
-}
-
-/**
- * Parse a token minted by {@link mintSandboxCustomToken}. Returns a
- * `DecodedIdToken`-shaped object — every required field is filled with a
- * sandbox-appropriate placeholder (`iss`/`aud` = `pyric-sandbox`, time
- * fields = now), and the developer claims are spread onto the result so
- * `decoded.role` etc. retain the familiar Firebase Admin shape.
- *
- * Throws on any token that doesn't match the
- * `${SANDBOX_TOKEN_PREFIX}:${uid}:${json}` shape — including real JWTs
- * that another verifier would parse. The sandbox backends are
- * intentionally not drop-ins for production token verification.
- */
-function verifySandboxIdToken(idToken: string): Promise<DecodedIdToken> {
-  if (typeof idToken !== 'string' || !idToken.startsWith(`${SANDBOX_TOKEN_PREFIX}:`)) {
-    return Promise.reject(
-      new Error(
-        'pyric-admin/auth: verifyIdToken on the sandbox backend only ' +
-          'accepts tokens minted by this sandbox\'s createCustomToken. ' +
-          `Token prefix must be "${SANDBOX_TOKEN_PREFIX}:".`,
-      ),
-    );
-  }
-  // The token is `prefix:uid:json`. Split on the first two colons
-  // only — the JSON payload may itself contain colons (e.g. inside
-  // a string value) so `split(':')` with no limit would corrupt it.
-  const firstColon = idToken.indexOf(':');
-  const secondColon = idToken.indexOf(':', firstColon + 1);
-  if (secondColon < 0) {
-    return Promise.reject(
-      new Error(
-        `pyric-admin/auth: verifyIdToken received a malformed sandbox token (missing claims segment): ${idToken}`,
-      ),
-    );
-  }
-  const uid = idToken.slice(firstColon + 1, secondColon);
-  const jsonClaims = idToken.slice(secondColon + 1);
-  let claims: Record<string, unknown>;
-  try {
-    claims = JSON.parse(jsonClaims) as Record<string, unknown>;
-  } catch (e) {
-    return Promise.reject(
-      new Error(
-        `pyric-admin/auth: verifyIdToken failed to parse sandbox token claims as JSON: ${(e as Error).message}`,
-      ),
-    );
-  }
-  const nowSec = Math.floor(Date.now() / 1000);
-  // `DecodedIdToken` requires `aud`/`iss`/`sub`/`uid`/`auth_time`/
-  // `exp`/`iat`/`firebase` to be present; the sandbox fills them
-  // with placeholders so consumers that read them get sensible
-  // values rather than `undefined`. Developer claims are spread on
-  // top so they shadow nothing critical.
-  const decoded: DecodedIdToken = {
-    aud: 'pyric-sandbox',
-    auth_time: nowSec,
-    exp: nowSec + 3600,
-    firebase: {
-      identities: {},
-      sign_in_provider: 'custom',
-    },
-    iat: nowSec,
-    iss: 'pyric-sandbox',
-    sub: uid,
-    uid,
-    ...claims,
-  };
-  return Promise.resolve(decoded);
 }
 
 /**

--- a/packages/pyric-admin/src/auth/token-decoders.ts
+++ b/packages/pyric-admin/src/auth/token-decoders.ts
@@ -1,0 +1,158 @@
+/**
+ * Modular token decoders for `pyric-admin/auth` verification.
+ * Each decoder strategy isolates prefix detection and claim decoding
+ * for one recognized token format.
+ */
+import type { DecodedIdToken } from './types.js';
+
+/**
+ * Token format minted by `createCustomToken` and parsed by
+ * `verifyIdToken`. Exported as a constant so tests can lock the shape.
+ *
+ * Layout: `pyric-sandbox-custom:${uid}:${jsonClaims}`
+ *
+ * - The prefix lets `verifyIdToken` reject foreign tokens with a clear
+ *   "not a sandbox token" error rather than NaN'ing out.
+ * - `uid` is colon-free per the auto-uid format above.
+ * - `jsonClaims` is the JSON-stringified developer claims (or `{}` when
+ *   none were provided). Round-trips losslessly through `JSON.parse`.
+ *
+ * NOT a JWT. NOT signed. Do not use this token format to talk to any
+ * real Firebase service — it only round-trips through this same
+ * sandbox backend.
+ */
+export const SANDBOX_TOKEN_PREFIX = 'pyric-sandbox-custom';
+
+export interface TokenDecoder {
+  readonly name: string;
+  readonly prefix: string;
+  decode(token: string, nowSec: number): DecodedIdToken;
+}
+
+function resolveStringClaim(claims: Record<string, unknown>, key: string, fallback: string): string {
+  const val = claims[key];
+  const hasStringValue = typeof val === 'string';
+  return hasStringValue ? val : fallback;
+}
+
+function resolveNumberClaim(claims: Record<string, unknown>, key: string, fallback: number): number {
+  const val = claims[key];
+  const hasNumberValue = typeof val === 'number';
+  return hasNumberValue ? val : fallback;
+}
+
+function resolveUid(idToken: string, firstColon: number, claims: Record<string, unknown>): string {
+  const rawSub = claims['sub'];
+  const hasExplicitSubjectClaim = typeof rawSub === 'string';
+  if (hasExplicitSubjectClaim) {
+    return rawSub;
+  }
+  const prefixSegment = idToken.slice('sandbox-id-token-'.length, firstColon);
+  const lastHyphen = prefixSegment.lastIndexOf('-');
+  const hasHyphenatedSerialSuffix = lastHyphen > 0;
+  if (hasHyphenatedSerialSuffix) {
+    return prefixSegment.slice(0, lastHyphen);
+  }
+  return prefixSegment;
+}
+
+function resolveFirebaseClaim(
+  claims: Record<string, unknown>,
+): { identities: Record<string, unknown>; sign_in_provider: string } {
+  const rawFirebase = claims['firebase'];
+  const isMissingFirebaseClaim = !rawFirebase || typeof rawFirebase !== 'object';
+  if (isMissingFirebaseClaim) {
+    return { identities: {}, sign_in_provider: 'custom' };
+  }
+  const fb = rawFirebase as Record<string, unknown>;
+  const signInProvider = resolveStringClaim(fb, 'sign_in_provider', 'custom');
+  const rawIdentities = fb['identities'];
+  const isMissingIdentitiesMap = !rawIdentities || typeof rawIdentities !== 'object';
+  if (isMissingIdentitiesMap) {
+    return { identities: {}, sign_in_provider: signInProvider };
+  }
+  return { identities: rawIdentities as Record<string, unknown>, sign_in_provider: signInProvider };
+}
+
+const customTokenDecoder: TokenDecoder = {
+  name: 'custom-token',
+  prefix: `${SANDBOX_TOKEN_PREFIX}:`,
+  decode(idToken: string, nowSec: number): DecodedIdToken {
+    const firstColon = idToken.indexOf(':');
+    const secondColon = idToken.indexOf(':', firstColon + 1);
+    const isMissingClaimsSegment = secondColon < 0;
+    if (isMissingClaimsSegment) {
+      throw new Error(
+        `pyric-admin/auth: verifyIdToken received a malformed sandbox token (missing claims segment): ${idToken}`,
+      );
+    }
+    const uid = idToken.slice(firstColon + 1, secondColon);
+    const jsonClaims = idToken.slice(secondColon + 1);
+    let claims: Record<string, unknown>;
+    try {
+      claims = JSON.parse(jsonClaims) as Record<string, unknown>;
+    } catch (e) {
+      throw new Error(
+        `pyric-admin/auth: verifyIdToken failed to parse sandbox token claims as JSON: ${(e as Error).message}`,
+      );
+    }
+    return {
+      aud: 'pyric-sandbox',
+      auth_time: nowSec,
+      exp: nowSec + 3600,
+      firebase: {
+        identities: {},
+        sign_in_provider: 'custom',
+      },
+      iat: nowSec,
+      iss: 'pyric-sandbox',
+      sub: uid,
+      uid,
+      ...claims,
+    };
+  },
+};
+
+const clientIdTokenDecoder: TokenDecoder = {
+  name: 'client-id-token',
+  prefix: 'sandbox-id-token-',
+  decode(idToken: string, nowSec: number): DecodedIdToken {
+    const firstColon = idToken.indexOf(':');
+    const isMissingClaimsSegment = firstColon < 0;
+    if (isMissingClaimsSegment) {
+      throw new Error(
+        `pyric-admin/auth: verifyIdToken received a malformed client ID token (missing claims segment after colon): ${idToken}`,
+      );
+    }
+    const jsonClaims = idToken.slice(firstColon + 1);
+    let claims: Record<string, unknown>;
+    try {
+      claims = JSON.parse(jsonClaims) as Record<string, unknown>;
+    } catch (e) {
+      throw new Error(
+        `pyric-admin/auth: verifyIdToken failed to parse client ID token claims as JSON: ${(e as Error).message}`,
+      );
+    }
+    const uid = resolveUid(idToken, firstColon, claims);
+    const aud = resolveStringClaim(claims, 'aud', 'pyric-sandbox');
+    const iss = resolveStringClaim(claims, 'iss', 'https://sandbox.pyric.dev');
+    const exp = resolveNumberClaim(claims, 'exp', nowSec + 3600);
+    const iat = resolveNumberClaim(claims, 'iat', nowSec);
+    const authTime = resolveNumberClaim(claims, 'auth_time', nowSec);
+    const firebase = resolveFirebaseClaim(claims);
+
+    return {
+      ...claims,
+      aud,
+      auth_time: authTime,
+      exp,
+      firebase,
+      iat,
+      iss,
+      sub: uid,
+      uid,
+    };
+  },
+};
+
+export const TOKEN_DECODERS: TokenDecoder[] = [customTokenDecoder, clientIdTokenDecoder];

--- a/packages/pyric-admin/src/auth/types.ts
+++ b/packages/pyric-admin/src/auth/types.ts
@@ -1,0 +1,81 @@
+/** Public interface types for `pyric-admin/auth`. */
+import type { PyricAdminApp } from '../app/index.js';
+
+export interface CreateRequest {
+  uid?: string;
+  email?: string;
+  emailVerified?: boolean;
+  displayName?: string | null;
+  photoURL?: string | null;
+  phoneNumber?: string | null;
+  disabled?: boolean;
+  password?: string;
+}
+
+export interface UpdateRequest extends Omit<CreateRequest, 'uid'> {
+  multiFactor?: unknown;
+  providerToLink?: unknown;
+  providersToUnlink?: unknown;
+}
+
+export interface DecodedIdToken extends Record<string, unknown> {
+  aud: string;
+  auth_time: number;
+  exp: number;
+  firebase: { identities: Record<string, unknown>; sign_in_provider: string };
+  iat: number;
+  iss: string;
+  sub: string;
+  uid: string;
+}
+
+export interface UserMetadata {
+  creationTime: string;
+  lastSignInTime: string;
+  toJSON(): Record<string, unknown>;
+}
+
+export interface UserInfo {
+  providerId: string;
+  uid: string;
+  displayName?: string;
+  email?: string;
+  photoURL?: string;
+  phoneNumber?: string;
+  toJSON(): Record<string, unknown>;
+}
+
+export interface UserRecord {
+  readonly uid: string;
+  readonly email?: string;
+  readonly emailVerified: boolean;
+  readonly displayName?: string;
+  readonly photoURL?: string;
+  readonly phoneNumber?: string;
+  readonly disabled: boolean;
+  readonly metadata: UserMetadata;
+  readonly providerData: UserInfo[];
+  readonly customClaims?: Record<string, unknown>;
+  readonly tenantId: string | null;
+  toJSON(): Record<string, unknown>;
+}
+
+export interface ListUsersResult {
+  users: UserRecord[];
+  pageToken?: string;
+}
+
+/** Sandbox Auth interface intentionally limited to implemented behavior. */
+export interface Auth {
+  readonly app: PyricAdminApp;
+  createCustomToken(uid: string, developerClaims?: object): Promise<string>;
+  verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<DecodedIdToken>;
+  createUser(properties: CreateRequest): Promise<UserRecord>;
+  getUser(uid: string): Promise<UserRecord>;
+  getUserByEmail(email: string): Promise<UserRecord>;
+  deleteUser(uid: string): Promise<void>;
+  setCustomUserClaims(uid: string, customUserClaims: object | null): Promise<void>;
+  updateUser(uid: string, properties: UpdateRequest): Promise<UserRecord>;
+  listUsers(maxResults?: number, pageToken?: string): Promise<ListUsersResult>;
+  [key: string]: unknown;
+}

--- a/packages/pyric-admin/src/auth/verify-token.ts
+++ b/packages/pyric-admin/src/auth/verify-token.ts
@@ -1,0 +1,42 @@
+/**
+ * Stateless ID token verification for `pyric-admin/auth`.
+ * Routes token parsing across recognized decoder strategies.
+ */
+import type { DecodedIdToken } from './types.js';
+import { SANDBOX_TOKEN_PREFIX, TOKEN_DECODERS } from './token-decoders.js';
+
+/**
+ * Parse a token minted by `createCustomToken` or a client ID token
+ * minted by `pyric/auth`'s `getIdToken()`. Routes to the appropriate
+ * modular token decoder based on token prefix.
+ *
+ * Throws on any token that doesn't match a recognized sandbox prefix —
+ * including real JWTs that another verifier would parse. The sandbox
+ * backends are intentionally not drop-ins for production verification.
+ */
+export function verifySandboxIdToken(idToken: string): Promise<DecodedIdToken> {
+  const isInvalidTokenArgument = typeof idToken !== 'string';
+  if (isInvalidTokenArgument) {
+    return Promise.reject(
+      new Error('pyric-admin/auth: verifyIdToken expects a string argument.'),
+    );
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  for (const decoder of TOKEN_DECODERS) {
+    const matchesDecoderPrefix = idToken.startsWith(decoder.prefix);
+    if (matchesDecoderPrefix) {
+      try {
+        return Promise.resolve(decoder.decode(idToken, nowSec));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+  }
+  return Promise.reject(
+    new Error(
+      'pyric-admin/auth: verifyIdToken on the sandbox backend only ' +
+        'accepts tokens minted by this sandbox\'s createCustomToken or client getIdToken(). ' +
+        `Token must begin with "${SANDBOX_TOKEN_PREFIX}:" or "sandbox-id-token-".`,
+    ),
+  );
+}

--- a/packages/pyric-admin/src/database/index.ts
+++ b/packages/pyric-admin/src/database/index.ts
@@ -84,6 +84,16 @@ import {
   type PyricAdminApp,
 } from '../app/index.js';
 import { assertAdminAppActive } from '../app/lifecycle.js';
+import { increment, serverTimestamp } from 'pyric/database';
+
+/** Mirror of `firebase-admin/database`'s `ServerValue` constant and sentinel constructors. */
+export const ServerValue: {
+  readonly TIMESTAMP: object;
+  readonly increment: (delta: number) => object;
+} = {
+  TIMESTAMP: serverTimestamp(),
+  increment: (delta: number) => increment(delta),
+};
 
 /** Mirror-owned structural types for the implemented admin RTDB surface. */
 export type EventType = 'value' | 'child_added' | 'child_changed' | 'child_removed' | 'child_moved';

--- a/packages/pyric-admin/src/storage/index.ts
+++ b/packages/pyric-admin/src/storage/index.ts
@@ -204,6 +204,15 @@ export function getStorage(app?: StorageApp): Storage {
   );
 }
 
+/**
+ * Link-compatible mirror of `firebase-admin/storage`'s `getDownloadURL(file)`.
+ * Returns a deterministic sandbox storage stub URL from `file.getSignedUrl()`.
+ */
+export async function getDownloadURL(file: File): Promise<string> {
+  const [url] = await file.getSignedUrl({ action: 'read', expires: '2099-01-01' });
+  return url;
+}
+
 // ─── Sandbox path ───────────────────────────────────────────────────────
 
 /**

--- a/packages/pyric-admin/test/app/ambient-init.test.ts
+++ b/packages/pyric-admin/test/app/ambient-init.test.ts
@@ -26,6 +26,7 @@ import {
 } from 'pyric/sandbox';
 
 import {
+  cert,
   deleteApp,
   getApps,
   initializeApp,
@@ -221,5 +222,32 @@ describe('ambient init — production guard', () => {
     process.env.NODE_ENV = 'development';
     const app = initializeApp();
     expect(isSandboxAdminApp(app)).toBe(true);
+  });
+
+  it('cert returns an inert credential object', () => {
+    expect(cert({ projectId: 'demo' })).toEqual({
+      [Symbol.for('pyric.admin.credential')]: 'cert',
+    });
+  });
+
+  it('initializeApp with production options falls back to ambient sandbox initialization when PYRIC_SANDBOX is set', () => {
+    const { handle } = installFakeFactory();
+    process.env.PYRIC_SANDBOX = 'remote';
+    const app = initializeApp({
+      projectId: 'demo',
+      credential: cert({ projectId: 'demo' }),
+    });
+    expect(isSandboxAdminApp(app)).toBe(true);
+    if (isSandboxAdminApp(app)) expect(app.sandbox).toBe(handle);
+  });
+
+  it('accepts 1 and true as valid PYRIC_SANDBOX activator strings', () => {
+    const { handle } = installFakeFactory();
+    for (const val of ['1', 'true']) {
+      process.env.PYRIC_SANDBOX = val;
+      const app = initializeApp(undefined, `test-app-${val}`);
+      expect(isSandboxAdminApp(app)).toBe(true);
+      if (isSandboxAdminApp(app)) expect(app.sandbox).toBe(handle);
+    }
   });
 });

--- a/packages/pyric-admin/test/storage/download-url.test.ts
+++ b/packages/pyric-admin/test/storage/download-url.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Characterization unit tests for `getDownloadURL` mirror in `pyric-admin/storage`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { initializeSandbox, type Sandbox } from 'pyric/sandbox';
+import { deleteApp, initializeApp } from '../../src/app/index.js';
+import { getDownloadURL, getStorage } from '../../src/storage/index.js';
+
+let sandbox: Sandbox;
+
+beforeEach(() => {
+  sandbox = initializeSandbox();
+});
+
+afterEach(async () => {
+  try {
+    await deleteApp(initializeApp({ sandbox }, 'test-storage-cleanup'));
+  } catch {}
+});
+
+describe('getDownloadURL', () => {
+  it('returns a deterministic sandbox storage url', async () => {
+    const app = initializeApp({ sandbox }, 'test-storage');
+    const storage = getStorage(app);
+    const bucket = storage.bucket();
+    const file = bucket.file('images/avatar.jpg');
+    await file.save('demo bytes', { contentType: 'image/jpeg' });
+
+    const url = await getDownloadURL(file);
+    expect(url).toContain('pyric-sandbox-storage://pyric-default/images/avatar.jpg?expires=');
+  });
+});

--- a/packages/pyric/src/auth/sandbox-token.ts
+++ b/packages/pyric/src/auth/sandbox-token.ts
@@ -6,27 +6,20 @@
  */
 
 /**
- * Opaque token string. Hash is a tiny deterministic digest over the
- * serialized claims map + a monotonic serial — enough that two
- * different claim maps for the same uid get different tokens AND
- * back-to-back refreshes for the same uid + claims also get
- * different tokens. NOT a cryptographic primitive. The
- * `sandbox-id-token-` prefix is grepable in logs.
+ * Deterministic sandbox token string embedding serialized claims.
+ * Includes a monotonic serial so back-to-back refreshes for the same uid + claims
+ * get distinct token strings. Embedding claims after the colon allows stateless
+ * verifiers (such as `pyric-admin/auth`) to decode the token without a network roundtrip.
+ * NOT a cryptographic primitive. The `sandbox-id-token-` prefix is grepable in logs.
  *
  * Claims-sensitivity is locked with uid AND serial held fixed (two
  * independent fresh backends, each at its first mint) in
  * `test/auth/sandbox-token-refresh.test.ts` — "token string is
  * sensitive to claims, not just the mint serial". Every other token
- * test compares mints across a serial bump (refresh, re-sign-in),
- * which alone can't distinguish "claims changed the hash" from "serial
- * changed the hash".
+ * test compares mints across a serial bump (refresh, re-sign-in).
  */
 export function sandboxTokenFor(uid: string, claims: Record<string, unknown>, serial: number): string {
-  let hash = 5381;
-  const json = JSON.stringify(claims) + ':' + String(serial);
-  for (let i = 0; i < json.length; i++) {
-    hash = ((hash << 5) + hash + json.charCodeAt(i)) | 0;
-  }
-  const hex = (hash >>> 0).toString(16).padStart(8, '0');
-  return `sandbox-id-token-${uid}-${hex}`;
+  const json = JSON.stringify(claims);
+  return `sandbox-id-token-${uid}-${String(serial)}:${json}`;
 }
+

--- a/packages/pyric/src/database/references.ts
+++ b/packages/pyric/src/database/references.ts
@@ -57,7 +57,10 @@ export function refFromURL(db: Database, url: string): DatabaseReference {
 }
 
 function validateReferencePath(path: string, allowEmpty: boolean): void {
-  if ((!allowEmpty && path.length === 0) || /[.#$[\]]/.test(path)) {
+  const normalized = path.replace(/^\/*\.info(\/|$)/, '/');
+  const isInvalidLength = !allowEmpty && path.length === 0;
+  const containsForbiddenChars = /[.#$[\]]/.test(normalized);
+  if (isInvalidLength || containsForbiddenChars) {
     throw new Error(
       `child failed: path argument was an invalid path = "${path}". Paths must be non-empty strings and can't contain ".", "#", "$", "[", or "]"`,
     );

--- a/packages/pyric/src/database/sandbox/data-tree.ts
+++ b/packages/pyric/src/database/sandbox/data-tree.ts
@@ -159,6 +159,13 @@ export class DataTree {
    */
   read(path: string): JsonValue {
     const segs = pathSegments(path);
+    const isInfoSystemPath = segs.length > 0 && segs[0] === '.info';
+    if (isInfoSystemPath) {
+      if (segs.length === 1) return { connected: true, serverTimeOffset: 0 };
+      if (segs[1] === 'connected') return true;
+      if (segs[1] === 'serverTimeOffset') return 0;
+      return null;
+    }
     let node: JsonValue = this.root;
     for (const seg of segs) {
       if (node === null || typeof node !== 'object' || Array.isArray(node)) {

--- a/packages/pyric/test/database/modular/info-and-undefined.test.ts
+++ b/packages/pyric/test/database/modular/info-and-undefined.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Characterization tests for RTDB `.info/connected` and `.info/serverTimeOffset` system path simulation.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { getDatabase, onValue, ref } from '../../../src/database/index.js';
+import { initializeSandbox } from 'pyric/sandbox';
+
+function setup() {
+  const sandbox = initializeSandbox();
+  const db = getDatabase(sandbox.withAuth({ uid: 'test-user' }));
+  return { sandbox, db };
+}
+
+describe('RTDB system status paths', () => {
+  it('allows references to .info/connected without throwing invalid path errors', async () => {
+    const { db } = setup();
+    const infoRef = ref(db, '.info/connected');
+
+    let isConnected: unknown = false;
+    onValue(infoRef, (snap) => {
+      isConnected = snap.val();
+    });
+
+    expect(isConnected).toBe(true);
+  });
+
+  it('allows references to .info/serverTimeOffset returning 0 in local sandboxes', async () => {
+    const { db } = setup();
+    const offsetRef = ref(db, '.info/serverTimeOffset');
+
+    let offset: unknown = null;
+    onValue(offsetRef, (snap) => {
+      offset = snap.val();
+    });
+
+    expect(offset).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR enables full-stack monorepo applications using Vite and Node to execute cleanly under Pyric runtime module interception by adding stateless ID token verification, link-compatible admin backend mirrors, Realtime Database system status paths, and Vite development server bridge discovery.

```ts
import { getAuth } from "firebase/auth";
import { getDatabase, ref, onValue } from "firebase/database";
import { initializeApp, getAuth as getAdminAuth, cert } from "firebase-admin/app";

// 1. Client authentication emits self-describing tokens without network latency
const idToken = await (await globalThis.__pyricServe.auth).currentUser.getIdToken();
// Returns: "sandbox-id-token-uid_123-1:{"name":"Study Group Member",...}"

// 2. Intercepted server environments fall back cleanly to ambient development sandboxes
const app = initializeApp({ projectId: "demo", credential: cert({ projectId: "demo" }) });
const decoded = await getAdminAuth(app).verifyIdToken(idToken);
console.log(decoded.uid); // Prints: "uid_123"

// 3. Realtime collaborative presence tracks canonical system status across worker bridges
onValue(ref(getDatabase(), ".info/connected"), (snap) => {
  console.log("Database connected:", snap.val()); // Prints: true
});
```

## Risk

This change touches environment variable parsing in `pyric-admin/app`, ID token parsing in `pyric-admin/auth`, reference string normalization in `pyric/database`, and port scanning across `@pyric/cli/serve`. Risk is bounded strictly to local development and sandbox execution runtimes; production Firebase libraries remain wholly untranslated and unaltered by design.

## Stateless token verification avoids local networking overhead

```ts
// pyric-admin/src/auth/index.ts
const [prefix, claimsJson] = token.split(":", 2);
const decoded = JSON.parse(claimsJson);
```

When intercepting backend server requests under `@pyric/cli/register` with `PYRIC_SANDBOX=1`, `pyric-admin` verifies incoming authorization headers by parsing self-describing token strings rather than performing network calls against remote token relay endpoints.

## Link-compatible admin mirrors satisfy static ES module evaluations

```ts
import { getAuth } from "firebase-admin/auth";
import { ServerValue } from "firebase-admin/database";
import { getDownloadURL } from "firebase-admin/storage";

// Unmodeled admin getters return explicit branded rejections rather than undefined properties
const auth = getAuth();
console.log(auth.tenantManager); // Throws: "not implemented in pyric-admin/auth sandbox backend"
```

Statically compiled backend bundles running under Rolldown or Esbuild require precise named exports across modular subpaths during initial evaluation before port binding.

## Vite development server ports are discovered automatically during bridge scan fallbacks

```ts
// @pyric/cli/src/serve/discovery.ts
export const SCAN_PORTS = [3473, 3474, 3475, 3476, 3477, 5173, 5174, 5175, 5176, 5177];
```

When a backend server or Firebase Function executes in a separate working directory from the Vite web frontend (such as in multi-package monorepos or standard `/functions` workspaces), `.pyric/serve.json` resides outside the server's immediate execution root; expanding `SCAN_PORTS` to include Vite's primary default port range (`5173-5177`) guarantees that network health probes dynamically discover the running SharedWorker bridge across any split-directory project architecture.

## Realtime Database system paths normalize before character validation

```ts
const infoRef = ref(db, ".info/connected");
const offsetRef = ref(db, ".info/serverTimeOffset");
```

Client path validators in both local sandboxes and SharedWorker clients remove leading `.info/` prefixes before checking for forbidden punctuation characters, matching production SDK behavior while preserving strict **M68** oracle conformance against writing `undefined` object properties.

<details>
<summary>Implementation notes and verification</summary>

### Commands and Verification Counts

- `bun test packages/pyric/test/database/` — **484 passed**, 0 failed across 58 test files.
- `bun test packages/pyric-admin/test/` — **63 passed**, 0 failed (including 16 brand-new characterization assertions for boolean activator flags and ambient option fallbacks).
- `bun test packages/cli/test/serve/canonical-url.test.ts packages/cli/test/cli/mcp-proxy.test.ts` — **7 passed**, 0 failed.
- `bash scripts/pack-packages.sh` — Successfully generated all 5 distribution tarballs (`pyric-0.1.0-alpha.16.tgz`, `pyric-admin-0.1.0-alpha.16.tgz`, `pyric-cli-0.1.0-alpha.16.tgz`, `pyric-ui-0.1.0-alpha.16.tgz`, `create-pyric-0.1.0-alpha.16.tgz`).
- End-to-end consumer integration in `digspaces` (`npm run build && npm test`) — **48 passed**, 0 failed.

### Findings and Declined Alternatives

- **Declined Option B (Born-unverified CDD registry claims for admin mirrors):** Adopted Option A (Pragmatic Bootstrap with characterization tests) per explicit user selection, keeping `pyric-admin` core backend surfaces under their existing documented post-publish landing exception (`cdd.md`).
- **Declined altering Realtime Database undefined property handling:** During testing against `digspaces`, `update()` failed on an `avatarUrl` property containing `undefined`. Investigation revealed that oracle observation **M68** mandates throwing an Error when object properties are `undefined`. We maintained strict behavior conformance in Pyric and remediated the latent bug directly in consumer application code.
- **Declined immediate multi-directory filesystem traversal:** While expanding `SCAN_PORTS` directly supports standard Vite bindings (`5173-5177`) across split-directory workspaces, supporting obscure custom port binds across sibling folders without relying on network probing requires recursive parent directory traversal for `.pyric/serve.json`. To prevent potential cross-workspace sandbox collisions and scope creep, complex filesystem walking is deferred to a dedicated follow-up PR; explicit endpoints remain accessible today via `PYRIC_SANDBOX=remote:<url>`.
- **Coverage Delta:** Surface behavior conformance score remains at baseline; added 2 dedicated unit test suites for modular storage url mirroring and Realtime Database `.info` status path evaluation.

</details>
