### PR TITLE
release: v0.1.0-alpha.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.16",
+      "version": "0.1.0-alpha.17",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -133,7 +133,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.16",
+      "version": "0.1.0-alpha.17",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -253,7 +253,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.16",
+      "version": "0.1.0-alpha.17",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -271,7 +271,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.16",
+      "version": "0.1.0-alpha.17",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -343,7 +343,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.16",
+      "version": "0.1.0-alpha.17",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.17`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.16

- docs: update readme for pyric studio (883e52cd)
- test(firestore): update surface census and export baselines for 100% completion (ed368ae2)
- feat(firestore): achieve 100% SDK public runtime and type surface coverage via CDD (7834f53d)
- feat(rules): attach authored rule source lines to denials (#370) (4d960ad1)
- feat(create-pyric): scope web scaffold posts to user UID with matching per-user rules (#365) (a8e2c4e5)
- feat(conformance): implement side-by-side rules construct scorecards and interactive CLI inspector (d1b9bbf1)
- test(conformance): update pinned census and surface counts for resumable storage upload exports (14782ebf)
- feat(cli): print copy-pasteable POSIX environment export commands during host-only startup (8876212f)
- feat(storage): implement resumable uploads and mock progress events (#159) (b457c119)
- fix(ci): run playwright install within CLI package to match locked browser build (92840e6b)
- fix(sandbox, rtdb): duplicate Realtime Database rules and tree state in throwaway simulation forks (#477) (d36f9b27)
- feat(conformance): close Firestore CDD rejection-parity gaps and resolve OAuth tokens dynamically (35416e52)
- fix(cli): implement toString, bucket, parent, and root on worker storage references (a84fe5b2)
- feat(storage): implement uploadString over SharedWorker client (9fb9cd4a)
- fix(cli/serve): restore missing closing brace in serve banner log (a7ad60d5)
- fix(cli/serve): log rtdb rules watching in serve banner (8bca8e0f)
- feat(serve/vite): hot-reload Realtime Database security rules (#481) (4dbcf56b)
- fix(rtdb, studio): allow .info system reads and show listener denials in traffic and inspect (#476) (10cc5292)
- fix(rtdb, studio): attach rich rules evaluation traces to errored listener events (#476) (4e7b36b0)
- fix(serve/ui): monorepo pointer discovery, AI passthrough optimizeDeps, and React peerDeps (6032f4be)
- feat(rules): elevate rules conformance to oracle-backed via dynamic CLI authentication and live production observation captures (a7078a8e)
- fix(template): restore environment-driven config without hardcoded credentials (7f5cd1da)
- feat(ai): add production pass-through, direct mode, and opt-in AI logic config (20ca2abe)
- refactor(studio): remove manual user impersonation controls to align with AI-first Simplification (4fcedfd9)
- docs: ADR-0011 — the SharedWorker transport as a versioned public API (f651d18d)
- refactor(studio): remove duplicate ruleset editing buffer to align with AI-first Simplification (#474) (f5e7775b)
- feat(next): add Next.js support (#471) (29c7a40d)
- docs: link compatibility evidence directly to verified GitHub source lines (#459) (b63d30de)
- feat(studio): add RTDB rules evaluation inspector with deciding-line highlighting (e1a35422)
- fix(cli, database): support commented RTDB rules files and ancestor firebase.json discovery (5298c78e)
- feat(rules): implement standard production behavior for atomic sibling merge and strict AST checking (e1487671)
- chore(deps): remove accidental @google/jules-cli dependency and clean lockfile (ad686845)
- fix(ci): keep the jules-cli dependency the branch point carries (f934b27b)
- perf(ci): restore built packages from a content-keyed cache (8c278153)
- feat: support Vite bridge discovery, admin ambient fallbacks, and RTDB system status paths (409debd1)
- perf(ci): shard the conformance suite into its own job (7f6b0a29)
- test(cli): pin the absent chromium apt step in the merge gate (e937c74f)
- feat(pyric-admin): implement stateless client ID token verification and modular decoders (1c1d96cd)
- feat(auth): emit self-describing sandbox ID tokens with serialized claims (1ca25731)
- perf(ci): overlap independent CI work inside jobs (5f29df19)
- fix(cli/vite): ignore .pyric in server watch config to prevent HMR reload loops (8defec1a)
- test: align merge gate with docs CI removal (ee75df81)
- docs: publish only RTDB compatibility claims (30867b04)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.17` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.17` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.17 && git push origin v0.1.0-alpha.17` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
