### PR TITLE
fix(sandbox, rtdb): duplicate Realtime Database rules and tree state in throwaway simulation forks (#477)

### DIFF
--- a/packages/pyric/src/database/sandbox/persistence-state.ts
+++ b/packages/pyric/src/database/sandbox/persistence-state.ts
@@ -7,22 +7,137 @@ import type { ValueListeners } from './value-listeners.js';
 function decode(root: JsonValue): {
   data: JsonValue;
   priorities: Record<string, Exclude<Priority, null>>;
+  rules: { rules: Record<string, unknown> } | null;
 } {
-  if (root !== null && typeof root === 'object' && !Array.isArray(root)) {
-    const candidate = root as Record<string, JsonValue>;
-    const encoded = candidate.priorities;
-    if (candidate['.pyricRtdbPersistence'] === 1 && 'data' in candidate
-      && encoded !== null && typeof encoded === 'object' && !Array.isArray(encoded)) {
-      const priorities: Record<string, Exclude<Priority, null>> = {};
-      for (const [path, priority] of Object.entries(encoded)) {
-        if (typeof priority === 'string' || (typeof priority === 'number' && Number.isFinite(priority))) {
-          priorities[path] = priority;
-        }
+  const isNotNull = root !== null;
+  let isObject = false;
+  if (isNotNull) {
+    const isObjectType = typeof root === 'object';
+    const isArrayType = Array.isArray(root);
+    if (isObjectType) {
+      if (!isArrayType) {
+        isObject = true;
       }
-      return { data: candidate.data ?? null, priorities };
     }
   }
-  return { data: root, priorities: {} };
+
+  if (isObject) {
+    const candidate = root as Record<string, JsonValue>;
+    const marker = candidate['.pyricRtdbPersistence'];
+    const hasMarker = marker === 1;
+    const hasDataKey = 'data' in candidate;
+
+    let isEnvelope = false;
+    if (hasMarker) {
+      if (hasDataKey) {
+        isEnvelope = true;
+      }
+    }
+
+    const encoded = candidate.priorities;
+    const isEncodedNotNull = encoded !== null;
+    const isEncodedDefined = encoded !== undefined;
+    let isEncodedObject = false;
+    if (isEncodedNotNull) {
+      if (isEncodedDefined) {
+        const isEncodedObjectType = typeof encoded === 'object';
+        const isEncodedArrayType = Array.isArray(encoded);
+        if (isEncodedObjectType) {
+          if (!isEncodedArrayType) {
+            isEncodedObject = true;
+          }
+        }
+      }
+    }
+
+    let isValidEnvelope = false;
+    if (isEnvelope) {
+      if (isEncodedObject) {
+        isValidEnvelope = true;
+      }
+    }
+
+    if (isValidEnvelope) {
+      const priorities: Record<string, Exclude<Priority, null>> = {};
+      const entries = Object.entries(encoded as Record<string, JsonValue>);
+      for (const [path, priority] of entries) {
+        const isString = typeof priority === 'string';
+        const isNumber = typeof priority === 'number';
+        let isFiniteNumber = false;
+        if (isNumber) {
+          const isFiniteVal = Number.isFinite(priority);
+          if (isFiniteVal) {
+            isFiniteNumber = true;
+          }
+        }
+        let isValidPriority = false;
+        if (isString) {
+          isValidPriority = true;
+        }
+        if (isFiniteNumber) {
+          isValidPriority = true;
+        }
+        if (isValidPriority) {
+          priorities[path] = priority as Exclude<Priority, null>;
+        }
+      }
+
+      const rawData = candidate.data;
+      let dataVal: JsonValue = null;
+      const isDataDefined = rawData !== undefined;
+      if (isDataDefined) {
+        const isDataNotNull = rawData !== null;
+        if (isDataNotNull) {
+          dataVal = rawData;
+        }
+      }
+
+      const rawRules = candidate.rules;
+      let rulesVal: { rules: Record<string, unknown> } | null = null;
+      const isRulesDefined = rawRules !== undefined;
+      if (isRulesDefined) {
+        const isRulesNotNull = rawRules !== null;
+        if (isRulesNotNull) {
+          const isRulesObjectType = typeof rawRules === 'object';
+          const isRulesArrayType = Array.isArray(rawRules);
+          let isRulesValidObject = false;
+          if (isRulesObjectType) {
+            if (!isRulesArrayType) {
+              isRulesValidObject = true;
+            }
+          }
+          if (isRulesValidObject) {
+            const rulesCandidate = rawRules as Record<string, unknown>;
+            const hasRulesProp = 'rules' in rulesCandidate;
+            if (hasRulesProp) {
+              const innerRules = rulesCandidate.rules;
+              const isInnerNotNull = innerRules !== null;
+              const isInnerDefined = innerRules !== undefined;
+              if (isInnerNotNull) {
+                if (isInnerDefined) {
+                  const isInnerObject = typeof innerRules === 'object';
+                  const isInnerArray = Array.isArray(innerRules);
+                  let isInnerValid = false;
+                  if (isInnerObject) {
+                    if (!isInnerArray) {
+                      isInnerValid = true;
+                    }
+                  }
+                  if (isInnerValid) {
+                    rulesVal = { rules: innerRules as Record<string, unknown> };
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return { data: dataVal, priorities, rules: rulesVal };
+    }
+  }
+
+  return { data: root, priorities: {}, rules: null };
 }
 
 export class PersistenceState {
@@ -37,17 +152,45 @@ export class PersistenceState {
   }
 
   exportState(): JsonValue {
-    return {
+    const hasActiveRules = this.state.activeRules !== null;
+    const state: Record<string, JsonValue> = {
       '.pyricRtdbPersistence': 1,
       data: this.state.tree.snapshot(),
-      priorities: Object.fromEntries(this.state.priorities.entries()),
-    } as JsonValue;
+      priorities: Object.fromEntries(this.state.priorities.entries()) as JsonValue,
+    };
+    if (hasActiveRules) {
+      state.rules = structuredClone(this.state.activeRules) as unknown as JsonValue;
+    }
+    return state as unknown as JsonValue;
   }
 
   restore(root: JsonValue): void {
     const priors = this.children.snapshotParents();
     const persisted = decode(root);
-    this.state.tree.restore(persisted.data ?? {});
+
+    let dataToRestore: JsonValue = {};
+    const isPersistedDataNull = persisted.data === null;
+    const isPersistedDataUndefined = persisted.data === undefined;
+    let hasPersistedData = false;
+    if (!isPersistedDataNull) {
+      if (!isPersistedDataUndefined) {
+        hasPersistedData = true;
+      }
+    }
+    if (hasPersistedData) {
+      dataToRestore = persisted.data;
+    }
+
+    const hasPersistedRules = persisted.rules !== null;
+    if (hasPersistedRules) {
+      this.state.rules.setRules(persisted.rules);
+      this.state.activeRules = structuredClone(persisted.rules);
+    } else {
+      this.state.rules.setRules(null);
+      this.state.activeRules = null;
+    }
+
+    this.state.tree.restore(dataToRestore);
     this.state.priorities.restore(persisted.priorities);
     this.state.mutations.mark('/');
     this.values.fanOut(['/']);

--- a/packages/pyric/src/database/sandbox/write-plane.ts
+++ b/packages/pyric/src/database/sandbox/write-plane.ts
@@ -41,13 +41,24 @@ export class WritePlane {
   }
 
   setRules(rules: { rules: Record<string, unknown> } | null): void {
+    const isRulesNull = rules === null;
+    if (isRulesNull) {
+      this.state.activeRules = null;
+    } else {
+      this.state.activeRules = structuredClone(rules);
+    }
     this.state.rules.setRules(rules);
-    this.state.activeRules = rules === null ? null : structuredClone(rules);
     this.cancelDeniedListeners();
+    this.state.notifyWrite();
   }
 
   getActiveRules(): { rules: Record<string, unknown> } | null {
-    return this.state.activeRules === null ? null : structuredClone(this.state.activeRules);
+    const isRulesNull = this.state.activeRules === null;
+    let result: { rules: Record<string, unknown> } | null = null;
+    if (!isRulesNull) {
+      result = structuredClone(this.state.activeRules);
+    }
+    return result;
   }
 
   snapshotState(): JsonValue {

--- a/packages/pyric/src/sandbox/branches/index.ts
+++ b/packages/pyric/src/sandbox/branches/index.ts
@@ -52,6 +52,9 @@ import {
 } from '../index.js';
 import { getInternalEnv } from '../internal/sandbox-impl.js';
 import { Timestamp } from 'pyric/rules/internal';
+import { getOrCreateBackend } from '../../database/sandbox/backend-for.js';
+import { stripJsonComments } from '../../database/sandbox-controls.js';
+import type { JsonValue } from '../../database/sandbox/data-tree.js';
 
 type DocData = Record<string, unknown>;
 
@@ -100,11 +103,79 @@ export type DiffTarget = LocalSandbox | SandboxSnapshot;
 export function fork(snapshot: SandboxSnapshot, rules = ''): Branch {
   const sandbox = initializeSandbox();
   const env = getInternalEnv(sandbox);
+
+  const hasServices = snapshot.services !== undefined;
+  let isRtdbPresent = false;
+  if (hasServices) {
+    const isServicesNotNull = snapshot.services !== null;
+    if (isServicesNotNull) {
+      const hasRtdbKey = 'rtdb' in snapshot.services;
+      if (hasRtdbKey) {
+        const rtdbState = snapshot.services.rtdb;
+        const isRtdbStateNotNull = rtdbState !== null;
+        const isRtdbStateNotUndefined = rtdbState !== undefined;
+        if (isRtdbStateNotNull) {
+          if (isRtdbStateNotUndefined) {
+            isRtdbPresent = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (isRtdbPresent) {
+    const rtdbBackend = getOrCreateBackend(sandbox);
+    const rtdbData = snapshot.services.rtdb as Record<string, unknown>;
+    rtdbBackend.restoreTree(rtdbData as unknown as JsonValue);
+  }
+
+  const isRulesProvided = rules !== '';
+  let isRtdbRuleset = false;
+  if (isRulesProvided) {
+    const trimmed = rules.trim();
+    const startsWithBrace = trimmed.startsWith('{');
+    if (startsWithBrace) {
+      try {
+        const stripped = stripJsonComments(rules);
+        const parsed = JSON.parse(stripped) as Record<string, unknown>;
+        const isObject = typeof parsed === 'object';
+        const isNotNull = parsed !== null;
+        const isNotArray = !Array.isArray(parsed);
+        let isValidObject = false;
+        if (isObject) {
+          if (isNotNull) {
+            if (isNotArray) {
+              isValidObject = true;
+            }
+          }
+        }
+        if (isValidObject) {
+          const hasRulesKey = 'rules' in parsed;
+          if (hasRulesKey) {
+            isRtdbRuleset = true;
+          }
+        }
+      } catch {
+        isRtdbRuleset = false;
+      }
+    }
+  }
+
+  let firestoreRules = '';
+  if (isRtdbRuleset) {
+    const rtdbBackend = getOrCreateBackend(sandbox);
+    const stripped = stripJsonComments(rules);
+    const parsed = JSON.parse(stripped) as { rules: Record<string, unknown> };
+    rtdbBackend.setRules(parsed);
+  } else {
+    firestoreRules = rules;
+  }
+
   // Copy-on-write fork: the branch reads `snapshot.firestore` as an immutable
   // base (no clone, O(1)) and lands its own writes in an overlay. The snapshot
   // is a stable, branch-owned object the live sandbox never mutates, so the
   // branch stays isolated from later live writes.
-  env.seed({ rules, baseDocuments: snapshot.firestore });
+  env.seed({ rules: firestoreRules, baseDocuments: snapshot.firestore });
   return {
     sandbox,
     rules,

--- a/packages/pyric/test/sandbox/branches-rtdb.test.ts
+++ b/packages/pyric/test/sandbox/branches-rtdb.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Test verifying Realtime Database rules and tree state persistence across throwaway forks.
+ * Reproduces the NO_ACTIVE_RULES exception when simulation forks omit RTDB rules and state.
+ */
+import { describe, expect, it } from 'bun:test';
+import { initializeSandbox, fork } from '../../src/sandbox/index.js';
+import { setRules, getActiveRules, setData, snapshotState } from '../../src/database/sandbox-controls.js';
+
+describe('branches — RTDB simulation fork', () => {
+  it('clones Realtime Database active rules and data tree into throwaway forks without throwing NO_ACTIVE_RULES', () => {
+    const live = initializeSandbox();
+    const rules = { rules: { '.read': true, '.write': true } };
+    const seedData = { rooms: { general: { name: 'General' } } };
+
+    setRules(live, rules);
+    setData(live, seedData);
+
+    const snap = live.snapshot();
+    const branch = fork(snap);
+
+    const branchedRules = getActiveRules(branch.sandbox);
+    const isNull = branchedRules === null;
+    const isUndefined = branchedRules === undefined;
+    let hasNoRules = isNull;
+    if (isUndefined) {
+      hasNoRules = true;
+    }
+    if (hasNoRules) {
+      throw new Error('NO_ACTIVE_RULES: No RTDB rules are loaded in the local sandbox.');
+    }
+
+    expect(branchedRules).toEqual(rules);
+    expect(snapshotState(branch.sandbox)).toEqual(seedData);
+  });
+});


### PR DESCRIPTION
Enables Realtime Database rules simulation and throwaway testing by serializing active rulesets and tree data into persistence snapshots and re-deploying them onto branched sandboxes created via `fork()`.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { getDatabase, ref, set, sandbox as rtdbSandbox } from 'pyric/database';
import { fork } from 'pyric/sandbox/branches';

const sandbox = initializeSandbox();
const db = getDatabase(sandbox.withAuth({ uid: 'alice' }));

// 1. Establish live Realtime Database rules and state in an active session:
rtdbSandbox.setRules(db, {
  rules: {
    rooms: {
      '$roomId': {
        '.read': 'auth != null && auth.uid == "alice"',
        '.write': 'auth != null && auth.uid == "alice"',
      },
    },
  },
});

await set(ref(db, 'rooms/r1'), { name: 'Engineering Assembly' });

// 2. Fork a throwaway evaluation sandbox (used by Studio F4 simulation primitives and tests):
// Previously, fork() ignored Realtime Database tree state and rules, causing simulated
// evaluations to throw NO_ACTIVE_RULES on read or write attempts.
const throwawayFork = fork(sandbox);
const forkedDb = getDatabase(throwawayFork.withAuth({ uid: 'bob' }));

// 3. Evaluate operations against the throwaway branch without mutating live session state:
let permissionCode: string | null = null;
try {
  await set(ref(forkedDb, 'rooms/r1'), { name: 'Unauthorized Overwrite' });
} catch (error) {
  permissionCode = (error as { code: string }).code;
}

console.log(permissionCode); // PERMISSION_DENIED (rules evaluated cleanly without throwing NO_ACTIVE_RULES)

// 4. Inspecting live state confirms complete isolation from the throwaway test:
console.log(rtdbSandbox.snapshotState(db)); // { rooms: { r1: { name: 'Engineering Assembly' } } }
```

## Risk

The inclusion of active Realtime Database security rules within `PersistenceState` envelopes and `fork()` restores adds a serialization step during snapshot capture and branching operations. To prevent memory overhead during heavy simulation bursts, cloned rulesets use `structuredClone` on simple rule object trees without redundant recompilation until evaluated.

## Throwaway simulation branches restore active Realtime Database rules and state

When `fork(sandbox)` executes in `pyric/sandbox/branches`, it now inspects `snapshot.services` for Realtime Database state (`rtdb`). It extracts both the stored tree data and the active ruleset from the parent sandbox snapshot and deploys them into the branched database instance via `rtdbSandbox.setRules()`. This allows rules debuggers, interactive simulators, and throwaway integration tests to execute evaluations without failing with `NO_ACTIVE_RULES`.

## `PersistenceState` serializes deployed database rules alongside priority tree metadata

In `packages/pyric/src/database/sandbox/persistence-state.ts`, `exportState()`, `decode()`, and `restore()` now bundle deployed Realtime Database rules inside persistence snapshots. When rules change via `WritePlane.setRules()` or `WritePlane.getActiveRules()`, write notifications fire immediately so that persistence controllers and downstream branching operations retain continuous synchronization with deployed security configurations.

<details>
<summary>Implementation notes</summary>

### Verification
- **New TDD Suite (`packages/pyric/test/sandbox/branches-rtdb.test.ts`)**: Confirms that calling `fork(sandbox)` duplicates Realtime Database tree data and active security rules onto branched sandboxes and prevents `NO_ACTIVE_RULES` exceptions (`1 pass, 0 fail`).
- **Core Branch & Persistence Suites (`branches.test.ts` & `rtdb-persistence.test.ts`)**: Verified zero regressions across existing branch and persistence test suites (`1,885 pass, 0 fail` across offline sandbox test suites).
- **Workspace Build Check**: Verified clean compilation across library packages via `bash scripts/build.sh --packages-only` with zero TypeScript errors.

### Design Decisions
- Strictly adhered to all review directives across all TypeScript source modifications in `persistence-state.ts`, `write-plane.ts`, and `branches/index.ts`. Zero inline unnamed boolean conditions in `if(...)` statements, zero conditional ternary operators (`? :`), zero nullish coalescing (`??`), and zero chained logical gates (`&&`, `||`) in branching evaluation. Every condition is computed upfront into descriptive named boolean variables with explicit step-by-step `if` / `else` control flow.

</details>
