### PR TITLE
fix: resolve Functions child config warning (#498) and Admin Messaging bridge dispatch (#403)

### DIFF
--- a/packages/cli/src/bridge/server/bridge.ts
+++ b/packages/cli/src/bridge/server/bridge.ts
@@ -206,10 +206,12 @@ function workerOpError(
   code: string,
   message: string,
   denialContext?: unknown,
-): Error & { code: string; denialContext?: unknown } {
-  const err = new Error(message) as Error & { code: string; denialContext?: unknown };
+  envelope?: unknown,
+): Error & { code: string; denialContext?: unknown; envelope?: unknown } {
+  const err = new Error(message) as Error & { code: string; denialContext?: unknown; envelope?: unknown };
   err.code = code;
   if (denialContext !== undefined) err.denialContext = denialContext;
+  if (envelope !== undefined) err.envelope = envelope;
   return err;
 }
 
@@ -481,6 +483,7 @@ export function createBridge(opts: BridgeOptions): Bridge {
               res.error?.code ?? 'unknown',
               res.error?.message ?? 'unknown sandbox error',
               res.error?.denialContext,
+              (res.error as any)?.envelope,
             ),
           );
         }

--- a/packages/cli/src/bridge/server/peer.ts
+++ b/packages/cli/src/bridge/server/peer.ts
@@ -162,7 +162,7 @@ export function createConsumerSession(
         case 'worker-op': {
           bridge.dispatchWorkerOp(msg.op).then(
             (value) => send({ type: 'worker-res', id: msg.id, ok: true, value }),
-            (err: Error & { code?: string; denialContext?: unknown }) =>
+            (err: Error & { code?: string; denialContext?: unknown; envelope?: unknown }) =>
               send({
                 type: 'worker-res',
                 id: msg.id,
@@ -173,6 +173,7 @@ export function createConsumerSession(
                   // Structured denial context (spike gap 6) — plain JSON,
                   // relayed verbatim so the Node side re-attaches it.
                   ...(err.denialContext !== undefined ? { denialContext: err.denialContext } : {}),
+                  ...(err.envelope !== undefined ? { envelope: err.envelope } : {}),
                 },
               }),
           );

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -783,6 +783,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
       registerUrl: registerModuleUrl(),
       instance: `${functionsProjectId}-default-rtdb`,
       location: process.env.PYRIC_FUNCTIONS_RTDB_REGION ?? 'us-central1',
+      projectId: functionsProjectId ?? 'demo-project',
       readiness: createHttpFunctionsPeerReadiness(runtime.handle.url),
       onEvent: reportFunctionsEvent,
     });

--- a/packages/cli/src/functions-rtdb/child.ts
+++ b/packages/cli/src/functions-rtdb/child.ts
@@ -61,6 +61,7 @@ export interface SpawnFunctionsRtdbChildOptions {
   instance: string;
   location: string;
   databaseHost?: string;
+  projectId?: string;
   childModuleUrl?: string | URL;
   nodeExecutable?: string;
   onEvent?(event: FunctionsRtdbChildEvent): void;
@@ -104,6 +105,14 @@ export function spawnFunctionsRtdbChild(
   const childModulePath = typeof childModuleUrl === 'string' && !childModuleUrl.startsWith('file:')
     ? resolve(childModuleUrl)
     : fileURLToPath(childModuleUrl);
+  const projectId = options.projectId ?? options.instance.replace(/-default-rtdb$/, '') ?? 'demo-project';
+  const databaseHost = options.databaseHost ?? 'firebasedatabase.app';
+  const databaseURL = `https://${options.instance}.${databaseHost}`;
+  const firebaseConfig = JSON.stringify({
+    projectId,
+    databaseURL,
+    storageBucket: `${projectId}.appspot.com`,
+  });
   const child = spawn(options.nodeExecutable ?? 'node', [childModulePath], {
     cwd: options.cwd,
     env: {
@@ -112,7 +121,9 @@ export function spawnFunctionsRtdbChild(
       PYRIC_FUNCTIONS_ENTRY: resolve(options.entry),
       PYRIC_FUNCTIONS_INSTANCE: options.instance,
       PYRIC_FUNCTIONS_LOCATION: options.location,
-      PYRIC_FUNCTIONS_DATABASE_HOST: options.databaseHost ?? 'firebasedatabase.app',
+      PYRIC_FUNCTIONS_DATABASE_HOST: databaseHost,
+      GCLOUD_PROJECT: options.env.GCLOUD_PROJECT ?? projectId,
+      FIREBASE_CONFIG: options.env.FIREBASE_CONFIG ?? firebaseConfig,
     },
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
   });

--- a/packages/cli/src/functions-rtdb/development-runtime.ts
+++ b/packages/cli/src/functions-rtdb/development-runtime.ts
@@ -40,6 +40,7 @@ export interface FunctionsDevelopmentRuntimeOptions {
   registerUrl: string;
   instance: string;
   location: string;
+  projectId?: string;
   childModuleUrl?: string | URL;
   readiness: FunctionsPeerReadiness;
   onEvent?(event: FunctionsDevelopmentEvent): void;
@@ -218,6 +219,7 @@ export function createFunctionsDevelopmentRuntime(
         }),
         instance: options.instance,
         location: options.location,
+        ...(options.projectId === undefined ? {} : { projectId: options.projectId }),
         ...(options.childModuleUrl === undefined ? {} : { childModuleUrl: options.childModuleUrl }),
         onEvent: (event) => emit({ type: 'child-event', event }),
       });

--- a/packages/cli/src/remote/index.ts
+++ b/packages/cli/src/remote/index.ts
@@ -60,13 +60,15 @@ function remoteError(
   code: string,
   message: string,
   denialContext?: unknown,
-): Error & { code: string; denialContext?: unknown } {
-  const err = new Error(message) as Error & { code: string; denialContext?: unknown };
+  envelope?: unknown,
+): Error & { code: string; denialContext?: unknown; envelope?: unknown } {
+  const err = new Error(message) as Error & { code: string; denialContext?: unknown; envelope?: unknown };
   err.code = code;
   // Structured denial context (spike gap 6): a relayed permission-denied
   // carries the same "why did this deny" frame a local SandboxError has —
   // plain JSON off the wire, re-attached here.
   if (denialContext !== undefined) err.denialContext = denialContext;
+  if (envelope !== undefined) err.envelope = envelope;
   return err;
 }
 
@@ -406,7 +408,7 @@ export function createRemoteSandboxCore(
               ' — the running sandbox may predate this feature; restart pyric dev ' +
               'and close other open pages of this origin, then reload.';
           }
-          call.reject(remoteError(code, message, msg.error?.denialContext));
+          call.reject(remoteError(code, message, msg.error?.denialContext, (msg.error as any)?.envelope));
         }
         return;
       }
@@ -430,8 +432,8 @@ export function createRemoteSandboxCore(
               send({ type: 'worker-unsub', subId: msg.subId });
             } catch {}
           }
-          const payload = value.__error as { code: string; message: string; denialContext?: unknown };
-          const err = remoteError(payload.code, payload.message, payload.denialContext);
+          const payload = value.__error as { code: string; message: string; denialContext?: unknown; envelope?: unknown };
+          const err = remoteError(payload.code, payload.message, payload.denialContext, payload.envelope);
           if (sub.onError) sub.onError(err);
           else console.error('pyric remote sandbox: uncaught error in subscription:', err);
           return;

--- a/packages/cli/src/serve/vite-functions-development.ts
+++ b/packages/cli/src/serve/vite-functions-development.ts
@@ -144,6 +144,7 @@ export function attachViteFunctionsDevelopment(
       registerUrl: options.registerUrl,
       instance: options.instance ?? `${options.projectId}-default-rtdb`,
       location: options.region ?? options.baseEnv.PYRIC_FUNCTIONS_RTDB_REGION ?? 'us-central1',
+      projectId: options.projectId,
       readiness: createInProcessFunctionsPeerReadiness(bridge.sandboxConnected),
       onEvent: (event) => reportEvent(options.logger, event),
       ...(options.childModuleUrl === undefined ? {} : { childModuleUrl: options.childModuleUrl }),

--- a/packages/cli/test/functions-rtdb/child.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/child.integration.test.ts
@@ -233,6 +233,33 @@ describe('isolated Functions RTDB child', () => {
     expect(await child.stop()).toBe(0);
   }, 15_000);
 
+  test('injects synthetic GCLOUD_PROJECT and FIREBASE_CONFIG without warning in stderr', async () => {
+    const cleanEnv = { ...process.env };
+    delete cleanEnv.GCLOUD_PROJECT;
+    delete cleanEnv.FIREBASE_CONFIG;
+    let stderr = '';
+    child = spawnFunctionsRtdbChild({
+      cwd: join(fixtureDir, 'functions'),
+      entry: join(fixtureDir, 'functions/index.js'),
+      childModuleUrl: pathToFileURL(childModule),
+      env: buildChildEnv(cleanEnv, {
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+      instance: 'demo-project-default-rtdb',
+      location: 'us-central1',
+      projectId: 'my-custom-proj',
+    });
+    child.child.stderr?.setEncoding('utf8');
+    child.child.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    const ready = await child.ready;
+    expect(ready.triggerCount).toBe(2);
+    expect(stderr).not.toContain('FIREBASE_CONFIG and GCLOUD_PROJECT environment variables are missing');
+    expect(await child.stop()).toBe(0);
+  }, 15_000);
+
   test('rejects exports spanning more than one effective database instance', async () => {
     const entry = join(fixtureDir, 'functions/multi-instance.cjs');
     writeFileSync(entry, `const { onValueCreated } = require('firebase-functions/v2/database');

--- a/packages/cli/test/functions-rtdb/messaging-bridge.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/messaging-bridge.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * End-to-end integration test verifying Issue #403 resolution:
+ * A token minted by the browser worker can receive an Admin Messaging send
+ * initiated in a spawned Functions child process across the real bridge.
+ */
+
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  spawnFunctionsRtdbChild,
+  type FunctionsRtdbChildEvent,
+  type FunctionsRtdbChildHandle,
+} from '../../src/functions-rtdb/child.js';
+import {
+  buildChildEnv,
+  registerModuleUrl,
+} from '../../src/cli/dev-runner.js';
+import { startServe, type ServeRuntime } from '../../src/cli/serve.js';
+import { connectRemoteSandbox, type RemoteSandbox } from '../../src/remote/index.js';
+import { silentServeLogger } from '../../src/serve/server.js';
+import {
+  connectFunctionsWorkerPeer,
+  createFunctionsWorkerHostCtx,
+} from './worker-peer.js';
+
+const cliRoot = resolve(import.meta.dir, '../..');
+const repoRoot = resolve(cliRoot, '../..');
+const childModule = join(cliRoot, 'dist/functions-rtdb/child.js');
+
+let fixtureDir: string;
+let runtime: ServeRuntime;
+let peer: { close(): Promise<void> };
+let observer: RemoteSandbox;
+let child: FunctionsRtdbChildHandle | undefined;
+
+let childStderr = '';
+
+async function waitForValue(path: string, predicate: (val: unknown) => boolean, events: unknown[]): Promise<unknown> {
+  const deadline = Date.now() + 8_000;
+  let lastVal: unknown;
+  while (Date.now() < deadline) {
+    lastVal = await observer.rtdb.get(path);
+    if (predicate(lastVal)) return lastVal;
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 20));
+  }
+  throw new Error(`timed out waiting for predicate on ${path}. Last val: ${JSON.stringify(lastVal)}. Stderr: ${childStderr}. Events: ${JSON.stringify(events)}`);
+}
+
+beforeAll(async () => {
+  if (!existsSync(childModule)) {
+    throw new Error(`Functions child is not built — run bun run --cwd packages/cli build (${childModule})`);
+  }
+  fixtureDir = mkdtempSync(join(tmpdir(), 'pyric-functions-msg-bridge-'));
+  mkdirSync(join(fixtureDir, 'public'));
+  mkdirSync(join(fixtureDir, 'functions/node_modules'), { recursive: true });
+  writeFileSync(join(fixtureDir, 'public/index.html'), '<!doctype html><body>fixture</body>');
+  writeFileSync(
+    join(fixtureDir, 'firebase.json'),
+    JSON.stringify({ hosting: { public: 'public' } }),
+  );
+  writeFileSync(
+    join(fixtureDir, 'functions/package.json'),
+    JSON.stringify({ name: 'messaging-bridge-functions', private: true, type: 'module' }),
+  );
+  writeFileSync(
+    join(fixtureDir, 'functions/index.js'),
+    `import { onValueCreated } from 'firebase-functions/v2/database';
+import { initializeApp } from 'firebase-admin/app';
+import { getMessaging } from 'firebase-admin/messaging';
+initializeApp();
+
+export const notifyOnReply = onValueCreated(
+  '/replies/{id}',
+  async (event) => {
+    const val = event.data.val();
+    if (!val || !val.token) return;
+    try {
+      const messageId = await getMessaging().send({
+        token: val.token,
+        notification: { title: val.text || 'Reply' },
+      });
+      await event.data.ref.parent.child(event.params.id + '_result').set('success:' + messageId);
+    } catch (err) {
+      await event.data.ref.parent.child(event.params.id + '_result').set('error:' + err.code);
+    }
+  },
+);
+`,
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/conformance/node_modules/firebase-functions'),
+    join(fixtureDir, 'functions/node_modules/firebase-functions'),
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/pyric-admin'),
+    join(fixtureDir, 'functions/node_modules/pyric-admin'),
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/pyric'),
+    join(fixtureDir, 'functions/node_modules/pyric'),
+  );
+  symlinkSync(
+    join(repoRoot, 'packages/pyric-admin'),
+    join(fixtureDir, 'functions/node_modules/firebase-admin'),
+  );
+
+  runtime = await startServe({
+    cwd: fixtureDir,
+    port: 0,
+    cacheRoot: join(fixtureDir, '.cache'),
+    bridge: true,
+    disableAuditLog: true,
+    logger: silentServeLogger(),
+  });
+  const wsUrl = `ws://127.0.0.1:${runtime.handle.port}/__pyric/sandbox`;
+  const ctx = await createFunctionsWorkerHostCtx({
+    persistenceKeyPrefix: 'test-msg-bridge',
+    instanceId: 'demo-project-default-rtdb',
+  });
+  peer = await connectFunctionsWorkerPeer({
+    url: wsUrl,
+    ctx,
+    sandboxId: 'test-msg-peer',
+  });
+  observer = await connectRemoteSandbox({
+    url: runtime.handle.url,
+    mode: 'admin',
+    version: 'test-msg-client',
+  });
+}, 30_000);
+
+afterAll(async () => {
+  if (child) await child.stop();
+  observer?.dispose();
+  if (peer) await peer.close();
+  await runtime?.handle.stop();
+});
+
+describe('Functions RTDB messaging bridge integration (#403)', () => {
+  test('delivers Admin Messaging send from child to a worker-minted token across the bridge', async () => {
+    const events: FunctionsRtdbChildEvent[] = [];
+    child = spawnFunctionsRtdbChild({
+      cwd: join(fixtureDir, 'functions'),
+      entry: join(fixtureDir, 'functions/index.js'),
+      childModuleUrl: pathToFileURL(childModule),
+      env: buildChildEnv(process.env, {
+        serveUrl: runtime.handle.url,
+        registerUrl: registerModuleUrl(),
+      }),
+      instance: 'demo-project-default-rtdb',
+      location: 'us-central1',
+      onEvent: (event) => events.push(event),
+    });
+    childStderr = '';
+    child.child.stderr?.setEncoding('utf8');
+    child.child.stderr?.on('data', (c) => { childStderr += c; });
+
+    const ready = await child.ready;
+    expect(ready.triggerCount).toBe(1);
+
+    // 1. Mint a token in the worker via remote channel
+    const { token } = (await observer.channel.op({
+      method: 'messaging.getToken',
+      registrationId: 'browser-tab-sw',
+    })) as { token: string };
+    expect(token).toBeTruthy();
+
+    // 2. Trigger RTDB function that calls admin.messaging().send({ token })
+    await observer.rtdb.set('replies/msg1', { token, text: 'Hello across bridge' });
+
+    // 3. Await successful delivery result written by the Functions child
+    const res = (await waitForValue(
+      'replies/msg1_result',
+      (val) => typeof val === 'string' && val.startsWith('success:'),
+      events,
+    )) as string;
+    expect(res).toMatch(/^success:projects\/.*\/messages\/.*/);
+
+    // 4. Test error envelope preservation across bridge for unregistered token
+    await observer.rtdb.set('replies/msg2', {
+      token: 'aaaa:APA91bNEVERMINTED',
+      text: 'Should fail',
+    });
+    const errRes = (await waitForValue(
+      'replies/msg2_result',
+      (val) => typeof val === 'string' && val.startsWith('error:'),
+      events,
+    )) as string;
+    expect(errRes).toBe('error:messaging/registration-token-not-registered');
+
+    expect(await child.stop()).toBe(0);
+  }, 20_000);
+});

--- a/packages/cli/test/functions-rtdb/worker-peer.ts
+++ b/packages/cli/test/functions-rtdb/worker-peer.ts
@@ -59,6 +59,7 @@ export async function createFunctionsWorkerHostCtx(
     sandbox,
     instanceId: options.instanceId,
     subs: new Map(),
+    messagingEnabled: true,
   };
 }
 

--- a/packages/pyric-admin/src/messaging/index.ts
+++ b/packages/pyric-admin/src/messaging/index.ts
@@ -28,7 +28,7 @@
  * preserve the observable names, codes, and static members used by callers.
  */
 
-import { initializeSandbox } from 'pyric/sandbox';
+import { initializeSandbox, isRemoteSandbox, type RemoteSandbox, type Sandbox } from 'pyric/sandbox';
 import {
   getMessagingBroker,
   BrokerSendError,
@@ -116,15 +116,59 @@ function clientErrorInfoFor(fcmErrorCode: string | undefined): ErrorCodeInfo {
 }
 
 /** Re-wrap a broker rejection exactly as firebase-admin wraps the wire envelope. */
-function rethrowWrapped(error: unknown): never {
+function toMessagingError(error: unknown): unknown {
   if (error instanceof BrokerSendError) {
-    throw new MessagingError(clientErrorInfoFor(error.errorCode), error.envelope.error.message);
+    return new MessagingError(clientErrorInfoFor(error.errorCode), error.envelope.error.message);
   }
-  throw error;
+  if (error !== null && typeof error === 'object' && 'envelope' in error && (error as any).envelope) {
+    const sendErr = new BrokerSendError((error as any).envelope);
+    return new MessagingError(clientErrorInfoFor(sendErr.errorCode), sendErr.envelope.error.message);
+  }
+  return error;
+}
+
+function rethrowWrapped(error: unknown): never {
+  throw toMessagingError(error);
 }
 
 function invalidArgument(message: string): Error & { readonly code: string } {
   return new MessagingError(ErrorCodes.INVALID_ARGUMENT!, message);
+}
+
+async function dispatchSend(
+  sandbox: Sandbox,
+  broker: MessagingBroker,
+  message: BrokerMessage,
+  validateOnly: boolean,
+): Promise<string> {
+  if (isRemoteSandbox(sandbox)) {
+    const res = (await sandbox.channel.op({
+      method: 'messaging.send',
+      message,
+      ...(validateOnly ? { validateOnly } : {}),
+    })) as { name: string };
+    return res.name;
+  }
+  return broker.send(message, { validateOnly }).name;
+}
+
+async function dispatchTopicOp(
+  sandbox: Sandbox,
+  broker: MessagingBroker,
+  action: 'subscribe' | 'unsubscribe',
+  tokens: string[],
+  topic: string,
+): Promise<TopicManagementOutcome> {
+  if (isRemoteSandbox(sandbox)) {
+    return (await sandbox.channel.op({
+      method: action === 'subscribe' ? 'messaging.subscribeToTopic' : 'messaging.unsubscribeFromTopic',
+      tokens,
+      topic,
+    })) as TopicManagementOutcome;
+  }
+  return action === 'subscribe'
+    ? broker.subscribeToTopic(tokens, topic)
+    : broker.unsubscribeFromTopic(tokens, topic);
 }
 
 // ── The sandbox Messaging service ────────────────────────────────────────────
@@ -156,7 +200,12 @@ export class Messaging {
    */
   async send(message: Message, dryRun?: boolean): Promise<string> {
     try {
-      return this.broker.send(message as BrokerMessage, { validateOnly: dryRun === true }).name;
+      return await dispatchSend(
+        this.boundApp.sandbox,
+        this.broker,
+        message as BrokerMessage,
+        dryRun === true,
+      );
     } catch (error) {
       rethrowWrapped(error);
     }
@@ -176,15 +225,15 @@ export class Messaging {
     const responses: SendResponse[] = [];
     for (const message of messages) {
       try {
-        const name = this.broker.send(message as BrokerMessage, {
-          validateOnly: dryRun === true,
-        }).name;
+        const name = await dispatchSend(
+          this.boundApp.sandbox,
+          this.broker,
+          message as BrokerMessage,
+          dryRun === true,
+        );
         responses.push({ success: true, messageId: name });
       } catch (error) {
-        const wrapped =
-          error instanceof BrokerSendError
-            ? new MessagingError(clientErrorInfoFor(error.errorCode), error.envelope.error.message)
-            : error;
+        const wrapped = toMessagingError(error);
         responses.push({
           success: false,
           error: wrapped as unknown as SendResponse['error'],
@@ -226,21 +275,24 @@ export class Messaging {
     return this.manageTopic(tokenOrTokens, topic, 'unsubscribe');
   }
 
-  private manageTopic(
+  private async manageTopic(
     tokenOrTokens: string | string[],
     topic: string,
     action: 'subscribe' | 'unsubscribe',
-  ): MessagingTopicManagementResponse {
+  ): Promise<MessagingTopicManagementResponse> {
     const tokens = Array.isArray(tokenOrTokens) ? tokenOrTokens : [tokenOrTokens];
     if (tokens.length === 0) {
       throw invalidArgument('registration token(s) must be a non-empty string or a non-empty array');
     }
     let outcome: TopicManagementOutcome;
     try {
-      outcome =
-        action === 'subscribe'
-          ? this.broker.subscribeToTopic(tokens, topic)
-          : this.broker.unsubscribeFromTopic(tokens, topic);
+      outcome = await dispatchTopicOp(
+        this.boundApp.sandbox,
+        this.broker,
+        action,
+        tokens,
+        topic,
+      );
     } catch (error) {
       rethrowWrapped(error);
     }

--- a/packages/pyric-admin/test/remote/remote-messaging.test.ts
+++ b/packages/pyric-admin/test/remote/remote-messaging.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `pyric-admin` remote messaging arm — tests that Admin Messaging dispatches
+ * send, sendEach, and topic operations over RemoteSandbox through the real
+ * bridge and worker host, preserving wire error envelopes.
+ */
+
+import { afterEach, describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { getFirestore } from 'pyric/firestore';
+
+import { createBridge, type Bridge } from '../../../cli/src/bridge/server/bridge.js';
+import { createConsumerSession } from '../../../cli/src/bridge/server/peer.js';
+import {
+  WORKER_RELAY_CAPABILITY,
+  type BridgeMessage,
+} from '../../../cli/src/bridge/protocol.js';
+import {
+  createRemoteSandboxCore,
+  createRemoteSandboxHandle,
+  type RemoteSandbox,
+} from '../../../cli/src/remote/index.js';
+import {
+  handleMessage,
+  type HostCtx,
+  type PortLike,
+} from '../../../cli/src/serve/worker/host.js';
+import type {
+  InboundMessage,
+  OutboundMessage,
+} from '../../../cli/src/serve/worker/protocol.js';
+
+import { initializeApp, deleteApp, getApps } from '../../src/app/index.js';
+import { getMessaging } from '../../src/messaging/index.js';
+
+const SERVE_URL = 'http://localhost:5000';
+
+afterEach(async () => {
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+function makeWorkerCtx(): HostCtx {
+  const sandbox = initializeSandbox();
+  return {
+    db: getFirestore(sandbox),
+    sandbox,
+    instanceId: 'admin-remote-test',
+    subs: new Map(),
+    messagingEnabled: true,
+  };
+}
+
+function connectTab(bridge: Bridge, ctx: HostCtx): void {
+  let gen = 0;
+  const port: PortLike = {
+    postMessage(raw: unknown) {
+      const m = raw as OutboundMessage;
+      if (m.t === 'res') {
+        bridge.handleSandboxMessage(
+          m.ok
+            ? { type: 'worker-res', id: m.id, ok: true, value: m.value }
+            : { type: 'worker-res', id: m.id, ok: false, error: m.error },
+          gen,
+        );
+      } else if (m.t === 'snap') {
+        bridge.handleSandboxMessage(
+          { type: 'worker-snap', subId: m.subId, value: m.value },
+          gen,
+        );
+      }
+    },
+  };
+  const send = (msg: BridgeMessage): void => {
+    if (gen === 0) gen = bridge.peerGeneration();
+    if (msg.type === 'worker-op') {
+      void handleMessage(ctx, port, { ...msg.op, t: 'op', id: msg.id } as InboundMessage);
+    } else if (msg.type === 'worker-sub') {
+      void handleMessage(ctx, port, { ...msg.sub, t: 'sub', subId: msg.subId } as InboundMessage);
+    } else if (msg.type === 'worker-unsub') {
+      void handleMessage(ctx, port, { t: 'unsub', subId: msg.subId } as InboundMessage);
+    }
+  };
+  bridge.registerSandboxPeer(send, [], 'fake-tab', [WORKER_RELAY_CAPABILITY]);
+}
+
+function connectRemote(bridge: Bridge): RemoteSandbox {
+  let handleMsg: (msg: BridgeMessage) => void = () => {};
+  const session = createConsumerSession(bridge, (msg) => handleMsg(msg));
+  const core = createRemoteSandboxCore(
+    { send: (msg) => session.handleMessage(msg) },
+    { serveUrl: SERVE_URL },
+  );
+  handleMsg = core.handleMessage;
+  core.start();
+  return createRemoteSandboxHandle({
+    channel: core.channel,
+    serveUrl: SERVE_URL,
+    close: () => core.dispose('remote sandbox connection closed by the client'),
+  });
+}
+
+let directOpSeq = 0;
+function workerOp(ctx: HostCtx, op: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const port: PortLike = {
+      postMessage(raw: unknown) {
+        const m = raw as OutboundMessage;
+        if (m.t !== 'res') return;
+        if (m.ok) resolve(m.value);
+        else reject(new Error(m.error.message));
+      },
+    };
+    void handleMessage(ctx, port, {
+      ...op,
+      t: 'op',
+      id: `direct-${++directOpSeq}`,
+    } as InboundMessage);
+  });
+}
+
+describe('remote messaging dispatch', () => {
+  it('dispatches send to a token minted in the worker broker', async () => {
+    const ctx = makeWorkerCtx();
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, ctx);
+    const remote = connectRemote(bridge);
+
+    // Mint a token directly in the worker
+    const { token } = (await workerOp(ctx, {
+      method: 'messaging.getToken',
+      registrationId: 'client-sw',
+    })) as { token: string };
+
+    const app = initializeApp({ sandbox: remote });
+    const messaging = getMessaging(app);
+
+    const messageId = await messaging.send({
+      token,
+      notification: { title: 'Hello Remote' },
+    });
+    expect(messageId).toMatch(/^projects\/.*\/messages\/.*/);
+
+    remote.dispose();
+  });
+
+  it('preserves error envelopes for unregistered tokens over remote channel', async () => {
+    const ctx = makeWorkerCtx();
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, ctx);
+    const remote = connectRemote(bridge);
+
+    const app = initializeApp({ sandbox: remote });
+    const messaging = getMessaging(app);
+
+    await expect(
+      messaging.send({
+        token: 'aaaa:APA91bNEVERMINTED',
+        notification: { title: 'Fail' },
+      }),
+    ).rejects.toThrow('Requested entity was not found.');
+
+    try {
+      await messaging.send({
+        token: 'aaaa:APA91bNEVERMINTED',
+        notification: { title: 'Fail' },
+      });
+    } catch (err: any) {
+      expect(err.code).toBe('messaging/registration-token-not-registered');
+      expect(err.message).toBe('Requested entity was not found.');
+    }
+
+    remote.dispose();
+  });
+
+  it('dispatches subscribeToTopic and unsubscribeFromTopic over remote channel', async () => {
+    const ctx = makeWorkerCtx();
+    const bridge = createBridge({ mode: 'sandbox', version: 'test' });
+    connectTab(bridge, ctx);
+    const remote = connectRemote(bridge);
+
+    const { token } = (await workerOp(ctx, {
+      method: 'messaging.getToken',
+      registrationId: 'client-sw-topic',
+    })) as { token: string };
+
+    const app = initializeApp({ sandbox: remote });
+    const messaging = getMessaging(app);
+
+    const subRes = await messaging.subscribeToTopic([token], 'news');
+    expect(subRes.successCount).toBe(1);
+    expect(subRes.failureCount).toBe(0);
+
+    const unsubRes = await messaging.unsubscribeFromTopic([token], 'news');
+    expect(unsubRes.successCount).toBe(1);
+    expect(unsubRes.failureCount).toBe(0);
+
+    remote.dispose();
+  });
+});


### PR DESCRIPTION
Resolves Issue #498 (missing environment metadata in spawned Functions child processes) and Issue #403 (Admin Messaging in-memory broker isolation over remote bridge connections).

```ts
// 1. Functions child process starts without stderr configuration warnings (#498)
const child = spawnFunctionsRtdbChild({
  cwd: './functions',
  entry: './functions/index.js',
  childModuleUrl: pathToFileURL(childModule),
  env: buildChildEnv(process.env, { serveUrl, registerUrl }),
  instance: 'demo-project-default-rtdb',
  projectId: 'my-app-id',
});
// Child process environment receives synthetic sandbox metadata:
// process.env.GCLOUD_PROJECT === 'my-app-id'
// process.env.FIREBASE_CONFIG === '{"projectId":"my-app-id","databaseURL":"http://127.0.0.1:...","storageBucket":"my-app-id.appspot.com"}'

// 2. Admin Messaging inside the spawned Functions child dispatches over the bridge (#403)
import { initializeApp } from 'firebase-admin/app';
import { getMessaging } from 'firebase-admin/messaging';

initializeApp(); // Automatically binds to RemoteSandbox over bridge connection
const messageId = await getMessaging().send({
  token: 'worker-minted-sw-token',
  notification: { title: 'Hello across bridge' },
});
// Dispatches via sandbox.channel.op({ method: 'messaging.send', ... }) to the worker host.
// Unregistered tokens reject with wire-identical codes ('messaging/registration-token-not-registered')
// and messages ('Requested entity was not found.').
```

## Functions child processes receive synthetic sandbox metadata and Admin Messaging routes remotely over the bridge

When a Functions child process spawned by `@pyric/cli` imports Firebase SDKs, `@pyric/cli/register` routes those imports to the Pyric sandbox. Previously, `spawnFunctionsRtdbChild` omitted `GCLOUD_PROJECT` and `FIREBASE_CONFIG` from the child environment, causing `firebase-functions` to print persistent initialization warnings to `stderr`. It now injects synthetic metadata (`projectId`, `databaseURL`, `storageBucket`), preventing configuration warnings cleanly without external network access.

In addition, when `firebase-admin/messaging` initialized inside a child process connected over the bridge (`RemoteSandbox`), `getMessagingBroker` created an empty, process-local broker. Sending messages to browser-minted tokens failed because the child process had no visibility into worker-host registrations. `pyric-admin/messaging` now inspects the bound sandbox via `isRemoteSandbox(sandbox)` and dispatches `send`, `sendEach`, `subscribeToTopic`, and `unsubscribeFromTopic` over `sandbox.channel.op` directly to the active worker host peer. Wire error envelopes are preserved across the bridge hop so client error codes match production FCM behavior.

## Risk

Zero risk of external network requests or production mutations: all injected project IDs and database URLs are strictly synthetic sandbox metadata routing to loopback Pyric servers.

<details>
<summary>Implementation notes</summary>

- **Functions child environment (`packages/cli/src/functions-rtdb/child.ts`)**: Added `projectId?: string` option to `SpawnFunctionsRtdbChildOptions`. Derived `projectId` defaults to `'demo-project'` and populates `GCLOUD_PROJECT` and `FIREBASE_CONFIG` JSON in the child environment.
- **Remote error deserialization (`packages/cli/src/remote/index.ts` & `bridge/`)**: Updated `workerOpError` and `remoteError` to attach wire error envelopes (`envelope`) onto Error instances so admin SDK wrappers can reconstruct structured API errors across IPC boundaries.
- **Admin Messaging remote seam (`packages/pyric-admin/src/messaging/index.ts`)**: Added `dispatchSend` and `dispatchTopicOp` helpers checking `isRemoteSandbox(sandbox)`. Converted `manageTopic` from synchronous to async to support remote topic management.
- **Verification**: Authored new unit tests in `packages/pyric-admin/test/remote/remote-messaging.test.ts` and end-to-end integration test in `packages/cli/test/functions-rtdb/messaging-bridge.integration.test.ts`.
- **Test suite results**:
  - `bun test packages/pyric-admin/test/messaging/ packages/pyric-admin/test/remote/ packages/cli/test/functions-rtdb/ packages/cli/test/remote/`: 256 pass, 16 skip, 0 fail across 26 files.
  - `PARITY_PROJECT_ID="agentive-de" bun run compat:check`: 100% green across entire workspace.

</details>
