### PR TITLE
feat(cli): print copy-pasteable environment export commands in host-only startup

### DIFF
--- a/packages/cli/src/cli/dev-runner.ts
+++ b/packages/cli/src/cli/dev-runner.ts
@@ -163,6 +163,27 @@ export function buildChildEnv(
   };
 }
 
+/**
+ * Format copy-pasteable POSIX export statements for host-only startup.
+ * Grouped in a cleanly formatted console block for easy selection and copying
+ * into a separate terminal (for example, when running Next.js independently).
+ */
+export function formatStartupEnvExport(opts: { serveUrl: string; registerUrl: string }): string {
+  const pyricSandbox = `remote:${opts.serveUrl}`;
+  const nodeOptions = `--import ${opts.registerUrl}`;
+  const line1 = `export PYRIC_SANDBOX="${pyricSandbox}"`;
+  const line2 = `export NODE_OPTIONS="${nodeOptions}"`;
+  const divider = '─'.repeat(Math.max(line1.length, line2.length) + 4);
+  return (
+    '\n' +
+    '  To run external commands against this sandbox, paste in another terminal:\n' +
+    `  ${divider}\n` +
+    `  ${line1}\n` +
+    `  ${line2}\n` +
+    `  ${divider}\n`
+  );
+}
+
 // ─── Line prefixing (pure core) ────────────────────────────────────────────
 
 /**

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -31,6 +31,7 @@ import { openBrowser, shouldAutoOpen } from '../serve/open-browser.js';
 import {
   buildChildEnv,
   detectPackageManager,
+  formatStartupEnvExport,
   readDevScript,
   registerModuleUrl,
   resolveDevChild,
@@ -802,6 +803,13 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
         registerUrl: registerModuleUrl(),
       }),
     });
+  } else if (!json) {
+    process.stdout.write(
+      formatStartupEnvExport({
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+    );
   }
 
   return await new Promise<number>((resolveExit) => {

--- a/packages/cli/test/cli/dev-runner.test.ts
+++ b/packages/cli/test/cli/dev-runner.test.ts
@@ -13,6 +13,7 @@ import {
   buildChildEnv,
   createLinePrefixer,
   detectPackageManager,
+  formatStartupEnvExport,
   readDevScript,
   registerModuleUrl,
   resolveDevChild,
@@ -196,5 +197,19 @@ describe('waitForSandboxPeer (first-run race guard)', () => {
       sleep: async () => {},
     });
     expect(ok).toBe(true);
+  });
+});
+
+describe('formatStartupEnvExport', () => {
+  it('formats copy-pasteable POSIX export commands for host-only startup', () => {
+    const output = formatStartupEnvExport({
+      serveUrl: 'http://localhost:3473',
+      registerUrl: 'file:///usr/local/pyric/dist/register/index.js',
+    });
+    expect(output).toContain('export PYRIC_SANDBOX="remote:http://localhost:3473"');
+    expect(output).toContain(
+      'export NODE_OPTIONS="--import file:///usr/local/pyric/dist/register/index.js"',
+    );
+    expect(output).toContain('To run external commands against this sandbox');
   });
 });

--- a/packages/cli/test/serve/integration.test.ts
+++ b/packages/cli/test/serve/integration.test.ts
@@ -6,7 +6,8 @@ import { afterAll, describe, expect, it } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { extractHosting, serveJsonLine, startServe, wantsSpaRewrite, type ServeRuntime } from '../../src/cli/serve.js';
+import { extractHosting, runServe, serveJsonLine, startServe, wantsSpaRewrite, type ServeRuntime } from '../../src/cli/serve.js';
+import { parseArgs } from '../../src/cli/index.js';
 import { silentServeLogger, type ServeLogger } from '../../src/serve/server.js';
 import { CAPTURE_RELATIVE_PATH } from '../../src/serve/capture-store.js';
 
@@ -312,5 +313,34 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
     const { existsSync: exists } = await import('node:fs');
     const capturePath = join(cwd, CAPTURE_RELATIVE_PATH);
     expect(exists(capturePath)).toBe(false);
+  }, 30_000);
+});
+
+describe('runServe host-only environment export', () => {
+  it('runServe prints copy-pasteable POSIX export commands in host-only mode', async () => {
+    const cwd = fixtureProject();
+    const prevCwd = process.cwd();
+    process.chdir(cwd);
+    let stdout = '';
+    let triggered = false;
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+      if (!triggered && stdout.includes('export PYRIC_SANDBOX=')) {
+        triggered = true;
+        setTimeout(() => process.emit('SIGINT'), 20);
+      }
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const parsed = parseArgs(['dev', '--port', '0', '--no-open', '--no-run', '--no-cache']);
+      const code = await runServe(parsed);
+      expect(code).toBe(0);
+      expect(stdout).toContain('export PYRIC_SANDBOX="remote:http://');
+      expect(stdout).toContain('export NODE_OPTIONS="--import file://');
+    } finally {
+      process.stdout.write = origWrite;
+      process.chdir(prevCwd);
+    }
   }, 30_000);
 });


### PR DESCRIPTION
Adds copy-pasteable POSIX environment export commands to `pyric dev` during host-only startup, enabling external developer processes to connect directly to the in-browser database sandbox without CLI orchestration or configuration files.

```bash
# Terminal 1: start the pyric host server without spawning a child command runner
$ pyric dev --no-run --port 3473

=== Serving from '/Users/deast/repos/my-nextjs-app'...

✔ hosting  Serving files from: .
✔ hosting  Local server: http://localhost:3473
✔ sandbox  pyric SDK bundles ready (cache)
• rules    no firestore.rules — sandbox runs with default rules
• rules    no database.rules — RTDB sandbox runs with default rules
• rules    no storage.rules — storage sandbox runs open (no rules configured)

  To run external commands against this sandbox, paste in another terminal:
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
  export PYRIC_SANDBOX="remote:http://localhost:3473"
  export NODE_OPTIONS="--import file:///Users/deast/repos/my-nextjs-app/node_modules/@pyric/cli/dist/register/index.js"
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────

  ⚠ the pyric sandbox runs IN the served page — keep the browser tab open.

# Terminal 2: connect an independent Next.js or test runner to the live sandbox session
$ export PYRIC_SANDBOX="remote:http://localhost:3473"
$ export NODE_OPTIONS="--import file:///Users/deast/repos/my-nextjs-app/node_modules/@pyric/cli/dist/register/index.js"
$ next dev # or bun test
```

## Host-only mode exposes copy-pasteable POSIX environment variables directly to stdout

When `pyric dev` runs in host-only mode (when `--no-run` is passed or no `dev` script is discovered in `package.json`), external processes like Next.js or custom task runners in separate terminals cannot receive the module-swapping loader hook without manual wiring. This change prints a copy-pasteable block containing POSIX `export` statements for `PYRIC_SANDBOX` and `NODE_OPTIONS` directly to `stdout`. The operation executes purely in memory without creating `.env` configuration files on disk, and suppresses itself during normal child dev command execution or machine `--json` mode.

## Risk

Zero behavior change to existing proxy or database routing paths. The startup logging block is completely suppressed when a child dev runner is spawned (`pyric dev` executing a package.json `dev` script or `-- <cmd>`) and when machine-readable `--json` mode is requested, ensuring normal terminal console logs remain clean and JSON parsing contracts stay untouched.

<details>
<summary>Implementation notes</summary>

- **Priorities Test (`PRIORITIES.md`):** Passes the **Top of Funnel** priority test by eliminating multi-terminal integration friction without adding a new step, concept, or config file to the first run.
- **UX formatting:** Omitted vertical ASCII box borders (`│`) so mouse drag-and-select copying across terminal lines captures valid shell commands without syntax-breaking trailing symbols.
- **Verification:**
  - Added unit test block in `dev-runner.test.ts` verifying POSIX export formatting and copy-pasteability.
  - Added end-to-end HTTP integration test in `integration.test.ts` invoking `runServe` in host-only mode and asserting `stdout` export block delivery.
  - Verified across the full monorepo test suite (`HOME="/tmp" bun run test`): all unit, integration, and conformance tests pass cleanly across `@pyric/cli`, `@pyric/ui`, `pyric`, `studio`, and `conformance`.

</details>
