### PR TITLE
docs(conformance): publish Rules construct scores

### DIFF
--- a/packages/conformance/src/conformance-model.ts
+++ b/packages/conformance/src/conformance-model.ts
@@ -25,6 +25,16 @@ import {
   type FirestoreRulesScorecard,
 } from './firestore-rules-scorecard.ts';
 import { loadAndValidateFirestoreAcceptanceEvidence } from './firestore-rules-acceptance-evidence.ts';
+import {
+  deriveStorageRulesScorecard,
+  type StorageRulesScorecard,
+} from './storage-rules-scorecard.ts';
+import { loadAndValidateStorageAcceptanceEvidence } from './storage-rules-acceptance-evidence.ts';
+import {
+  deriveRtdbRulesScorecard,
+  type RtdbRulesScorecard,
+} from './rtdb-rules-scorecard.ts';
+import { loadAndValidateRtdbAcceptanceEvidence } from './rtdb-rules-acceptance-evidence.ts';
 import type { SurfaceDescriptor } from '../surfaces/types.ts';
 import type { CompatibilitySurfaceRegistry } from '../registry/types.ts';
 import coverageBaselineJson from '../baselines/coverage-baseline.json' with { type: 'json' };
@@ -93,6 +103,8 @@ export interface ConformanceModel {
     capability: CapabilityReport;
     coverage: CoverageReport;
     firestoreScorecard: FirestoreRulesScorecard;
+    storageScorecard: StorageRulesScorecard;
+    rtdbScorecard: RtdbRulesScorecard;
   };
   documentation: {
     registries: readonly CompatibilitySurfaceRegistry[];
@@ -282,14 +294,36 @@ async function buildConformanceModel(enforceCensusPolicy: boolean): Promise<Conf
   const firestoreSnapshot = snapshots.find(({ engine }) => engine === 'firestore');
   const firestoreCapability = evidence.capabilityReport.engines.find(({ engine }) => engine === 'firestore');
   const firestoreCoverage = evidence.coverageReport.engines.find(({ engine }) => engine === 'firestore');
-  if (!firestoreSnapshot || !firestoreCapability || !firestoreCoverage) {
-    throw new Error('Firestore Rules scorecard inputs are missing from the central conformance model');
+  const storageSnapshot = snapshots.find(({ engine }) => engine === 'storage');
+  const storageCapability = evidence.capabilityReport.engines.find(({ engine }) => engine === 'storage');
+  const storageCoverage = evidence.coverageReport.engines.find(({ engine }) => engine === 'storage');
+  const rtdbSnapshot = snapshots.find(({ engine }) => engine === 'rtdb');
+  const rtdbCapability = evidence.capabilityReport.engines.find(({ engine }) => engine === 'rtdb');
+  const rtdbCoverage = evidence.coverageReport.engines.find(({ engine }) => engine === 'rtdb');
+  if (
+    !firestoreSnapshot || !firestoreCapability || !firestoreCoverage
+    || !storageSnapshot || !storageCapability || !storageCoverage
+    || !rtdbSnapshot || !rtdbCapability || !rtdbCoverage
+  ) {
+    throw new Error('Security Rules scorecard inputs are missing from the central conformance model');
   }
   loadAndValidateFirestoreAcceptanceEvidence(firestoreSnapshot.constructs);
   const firestoreScorecard = deriveFirestoreRulesScorecard({
     constructs: firestoreSnapshot.constructs,
     capabilities: firestoreCapability.constructs,
     coverage: firestoreCoverage.constructs,
+  });
+  loadAndValidateStorageAcceptanceEvidence(storageSnapshot.constructs);
+  const storageScorecard = deriveStorageRulesScorecard({
+    constructs: storageSnapshot.constructs,
+    capabilities: storageCapability.constructs,
+    coverage: storageCoverage.constructs,
+  });
+  loadAndValidateRtdbAcceptanceEvidence(rtdbSnapshot.constructs);
+  const rtdbScorecard = deriveRtdbRulesScorecard({
+    constructs: rtdbSnapshot.constructs,
+    capabilities: rtdbCapability.constructs,
+    coverage: rtdbCoverage.constructs,
   });
   const firestoreScoreById = new Map(firestoreScorecard.constructs.map((construct) => [construct.id, construct]));
   for (const construct of firestoreScorecard.constructs) {
@@ -531,6 +565,8 @@ async function buildConformanceModel(enforceCensusPolicy: boolean): Promise<Conf
       capability: evidence.capabilityReport,
       coverage: evidence.coverageReport,
       firestoreScorecard,
+      storageScorecard,
+      rtdbScorecard,
     },
     documentation: {
       registries: surfaceRegistries,

--- a/packages/conformance/src/generate-docs.ts
+++ b/packages/conformance/src/generate-docs.ts
@@ -179,22 +179,60 @@ function scoreRow(
   ];
 }
 
+type RulesLanguageScores = ConformanceModel['rulesLanguage'];
+type RulesScore = RulesLanguageScores['firestoreScorecard']['score'];
+
+function rulesEngineScore(label: string, score: RulesScore): string {
+  return [
+    '<div class="compat-score-engine">',
+    `<span class="compat-score-engine-name">${escapeHtml(label)}</span>`,
+    meterCell(
+      score.percent,
+      `${score.numerator} of ${score.denominator} rules-language constructs verified`,
+    ),
+    '</div>',
+  ].join('\n');
+}
+
+function rulesScoreRow(
+  surface: CompatibilitySurfaceRegistry,
+  rulesLanguage: RulesLanguageScores,
+): string[] {
+  return [
+    '<tr class="compat-score-row--rules">',
+    `<th scope="row" class="compat-score-name"><a href="${compatibilityHref(surface.compatPath)}">${escapeCell(surface.label)}</a></th>`,
+    '<td class="compat-score-cell">',
+    '<div class="compat-score-group">',
+    rulesEngineScore('Firestore Rules', rulesLanguage.firestoreScorecard.score),
+    rulesEngineScore('Storage Rules', rulesLanguage.storageScorecard.score),
+    rulesEngineScore('Realtime Database Rules', rulesLanguage.rtdbScorecard.score),
+    '</div>',
+    '</td>',
+    '</tr>',
+  ];
+}
+
 /** Central scoreboard across every scored COMPAT surface. */
-export function renderScoreboardMarkdown(projection: DocumentationProjection): string {
+export function renderScoreboardMarkdown(model: ConformanceModel): string {
+  const projection = model.documentation;
   const lines: string[] = [
     GENERATED_HEADER,
     '',
-    '# Public API coverage',
+    '# Conformance scores',
     '',
-    'This is the share of Firebase\'s public API that Pyric supports. Not-implemented-yet, deprecated, and deferred APIs still count against the total. [How does Pyric know it works like Firebase?](../trust/how-we-know-it-matches-firebase/) explains the evidence and its limits.',
+    'Mirror services measure the share of Firebase\'s public API that Pyric supports. Rules engines measure production-verified rules-language constructs. Not-implemented-yet, deprecated, deferred, and unverified items remain in their respective denominators. Overall combines only the public API rows. [How does Pyric know it works like Firebase?](../trust/how-we-know-it-matches-firebase/) explains the evidence and its limits.',
     '',
     '## Services',
     '',
     '<table class="compat-score-table">',
-    '<thead><tr><th>Service</th><th>Public API supported</th></tr></thead>',
+    '<thead><tr><th>Service</th><th>Measured coverage</th></tr></thead>',
     '<tbody>',
   ];
   for (const surface of projection.registries) {
+    if (surface.surface === 'rules') {
+      lines.push(...rulesScoreRow(surface, model.rulesLanguage));
+      continue;
+    }
     const spec = scoreSpec(surface, projection);
     const coverage = computeSurface(spec, projection.census);
     lines.push(...scoreRow(
@@ -690,7 +728,7 @@ export function generatedRowLineNumbers(surface: CompatibilitySurfaceRegistry, p
 export function renderAllCompatibilityMarkdown(model: ConformanceModel): Map<string, string> {
   const projection = model.documentation;
   const out = new Map(projection.registries.map((surface) => [surface.compatPath, renderSurfaceMarkdown(surface, projection)]));
-  out.set(SCOREBOARD_PATH, renderScoreboardMarkdown(projection));
+  out.set(SCOREBOARD_PATH, renderScoreboardMarkdown(model));
   return out;
 }
 
@@ -704,7 +742,7 @@ export interface CompatibilityPageCatalogEntry {
  * a list of paths that can silently drift. */
 export function compatibilityPageCatalog(model: ConformanceModel): readonly CompatibilityPageCatalogEntry[] {
   return [
-    { path: SCOREBOARD_PATH, label: 'Public API coverage' },
+    { path: SCOREBOARD_PATH, label: 'Conformance scores' },
     ...model.documentation.registries.map(({ compatPath, label }) => ({ path: compatPath, label })),
   ];
 }

--- a/packages/conformance/test/src/conformance-model.test.ts
+++ b/packages/conformance/test/src/conformance-model.test.ts
@@ -24,6 +24,12 @@ describe('multi-axis conformance model', () => {
     expect(model.rulesLanguage.firestoreScorecard.score).toEqual({
       numerator: 136, denominator: 140, ratio: 136 / 140, percent: 97.1,
     });
+    expect(model.rulesLanguage.storageScorecard.score).toEqual({
+      numerator: 67, denominator: 69, ratio: 67 / 69, percent: 97.1,
+    });
+    expect(model.rulesLanguage.rtdbScorecard.score).toEqual({
+      numerator: 56, denominator: 56, ratio: 1, percent: 100,
+    });
     expect(model.documentation.registries.length).toBeGreaterThan(0);
     expect(model.documentation.descriptors.length).toBeGreaterThan(0);
     expect(model.documentation.rows.length).toBeGreaterThan(600);

--- a/packages/conformance/test/src/generate-docs-scoreboard.test.ts
+++ b/packages/conformance/test/src/generate-docs-scoreboard.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { deriveConformanceModel, type ConformanceModel } from '../../src/conformance-model.ts';
+import { renderScoreboardMarkdown } from '../../src/generate-docs.ts';
+
+let model: ConformanceModel;
+beforeAll(async () => {
+  model = await deriveConformanceModel();
+}, 60_000);
+
+describe('generated conformance scoreboard', () => {
+  it('publishes each Rules engine score from the canonical construct scorecards', () => {
+    const markdown = renderScoreboardMarkdown(model);
+    const rulesRow = markdown.match(
+      /<tr class="compat-score-row--rules">[\s\S]*?<\/tr>/,
+    )?.[0];
+
+    expect(rulesRow).toBeDefined();
+    expect(rulesRow).toContain('>Firestore Rules<');
+    expect(rulesRow).toContain('>Storage Rules<');
+    expect(rulesRow).toContain('>Realtime Database Rules<');
+    expect(rulesRow).toContain('<span class="compat-score-pct">97.1%</span>');
+    expect(rulesRow).toContain('136 of 140 rules-language constructs verified');
+    expect(rulesRow).toContain('67 of 69 rules-language constructs verified');
+    expect(rulesRow).toContain('<span class="compat-score-pct">100%</span>');
+    expect(rulesRow).toContain('56 of 56 rules-language constructs verified');
+    expect(rulesRow).not.toContain('Gathering metrics');
+  });
+
+  it('keeps Overall scoped to the Firebase public API census', () => {
+    const markdown = renderScoreboardMarkdown(model);
+    const overallRow = markdown.match(
+      /<tr class="compat-score-row--overall">[\s\S]*?<\/tr>/,
+    )?.[0];
+
+    expect(overallRow).toBeDefined();
+    expect(overallRow).toContain('public API');
+    expect(overallRow).not.toContain('rules-language constructs');
+  });
+});

--- a/packages/site-docs/src/styles/conformance.css
+++ b/packages/site-docs/src/styles/conformance.css
@@ -276,3 +276,36 @@
   font-size: 0.8125rem;
   color: var(--ink-3, #667);
 }
+
+.prose .compat-score-row--rules .compat-score-cell {
+  white-space: normal;
+}
+
+.prose .compat-score-row--rules th[scope="row"] {
+  vertical-align: top;
+}
+
+.prose .compat-score-group {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.prose .compat-score-engine {
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.7fr) minmax(14rem, 1.3fr);
+  align-items: start;
+  gap: var(--space-3);
+}
+
+.prose .compat-score-engine-name {
+  padding-top: 1px;
+  color: var(--ink);
+  font-weight: 550;
+}
+
+@media (max-width: 760px) {
+  .prose .compat-score-engine {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
+}


### PR DESCRIPTION
Publishes the three canonical Security Rules construct scorecards on the generated conformance scoreboard.

```text
Rules
  Firestore Rules          97.1%  136 of 140 rules-language constructs verified
  Storage Rules            97.1%   67 of 69 rules-language constructs verified
  Realtime Database Rules   100%   56 of 56 rules-language constructs verified
```

## Rules no longer says “Gathering metrics”

The central conformance model now exposes the already-ratcheted Storage and RTDB scorecards alongside Firestore. The generated scoreboard consumes those model facts directly, gives each engine its own to-scale bar and denominator, and labels the page “Conformance scores” because its rows now use two honest measurement kinds.

Mirror rows still measure supported Firebase public API. Rules rows measure production-verified rules-language constructs. `Overall` remains mirror-census-only at 536/673; Rules scores are not blended into it.

Published delta: TBD → Firestore 136/140, Storage 67/69, RTDB 56/56. The underlying scores moved by zero points. No denominator, observation, registry status, construct status, baseline, or expectation changed.

## Risk

The public page now exposes three trust numbers, so accidental numerator inflation or denominator shrinkage would misstate conformance. The renderer receives scorecards from `deriveConformanceModel()` rather than deriving its own fractions, exact current scores are pinned at the model seam, and the existing per-engine baseline gates still reject denominator or per-construct drift.

The generated page title and navigation label change from “Public API coverage” to “Conformance scores.” The route remains `/docs/conformance-scores/`.

This implements the Rules portion of #344. The Functions · RTDB census remains explicitly out of scope and continues to show its existing placeholder.

<details>
<summary>Implementation notes</summary>

Coverage-adversary verdict: **EARNED**. This publishes existing earned values; it does not claim a conformance improvement. Zero reclassifications, denominator edits, evidence edits, assertion weakening, or analyzer-credit changes.

Verification:

- `bun run compat:rules-score` — 35 replay tests pass; all three scores, denominators, and per-construct facts match baselines.
- `bun test --cwd packages/conformance` — 359 pass.
- `bun run --cwd packages/site-docs test` — 43 pass.
- `bun run compat:check` — passes all registry, census, entry-path, projection, Rules-score, and coverage gates.
- `bun run build --packages-only` — all packages build.
- `bash scripts/build-site.sh` — 108 pages build and the composed site completes.
- Desktop and 390px mobile screenshots inspected from the composed static site.

</details>
