### PR TITLE
feat(serve/vite): hot-reload Realtime Database security rules (#481)

### DIFF
--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -516,6 +516,7 @@ export async function startServe(opts: {
   }
   if (session.summary.capturePath) {
     logger.info(`✔ capture  session → ${session.summary.capturePath} (run \`pyric verify\` to replay it)`);
+  }
   if (watching) {
     logger.info(`✔ watch    hot-reloading ${rulesSourcePath} over /__pyric/events`);
   }

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -404,6 +404,47 @@ export async function startServe(opts: {
       watcher.close();
     });
   }
+  const dbRulesSourcePath = session.summary.rules.database.sourcePath;
+  const isWatchEnabled = opts.watch !== false;
+  const hasDbRulesPath = dbRulesSourcePath !== null;
+  const watchingDb = isWatchEnabled && hasDbRulesPath;
+  if (watchingDb) {
+    let debounceDb: ReturnType<typeof setTimeout> | null = null;
+    const dbWatcher = watchFile(dbRulesSourcePath as string, () => {
+      const hasDebounceDb = debounceDb !== null;
+      if (hasDebounceDb) {
+        clearTimeout(debounceDb as ReturnType<typeof setTimeout>);
+      }
+      debounceDb = setTimeout(() => {
+        void session.reloadDatabaseRules().then((result) => {
+          const isReloaded = result.kind === 'reloaded';
+          if (isReloaded) {
+            logger.note(`  ↻ rtdb rules reloaded (hash ${result.rulesHash}) → ${result.clients} page(s)`);
+          } else {
+            const isRejected = result.kind === 'rejected';
+            if (isRejected) {
+              logger.note(`  ⚠ rtdb rules NOT reloaded (last-good stays live): ${result.error.message}`);
+            }
+          }
+        });
+      }, 150);
+    });
+    dbWatcher.on('error', (error) => {
+      const isErrorInstance = error instanceof Error;
+      let errorMsg = String(error);
+      if (isErrorInstance) {
+        errorMsg = (error as Error).message;
+      }
+      logger.note(`  ⚠ rtdb rules watcher failed (hot reload off): ${errorMsg}`);
+    });
+    handle.server.once('close', () => {
+      const hasDebounceDb = debounceDb !== null;
+      if (hasDebounceDb) {
+        clearTimeout(debounceDb as ReturnType<typeof setTimeout>);
+      }
+      dbWatcher.close();
+    });
+  }
 
   logger.info(`=== Serving from '${opts.cwd}'...`);
   logger.info('');

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -516,8 +516,12 @@ export async function startServe(opts: {
   }
   if (session.summary.capturePath) {
     logger.info(`✔ capture  session → ${session.summary.capturePath} (run \`pyric verify\` to replay it)`);
+  if (watching) {
+    logger.info(`✔ watch    hot-reloading ${rulesSourcePath} over /__pyric/events`);
   }
-  if (watching) logger.info(`✔ watch    hot-reloading ${rulesSourcePath} over /__pyric/events`);
+  if (watchingDb) {
+    logger.info(`✔ watch    hot-reloading ${dbRulesSourcePath} over /__pyric/events`);
+  }
   // Browser-honesty: the sandbox is browser-resident — firestore/auth and
   // persistence run IN the served page. With no page open, data ops silently
   // no-op. This warning (paired with auto-open in runServe) is the fix for the

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -553,4 +553,29 @@ if (!useWorker && typeof EventSource !== 'undefined') {
       console.error('[pyric dev] rules hot-reload failed:', err instanceof Error ? err.message : String(err));
     }
   });
+  events.addEventListener('rtdb-rules-update', (e) => {
+    try {
+      const { rules, rulesHash } = JSON.parse((e as MessageEvent).data as string) as {
+        rules: { rules: Record<string, unknown> };
+        rulesHash: string;
+      };
+      rtdbSandbox.setRules(getDatabase(sandbox), rules);
+      diagnostics.databaseRulesDeployed = true;
+      let newHash: string | null = null;
+      const isHashDefined = rulesHash !== undefined;
+      if (isHashDefined) {
+        newHash = rulesHash;
+      }
+      diagnostics.databaseRulesHash = newHash;
+      console.info(`[pyric dev] database.rules.json hot-reloaded (hash ${rulesHash})`);
+    } catch (err) {
+      runtimeStatus.reportError(err, 'runtime');
+      const isErrorInstance = err instanceof Error;
+      let errorMessage = String(err);
+      if (isErrorInstance) {
+        errorMessage = (err as Error).message;
+      }
+      console.error('[pyric dev] database rules hot-reload failed:', errorMessage);
+    }
+  });
 }

--- a/packages/cli/src/serve/sandbox-session.ts
+++ b/packages/cli/src/serve/sandbox-session.ts
@@ -63,6 +63,7 @@ export interface SandboxSession {
   payload(): InitPayload;
   handle(req: IncomingMessage, res: ServerResponse, url: URL): boolean | Promise<boolean>;
   reloadFirestoreRules(): Promise<RulesReloadResult>;
+  reloadDatabaseRules(): Promise<RulesReloadResult>;
   close(): Promise<void>;
 }
 
@@ -93,6 +94,8 @@ export async function createSandboxSession(
   const live = {
     rules: firestore.rules,
     rulesHash: firestore.rulesHash,
+    databaseRules: database.rules,
+    databaseRulesHash: database.rulesHash,
   };
   const events = createEventHub();
   const capture: CaptureStore | undefined = (options.capture ?? true)
@@ -145,8 +148,8 @@ export async function createSandboxSession(
   const payload = (): InitPayload => ({
     rules: live.rules,
     rulesHash: live.rulesHash,
-    databaseRules: database.rules,
-    databaseRulesHash: database.rulesHash,
+    databaseRules: live.databaseRules,
+    databaseRulesHash: live.databaseRulesHash,
     databaseUrl: database.databaseUrl,
     storageRules: storage.rules,
     storageRulesHash: storage.rulesHash,
@@ -217,6 +220,31 @@ export async function createSandboxSession(
       return { kind: 'rejected', error: error instanceof Error ? error : new Error(String(error)) };
     }
   };
+  const reloadDatabaseRules = async (): Promise<RulesReloadResult> => {
+    const isMissingDatabaseRules = database.sourcePath === null;
+    if (isMissingDatabaseRules) {
+      return { kind: 'not-configured' };
+    }
+    try {
+      const updated = await loadProjectDatabaseRules(options.projectDir, options.firebaseConfig);
+      const isMissingUpdatedRules = updated.rules === null || updated.rulesHash === null;
+      if (isMissingUpdatedRules) {
+        return { kind: 'not-configured' };
+      }
+      live.databaseRules = updated.rules;
+      live.databaseRulesHash = updated.rulesHash;
+      events.broadcast('rtdb-rules-update', { rules: updated.rules, rulesHash: updated.rulesHash });
+      return { kind: 'reloaded', rulesHash: updated.rulesHash as string, clients: events.clientCount() };
+    } catch (error) {
+      const isErrorInstance = error instanceof Error;
+      let errorResult: Error = new Error(String(error));
+      if (isErrorInstance) {
+        errorResult = error as Error;
+      }
+      return { kind: 'rejected', error: errorResult };
+    }
+  };
+
   let closePromise: Promise<void> | null = null;
   const close = (): Promise<void> => {
     closePromise ??= Promise.resolve().then(() => events.close());
@@ -228,6 +256,7 @@ export async function createSandboxSession(
     payload,
     handle: namespace,
     reloadFirestoreRules,
+    reloadDatabaseRules,
     close,
   };
 }

--- a/packages/cli/src/serve/vite-generation-rules-watch.ts
+++ b/packages/cli/src/serve/vite-generation-rules-watch.ts
@@ -8,30 +8,82 @@ export function watchViteGenerationRules(input: {
   session: SandboxSession;
 }): (() => void) | null {
   const { server, session } = input;
-  const rulesFile = session.summary.rules.firestore.sourcePath;
-  if (!rulesFile) return null;
+  const firestoreFile = session.summary.rules.firestore.sourcePath;
+  const databaseFile = session.summary.rules.database.sourcePath;
+  const hasFirestoreFile = firestoreFile !== null;
+  const hasDatabaseFile = databaseFile !== null;
+  const hasNeitherFile = !hasFirestoreFile && !hasDatabaseFile;
+  if (hasNeitherFile) {
+    return null;
+  }
 
   let debounce: ReturnType<typeof setTimeout> | null = null;
   const onRulesChange = (file: string): void => {
-    if (path.resolve(file) !== path.resolve(rulesFile)) return;
-    if (debounce) clearTimeout(debounce);
+    const resolvedFile = path.resolve(file);
+    let isFirestoreMatch = false;
+    if (hasFirestoreFile) {
+      const firestoreResolved = path.resolve(firestoreFile);
+      isFirestoreMatch = resolvedFile === firestoreResolved;
+    }
+    let isDatabaseMatch = false;
+    if (hasDatabaseFile) {
+      const databaseResolved = path.resolve(databaseFile);
+      isDatabaseMatch = resolvedFile === databaseResolved;
+    }
+    const isNeitherMatch = !isFirestoreMatch && !isDatabaseMatch;
+    if (isNeitherMatch) {
+      return;
+    }
+    const hasDebounce = debounce !== null;
+    if (hasDebounce) {
+      clearTimeout(debounce as ReturnType<typeof setTimeout>);
+    }
     debounce = setTimeout(() => {
-      void session.reloadFirestoreRules().then((result) => {
-        if (result.kind === 'reloaded') {
-          server.config.logger.info(`  ↻ [pyric] rules reloaded (${result.rulesHash})`);
-        } else if (result.kind === 'rejected') {
-          server.config.logger.warn(
-            `  ⚠ [pyric] rules NOT reloaded (last-good stays live): ${result.error.message}`,
-          );
-        }
-      });
+      if (isFirestoreMatch) {
+        void session.reloadFirestoreRules().then((result) => {
+          const isReloaded = result.kind === 'reloaded';
+          if (isReloaded) {
+            server.config.logger.info(`  ↻ [pyric] rules reloaded (${result.rulesHash})`);
+          } else {
+            const isRejected = result.kind === 'rejected';
+            if (isRejected) {
+              server.config.logger.warn(
+                `  ⚠ [pyric] rules NOT reloaded (last-good stays live): ${result.error.message}`,
+              );
+            }
+          }
+        });
+      }
+      if (isDatabaseMatch) {
+        void session.reloadDatabaseRules().then((result) => {
+          const isReloaded = result.kind === 'reloaded';
+          if (isReloaded) {
+            server.config.logger.info(`  ↻ [pyric] rtdb rules reloaded (${result.rulesHash})`);
+          } else {
+            const isRejected = result.kind === 'rejected';
+            if (isRejected) {
+              server.config.logger.warn(
+                `  ⚠ [pyric] rtdb rules NOT reloaded (last-good stays live): ${result.error.message}`,
+              );
+            }
+          }
+        });
+      }
     }, 150);
   };
 
-  server.watcher.add(rulesFile);
+  if (hasFirestoreFile) {
+    server.watcher.add(firestoreFile);
+  }
+  if (hasDatabaseFile) {
+    server.watcher.add(databaseFile);
+  }
   server.watcher.on('change', onRulesChange);
   return () => {
-    if (debounce) clearTimeout(debounce);
+    const hasDebounce = debounce !== null;
+    if (hasDebounce) {
+      clearTimeout(debounce as ReturnType<typeof setTimeout>);
+    }
     server.watcher.off('change', onRulesChange);
   };
 }

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -84,6 +84,36 @@ export function setupWorkerHotReload(
       console.error('[pyric worker] rules hot-reload failed:', err instanceof Error ? err.message : String(err));
     }
   });
+  events.addEventListener('rtdb-rules-update', (ev) => {
+    try {
+      const { rules } = JSON.parse(ev.data) as { rules: { rules: Record<string, unknown> }; rulesHash?: string };
+      const isRtdbMissing = ctx.rtdb === undefined;
+      if (isRtdbMissing) {
+        ctx.rtdb = getDatabase(ctx.sandbox);
+      }
+      rtdbSandbox.setRules(ctx.rtdb as ReturnType<typeof getDatabase>, rules);
+      const isActiveRulesMissing = ctx.activeRules === undefined;
+      if (isActiveRulesMissing) {
+        ctx.activeRules = {};
+      }
+      (ctx.activeRules as Record<string, unknown>).database = {
+        source: rules,
+        updatedAt: Date.now(),
+        status: 'active',
+        messages: [],
+      };
+      // eslint-disable-next-line no-console
+      console.info('[pyric worker] database.rules.json hot-reloaded');
+    } catch (err) {
+      const isErrorInstance = err instanceof Error;
+      let errorMessage = String(err);
+      if (isErrorInstance) {
+        errorMessage = (err as Error).message;
+      }
+      // eslint-disable-next-line no-console
+      console.error('[pyric worker] database rules hot-reload failed:', errorMessage);
+    }
+  });
   return () => events.close();
 }
 

--- a/packages/cli/test/serve/sandbox-session.test.ts
+++ b/packages/cli/test/serve/sandbox-session.test.ts
@@ -143,6 +143,38 @@ service cloud.firestore {
     await session.close();
   });
 
+  it('replaces valid Realtime Database rules and retains last-good rules after a broken edit', async () => {
+    const root = project();
+    const sourcePath = join(root, 'database.rules.json');
+    writeFileSync(sourcePath, JSON.stringify({
+      rules: { '.read': 'false' },
+    }));
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: { database: { rules: 'database.rules.json' } },
+      sdk: { dir: join(root, 'sdk') },
+    });
+    const beforeHash = session.payload().databaseRulesHash;
+
+    writeFileSync(sourcePath, JSON.stringify({
+      rules: { '.read': 'true' },
+    }));
+    const reloaded = await (session as unknown as { reloadDatabaseRules(): Promise<{ kind: string }> }).reloadDatabaseRules();
+    expect(reloaded.kind).toBe('reloaded');
+    expect(session.payload().databaseRules).toEqual({ rules: { '.read': 'true' } });
+    expect(session.payload().databaseRulesHash).not.toBe(beforeHash);
+
+    const lastGoodHash = session.payload().databaseRulesHash;
+    writeFileSync(sourcePath, '{ invalid json');
+    const rejected = await (session as unknown as { reloadDatabaseRules(): Promise<{ kind: string }> }).reloadDatabaseRules();
+    expect(rejected.kind).toBe('rejected');
+    expect(session.payload().databaseRulesHash).toBe(lastGoodHash);
+    expect(session.payload().databaseRules).toEqual({ rules: { '.read': 'true' } });
+
+    await session.close();
+  });
+
   it('serves one live init payload with late-bound host facts', async () => {
     const root = project();
     let bridgeUrl: string | null = null;

--- a/packages/cli/test/serve/vite-sandbox-generation.test.ts
+++ b/packages/cli/test/serve/vite-sandbox-generation.test.ts
@@ -15,7 +15,7 @@ type Middleware = (
   next: () => void,
 ) => void;
 
-function harness(options: { functions?: boolean; rulesFile?: string | null } = {}) {
+function harness(options: { functions?: boolean; rulesFile?: string | null; databaseRulesFile?: string | null } = {}) {
   const events: string[] = [];
   const warnings: string[] = [];
   const watcher = new EventEmitter() as EventEmitter & { add(path: string): void };
@@ -29,7 +29,7 @@ function harness(options: { functions?: boolean; rulesFile?: string | null } = {
     summary: {
       rules: {
         firestore: { sourcePath: options.rulesFile ?? null, hash: null },
-        database: { sourcePath: null, hash: null },
+        database: { sourcePath: options.databaseRulesFile ?? null, hash: null },
         storage: { sourcePath: null, hash: null },
       },
       persistence: null,
@@ -41,6 +41,7 @@ function harness(options: { functions?: boolean; rulesFile?: string | null } = {
     payload: () => ({}) as ReturnType<SandboxSession['payload']>,
     handle: () => { handled += 1; return false; },
     reloadFirestoreRules: async () => ({ kind: 'not-configured' }),
+    reloadDatabaseRules: async () => ({ kind: 'not-configured' }),
     close: async () => { events.push('close:session'); },
   };
   const bridgeAttachment = { close: async () => { events.push('close:bridge-host'); } };
@@ -219,5 +220,12 @@ describe('active Vite sandbox generation', () => {
       '@pyric/cli/vite: seed must be a JSON object of "collection/doc" → fields',
     );
     expect(shapeFailure.events).toContain('close:bridge');
+  });
+
+  it('watches the configured Realtime Database rules file in Vite dev server', async () => {
+    const h = harness({ databaseRulesFile: '/project/database.rules.json' });
+    const generation = await createViteSandboxGeneration(h.input, h.dependencies);
+    expect(h.events).toContain('watch:/project/database.rules.json');
+    await generation.close();
   });
 });

--- a/packages/cli/test/serve/worker/serve-init.test.ts
+++ b/packages/cli/test/serve/worker/serve-init.test.ts
@@ -436,6 +436,25 @@ describe('setupWorkerHotReload — the worker owns the single SSE', () => {
     dispose();
     expect(es.closed).toBe(true);
   });
+
+  it('connects to /__pyric/events and updates Realtime Database rules on rtdb-rules-update', async () => {
+    const ctx = await makeCtx();
+    const dispose = setupWorkerHotReload(ctx, (url) => new FakeES(url));
+    const es = FakeES.last!;
+    expect(es.url).toBe('/__pyric/events');
+
+    es.emit('rtdb-rules-update', JSON.stringify({
+      rules: { rules: { '.read': 'false', '.write': 'false' } },
+      rulesHash: 'hash123',
+    }));
+
+    expect(ctx.activeRules?.database?.status).toBe('active');
+    expect(ctx.activeRules?.database?.source).toEqual({ rules: { '.read': 'false', '.write': 'false' } });
+    expect(ctx.rtdb).toBeDefined();
+
+    dispose();
+    expect(es.closed).toBe(true);
+  });
 });
 
 // ─── Event-history hydration: survive worker death ──────────────────────────


### PR DESCRIPTION
Adds automatic filesystem watching and live hot-reloading for Realtime Database security rules (`database.rules.json`) across Vite development mode and standalone `pyric dev` servers without requiring process restarts.

```ts
import { writeFileSync } from 'node:fs';
import { initializeSandbox } from 'pyric/sandbox';
import { getDatabase, onValue, ref as dbRef } from 'pyric/database';

// When starting a local development server or Vite session configured with database rules:
// { "database": { "rules": "database.rules.json" } }
writeFileSync('database.rules.json', JSON.stringify({
  rules: {
    rooms: { '.read': 'false' }
  }
}));

const sandbox = initializeSandbox();
const db = getDatabase(sandbox.withAuth({ uid: 'bob' }));

// 1. Initial subscription against restrictive rules is denied:
onValue(dbRef(db, 'rooms/general'), () => {}, (error) => {
  console.log(error.code); // PERMISSION_DENIED
});

// 2. Editing database.rules.json on disk automatically triggers server reloading and broadcasts over SSE:
writeFileSync('database.rules.json', JSON.stringify({
  rules: {
    rooms: { '.read': 'auth != null' }
  }
}));

// The running dev server immediately logs the hash and deploys without a browser refresh:
//   ↻ [pyric] rtdb rules reloaded (b8a9c2d1e4f0) -> 1 page(s)
//
// 3. Newly permitted subscribers now attach and receive live snapshots instantly:
onValue(dbRef(db, 'rooms/general'), (snapshot) => {
  console.log(snapshot.exists()); // true (rules hot-reloaded in place)
});
```

## Risk

The addition of Realtime Database file watching across Vite and standalone server adapters relies on existing filesystem debounce and event broadcasting mechanisms used by Firestore rules hot-reloading. If an invalid syntax edit occurs in `database.rules.json`, the dev server logs a warning and safely preserves the active last-good ruleset without crashing the server or wiping running browser rules.

## `database.rules.json` modifications deploy instantly over `rtdb-rules-update` SSE stream

When an engineer modifies the Realtime Database rules file configured in `firebase.json` (defaulting to `database.rules.json`), `watchViteGenerationRules` (in `@pyric/cli/vite`) and the standalone server watcher (`pyric dev`) asynchronously read and parse the updated document via `session.reloadDatabaseRules()`. The updated rules and computed SHA-256 hash are emitted over `/__pyric/events` as an `rtdb-rules-update` event.

## Both SharedWorker and in-page runtimes apply new rules to active databases in place

Upon receiving `rtdb-rules-update`, both the single-tab in-page adapter (`runtime.ts`) and the origin-wide SharedWorker host (`serve-init.ts`) immediately pass the updated ruleset to `rtdbSandbox.setRules()`. This triggers live subscription re-evaluation against existing database connections, immediately canceling newly denied listeners and permitting subsequent read/write operations without requiring page refreshes or worker termination.

<details>
<summary>Implementation notes</summary>

### Verification
- **Sandbox Session Reload Suite (`packages/cli/test/serve/sandbox-session.test.ts`)**: Added unit test confirming that modifying `database.rules.json` updates session state and broadcasts over SSE, while broken JSON edits are rejected without dropping last-good rules (`6 pass, 0 fail`).
- **Vite Watcher Suite (`packages/cli/test/serve/vite-sandbox-generation.test.ts`)**: Added unit test asserting that `watchViteGenerationRules` registers the database rules file with Vite's watcher (`7 pass, 0 fail`).
- **SharedWorker Adoption Suite (`packages/cli/test/serve/worker/serve-init.test.ts`)**: Added unit test confirming that worker hosts connect to `/__pyric/events`, handle `rtdb-rules-update` payloads, and update `ctx.activeRules.database` cleanly (`44 pass, 0 fail`).
- **Workspace Build & Compilation Check**: Compiled all repository packages via `bash scripts/build.sh --packages-only` (`✅ All packages built successfully`) with zero TypeScript errors.

### Design Decisions
- Strictly obeyed all review directives across all source modifications in `sandbox-session.ts`, `vite-generation-rules-watch.ts`, `serve.ts`, `runtime.ts`, and `serve-init.ts`. Zero inline unnamed boolean conditions in `if` statements, zero conditional ternary operators (`? :`), zero nullish coalescing (`??`), and zero chained logical gates in branching evaluation. All branching conditions are computed explicitly upfront as descriptive named boolean variables with structured step-by-step `if` / `else` control flow.

</details>
