### PR TITLE
feat(studio): add RTDB rules evaluation inspector with deciding-line highlighting

### DIFF
--- a/packages/studio/src/features/rules-debug/RulesDebug.tsx
+++ b/packages/studio/src/features/rules-debug/RulesDebug.tsx
@@ -284,8 +284,10 @@ function RuleDetail({
   exp: RuleExplanation;
   rulesSource?: string;
 }) {
-  if (exp.engine === 'rtdb') return <RtdbRuleDetail denial={denial} exp={exp} />;
-  if (exp.engine === 'storage') return <StorageRuleDetail exp={exp} />;
+  const isRtdb = exp.engine === 'rtdb';
+  const isStorage = exp.engine === 'storage';
+  if (isRtdb) return <RtdbRuleDetail denial={denial} exp={exp} rulesSource={rulesSource} />;
+  if (isStorage) return <StorageRuleDetail exp={exp} />;
   return <FirestoreRuleDetail denial={denial} exp={exp} rulesSource={rulesSource} />;
 }
 
@@ -487,19 +489,123 @@ function ValueTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
   );
 }
 
+/**
+ * Resolves the 1-indexed source code line in `database.rules.json` that corresponds
+ * to an evaluated Realtime Database access verdict. Matches the rule expression
+ * and phase directive, using preceding path segment hits to break ties when
+ * multiple paths declare identical boolean or common expressions.
+ */
+export function findRtdbRuleLine(
+  rulesSource?: string,
+  phase?: string,
+  matchedRule?: string,
+  matchedPath?: string,
+): number | undefined {
+  const isMissingSource = !rulesSource || !matchedRule;
+  if (isMissingSource) return undefined;
+
+  const lines = rulesSource.split(/\r?\n/);
+  const hasPhase = phase !== undefined && phase.length > 0;
+  let targetDirective: string | null;
+  if (hasPhase) {
+    targetDirective = `".${phase}"`;
+  } else {
+    targetDirective = null;
+  }
+
+  const candidates: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const hasExpression = line.includes(matchedRule);
+    if (!hasExpression) continue;
+    const hasDirective = targetDirective === null || line.includes(targetDirective);
+    if (!hasDirective) continue;
+    candidates.push(i + 1);
+  }
+
+  const hasSingleMatch = candidates.length === 1;
+  if (hasSingleMatch) return candidates[0];
+  if (candidates.length === 0) return undefined;
+
+  const pathSegments = (matchedPath ?? '').split('/').filter(Boolean);
+  if (pathSegments.length === 0) return candidates[0];
+
+  let bestLine = candidates[0];
+  let bestScore = -1;
+
+  for (const candidateLine of candidates) {
+    let score = 0;
+    const zeroIndexedPrevLine = candidateLine - 2;
+    const searchWindowLimit = Math.max(0, zeroIndexedPrevLine - 30);
+    for (let j = zeroIndexedPrevLine; j >= searchWindowLimit; j--) {
+      const lineText = lines[j];
+      for (const segment of pathSegments) {
+        if (lineText.includes(`"${segment}"`)) {
+          score++;
+        }
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestLine = candidateLine;
+    }
+  }
+
+  return bestLine;
+}
+
 /** RTDB: WHICH node in the cascade denied (`.write` vs `.validate`, at which
  *  rule-tree path), its raw rule text, and the `$variable` bindings —
- *  `SimulateHandler`'s verdict, not a re-derivation. */
-function RtdbRuleDetail({ denial, exp }: { denial: Denial; exp: RuleExplanation }) {
+ *  `SimulateHandler`'s verdict, not a re-derivation. When `rulesSource` is
+ *  present, mounts CodeMirror to highlight the deciding 1-indexed source line. */
+function RtdbRuleDetail({
+  denial,
+  exp,
+  rulesSource,
+}: {
+  denial: Denial;
+  exp: RuleExplanation;
+  rulesSource?: string;
+}) {
+  const line = findRtdbRuleLine(rulesSource, exp.phase, exp.ruleExpression, denial.rules?.matchedPath);
+  const isAllowed = denial.result === 'allow';
+  const hasSource = rulesSource !== undefined && rulesSource.trim().length > 0;
+  let ruleNodeLabel: string;
+  if (exp.implicitDeny || !exp.ruleNode) {
+    ruleNodeLabel = 'rule node';
+  } else if (line !== undefined) {
+    ruleNodeLabel = `rule node — ${exp.ruleNode} · line ${line}`;
+  } else {
+    ruleNodeLabel = `rule node — ${exp.ruleNode}`;
+  }
+
+  let ariaLabelText: string;
+  if (isAllowed) {
+    ariaLabelText = 'Deployed database.rules.json — the allowing rule is marked';
+  } else {
+    ariaLabelText = 'Deployed database.rules.json — the denying rule is marked';
+  }
+
   return (
     <>
-      <Field label={exp.implicitDeny ? 'rule node' : `rule node — ${exp.ruleNode}`}>
-        <code className="font-mono text-xs text-soft-white">
-          {exp.phase ? `.${exp.phase}` : '(no matching rule)'}
-          {denial.rules?.matchedPath ? ` at ${denial.rules.matchedPath}` : ''}
-        </code>
+      <Field label={ruleNodeLabel}>
+        {hasSource ? (
+          <LazyRulesCodeEditor
+            value={rulesSource}
+            readOnly
+            markLine={line}
+            markKind={isAllowed ? 'allow' : 'deny'}
+            minHeightRem={12}
+            ariaLabel={ariaLabelText}
+          />
+        ) : (
+          <code className="font-mono text-xs text-soft-white">
+            {exp.phase ? `.${exp.phase}` : '(no matching rule)'}
+            {denial.rules?.matchedPath ? ` at ${denial.rules.matchedPath}` : ''}
+          </code>
+        )}
       </Field>
-      {exp.ruleExpression ? (
+      {!hasSource && exp.ruleExpression ? (
         <Field label="rule expression">
           <pre className="overflow-auto rounded-md border border-border bg-content-bg p-3 font-mono text-xs text-slate-gray">
             {exp.ruleExpression}

--- a/packages/studio/src/features/rules-debug/SPEC.md
+++ b/packages/studio/src/features/rules-debug/SPEC.md
@@ -169,11 +169,7 @@ raw `matchedRule` expression are surfaced verbatim.
 path, the raw rule expression (`matchedRule`), `$variable` bindings, the data
 evaluated (proposed write / existing value), `request.auth`.
 
-**Re-runs**: both **pending** — the pure `SimulateHandler` is the mechanical
-substrate, but the Studio worker does not yet expose a denial re-run operation.
-There is also no whole-ruleset RTDB linter yet, so the edited-ruleset re-run
-must name that gap. Re-running is honestly a simulation, never framed as a
-production operation.
+**Re-runs**: both **live** — the pure `SimulateHandler` (`rtdbRules(rules).simulate`) is the mechanical substrate. Impersonated re-runs execute against active sandbox rules via `issueOp`, while edited-ruleset re-runs validate JSON syntax and re-simulate over an in-memory branch (`fork + setRules + simulate`). Re-running is honestly a simulation, never framed as a live inline enforcement gate.
 
 ### Storage
 

--- a/packages/studio/src/features/rules-debug/rerun-support.ts
+++ b/packages/studio/src/features/rules-debug/rerun-support.ts
@@ -32,14 +32,12 @@ export function rerunSupport(denial: Denial): ServiceRerunSupport {
     case 'rtdb':
       return {
         impersonate: {
-          kind: 'pending',
-          tool: 'rtdb_simulate_access',
-          hint: 'RTDB re-runs through the local rules simulator as this user once the Studio worker exposes rtdb_simulate_access. This is a simulation, not a live re-issue — RTDB has no live local enforcement path.',
+          kind: 'live',
+          tool: 'rtdb_simulate_access replay',
         },
         editedRuleset: {
-          kind: 'pending',
-          tool: 'RulesEvaluator.setRules + rtdb_simulate_access',
-          hint: 'Editing the RTDB ruleset re-simulates the write once the worker exposes the RTDB simulator. Note: there is no whole-ruleset RTDB linter yet (rtdb_build_expression lints a single expression).',
+          kind: 'live',
+          tool: 'fork + rtdb_simulate_access',
         },
       };
     case 'storage':

--- a/packages/studio/src/features/rules-debug/rerun.ts
+++ b/packages/studio/src/features/rules-debug/rerun.ts
@@ -44,6 +44,8 @@ import {
   getDocs,
   query,
 } from 'pyric/firestore';
+import { setRules as setRtdbRules, getActiveRules, snapshotState, stripJsonComments, type RtdbRulesJson } from 'pyric/sandbox/database';
+import { rtdbRules, type RtdbCase } from 'pyric/rules';
 import { lintFirestoreRules, type LintWarning } from 'pyric/rules/internal';
 import type { Denial } from './model.js';
 
@@ -86,7 +88,21 @@ export interface RulesetLint {
  * call from the UI to annotate the editor live, and called by
  * {@link rerunAgainstRules} before it forks.
  */
-export function lintEditedRuleset(rules: string): RulesetLint {
+export function lintEditedRuleset(rules: string, service: string = 'firestore'): RulesetLint {
+  const isRtdb = service === 'rtdb';
+  if (isRtdb) {
+    try {
+      JSON.parse(stripJsonComments(rules));
+      return { parseable: true, findings: [] };
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      return {
+        parseable: false,
+        parseError: `Invalid RTDB rules JSON: ${err}`,
+        findings: [],
+      };
+    }
+  }
   const result = lintFirestoreRules(rules);
   const findings: RulesetLintFinding[] = result.warnings.map((w) => ({
     rule: w.rule,
@@ -139,12 +155,14 @@ export async function rerunAgainstRules(
   editedRules: string,
   live: LocalSandbox | SandboxSnapshot,
 ): Promise<EditedRulesetRerun> {
-  // Lint first (firestore_lint_rules). A parse failure is the only hard blocker
+  // Lint first (firestore_lint_rules / JSON syntax for RTDB). A parse failure is the only hard blocker
   // — an unparseable ruleset can't be forked/simulated — so short-circuit and
   // report it rather than throwing an opaque fork error. Non-parse findings
   // (including security-level lints) are surfaced but do not block the run.
-  const lint = lintEditedRuleset(editedRules);
-  if (!lint.parseable) {
+  const isRtdb = denial.service === 'rtdb' || denial.rules?.engine === 'rtdb';
+  const lint = lintEditedRuleset(editedRules, denial.service);
+  const isUnparseable = !lint.parseable;
+  if (isUnparseable) {
     return {
       result: {
         outcome: 'error',
@@ -154,6 +172,22 @@ export async function rerunAgainstRules(
       diff: [],
       lint,
     };
+  }
+
+  if (isRtdb) {
+    const branch = fork(snapshot, '');
+    try {
+      const hasServices = snapshot.services !== undefined && Object.keys(snapshot.services).length > 0;
+      if (hasServices) {
+        branch.sandbox.loadSnapshot(snapshot);
+      }
+      const parsedRules = JSON.parse(editedRules) as RtdbRulesJson;
+      setRtdbRules(branch.sandbox as unknown as LocalSandbox, parsedRules);
+      const result = await issueOp(branch.sandbox, denial);
+      return { result, diff: [], lint };
+    } finally {
+      discard(branch);
+    }
   }
 
   const branch = fork(snapshot, editedRules);
@@ -180,6 +214,60 @@ export async function rerunAgainstRules(
  * the fresh denial reasons; any other throw is `{ outcome: 'error' }`.
  */
 export async function issueOp(sandbox: Sandbox, denial: Denial): Promise<RerunResult> {
+  const isRtdb = denial.service === 'rtdb' || denial.rules?.engine === 'rtdb';
+  if (isRtdb) {
+    const localSandbox = sandbox as unknown as LocalSandbox;
+    const rules = getActiveRules(localSandbox);
+    const hasNoRules = rules === undefined || rules === null;
+    if (hasNoRules) {
+      return {
+        outcome: 'error',
+        code: 'NO_ACTIVE_RULES',
+        message: 'No RTDB rules are loaded in the local sandbox.',
+      };
+    }
+    const state = snapshotState(localSandbox);
+    const isRecordState = state !== null && typeof state === 'object' && !Array.isArray(state);
+    const data = isRecordState ? (state as Record<string, unknown>) : {};
+    const isReadMethod = denial.method === 'get' || denial.method === 'list' || denial.method === 'listen';
+    const operation = isReadMethod ? 'read' : 'write';
+    const uid = denial.auth?.uid;
+    const auth = uid !== undefined
+      ? { uid, token: ((denial.auth as Record<string, unknown>)?.token ?? (denial.auth as Record<string, unknown>)?.claims ?? {}) as Record<string, unknown> }
+      : null;
+    const oneCase: RtdbCase = {
+      expectation: 'ALLOW',
+      operation,
+      path: denial.path,
+      auth,
+      data,
+      ...(denial.resourceData !== undefined ? { newData: denial.resourceData } : {}),
+    };
+    const result = rtdbRules(rules).simulate([oneCase]).cases[0];
+    const isAllowed = result.decision === 'ALLOW';
+    const isUnsupported = result.decision === 'UNSUPPORTED' || result.unsupported;
+    if (isUnsupported) {
+      return {
+        outcome: 'error',
+        code: 'unsupported',
+        message: result.reason || 'Simulation hit an unmodelled RTDB feature.',
+      };
+    }
+    if (isAllowed) {
+      return { outcome: 'allow' };
+    }
+    const reasons = [
+      result.reason,
+      result.matchedPath ? `path: ${result.matchedPath}` : '',
+      result.matchedRule ? `rule: ${result.matchedRule}` : '',
+    ].filter(Boolean);
+    return {
+      outcome: 'deny',
+      code: 'PERMISSION_DENIED',
+      message: result.reason || 'PERMISSION_DENIED: Permission denied',
+      reasons,
+    };
+  }
   const db = getSandboxFirestore(sandbox.withAuth(denial.auth as AuthState));
   const resourceData = documentData(denial.resourceData);
   try {

--- a/packages/studio/src/features/rules-debug/rules-debug.test.ts
+++ b/packages/studio/src/features/rules-debug/rules-debug.test.ts
@@ -50,6 +50,7 @@ import {
   lintEditedRuleset,
   type ImpersonationClient,
 } from './rerun.js';
+import { findRtdbRuleLine } from './RulesDebug.js';
 
 const OWNER_RULES = `rules_version = '2';
 service cloud.firestore {
@@ -259,6 +260,37 @@ describe('rules-debug model: RTDB denial → rule node → bindings', () => {
   });
 });
 
+describe('rules-debug: RTDB source line resolution (findRtdbRuleLine)', () => {
+  const SAMPLE_RTDB_JSON = `{
+  "rules": {
+    "rooms": {
+      "$roomId": {
+        ".read": "auth != null",
+        ".write": false
+      }
+    },
+    "public": {
+      ".read": true,
+      ".write": false
+    }
+  }
+}`;
+
+  it('locates a unique rule expression and phase line number in database.rules.json', () => {
+    const line = findRtdbRuleLine(SAMPLE_RTDB_JSON, 'read', 'auth != null', 'rooms/r1');
+    expect(line).toBe(5);
+  });
+
+  it('disambiguates identical rules using preceding path segment context', () => {
+    // Both rooms/$roomId and public have ".write": false on lines 6 and 11
+    const lineRooms = findRtdbRuleLine(SAMPLE_RTDB_JSON, 'write', 'false', 'rooms/r1');
+    expect(lineRooms).toBe(6);
+
+    const linePublic = findRtdbRuleLine(SAMPLE_RTDB_JSON, 'write', 'false', 'public/data');
+    expect(linePublic).toBe(11);
+  });
+});
+
 describe('rules-debug re-run: capability grading per service (rerunSupport)', () => {
   it('Firestore: both re-run paths are live', () => {
     const d: Denial = {
@@ -271,7 +303,7 @@ describe('rules-debug re-run: capability grading per service (rerunSupport)', ()
     expect(support.editedRuleset.kind).toBe('live');
   });
 
-  it('RTDB: both re-run paths are pending, naming rtdb_simulate_access', () => {
+  it('RTDB: both re-run paths are live', () => {
     const d: Denial = {
       result: 'deny',
       id: 'r1', at: 0, method: 'set', path: 'rooms/r1', service: 'rtdb',
@@ -279,11 +311,8 @@ describe('rules-debug re-run: capability grading per service (rerunSupport)', ()
       auth: { uid: 'bob' }, reasons: [], origin: 'user', unsupported: false,
     };
     const support = rerunSupport(d);
-    expect(support.impersonate.kind).toBe('pending');
-    expect(support.editedRuleset.kind).toBe('pending');
-    if (support.impersonate.kind === 'pending') {
-      expect(support.impersonate.tool).toBe('rtdb_simulate_access');
-    }
+    expect(support.impersonate.kind).toBe('live');
+    expect(support.editedRuleset.kind).toBe('live');
   });
 
   it('Storage: both re-run paths are absent, naming storage_simulate_rules', () => {
@@ -390,6 +419,48 @@ describe('rules-debug re-run: edited ruleset (lint + fork + diff)', () => {
     const lint = lintEditedRuleset(RECURSIVE_OPEN_RULES);
     expect(lint.parseable).toBe(true);
     expect(lint.findings.some((f) => f.severity === 'error')).toBe(true);
+  });
+});
+
+describe('rules-debug re-run: RTDB edited ruleset simulation', () => {
+  it('re-running a denied RTDB write against permissive JSON rules ALLOWS', async () => {
+    const sandbox = initializeSandbox();
+    const adminDb = getDatabase(sandbox);
+    rtdbSandbox.setRules(adminDb, {
+      rules: {
+        rooms: { '.write': false },
+      },
+    });
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+    const dbBob = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    try {
+      await set(ref(dbBob, '/rooms/r1/messages/m1'), { text: 'hi' });
+    } catch { /* expected */ }
+    const denials = selectDenials(events);
+    const denial = denials.find((x) => x.service === 'rtdb')!;
+    expect(denial).toBeDefined();
+
+    const permissiveJson = JSON.stringify({ rules: { '.read': true, '.write': true } });
+    const rerun = await rerunAgainstRules(sandbox.snapshot(), denial, permissiveJson, sandbox);
+    expect(rerun.result.outcome).toBe('allow');
+    expect(rerun.lint.parseable).toBe(true);
+  });
+
+  it('re-running against invalid RTDB rules JSON returns lint-parse-error', async () => {
+    const sandbox = initializeSandbox();
+    const d: Denial = {
+      result: 'deny',
+      id: 'r1', at: 0, method: 'set', path: 'rooms/r1', service: 'rtdb',
+      rules: { engine: 'rtdb' },
+      auth: { uid: 'bob' }, reasons: [], origin: 'user', unsupported: false,
+    };
+    const rerun = await rerunAgainstRules(sandbox.snapshot(), d, '{ invalid json', sandbox);
+    expect(rerun.result.outcome).toBe('error');
+    if (rerun.result.outcome === 'error') {
+      expect(rerun.result.code).toBe('lint-parse-error');
+    }
+    expect(rerun.lint.parseable).toBe(false);
   });
 });
 

--- a/packages/studio/src/features/traffic/TrafficRulesInspector.tsx
+++ b/packages/studio/src/features/traffic/TrafficRulesInspector.tsx
@@ -49,8 +49,9 @@ export function TrafficRulesInspector({
 }) {
   const ops = useStudioRuleEvaluations();
   const getSnapshot = useStudioSnapshot();
-  const rulesSource = useStudioRulesSource();
   const op = ops.find((d) => d.id === eventId);
+  const targetService = op?.service ?? 'firestore';
+  const rulesSource = useStudioRulesSource(targetService);
 
   // The "what if" buffer. Keyed per op by the parent (`key={eventId}`), so
   // switching ops resets it; prefilled from the live rules once they resolve

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -29,12 +29,14 @@ import { sandbox as authSandbox, type CreateUserRequest } from 'pyric/auth';
 import { setRules as workerSetRules } from '@pyric/cli/serve/worker';
 import type {
   EventProvenance,
+  LocalSandbox,
   RequestEvent,
   SandboxEvent,
   SandboxOperationEvent,
   SandboxSnapshot,
 } from 'pyric/sandbox';
 import { toOperationRecord } from 'pyric/sandbox';
+import { getActiveRules as getActiveDatabaseRules } from 'pyric/sandbox/database';
 import type { StudioTrafficEvent } from '../features/traffic/verdict.js';
 import { foldSessionEventLog } from '../events/fold.js';
 import { useDevSeed } from '../dev/DevSeedProvider.js';
@@ -617,26 +619,45 @@ export function useStudioBranches(): StudioBranches {
 }
 
 /**
- * The deployed Firestore rules text the denial inspector traces against,
+ * The deployed security rules text the denial inspector traces against,
  * dev-seed first. In served mode the rules the server deployed ride
  * `/__pyric/init.json` (the page init payload), so a one-shot same-origin fetch
  * reads them without a worker round-trip. Empty until resolved (the inspector
  * still shows the denial's path/method/auth; the trace fills in once present).
+ * Supports Firestore, Realtime Database (`databaseRules`), and Storage.
  */
-export function useStudioRulesSource(): string {
+export function useStudioRulesSource(service: string = 'firestore'): string {
   const seed = useDevSeed();
   const seedReady = seed.status === 'ready';
-  const [servedRules, setServedRules] = useState('');
+  const [servedRules, setServedRules] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (seedReady) return;
     let alive = true;
     fetch('/__pyric/init.json')
       .then((r) => (r.ok ? r.json() : null))
-      .then((payload: { rules?: string | null } | null) => {
-        if (alive && payload && typeof payload.rules === 'string') {
-          setServedRules(payload.rules);
+      .then((payload: { rules?: string | null; databaseRules?: unknown | null; storageRules?: string | null } | null) => {
+        const isInvalidPayload = !alive || !payload || typeof payload !== 'object';
+        if (isInvalidPayload) return;
+        const resolved: Record<string, string> = {};
+        const hasFirestore = typeof payload.rules === 'string';
+        if (hasFirestore) {
+          resolved.firestore = payload.rules as string;
         }
+        const hasDatabase = payload.databaseRules !== undefined && payload.databaseRules !== null;
+        if (hasDatabase) {
+          const isStringRule = typeof payload.databaseRules === 'string';
+          if (isStringRule) {
+            resolved.rtdb = payload.databaseRules as string;
+          } else {
+            resolved.rtdb = JSON.stringify(payload.databaseRules, null, 2);
+          }
+        }
+        const hasStorage = typeof payload.storageRules === 'string';
+        if (hasStorage) {
+          resolved.storage = payload.storageRules as string;
+        }
+        setServedRules(resolved);
       })
       .catch(() => {
         /* best-effort: no text, the inspector still renders the denial. */
@@ -647,11 +668,25 @@ export function useStudioRulesSource(): string {
   }, [seedReady]);
 
   return useMemo<string>(() => {
-    if (seed.status !== 'ready') return servedRules;
+    const isOfflineSeed = seed.status === 'ready';
+    const normalizedService = service === 'database' ? 'rtdb' : service;
+    if (!isOfflineSeed) {
+      const source = servedRules[normalizedService];
+      if (source !== undefined) return source;
+      return '';
+    }
     try {
+      const isRtdb = normalizedService === 'rtdb';
+      if (isRtdb) {
+        const active = getActiveDatabaseRules(seed.handles.sandbox as unknown as LocalSandbox);
+        if (active !== undefined && active !== null) {
+          return JSON.stringify(active, null, 2);
+        }
+        return '';
+      }
       return getInternalEnv(seed.handles.sandbox).getRules();
     } catch {
       return '';
     }
-  }, [seed, servedRules]);
+  }, [seed, servedRules, service]);
 }


### PR DESCRIPTION
Adds live Realtime Database rules inspection to Pyric Studio, resolving active rule source files across dev sessions and highlighting the evaluated deciding allow or deny row directly inside the read-only CodeMirror viewer.

```ts
// In Pyric Studio's Traffic inspector, clicking an RTDB read or write mounts the full rules document and highlights the deciding line
import { findRtdbRuleLine } from '@pyric/studio/features/rules-debug/RulesDebug';

const rtdbRulesSource = `{
  "rules": {
    "spaces_app": {
      "client_freshness": {
        ".read": true
      }
    }
  }
}`;

// Before: Studio exclusively checked init.json for firestore.rules, rendering an empty code buffer with "RULE NODE — UNDEFINED"
// After: dynamically loads databaseRules and deterministically scans JSON structures to mark row numbers
const line = findRtdbRuleLine(rtdbRulesSource, 'read', 'true', '/spaces_app/client_freshness');
console.log(line); // => 5 (marks line 5 with green ✓ allow row emphasis in CodeMirror)
```

## Studio inspector automatically loads active Realtime Database rules

Previously, Studio's data hook (`useStudioRulesSource()`) exclusively extracted `payload.rules` (Firestore rules) from `/__pyric/init.json` and offline dev-seeds, entirely ignoring `payload.databaseRules` and `payload.storageRules`. Even when an RTDB denial occurred, Studio checked for `firestore.rules` and rendered an empty CodeMirror buffer. `useStudioRulesSource(service?: string)` now dynamically queries the inspected operation's service type (`op?.service ?? 'firestore'`), automatically loading `database.rules.json` whenever a Realtime Database event is examined.

## Deciding allow and deny lines receive visual gutter highlighting

When inspecting traffic denials or allowed read operations, `findRtdbRuleLine()` traverses `database.rules.json` line-by-line for matching directives (`".write"`, `".read"`, `".validate"`) and evaluated expressions. It scores backward path-segment context (`spaces_app`, `$uid`) to disambiguate paths declaring identical rules (e.g. `".write": false`). The resolving row is threaded directly into `LazyRulesCodeEditor`, rendering gutter markers and background row tinting (green ✓ for allow, red ✗ for deny) to match Firestore's visual diagnostic design.

## Live simulation engine upgrades Realtime Database re-runs from pending to live

In F4 rules debugging, Realtime Database simulation re-runs (`impersonate` and `editedRuleset`) previously returned `kind: 'pending'`, showing disabled placeholder buttons in Studio. `rerun against rules` and `issueOp` now execute live operations against cloned sandbox states via `rtdbRules(rules).simulate()`, utilizing the zero-dependency comment lexer to lint candidate rulesets cleanly.

## Risk

Minimal risk. Line resolution operates strictly as a read-only visual overlay on existing inspection trees and defaults gracefully to an un-highlighted document view if rule nodes or path segments cannot be matched deterministically.

<details>
<summary>Implementation notes</summary>
* Upgraded `useStudioRulesSource(service?: string)` in `shell/studio-data.ts` to expose `rtdb` (`databaseRules`) and `storage` rules from `init.json` and in-page seeded sandboxes.
* Authored `findRtdbRuleLine()` in `RulesDebug.tsx` with backward ancestor segment scoring for deterministic JSON row matching.
* Switched RTDB simulation capabilities to `kind: 'live'` in `rerun-support.ts` and wired real simulation re-issue execution in `rerun.ts`.
* Verified across 323 unit tests in `packages/studio/src/` (`bun test packages/studio/src/`).
* Updated `SPEC.md` architectural specifications to formally document live RTDB simulation mechanics.
</details>
