### PR TITLE
fix(cli): implement toString, bucket, parent, and root on worker storage references

### DIFF
--- a/packages/cli/src/serve/worker/client/storage.ts
+++ b/packages/cli/src/serve/worker/client/storage.ts
@@ -20,14 +20,55 @@ import type { ClientDb, ClientPort } from './handles.js';
 export interface ClientFirebaseStorage {
   readonly __kind: 'client-storage';
   readonly port: ClientPort;
+  readonly bucket: string;
 }
 
 /** Worker-backed Storage reference (path + name; carries the port for ops). */
 export interface ClientStorageReference {
   readonly __kind: 'storage-ref';
   readonly port: ClientPort;
+  readonly storage?: ClientFirebaseStorage;
+  readonly bucket: string;
   readonly fullPath: string;
   readonly name: string;
+  readonly parent: ClientStorageReference | null;
+  readonly root: ClientStorageReference;
+  toString(): string;
+}
+
+class ClientStorageReferenceImpl implements ClientStorageReference {
+  readonly __kind = 'storage-ref';
+  readonly port: ClientPort;
+  readonly storage?: ClientFirebaseStorage;
+  readonly bucket: string;
+  readonly fullPath: string;
+  readonly name: string;
+
+  constructor(port: ClientPort, bucket: string, fullPath: string, storage?: ClientFirebaseStorage) {
+    this.port = port;
+    this.bucket = bucket;
+    this.fullPath = fullPath;
+    this.name = lastSegment(fullPath);
+    if (storage) {
+      this.storage = storage;
+    }
+  }
+
+  get parent(): ClientStorageReference | null {
+    if (this.fullPath === '') return null;
+    const idx = this.fullPath.lastIndexOf('/');
+    const parentPath = idx === -1 ? '' : this.fullPath.slice(0, idx);
+    return new ClientStorageReferenceImpl(this.port, this.bucket, parentPath, this.storage);
+  }
+
+  get root(): ClientStorageReference {
+    if (this.fullPath === '') return this;
+    return new ClientStorageReferenceImpl(this.port, this.bucket, '', this.storage);
+  }
+
+  toString(): string {
+    return `gs://${this.bucket}/${this.fullPath}`;
+  }
 }
 
 /** Strip leading/trailing slashes (the worker keyspace uses bare paths). */
@@ -39,7 +80,7 @@ function normalizeStorageRefPath(path: string): string {
  * Get the worker-backed Storage handle. Like `getAuth`, accepts an existing
  * `ClientDb` (reusing its port) or a worker URL (standalone).
  */
-export function getStorage(source: ClientDb | string | URL, name?: string): ClientFirebaseStorage {
+export function getStorage(source: ClientDb | string | URL, name?: string, bucketUrl?: string): ClientFirebaseStorage {
   let port: ClientPort;
   if (typeof source === 'object' && '__kind' in source && source.__kind === 'client-db') {
     port = source.port;
@@ -58,7 +99,7 @@ export function getStorage(source: ClientDb | string | URL, name?: string): Clie
     port.start();
     wirePort(port);
   }
-  return { __kind: 'client-storage', port };
+  return { __kind: 'client-storage', port, bucket: bucketUrl ?? 'pyric-default' };
 }
 
 /** Build a Storage reference. Mirrors `pyric/storage`'s `ref(storage, path?)` /
@@ -69,13 +110,23 @@ export function ref(
 ): ClientStorageReference {
   const rel = normalizeStorageRefPath(path ?? '');
   let fullPath: string;
+  let port: ClientPort;
+  let bucket = 'pyric-default';
+  let storage: ClientFirebaseStorage | undefined;
+
   if (parent.__kind === 'client-storage') {
     fullPath = rel;
+    port = parent.port;
+    bucket = parent.bucket;
+    storage = parent;
   } else {
     const base = parent.fullPath;
     fullPath = rel ? (base ? `${base}/${rel}` : rel) : base;
+    port = parent.port;
+    bucket = parent.bucket;
+    storage = parent.storage;
   }
-  return { __kind: 'storage-ref', port: parent.port, fullPath, name: lastSegment(fullPath) };
+  return new ClientStorageReferenceImpl(port, bucket, fullPath, storage);
 }
 
 /** Enumerate immediate child items + sub-prefixes under a ref (Pyric Studio
@@ -86,9 +137,8 @@ export async function listAll(
   const r = (await dataRpc(reference.port, {
     t: 'op', id: nextId(), method: 'storage.listAll', path: reference.fullPath,
   })) as { items: Array<{ fullPath: string; name: string }>; prefixes: Array<{ fullPath: string; name: string }> };
-  const mk = (e: { fullPath: string; name: string }): ClientStorageReference => ({
-    __kind: 'storage-ref', port: reference.port, fullPath: e.fullPath, name: e.name,
-  });
+  const mk = (e: { fullPath: string; name: string }): ClientStorageReference =>
+    new ClientStorageReferenceImpl(reference.port, reference.bucket, e.fullPath, reference.storage);
   return { items: r.items.map(mk), prefixes: r.prefixes.map(mk) };
 }
 

--- a/packages/cli/test/serve/worker/storage-ref-surface.test.ts
+++ b/packages/cli/test/serve/worker/storage-ref-surface.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Characterization test for ClientStorageReference surface (worker mode).
+ *
+ * Verifies that ref(storage, path) in worker mode implements toString(),
+ * bucket, parent, and root, matching the genuine Firebase Storage reference contract.
+ */
+import { describe, expect, test } from 'bun:test';
+import { getStorage, ref } from '../../../src/serve/worker/client/storage.js';
+import type { ClientDb } from '../../../src/serve/worker/client/handles.js';
+
+describe('worker ClientStorageReference surface', () => {
+  const fakeDb = { __kind: 'client-db' as const, port: {} as any };
+
+  test('ref implements toString(), bucket, parent, and root', () => {
+    const storage = getStorage(fakeDb, undefined, 'test-bucket.appspot.com');
+    expect(storage.bucket).toBe('test-bucket.appspot.com');
+
+    const rootRef = ref(storage);
+    expect(rootRef.fullPath).toBe('');
+    expect(rootRef.name).toBe('');
+    expect(rootRef.bucket).toBe('test-bucket.appspot.com');
+    expect(rootRef.toString()).toBe('gs://test-bucket.appspot.com/');
+    expect(rootRef.parent).toBeNull();
+    expect(rootRef.root).toBe(rootRef);
+
+    const childRef = ref(storage, 'feed/photo-123.png');
+    expect(childRef.fullPath).toBe('feed/photo-123.png');
+    expect(childRef.name).toBe('photo-123.png');
+    expect(childRef.bucket).toBe('test-bucket.appspot.com');
+    expect(childRef.toString()).toBe('gs://test-bucket.appspot.com/feed/photo-123.png');
+
+    const parentRef = childRef.parent;
+    expect(parentRef).not.toBeNull();
+    expect(parentRef!.fullPath).toBe('feed');
+    expect(parentRef!.name).toBe('feed');
+    expect(parentRef!.toString()).toBe('gs://test-bucket.appspot.com/feed');
+    expect(parentRef!.parent!.fullPath).toBe('');
+    expect(parentRef!.parent!.parent).toBeNull();
+
+    expect(childRef.root.fullPath).toBe('');
+    expect(childRef.root.toString()).toBe('gs://test-bucket.appspot.com/');
+  });
+
+  test('ref(parent, path) inherits bucket and storage', () => {
+    const storage = getStorage(fakeDb, undefined, 'my-bucket');
+    const baseRef = ref(storage, 'users');
+    const userRef = ref(baseRef, 'ada/profile.jpg');
+
+    expect(userRef.fullPath).toBe('users/ada/profile.jpg');
+    expect(userRef.name).toBe('profile.jpg');
+    expect(userRef.bucket).toBe('my-bucket');
+    expect(userRef.toString()).toBe('gs://my-bucket/users/ada/profile.jpg');
+    expect(userRef.storage).toBe(storage);
+  });
+});


### PR DESCRIPTION
Implements `.toString()`, `.bucket`, `.parent`, and `.root` on `ClientStorageReference` and `ClientFirebaseStorage` in Pyric CLI's SharedWorker client surface to match the canonical Firebase Storage reference contract.

```ts
import { getStorage, ref } from '@pyric/cli/serve/worker';

const storage = getStorage(workerPort);
const storageRef = ref(storage, 'feed/photo-123.png');

console.log(storageRef.toString());
// => "gs://pyric-default/feed/photo-123.png"

console.log(storageRef.bucket);
// => "pyric-default"

console.log(storageRef.parent?.fullPath);
// => "feed"

console.log(storageRef.root.fullPath);
// => ""
```

## Worker Storage references implement toString, bucket, parent, and root

Prior to this change, `ref(...)` in worker mode (`useWorker: true`) returned a plain object literal (`ClientStorageReference`) without `.toString()`, `.bucket`, `.parent`, or `.root`. Calling `.toString()` on a worker Storage reference fell back to `Object.prototype.toString()` (`"[object Object]"`), causing applications storing `storageRef.toString()` in Firestore fields or logs to write `bucketLocation: "[object Object]"`.

`ClientStorageReferenceImpl` now encapsulates worker Storage references, providing complete parity with Pyric's in-page `SandboxStorageReference` and the official Firebase Storage v9+ SDK.

## Risk

Low. `ClientStorageReferenceImpl` is an additive class implementation for worker Storage references. Existing properties (`__kind`, `port`, `fullPath`, `name`) remain untouched.

<details>
<summary>Implementation notes</summary>

- Replaced plain object factory in `packages/cli/src/serve/worker/client/storage.ts` with `ClientStorageReferenceImpl`.
- Updated `ClientFirebaseStorage` interface to include `readonly bucket: string`.
- Added unit test suite `packages/cli/test/serve/worker/storage-ref-surface.test.ts`.
- Verified 14/14 tests pass across `storage-ref-surface.test.ts`, `client-surface.test.ts`, and `storage-ops.test.ts`.
- Verified TypeScript type checking (`bun x tsc -p tsconfig.json --noEmit`): 0 errors.
- Verified in `simple-pics` browser app with Playwright: `storageRef.toString()` returns `"gs://pyric-default/feed/_"`.

</details>
