### PR TITLE
feat(next): add Next.js support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,6 +96,7 @@ map those canonical imports to the sandbox mirrors without changing source.
 - `@pyric/cli/bridge/client`
 - `@pyric/cli/discover`
 - `@pyric/cli/vite`
+- `@pyric/cli/next`
 - `@pyric/cli/serve/worker`
 - `@pyric/cli/remote`
 - `@pyric/cli/register`

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@pyric/cli": "workspace:*",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,26 @@
         "typescript": "^5.7.0",
       },
     },
+    "examples/nextjs-sandbox-app": {
+      "name": "nextjs-sandbox-app",
+      "version": "0.0.0",
+      "dependencies": {
+        "firebase": "^12.12.0",
+        "firebase-admin": "^13.0.0",
+        "next": "^15.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@pyric/cli": "workspace:*",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "pyric": "workspace:*",
+        "pyric-admin": "workspace:*",
+        "typescript": "^5.7.0",
+      },
+    },
     "examples/vite-sandbox-app": {
       "name": "vite-sandbox-app",
       "version": "0.0.0",
@@ -923,6 +943,24 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
+    "@next/env": ["@next/env@15.5.21", "", {}, "sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw=="],
+
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ=="],
+
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A=="],
+
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.21", "", { "os": "linux", "cpu": "x64" }, "sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.21", "", { "os": "linux", "cpu": "x64" }, "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.21", "", { "os": "win32", "cpu": "x64" }, "sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ=="],
+
     "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
@@ -1156,6 +1194,8 @@
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
@@ -1528,6 +1568,8 @@
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -2447,6 +2489,10 @@
 
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
+    "next": ["next@15.5.21", "", { "dependencies": { "@next/env": "15.5.21", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.21", "@next/swc-darwin-x64": "15.5.21", "@next/swc-linux-arm64-gnu": "15.5.21", "@next/swc-linux-arm64-musl": "15.5.21", "@next/swc-linux-x64-gnu": "15.5.21", "@next/swc-linux-x64-musl": "15.5.21", "@next/swc-win32-arm64-msvc": "15.5.21", "@next/swc-win32-x64-msvc": "15.5.21", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ=="],
+
+    "nextjs-sandbox-app": ["nextjs-sandbox-app@workspace:examples/nextjs-sandbox-app"],
+
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
     "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
@@ -2964,6 +3010,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -3570,6 +3618,8 @@
     "morgan/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "nearley/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/examples/nextjs-sandbox-app/.gitignore
+++ b/examples/nextjs-sandbox-app/.gitignore
@@ -1,0 +1,32 @@
+# next.js
+/.next/
+/out/
+/build/
+
+# production
+/build
+/dist
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+.env.pyric
+
+# pyric session files
+.pyric/
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-sandbox-app/README.md
+++ b/examples/nextjs-sandbox-app/README.md
@@ -1,0 +1,27 @@
+# nextjs-sandbox-app
+
+Reference example: a Firebase application built with **Next.js** and the
+`@pyric/cli/next` (`withPyric`) configuration wrapper. This is the exact shape
+scaffolding generates when using `pyric init --template nextjs` or
+`npm create pyric@latest -- --template nextjs`, maintained here as an automated
+verification test and integration reference.
+
+During local development, the application runs entirely against Pyric's local
+sandbox backend—requiring zero Firebase project setup, cloud credentials, or
+Java emulator installation.
+
+- **Develop:** `bun run dev` or `npm run dev` — runs `pyric dev -- next dev`.
+  The `withPyric` wrapper automatically aliases client-side SDK imports to sandbox
+  browser mirrors, preserves `@pyric/cli/register` Node runtime loader interception
+  for Server Components and Route Handlers, and deploys your `firestore.rules`
+  with real-time feedback in Pyric Studio.
+- **Build for production:** `bun run build` or `npm run build` — running `next build`
+  in production mode triggers identity passthrough in `withPyric`, packaging the
+  canonical `firebase` and `firebase-admin` SDKs without modification or runtime
+  overhead. Configure `.env.local` or environment keys using `.env.example` as a reference.
+- **Deploy:** `npx firebase-tools deploy` (via Firebase Web Frameworks) after production build, or deploy standard built artifacts directly to Vercel and cloud compute platforms.
+
+> Your source code imports canonical `firebase/*` and `firebase-admin/*` specifiers
+> uniformly. Switching between local sandbox environments and production cloud
+> infrastructure occurs purely through the environment runtime (`pyric dev` vs `next build`),
+> never requiring code edits.

--- a/examples/nextjs-sandbox-app/firebase.json
+++ b/examples/nextjs-sandbox-app/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/examples/nextjs-sandbox-app/firestore.indexes.json
+++ b/examples/nextjs-sandbox-app/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/examples/nextjs-sandbox-app/firestore.rules
+++ b/examples/nextjs-sandbox-app/firestore.rules
@@ -1,0 +1,20 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Owner-based security rules from line 1 — Pyric deploys and hot-reloads
+    // this configuration into the local sandbox environment. These deploy as-is
+    // to production Firebase instances.
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if request.auth != null
+                    && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if request.auth != null
+                            && resource.data.uid == request.auth.uid;
+    }
+
+    // Default deny — require explicit authorization rules per collection.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/examples/nextjs-sandbox-app/next.config.mjs
+++ b/examples/nextjs-sandbox-app/next.config.mjs
@@ -1,0 +1,14 @@
+import { withPyric } from '@pyric/cli/next';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+// Under development mode (`pyric dev -- next dev`), withPyric maps client-side
+// firebase/* SDK imports to Pyric sandbox adapters via Webpack/Turbopack aliases,
+// externalizes server-side firebase and firebase-admin imports for Node loader
+// hooks (@pyric/cli/register), and proxies /__pyric/* bridge traffic.
+// Under `next build` (mode production), withPyric acts as an identity passthrough,
+// compiling canonical Firebase SDKs untouched with zero runtime overhead.
+export default withPyric(nextConfig);

--- a/examples/nextjs-sandbox-app/next.config.mjs
+++ b/examples/nextjs-sandbox-app/next.config.mjs
@@ -1,8 +1,22 @@
+import { fileURLToPath } from 'node:url';
 import { withPyric } from '@pyric/cli/next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: fileURLToPath(new URL('.', import.meta.url)),
+  allowedDevOrigins: [
+    'localhost',
+    '127.0.0.1',
+    'localhost:3000',
+    '127.0.0.1:3000',
+    'localhost:4000',
+    '127.0.0.1:4000',
+    'localhost:4288',
+    '127.0.0.1:4288',
+    'localhost:4289',
+    '127.0.0.1:4289',
+  ],
 };
 
 // Under development mode (`pyric dev -- next dev`), withPyric maps client-side

--- a/examples/nextjs-sandbox-app/package.json
+++ b/examples/nextjs-sandbox-app/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "nextjs-sandbox-app",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "description": "Reference example: a Next.js app wrapped with @pyric/cli/next — `pyric dev -- next dev` runs against the local sandbox, `next build` ships real Firebase. This is the shape `pyric init --template nextjs` scaffolds.",
+  "scripts": {
+    "dev": "pyric dev -- next dev",
+    "dev:direct": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "firebase": "^12.12.0",
+    "firebase-admin": "^13.0.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@pyric/cli": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "pyric": "workspace:*",
+    "pyric-admin": "workspace:*",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/nextjs-sandbox-app/package.json
+++ b/examples/nextjs-sandbox-app/package.json
@@ -9,6 +9,7 @@
     "dev:direct": "next dev",
     "build": "next build",
     "start": "next start",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@pyric/cli": "workspace:*",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/examples/nextjs-sandbox-app/playwright.config.ts
+++ b/examples/nextjs-sandbox-app/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const cli = fileURLToPath(new URL('../../packages/cli/dist/cli/index.js', import.meta.url));
+
+export default defineConfig({
+  testDir: './test',
+  testMatch: '**/*.pw.ts',
+  timeout: 60_000,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4289',
+    headless: true,
+  },
+  webServer: {
+    command: `bun ${cli} dev --port 4288 --no-open -- bun x next dev --port 4289`,
+    url: 'http://127.0.0.1:4289',
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+});

--- a/examples/nextjs-sandbox-app/src/app/api/status/route.ts
+++ b/examples/nextjs-sandbox-app/src/app/api/status/route.ts
@@ -19,12 +19,28 @@ function resolveRuntimeEnvironment(): string {
   return 'production';
 }
 
+async function fetchPostsSnapshot(db: FirebaseFirestore.Firestore, maxRetries = 6, delayMs = 500): Promise<FirebaseFirestore.QuerySnapshot> {
+  let attempts = 0;
+  for (;;) {
+    try {
+      attempts += 1;
+      const snapshot = await db.collection('posts').get();
+      return snapshot;
+    } catch (error) {
+      if (attempts >= maxRetries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 export async function GET(): Promise<NextResponse> {
   const app = getAdminApp();
   const db = getFirestore(app);
-  
+
   try {
-    const postsSnapshot = await db.collection('posts').get();
+    const postsSnapshot = await fetchPostsSnapshot(db);
     const documentCount = postsSnapshot.size;
     const runtimeTarget = resolveRuntimeEnvironment();
 

--- a/examples/nextjs-sandbox-app/src/app/api/status/route.ts
+++ b/examples/nextjs-sandbox-app/src/app/api/status/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const DEFAULT_PROJECT_ID = 'demo-nextjs-app';
+
+function getAdminApp() {
+  const activeApps = getApps();
+  if (activeApps.length > 0) {
+    return activeApps[0];
+  }
+  return initializeApp({ projectId: DEFAULT_PROJECT_ID });
+}
+
+function resolveRuntimeEnvironment(): string {
+  if (process.env.PYRIC_SANDBOX !== undefined) {
+    return 'pyric-sandbox';
+  }
+  return 'production';
+}
+
+export async function GET(): Promise<NextResponse> {
+  const app = getAdminApp();
+  const db = getFirestore(app);
+  
+  try {
+    const postsSnapshot = await db.collection('posts').get();
+    const documentCount = postsSnapshot.size;
+    const runtimeTarget = resolveRuntimeEnvironment();
+
+    return NextResponse.json({
+      status: 'ok',
+      environment: runtimeTarget,
+      count: documentCount,
+    });
+  } catch (error) {
+    const errCode = (error as { code?: string }).code;
+    const errMessage = errCode !== undefined ? errCode : String(error);
+    return NextResponse.json(
+      { status: 'error', details: errMessage },
+      { status: 500 },
+    );
+  }
+}

--- a/examples/nextjs-sandbox-app/src/app/layout.tsx
+++ b/examples/nextjs-sandbox-app/src/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: 'nextjs-sandbox-app',
+  description: 'Local Firebase development with Pyric and Next.js',
+};
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function RootLayout({ children }: LayoutProps): React.JSX.Element {
+  const containerStyle: React.CSSProperties = {
+    font: '16px/1.5 system-ui, sans-serif',
+    maxWidth: '640px',
+    margin: '3rem auto',
+    padding: '0 1rem',
+  };
+
+  return (
+    <html lang="en">
+      <body style={containerStyle}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/nextjs-sandbox-app/src/app/page.tsx
+++ b/examples/nextjs-sandbox-app/src/app/page.tsx
@@ -93,28 +93,29 @@ export default function HomePage(): React.JSX.Element {
         currentPosts.push(postEntry);
       }
       setPostsList(currentPosts);
-    });
 
-    fetch('/api/status')
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`Server returned HTTP ${response.status}`);
-        }
-        const payload = (await response.json()) as ServerStatusResponse;
-        return payload;
-      })
-      .then((payload) => {
-        if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
-          setBackendApiStatusText(`Server-Side Admin API Runtime: ${payload.environment} (${payload.count} database records)`);
-        } else {
-          const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
-          setBackendApiStatusText(`Server-Side Admin API reported an error: ${failureDetail}`);
-        }
-      })
-      .catch((err: unknown) => {
-        const failureDetail = err instanceof Error ? err.message : String(err);
-        setBackendApiStatusText(`Server-Side Admin API unavailable (${failureDetail})`);
-      });
+      fetch('/api/status')
+        .then(async (response) => {
+          const payload = (await response.json().catch(() => ({ status: 'error', details: `HTTP ${response.status}` }))) as ServerStatusResponse;
+          if (!response.ok) {
+            const failureDetail = payload.details !== undefined ? payload.details : `HTTP ${response.status}`;
+            throw new Error(failureDetail);
+          }
+          return payload;
+        })
+        .then((payload) => {
+          if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
+            setBackendApiStatusText(`Server-Side Admin API Runtime: ${payload.environment} (${payload.count} database records)`);
+          } else {
+            const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
+            setBackendApiStatusText(`Server-Side Admin API reported an error: ${failureDetail}`);
+          }
+        })
+        .catch((err: unknown) => {
+          const failureDetail = err instanceof Error ? err.message : String(err);
+          setBackendApiStatusText(`Server-Side Admin API unavailable (${failureDetail})`);
+        });
+    });
 
     return () => {
       unsubscribeAuth();

--- a/examples/nextjs-sandbox-app/src/app/page.tsx
+++ b/examples/nextjs-sandbox-app/src/app/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useEffect, useState, type FormEvent, type CSSProperties } from 'react';
+import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+  GoogleAuthProvider,
+  type User,
+} from 'firebase/auth';
+import {
+  getFirestore,
+  collection,
+  onSnapshot,
+  addDoc,
+  serverTimestamp,
+  type DocumentData,
+} from 'firebase/firestore';
+
+interface PostRecord {
+  id: string;
+  title: string;
+  uid: string;
+}
+
+interface ServerStatusResponse {
+  status: string;
+  environment?: string;
+  count?: number;
+  details?: string;
+}
+
+const DEFAULT_FIREBASE_CONFIG = {
+  apiKey: 'demo-api-key',
+  authDomain: 'demo-nextjs-app.firebaseapp.com',
+  projectId: 'demo-nextjs-app',
+};
+
+function resolveClientFirebaseApp(): FirebaseApp {
+  const existingApps = getApps();
+  if (existingApps.length > 0) {
+    return getApp();
+  }
+  return initializeApp(DEFAULT_FIREBASE_CONFIG);
+}
+
+function resolveUserDisplayLabel(currentUser: User): string {
+  if (currentUser.displayName !== null && currentUser.displayName !== '') {
+    return `Signed in as ${currentUser.displayName}`;
+  }
+  if (currentUser.email !== null && currentUser.email !== '') {
+    return `Signed in as ${currentUser.email}`;
+  }
+  return `Signed in as ${currentUser.uid}`;
+}
+
+export default function HomePage(): React.JSX.Element {
+  const [activeUser, setActiveUser] = useState<User | null>(null);
+  const [postsList, setPostsList] = useState<PostRecord[]>([]);
+  const [newPostTitle, setNewPostTitle] = useState<string>('');
+  const [authStatusText, setAuthStatusText] = useState<string>('Checking authentication state...');
+  const [backendApiStatusText, setBackendApiStatusText] = useState<string>('Connecting to Server API...');
+
+  useEffect(() => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const firestoreDb = getFirestore(clientApp);
+
+    const unsubscribeAuth = onAuthStateChanged(authService, (userState) => {
+      setActiveUser(userState);
+      if (userState !== null) {
+        const userLabel = resolveUserDisplayLabel(userState);
+        setAuthStatusText(userLabel);
+      } else {
+        setAuthStatusText('Signed out');
+      }
+    });
+
+    const postsCollectionRef = collection(firestoreDb, 'posts');
+    const unsubscribeSnapshot = onSnapshot(postsCollectionRef, (snapshot) => {
+      const currentPosts: PostRecord[] = [];
+      for (const documentSnapshot of snapshot.docs) {
+        const rawData = documentSnapshot.data() as DocumentData;
+        const documentTitle = typeof rawData.title === 'string' ? rawData.title : 'Untitled Post';
+        const authorId = typeof rawData.uid === 'string' ? rawData.uid : 'anonymous';
+        const postEntry: PostRecord = {
+          id: documentSnapshot.id,
+          title: documentTitle,
+          uid: authorId,
+        };
+        currentPosts.push(postEntry);
+      }
+      setPostsList(currentPosts);
+    });
+
+    fetch('/api/status')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Server returned HTTP ${response.status}`);
+        }
+        const payload = (await response.json()) as ServerStatusResponse;
+        return payload;
+      })
+      .then((payload) => {
+        if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
+          setBackendApiStatusText(`Server-Side Admin API Runtime: ${payload.environment} (${payload.count} database records)`);
+        } else {
+          const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
+          setBackendApiStatusText(`Server-Side Admin API reported an error: ${failureDetail}`);
+        }
+      })
+      .catch((err: unknown) => {
+        const failureDetail = err instanceof Error ? err.message : String(err);
+        setBackendApiStatusText(`Server-Side Admin API unavailable (${failureDetail})`);
+      });
+
+    return () => {
+      unsubscribeAuth();
+      unsubscribeSnapshot();
+    };
+  }, []);
+
+  const onSignInClicked = async () => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const googleProvider = new GoogleAuthProvider();
+    await signInWithPopup(authService, googleProvider);
+  };
+
+  const onSignOutClicked = async () => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    await signOut(authService);
+  };
+
+  const onPostFormSubmitted = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const firestoreDb = getFirestore(clientApp);
+    const currentUser = authService.currentUser;
+
+    const trimmedTitle = newPostTitle.trim();
+    if (trimmedTitle === '') {
+      return;
+    }
+
+    try {
+      const postsCollectionRef = collection(firestoreDb, 'posts');
+      const authorId = currentUser !== null ? currentUser.uid : 'anonymous';
+      await addDoc(postsCollectionRef, {
+        title: trimmedTitle,
+        uid: authorId,
+        createdAt: serverTimestamp(),
+      });
+      setNewPostTitle('');
+    } catch (writeError) {
+      const errorCode = (writeError as { code?: string }).code;
+      const displayMessage = errorCode !== undefined ? errorCode : String(writeError);
+      if (currentUser !== null) {
+        setAuthStatusText(`Write operation failed: ${displayMessage}`);
+      } else {
+        setAuthStatusText('Denied by security rules (signed out) — check the Traffic tab in Pyric Studio.');
+      }
+    }
+  };
+
+  const buttonStyle: CSSProperties = { padding: '0.4rem 0.9rem', cursor: 'pointer' };
+  const inputStyle: CSSProperties = { flex: 1, padding: '0.4rem 0.6rem' };
+  const formStyle: CSSProperties = { display: 'flex', gap: '0.5rem', margin: '1rem 0' };
+
+  return (
+    <main>
+      <h1>nextjs-sandbox-app</h1>
+      <p id="auth-status" style={{ color: '#555', fontWeight: 'bold' }}>
+        {authStatusText}
+      </p>
+      <p id="api-status" style={{ color: '#0066cc', fontSize: '0.9rem', marginBottom: '1rem' }}>
+        {backendApiStatusText}
+      </p>
+
+      {activeUser === null ? (
+        <button id="sign-in-button" type="button" onClick={onSignInClicked} style={buttonStyle}>
+          Sign in with Google
+        </button>
+      ) : (
+        <button id="sign-out-button" type="button" onClick={onSignOutClicked} style={buttonStyle}>
+          Sign out
+        </button>
+      )}
+
+      <form id="add-post-form" onSubmit={onPostFormSubmitted} style={formStyle}>
+        <input
+          id="post-title-input"
+          type="text"
+          value={newPostTitle}
+          onChange={(event) => setNewPostTitle(event.target.value)}
+          placeholder="Post title"
+          required
+          style={inputStyle}
+        />
+        <button id="submit-post-button" type="submit" style={buttonStyle}>
+          Add post
+        </button>
+      </form>
+
+      <h2>Posts</h2>
+      {postsList.length === 0 ? (
+        <p style={{ color: '#888', fontStyle: 'italic' }}>No posts yet in database.</p>
+      ) : (
+        <ul id="posts-list" style={{ paddingLeft: '1.2rem' }}>
+          {postsList.map((postItem) => (
+            <li key={postItem.id}>
+              <strong>{postItem.title}</strong>{' '}
+              <span style={{ color: '#777', fontSize: '0.8rem' }}>(by {postItem.uid})</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/examples/nextjs-sandbox-app/test/auth-post.pw.ts
+++ b/examples/nextjs-sandbox-app/test/auth-post.pw.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+test('handles authentication and adding a post without errors from pyric', async ({ page }) => {
+  const consoleMessages: string[] = [];
+  const consoleErrors: string[] = [];
+
+  page.on('console', (msg) => {
+    const text = msg.text();
+    console.log('[Browser Console]:', text);
+    consoleMessages.push(text);
+    if (msg.type() === 'error') {
+      consoleErrors.push(text);
+    }
+  });
+
+  const pageErrors: Error[] = [];
+  page.on('pageerror', (err) => {
+    console.log('[Browser PageError]:', err.message, err.stack);
+    pageErrors.push(err);
+  });
+
+  await page.goto('/');
+
+  await expect(page.locator('#auth-status')).toHaveText('Signed out', { timeout: 15_000 });
+  await expect(page.locator('#api-status')).toContainText('Server-Side Admin API Runtime: pyric-sandbox (0 database records)', { timeout: 15_000 });
+
+  await page.evaluate(() => new Promise<void>((resolve, reject) => {
+    const workerGeneration = localStorage.getItem('pyric:worker-generation');
+    const workerName = workerGeneration !== null ? `pyric-shared-worker:${workerGeneration}` : 'pyric-shared-worker';
+    const worker = new SharedWorker('/__pyric/sdk/worker.js', {
+      type: 'classic',
+      name: workerName,
+    });
+    const operationId = `enable-google-${Date.now()}`;
+    worker.port.onmessage = (event) => {
+      const payload = event.data as { t?: string; id?: string; ok?: boolean; error?: { message?: string } };
+      if (payload.t !== 'res' || payload.id !== operationId) {
+        return;
+      }
+      worker.port.close();
+      if (payload.ok === true) {
+        resolve();
+      } else {
+        const errMessage = payload.error?.message !== undefined ? payload.error.message : 'Worker operation failed';
+        reject(new Error(errMessage));
+      }
+    };
+    worker.port.start();
+    worker.port.postMessage({
+      t: 'op',
+      id: operationId,
+      method: 'auth.setProviderConfig',
+      providerId: 'google.com',
+      enabled: true,
+    });
+  }));
+
+  await page.locator('#sign-in-button').click();
+  const pyricAuthDialog = page.locator('dialog[data-pyric-auth]');
+  await expect(pyricAuthDialog).toBeVisible({ timeout: 10_000 });
+
+  await pyricAuthDialog.locator('input[type="email"]').fill('ada@example.com');
+  await pyricAuthDialog.locator('input[placeholder="Display name (optional)"]').fill('Ada Lovelace');
+  await pyricAuthDialog.locator('button.submit').click();
+
+  await expect(page.locator('#auth-status')).toHaveText('Signed in as Ada Lovelace', { timeout: 15_000 });
+  await expect(pyricAuthDialog).toBeHidden();
+
+  await page.locator('#post-title-input').fill('Hello Pyric Sandbox!');
+  await page.locator('#submit-post-button').click();
+
+  const postsListLocator = page.locator('#posts-list');
+  await expect(postsListLocator).toBeVisible({ timeout: 10_000 });
+  await expect(postsListLocator).toContainText('Hello Pyric Sandbox!');
+  await expect(postsListLocator).toContainText('(by ');
+
+  await expect(page.locator('#api-status')).toContainText('Server-Side Admin API Runtime: pyric-sandbox (1 database records)', { timeout: 15_000 });
+
+  for (const errText of consoleErrors) {
+    expect(errText).not.toContain('pyric');
+    expect(errText).not.toContain('operation-not-allowed');
+    expect(errText).not.toContain('permission-denied');
+    expect(errText).not.toContain('500');
+  }
+
+  expect(pageErrors, `Unexpected page errors occurred: ${pageErrors.map((e) => e.message).join(', ')}`).toHaveLength(0);
+});

--- a/examples/nextjs-sandbox-app/tsconfig.json
+++ b/examples/nextjs-sandbox-app/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "packages/*",
     "examples/admin-playground",
     "examples/vite-sandbox-app",
+    "examples/nextjs-sandbox-app",
     "packages/create-pyric/templates/chat",
     "packages/create-pyric/templates/chat/functions"
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,10 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
     },
+    "./next": {
+      "types": "./dist/next/index.d.ts",
+      "import": "./dist/next/index.js"
+    },
     "./serve/worker": {
       "types": "./dist/serve/worker/index.d.ts",
       "import": "./dist/serve/worker/index.js"

--- a/packages/cli/src/cli/cli.test.ts
+++ b/packages/cli/src/cli/cli.test.ts
@@ -490,4 +490,18 @@ describe('scanForInlinedFirebase', () => {
     );
     expect(scanForInlinedFirebase(dir)).toEqual([]);
   });
+
+  it('ignores hidden frameworks and build cache directories like .next and .git', async () => {
+    const { scanForInlinedFirebase } = await import('./serve.js');
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-inline-ignore-'));
+    mkdirSync(join(dir, '.next'));
+    writeFileSync(
+      join(dir, '.next', 'bundle.js'),
+      'fetch("https://identitytoolkit.googleapis.com/v1/projects?key="+k)',
+    );
+    expect(scanForInlinedFirebase(dir)).toEqual([]);
+  });
 });

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -570,7 +570,8 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
 
   const json = Boolean(parsed.flags.get('json'));
 
-  const uiOn = Boolean(parsed.flags.get('ui'));
+  const explicitUi = Boolean(parsed.flags.get('ui'));
+  const uiOn = !parsed.flags.get('no-ui');
 
   // Resolve the child plan BEFORE the server starts: a planned child implies
   // the bridge (see bridgeEnabledFor) — the child's injected PYRIC_SANDBOX
@@ -661,8 +662,9 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     env: process.env,
   });
   if (opened) {
-    // With --ui, open Studio directly; the served page is still available.
-    void openBrowser(runtime.uiUrl ?? runtime.handle.url);
+    // When explicit --ui is passed, open Studio directly; otherwise open the served page.
+    const targetUrl = explicitUi && runtime.uiUrl !== null ? runtime.uiUrl : runtime.handle.url;
+    void openBrowser(targetUrl);
   }
 
   let devChild: DevChildHandle | null = null;
@@ -886,7 +888,8 @@ export function scanForInlinedFirebase(dir: string): string[] {
       if (st.isDirectory()) {
         // The pyric namespace itself never lands in hosting.public, but a
         // node_modules inside a served dir would be a scan-cost trap.
-        if (name === 'node_modules') continue;
+        // Dot-directories (.next, .git, .pyric) are internal caches and must be ignored.
+        if (name === 'node_modules' || name.startsWith('.')) continue;
         walk(p, r, depth + 1);
       } else if (/\.(js|mjs)$/.test(name)) {
         scanned++;

--- a/packages/cli/src/next/client-aliases.ts
+++ b/packages/cli/src/next/client-aliases.ts
@@ -1,0 +1,39 @@
+/**
+ * Client-side module aliasing definitions for Firebase Web SDKs.
+ */
+import { defaultSdkEntries } from '../serve/bundler.js';
+
+/**
+ * Retrieve the explicit map of canonical Firebase import specifiers to their
+ * standalone Pyric browser wrapper entries.
+ */
+export function getClientAliases(): Record<string, string> {
+  const entries = defaultSdkEntries();
+  const aliases: Record<string, string> = {
+    'firebase/ai': entries.ai,
+    'firebase/app': entries.app,
+    'firebase/auth': entries.auth,
+    'firebase/firestore': entries.firestore,
+    'firebase/database': entries.database,
+    'firebase/messaging': entries.messaging,
+    'firebase/messaging/sw': entries['messaging-sw'],
+    'firebase/storage': entries.storage,
+  };
+  return aliases;
+}
+
+/**
+ * Retrieve benign boolean fallback replacements for Node built-in modules
+ * accessible in browser packaging bundles.
+ */
+export function getNodeBuiltinFallbacks(): Record<string, boolean> {
+  const fallbacks: Record<string, boolean> = {
+    fs: false,
+    path: false,
+    url: false,
+    'node:fs': false,
+    'node:path': false,
+    'node:url': false,
+  };
+  return fallbacks;
+}

--- a/packages/cli/src/next/dev-rewrites.ts
+++ b/packages/cli/src/next/dev-rewrites.ts
@@ -1,0 +1,77 @@
+/**
+ * Next.js dev-time rewrite rules for routing Pyric bridge and socket traffic.
+ */
+import type { NextConfigObject, PyricNextOptions } from './types.js';
+import { resolveSandboxTargetUrl } from './target-url.js';
+
+const PYRIC_PROXY_SOURCE = '/__pyric/:path*';
+const PYRIC_PROXY_PATH = '/__pyric/:path*';
+
+interface RewriteRule {
+  source: string;
+  destination: string;
+}
+
+interface RewritesObject {
+  beforeFiles?: RewriteRule[];
+  afterFiles?: RewriteRule[];
+  fallback?: RewriteRule[];
+  [key: string]: unknown;
+}
+
+function shouldSkipRewrites(options?: PyricNextOptions): boolean {
+  if (options === undefined) {
+    return false;
+  }
+  return options.rewrites === false;
+}
+
+function assembleRewriteRule(options?: PyricNextOptions): RewriteRule {
+  const targetUrl = resolveSandboxTargetUrl(options);
+  const destinationUrl = `${targetUrl}${PYRIC_PROXY_PATH}`;
+  const rule: RewriteRule = {
+    source: PYRIC_PROXY_SOURCE,
+    destination: destinationUrl,
+  };
+  return rule;
+}
+
+function prependToArrayRewrites(existing: RewriteRule[], pyricRule: RewriteRule): RewriteRule[] {
+  const combinedRules = [pyricRule, ...existing];
+  return combinedRules;
+}
+
+function prependToObjectRewrites(existing: RewritesObject, pyricRule: RewriteRule): RewritesObject {
+  const beforeFilesList = Array.isArray(existing.beforeFiles) ? existing.beforeFiles : [];
+  const updatedBeforeFiles = [pyricRule, ...beforeFilesList];
+  const updatedObject: RewritesObject = Object.assign({}, existing, { beforeFiles: updatedBeforeFiles });
+  return updatedObject;
+}
+
+/**
+ * Attach Pyric dev-time rewrites to ensure zero-CORS browser runtime communication.
+ */
+export function augmentDevRewrites(config: NextConfigObject, options?: PyricNextOptions): NextConfigObject {
+  if (shouldSkipRewrites(options)) {
+    return config;
+  }
+
+  const updatedConfig: NextConfigObject = Object.assign({}, config);
+  const pyricRule = assembleRewriteRule(options);
+  const originalRewrites = updatedConfig.rewrites;
+
+  updatedConfig.rewrites = async () => {
+    if (typeof originalRewrites === 'function') {
+      const existingRewrites = await originalRewrites();
+      if (Array.isArray(existingRewrites)) {
+        return prependToArrayRewrites(existingRewrites, pyricRule);
+      }
+      if (typeof existingRewrites === 'object' && existingRewrites !== null) {
+        return prependToObjectRewrites(existingRewrites as RewritesObject, pyricRule);
+      }
+    }
+    return [pyricRule];
+  };
+
+  return updatedConfig;
+}

--- a/packages/cli/src/next/guard.ts
+++ b/packages/cli/src/next/guard.ts
@@ -1,0 +1,61 @@
+/**
+ * Execution policies and safety interlocks for Next.js configuration loading.
+ */
+import type { PyricNextOptions } from './types.js';
+
+const PRODUCTION_ENVIRONMENT = 'production';
+const FORCED_SANDBOX_FLAG = '1';
+
+/**
+ * Check whether the active environment requires production build passthrough
+ * without Pyric sandbox module substitution.
+ */
+export function isProductionPassthrough(): boolean {
+  const isProductionEnv = process.env.NODE_ENV === PRODUCTION_ENVIRONMENT;
+  const isForcedOverride = process.env.PYRIC_SANDBOX_FORCE === FORCED_SANDBOX_FLAG;
+  if (!isProductionEnv) {
+    return false;
+  }
+  return !isForcedOverride;
+}
+
+/**
+ * Check whether the developer opted out of the sandbox environment guard.
+ */
+function isGuardExplicitlyDisabled(options?: PyricNextOptions): boolean {
+  if (options === undefined) {
+    return false;
+  }
+  return options.guard === false;
+}
+
+/**
+ * Check whether an active Pyric sandbox environment variable is present in the process.
+ */
+function hasActiveSandboxEnvironment(): boolean {
+  const sandboxValue = process.env.PYRIC_SANDBOX;
+  if (sandboxValue === undefined) {
+    return false;
+  }
+  return sandboxValue.length > 0;
+}
+
+/**
+ * Verify whether the Next.js development server is booting under a secure,
+ * activated sandbox environment. Throws a protective terminal error if un-sandboxed.
+ */
+export function enforceSandboxGuard(options?: PyricNextOptions): void {
+  if (isGuardExplicitlyDisabled(options)) {
+    return;
+  }
+  if (hasActiveSandboxEnvironment()) {
+    return;
+  }
+  const errorMessage =
+    '[Pyric] Next.js development server started without active Pyric sandbox environment variables.\n' +
+    'To prevent accidental connections to production Firebase databases, launch this server using:\n' +
+    '  pyric dev -- next dev\n' +
+    'or source environment keys via `pyric env`.\n' +
+    'To disable this guard, pass { guard: false } to withPyric(config, options).';
+  throw new Error(errorMessage);
+}

--- a/packages/cli/src/next/index.ts
+++ b/packages/cli/src/next/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@pyric/cli/next` — the dev-only Next.js configuration wrapper (`withPyric`)
+ * that configures module aliasing for Webpack & Turbopack, externalizes server
+ * SDKs for Node runtime loader interception, and establishes dev-time rewrites
+ * for Pyric sandbox socket & bridge communication.
+ *
+ *   import { withPyric } from '@pyric/cli/next';
+ *   export default withPyric({ /* your next config * / });
+ */
+export { withPyric } from './with-pyric.js';
+export type {
+  PyricNextOptions,
+  NextConfig,
+  NextConfigObject,
+  NextConfigFunction,
+} from './types.js';

--- a/packages/cli/src/next/runtime-env.ts
+++ b/packages/cli/src/next/runtime-env.ts
@@ -1,0 +1,18 @@
+/**
+ * Augment Next.js configuration environment variables to pass Pyric runtime
+ * options (such as chip state) down into browser client builds.
+ */
+import type { NextConfigObject, PyricNextOptions } from './types.js';
+import { runtimeChipMetaValue } from '../serve/runtime/chip-config.js';
+
+export function augmentRuntimeEnv(config: NextConfigObject, options?: PyricNextOptions): NextConfigObject {
+  if (options === undefined || options.runtimeChip === undefined) {
+    return config;
+  }
+  const updatedConfig: NextConfigObject = Object.assign({}, config);
+  const existingEnv = updatedConfig.env !== undefined ? Object.assign({}, updatedConfig.env) : {};
+  const chipValue = runtimeChipMetaValue(options.runtimeChip);
+  existingEnv.PYRIC_RUNTIME_CHIP = chipValue;
+  updatedConfig.env = existingEnv;
+  return updatedConfig;
+}

--- a/packages/cli/src/next/server-external-packages.ts
+++ b/packages/cli/src/next/server-external-packages.ts
@@ -1,0 +1,43 @@
+/**
+ * Server module externalization logic for Next.js runtime loader interception.
+ */
+import type { NextConfigObject } from './types.js';
+
+const TARGET_SERVER_PACKAGES = ['firebase', 'firebase-admin'];
+
+function appendExternalPackages(existingPackages?: unknown): string[] {
+  const packageSet = new Set<string>();
+  if (Array.isArray(existingPackages)) {
+    for (const pkg of existingPackages) {
+      if (typeof pkg === 'string') {
+        packageSet.add(pkg);
+      }
+    }
+  }
+  for (const pkg of TARGET_SERVER_PACKAGES) {
+    packageSet.add(pkg);
+  }
+  return Array.from(packageSet);
+}
+
+/**
+ * Inject Pyric backend target packages into `serverExternalPackages` so Next.js
+ * avoids inlining them during Server Component and API Route bundling.
+ */
+export function augmentServerExternalPackages(config: NextConfigObject): NextConfigObject {
+  const updatedConfig: NextConfigObject = Object.assign({}, config);
+
+  const currentExternalPackages = updatedConfig.serverExternalPackages;
+  updatedConfig.serverExternalPackages = appendExternalPackages(currentExternalPackages);
+
+  const hasExperimentalSection = typeof updatedConfig.experimental === 'object' && updatedConfig.experimental !== null;
+  const shouldAugmentLegacySection = hasExperimentalSection || updatedConfig.serverExternalPackages === undefined;
+  if (shouldAugmentLegacySection) {
+    const experimentalSection = hasExperimentalSection ? Object.assign({}, updatedConfig.experimental) : {};
+    const legacyPackages = experimentalSection.serverComponentsExternalPackages;
+    experimentalSection.serverComponentsExternalPackages = appendExternalPackages(legacyPackages);
+    updatedConfig.experimental = experimentalSection;
+  }
+
+  return updatedConfig;
+}

--- a/packages/cli/src/next/target-url.ts
+++ b/packages/cli/src/next/target-url.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolution logic for determining the local Pyric dev server URL.
+ */
+import type { PyricNextOptions } from './types.js';
+
+const DEFAULT_LOOPBACK_HOST = 'http://127.0.0.1';
+const DEFAULT_SANDBOX_PORT = 4000;
+const REMOTE_PREFIX = 'remote:';
+
+function stripTrailingSlash(url: string): string {
+  if (url.endsWith('/')) {
+    return url.slice(0, -1);
+  }
+  return url;
+}
+
+/**
+ * Resolve the destination URL for Next.js dev-time rewrites using explicit
+ * fallback precedence: option URL → option port → PYRIC_SANDBOX remote URL →
+ * PYRIC_SANDBOX_PORT → default port 4000.
+ */
+export function resolveSandboxTargetUrl(options?: PyricNextOptions): string {
+  if (options !== undefined && options.url !== undefined) {
+    return stripTrailingSlash(options.url);
+  }
+
+  if (options !== undefined && options.port !== undefined) {
+    return `${DEFAULT_LOOPBACK_HOST}:${options.port}`;
+  }
+
+  const envSandbox = process.env.PYRIC_SANDBOX;
+  if (envSandbox !== undefined && envSandbox.startsWith(REMOTE_PREFIX)) {
+    const rawRemoteUrl = envSandbox.slice(REMOTE_PREFIX.length);
+    return stripTrailingSlash(rawRemoteUrl);
+  }
+
+  const envPort = process.env.PYRIC_SANDBOX_PORT;
+  if (envPort !== undefined) {
+    const parsedPort = Number(envPort);
+    if (!Number.isNaN(parsedPort)) {
+      return `${DEFAULT_LOOPBACK_HOST}:${parsedPort}`;
+    }
+  }
+
+  return `${DEFAULT_LOOPBACK_HOST}:${DEFAULT_SANDBOX_PORT}`;
+}

--- a/packages/cli/src/next/turbopack-config.ts
+++ b/packages/cli/src/next/turbopack-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Turbopack configuration augmentation for Next.js client SDK aliases.
+ */
+import type { NextConfigObject } from './types.js';
+import { getClientAliases } from './client-aliases.js';
+
+function assembleTurbopackAliases(existingTurbo: Record<string, any> | undefined): Record<string, any> {
+  const turboSection = existingTurbo !== undefined ? Object.assign({}, existingTurbo) : {};
+  const currentAliases = turboSection.resolveAlias !== undefined ? Object.assign({}, turboSection.resolveAlias) : {};
+  const pyricAliases = getClientAliases();
+  turboSection.resolveAlias = Object.assign(currentAliases, pyricAliases);
+  return turboSection;
+}
+
+/**
+ * Configure Turbopack module aliases across standard and experimental sections.
+ */
+export function augmentTurbopackConfig(config: NextConfigObject): NextConfigObject {
+  const updatedConfig: NextConfigObject = Object.assign({}, config);
+
+  const hasTopLevelTurbo = typeof updatedConfig.turbo === 'object' && updatedConfig.turbo !== null;
+  const hasExperimentalTurbo =
+    typeof updatedConfig.experimental === 'object' &&
+    updatedConfig.experimental !== null &&
+    typeof updatedConfig.experimental.turbo === 'object' &&
+    updatedConfig.experimental.turbo !== null;
+
+  const shouldConfigureTopLevel = hasTopLevelTurbo || !hasExperimentalTurbo;
+  if (shouldConfigureTopLevel) {
+    const currentTurbo = updatedConfig.turbo;
+    updatedConfig.turbo = assembleTurbopackAliases(currentTurbo);
+  }
+
+  if (hasExperimentalTurbo) {
+    const experimentalSection = Object.assign({}, updatedConfig.experimental);
+    const currentTurbo = experimentalSection.turbo;
+    experimentalSection.turbo = assembleTurbopackAliases(currentTurbo);
+    updatedConfig.experimental = experimentalSection;
+  }
+
+  return updatedConfig;
+}

--- a/packages/cli/src/next/turbopack-config.ts
+++ b/packages/cli/src/next/turbopack-config.ts
@@ -17,26 +17,38 @@ function assembleTurbopackAliases(existingTurbo: Record<string, any> | undefined
  */
 export function augmentTurbopackConfig(config: NextConfigObject): NextConfigObject {
   const updatedConfig: NextConfigObject = Object.assign({}, config);
-
-  const hasTopLevelTurbo = typeof updatedConfig.turbo === 'object' && updatedConfig.turbo !== null;
+  const hasModernTurbopack = typeof updatedConfig.turbopack === 'object' && updatedConfig.turbopack !== null;
+  const hasLegacyTopLevelTurbo = typeof updatedConfig.turbo === 'object' && updatedConfig.turbo !== null;
   const hasExperimentalTurbo =
     typeof updatedConfig.experimental === 'object' &&
     updatedConfig.experimental !== null &&
     typeof updatedConfig.experimental.turbo === 'object' &&
     updatedConfig.experimental.turbo !== null;
 
-  const shouldConfigureTopLevel = hasTopLevelTurbo || !hasExperimentalTurbo;
-  if (shouldConfigureTopLevel) {
+  const shouldDefaultToModernTurbopack =
+    !hasModernTurbopack && !hasLegacyTopLevelTurbo && !hasExperimentalTurbo;
+
+  if (hasModernTurbopack || shouldDefaultToModernTurbopack) {
+    const currentTurbopack = updatedConfig.turbopack;
+    updatedConfig.turbopack = assembleTurbopackAliases(currentTurbopack);
+  }
+
+  if (hasLegacyTopLevelTurbo) {
     const currentTurbo = updatedConfig.turbo;
     updatedConfig.turbo = assembleTurbopackAliases(currentTurbo);
   }
 
   if (hasExperimentalTurbo) {
-    const experimentalSection = Object.assign({}, updatedConfig.experimental);
-    const currentTurbo = experimentalSection.turbo;
-    experimentalSection.turbo = assembleTurbopackAliases(currentTurbo);
-    updatedConfig.experimental = experimentalSection;
+    const existingExperimental =
+      typeof updatedConfig.experimental === 'object' && updatedConfig.experimental !== null
+        ? Object.assign({}, updatedConfig.experimental)
+        : {};
+    const currentTurbo = existingExperimental.turbo;
+    existingExperimental.turbo = assembleTurbopackAliases(currentTurbo);
+    updatedConfig.experimental = existingExperimental;
   }
 
   return updatedConfig;
 }
+
+

--- a/packages/cli/src/next/types.ts
+++ b/packages/cli/src/next/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Public configuration types for the `@pyric/cli/next` integration.
+ */
+
+export interface PyricNextOptions {
+  /**
+   * Guard against starting Next.js dev server directly (`next dev`) without
+   * active Pyric sandbox environment variables. When `true` (default), throws
+   * an early error if `PYRIC_SANDBOX` is missing during development builds.
+   * Pass `false` to opt out of safety checking.
+   */
+  guard?: boolean;
+  /**
+   * Port override for the local Pyric sandbox server when configuring dev-time
+   * rewrites (`/__pyric/:path*`). By default, resolves from `PYRIC_SANDBOX`
+   * or `PYRIC_SANDBOX_PORT`, falling back to `4000`.
+   */
+  port?: number;
+  /**
+   * Explicit URL override for the local Pyric sandbox server when configuring
+   * dev-time rewrites (e.g., `http://localhost:4000`).
+   */
+  url?: string;
+  /**
+   * Whether to configure Next.js dev-time rewrites to proxy `/__pyric/:path*`
+   * traffic to the local Pyric dev server. Default `true`.
+   */
+  rewrites?: boolean;
+}
+
+export type NextConfigObject = Record<string, any>;
+
+export type NextConfigFunction = (
+  phase: string,
+  defaults: Record<string, any>,
+) => NextConfigObject | Promise<NextConfigObject>;
+
+export type NextConfig = NextConfigObject | NextConfigFunction;

--- a/packages/cli/src/next/types.ts
+++ b/packages/cli/src/next/types.ts
@@ -2,6 +2,9 @@
  * Public configuration types for the `@pyric/cli/next` integration.
  */
 
+import type { PyricRuntimeChipOption } from '../serve/runtime/chip-config.js';
+export type { PyricRuntimeChipOption };
+
 export interface PyricNextOptions {
   /**
    * Guard against starting Next.js dev server directly (`next dev`) without
@@ -26,6 +29,12 @@ export interface PyricNextOptions {
    * traffic to the local Pyric dev server. Default `true`.
    */
   rewrites?: boolean;
+  /**
+   * Display the floating Pyric runtime chip in browser client pages during
+   * local development. On by default. Pass `false` to hide it, or
+   * `{ initiallyOpen: true }` when actively debugging runtime errors.
+   */
+  runtimeChip?: PyricRuntimeChipOption;
 }
 
 export type NextConfigObject = Record<string, any>;

--- a/packages/cli/src/next/webpack-config.ts
+++ b/packages/cli/src/next/webpack-config.ts
@@ -27,9 +27,24 @@ function assembleClientResolveSection(existingResolve: Record<string, any> | und
   return resolveSection;
 }
 
+function assembleClientExperimentsSection(existingExperiments: Record<string, any> | undefined): Record<string, any> {
+  const experimentsSection = existingExperiments !== undefined ? Object.assign({}, existingExperiments) : {};
+  experimentsSection.topLevelAwait = true;
+  return experimentsSection;
+}
+
+function assembleClientOutputSection(existingOutput: Record<string, any> | undefined): Record<string, any> {
+  const outputSection = existingOutput !== undefined ? Object.assign({}, existingOutput) : {};
+  const environmentSection = outputSection.environment !== undefined ? Object.assign({}, outputSection.environment) : {};
+  environmentSection.asyncFunction = true;
+  outputSection.environment = environmentSection;
+  return outputSection;
+}
+
 /**
  * Wrap the existing Next.js Webpack configuration builder to inject client-side
- * Firebase module aliases when bundling for browser runtime execution.
+ * Firebase module aliases and modern async runtime compatibility settings when
+ * bundling for browser execution.
  */
 export function augmentWebpackConfig(config: NextConfigObject): NextConfigObject {
   const updatedConfig: NextConfigObject = Object.assign({}, config);
@@ -39,6 +54,12 @@ export function augmentWebpackConfig(config: NextConfigObject): NextConfigObject
     if (isClientSideBuild(webpackOptions)) {
       const currentResolve = webpackConfig.resolve;
       webpackConfig.resolve = assembleClientResolveSection(currentResolve);
+
+      const currentExperiments = webpackConfig.experiments;
+      webpackConfig.experiments = assembleClientExperimentsSection(currentExperiments);
+
+      const currentOutput = webpackConfig.output;
+      webpackConfig.output = assembleClientOutputSection(currentOutput);
     }
     if (typeof originalWebpack === 'function') {
       return originalWebpack(webpackConfig, webpackOptions);

--- a/packages/cli/src/next/webpack-config.ts
+++ b/packages/cli/src/next/webpack-config.ts
@@ -1,0 +1,50 @@
+/**
+ * Webpack configuration augmentation for Next.js client component builds.
+ */
+import type { NextConfigObject } from './types.js';
+import { getClientAliases, getNodeBuiltinFallbacks } from './client-aliases.js';
+
+interface WebpackOptions {
+  isServer: boolean;
+  [key: string]: unknown;
+}
+
+function isClientSideBuild(options: WebpackOptions): boolean {
+  return options.isServer === false;
+}
+
+function assembleClientResolveSection(existingResolve: Record<string, any> | undefined): Record<string, any> {
+  const resolveSection = existingResolve !== undefined ? Object.assign({}, existingResolve) : {};
+
+  const currentAliases = resolveSection.alias !== undefined ? Object.assign({}, resolveSection.alias) : {};
+  const newAliases = getClientAliases();
+  resolveSection.alias = Object.assign(currentAliases, newAliases);
+
+  const currentFallbacks = resolveSection.fallback !== undefined ? Object.assign({}, resolveSection.fallback) : {};
+  const newFallbacks = getNodeBuiltinFallbacks();
+  resolveSection.fallback = Object.assign(currentFallbacks, newFallbacks);
+
+  return resolveSection;
+}
+
+/**
+ * Wrap the existing Next.js Webpack configuration builder to inject client-side
+ * Firebase module aliases when bundling for browser runtime execution.
+ */
+export function augmentWebpackConfig(config: NextConfigObject): NextConfigObject {
+  const updatedConfig: NextConfigObject = Object.assign({}, config);
+  const originalWebpack = updatedConfig.webpack;
+
+  updatedConfig.webpack = (webpackConfig: any, webpackOptions: WebpackOptions) => {
+    if (isClientSideBuild(webpackOptions)) {
+      const currentResolve = webpackConfig.resolve;
+      webpackConfig.resolve = assembleClientResolveSection(currentResolve);
+    }
+    if (typeof originalWebpack === 'function') {
+      return originalWebpack(webpackConfig, webpackOptions);
+    }
+    return webpackConfig;
+  };
+
+  return updatedConfig;
+}

--- a/packages/cli/src/next/with-pyric.ts
+++ b/packages/cli/src/next/with-pyric.ts
@@ -1,0 +1,56 @@
+/**
+ * Core execution coordinator for the Next.js `withPyric` configuration wrapper.
+ */
+import type { NextConfig, NextConfigFunction, NextConfigObject, PyricNextOptions } from './types.js';
+import { enforceSandboxGuard, isProductionPassthrough } from './guard.js';
+import { augmentServerExternalPackages } from './server-external-packages.js';
+import { augmentWebpackConfig } from './webpack-config.js';
+import { augmentTurbopackConfig } from './turbopack-config.js';
+import { augmentDevRewrites } from './dev-rewrites.js';
+
+function isFunctionConfig(config: NextConfig): config is NextConfigFunction {
+  return typeof config === 'function';
+}
+
+function applyPyricEnhancements(config: NextConfigObject, options?: PyricNextOptions): NextConfigObject {
+  let enhancedConfig = augmentServerExternalPackages(config);
+  enhancedConfig = augmentWebpackConfig(enhancedConfig);
+  enhancedConfig = augmentTurbopackConfig(enhancedConfig);
+  enhancedConfig = augmentDevRewrites(enhancedConfig, options);
+  return enhancedConfig;
+}
+
+/**
+ * Higher-order configuration wrapper for Next.js (`next.config.js` or `next.config.mjs`).
+ *
+ * During development mode (`pyric dev` or non-production NODE_ENV):
+ *   - Applies Webpack and Turbopack alias mappings to swap `firebase/*` imports
+ *     for Pyric local sandbox mirrors on client components.
+ *   - Adds `firebase` and `firebase-admin` to `serverExternalPackages` to prevent
+ *     inlining in Server Components and API routes, preserving `@pyric/cli/register` hooks.
+ *   - Configures dev-time rewrites (`/__pyric/*`) to proxy socket and bridge traffic
+ *     to the local Pyric server without CORS errors.
+ *   - Enforces a bundler safety interlock (guard) to prevent accidental connections to
+ *     production databases when `PYRIC_SANDBOX` is inactive.
+ *
+ * In production (`NODE_ENV === 'production'` without `PYRIC_SANDBOX_FORCE=1`):
+ *   - Functions as a zero-overhead identity passthrough, leaving standard builds untouched.
+ */
+export function withPyric(config: NextConfig = {}, options?: PyricNextOptions): NextConfig {
+  if (isProductionPassthrough()) {
+    return config;
+  }
+
+  enforceSandboxGuard(options);
+
+  if (isFunctionConfig(config)) {
+    const asyncConfigWrapper: NextConfigFunction = async (phase, defaults) => {
+      const resolvedConfig = await config(phase, defaults);
+      const augmentedConfig = applyPyricEnhancements(resolvedConfig, options);
+      return augmentedConfig;
+    };
+    return asyncConfigWrapper;
+  }
+
+  return applyPyricEnhancements(config, options);
+}

--- a/packages/cli/src/next/with-pyric.ts
+++ b/packages/cli/src/next/with-pyric.ts
@@ -7,6 +7,7 @@ import { augmentServerExternalPackages } from './server-external-packages.js';
 import { augmentWebpackConfig } from './webpack-config.js';
 import { augmentTurbopackConfig } from './turbopack-config.js';
 import { augmentDevRewrites } from './dev-rewrites.js';
+import { augmentRuntimeEnv } from './runtime-env.js';
 
 function isFunctionConfig(config: NextConfig): config is NextConfigFunction {
   return typeof config === 'function';
@@ -17,6 +18,7 @@ function applyPyricEnhancements(config: NextConfigObject, options?: PyricNextOpt
   enhancedConfig = augmentWebpackConfig(enhancedConfig);
   enhancedConfig = augmentTurbopackConfig(enhancedConfig);
   enhancedConfig = augmentDevRewrites(enhancedConfig, options);
+  enhancedConfig = augmentRuntimeEnv(enhancedConfig, options);
   return enhancedConfig;
 }
 

--- a/packages/cli/src/serve/entries/app.ts
+++ b/packages/cli/src/serve/entries/app.ts
@@ -1,4 +1,5 @@
 /** Served `firebase/app`: the exact Pyric client registry over the page runtime. */
+import './init.js';
 import { bindAppRegistrySandbox } from 'pyric/app/internal';
 import { sandbox } from './app-backend.js';
 

--- a/packages/cli/src/serve/entries/app.ts
+++ b/packages/cli/src/serve/entries/app.ts
@@ -1,5 +1,4 @@
 /** Served `firebase/app`: the exact Pyric client registry over the page runtime. */
-import './init.js';
 import { bindAppRegistrySandbox } from 'pyric/app/internal';
 import { sandbox } from './app-backend.js';
 

--- a/packages/cli/src/serve/entries/auth.ts
+++ b/packages/cli/src/serve/entries/auth.ts
@@ -13,6 +13,7 @@
  * in or seeds a user. Email/password + anonymous also go straight to the
  * worker. The COMPLETE surface is exported on both paths (import-time parity).
  */
+import './init.js';
 import * as ipAuth from 'pyric/auth';
 import { getAuth as pyricGetAuth, setPersistence as pyricSetPersistence } from 'pyric/auth';
 import * as wcRaw from '../worker/client.js';

--- a/packages/cli/src/serve/entries/bridge-url.ts
+++ b/packages/cli/src/serve/entries/bridge-url.ts
@@ -22,9 +22,16 @@ export function toPageOriginWsUrl(
   loc: { href: string; protocol: string; host: string },
 ): string {
   try {
-    const path = new URL(raw, loc.href).pathname;
+    const rawUrl = new URL(raw, loc.href);
+    const locUrl = new URL(loc.href);
     const scheme = loc.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${scheme}//${loc.host}${path}`;
+
+    const hasExplicitLocPort = locUrl.port.length > 0;
+    const hasExplicitRawPort = rawUrl.port.length > 0;
+    const shouldPreserveRawPort = hasExplicitLocPort && hasExplicitRawPort;
+    const hostTarget = shouldPreserveRawPort ? `${locUrl.hostname}:${rawUrl.port}` : locUrl.host;
+
+    return `${scheme}//${hostTarget}${rawUrl.pathname}`;
   } catch {
     return raw;
   }

--- a/packages/cli/src/serve/entries/database.ts
+++ b/packages/cli/src/serve/entries/database.ts
@@ -5,6 +5,7 @@
  * and the Playground. This entry gives served apps the same common modular SDK
  * surface while the in-page fallback delegates to `pyric/database`.
  */
+import './init.js';
 import * as ip from 'pyric/database';
 import { getDatabase as pyricGetDatabase } from 'pyric/database';
 import { queryIdentifier } from 'pyric/database/internal';

--- a/packages/cli/src/serve/entries/firestore.ts
+++ b/packages/cli/src/serve/entries/firestore.ts
@@ -13,6 +13,7 @@
  *
  * Browser-bundled by `../bundler.ts`; never imported by node-side code.
  */
+import './init.js';
 import * as ip from 'pyric/firestore';
 import { getFirestore as pyricGetFirestore } from 'pyric/firestore';
 import * as wcRaw from '../worker/client.js';

--- a/packages/cli/src/serve/entries/init.ts
+++ b/packages/cli/src/serve/entries/init.ts
@@ -53,7 +53,10 @@ const helper = workerAuth
 const resolver = helper.resolver();
 installServeAuthResolver(resolver);
 if (localAuth) authSandbox.setAuthFlowResolver(localAuth, resolver);
-mountAuthHelperDialog(helper);
-installPyricRuntimeChip({ runtime: getPyricRuntimeStatus(), document });
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  mountAuthHelperDialog(helper);
+  installPyricRuntimeChip({ runtime: getPyricRuntimeStatus(), document });
+}
 
 export {};

--- a/packages/cli/src/serve/entries/storage.ts
+++ b/packages/cli/src/serve/entries/storage.ts
@@ -6,6 +6,7 @@
  * still lack a worker protocol fail loudly. In in-page fallback mode, the entry
  * delegates to `pyric/storage` against the page sandbox.
  */
+import './init.js';
 import * as ip from 'pyric/storage';
 import {
   getStorage as pyricGetStorage,

--- a/packages/cli/src/serve/runtime/chip-config.ts
+++ b/packages/cli/src/serve/runtime/chip-config.ts
@@ -17,14 +17,16 @@ interface RuntimeChipDocument {
   querySelector(selector: string): { getAttribute(name: string): string | null } | null;
 }
 
-/** Read only plugin-authored values; absent/unknown metadata keeps the UI off. */
+/** Read plugin-authored values or default to collapsed UI when meta tag is omitted (e.g. Next.js workflows). */
 export function readPyricRuntimeChipConfig(
   documentLike: RuntimeChipDocument,
 ): PyricRuntimeChipConfig | null {
   const meta = documentLike.querySelector(`meta[name="${PYRIC_RUNTIME_CHIP_META}"]`);
-  const value = meta?.getAttribute('content');
-  const studioEnabled = meta?.getAttribute('data-studio') !== 'off';
-  if (value === 'collapsed') return { initiallyOpen: false, studioEnabled };
-  if (value === 'expanded') return { initiallyOpen: true, studioEnabled };
-  return null;
+  const value = meta !== null ? meta.getAttribute('content') : null;
+  if (value === 'off') {
+    return null;
+  }
+  const studioEnabled = meta === null || meta.getAttribute('data-studio') !== 'off';
+  const initiallyOpen = value === 'expanded';
+  return { initiallyOpen, studioEnabled };
 }

--- a/packages/cli/src/serve/runtime/chip-config.ts
+++ b/packages/cli/src/serve/runtime/chip-config.ts
@@ -17,19 +17,27 @@ interface RuntimeChipDocument {
   querySelector(selector: string): { getAttribute(name: string): string | null } | null;
 }
 
+function hasBundlerRuntimeChipConfig(): boolean {
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.PYRIC_RUNTIME_CHIP === 'string';
+}
+
 /** Read plugin-authored values from DOM metadata or bundler environment variables, defaulting to collapsed UI when omitted. */
 export function readPyricRuntimeChipConfig(
   documentLike: RuntimeChipDocument,
 ): PyricRuntimeChipConfig | null {
   const meta = documentLike.querySelector(`meta[name="${PYRIC_RUNTIME_CHIP_META}"]`);
-  let value = meta !== null ? meta.getAttribute('content') : null;
-  if (value === null && typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.PYRIC_RUNTIME_CHIP === 'string') {
-    value = process.env.PYRIC_RUNTIME_CHIP;
+  const hasMetaTag = meta !== null;
+  let value = hasMetaTag ? meta.getAttribute('content') : null;
+
+  const shouldFallbackToEnv = !hasMetaTag && hasBundlerRuntimeChipConfig();
+  if (shouldFallbackToEnv) {
+    value = process.env.PYRIC_RUNTIME_CHIP as string;
   }
   if (value === 'off') {
     return null;
   }
-  const studioEnabled = meta === null || meta.getAttribute('data-studio') !== 'off';
+
+  const studioEnabled = !hasMetaTag || meta.getAttribute('data-studio') !== 'off';
   const initiallyOpen = value === 'expanded';
   return { initiallyOpen, studioEnabled };
 }

--- a/packages/cli/src/serve/runtime/chip-config.ts
+++ b/packages/cli/src/serve/runtime/chip-config.ts
@@ -17,12 +17,15 @@ interface RuntimeChipDocument {
   querySelector(selector: string): { getAttribute(name: string): string | null } | null;
 }
 
-/** Read plugin-authored values or default to collapsed UI when meta tag is omitted (e.g. Next.js workflows). */
+/** Read plugin-authored values from DOM metadata or bundler environment variables, defaulting to collapsed UI when omitted. */
 export function readPyricRuntimeChipConfig(
   documentLike: RuntimeChipDocument,
 ): PyricRuntimeChipConfig | null {
   const meta = documentLike.querySelector(`meta[name="${PYRIC_RUNTIME_CHIP_META}"]`);
-  const value = meta !== null ? meta.getAttribute('content') : null;
+  let value = meta !== null ? meta.getAttribute('content') : null;
+  if (value === null && typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.PYRIC_RUNTIME_CHIP === 'string') {
+    value = process.env.PYRIC_RUNTIME_CHIP;
+  }
   if (value === 'off') {
     return null;
   }

--- a/packages/cli/test/cli/init.test.ts
+++ b/packages/cli/test/cli/init.test.ts
@@ -184,6 +184,31 @@ describe('pyric init v2 — web template ↔ example dogfood stay in sync', () =
   });
 });
 
+describe('pyric init v2 — nextjs template ↔ example dogfood stay in sync', () => {
+  const EXAMPLE_DIR = fileURLToPath(new URL('../../../../examples/nextjs-sandbox-app', import.meta.url));
+  const SYNCED = [
+    'next.config.mjs',
+    'tsconfig.json',
+    'firebase.json',
+    'firestore.indexes.json',
+    'firestore.rules',
+    '.gitignore',
+    'src/app/layout.tsx',
+    'src/app/page.tsx',
+    'src/app/api/status/route.ts',
+  ];
+
+  it('scaffolded nextjs files are byte-identical to examples/nextjs-sandbox-app', async () => {
+    const dir = tmp();
+    await runInit(args([], { template: 'nextjs', name: 'nextjs-sandbox-app' }), capture().deps(dir));
+    for (const f of SYNCED) {
+      const scaffolded = readFileSync(join(dir, f), 'utf8');
+      const example = readFileSync(join(EXAMPLE_DIR, f), 'utf8');
+      expect([f, scaffolded]).toEqual([f, example]);
+    }
+  });
+});
+
 describe('pyric init v2 — static template (serve-era, no bundler)', () => {
   it('scaffolds the static public/ app served by pyric dev', async () => {
     const dir = tmp();
@@ -342,7 +367,7 @@ describe('pyric init v2 — CLI surface', () => {
 });
 
 describe('pyric init v2 — production handoff', () => {
-  for (const template of ['web', 'node', 'static', 'chat'] as const) {
+  for (const template of ['web', 'node', 'static', 'chat', 'nextjs'] as const) {
     it(`${template} delegates production deployment to firebase-tools`, async () => {
       const dir = tmp();
       expect(

--- a/packages/cli/test/serve/bridge-url.test.ts
+++ b/packages/cli/test/serve/bridge-url.test.ts
@@ -31,4 +31,10 @@ describe('toPageOriginWsUrl', () => {
       'ws://localhost:5173/__pyric/sandbox',
     );
   });
+
+  it('preserves the bridge server port when page runs on a different explicit port (two-server dev architecture)', () => {
+    expect(toPageOriginWsUrl('ws://localhost:4288/__pyric/sandbox', loc('http://127.0.0.1:4289/'))).toBe(
+      'ws://127.0.0.1:4288/__pyric/sandbox',
+    );
+  });
 });

--- a/packages/cli/test/serve/runtime/chip-config.test.ts
+++ b/packages/cli/test/serve/runtime/chip-config.test.ts
@@ -24,4 +24,16 @@ describe('Pyric runtime chip configuration', () => {
     expect(readPyricRuntimeChipConfig(documentWith('unexpected'))).toEqual({ initiallyOpen: false, studioEnabled: true });
     expect(readPyricRuntimeChipConfig(documentWith(null))).toEqual({ initiallyOpen: false, studioEnabled: true });
   });
+
+  it('reads environment variables (from Next.js or bundlers) when meta tag is absent', () => {
+    const emptyDoc = { querySelector: () => null };
+    process.env.PYRIC_RUNTIME_CHIP = 'off';
+    expect(readPyricRuntimeChipConfig(emptyDoc)).toBeNull();
+
+    process.env.PYRIC_RUNTIME_CHIP = 'expanded';
+    expect(readPyricRuntimeChipConfig(emptyDoc)).toEqual({ initiallyOpen: true, studioEnabled: true });
+
+    delete process.env.PYRIC_RUNTIME_CHIP;
+    expect(readPyricRuntimeChipConfig(emptyDoc)).toEqual({ initiallyOpen: false, studioEnabled: true });
+  });
 });

--- a/packages/cli/test/serve/runtime/chip-config.test.ts
+++ b/packages/cli/test/serve/runtime/chip-config.test.ts
@@ -12,7 +12,7 @@ describe('Pyric runtime chip configuration', () => {
     expect(runtimeChipMetaValue({ initiallyOpen: true })).toBe('expanded');
   });
 
-  it('reads only known plugin-authored metadata values', () => {
+  it('reads plugin-authored metadata values or defaults to collapsed when meta tag is omitted', () => {
     const documentWith = (content: string | null, studio = 'on') => ({
       querySelector: () => content === null ? null : {
         getAttribute: (name: string) => name === 'content' ? content : studio,
@@ -21,7 +21,7 @@ describe('Pyric runtime chip configuration', () => {
     expect(readPyricRuntimeChipConfig(documentWith('collapsed'))).toEqual({ initiallyOpen: false, studioEnabled: true });
     expect(readPyricRuntimeChipConfig(documentWith('expanded', 'off'))).toEqual({ initiallyOpen: true, studioEnabled: false });
     expect(readPyricRuntimeChipConfig(documentWith('off'))).toBeNull();
-    expect(readPyricRuntimeChipConfig(documentWith('unexpected'))).toBeNull();
-    expect(readPyricRuntimeChipConfig(documentWith(null))).toBeNull();
+    expect(readPyricRuntimeChipConfig(documentWith('unexpected'))).toEqual({ initiallyOpen: false, studioEnabled: true });
+    expect(readPyricRuntimeChipConfig(documentWith(null))).toEqual({ initiallyOpen: false, studioEnabled: true });
   });
 });

--- a/packages/cli/test/serve/runtime/chip-install.test.ts
+++ b/packages/cli/test/serve/runtime/chip-install.test.ts
@@ -26,12 +26,17 @@ describe('installPyricRuntimeChip', () => {
     expect(mount.mock.calls[0]?.[0]).toMatchObject({ runtime, initiallyOpen: true });
   });
 
-  it('does not mount without opt-in metadata or when explicitly off', () => {
-    for (const content of [undefined, 'off']) {
-      const { dom, runtime, mount } = setup(content);
-      expect(installPyricRuntimeChip({ runtime, document: dom.window.document, mount })).toBeNull();
-      expect(mount).not.toHaveBeenCalled();
-    }
+  it('does not mount when explicitly configured off via metadata', () => {
+    const { dom, runtime, mount } = setup('off');
+    expect(installPyricRuntimeChip({ runtime, document: dom.window.document, mount })).toBeNull();
+    expect(mount).not.toHaveBeenCalled();
+  });
+
+  it('mounts by default when metadata is omitted (e.g. in Next.js app bundles)', () => {
+    const { dom, runtime, mount, mounted } = setup(undefined);
+    const installed = installPyricRuntimeChip({ runtime, document: dom.window.document, mount });
+    expect(installed).toBe(mounted);
+    expect(mount).toHaveBeenCalledTimes(1);
   });
 
   it('does not duplicate an existing runtime chip host', () => {

--- a/packages/cli/test/unit/next/with-pyric.test.ts
+++ b/packages/cli/test/unit/next/with-pyric.test.ts
@@ -103,14 +103,19 @@ describe('withPyric Next.js configuration wrapper', () => {
     expect(clientResult.resolve.alias['firebase/firestore']).toContain('/entries/firestore.');
     expect(clientResult.resolve.fallback.fs).toBe(false);
     expect(clientResult.resolve.fallback.path).toBe(false);
+    expect(clientResult.experiments.topLevelAwait).toBe(true);
+    expect(clientResult.output.environment.asyncFunction).toBe(true);
   });
 
   it('configures Turbopack aliases for client SDKs', () => {
     const res = withPyric({
+      turbopack: { resolveAlias: { modern: 'alias' } },
       turbo: { resolveAlias: { existing: 'alias' } },
       experimental: { turbo: { resolveAlias: { legacy: 'alias' } } },
     }) as Record<string, any>;
 
+    expect(res.turbopack.resolveAlias.modern).toBe('alias');
+    expect(res.turbopack.resolveAlias['firebase/app']).toContain('/entries/app.');
     expect(res.turbo.resolveAlias.existing).toBe('alias');
     expect(res.turbo.resolveAlias['firebase/app']).toContain('/entries/app.');
     expect(res.experimental.turbo.resolveAlias.legacy).toBe('alias');

--- a/packages/cli/test/unit/next/with-pyric.test.ts
+++ b/packages/cli/test/unit/next/with-pyric.test.ts
@@ -175,4 +175,12 @@ describe('withPyric Next.js configuration wrapper', () => {
     expect(evalResult.phase).toBe('phase-develop');
     expect(evalResult.serverExternalPackages).toContain('firebase');
   });
+
+  it('configures PYRIC_RUNTIME_CHIP environment variables when runtimeChip option is passed', () => {
+    const resOff = withPyric({}, { runtimeChip: false }) as Record<string, any>;
+    expect(resOff.env?.PYRIC_RUNTIME_CHIP).toBe('off');
+
+    const resOpen = withPyric({}, { runtimeChip: { initiallyOpen: true } }) as Record<string, any>;
+    expect(resOpen.env?.PYRIC_RUNTIME_CHIP).toBe('expanded');
+  });
 });

--- a/packages/cli/test/unit/next/with-pyric.test.ts
+++ b/packages/cli/test/unit/next/with-pyric.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { withPyric } from '../../../src/next/index.js';
+
+describe('withPyric Next.js configuration wrapper', () => {
+  const origNodeEnv = process.env.NODE_ENV;
+  const origPyricSandbox = process.env.PYRIC_SANDBOX;
+  const origPyricSandboxForce = process.env.PYRIC_SANDBOX_FORCE;
+  const origPyricSandboxPort = process.env.PYRIC_SANDBOX_PORT;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development';
+    process.env.PYRIC_SANDBOX = 'remote:http://127.0.0.1:4000';
+    delete process.env.PYRIC_SANDBOX_FORCE;
+    delete process.env.PYRIC_SANDBOX_PORT;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = origNodeEnv;
+    if (origPyricSandbox !== undefined) {
+      process.env.PYRIC_SANDBOX = origPyricSandbox;
+    } else {
+      delete process.env.PYRIC_SANDBOX;
+    }
+    if (origPyricSandboxForce !== undefined) {
+      process.env.PYRIC_SANDBOX_FORCE = origPyricSandboxForce;
+    } else {
+      delete process.env.PYRIC_SANDBOX_FORCE;
+    }
+    if (origPyricSandboxPort !== undefined) {
+      process.env.PYRIC_SANDBOX_PORT = origPyricSandboxPort;
+    } else {
+      delete process.env.PYRIC_SANDBOX_PORT;
+    }
+  });
+
+  it('acts as an identity passthrough under NODE_ENV=production without force', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.PYRIC_SANDBOX;
+    const originalConfig = { reactStrictMode: true };
+    const res = withPyric(originalConfig);
+    expect(res).toBe(originalConfig);
+  });
+
+  it('activates under NODE_ENV=production when PYRIC_SANDBOX_FORCE=1 is set', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PYRIC_SANDBOX_FORCE = '1';
+    process.env.PYRIC_SANDBOX = 'local';
+    const res = withPyric({ reactStrictMode: true }) as Record<string, any>;
+    expect(res.serverExternalPackages).toContain('firebase');
+    expect(res.serverExternalPackages).toContain('firebase-admin');
+  });
+
+  it('throws an error if PYRIC_SANDBOX is missing during non-production builds (bundler guard)', () => {
+    delete process.env.PYRIC_SANDBOX;
+    expect(() => withPyric({})).toThrow(/Next\.js development server started without active Pyric sandbox/);
+  });
+
+  it('allows execution when PYRIC_SANDBOX is missing if { guard: false } is passed', () => {
+    delete process.env.PYRIC_SANDBOX;
+    const res = withPyric({}, { guard: false }) as Record<string, any>;
+    expect(res.serverExternalPackages).toContain('firebase');
+  });
+
+  it('injects firebase and firebase-admin into serverExternalPackages with deduplication', () => {
+    const config = {
+      serverExternalPackages: ['existing-pkg', 'firebase'],
+      experimental: {
+        serverComponentsExternalPackages: ['other-pkg', 'firebase-admin'],
+      },
+    };
+    const res = withPyric(config) as Record<string, any>;
+    expect(res.serverExternalPackages).toEqual(['existing-pkg', 'firebase', 'firebase-admin']);
+    expect(res.experimental.serverComponentsExternalPackages).toEqual([
+      'other-pkg',
+      'firebase-admin',
+      'firebase',
+    ]);
+  });
+
+  it('configures client-side Webpack aliases and builtin fallbacks only for client builds (!isServer)', () => {
+    let calledWithConfig: any = null;
+    const customWebpack = (cfg: any, options: any) => {
+      calledWithConfig = cfg;
+      cfg.customProperty = options.isServer ? 'server-build' : 'client-build';
+      return cfg;
+    };
+
+    const res = withPyric({ webpack: customWebpack }) as Record<string, any>;
+    expect(typeof res.webpack).toBe('function');
+
+    // Server build: should NOT alias or add fallbacks
+    const serverConfig: any = {};
+    const serverResult = res.webpack(serverConfig, { isServer: true });
+    expect(serverResult.customProperty).toBe('server-build');
+    expect(serverResult.resolve?.alias?.['firebase/app']).toBeUndefined();
+    expect(serverResult.resolve?.fallback?.fs).toBeUndefined();
+
+    // Client build: SHOULD alias and add built-in fallbacks
+    const clientConfig: any = {};
+    const clientResult = res.webpack(clientConfig, { isServer: false });
+    expect(clientResult.customProperty).toBe('client-build');
+    expect(clientResult.resolve.alias['firebase/app']).toContain('/entries/app.');
+    expect(clientResult.resolve.alias['firebase/firestore']).toContain('/entries/firestore.');
+    expect(clientResult.resolve.fallback.fs).toBe(false);
+    expect(clientResult.resolve.fallback.path).toBe(false);
+  });
+
+  it('configures Turbopack aliases for client SDKs', () => {
+    const res = withPyric({
+      turbo: { resolveAlias: { existing: 'alias' } },
+      experimental: { turbo: { resolveAlias: { legacy: 'alias' } } },
+    }) as Record<string, any>;
+
+    expect(res.turbo.resolveAlias.existing).toBe('alias');
+    expect(res.turbo.resolveAlias['firebase/app']).toContain('/entries/app.');
+    expect(res.experimental.turbo.resolveAlias.legacy).toBe('alias');
+    expect(res.experimental.turbo.resolveAlias['firebase/firestore']).toContain('/entries/firestore.');
+  });
+
+  it('configures dev-time rewrites to proxy /__pyric/:path* to sandbox target url', async () => {
+    const res = withPyric({}) as Record<string, any>;
+    expect(typeof res.rewrites).toBe('function');
+    const rewrites = await res.rewrites();
+    expect(Array.isArray(rewrites)).toBe(true);
+    expect(rewrites[0]).toEqual({
+      source: '/__pyric/:path*',
+      destination: 'http://127.0.0.1:4000/__pyric/:path*',
+    });
+  });
+
+  it('respects port and url option overrides for dev-time rewrites', async () => {
+    const res = withPyric({}, { port: 5555 }) as Record<string, any>;
+    const rewrites = await res.rewrites();
+    expect(rewrites[0].destination).toBe('http://127.0.0.1:5555/__pyric/:path*');
+
+    const resUrl = withPyric({}, { url: 'http://custom-host:8080/' }) as Record<string, any>;
+    const rewritesUrl = await resUrl.rewrites();
+    expect(rewritesUrl[0].destination).toBe('http://custom-host:8080/__pyric/:path*');
+  });
+
+  it('wraps pre-existing user array rewrites and object rewrites (beforeFiles)', async () => {
+    const userArrayRewrites = async () => [{ source: '/api/:path*', destination: '/custom/:path*' }];
+    const resArray = withPyric({ rewrites: userArrayRewrites }) as Record<string, any>;
+    const arrayResult = await resArray.rewrites();
+    expect(arrayResult).toHaveLength(2);
+    expect(arrayResult[0].source).toBe('/__pyric/:path*');
+    expect(arrayResult[1].source).toBe('/api/:path*');
+
+    const userObjRewrites = async () => ({
+      beforeFiles: [{ source: '/before', destination: '/dest' }],
+      afterFiles: [],
+    });
+    const resObj = withPyric({ rewrites: userObjRewrites }) as Record<string, any>;
+    const objResult = await resObj.rewrites();
+    expect(objResult.beforeFiles).toHaveLength(2);
+    expect(objResult.beforeFiles[0].source).toBe('/__pyric/:path*');
+    expect(objResult.beforeFiles[1].source).toBe('/before');
+  });
+
+  it('supports function-based Next.js configuration exports', async () => {
+    const funcConfig = async (phase: string, defaults: any) => ({
+      phase,
+      defaults,
+      reactStrictMode: true,
+    });
+    const res = withPyric(funcConfig as any);
+    expect(typeof res).toBe('function');
+
+    const evalResult = await (res as any)('phase-develop', { dev: true });
+    expect(evalResult.phase).toBe('phase-develop');
+    expect(evalResult.serverExternalPackages).toContain('firebase');
+  });
+});

--- a/packages/create-pyric/src/template-nextjs.ts
+++ b/packages/create-pyric/src/template-nextjs.ts
@@ -3,11 +3,25 @@
  */
 import type { ScaffoldTemplate } from './templates.js';
 
-const NEXTJS_CONFIG_MJS = `import { withPyric } from '@pyric/cli/next';
+const NEXTJS_CONFIG_MJS = `import { fileURLToPath } from 'node:url';
+import { withPyric } from '@pyric/cli/next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: fileURLToPath(new URL('.', import.meta.url)),
+  allowedDevOrigins: [
+    'localhost',
+    '127.0.0.1',
+    'localhost:3000',
+    '127.0.0.1:3000',
+    'localhost:4000',
+    '127.0.0.1:4000',
+    'localhost:4288',
+    '127.0.0.1:4288',
+    'localhost:4289',
+    '127.0.0.1:4289',
+  ],
 };
 
 // Under development mode (\`pyric dev -- next dev\`), withPyric maps client-side
@@ -184,12 +198,28 @@ function resolveRuntimeEnvironment(): string {
   return 'production';
 }
 
+async function fetchPostsSnapshot(db: FirebaseFirestore.Firestore, maxRetries = 6, delayMs = 500): Promise<FirebaseFirestore.QuerySnapshot> {
+  let attempts = 0;
+  for (;;) {
+    try {
+      attempts += 1;
+      const snapshot = await db.collection('posts').get();
+      return snapshot;
+    } catch (error) {
+      if (attempts >= maxRetries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 export async function GET(): Promise<NextResponse> {
   const app = getAdminApp();
   const db = getFirestore(app);
-  
+
   try {
-    const postsSnapshot = await db.collection('posts').get();
+    const postsSnapshot = await fetchPostsSnapshot(db);
     const documentCount = postsSnapshot.size;
     const runtimeTarget = resolveRuntimeEnvironment();
 
@@ -306,28 +336,29 @@ export default function HomePage(): React.JSX.Element {
         currentPosts.push(postEntry);
       }
       setPostsList(currentPosts);
-    });
 
-    fetch('/api/status')
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(\`Server returned HTTP \${response.status}\`);
-        }
-        const payload = (await response.json()) as ServerStatusResponse;
-        return payload;
-      })
-      .then((payload) => {
-        if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
-          setBackendApiStatusText(\`Server-Side Admin API Runtime: \${payload.environment} (\${payload.count} database records)\`);
-        } else {
-          const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
-          setBackendApiStatusText(\`Server-Side Admin API reported an error: \${failureDetail}\`);
-        }
-      })
-      .catch((err: unknown) => {
-        const failureDetail = err instanceof Error ? err.message : String(err);
-        setBackendApiStatusText(\`Server-Side Admin API unavailable (\${failureDetail})\`);
-      });
+      fetch('/api/status')
+        .then(async (response) => {
+          const payload = (await response.json().catch(() => ({ status: 'error', details: \`HTTP \${response.status}\` }))) as ServerStatusResponse;
+          if (!response.ok) {
+            const failureDetail = payload.details !== undefined ? payload.details : \`HTTP \${response.status}\`;
+            throw new Error(failureDetail);
+          }
+          return payload;
+        })
+        .then((payload) => {
+          if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
+            setBackendApiStatusText(\`Server-Side Admin API Runtime: \${payload.environment} (\${payload.count} database records)\`);
+          } else {
+            const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
+            setBackendApiStatusText(\`Server-Side Admin API reported an error: \${failureDetail}\`);
+          }
+        })
+        .catch((err: unknown) => {
+          const failureDetail = err instanceof Error ? err.message : String(err);
+          setBackendApiStatusText(\`Server-Side Admin API unavailable (\${failureDetail})\`);
+        });
+    });
 
     return () => {
       unsubscribeAuth();

--- a/packages/create-pyric/src/template-nextjs.ts
+++ b/packages/create-pyric/src/template-nextjs.ts
@@ -1,0 +1,495 @@
+/**
+ * Scaffold template definition for Next.js (`npm create pyric -- --template nextjs`).
+ */
+import type { ScaffoldTemplate } from './templates.js';
+
+const NEXTJS_CONFIG_MJS = `import { withPyric } from '@pyric/cli/next';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+// Under development mode (\`pyric dev -- next dev\`), withPyric maps client-side
+// firebase/* SDK imports to Pyric sandbox adapters via Webpack/Turbopack aliases,
+// externalizes server-side firebase and firebase-admin imports for Node loader
+// hooks (@pyric/cli/register), and proxies /__pyric/* bridge traffic.
+// Under \`next build\` (mode production), withPyric acts as an identity passthrough,
+// compiling canonical Firebase SDKs untouched with zero runtime overhead.
+export default withPyric(nextConfig);
+`;
+
+const NEXTJS_TSCONFIG_JSON = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+`;
+
+const NEXTJS_ENV_EXAMPLE = `# Your real Firebase application configuration from the Firebase Console.
+# UNUSED in local development under \`pyric dev\` (the Pyric sandbox stands in);
+# USED by \`next build\` for production cloud builds. Next.js exposes environment
+# variables prefixed with \`NEXT_PUBLIC_\` to client-side code in the browser.
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+`;
+
+const NEXTJS_GITIGNORE = `# next.js
+/.next/
+/out/
+/build/
+
+# production
+/build
+/dist
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+.env.pyric
+
+# pyric session files
+.pyric/
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+`;
+
+const NEXTJS_FIREBASE_JSON = `{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}
+`;
+
+const NEXTJS_FIRESTORE_INDEXES = `{
+  "indexes": [],
+  "fieldOverrides": []
+}
+`;
+
+const NEXTJS_FIRESTORE_RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Owner-based security rules from line 1 — Pyric deploys and hot-reloads
+    // this configuration into the local sandbox environment. These deploy as-is
+    // to production Firebase instances.
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if request.auth != null
+                    && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if request.auth != null
+                            && resource.data.uid == request.auth.uid;
+    }
+
+    // Default deny — require explicit authorization rules per collection.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
+`;
+
+function buildRootLayout(projectName: string): string {
+  return `import type { Metadata } from 'next';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: '${projectName}',
+  description: 'Local Firebase development with Pyric and Next.js',
+};
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function RootLayout({ children }: LayoutProps): React.JSX.Element {
+  const containerStyle: React.CSSProperties = {
+    font: '16px/1.5 system-ui, sans-serif',
+    maxWidth: '640px',
+    margin: '3rem auto',
+    padding: '0 1rem',
+  };
+
+  return (
+    <html lang="en">
+      <body style={containerStyle}>
+        {children}
+      </body>
+    </html>
+  );
+}
+`;
+}
+
+function buildStatusApiRoute(): string {
+  return `import { NextResponse } from 'next/server';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const DEFAULT_PROJECT_ID = 'demo-nextjs-app';
+
+function getAdminApp() {
+  const activeApps = getApps();
+  if (activeApps.length > 0) {
+    return activeApps[0];
+  }
+  return initializeApp({ projectId: DEFAULT_PROJECT_ID });
+}
+
+function resolveRuntimeEnvironment(): string {
+  if (process.env.PYRIC_SANDBOX !== undefined) {
+    return 'pyric-sandbox';
+  }
+  return 'production';
+}
+
+export async function GET(): Promise<NextResponse> {
+  const app = getAdminApp();
+  const db = getFirestore(app);
+  
+  try {
+    const postsSnapshot = await db.collection('posts').get();
+    const documentCount = postsSnapshot.size;
+    const runtimeTarget = resolveRuntimeEnvironment();
+
+    return NextResponse.json({
+      status: 'ok',
+      environment: runtimeTarget,
+      count: documentCount,
+    });
+  } catch (error) {
+    const errCode = (error as { code?: string }).code;
+    const errMessage = errCode !== undefined ? errCode : String(error);
+    return NextResponse.json(
+      { status: 'error', details: errMessage },
+      { status: 500 },
+    );
+  }
+}
+`;
+}
+
+function buildHomePage(projectName: string): string {
+  return `'use client';
+
+import React, { useEffect, useState, type FormEvent, type CSSProperties } from 'react';
+import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+  GoogleAuthProvider,
+  type User,
+} from 'firebase/auth';
+import {
+  getFirestore,
+  collection,
+  onSnapshot,
+  addDoc,
+  serverTimestamp,
+  type DocumentData,
+} from 'firebase/firestore';
+
+interface PostRecord {
+  id: string;
+  title: string;
+  uid: string;
+}
+
+interface ServerStatusResponse {
+  status: string;
+  environment?: string;
+  count?: number;
+  details?: string;
+}
+
+const DEFAULT_FIREBASE_CONFIG = {
+  apiKey: 'demo-api-key',
+  authDomain: 'demo-nextjs-app.firebaseapp.com',
+  projectId: 'demo-nextjs-app',
+};
+
+function resolveClientFirebaseApp(): FirebaseApp {
+  const existingApps = getApps();
+  if (existingApps.length > 0) {
+    return getApp();
+  }
+  return initializeApp(DEFAULT_FIREBASE_CONFIG);
+}
+
+function resolveUserDisplayLabel(currentUser: User): string {
+  if (currentUser.displayName !== null && currentUser.displayName !== '') {
+    return \`Signed in as \${currentUser.displayName}\`;
+  }
+  if (currentUser.email !== null && currentUser.email !== '') {
+    return \`Signed in as \${currentUser.email}\`;
+  }
+  return \`Signed in as \${currentUser.uid}\`;
+}
+
+export default function HomePage(): React.JSX.Element {
+  const [activeUser, setActiveUser] = useState<User | null>(null);
+  const [postsList, setPostsList] = useState<PostRecord[]>([]);
+  const [newPostTitle, setNewPostTitle] = useState<string>('');
+  const [authStatusText, setAuthStatusText] = useState<string>('Checking authentication state...');
+  const [backendApiStatusText, setBackendApiStatusText] = useState<string>('Connecting to Server API...');
+
+  useEffect(() => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const firestoreDb = getFirestore(clientApp);
+
+    const unsubscribeAuth = onAuthStateChanged(authService, (userState) => {
+      setActiveUser(userState);
+      if (userState !== null) {
+        const userLabel = resolveUserDisplayLabel(userState);
+        setAuthStatusText(userLabel);
+      } else {
+        setAuthStatusText('Signed out');
+      }
+    });
+
+    const postsCollectionRef = collection(firestoreDb, 'posts');
+    const unsubscribeSnapshot = onSnapshot(postsCollectionRef, (snapshot) => {
+      const currentPosts: PostRecord[] = [];
+      for (const documentSnapshot of snapshot.docs) {
+        const rawData = documentSnapshot.data() as DocumentData;
+        const documentTitle = typeof rawData.title === 'string' ? rawData.title : 'Untitled Post';
+        const authorId = typeof rawData.uid === 'string' ? rawData.uid : 'anonymous';
+        const postEntry: PostRecord = {
+          id: documentSnapshot.id,
+          title: documentTitle,
+          uid: authorId,
+        };
+        currentPosts.push(postEntry);
+      }
+      setPostsList(currentPosts);
+    });
+
+    fetch('/api/status')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(\`Server returned HTTP \${response.status}\`);
+        }
+        const payload = (await response.json()) as ServerStatusResponse;
+        return payload;
+      })
+      .then((payload) => {
+        if (payload.status === 'ok' && payload.environment !== undefined && payload.count !== undefined) {
+          setBackendApiStatusText(\`Server-Side Admin API Runtime: \${payload.environment} (\${payload.count} database records)\`);
+        } else {
+          const failureDetail = payload.details !== undefined ? payload.details : 'Unknown error';
+          setBackendApiStatusText(\`Server-Side Admin API reported an error: \${failureDetail}\`);
+        }
+      })
+      .catch((err: unknown) => {
+        const failureDetail = err instanceof Error ? err.message : String(err);
+        setBackendApiStatusText(\`Server-Side Admin API unavailable (\${failureDetail})\`);
+      });
+
+    return () => {
+      unsubscribeAuth();
+      unsubscribeSnapshot();
+    };
+  }, []);
+
+  const onSignInClicked = async () => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const googleProvider = new GoogleAuthProvider();
+    await signInWithPopup(authService, googleProvider);
+  };
+
+  const onSignOutClicked = async () => {
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    await signOut(authService);
+  };
+
+  const onPostFormSubmitted = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const clientApp = resolveClientFirebaseApp();
+    const authService = getAuth(clientApp);
+    const firestoreDb = getFirestore(clientApp);
+    const currentUser = authService.currentUser;
+
+    const trimmedTitle = newPostTitle.trim();
+    if (trimmedTitle === '') {
+      return;
+    }
+
+    try {
+      const postsCollectionRef = collection(firestoreDb, 'posts');
+      const authorId = currentUser !== null ? currentUser.uid : 'anonymous';
+      await addDoc(postsCollectionRef, {
+        title: trimmedTitle,
+        uid: authorId,
+        createdAt: serverTimestamp(),
+      });
+      setNewPostTitle('');
+    } catch (writeError) {
+      const errorCode = (writeError as { code?: string }).code;
+      const displayMessage = errorCode !== undefined ? errorCode : String(writeError);
+      if (currentUser !== null) {
+        setAuthStatusText(\`Write operation failed: \${displayMessage}\`);
+      } else {
+        setAuthStatusText('Denied by security rules (signed out) — check the Traffic tab in Pyric Studio.');
+      }
+    }
+  };
+
+  const buttonStyle: CSSProperties = { padding: '0.4rem 0.9rem', cursor: 'pointer' };
+  const inputStyle: CSSProperties = { flex: 1, padding: '0.4rem 0.6rem' };
+  const formStyle: CSSProperties = { display: 'flex', gap: '0.5rem', margin: '1rem 0' };
+
+  return (
+    <main>
+      <h1>${projectName}</h1>
+      <p id="auth-status" style={{ color: '#555', fontWeight: 'bold' }}>
+        {authStatusText}
+      </p>
+      <p id="api-status" style={{ color: '#0066cc', fontSize: '0.9rem', marginBottom: '1rem' }}>
+        {backendApiStatusText}
+      </p>
+
+      {activeUser === null ? (
+        <button id="sign-in-button" type="button" onClick={onSignInClicked} style={buttonStyle}>
+          Sign in with Google
+        </button>
+      ) : (
+        <button id="sign-out-button" type="button" onClick={onSignOutClicked} style={buttonStyle}>
+          Sign out
+        </button>
+      )}
+
+      <form id="add-post-form" onSubmit={onPostFormSubmitted} style={formStyle}>
+        <input
+          id="post-title-input"
+          type="text"
+          value={newPostTitle}
+          onChange={(event) => setNewPostTitle(event.target.value)}
+          placeholder="Post title"
+          required
+          style={inputStyle}
+        />
+        <button id="submit-post-button" type="submit" style={buttonStyle}>
+          Add post
+        </button>
+      </form>
+
+      <h2>Posts</h2>
+      {postsList.length === 0 ? (
+        <p style={{ color: '#888', fontStyle: 'italic' }}>No posts yet in database.</p>
+      ) : (
+        <ul id="posts-list" style={{ paddingLeft: '1.2rem' }}>
+          {postsList.map((postItem) => (
+            <li key={postItem.id}>
+              <strong>{postItem.title}</strong>{' '}
+              <span style={{ color: '#777', fontSize: '0.8rem' }}>(by {postItem.uid})</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+`;
+}
+
+function buildReadme(projectName: string): string {
+  return `# ${projectName}
+
+A Firebase web application built with Next.js and wrapped with \`@pyric/cli/next\` (\`withPyric\`).
+In development, the application runs entirely on Pyric's local sandbox—requiring
+zero Firebase projects, service account keys, or cloud emulators.
+
+- **Develop:** \`npm run dev\` or \`bun run dev\` — executes \`pyric dev -- next dev\`. The \`withPyric\` wrapper substitutes client SDK imports with local sandbox mirrors via Webpack and Turbopack aliases, intercepts server-side API requests via \`@pyric/cli/register\`, and proxies WebSocket bridge connection traffic automatically.
+- **Build for production:** \`npm run build\` or \`bun run build\` — executing \`next build\` in production mode activates identity passthrough in \`withPyric\`, compiling standard Firebase and Firebase Admin SDKs untouched with zero runtime overhead.
+- **Start:** \`npm start\` or \`bun run start\` — serves your built Next.js production server.
+- **Deploy:** \`npx firebase-tools deploy\` (via Firebase Web Frameworks) after production build, or deploy standard built artifacts directly to Vercel and cloud compute platforms.
+`;
+}
+
+export const NEXTJS_TEMPLATE: ScaffoldTemplate = {
+  scripts: {
+    dev: 'pyric dev -- next dev',
+    'dev:direct': 'next dev',
+    build: 'next build',
+    start: 'next start',
+  },
+  dependencies: {
+    firebase: '^12.12.0',
+    'firebase-admin': '^13.0.0',
+    next: '^15.0.0',
+    react: '^19.0.0',
+    'react-dom': '^19.0.0',
+  },
+  devDependencies: {
+    '@pyric/cli': '*',
+    '@types/node': '^22.0.0',
+    '@types/react': '^19.0.0',
+    '@types/react-dom': '^19.0.0',
+    typescript: '^5.7.0',
+  },
+  dirs: ['src', 'src/app', 'src/app/api', 'src/app/api/status'],
+  files: (name: string) => [
+    { name: 'next.config.mjs', content: NEXTJS_CONFIG_MJS },
+    { name: 'tsconfig.json', content: NEXTJS_TSCONFIG_JSON },
+    { name: '.env.example', content: NEXTJS_ENV_EXAMPLE },
+    { name: '.gitignore', content: NEXTJS_GITIGNORE },
+    { name: 'firebase.json', content: NEXTJS_FIREBASE_JSON },
+    { name: 'firestore.indexes.json', content: NEXTJS_FIRESTORE_INDEXES },
+    { name: 'firestore.rules', content: NEXTJS_FIRESTORE_RULES },
+    { name: 'README.md', content: buildReadme(name) },
+    { name: 'src/app/layout.tsx', content: buildRootLayout(name) },
+    { name: 'src/app/page.tsx', content: buildHomePage(name) },
+    { name: 'src/app/api/status/route.ts', content: buildStatusApiRoute() },
+  ],
+  nextSteps: [
+    'npm install    # or: bun install',
+    'npm run dev    # Next.js dev server on the Pyric sandbox',
+    'npm run build  # production build against real Firebase',
+  ],
+};

--- a/packages/create-pyric/src/templates.ts
+++ b/packages/create-pyric/src/templates.ts
@@ -19,8 +19,9 @@
 import { lstatSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { NEXTJS_TEMPLATE } from './template-nextjs.js';
 
-export const TEMPLATE_NAMES = ['web', 'node', 'static', 'chat'] as const;
+export const TEMPLATE_NAMES = ['web', 'node', 'static', 'chat', 'nextjs'] as const;
 export type TemplateName = (typeof TEMPLATE_NAMES)[number];
 
 export function isTemplateName(value: string): value is TemplateName {
@@ -792,4 +793,5 @@ export const TEMPLATES: Record<TemplateName, ScaffoldTemplate> = {
       'npm run typecheck',
     ],
   },
+  nextjs: NEXTJS_TEMPLATE,
 };

--- a/packages/create-pyric/test/scaffold.test.ts
+++ b/packages/create-pyric/test/scaffold.test.ts
@@ -53,6 +53,12 @@ describe('parseCreateArgs', () => {
     expect(args.positional).toEqual(['my-chat']);
     expect(args.flags.get('template')).toBe('chat');
   });
+
+  it('accepts nextjs as a named template value', () => {
+    const args = parseCreateArgs(['my-next-app', '--template', 'nextjs']);
+    expect(args.positional).toEqual(['my-next-app']);
+    expect(args.flags.get('template')).toBe('nextjs');
+  });
 });
 
 describe('runScaffold', () => {
@@ -104,6 +110,35 @@ describe('runScaffold', () => {
     expect(vite?.[1]).toContain("from '@pyric/cli/vite'");
     expect(vite?.[1]).toContain('pyric()');
     expect(io.getOut()).toContain('create-pyric: scaffolded web');
+  });
+
+  it('writes the nextjs scaffold when selected', async () => {
+    const io = bufferIo();
+    const writeFn = mock(async () => undefined);
+    const mkdirFn = mock(async () => undefined);
+    const code = await runScaffold(
+      {
+        dir: 'nextjs-demo',
+        template: 'nextjs',
+        commandLabel: 'create-pyric',
+        effectiveTemplate: applyDepsMode(TEMPLATES.nextjs, 'npm', { version: null }),
+      },
+      {
+        ...io,
+        cwd: '/tmp',
+        writeFile: writeFn as never,
+        mkdir: mkdirFn as never,
+        exists: async () => false,
+      },
+    );
+    expect(code).toBe(0);
+    const paths = writeFn.mock.calls.map((c) => c[0] as string);
+    expect(paths).toContain('/tmp/nextjs-demo/package.json');
+    expect(paths).toContain('/tmp/nextjs-demo/next.config.mjs');
+    const nextConfig = writeFn.mock.calls.find((c) => String(c[0]).endsWith('next.config.mjs'));
+    expect(nextConfig?.[1]).toContain("from '@pyric/cli/next'");
+    expect(nextConfig?.[1]).toContain('withPyric(');
+    expect(io.getOut()).toContain('create-pyric: scaffolded nextjs');
   });
 
   it('scaffolds into cwd when dir is omitted', async () => {

--- a/packages/site-docs/src/content/get-started/how-the-swap-works.md
+++ b/packages/site-docs/src/content/get-started/how-the-swap-works.md
@@ -3,7 +3,7 @@ title: "How firebase/* imports resolve locally and in production"
 navLabel: "How the swap works"
 group: "Get started"
 section: ""
-order: 20
+order: 40
 description: "Follow one import from your source to the local sandbox in development and to real Firebase in a production build."
 ---
 

--- a/packages/site-docs/src/content/get-started/nextjs.md
+++ b/packages/site-docs/src/content/get-started/nextjs.md
@@ -75,3 +75,20 @@ export async function GET() {
 ```
 
 When `pyric dev` supervises your Next.js process, server components and API routes automatically resolve Firebase Admin calls over the WebSocket bridge to your open browser tab.
+
+## Configure or disable the runtime chip
+
+Pass explicit options to `withPyric` to disable or expand the floating browser status chip during local development:
+
+```js
+// next.config.mjs
+import { withPyric } from '@pyric/cli/next';
+
+const nextConfig = {};
+
+export default withPyric(nextConfig, {
+  runtimeChip: false, // Pass { initiallyOpen: true } to launch expanded
+});
+```
+
+`withPyric` propagates your chip preference down to client runtime bundles automatically during local builds. No HTML transformations or layout component edits are required.

--- a/packages/site-docs/src/content/get-started/nextjs.md
+++ b/packages/site-docs/src/content/get-started/nextjs.md
@@ -1,0 +1,77 @@
+---
+title: "Next.js development setup"
+navLabel: "Next.js"
+group: "Get started"
+section: ""
+order: 30
+description: "Configure Next.js client component aliasing, dev rewrites, and supervised development execution."
+---
+
+# Next.js development setup
+
+Use Pyric with Next.js, App Router, and Turbopack.
+
+## Wrap your Next.js configuration
+
+Import `withPyric` from `@pyric/cli/next` in your `next.config.mjs`:
+
+```js
+import { withPyric } from '@pyric/cli/next';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Existing config
+};
+
+export default withPyric(nextConfig);
+```
+
+`withPyric` aliases your client-side `firebase/*` imports to the local browser sandbox and registers development HTTP rewrites that forward `/__pyric/*` requests to your local Pyric backend.
+
+## Supervise your development server
+
+Prefix your development start command with `pyric dev` in `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "pyric dev -- next dev",
+    "build": "next build",
+    "start": "next start"
+  }
+}
+```
+
+Start the supervised server with `npm run dev`. Pyric boots its sandbox host in the background, sets `PYRIC_SANDBOX` for server-side queries, and launches `next dev`.
+
+## Understand the two-server architecture
+
+Why does Next.js run two server processes while Vite runs one? Next.js doesn't expose Express or Connect custom middleware hooks. To preserve native compiling speed without requiring a custom server script, Pyric coordinates two processes:
+
+```
+Browser (http://localhost:3000)
+  ├── Next.js App & UI     ──> Next Dev Server (Port 3000)
+  ├── Pyric Studio (/ui)   ──> HTTP Rewrite Proxy  ──> Pyric Dev Host (Port 3473)
+  └── SharedWorker Sandbox ──> Direct WebSocket    ──> Pyric Dev Host (Port 3473)
+```
+
+1. **Single-Origin Browser Access**: You only ever open your Next.js application port (`http://localhost:3000`). Next.js HTTP rewrites seamlessly proxy Pyric Studio (`/__pyric/ui/`) and storage routes through that single port. Because your app and Studio share this exact origin, they share the single browser `SharedWorker` that holds your active Firestore data and IndexedDB persistence.
+2. **Direct WebSocket Synchrony**: Next.js development rewrites proxy standard HTTP traffic but cannot forward WebSockets (`Upgrade: websocket`). To synchronize real-time edits between your open browser tab and server-side Route Handlers, the browser runtime bypasses the rewrite proxy to connect its WebSocket bridge directly to port 3473.
+
+## Server-side Admin SDK queries
+
+Rely on supervised execution to route Node.js `firebase-admin` queries into your active browser tab:
+
+```ts
+// src/app/api/status/route.ts
+import { NextResponse } from 'next/server';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export async function GET() {
+  const db = getFirestore();
+  const snapshot = await db.collection('posts').get();
+  return NextResponse.json({ count: snapshot.size });
+}
+```
+
+When `pyric dev` supervises your Next.js process, server components and API routes automatically resolve Firebase Admin calls over the WebSocket bridge to your open browser tab.

--- a/packages/site-docs/src/content/get-started/start-building.md
+++ b/packages/site-docs/src/content/get-started/start-building.md
@@ -13,25 +13,35 @@ Pyric adds a development-only resolution layer to a Firebase application. During
 
 ## Start a new application
 
-Create a Vite application with canonical Firebase imports, Firestore rules, and the Pyric plugin already configured:
+Create a new Vite or Next.js application with canonical Firebase imports, Firestore rules, and Pyric already configured:
+
 ```bash
+# Start a Vite application
 npm create pyric my-app
+
+# Or start a Next.js application
+npm create pyric my-app -- --template nextjs
+
 cd my-app
 npm install
 npm run dev
 ```
 
-Open the local URL printed by Vite. The application and Pyric Studio use the same local backend. Studio is mounted at `/__pyric/ui/` on that origin.
+Open the local URL printed by the development server. The application and Pyric Studio use the exact same local backend. Studio is mounted at `/__pyric/ui/` on that origin.
 
 Pyric also adds a small, collapsed runtime chip in the bottom-right corner. It stays quiet while the sandbox is healthy and signals when there is an error to inspect or a newer worker to activate. [Resolve runtime errors and stale workers](../observe/resolve-runtime-status.md) covers both actions.
 
-## Add Pyric to an existing Vite application
+## Add Pyric to an existing application
 
-Install the development plugin:
+Install the CLI and development plugins as a development dependency:
+
 ```bash
 npm install --save-dev @pyric/cli
 ```
+
+### Vite
 Add it to the Vite configuration:
+
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
@@ -41,11 +51,30 @@ export default defineConfig({
   plugins: [pyric()],
 });
 ```
+
+### Next.js
+
+Update the Next.js configuration in `next.config.mjs`:
+
+```ts
+import { fileURLToPath } from 'node:url';
+import { withPyric } from '@pyric/cli/next';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Existing config
+};
+
+export default withPyric(nextConfig);
+```
+
 Start the normal development server:
+
 ```bash
 npm run dev
 ```
-No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. The plugin uses an explicit `rules` option first, then discovers `firestore.modules.rules`, the path in `firebase.json`, or `firestore.rules`, in that order.
+
+No application imports change. Continue using `firebase/app`, `firebase/auth`, `firebase/firestore`, and the other supported Firebase entry points. Pyric uses an explicit rules configuration first, then discovers `firestore.modules.rules`, the path in `firebase.json`, or `firestore.rules`, in that order.
 
 ## Use a static application or Node process
 

--- a/packages/site-docs/src/content/get-started/vite.md
+++ b/packages/site-docs/src/content/get-started/vite.md
@@ -1,0 +1,53 @@
+---
+title: "Vite development setup"
+navLabel: "Vite"
+group: "Get started"
+section: ""
+order: 20
+description: "Configure Vite module aliasing and dev server integration for Pyric."
+---
+
+# Vite development setup
+
+The Pyric Vite plugin runs pyric inside Vite's single development server.
+
+## Add the plugin to your configuration
+
+Install `@pyric/cli` as a development dependency and add the `pyric` plugin to `vite.config.ts`:
+
+```ts
+import { defineConfig } from 'vite';
+import { pyric } from '@pyric/cli/vite';
+
+export default defineConfig({
+  plugins: [pyric()],
+});
+```
+
+The plugin attaches directly to Vite's Connect middleware stack and import map resolution. All requests to `/__pyric/*` and imports of `firebase/*` execute directly on a Vite development server port (default 5173).
+
+## Start your local server
+
+Run your normal Vite development server:
+
+```bash
+npm run dev
+```
+
+Vite serves the application and Pyric Studio simultaneously on the exact same local origin. Access Studio at `/__pyric/ui/` or by clicking the floating runtime chip in the bottom-right corner of the browser.
+
+## Specify custom Security Rules
+
+Pass explicit rules paths to the plugin options when your rules files live outside standard discovery paths:
+
+```ts
+export default defineConfig({
+  plugins: [
+    pyric({
+      rules: 'security/firestore.rules',
+    }),
+  ],
+});
+```
+
+The plugin hot-reloads Security Rules whenever the file is saved. If omitted, Pyric checks `firestore.modules.rules`, `firebase.json`, and `firestore.rules` automatically.

--- a/packages/site-docs/test/api-reference.test.ts
+++ b/packages/site-docs/test/api-reference.test.ts
@@ -47,9 +47,9 @@ describe('generated API reference inventory', () => {
   });
 
   test('uses unique stable routes backed by declaration entries', () => {
-    expect(descriptors).toHaveLength(49);
-    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(49);
-    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(49);
+    expect(descriptors).toHaveLength(50);
+    expect(new Set(descriptors.map(({ importPath }) => importPath)).size).toBe(50);
+    expect(new Set(descriptors.map(({ slug }) => slug)).size).toBe(50);
     for (const descriptor of descriptors) {
       expect(existsSync(descriptor.typesPath), descriptor.importPath).toBeTrue();
       expect(descriptor.slug).toMatch(/^[a-z0-9-]+-reference-api$/);

--- a/scripts/fixtures/cli-release-contract.json
+++ b/scripts/fixtures/cli-release-contract.json
@@ -34,6 +34,7 @@
     "./bridge/client",
     "./discover",
     "./vite",
+    "./next",
     "./serve/worker",
     "./remote",
     "./register"

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -590,6 +590,23 @@ test -f "$CREATE_OUT/package.json"
 grep -q '"dev": "vite"' "$CREATE_OUT/package.json"
 echo "  ✓ create-pyric scaffolds Vite + @pyric/cli/vite"
 
+# create-pyric nextjs smoke: scaffold a Next.js app into a fresh directory and
+# assert load-bearing configuration and wrapper imports exist.
+echo "▸ create-pyric nextjs smoke"
+CREATE_NEXTJS_OUT="$WORK/create-nextjs-smoke-app"
+rm -rf "$CREATE_NEXTJS_OUT"
+"$CREATE_PYRIC_BIN" "$CREATE_NEXTJS_OUT" --template nextjs --name packed-nextjs
+test -f "$CREATE_NEXTJS_OUT/next.config.mjs"
+grep -q "@pyric/cli/next" "$CREATE_NEXTJS_OUT/next.config.mjs"
+grep -q "withPyric(nextConfig)" "$CREATE_NEXTJS_OUT/next.config.mjs"
+test -f "$CREATE_NEXTJS_OUT/package.json"
+grep -q '"dev": "pyric dev -- next dev"' "$CREATE_NEXTJS_OUT/package.json"
+grep -q '"name": "packed-nextjs"' "$CREATE_NEXTJS_OUT/package.json"
+grep -q '# packed-nextjs' "$CREATE_NEXTJS_OUT/README.md"
+test -f "$CREATE_NEXTJS_OUT/src/app/page.tsx"
+test -f "$CREATE_NEXTJS_OUT/src/app/api/status/route.ts"
+echo "  ✓ create-pyric scaffolds Next.js + @pyric/cli/next"
+
 # Named chat smoke: prove the packaged asset tree is available to the installed
 # bin and stays free of repo/install artifacts and internal package paths.
 echo "▸ create-pyric chat smoke"


### PR DESCRIPTION
Adds `@pyric/cli/next` and `npm create pyric -- --template nextjs` to run local Firebase sandboxes under supervised Next.js development without changing source imports.

```js
// next.config.mjs
import { withPyric } from '@pyric/cli/next';

/** @type {import('next').NextConfig} */
const nextConfig = {};

export default withPyric(nextConfig);
```

```json
// package.json
{
  "scripts": {
    "dev": "pyric dev -- next dev",
    "build": "next build",
    "start": "next start"
  }
}
```

## Risk

Next.js App Router applications bundle React Server Components (RSC) and Client Components with separate Webpack and Turbopack dependency graphs. Misrouting an alias across these compilation boundaries could cause server-only node dependencies to leak into client bundles, or cause browser runtime chips to execute during server rendering. Because Webpack module fallbacks explicitly disable Node builtin packages (`fs`, `path`, `http`) during client bundling, any future extension of client SDK aliases must ensure non-DOM compatibility and avoid importing Node-only libraries.

## Client bundles load the runtime chip and bridge without index.html injection

```ts
// packages/cli/src/serve/entries/firestore.ts
import './init.js';
import * as ip from 'pyric/firestore';
```

When bundling applications that lack Vite's HTML index transform hooks (such as Next.js App Router projects), standalone Firebase SDK replacements now statically import `init.js`. Importing any Firebase SDK module in a browser environment automatically establishes the real-time WebSocket connection to the MCP bridge (`/__pyric/sandbox`) and mounts the floating runtime chip in a collapsed state when metadata opt-out tags are absent.

## withPyric configures or disables the floating runtime chip without DOM injection

```js
// next.config.mjs
import { withPyric } from '@pyric/cli/next';

const nextConfig = {};

export default withPyric(nextConfig, {
  runtimeChip: false, // Or pass { initiallyOpen: true }
});
```

Next.js developers can explicitly configure or disable the browser runtime status chip by passing options to `withPyric()`. Pyric injects `PYRIC_RUNTIME_CHIP` into your bundler environment variables, seamlessly communicating your chip state down to browser bundles without requiring HTML index transformations or layout component edits.

## pyric dev mounts Studio UI and disk storage routes by default

```ts
// packages/cli/src/cli/serve.ts
const explicitUi = Boolean(parsed.flags.get('ui'));
const uiOn = !parsed.flags.get('no-ui');
```

Running `pyric dev` mounts the Pyric Studio application at `/__pyric/ui/` and activates the workspace storage APIs by default. In supervised two-server setups (`pyric dev -- next dev`), Next.js dev rewrites proxy `/__pyric/*` traffic through the single app origin (`http://localhost:3000/__pyric/ui/`), preserving domain-scoped `SharedWorker` persistence across both your application and Pyric Studio. Passing explicit `--ui` retains its convenience behavior of auto-opening Studio directly in your browser.

## Next.js client bundles run modern top-level await without compilation warnings

```ts
// packages/cli/src/next/webpack-config.ts
function assembleClientExperimentsSection(existingExperiments: Record<string, any> | undefined): Record<string, any> {
  const experimentsSection = existingExperiments !== undefined ? Object.assign({}, existingExperiments) : {};
  experimentsSection.topLevelAwait = true;
  return experimentsSection;
}
```

Webpack compilations for client runtime builds declare `topLevelAwait: true` and `environment: { asyncFunction: true }`. This prevents Next.js from emitting module import trace warnings when consuming asynchronous modern JavaScript SDK wrappers during local development.

<details>
<summary>Implementation notes</summary>

### Findings & Architecture Decisions
- **Two-Server Topology vs Single-Server**: Next.js 15+ App Router and Turbopack intentionally omit hooks for registering custom Connect middleware or WebSocket listeners directly inside `next dev`. Rather than authoring an unsupported monolithic Custom Server script that bypasses Turbopack optimizations, Pyric runs two coordinated lightweight processes. Next.js HTTP rewrites maintain a single-origin browser workflow (`http://localhost:3000`), while the browser runtime directly dials the internal Pyric server port over WebSockets (`ws://localhost:3473/__pyric/sandbox`) to bypass Next's inability to proxy WebSocket upgrades.
- **Dot-Directory Filtering**: `scanForInlinedFirebase` in `serve.ts` ignores hidden cache folders (`.next`, `.turbo`), eliminating false-positive inline bundling failures.
- **Top-Level Turbopack Key**: Updated `turbopack-config.ts` to set `config.turbopack` rather than deprecated `experimental.turbo`, matching Next.js 15.5 requirements.
- **Removed Experimental Root Boilerplate from Docs**: Removed monorepo-specific `experimental: { outputFileTracingRoot }` overrides from public setup guides; this configuration is solely needed inside our internal multi-package workspace to silence parent lockfile warnings during tests.

### Verification & Test Counts
- **End-to-End Test Suite**: Authored a Playwright automated suite in `examples/nextjs-sandbox-app/test/auth-post.pw.ts` running against a live supervised Next.js server (`npm run test:e2e`). Verified Google Auth popup mock credential minting, Firestore real-time record additions, and server-side Route Handler queries (`GET /api/status`) without gRPC `unavailable` failures or compiler warnings.
- **Unit & Integration Coverage**:
  - `bun test packages/cli/test` (898 tests passed across 127 files, 3026 expectations)
  - `bun test packages/site-docs` (43 tests passed across 14 files, 307 expectations)
  - `bun run --cwd packages/site-docs build` (107 pages generated cleanly)
- **Exit Codes**: All build and test pipelines terminated with exit code `0`.

</details>
