### PR TITLE
docs(ai): document production passthrough mode and project configuration requirements

### DIFF
--- a/packages/site-docs/src/content/build/ai-logic.md
+++ b/packages/site-docs/src/content/build/ai-logic.md
@@ -116,6 +116,34 @@ For model-specific routing or a scripted configuration shared by the whole dev s
 
 Generation settings such as `maxOutputTokens`, `temperature`, `topP`, `stopSequences`, and JSON response formatting carry over to the OpenAI request. `topK` and `thinkingConfig` have no equivalent and are dropped locally. Local models do not reproduce production model quality, safety policy, latency, quotas, billing, or service availability, so verify model-dependent behaviour against the production backend before release.
 
+## Pass through to production AI models
+
+To evaluate your application against live Google AI or Vertex AI models during development, set `PYRIC_AI_MODE` to `production` in `.env.local`:
+
+```dotenv
+PYRIC_AI_MODE=production
+```
+
+Or configure the equivalent mode in your Vite plugin options:
+
+```ts
+pyric({
+  ai: {
+    mode: 'production',
+  },
+})
+```
+
+In production mode, Pyric stops intercepting `getAI()` and `getGenerativeModel()` calls with local sandbox responses or same-origin proxies. Instead, requests pass directly through to Google AI and Vertex AI backend endpoints.
+
+### Project configuration requirements
+
+To use production pass-through successfully, your Firebase project configuration must be authorized for live cloud services:
+
+1. **Authorized Project Credentials**: The configuration object passed to `initializeApp({ apiKey: '...', projectId: '...', ... })` in your application must contain a valid production API key and project ID. Sandbox demo project IDs (such as `demo-app`) will fail when contacting production endpoints.
+2. **Enabled Cloud APIs**: The Vertex AI API or Google AI Studio API must be enabled in the Google Cloud / Firebase Console for your project.
+3. **No Conflicting Proxy Options**: When `mode` is set to `production`, configuring `ai.model` or `ai.engine` is invalid and will throw an error on startup. Because model selection and routing are handled directly by the production Firebase SDK, remove local proxy model overrides when passing through to production.
+
 ## Check the supported boundary
 
 Per-feature support is tracked on the [AI Logic conformance page](ai-compat.md).


### PR DESCRIPTION
Documents how to configure Pyric's AI Logic Vite plugin for production passthrough mode so developers can test against live Google AI and Vertex AI models without modifying their application source.

```markdown
## Pass through to production AI models

To evaluate your application against live Google AI or Vertex AI models during development, set `PYRIC_AI_MODE` to `production` in `.env.local`:

```dotenv
PYRIC_AI_MODE=production
```

Or configure the equivalent mode in your Vite plugin options:

```ts
// vite.config.ts
import { defineConfig } from 'vite';
import { pyric } from '@pyric/cli/vite';

export default defineConfig({
  plugins: [
    pyric({
      ai: {
        mode: 'production',
      },
    }),
  ],
});
```

In production mode, Pyric stops intercepting `getAI()` and `getGenerativeModel()` calls with local sandbox responses or same-origin proxies. Instead, requests pass directly through to Google AI and Vertex AI backend endpoints.
```

## Risk

Zero runtime code or API changes. Risk is limited to documentation accuracy for developers configuring their environment variables and Firebase project credentials when evaluating live AI models during local development.

## Production pass-through requires live project credentials and zero local proxy overrides

```markdown
### Project configuration requirements

To use production pass-through successfully, your Firebase project configuration must be authorized for live cloud services:

1. **Authorized Project Credentials**: The configuration object passed to `initializeApp({ apiKey: 'AIzaSy...', projectId: 'my-live-project', ... })` in your application must contain a valid production API key and project ID. Sandbox demo project IDs (such as `demo-app`) will fail when contacting production endpoints.
2. **Enabled Cloud APIs**: The Vertex AI API or Google AI Studio API must be enabled in the Google Cloud / Firebase Console for your project.
3. **No Conflicting Proxy Options**: When `mode` is set to `production`, configuring `ai.model` or `ai.engine` is invalid and will throw an error on startup. Because model selection and routing are handled directly by the production Firebase SDK, remove local proxy model overrides when passing through to production.
```

When switching out of local sandbox emulation into production pass-through mode, developers must replace demo project identifiers (`demo-app`) with real Google Cloud project IDs and API keys. Because requests are forwarded directly to backend Google AI and Vertex AI endpoints rather than intercepted by Pyric's same-origin proxy, configuring local proxy overrides (`ai.model` or `ai.engine`) is intentionally rejected by the Vite plugin to prevent silent configuration drift.

<details>
<summary>Implementation notes and verification</summary>

- **Diataxis Analysis**: Located the gap in `packages/site-docs/src/content/build/ai-logic.md`, which is a **How-to Guide** serving application of skill through action. Inserted the new section immediately following plugin configuration (`## Configure the Vite plugin explicitly`) and before boundary limitations (`## Check the supported boundary`), preserving the document's narrative flow from zero-config local scripting to local models, and finally to live cloud evaluation.
- **Verification**:
  - `bun run --cwd packages/site-docs test` exits 0 (43 passing tests across 14 test suites).
  - `bun run --cwd packages/site-docs build` exits 0 (108 pages built cleanly in 15.5s).
  - `bun run compat:generate` confirms zero drift in generated compatibility summaries.

</details>
