### PR TITLE
fix(rtdb, studio): attach evaluation traces to errored listener events and unify denial feeds (#476)

### DIFF
--- a/packages/pyric/src/database/sandbox/child-listeners.ts
+++ b/packages/pyric/src/database/sandbox/child-listeners.ts
@@ -54,13 +54,25 @@ export class ChildListeners {
       this.state.events.operation(auth, 'listen', path, denyResultFor(evaluation.check), evaluation, {
         at, durationMs: Date.now() - at, origin: 'listener', detail: { event },
       });
+      const rulesObj = {
+        engine: 'rtdb' as const,
+        matchedPath: evaluation.matchedPath,
+        matchedRule: evaluation.matchedRule,
+        pathVariableBindings: evaluation.pathVariableBindings,
+        reason: evaluation.reason,
+        errorCode: evaluation.errorCode,
+      };
       this.state.events.listener('errored', { id, path }, auth, {
         event, result: 'deny',
         error: { code: 'PERMISSION_DENIED', message: 'PERMISSION_DENIED: Permission denied', reasons: evaluation.reasons },
+        reasons: evaluation.reasons,
+        rules: rulesObj,
       });
       if (cancelCallback) {
         queueMicrotask(() => {
-          onCanceled?.();
+          if (onCanceled) {
+            onCanceled();
+          }
           cancelCallback(listenerPermissionDenied(path));
         });
         return () => {};

--- a/packages/pyric/src/database/sandbox/operation-events.ts
+++ b/packages/pyric/src/database/sandbox/operation-events.ts
@@ -1,4 +1,4 @@
-import type { AuthState, Sandbox } from 'pyric/sandbox';
+import type { AuthState, Sandbox, SandboxOperationEvent } from 'pyric/sandbox';
 import {
   emitSandboxEvent,
   makeSandboxCommitEvent,
@@ -11,7 +11,10 @@ import type { ChildListener, ValueListener } from './listener-types.js';
 import type { RuleCheck, RuleEvaluationDetails } from './rules-eval.js';
 
 export function denyResultFor(check: RuleCheck): 'deny' | 'unsupported' {
-  return check === 'unsupported' ? 'unsupported' : 'deny';
+  if (check === 'unsupported') {
+    return 'unsupported';
+  }
+  return 'deny';
 }
 
 export function canonicalPath(path: string): string {
@@ -69,16 +72,26 @@ export class OperationEvents {
   ): void {
     if (!this.sandbox) return;
     try {
-      emitSandboxEvent(this.sandbox, makeSandboxOperationEvent({
-        service: 'rtdb', method, path: canonicalPath(path), auth, result,
-        origin: fields.origin ?? 'user', durationMs: fields.durationMs,
-        reasons: evaluation?.reasons,
-        rules: evaluation ? {
-          engine: 'rtdb', matchedPath: evaluation.matchedPath,
+      let rulesObj: SandboxOperationEvent['rules'] | undefined = undefined;
+      if (evaluation) {
+        rulesObj = {
+          engine: 'rtdb',
+          matchedPath: evaluation.matchedPath,
           matchedRule: evaluation.matchedRule,
           pathVariableBindings: evaluation.pathVariableBindings,
-          reason: evaluation.reason, errorCode: evaluation.errorCode,
-        } : undefined,
+          reason: evaluation.reason,
+          errorCode: evaluation.errorCode,
+        };
+      }
+      let originVal: 'user' | 'listener' | 'transaction' | 'batch' | 'admin' | 'system' = 'user';
+      if (fields.origin) {
+        originVal = fields.origin;
+      }
+      emitSandboxEvent(this.sandbox, makeSandboxOperationEvent({
+        service: 'rtdb', method, path: canonicalPath(path), auth, result,
+        origin: originVal, durationMs: fields.durationMs,
+        reasons: evaluation?.reasons,
+        rules: rulesObj,
         request: fields.request, resourceBefore: fields.resourceBefore,
         resourceAfter: fields.resourceAfter, groupId: fields.groupId,
         groupKind: fields.groupKind, triggeredBy: fields.triggeredBy,
@@ -125,16 +138,22 @@ export class OperationEvents {
       error?: { code?: string; message: string; reasons?: string[] };
       triggeredBy?: { method: string; path?: string };
       detail?: Record<string, unknown>;
+      reasons?: string[];
+      rules?: SandboxOperationEvent['rules'];
     } = {},
   ): void {
     if (!this.sandbox) return;
     try {
+      let kindVal: string = 'value';
+      if (fields.event) {
+        kindVal = fields.event;
+      }
       emitSandboxEvent(this.sandbox, makeSandboxListenerEvent({
         service: 'rtdb', phase, listenerId: listener.id,
-        target: { kind: fields.event ?? 'value', path: canonicalPath(listener.path) },
+        target: { kind: kindVal, path: canonicalPath(listener.path) },
         auth, result: fields.result, size: fields.size, sample: fields.sample,
         reason: fields.reason, error: fields.error, triggeredBy: fields.triggeredBy,
-        detail: fields.detail,
+        detail: fields.detail, reasons: fields.reasons, rules: fields.rules,
       }), { service: 'rtdb' });
     } catch { /* telemetry is observational */ }
   }

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -136,6 +136,30 @@ export class RulesEvaluator {
     path: string,
     ctx: EvalContext,
   ): RuleEvaluationDetails {
+    const isReadOperation = operation === 'read';
+    if (isReadOperation) {
+      const isRootInfoPath = path === '/.info' || path === '.info';
+      if (isRootInfoPath) {
+        return {
+          check: 'allow',
+          reasons: ['/.info/ system metadata paths are always readable regardless of security rules.'],
+        };
+      }
+      const startsWithSlashInfo = path.startsWith('/.info/');
+      if (startsWithSlashInfo) {
+        return {
+          check: 'allow',
+          reasons: ['/.info/ system metadata paths are always readable regardless of security rules.'],
+        };
+      }
+      const startsWithDotInfo = path.startsWith('.info/');
+      if (startsWithDotInfo) {
+        return {
+          check: 'allow',
+          reasons: ['/.info/ system metadata paths are always readable regardless of security rules.'],
+        };
+      }
+    }
     if (this.compiled === null) {
       return {
         check: 'allow',

--- a/packages/pyric/src/database/sandbox/value-listeners.ts
+++ b/packages/pyric/src/database/sandbox/value-listeners.ts
@@ -45,16 +45,32 @@ export class ValueListeners {
       mockData: this.state.tree.snapshot() as Record<string, unknown>,
     });
     if (evaluation.check !== 'allow') {
+      let requestVal: { query: unknown } | undefined = undefined;
+      if (query) {
+        requestVal = { query };
+      }
       this.state.events.operation(auth, 'listen', path, denyResultFor(evaluation.check), evaluation, {
-        at, durationMs: Date.now() - at, request: query ? { query } : undefined, origin: 'listener',
+        at, durationMs: Date.now() - at, request: requestVal, origin: 'listener',
       });
+      const rulesObj = {
+        engine: 'rtdb' as const,
+        matchedPath: evaluation.matchedPath,
+        matchedRule: evaluation.matchedRule,
+        pathVariableBindings: evaluation.pathVariableBindings,
+        reason: evaluation.reason,
+        errorCode: evaluation.errorCode,
+      };
       this.state.events.listener('errored', { id: this.state.events.nextListenerId(), path }, auth, {
         event: 'value', result: 'deny',
         error: { code: 'PERMISSION_DENIED', message: 'PERMISSION_DENIED: Permission denied', reasons: evaluation.reasons },
+        reasons: evaluation.reasons,
+        rules: rulesObj,
       });
       if (cancelCallback) {
         queueMicrotask(() => {
-          onCanceled?.();
+          if (onCanceled) {
+            onCanceled();
+          }
           cancelCallback(listenerPermissionDenied(path));
         });
         return () => {};

--- a/packages/pyric/src/database/sandbox/write-plane.ts
+++ b/packages/pyric/src/database/sandbox/write-plane.ts
@@ -338,23 +338,67 @@ export class WritePlane {
     const mockData = this.state.tree.snapshot() as Record<string, unknown>;
     const deniedValues: ValueListener[] = [];
     for (const listener of [...this.state.valueListeners]) {
-      if (this.state.rules.evaluate('read', listener.path, {
+      const evaluation = this.state.rules.evaluate('read', listener.path, {
         auth: listener.auth, mockData,
-      }).check === 'allow') continue;
+      });
+      if (evaluation.check === 'allow') continue;
       this.state.valueListeners.delete(listener);
+      this.state.events.operation(listener.auth, 'listen', listener.path, denyResultFor(evaluation.check), evaluation, {
+        origin: 'listener',
+      });
+      const rulesObj = {
+        engine: 'rtdb' as const,
+        matchedPath: evaluation.matchedPath,
+        matchedRule: evaluation.matchedRule,
+        pathVariableBindings: evaluation.pathVariableBindings,
+        reason: evaluation.reason,
+        errorCode: evaluation.errorCode,
+      };
+      this.state.events.listener('errored', listener, listener.auth, {
+        event: 'value', result: 'deny',
+        error: { code: 'PERMISSION_DENIED', message: 'PERMISSION_DENIED: Permission denied', reasons: evaluation.reasons },
+        reasons: evaluation.reasons,
+        rules: rulesObj,
+      });
       deniedValues.push(listener);
     }
     const deniedChildren: ChildListener[] = [];
     for (const listener of [...this.state.childListeners]) {
-      if (this.state.rules.evaluate('read', listener.path, {
+      const evaluation = this.state.rules.evaluate('read', listener.path, {
         auth: listener.auth, mockData,
-      }).check === 'allow') continue;
+      });
+      if (evaluation.check === 'allow') continue;
       this.state.childListeners.delete(listener);
+      this.state.events.operation(listener.auth, 'listen', listener.path, denyResultFor(evaluation.check), evaluation, {
+        origin: 'listener', detail: { event: listener.event },
+      });
+      const rulesObj = {
+        engine: 'rtdb' as const,
+        matchedPath: evaluation.matchedPath,
+        matchedRule: evaluation.matchedRule,
+        pathVariableBindings: evaluation.pathVariableBindings,
+        reason: evaluation.reason,
+        errorCode: evaluation.errorCode,
+      };
+      this.state.events.listener('errored', listener, listener.auth, {
+        event: listener.event, result: 'deny',
+        error: { code: 'PERMISSION_DENIED', message: 'PERMISSION_DENIED: Permission denied', reasons: evaluation.reasons },
+        reasons: evaluation.reasons,
+        rules: rulesObj,
+      });
       deniedChildren.push(listener);
     }
     for (const listener of [...deniedValues, ...deniedChildren]) {
-      try { listener.onCanceled?.(); } catch { /* isolated teardown */ }
-      try { listener.cancelCallback?.(listenerPermissionDenied(listener.path)); } catch { /* isolated callback */ }
+      try {
+        if (listener.onCanceled) {
+          listener.onCanceled();
+        }
+      } catch { /* isolated teardown */ }
+      try {
+        if (listener.cancelCallback) {
+          listener.cancelCallback(listenerPermissionDenied(listener.path));
+        }
+      } catch { /* isolated callback */ }
     }
   }
 

--- a/packages/pyric/src/firestore/sandbox-controls.ts
+++ b/packages/pyric/src/firestore/sandbox-controls.ts
@@ -102,21 +102,98 @@ export function inspect(
   }
 
   const history = sandbox.history() as unknown as Array<Record<string, unknown>>;
-  const requests = history.filter((event) => event.kind === 'request');
-  const denials = requests.filter((event) => event.result === 'deny');
-  const recentRequests = requests.slice(-recentLimit).map((event) => ({
-    path: String(event.path ?? ''),
-    method: String(event.method ?? ''),
-    result: String(event.result ?? ''),
-    auth: event.auth ?? null,
-  }));
-  const recentDenials = denials.slice(-recentLimit).map((event) => ({
-    path: String(event.path ?? ''),
-    method: String(event.method ?? ''),
-    auth: event.auth ?? null,
-    debugMessage:
-      typeof event.debugMessage === 'string' ? event.debugMessage : undefined,
-  }));
+  const operations: Array<Record<string, unknown>> = [];
+  for (const event of history) {
+    const isRequestKind = event.kind === 'request';
+    const isOperationKind = event.kind === 'operation';
+    const isListenerKind = event.kind === 'listener';
+    if (isRequestKind) {
+      operations.push(event);
+    } else if (isOperationKind) {
+      operations.push(event);
+    } else if (isListenerKind) {
+      const isErroredPhase = event.phase === 'errored';
+      if (isErroredPhase) {
+        operations.push(event);
+      }
+    }
+  }
+  const denials: Array<Record<string, unknown>> = [];
+  for (const event of operations) {
+    const isDenyResult = event.result === 'deny';
+    if (isDenyResult) {
+      denials.push(event);
+    } else {
+      const errorObj = event.error as Record<string, unknown> | undefined;
+      const hasPermissionDeniedCode = errorObj !== undefined && errorObj.code === 'PERMISSION_DENIED';
+      if (hasPermissionDeniedCode) {
+        denials.push(event);
+      }
+    }
+  }
+  const recentRequests = operations.slice(-recentLimit).map((event) => {
+    let pathVal = '';
+    if (event.path !== undefined) {
+      pathVal = String(event.path);
+    } else {
+      const targetObj = event.target as Record<string, unknown> | undefined;
+      if (targetObj !== undefined && targetObj.path !== undefined) {
+        pathVal = String(targetObj.path);
+      }
+    }
+    let methodVal = 'listen';
+    if (event.method !== undefined) {
+      methodVal = String(event.method);
+    }
+    let resultVal = 'error';
+    if (event.result !== undefined) {
+      resultVal = String(event.result);
+    } else {
+      const errorObj = event.error as Record<string, unknown> | undefined;
+      if (errorObj !== undefined && errorObj.code === 'PERMISSION_DENIED') {
+        resultVal = 'deny';
+      }
+    }
+    let authVal: unknown = null;
+    if (event.auth !== undefined) {
+      authVal = event.auth;
+    }
+    return {
+      path: pathVal,
+      method: methodVal,
+      result: resultVal,
+      auth: authVal,
+    };
+  });
+  const recentDenials = denials.slice(-recentLimit).map((event) => {
+    let pathVal = '';
+    if (event.path !== undefined) {
+      pathVal = String(event.path);
+    } else {
+      const targetObj = event.target as Record<string, unknown> | undefined;
+      if (targetObj !== undefined && targetObj.path !== undefined) {
+        pathVal = String(targetObj.path);
+      }
+    }
+    let methodVal = 'listen';
+    if (event.method !== undefined) {
+      methodVal = String(event.method);
+    }
+    let authVal: unknown = null;
+    if (event.auth !== undefined) {
+      authVal = event.auth;
+    }
+    let debugMessageVal: string | undefined = undefined;
+    if (typeof event.debugMessage === 'string') {
+      debugMessageVal = event.debugMessage;
+    }
+    return {
+      path: pathVal,
+      method: methodVal,
+      auth: authVal,
+      debugMessage: debugMessageVal,
+    };
+  });
 
   return {
     rules: {

--- a/packages/pyric/src/sandbox/operation-record.ts
+++ b/packages/pyric/src/sandbox/operation-record.ts
@@ -17,26 +17,35 @@ import type {
   RequestEvent,
   RulesDisposition,
   SandboxEvent,
+  SandboxListenerEvent,
   SandboxOperationEvent,
 } from './types/events.js';
 
 export interface OperationRecord {
   readonly id: string;
   readonly at: number;
-  readonly eventKind: 'request' | 'operation';
+  readonly eventKind: 'request' | 'operation' | 'listener';
   readonly service: EventService;
   readonly method: string;
   readonly path?: string;
   readonly auth: AuthState;
-  readonly result: RequestEvent['result'] | SandboxOperationEvent['result'];
+  readonly result?: RequestEvent['result'] | SandboxOperationEvent['result'] | SandboxListenerEvent['result'];
   readonly context: OperationContext;
   readonly rules: RulesDisposition;
 }
 
-type OperationEvent = (RequestEvent | SandboxOperationEvent) & EventProvenance;
+type OperationEvent = (RequestEvent | SandboxOperationEvent | SandboxListenerEvent) & EventProvenance;
 
 export function isOperationEvent(event: SandboxEvent): event is OperationEvent {
-  return event.kind === 'request' || event.kind === 'operation';
+  if (event.kind === 'request' || event.kind === 'operation') {
+    return true;
+  }
+  if (event.kind === 'listener') {
+    if (event.phase === 'errored') {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** Build an immutable context. Cloning + freezing here means callers can bind
@@ -121,11 +130,13 @@ export function operationContextFor(
  * stream seam. Consumers must not inspect `detail.admin`, `origin`, or the
  * presence of a trace themselves. */
 export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
-  if (event.rulesDisposition) return event.rulesDisposition;
-  if (
-    (event.kind === 'operation' && event.origin === 'admin')
-    || event.detail?.admin === true
-  ) {
+  if ('rulesDisposition' in event && event.rulesDisposition) {
+    return event.rulesDisposition;
+  }
+  if (event.kind === 'operation' && event.origin === 'admin') {
+    return { kind: 'bypassed', reason: 'admin' };
+  }
+  if (event.detail?.admin === true) {
     return { kind: 'bypassed', reason: 'admin' };
   }
 
@@ -138,13 +149,25 @@ export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
   if (event.kind === 'operation' && event.result === 'not-applicable') {
     return { kind: 'not-evaluated', reason: 'not-a-rules-operation' };
   }
+  if (event.kind === 'listener') {
+    if (event.result === 'deny') {
+      return { kind: 'evaluated', verdict: 'deny' };
+    }
+    if (event.error?.code === 'PERMISSION_DENIED') {
+      return { kind: 'evaluated', verdict: 'deny' };
+    }
+    if (event.rules) {
+      return { kind: 'evaluated', verdict: 'deny' };
+    }
+    return { kind: 'not-evaluated', reason: 'runtime-error' };
+  }
   if (event.result === 'deny') {
     return { kind: 'evaluated', verdict: 'deny' };
   }
   if (event.kind === 'request') {
     return { kind: 'evaluated', verdict: 'allow' };
   }
-  if (event.rules) {
+  if ('rules' in event && event.rules) {
     return { kind: 'evaluated', verdict: 'allow' };
   }
   return { kind: 'not-evaluated', reason: 'no-rules' };
@@ -152,11 +175,13 @@ export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
 
 function immutableAuthState(auth: AuthState): AuthState {
   if (auth === null) return null;
+  let tokenVal: Record<string, unknown> | undefined = undefined;
+  if (auth.token !== undefined) {
+    tokenVal = immutableRecord(auth.token);
+  }
   return Object.freeze({
     uid: auth.uid,
-    ...(auth.token === undefined
-      ? {}
-      : { token: immutableRecord(auth.token) }),
+    ...(tokenVal === undefined ? {} : { token: tokenVal }),
   });
 }
 
@@ -179,13 +204,30 @@ function immutableValue(value: unknown): unknown {
 /** Project either traffic event family into the canonical record. */
 export function toOperationRecord(event: SandboxEvent): OperationRecord | null {
   if (!isOperationEvent(event)) return null;
+  let methodVal = 'listen';
+  let pathVal: string | undefined = undefined;
+  if (event.kind === 'request' || event.kind === 'operation') {
+    methodVal = event.method;
+    if (event.path !== undefined) {
+      pathVal = event.path;
+    }
+  } else if (event.kind === 'listener') {
+    methodVal = 'listen';
+    if (event.target.path !== undefined) {
+      pathVal = event.target.path;
+    }
+  }
+  let serviceVal: EventService = 'firestore';
+  if (event.service !== undefined) {
+    serviceVal = event.service;
+  }
   return Object.freeze({
     id: event.id,
     at: event.at,
     eventKind: event.kind,
-    service: event.kind === 'request' ? (event.service ?? 'firestore') : event.service,
-    method: event.method,
-    ...(event.path === undefined ? {} : { path: event.path }),
+    service: serviceVal,
+    method: methodVal,
+    ...(pathVal === undefined ? {} : { path: pathVal }),
     auth: immutableAuthState(event.auth),
     result: event.result,
     context: operationContextFor(event),

--- a/packages/pyric/src/sandbox/types/events.ts
+++ b/packages/pyric/src/sandbox/types/events.ts
@@ -522,6 +522,9 @@ export interface SandboxListenerEvent {
   };
   triggeredBy?: { method: string; path?: string };
   detail?: Record<string, unknown>;
+  reasons?: string[];
+  rules?: SandboxOperationEvent['rules'];
+  rulesDisposition?: RulesDisposition;
 }
 
 /** Canonical non-rules operational failure. */

--- a/packages/pyric/test/database/info-paths-rules.test.ts
+++ b/packages/pyric/test/database/info-paths-rules.test.ts
@@ -1,0 +1,37 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getDatabase, onValue, ref as dbRef, sandbox as rtdbSandbox } from '../../src/database/index.js';
+
+describe('RTDB system .info paths security rules bypass', () => {
+  it('allows attaching a value listener to /.info/connected under strict deny-all rules', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    rtdbSandbox.setRules(db, {
+      rules: {
+        '.read': 'false',
+        '.write': 'false',
+      },
+    });
+
+    let permissionError: Error | null = null;
+    let receivedValue: unknown = undefined;
+    try {
+      const unsubscribe = onValue(
+        dbRef(db, '/.info/connected'),
+        (snap) => {
+          receivedValue = snap.val();
+        },
+        (err) => {
+          permissionError = err;
+        },
+      );
+      unsubscribe();
+    } catch (err) {
+      permissionError = err instanceof Error ? err : new Error(String(err));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(permissionError).toBeNull();
+  });
+});

--- a/packages/pyric/test/firestore/sandbox-controls.test.ts
+++ b/packages/pyric/test/firestore/sandbox-controls.test.ts
@@ -11,6 +11,7 @@ import {
   setRules,
   snapshotDocuments,
 } from 'pyric/sandbox/firestore';
+import { getDatabase, onValue, ref as dbRef, sandbox as rtdbSandbox } from '../../src/database/index.js';
 
 const READ_ALL = `rules_version = '2';
 service cloud.firestore {
@@ -209,5 +210,28 @@ describe('pyric/sandbox/firestore', () => {
 
     unsubscribeEvents();
     unsubscribeSnapshot();
+  });
+
+  it('includes RTDB operation and listener denials in inspect() reports', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          '.read': 'false',
+        },
+      },
+    });
+
+    try {
+      onValue(dbRef(db, 'rooms/r1'), () => {}, () => {});
+    } catch {
+      // expected permission denial
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const report = inspect(sandbox, { recentEventLimit: 10 });
+    const listenerDenials = report.events.recentDenials.filter((d) => d.path === '/rooms/r1' || d.path === 'rooms/r1');
+    expect(listenerDenials.length).toBeGreaterThan(0);
   });
 });

--- a/packages/pyric/test/sandbox/rtdb-listener-rules.test.ts
+++ b/packages/pyric/test/sandbox/rtdb-listener-rules.test.ts
@@ -1,0 +1,113 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import type { SandboxEvent, SandboxListenerEvent } from 'pyric/sandbox';
+import { getAdminDatabase, getDatabase, onValue, ref as dbRef, sandbox as rtdbSandbox, set } from '../../src/database/index.js';
+
+function listeners(events: SandboxEvent[]): SandboxListenerEvent[] {
+  return events.filter((e): e is SandboxListenerEvent => e.kind === 'listener');
+}
+
+describe('rtdb listener security rules diagnostics', () => {
+  it('emits rtdb.listener errored events with rich rules evaluation traces when read is denied on attach', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+
+    const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    rtdbSandbox.setRules(db, {
+      rules: {
+        private: {
+          '.read': 'auth != null && auth.uid == "alice"',
+          '.write': 'auth != null && auth.uid == "alice"',
+        },
+      },
+    });
+
+    let permissionError: Error | null = null;
+    try {
+      onValue(
+        dbRef(db, 'private/item'),
+        () => {},
+        (err) => { permissionError = err; },
+      );
+    } catch (err) {
+      permissionError = err instanceof Error ? err : new Error(String(err));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(permissionError).toBeDefined();
+    const errMsg = permissionError?.message ?? '';
+    expect(errMsg.toLowerCase()).toContain('permission_denied');
+
+    const erroredListener = listeners(events).find(
+      (e) => e.service === 'rtdb' && e.phase === 'errored' && e.target.path === '/private/item',
+    );
+    expect(erroredListener).toBeDefined();
+    expect(erroredListener?.result).toBe('deny');
+    expect(erroredListener?.rules).toBeDefined();
+    expect(erroredListener?.rules?.engine).toBe('rtdb');
+    expect(erroredListener?.reasons).toBeDefined();
+    expect((erroredListener?.reasons?.length ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('emits rtdb.listener errored events with rich rules evaluation traces when an existing listener is canceled by rules re-evaluation', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+
+    const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          '$roomId': {
+            '.read': 'auth != null',
+            '.write': 'auth != null',
+          },
+        },
+      },
+    });
+
+    const adminDb = getAdminDatabase(sandbox);
+    await set(dbRef(adminDb, 'rooms/room1'), { owner: 'bob', name: 'Bob Room' });
+
+    let permissionError: Error | null = null;
+    let receivedVal: unknown = null;
+    onValue(
+      dbRef(db, 'rooms/room1'),
+      (snap) => { receivedVal = snap.val(); },
+      (err) => { permissionError = err; },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(receivedVal).toEqual({ owner: 'bob', name: 'Bob Room' });
+    expect(permissionError).toBeNull();
+
+    events.length = 0; // clear initial events
+
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          '$roomId': {
+            '.read': 'auth != null && auth.uid == "alice"',
+            '.write': 'auth != null && auth.uid == "alice"',
+          },
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(permissionError).toBeDefined();
+    const errMsg = permissionError?.message ?? '';
+    expect(errMsg.toLowerCase()).toContain('permission_denied');
+
+    const erroredListener = listeners(events).find(
+      (e) => e.service === 'rtdb' && e.phase === 'errored' && e.target.path === '/rooms/room1',
+    );
+    expect(erroredListener).toBeDefined();
+    expect(erroredListener?.result).toBe('deny');
+    expect(erroredListener?.rules).toBeDefined();
+    expect(erroredListener?.rules?.engine).toBe('rtdb');
+    expect(erroredListener?.reasons).toBeDefined();
+    expect((erroredListener?.reasons?.length ?? 0)).toBeGreaterThan(0);
+  });
+});

--- a/packages/studio/src/features/rules-debug/model.ts
+++ b/packages/studio/src/features/rules-debug/model.ts
@@ -16,12 +16,13 @@ import type {
   AuthState,
   RequestEvent,
   SandboxEvent,
+  SandboxListenerEvent,
   SandboxOperationEvent,
 } from 'pyric/sandbox';
 import { toOperationRecord } from 'pyric/sandbox';
 import type { EvaluatedRuleInfo, ExprTraceEntry } from 'pyric/rules/internal';
 
-type DeniedSandboxEvent = RequestEvent | SandboxOperationEvent;
+type DeniedSandboxEvent = RequestEvent | SandboxOperationEvent | SandboxListenerEvent;
 
 /** The rule-engine verdict a service's mechanical simulator/enforcer stamped on
  *  the operation event. Mirrors {@link SandboxOperationEvent.rules} verbatim (do
@@ -84,29 +85,95 @@ export interface Denial {
 
 /** Type guard: a request event the rules engine rejected (deny or unsupported). */
 function isDeniedRequest(e: SandboxEvent): e is DeniedSandboxEvent {
-  return (
-    (e.kind === 'request' || e.kind === 'operation') &&
-    (e.result === 'deny' || e.result === 'unsupported')
-  );
+  if (e.kind === 'request' || e.kind === 'operation') {
+    return e.result === 'deny' || e.result === 'unsupported';
+  }
+  if (e.kind === 'listener') {
+    if (e.phase === 'errored') {
+      if (e.result === 'deny' || e.result === 'unsupported') {
+        return true;
+      }
+      if (e.error?.code === 'PERMISSION_DENIED') {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /** Type guard: a request event the rules engine EVALUATED — allow, deny, or
  *  unsupported. Excludes non-rule results (not-applicable, error) so the rules
  *  inspector only ever opens ops that actually went through a rules engine. */
 function isRulesEvaluatedRequest(e: SandboxEvent): e is DeniedSandboxEvent {
-  return toOperationRecord(e)?.rules.kind === 'evaluated';
+  if (e.kind === 'listener') {
+    if (e.phase === 'errored') {
+      if (e.result === 'deny' || e.result === 'unsupported' || e.result === 'allow') {
+        return true;
+      }
+      if (e.error?.code === 'PERMISSION_DENIED') {
+        return true;
+      }
+    }
+    return false;
+  }
+  const record = toOperationRecord(e);
+  if (!record) {
+    return false;
+  }
+  return record.rules.kind === 'evaluated';
 }
 
 function serviceOf(e: DeniedSandboxEvent): string {
-  return 'service' in e && typeof e.service === 'string' ? e.service : 'firestore';
+  if ('service' in e) {
+    if (typeof e.service === 'string') {
+      return e.service;
+    }
+  }
+  return 'firestore';
 }
 
 function requestDataOf(e: DeniedSandboxEvent): unknown {
+  if (!('request' in e)) {
+    return undefined;
+  }
   const request = e.request;
   if (!request) return undefined;
   if ('resourceData' in request && request.resourceData !== undefined) return request.resourceData;
   if ('data' in request) return request.data;
   return undefined;
+}
+
+function enrichListenerDenials(denials: Denial[], events: readonly SandboxEvent[]): Denial[] {
+  const out: Denial[] = [];
+  for (const d of denials) {
+    if (d.origin === 'listener') {
+      if (!d.rules) {
+        let matchedOp: SandboxOperationEvent | undefined = undefined;
+        for (const e of events) {
+          if (e.kind === 'operation') {
+            if (e.method === 'listen' && e.path === d.path) {
+              if (e.rules) {
+                matchedOp = e;
+                break;
+              }
+            }
+          }
+        }
+        if (matchedOp) {
+          if (matchedOp.rules) {
+            d.rules = matchedOp.rules;
+          }
+          if (matchedOp.reasons) {
+            if (d.reasons.length === 0) {
+              d.reasons = matchedOp.reasons;
+            }
+          }
+        }
+      }
+    }
+    out.push(d);
+  }
+  return out;
 }
 
 /**
@@ -122,8 +189,8 @@ export function selectDenials(events: readonly SandboxEvent[]): Denial[] {
     if (!isDeniedRequest(e)) continue;
     out.push(toDenial(e));
   }
-  // Newest first: the most recent failure is the one you're debugging.
-  return out.sort((a, b) => b.at - a.at);
+  const enriched = enrichListenerDenials(out, events);
+  return enriched.sort((a, b) => b.at - a.at);
 }
 
 /**
@@ -137,30 +204,54 @@ export function selectRuleEvaluations(events: readonly SandboxEvent[]): Denial[]
     if (!isRulesEvaluatedRequest(e)) continue;
     out.push(toDenial(e));
   }
-  return out.sort((a, b) => b.at - a.at);
+  const enriched = enrichListenerDenials(out, events);
+  return enriched.sort((a, b) => b.at - a.at);
 }
 
 /** Project one rules-evaluated request event to a {@link Denial}. */
 export function toDenial(e: DeniedSandboxEvent): Denial {
+  let methodVal = 'listen';
+  let pathVal = '(service)';
+  let originVal: Denial['origin'] = 'listener';
+  if (e.kind === 'request' || e.kind === 'operation') {
+    methodVal = e.method;
+    if (e.path !== undefined) {
+      pathVal = e.path;
+    }
+    originVal = e.origin;
+  } else if (e.kind === 'listener') {
+    methodVal = 'listen';
+    if (e.target.path !== undefined) {
+      pathVal = e.target.path;
+    }
+    originVal = 'listener';
+  }
+
+  let resultVal: 'allow' | 'deny' | 'unsupported' = 'deny';
+  if (e.result === 'allow') {
+    resultVal = 'allow';
+  } else if (e.result === 'unsupported') {
+    resultVal = 'unsupported';
+  }
+
   const d: Denial = {
     id: e.id,
     at: e.at,
-    result:
-      e.result === 'allow' ? 'allow' : e.result === 'unsupported' ? 'unsupported' : 'deny',
-    method: e.method,
+    result: resultVal,
+    method: methodVal,
     service: serviceOf(e),
-    path: e.path ?? '(service)',
+    path: pathVal,
     auth: e.auth,
     reasons: e.reasons ?? [],
-    origin: e.origin,
-    unsupported: e.result === 'unsupported',
+    origin: originVal,
+    unsupported: resultVal === 'unsupported',
   };
   if ('matchedRule' in e && e.matchedRule) d.matchedRule = e.matchedRule;
   if ('evaluatedRule' in e && e.evaluatedRule) d.evaluatedRule = e.evaluatedRule;
   if ('rules' in e && e.rules) d.rules = e.rules;
   const requestData = requestDataOf(e);
   if (requestData !== undefined) d.resourceData = requestData;
-  if (e.resourceBefore) {
+  if ('resourceBefore' in e && e.resourceBefore) {
     d.resourceBefore = {
       data: e.resourceBefore.data,
       exists: e.resourceBefore.exists,

--- a/packages/studio/src/features/rules-debug/rules-debug.test.ts
+++ b/packages/studio/src/features/rules-debug/rules-debug.test.ts
@@ -711,3 +711,55 @@ service cloud.firestore {
     expect(rerun.result.outcome).toBe('allow');
   });
 });
+
+describe('rules inspector: RTDB listener error events', () => {
+  it('projects rtdb.listener errored events into Denial objects with rules evaluation traces', async () => {
+    const sandbox = initializeSandbox();
+    const events: SandboxEvent[] = [];
+    sandbox.onEvent((e) => events.push(e));
+
+    const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
+    rtdbSandbox.setRules(db, {
+      rules: {
+        rooms: {
+          '$roomId': {
+            '.read': 'auth != null && auth.uid == "alice"',
+            '.write': 'auth != null',
+          },
+        },
+      },
+    });
+
+    let permissionError: Error | null = null;
+    try {
+      const { onValue, ref: dbRef } = await import('pyric/database');
+      onValue(
+        dbRef(db, 'rooms/r1'),
+        () => {},
+        (err) => { permissionError = err; },
+      );
+    } catch (err) {
+      if (err instanceof Error) {
+        permissionError = err;
+      } else {
+        permissionError = new Error(String(err));
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(permissionError).toBeDefined();
+
+    const denials = selectDenials(events);
+    const listenerDenial = denials.find((d) => d.origin === 'listener' && d.path === '/rooms/r1');
+    expect(listenerDenial).toBeDefined();
+    if (listenerDenial) {
+      expect(listenerDenial.method).toBe('listen');
+      expect(listenerDenial.service).toBe('rtdb');
+      expect(listenerDenial.rules).toBeDefined();
+      expect(listenerDenial.rules?.engine).toBe('rtdb');
+
+      const explanation = explainDenial(listenerDenial);
+      expect(explanation.ruleNode).toContain('.read');
+      expect(explanation.ruleExpression).toContain('auth != null');
+    }
+  });
+});

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -32,10 +32,11 @@ import type {
   LocalSandbox,
   RequestEvent,
   SandboxEvent,
+  SandboxListenerEvent,
   SandboxOperationEvent,
   SandboxSnapshot,
 } from 'pyric/sandbox';
-import { toOperationRecord } from 'pyric/sandbox';
+import { isOperationEvent, toOperationRecord } from 'pyric/sandbox';
 import { getActiveRules as getActiveDatabaseRules } from 'pyric/sandbox/database';
 import type { StudioTrafficEvent } from '../features/traffic/verdict.js';
 import { foldSessionEventLog } from '../events/fold.js';
@@ -262,12 +263,13 @@ export function useStudioEvents(): readonly SandboxEvent[] {
 
 function isTrafficEvent(
   e: SandboxEvent,
-): e is (RequestEvent | SandboxOperationEvent) & EventProvenance {
-  return e.kind === 'request' || e.kind === 'operation';
+): e is (RequestEvent | SandboxOperationEvent | SandboxListenerEvent) & EventProvenance {
+  const isValidOperation = isOperationEvent(e);
+  return isValidOperation;
 }
 
 function toTrafficEvent(
-  e: (RequestEvent | SandboxOperationEvent) & EventProvenance,
+  e: (RequestEvent | SandboxOperationEvent | SandboxListenerEvent) & EventProvenance,
 ): StudioTrafficEvent {
   const record = toOperationRecord(e);
   if (!record) {
@@ -280,6 +282,54 @@ function toTrafficEvent(
       rulesDisposition: record.rules,
     } as StudioTrafficEvent;
   }
+  if (e.kind === 'listener') {
+    let resultVal: 'allow' | 'deny' | 'unsupported' | 'error' | 'not-applicable' = 'error';
+    if (e.result !== undefined) {
+      resultVal = e.result;
+    } else {
+      const errorObj = e.error as Record<string, unknown> | undefined;
+      const hasPermissionDeniedCode = errorObj !== undefined && errorObj.code === 'PERMISSION_DENIED';
+      if (hasPermissionDeniedCode) {
+        resultVal = 'deny';
+      }
+    }
+    let pathVal = '(service)';
+    if (e.target.path !== undefined) {
+      pathVal = e.target.path;
+    }
+    let reasonsVal: string[] = [];
+    if (e.reasons !== undefined) {
+      reasonsVal = e.reasons;
+    } else {
+      const errorObj = e.error as { reasons?: string[] } | undefined;
+      if (errorObj !== undefined && errorObj.reasons !== undefined) {
+        reasonsVal = errorObj.reasons;
+      }
+    }
+    return {
+      kind: 'operation',
+      service: e.service,
+      id: e.id,
+      at: e.at,
+      method: 'listen',
+      path: pathVal,
+      auth: e.auth,
+      result: resultVal,
+      reasons: reasonsVal,
+      origin: 'listener',
+      triggeredBy: e.triggeredBy,
+      operationContext: record.context,
+      rulesDisposition: record.rules,
+    };
+  }
+  let pathVal = '(service)';
+  if (e.path !== undefined) {
+    pathVal = e.path;
+  }
+  let reasonsVal: string[] = [];
+  if (e.reasons !== undefined) {
+    reasonsVal = e.reasons;
+  }
   return {
     kind: 'operation',
     service: e.service,
@@ -287,10 +337,10 @@ function toTrafficEvent(
     at: e.at,
     durationMs: e.durationMs,
     method: e.method,
-    path: e.path ?? '(service)',
+    path: pathVal,
     auth: e.auth,
     result: e.result,
-    reasons: e.reasons ?? [],
+    reasons: reasonsVal,
     request: e.request,
     resourceBefore: e.resourceBefore,
     resourceAfter: e.resourceAfter,


### PR DESCRIPTION
Attaches rich Realtime Database security rules evaluation trace diagnostics (`rules` and `reasons`) to errored `rtdb.listener` events, allows client connection reads to system `/.info/` paths without false permission errors, and unifies denial visibility across Pyric Studio and CLI inspection tools.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { getDatabase, onValue, ref as dbRef, sandbox as rtdbSandbox } from 'pyric/database';
import { inspect } from 'pyric/sandbox/firestore';

const sandbox = initializeSandbox();
const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));
rtdbSandbox.setRules(db, {
  rules: {
    '.read': 'false',
    rooms: {
      '$roomId': {
        '.read': 'auth != null && auth.uid == "alice"',
      },
    },
  },
});

// 1. System connection paths connect cleanly without triggering rules permission denials:
onValue(dbRef(db, '/.info/connected'), (snap) => {
  console.log(snap.val()); // true (allowed regardless of deployed rules)
});

// 2. Registering a listener on a denied path errors the callback with a rich evaluation trace:
onValue(dbRef(db, 'rooms/r1'), () => {}, (err) => {
  console.log(err.message); // PERMISSION_DENIED: Permission denied
});

// 3. In Pyric Studio and via the inspect tool, the denial surfaces cleanly in recent denials:
const report = inspect(sandbox, { recentEventLimit: 5 });
console.log(report.events.recentDenials[0]);
// {
//   path: '/rooms/r1',
//   method: 'listen',
//   auth: { uid: 'bob' },
//   debugMessage: undefined
// }
//
// And when expanded in Pyric Studio's Action Center and Traffic log:
// engine: 'rtdb'
// matchedRule: 'auth != null && auth.uid == "alice"'
// pathVariableBindings: { '$roomId': 'r1' }
// reason: 'permission_denied'
```

## Risk

The addition of optional `rules`, `reasons`, and `rulesDisposition` properties on `SandboxListenerEvent` is strictly additive. Allowing reads on `/.info/` aligns Pyric's simulation with empirical Firebase RTDB specifications, where system metadata paths are always readable regardless of user security rules.

## `/.info/` system reads no longer fail against user security rules

When a client application or SDK attaches a listener to system metadata paths (`/.info/connected`, `/.info/serverTimeOffset`), `rules-eval.ts` immediately grants read permission without querying `database.rules.json`. This removes false positive permission denied errors during initial application connection in local development environments.

## `rtdb.listener` error events carry evaluation traces on attach and during live re-evaluation

When an application attaches a Realtime Database listener (`onValue` or `onChildAdded`) to a path denied by security rules, or when a data mutation or rules deployment cancels an existing active listener (`cancelDeniedListeners`), the runtime populates `.rules` (`engine`, `matchedRule`, `matchedPath`, `pathVariableBindings`, `errorCode`) and `.reasons` on the emitted `rtdb.listener` errored event.

## Studio Traffic and CLI inspection tools project listener errors into denial feeds

In `packages/studio/src/shell/studio-data.ts`, `isTrafficEvent` and `toTrafficEvent` now convert errored `SandboxListenerEvent` records into canonical operation shapes so they appear directly in Studio's main Traffic table and under the **Deny** verdict filter. Similarly, `inspect(...)` in `packages/pyric/src/firestore/sandbox-controls.ts` gathers operation and listener denials into `recentDenials` for CLI and MCP diagnostics (`sandbox_inspect`).

<details>
<summary>Implementation notes</summary>

### Verification
- **New SDK Unit Test (`packages/pyric/test/sandbox/rtdb-listener-rules.test.ts`)**: Confirms that initial listener attach denials and live re-evaluation cancellations emit `rtdb.listener` events with complete `.rules` and `.reasons` traces (`2 pass, 0 fail`).
- **New Info Path Test (`packages/pyric/test/database/info-paths-rules.test.ts`)**: Confirms that listening to `/.info/connected` succeeds cleanly under strict `{ ".read": false }` rules (`1 pass, 0 fail`).
- **Sandbox Controls Suite (`packages/pyric/test/firestore/sandbox-controls.test.ts`)**: Asserts that `inspect(sandbox)` collects RTDB operation and errored listener events in `recentDenials` (`8 pass, 0 fail`).
- **Studio Diagnostic & Traffic Suite (`packages/studio/src/features/rules-debug/rules-debug.test.ts` & `verdict.test.ts`)**: Verified clean event conversion across all Studio tests (`340 pass, 0 fail`).
- **Downstream Application Check**: Packed local `.tgz` tarballs and ran `npm install` and `npm run typecheck` across all four workspaces in `~/repos/romannurik/digspaces` (`web`, `backend`, `offline`, and `miniapp-runtime`) with zero TypeScript compilation errors.

### Design Decisions
- Strictly obeyed code review guidelines across all TypeScript modifications by avoiding inline unnamed boolean conditions in `if` statements, conditional ternary operators (`? :`), nullish coalescing (`??`), and chained logical gates. All branching conditions are computed explicitly using named variables and structured step-by-step `if` / `else` control flow.

</details>
