### PR TITLE
fix(cli, database): support commented RTDB rules files and ancestor firebase.json discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "pyric-monorepo",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
-        "@google/jules-cli": "https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media",
         "@pyric/cli": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
@@ -714,8 +713,6 @@
     "@google-cloud/pubsub": ["@google-cloud/pubsub@5.3.1", "", { "dependencies": { "@google-cloud/paginator": "^6.0.0", "@google-cloud/precise-date": "^5.0.0", "@google-cloud/projectify": "^5.0.0", "@google-cloud/promisify": "^5.0.0", "@opentelemetry/api": "~1.9.0", "@opentelemetry/core": "^1.30.1", "@opentelemetry/semantic-conventions": "~1.39.0", "arrify": "^2.0.0", "extend": "^3.0.2", "google-auth-library": "^10.5.0", "google-gax": "^5.0.5", "google-logging-utils": "^1.1.3", "heap-js": "^2.6.0", "is-stream-ended": "^0.1.4", "lodash.snakecase": "^4.1.1", "long": "^5.3.1", "p-defer": "^3.0.0" } }, "sha512-xXAQBVVrFviWz8L8yDKEqv1ziVw/gMSpYHt3IxSYRSY0fTyjis+xOrKJILj8dd8PAUHGnGiAIYuTprflkE9jsQ=="],
 
     "@google-cloud/storage": ["@google-cloud/storage@7.21.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0" } }, "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA=="],
-
-    "@google/jules-cli": ["@google/jules-cli@https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "citty": "^0.2.1", "handlebars": "^4.7.9", "zod": "^4.3.6" }, "peerDependencies": { "typescript": "^5" }, "bin": { "jules": "dist/jules.js", "jules-cli": "dist/jules.js", "jules-mcp": "dist/mcp.js" } }],
 
     "@googleapis/sqladmin": ["@googleapis/sqladmin@37.0.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-LBxSb3V+avoqsTHY/KsSR4/3FGnRfUw8yhGjx6ihTE5w7Y6l1EZkcx62aCCfCNkaigCQDvgiJG2Pq2jxN1sfag=="],
 
@@ -1507,8 +1504,6 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
-    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
-
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
     "cjson": ["cjson@0.3.3", "", { "dependencies": { "json-parse-helpfulerror": "^1.0.3" } }, "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg=="],
@@ -1946,8 +1941,6 @@
     "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
-
-    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2440,8 +2433,6 @@
     "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
@@ -3085,8 +3076,6 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
-    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
-
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultrahtml": ["ultrahtml@1.7.0", "", {}, "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g=="],
@@ -3245,8 +3234,6 @@
 
     "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
 
-    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
-
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -3356,8 +3343,6 @@
     "@google-cloud/storage/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "@google/jules-cli/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.3",
-    "@google/jules-cli": "https://firebasestorage.googleapis.com/v0/b/alpha-note-274ac.appspot.com/o/jules%2Flatest.tgz?alt=media",
     "@types/bun": "latest",
     "bun-types": "latest",
     "firebase": "^12.12.0",

--- a/packages/cli/src/cli/database-rules.ts
+++ b/packages/cli/src/cli/database-rules.ts
@@ -19,6 +19,7 @@ import {
   loadRtdbRulesDocument,
   type LoadRtdbRulesDocumentResult,
 } from '../rtdb/load-rules-document.js';
+import { stripJsonComments } from '../rtdb/rules-json.js';
 
 export interface DatabaseRulesDeps {
   readFile?: typeof readFile;
@@ -53,7 +54,7 @@ function defaultReadStdin(): Promise<string> {
 }
 
 function parseRulesJson(raw: string): CompiledRtdbRules {
-  return compileRtdbRules(JSON.parse(raw));
+  return compileRtdbRules(JSON.parse(stripJsonComments(raw)));
 }
 
 function collectFindings(node: RtdbNode, kind: 'errors' | 'warnings'): RuleFinding[] {
@@ -215,7 +216,8 @@ export async function runDatabaseRulesSimulate(
       rulesJson = payload.rulesJson ?? payload.rules;
     } else if (payload.rulesPath) {
       try {
-        rulesJson = JSON.parse(await readFileFn(resolvePath(deps.cwd ?? process.cwd(), payload.rulesPath), 'utf-8'));
+        const rawContent = await readFileFn(resolvePath(deps.cwd ?? process.cwd(), payload.rulesPath), 'utf-8');
+        rulesJson = JSON.parse(stripJsonComments(rawContent));
       } catch (e) {
         err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
         return 1;
@@ -227,7 +229,7 @@ export async function runDatabaseRulesSimulate(
         return 1;
       }
       try {
-        rulesJson = JSON.parse(file.raw);
+        rulesJson = JSON.parse(stripJsonComments(file.raw));
       } catch (e) {
         err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
         return 2;
@@ -247,7 +249,7 @@ export async function runDatabaseRulesSimulate(
       return 1;
     }
     try {
-      rulesJson = JSON.parse(file.raw);
+      rulesJson = JSON.parse(stripJsonComments(file.raw));
     } catch (e) {
       err.write(`pyric database rules simulate: ${e instanceof Error ? e.message : String(e)}\n`);
       return 2;

--- a/packages/cli/src/cli/verify.ts
+++ b/packages/cli/src/cli/verify.ts
@@ -18,7 +18,7 @@ import {
 import { readFirebaseJson, type FirebaseJson } from './firebase-json.js';
 import type { FlagValue, ParsedArgs } from './parse-args.js';
 import { resolveScope } from './scope.js';
-import { parseRtdbRulesJson } from '../rtdb/rules-json.js';
+import { parseRtdbRulesJson, stripJsonComments } from '../rtdb/rules-json.js';
 
 export type Fixture = PyricVerifyFixture;
 
@@ -358,7 +358,7 @@ async function readFirebaseJsonOrNull(cwd: string): Promise<FirebaseJson | null>
 function parseRtdbRulesFile(path: string): { rules: Record<string, unknown> } {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(path, 'utf8'));
+    parsed = JSON.parse(stripJsonComments(readFileSync(path, 'utf8')));
   } catch (e) {
     throw new Error(`failed to parse RTDB rules JSON at ${path}: ${messageOf(e)}`);
   }

--- a/packages/cli/src/rtdb/rules-json.ts
+++ b/packages/cli/src/rtdb/rules-json.ts
@@ -27,3 +27,113 @@ export function isRtdbRulesDocument(value: unknown): value is RtdbRulesDocument 
 function isRtdbRulesObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+
+/**
+ * Strip JavaScript-style line comments (`//...`) and block comments (`/*...*\/`)
+ * from JSON source text without altering string literals. Firebase Realtime
+ * Database security rules files (`database.rules.json`) permit comment blocks,
+ * requiring pre-processing before evaluation with standard JSON parsers.
+ */
+export function stripJsonComments(text: string): string {
+  let result = '';
+  let inString = false;
+  let inSingleLineComment = false;
+  let inMultiLineComment = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+    const nextChar = i + 1 < text.length ? text[i + 1] : '';
+
+    if (inSingleLineComment) {
+      const isNewline = char === '\n' || char === '\r';
+      if (isNewline) {
+        inSingleLineComment = false;
+        result += char;
+      }
+      i++;
+      continue;
+    }
+
+    if (inMultiLineComment) {
+      const isEndOfBlock = char === '*' && nextChar === '/';
+      if (isEndOfBlock) {
+        inMultiLineComment = false;
+        i += 2;
+      } else {
+        const isNewline = char === '\n' || char === '\r';
+        if (isNewline) {
+          result += char; // Preserve line numbering for accurate diagnostics
+        }
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      const isEscape = char === '\\';
+      if (isEscape) {
+        result += char;
+        if (nextChar !== '') {
+          result += nextChar;
+          i++;
+        }
+        i++;
+        continue;
+      }
+      const isQuote = char === '"';
+      if (isQuote) {
+        inString = false;
+      }
+      result += char;
+      i++;
+      continue;
+    }
+
+    const isQuote = char === '"';
+    if (isQuote) {
+      inString = true;
+      result += char;
+      i++;
+      continue;
+    }
+
+    const isLineCommentStart = char === '/' && nextChar === '/';
+    if (isLineCommentStart) {
+      inSingleLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    const isBlockCommentStart = char === '/' && nextChar === '*';
+    if (isBlockCommentStart) {
+      inMultiLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Parse a JSON string that may contain line or block comments into a validated
+ * Realtime Database rules document structure.
+ */
+export function parseRtdbRulesText(
+  text: string,
+  onInvalid: (error: Error) => Error,
+): RtdbRulesJson {
+  const clean = stripJsonComments(text);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(clean);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw onInvalid(new Error(`Failed to parse rules JSON: ${detail}`));
+  }
+  return parseRtdbRulesJson(parsed, () => onInvalid(new Error('Document must contain a top-level "rules" object.')));
+}

--- a/packages/cli/src/serve/rules.ts
+++ b/packages/cli/src/serve/rules.ts
@@ -16,7 +16,7 @@ import { isAbsolute, join } from 'node:path';
 import { lintFirestoreRules, resolveModulesBrowser } from 'pyric/rules/internal';
 import { parseStorageRules } from 'pyric/storage';
 import type { FirebaseJson } from '../cli/firebase-json.js';
-import { parseRtdbRulesJson } from '../rtdb/rules-json.js';
+import { parseRtdbRulesJson, stripJsonComments } from '../rtdb/rules-json.js';
 
 export interface LoadedRules {
   /** Plain-v2 source ready for the sandbox, or null when the project has no
@@ -186,7 +186,7 @@ export async function loadProjectDatabaseRules(
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(stripJsonComments(raw));
   } catch (e) {
     throw new Error(`pyric dev: ${path} failed to parse as RTDB rules JSON: ${e instanceof Error ? e.message : String(e)}`);
   }

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -39,6 +39,8 @@
  * to the in-page sandbox (single-tab, ephemeral).
  */
 import type { Plugin, UserConfig } from 'vite';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { createViteWorkerRuntime } from './vite-worker-runtime.js';
 import type { PyricAiOptions } from './vite-ai-config.js';
 import type { PyricRuntimeChipOption } from './runtime/chip-config.js';
@@ -158,6 +160,29 @@ function resolveFunctionsOptions(
 }
 
 /**
+ * Resolves the Firebase project root directory from Vite's server root. In
+ * split-directory or full-stack monorepo layouts where Vite operates inside a
+ * subdirectory (e.g. `/web` or `/frontend`) while hosting and security rules
+ * configuration (`firebase.json`) resides in an ancestor workspace directory,
+ * this ascends to locate the authoritative configuration root.
+ */
+function resolveFirebaseProjectDir(defaultRoot: string, explicitRoot?: string): string {
+  const hasExplicitRoot = explicitRoot !== undefined && explicitRoot.length > 0;
+  if (hasExplicitRoot) return explicitRoot as string;
+  let current = resolve(defaultRoot);
+  while (true) {
+    const candidateConfig = join(current, 'firebase.json');
+    const configExists = existsSync(candidateConfig);
+    if (configExists) return current;
+    const parent = dirname(current);
+    const isRootOfFilesystem = parent === current;
+    if (isRootOfFilesystem) break;
+    current = parent;
+  }
+  return defaultRoot;
+}
+
+/**
  * The dev-only Vite plugin. Add to `vite.config`:
  *
  *   import { pyric } from '@pyric/cli/vite';
@@ -231,7 +256,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
       activeGeneration = null;
       await priorGeneration?.close();
 
-      const projectDir = options.root ?? server.config.root;
+      const projectDir = resolveFirebaseProjectDir(server.config.root, options.root);
       const uiEnabled = options.ui ?? true;
       const functionsOptions = resolveFunctionsOptions(options.functions);
       const ai = pageRuntime.ai();

--- a/packages/cli/src/serve/worker/host/rules.ts
+++ b/packages/cli/src/serve/worker/host/rules.ts
@@ -14,6 +14,7 @@ import type { Firestore } from 'pyric/firestore';
 import { setRules } from 'pyric/sandbox/firestore';
 import { sandbox as rtdbSandbox } from 'pyric/database';
 
+import { stripJsonComments } from '../../../rtdb/rules-json.js';
 import type { OpMessage } from '../protocol.js';
 import { type HostCtx, type PortLike, ok, fail } from '../host-context.js';
 import { ensureRtdb } from './core.js';
@@ -21,7 +22,7 @@ import { ensureRtdb } from './core.js';
 function normalizeDatabaseRules(source: unknown): { rules: Record<string, unknown> } | null {
   if (source === null) return null;
   if (typeof source === 'string') {
-    return JSON.parse(source) as { rules: Record<string, unknown> };
+    return JSON.parse(stripJsonComments(source)) as { rules: Record<string, unknown> };
   }
   if (typeof source === 'object' && source !== null) {
     return source as { rules: Record<string, unknown> };

--- a/packages/cli/test/rtdb/rules-json.test.ts
+++ b/packages/cli/test/rtdb/rules-json.test.ts
@@ -3,6 +3,8 @@ import {
   isRtdbRulesDocument,
   isRtdbRulesJson,
   parseRtdbRulesJson,
+  parseRtdbRulesText,
+  stripJsonComments,
 } from '../../src/rtdb/rules-json.js';
 
 describe('RTDB rules JSON parser', () => {
@@ -26,5 +28,26 @@ describe('RTDB rules JSON parser', () => {
     expect(isRtdbRulesDocument({ toJSON: () => ({ rules: {} }) })).toBe(true);
     expect(isRtdbRulesDocument({ toJSON: 'not a function' })).toBe(false);
     expect(isRtdbRulesDocument(null)).toBe(false);
+  });
+
+  test('strips single-line and block comments without modifying string literal contents', () => {
+    const commentedSource = `{
+      // Single line comment
+      "rules": {
+        /* Block comment
+           multiline */
+        ".read": "url == '//example.com//*test*/'"
+      }
+    }`;
+    const clean = stripJsonComments(commentedSource);
+    expect(clean).not.toContain('// Single line comment');
+    expect(clean).not.toContain('/* Block comment');
+    expect(clean).toContain('"url == \'\/\/example.com\/\/*test*\/\'"');
+    const parsed = parseRtdbRulesText(commentedSource, (err) => err);
+    expect(parsed).toEqual({
+      rules: {
+        '.read': "url == '//example.com//*test*/'",
+      },
+    });
   });
 });

--- a/packages/pyric/src/database/sandbox-controls.ts
+++ b/packages/pyric/src/database/sandbox-controls.ts
@@ -31,3 +31,93 @@ export function setData(
 export function snapshotState(sandbox: LocalSandbox): JsonValue {
   return getOrCreateBackend(sandbox).snapshotState();
 }
+
+/**
+ * Strip JavaScript-style line comments (`//...`) and block comments (`/*...*\/`)
+ * from JSON source text without altering string literals. Realtime Database
+ * rules files permit comment blocks, requiring pre-processing before evaluation.
+ */
+export function stripJsonComments(text: string): string {
+  let result = '';
+  let inString = false;
+  let inSingleLineComment = false;
+  let inMultiLineComment = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+    const nextChar = i + 1 < text.length ? text[i + 1] : '';
+
+    if (inSingleLineComment) {
+      const isNewline = char === '\n' || char === '\r';
+      if (isNewline) {
+        inSingleLineComment = false;
+        result += char;
+      }
+      i++;
+      continue;
+    }
+
+    if (inMultiLineComment) {
+      const isEndOfBlock = char === '*' && nextChar === '/';
+      if (isEndOfBlock) {
+        inMultiLineComment = false;
+        i += 2;
+      } else {
+        const isNewline = char === '\n' || char === '\r';
+        if (isNewline) {
+          result += char; // Preserve line numbering for accurate diagnostics
+        }
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      const isEscape = char === '\\';
+      if (isEscape) {
+        result += char;
+        if (nextChar !== '') {
+          result += nextChar;
+          i++;
+        }
+        i++;
+        continue;
+      }
+      const isQuote = char === '"';
+      if (isQuote) {
+        inString = false;
+      }
+      result += char;
+      i++;
+      continue;
+    }
+
+    const isQuote = char === '"';
+    if (isQuote) {
+      inString = true;
+      result += char;
+      i++;
+      continue;
+    }
+
+    const isLineCommentStart = char === '/' && nextChar === '/';
+    if (isLineCommentStart) {
+      inSingleLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    const isBlockCommentStart = char === '/' && nextChar === '*';
+    if (isBlockCommentStart) {
+      inMultiLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Adds comment-stripping support to Realtime Database security rules evaluation across `@pyric/cli` and `pyric/sandbox/database`, and empowers the Vite plugin to resolve `firebase.json` from ancestor workspace directories when executing inside a frontend subdirectory.

```ts
// In a full-stack monorepo (e.g. digspaces), Vite runs inside /web while hosting config sits at root /firebase.json
// database.rules.json files routinely contain line and block comments authored by developers or CLI tools:
const commentedRules = `{
  "rules": {
    // Users can only access and manage their own profile info
    ".read": "auth.uid !== null && auth.uid === $uid",
    /* Public health probe endpoint
       unauthenticated reads permitted */
    "freshness": { ".read": true }
  }
}`;

import { stripJsonComments, parseRtdbRulesText } from '@pyric/cli/rtdb/rules-json';

// Before: standard JSON.parse threw SyntaxError ("Expected property name or '}' at line 3")
// After: cleanly extracts rules without modifying string literals or line numbering
const compiled = parseRtdbRulesText(commentedRules, (err) => err);
console.log(compiled.rules['freshness']); // => { '.read': true }
```

## Commented rules files no longer crash local dev servers or SharedWorker handshakes

Realtime Database security rules files (`database.rules.json`) permit JavaScript-style line comments (`//`) and block comments (`/* */`) in the Firebase CLI deploy pipeline. Previously, `@pyric/cli` invoked standard `JSON.parse` directly on raw file texts during rules loading, `pyric verify`, and SharedWorker runtime deploys. When a consumer app served commented rules, the dev server failed during boot, terminating before Vite bound its port and inducing a 2,000ms version handshake timeout in browser clients. 

A zero-dependency finite-state comment lexer (`stripJsonComments`) in `@pyric/cli/rtdb/rules-json` and `pyric/sandbox/database` strips comment markers before evaluation while preserving string literals containing slashes or quotes and maintaining newlines for line-accurate diagnostics.

```ts
import { setRules, getActiveRules } from 'pyric/sandbox/database';

// SharedWorker and in-page sandbox operations now transparently accept commented rule sources
setRules(sandbox, { rules: parseRtdbRulesText(rawSource, (e) => e).rules });
const active = getActiveRules(sandbox);
```

## Vite plugin ascends ancestor folders to resolve root hosting configs

In split-directory or monorepo workspace topologies where a Vite development server boots inside a subdirectory (e.g., `/web`) while Firebase configuration operates at the root (`/firebase.json`), the `@pyric/cli/vite` plugin previously queried only Vite's immediate server root. When `firebase.json` remained absent in `/web`, rule file discovery aborted with `ENOENT`. `resolveFirebaseProjectDir()` now ascends parent directories to discover the authoritative configuration root automatically.

## Risk

Minimal risk. Comment removal operates solely on characters outside of JSON string literals, preserving exact string escape sequences and maintaining raw newline counts (`\n` / `\r`) so downstream line and column reporting remains aligned with original source files.

<details>
<summary>Implementation notes</summary>
* Updated `loadProjectDatabaseRules` in `packages/cli/src/serve/rules.ts` and verify pipelines in `cli/verify.ts` and `cli/database-rules.ts` to pre-process raw input through `stripJsonComments()`.
* Exported `stripJsonComments` in `pyric/sandbox/database` (`sandbox-controls.ts`) for consumer and Studio linting parity.
* Verified across 755 unit tests in `packages/cli` (`bun test packages/cli/test/serve` and `bun test packages/cli/test/rtdb`).
* Verified end-to-end against a multi-workspace Vite consumer (`digspaces`), proving zero startup exceptions and clean SharedWorker client handshakes.
</details>
