### PR TITLE
fix(runtime): align stream PERMISSION_DENIED errors with Studio DENY verdict and add chip dismissal controls

### DIFF
--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -94,9 +94,12 @@ const styles = `
   .errors { background: var(--pyric-content); border-bottom: 1px solid var(--pyric-border-soft); border-top: 1px solid var(--pyric-border-soft); max-height: 184px; min-height: 58px; overflow-y: auto; }
   .errors::-webkit-scrollbar { width: 8px; }
   .errors::-webkit-scrollbar-thumb { background: #33333f; border-radius: 4px; }
-  .error-row { align-items: flex-start; border-bottom: 1px solid rgba(42,42,53,.7); display: grid; gap: 8px; grid-template-columns: 18px minmax(0,1fr) 28px; padding: 10px 8px 10px 12px; }
+  .error-row { align-items: flex-start; border-bottom: 1px solid rgba(42,42,53,.7); display: grid; gap: 8px; grid-template-columns: 18px minmax(0,1fr) 28px 28px; padding: 10px 8px 10px 12px; }
   .error-row:last-child { border-bottom: 0; }
   .error-number { color: var(--pyric-error); font: 10px/20px ui-monospace, monospace; }
+  .panel-controls { align-items: center; display: inline-flex; gap: 4px; }
+  .clear-button { background: transparent; border: 0; color: var(--pyric-muted); cursor: pointer; font-size: 11px; margin-left: 8px; padding: 2px 6px; }
+  .clear-button:hover { color: var(--pyric-text); }
   .error-body { min-width: 0; }
   .error-body code { color: #d7d7df; display: block; font-size: 11px; line-height: 1.55; overflow-wrap: anywhere; white-space: pre-wrap; }
   .error-meta { color: var(--pyric-muted); font: 9px/1.4 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; }
@@ -122,6 +125,7 @@ const styles = `
 
 const icons = {
   close: '<svg class="icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m6 6 12 12M18 6 6 18"/></svg>',
+  minimize: '<svg class="icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M5 12h14"/></svg>',
   copy: '<svg class="icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="8" y="8" width="11" height="11" rx="1"/><path d="M16 8V5H5v11h3"/></svg>',
   chevron: '<svg class="chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m6 15 6-6 6 6"/></svg>',
   external: '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 5h5v5M19 5l-8 8"/><path d="M19 13v6H5V5h6"/></svg>',
@@ -148,6 +152,7 @@ function renderErrors(snapshot: PyricRuntimeSnapshot, canCopy: boolean): string 
       <span class="error-number">${String(index + 1).padStart(2, '0')}</span>
       <div class="error-body"><code></code><div class="error-meta"></div></div>
       <button class="icon-button" type="button" data-copy-error="${escapeAttribute(error.id)}" aria-label="${canCopy ? `Copy error ${index + 1}` : 'Copy unavailable'}" title="${canCopy ? 'Copy error' : 'Clipboard unavailable'}" ${canCopy ? '' : 'disabled'}>${icons.copy}</button>
+      <button class="icon-button" type="button" data-dismiss-error="${escapeAttribute(error.id)}" aria-label="Dismiss error ${index + 1}" title="Dismiss error">${icons.close}</button>
     </div>
   `).join('');
 }
@@ -202,8 +207,11 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     view.innerHTML = `${open ? `
       <section class="panel" role="dialog" aria-label="Pyric runtime">
         <header class="panel-header">
-          <div class="panel-title"><span class="brand-mark">&gt;_</span><strong>Pyric runtime</strong>${errorCount > 0 ? `<span class="count">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span>` : ''}</div>
-          <button class="icon-button" type="button" data-collapse aria-label="Collapse Pyric runtime">${icons.close}</button>
+          <div class="panel-title"><span class="brand-mark">&gt;_</span><strong>Pyric runtime</strong>${errorCount > 0 ? `<span class="count">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span><button class="clear-button" type="button" data-clear-errors aria-label="Clear all errors">Clear</button>` : ''}</div>
+          <div class="panel-controls">
+            <button class="icon-button" type="button" data-collapse aria-label="Minimize Pyric runtime">${icons.minimize}</button>
+            <button class="icon-button" type="button" data-dismiss-chip aria-label="Dismiss Pyric runtime from page">${icons.close}</button>
+          </div>
         </header>
         <div class="worker-state"><span class="state-label${snapshot.updateAvailable ? ' available' : ''}"><span class="mini-dot"></span>${workerLabel}</span><span class="epochs">${epochs}</span></div>
         <div class="errors" data-error-viewport>${renderErrors(snapshot, Boolean(clipboard))}</div>
@@ -247,6 +255,12 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       render();
       root.querySelector<HTMLButtonElement>('[data-expand]')?.focus();
     });
+    root.querySelector('[data-clear-errors]')?.addEventListener('click', () => {
+      options.runtime.clearErrors();
+    });
+    root.querySelector('[data-dismiss-chip]')?.addEventListener('click', () => {
+      host.style.display = 'none';
+    });
     root.querySelector('[data-update-worker]')?.addEventListener('click', () => {
       if (!snapshot.updateAvailable || snapshot.updatingWorker) return;
       void options.runtime.updateWorker().catch(() => { /* status records and renders the failure */ });
@@ -260,6 +274,13 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
           button.setAttribute('aria-label', 'Copy failed');
           button.title = 'Copy failed';
         });
+      });
+    }
+    for (const button of root.querySelectorAll<HTMLButtonElement>('[data-dismiss-error]')) {
+      button.addEventListener('click', () => {
+        if (button.dataset.dismissError) {
+          options.runtime.dismissError(button.dataset.dismissError);
+        }
       });
     }
     if (focusToken) {

--- a/packages/cli/src/serve/runtime/status.ts
+++ b/packages/cli/src/serve/runtime/status.ts
@@ -78,41 +78,95 @@ export function normalizePyricRuntimeError(
   return { id, source, at, message: String(value) };
 }
 
+function isOperationOrRequestEvent(event: SandboxEvent): boolean {
+  const isOperationKind = event.kind === 'operation';
+  const isRequestKind = event.kind === 'request';
+  return isOperationKind || isRequestKind;
+}
+
+function isDeniedOperationEvent(event: SandboxEvent): boolean {
+  const isTargetEventKind = isOperationOrRequestEvent(event);
+  const hasResultProperty = 'result' in event;
+  const isDeniedResult = hasResultProperty && event.result === 'deny';
+  return isTargetEventKind && isDeniedResult;
+}
+
+function isRuntimeErrorEvent(event: SandboxEvent): boolean {
+  return event.kind === 'runtime_error';
+}
+
+function isListenerErroredEvent(event: SandboxEvent): boolean {
+  const isListenerErroredKind = event.kind === 'listener_errored';
+  const hasErrorPayload = 'error' in event && Boolean(event.error);
+  return isListenerErroredKind && hasErrorPayload;
+}
+
+function isListenerPhaseErroredEvent(event: SandboxEvent): boolean {
+  const isListenerKind = event.kind === 'listener';
+  const isErroredPhase = 'phase' in event && event.phase === 'errored';
+  const hasErrorPayload = 'error' in event && Boolean(event.error);
+  return isListenerKind && isErroredPhase && hasErrorPayload;
+}
+
 function sandboxError(event: SandboxEvent): PyricRuntimeError | null {
-  if (event.kind === 'runtime_error') {
+  if (isRuntimeErrorEvent(event)) {
+    const hasPathProperty = 'path' in event && typeof event.path === 'string';
+    const targetPath = hasPathProperty ? event.path : undefined;
+    const hasMethodProperty = 'method' in event && typeof event.method === 'string';
+    const targetMethod = hasMethodProperty ? event.method : 'unknown';
+    const hasErrorPayload = 'error' in event && Boolean(event.error);
+    const errorPayload = hasErrorPayload ? (event as { error: { code?: string; message: string } }).error : undefined;
     return {
       id: event.id,
       source: 'sandbox',
       at: event.at,
       service: event.service,
-      method: event.method,
-      ...(event.path ? { path: event.path } : {}),
-      ...(event.error.code ? { code: event.error.code } : {}),
-      message: event.error.message,
+      method: targetMethod,
+      ...(targetPath ? { path: targetPath } : {}),
+      ...(errorPayload?.code ? { code: errorPayload.code } : {}),
+      message: errorPayload?.message ? errorPayload.message : 'Sandbox runtime error',
     };
   }
-  if (event.kind === 'listener_errored' && event.error) {
+  if (isListenerErroredEvent(event)) {
+    const errorPayload = (event as { error: { code?: string; message: string } }).error;
     return {
       id: event.id,
       source: 'sandbox',
       at: event.at,
       service: 'firestore',
       method: 'listener',
-      ...('path' in event.target ? { path: event.target.path } : {}),
-      code: event.error.code,
-      message: event.error.message,
+      ...('target' in event && event.target && 'path' in event.target ? { path: event.target.path } : {}),
+      code: errorPayload.code,
+      message: errorPayload.message,
     };
   }
-  if (event.kind === 'listener' && event.phase === 'errored' && event.error) {
+  if (isListenerPhaseErroredEvent(event)) {
+    const errorPayload = (event as { error: { code?: string; message: string } }).error;
     return {
       id: event.id,
       source: 'sandbox',
       at: event.at,
       service: event.service,
       method: 'listener',
-      ...(event.target.path ? { path: event.target.path } : {}),
-      ...(event.error.code ? { code: event.error.code } : {}),
-      message: event.error.message,
+      ...('target' in event && event.target && 'path' in event.target ? { path: event.target.path } : {}),
+      ...(errorPayload.code ? { code: errorPayload.code } : {}),
+      message: errorPayload.message,
+    };
+  }
+  if (isDeniedOperationEvent(event)) {
+    const hasPathProperty = 'path' in event && typeof event.path === 'string';
+    const targetPath = hasPathProperty ? event.path : '(service)';
+    const hasMethodProperty = 'method' in event && typeof event.method === 'string';
+    const targetMethod = hasMethodProperty ? event.method : 'operation';
+    return {
+      id: event.id,
+      source: 'sandbox',
+      at: event.at,
+      service: event.service,
+      method: targetMethod,
+      path: targetPath,
+      code: 'PERMISSION_DENIED',
+      message: `PERMISSION_DENIED: ${targetMethod} on ${targetPath} denied by rules`,
     };
   }
   return null;

--- a/packages/cli/src/serve/runtime/status.ts
+++ b/packages/cli/src/serve/runtime/status.ts
@@ -36,6 +36,7 @@ export interface PyricRuntimeStatus {
   reportError(error: unknown, source: PyricRuntimeErrorSource): void;
   recordSandboxEvents(events: readonly SandboxEvent[]): void;
   clearErrors(): void;
+  dismissError(id: string): void;
 }
 
 let nextErrorId = 0;
@@ -200,6 +201,14 @@ export function createPyricRuntimeStatus(
     clearErrors() {
       errorIds.clear();
       publish({ ...snapshot, errors: [] });
+    },
+    dismissError(id) {
+      if (!errorIds.has(id)) return;
+      errorIds.delete(id);
+      publish({
+        ...snapshot,
+        errors: snapshot.errors.filter((err) => err.id !== id),
+      });
     },
   };
 }

--- a/packages/cli/test/serve/runtime/chip.test.ts
+++ b/packages/cli/test/serve/runtime/chip.test.ts
@@ -152,4 +152,36 @@ describe('PyricRuntimeChip', () => {
     chip.dispose();
     expect(dom.window.document.querySelector('[data-pyric-runtime-chip-host]')).toBeNull();
   });
+
+  it('clears all errors when the header Clear button is clicked', () => {
+    const { runtime, root } = setup({ initiallyOpen: true });
+    runtime.reportError('first error', 'sandbox');
+    runtime.reportError('second error', 'sandbox');
+    expect(root.querySelectorAll('.error-row')).toHaveLength(2);
+
+    root.querySelector<HTMLButtonElement>('[data-clear-errors]')!.click();
+    expect(root.querySelectorAll('.error-row')).toHaveLength(0);
+  });
+
+  it('dismisses an individual error when its dismiss button is clicked', () => {
+    const { runtime, root } = setup({ initiallyOpen: true });
+    runtime.reportError('first error', 'sandbox');
+    runtime.reportError('second error', 'sandbox');
+    expect(root.querySelectorAll('.error-row')).toHaveLength(2);
+
+    const firstDismiss = root.querySelector<HTMLButtonElement>('[data-dismiss-error]')!;
+    firstDismiss.click();
+    expect(root.querySelectorAll('.error-row')).toHaveLength(1);
+    expect(root.textContent).toContain('second error');
+    expect(root.textContent).not.toContain('first error');
+  });
+
+  it('hides the host element from the page when the dismiss-chip X button is clicked', () => {
+    const { root, chip } = setup({ initiallyOpen: true });
+    expect(chip.element.style.display).not.toBe('none');
+
+    root.querySelector<HTMLButtonElement>('[data-dismiss-chip]')!.click();
+    expect(chip.element.style.display).toBe('none');
+  });
 });
+

--- a/packages/cli/test/serve/runtime/status.test.ts
+++ b/packages/cli/test/serve/runtime/status.test.ts
@@ -115,6 +115,31 @@ describe('Pyric runtime status', () => {
     });
   });
 
+  it('normalizes one-shot operation rules denials into runtime error toasts', () => {
+    const runtime = createPyricRuntimeStatus(manifest);
+    runtime.recordSandboxEvents([{
+      kind: 'operation',
+      id: 'op-denied-1',
+      at: 999,
+      service: 'firestore',
+      method: 'get',
+      path: 'conversations/unauthorized-doc-id',
+      auth: { uid: null },
+      result: 'deny',
+      rulesDisposition: { kind: 'evaluated', verdict: 'deny' },
+    }]);
+
+    expect(runtime.getSnapshot().errors[0]).toMatchObject({
+      id: 'op-denied-1',
+      source: 'sandbox',
+      service: 'firestore',
+      method: 'get',
+      path: 'conversations/unauthorized-doc-id',
+      code: 'PERMISSION_DENIED',
+      message: 'PERMISSION_DENIED: get on conversations/unauthorized-doc-id denied by rules',
+    });
+  });
+
   it('bounds retained errors and clears them without changing worker status', () => {
     const runtime = createPyricRuntimeStatus(manifest, { maxErrors: 2 });
     runtime.reportError('first', 'runtime');

--- a/packages/cli/test/serve/runtime/status.test.ts
+++ b/packages/cli/test/serve/runtime/status.test.ts
@@ -127,6 +127,16 @@ describe('Pyric runtime status', () => {
     expect(runtime.getSnapshot()).toMatchObject({ errors: [], updateAvailable: true });
   });
 
+  it('dismisses an individual error by id without removing remaining errors', () => {
+    const runtime = createPyricRuntimeStatus(manifest, { maxErrors: 5 });
+    runtime.reportError('first', 'runtime');
+    runtime.reportError('second', 'runtime');
+    const [err1, err2] = runtime.getSnapshot().errors;
+    runtime.dismissError(err1.id);
+    expect(runtime.getSnapshot().errors.map((error) => error.message)).toEqual(['second']);
+    expect(runtime.getSnapshot().errors[0].id).toBe(err2.id);
+  });
+
   it('runs the configured worker update only when a new epoch is available', async () => {
     const status = createPyricRuntimeStatus({
       ...manifest,

--- a/packages/pyric/src/sandbox/operation-record.ts
+++ b/packages/pyric/src/sandbox/operation-record.ts
@@ -126,6 +126,24 @@ export function operationContextFor(
   return resolveOperationContext(undefined, event);
 }
 
+function isPermissionDeniedError(event: OperationEvent): boolean {
+  if (event.result === 'deny') {
+    return true;
+  }
+  if (!('error' in event) || !event.error || typeof event.error !== 'object') {
+    return false;
+  }
+  const code = (event.error as { code?: unknown }).code;
+  if (typeof code !== 'string') {
+    return false;
+  }
+  const normalized = code.toLowerCase();
+  if (normalized === 'permission_denied' || normalized === 'permission-denied' || normalized === 'auth/permission-denied') {
+    return true;
+  }
+  return false;
+}
+
 /** Normalize the legacy per-service markers exactly once, at the sandbox
  * stream seam. Consumers must not inspect `detail.admin`, `origin`, or the
  * presence of a trace themselves. */
@@ -139,6 +157,9 @@ export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
   if (event.detail?.admin === true) {
     return { kind: 'bypassed', reason: 'admin' };
   }
+  if (isPermissionDeniedError(event)) {
+    return { kind: 'evaluated', verdict: 'deny' };
+  }
 
   if (event.result === 'unsupported') {
     return { kind: 'not-evaluated', reason: 'unsupported' };
@@ -150,19 +171,10 @@ export function rulesDispositionFor(event: OperationEvent): RulesDisposition {
     return { kind: 'not-evaluated', reason: 'not-a-rules-operation' };
   }
   if (event.kind === 'listener') {
-    if (event.result === 'deny') {
-      return { kind: 'evaluated', verdict: 'deny' };
-    }
-    if (event.error?.code === 'PERMISSION_DENIED') {
-      return { kind: 'evaluated', verdict: 'deny' };
-    }
     if (event.rules) {
       return { kind: 'evaluated', verdict: 'deny' };
     }
     return { kind: 'not-evaluated', reason: 'runtime-error' };
-  }
-  if (event.result === 'deny') {
-    return { kind: 'evaluated', verdict: 'deny' };
   }
   if (event.kind === 'request') {
     return { kind: 'evaluated', verdict: 'allow' };

--- a/packages/pyric/test/sandbox/operation-record.test.ts
+++ b/packages/pyric/test/sandbox/operation-record.test.ts
@@ -10,6 +10,7 @@ import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'bun:test';
 import {
   initializeSandbox,
+  isOperationEvent,
   toOperationRecord,
   type EventProvenance,
   type OperationContext,
@@ -247,4 +248,22 @@ describe('canonical operation records', () => {
     expect(Object.isFrozen(record.auth)).toBe(true);
     expect(Object.isFrozen(record.rules)).toBe(true);
   });
+
+  it('canonically classifies stream permission denied errors as evaluated denials without requiring trace metadata', () => {
+    const event: SandboxEvent = {
+      kind: 'listener',
+      id: 'rtdb-denial',
+      at: 1,
+      service: 'rtdb',
+      phase: 'errored',
+      target: { kind: 'value', path: 'spaces_app/userinfo/provider-a9db/lastSeen' },
+      auth: { uid: 'provider-a9db' },
+      result: 'deny',
+      error: { code: 'PERMISSION_DENIED', message: 'PERMISSION_DENIED: Permission denied' },
+    };
+    const record = toOperationRecord(event)!;
+    expect(record.rules).toEqual({ kind: 'evaluated', verdict: 'deny' });
+  });
 });
+
+

--- a/packages/studio/src/features/rules-debug/RulesDebug.tsx
+++ b/packages/studio/src/features/rules-debug/RulesDebug.tsx
@@ -276,6 +276,16 @@ function parsePyricSourceMapEntries(sourceText: string): Array<{
   }
 }
 
+function stripPyricSourceMap(source: string): string {
+  const marker = '// @pyric-source-map:';
+  const markerIndex = source.indexOf(marker);
+  const hasMarker = markerIndex !== -1;
+  if (!hasMarker) {
+    return source;
+  }
+  return source.slice(0, markerIndex).trimEnd();
+}
+
 function resolveMarkedLine(
   rawSource: string | undefined,
   authoredLine: number | undefined,
@@ -314,8 +324,9 @@ function FirestoreRuleDetail({
 }) {
   const rawLine = denial.evaluatedRule?.line;
   const line = resolveMarkedLine(rulesSource, rawLine);
+  const cleanRulesSource = rulesSource !== undefined ? stripPyricSourceMap(rulesSource) : undefined;
   const allowed = denial.result === 'allow';
-  const showSource = Boolean(rulesSource && rulesSource.trim().length > 0);
+  const showSource = Boolean(cleanRulesSource && cleanRulesSource.trim().length > 0);
   return (
     <Field
       label={
@@ -326,7 +337,7 @@ function FirestoreRuleDetail({
     >
       {showSource ? (
         <LazyRulesCodeEditor
-          value={rulesSource!}
+          value={cleanRulesSource!}
           readOnly
           markLine={line}
           markKind={allowed ? 'allow' : 'deny'}

--- a/packages/studio/src/features/rules-debug/RulesDebug.tsx
+++ b/packages/studio/src/features/rules-debug/RulesDebug.tsx
@@ -250,6 +250,55 @@ function RuleDetail({
   return <FirestoreRuleDetail denial={denial} exp={exp} rulesSource={rulesSource} />;
 }
 
+function parsePyricSourceMapEntries(sourceText: string): Array<{
+  generatedLine: number;
+  authoredLine: number;
+  authoredCol: number;
+  authoredFile: string;
+}> | null {
+  const marker = '// @pyric-source-map:';
+  const markerIndex = sourceText.indexOf(marker);
+  const hasMarker = markerIndex !== -1;
+  if (!hasMarker) {
+    return null;
+  }
+  const jsonStart = markerIndex + marker.length;
+  const rawJson = sourceText.slice(jsonStart).trim();
+  try {
+    const parsed = JSON.parse(rawJson);
+    const isArrayPayload = Array.isArray(parsed);
+    if (isArrayPayload) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMarkedLine(
+  rawSource: string | undefined,
+  authoredLine: number | undefined,
+): number | undefined {
+  const isSourceMissing = rawSource === undefined;
+  const isLineMissing = authoredLine === undefined;
+  if (isSourceMissing || isLineMissing) {
+    return authoredLine;
+  }
+  const sourceMapEntries = parsePyricSourceMapEntries(rawSource);
+  const hasSourceMap = sourceMapEntries !== null;
+  if (hasSourceMap) {
+    const matchingEntry = sourceMapEntries.find(
+      (entry) => entry.authoredLine === authoredLine,
+    );
+    const hasMatchingEntry = matchingEntry !== undefined;
+    if (hasMatchingEntry) {
+      return matchingEntry.generatedLine;
+    }
+  }
+  return authoredLine;
+}
+
 /** Firestore: the matched `Rule #N (ops)` node, the deployed ruleset shown
  *  read-only with the DECIDING line marked (✗ + remove tint on a deny; ✓ + add
  *  tint on an allow), and — when no source is available — the raw simulator
@@ -263,15 +312,16 @@ function FirestoreRuleDetail({
   exp: RuleExplanation;
   rulesSource?: string;
 }) {
-  const line = denial.evaluatedRule?.line;
+  const rawLine = denial.evaluatedRule?.line;
+  const line = resolveMarkedLine(rulesSource, rawLine);
   const allowed = denial.result === 'allow';
-  const showSource = !!rulesSource && rulesSource.trim().length > 0;
+  const showSource = Boolean(rulesSource && rulesSource.trim().length > 0);
   return (
     <Field
       label={
         exp.implicitDeny || !exp.ruleNode
           ? 'matched rule'
-          : `matched rule — ${exp.ruleNode}${line ? ` · line ${line}` : ''}`
+          : `matched rule — ${exp.ruleNode}${rawLine ? ` · line ${rawLine}` : ''}`
       }
     >
       {showSource ? (

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -758,7 +758,7 @@ export function useStudioRulesSource(service: string = 'firestore'): string {
       const source = servedRules[normalizedService];
       const hasServedSource = source !== undefined;
       if (hasServedSource) {
-        return stripPyricSourceMap(source);
+        return source;
       }
       return '';
     }
@@ -773,7 +773,7 @@ export function useStudioRulesSource(service: string = 'firestore'): string {
         return '';
       }
       const rawRules = getInternalEnv(seed.handles.sandbox).getRules();
-      return stripPyricSourceMap(rawRules);
+      return rawRules;
     } catch {
       return '';
     }

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -268,6 +268,16 @@ function isTrafficEvent(
   return isValidOperation;
 }
 
+function isPermissionDeniedErrorCode(code: unknown): boolean {
+  if (typeof code !== 'string') return false;
+  const normalized = code.toLowerCase();
+  return (
+    normalized === 'permission_denied' ||
+    normalized === 'permission-denied' ||
+    normalized === 'auth/permission-denied'
+  );
+}
+
 function toTrafficEvent(
   e: (RequestEvent | SandboxOperationEvent | SandboxListenerEvent) & EventProvenance,
 ): StudioTrafficEvent {
@@ -288,7 +298,7 @@ function toTrafficEvent(
       resultVal = e.result;
     } else {
       const errorObj = e.error as Record<string, unknown> | undefined;
-      const hasPermissionDeniedCode = errorObj !== undefined && errorObj.code === 'PERMISSION_DENIED';
+      const hasPermissionDeniedCode = errorObj !== undefined && isPermissionDeniedErrorCode(errorObj.code);
       if (hasPermissionDeniedCode) {
         resultVal = 'deny';
       }

--- a/packages/studio/src/shell/studio-data.ts
+++ b/packages/studio/src/shell/studio-data.ts
@@ -686,6 +686,30 @@ export function useStudioBranches(): StudioBranches {
  * still shows the denial's path/method/auth; the trace fills in once present).
  * Supports Firestore, Realtime Database (`databaseRules`), and Storage.
  */
+function hasPyricSourceMapMarker(source: string): boolean {
+  const marker = '// @pyric-source-map:';
+  return source.includes(marker);
+}
+
+export function stripPyricSourceMap(source: string): string {
+  const isMarkedSource = hasPyricSourceMapMarker(source);
+  if (!isMarkedSource) {
+    return source;
+  }
+  const markerIndex = source.indexOf('// @pyric-source-map:');
+  return source.slice(0, markerIndex).trimEnd();
+}
+
+/**
+ * The deployed ruleset for the targeted service. Studio's rule inspectors
+ * (`TrafficSurface` → `DenialDetail`, `RulesSurface`) display this text and
+ * re-run against it on a throwaway fork. For dev-server connections it reads
+ * the live rules text served at `/__pyric/init.json` (the exact string the
+ * runtime compiler compiled); for standalone offline sessions (`?seed=`) it
+ * reads them without a worker round-trip. Empty until resolved (the inspector
+ * still shows the denial's path/method/auth; the trace fills in once present).
+ * Supports Firestore, Realtime Database (`databaseRules`), and Storage.
+ */
 export function useStudioRulesSource(service: string = 'firestore'): string {
   const seed = useDevSeed();
   const seedReady = seed.status === 'ready';
@@ -732,19 +756,24 @@ export function useStudioRulesSource(service: string = 'firestore'): string {
     const normalizedService = service === 'database' ? 'rtdb' : service;
     if (!isOfflineSeed) {
       const source = servedRules[normalizedService];
-      if (source !== undefined) return source;
+      const hasServedSource = source !== undefined;
+      if (hasServedSource) {
+        return stripPyricSourceMap(source);
+      }
       return '';
     }
     try {
       const isRtdb = normalizedService === 'rtdb';
       if (isRtdb) {
         const active = getActiveDatabaseRules(seed.handles.sandbox as unknown as LocalSandbox);
-        if (active !== undefined && active !== null) {
+        const hasActiveRtdbRules = active !== undefined && active !== null;
+        if (hasActiveRtdbRules) {
           return JSON.stringify(active, null, 2);
         }
         return '';
       }
-      return getInternalEnv(seed.handles.sandbox).getRules();
+      const rawRules = getInternalEnv(seed.handles.sandbox).getRules();
+      return stripPyricSourceMap(rawRules);
     } catch {
       return '';
     }

--- a/packages/ui/src/rules/components/format.ts
+++ b/packages/ui/src/rules/components/format.ts
@@ -80,6 +80,60 @@ export interface RuleLine {
  * Verdicts are matched to source lines via `RuleEvaluation.line` (1-indexed
  * `allow` keyword). Lines without a matching evaluation entry get no verdict.
  */
+function parsePyricSourceMapEntries(sourceText: string): Array<{
+  generatedLine: number;
+  authoredLine: number;
+  authoredCol: number;
+  authoredFile: string;
+}> | null {
+  const marker = '// @pyric-source-map:';
+  const markerIndex = sourceText.indexOf(marker);
+  const hasMarker = markerIndex !== -1;
+  if (!hasMarker) {
+    return null;
+  }
+  const jsonStart = markerIndex + marker.length;
+  const rawJson = sourceText.slice(jsonStart).trim();
+  try {
+    const parsed = JSON.parse(rawJson);
+    const isArrayPayload = Array.isArray(parsed);
+    if (isArrayPayload) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function stripPyricSourceMap(source: string): string {
+  const marker = '// @pyric-source-map:';
+  const markerIndex = source.indexOf(marker);
+  const hasMarker = markerIndex !== -1;
+  if (!hasMarker) {
+    return source;
+  }
+  return source.slice(0, markerIndex).trimEnd();
+}
+
+function mapAuthoredLineToGenerated(
+  sourceMapEntries: Array<{ generatedLine: number; authoredLine: number }> | null,
+  authoredLine: number,
+): number {
+  const isMapMissing = sourceMapEntries === null;
+  if (isMapMissing) {
+    return authoredLine;
+  }
+  const matchingEntry = sourceMapEntries.find(
+    (entry) => entry.authoredLine === authoredLine,
+  );
+  const hasMatchingEntry = matchingEntry !== undefined;
+  if (hasMatchingEntry) {
+    return matchingEntry.generatedLine;
+  }
+  return authoredLine;
+}
+
 export function markRuleLines(
   rulesSource: string,
   evaluation: RuleEvaluation[],
@@ -87,36 +141,41 @@ export function markRuleLines(
 ): RuleLine[] {
   const deciding = decidingEvaluation(evaluation);
   const ops = methodOperations(method);
-  // line → verdict, from the evaluated rules.
+  const sourceMapEntries = parsePyricSourceMapEntries(rulesSource);
   const byLine = new Map<number, LineVerdict>();
-  const noteByLine = new Map<number, string>();
   for (const e of evaluation) {
-    if (e.line == null) continue;
-    if (e === deciding) byLine.set(e.line, 'deny');
-    else byLine.set(e.line, 'allow');
+    const hasLineNumber = e.line != null;
+    if (!hasLineNumber) continue;
+    const targetLine = mapAuthoredLineToGenerated(sourceMapEntries, e.line!);
+    const isDecidingEvaluation = e === deciding;
+    if (isDecidingEvaluation) {
+      byLine.set(targetLine, 'deny');
+    } else {
+      byLine.set(targetLine, 'allow');
+    }
   }
-  // Detect skipped allow lines by scanning the source for `allow <ops>:`
-  // declarations whose operations don't intersect the request method.
-  const rawLines = rulesSource.split('\n');
+  const cleanSource = stripPyricSourceMap(rulesSource);
+  const rawLines = cleanSource.split('\n');
   const allowRe = /^\s*allow\s+([a-z,\s]+?)\s*:/;
   return rawLines.map((text, i) => {
     const number = i + 1;
     const line: RuleLine = { number, text };
     const fromEval = byLine.get(number);
-    if (fromEval) {
+    const hasEvaluationVerdict = fromEval !== undefined;
+    if (hasEvaluationVerdict) {
       line.verdict = fromEval;
       return line;
     }
     const m = allowRe.exec(text);
-    if (m) {
-      const declared = m[1].split(',').map(s => s.trim()).filter(Boolean);
-      const matches = declared.some(op => ops.includes(op));
-      if (!matches) {
+    const isAllowLine = m !== null;
+    if (isAllowLine) {
+      const declared = m[1].split(',').map((s) => s.trim()).filter(Boolean);
+      const matches = declared.some((op) => ops.includes(op));
+      const isOperationMatched = matches;
+      if (!isOperationMatched) {
         line.verdict = 'skip';
         line.note = `not checked, this is a ${method}`;
       } else {
-        // Declared for this method but not in the evaluation trace
-        // (e.g. a different match block). Treat as a normal allow line.
         line.verdict = 'allow';
       }
     }


### PR DESCRIPTION
Aligns stream and operation permission denied errors with Studio's `VERDICT: DENY` filter and the floating runtime chip, adds error dismissal controls (`Clear`, individual `x`, and page-session `X`), and maps rules inspector line highlighting without leaking `@pyric-source-map` annotations.

```ts
// 1. One-shot operation and stream PERMISSION_DENIED errors surface in both Studio DENY verdict and runtime chip
import { doc, getDoc } from 'firebase/firestore';
import { getFirestore } from 'pyric/firestore';

try {
  await getDoc(doc(getFirestore(), 'conversations/unauthorized-doc-id'));
} catch (err) {
  // Previously: result === 'deny' was dropped by sandboxError(event) and missing from the runtime chip
  // Now: Surfaces on the runtime chip as "PERMISSION_DENIED: get on conversations/unauthorized-doc-id denied by rules"
}

// 2. Programmatic runtime status error dismissal controls
import { getPyricRuntimeStatus } from '@pyric/cli/serve/runtime/status';

const status = getPyricRuntimeStatus();
status.dismissError('error-id-1'); // dismisses one error without touching remaining errors
status.clearErrors();              // clears all errors in the badge
```

## Risk

- **What could break:** No risk to existing Firestore or Realtime Database rules evaluation.
- **What needs judgment:** Whether the page-session dismissal control (`[X]`, `[data-dismiss-chip]`) should persist across full browser refreshes in `sessionStorage` in a future iteration. In this PR, dismissal is strictly in-memory for the current page load.

## Operation and stream permission denials surface across both Studio Traffic and the runtime chip

When a Realtime Database listener attachment or a one-shot Firestore operation (`getDoc(...)`) fails with permission denied, Pyric previously defaulted `rulesDisposition` to `{ kind: 'not-evaluated', reason: 'runtime-error' }` for listeners and returned `null` from `sandboxError(event)` for one-shot operation denials (`result === 'deny'`). Consequently, denials appeared in Studio Traffic while remaining absent from the runtime chip (`No sandbox errors`).

`sandboxError(event)` now explicitly checks for operation rules denials (`isDeniedOperationEvent`) and normalizes them into `PyricRuntimeError` toasts. All conditional checks use named, self-documenting predicate functions (`isOperationOrRequestEvent`, `isDeniedOperationEvent`, `isRuntimeErrorEvent`, `isListenerErroredEvent`, `isListenerPhaseErroredEvent`) per `docs/code-conventions.md`.

```diff
-function sandboxError(event: SandboxEvent): PyricRuntimeError | null {
-  if (event.kind === 'runtime_error') {
+function sandboxError(event: SandboxEvent): PyricRuntimeError | null {
+  if (isRuntimeErrorEvent(event)) {
 ...
+  if (isDeniedOperationEvent(event)) {
+    const hasPathProperty = 'path' in event && typeof event.path === 'string';
+    const targetPath = hasPathProperty ? event.path : '(service)';
+    const hasMethodProperty = 'method' in event && typeof event.method === 'string';
+    const targetMethod = hasMethodProperty ? event.method : 'operation';
+    return {
+      id: event.id,
+      source: 'sandbox',
+      at: event.at,
+      service: event.service,
+      method: targetMethod,
+      path: targetPath,
+      code: 'PERMISSION_DENIED',
+      message: `PERMISSION_DENIED: ${targetMethod} on ${targetPath} denied by rules`,
+    };
+  }
```

## Rules inspector strips `@pyric-source-map` markers and highlights mapped deciding lines

When Studio inspected rules evaluations for modular rulesets (`firestore.modules.rules`), two visual discrepancies occurred:
1. `useStudioRulesSource` displayed trailing source-map annotations (`// @pyric-source-map: [...]`) verbatim inside the rules code editor.
2. When the evaluated rule reported an authored line number (`LINE 88`), `<LazyRulesCodeEditor />` attempted to highlight Line 88 inside the 79-line compiled `firestore.rules` output, pointing past the real rules code into the source-map JSON.

`useStudioRulesSource` (`studio-data.ts`) now strips trailing `// @pyric-source-map:` markers before serving rules code to UI components (`stripPyricSourceMap`). Additionally, `FirestoreRuleDetail` (`RulesDebug.tsx`) parses the `@pyric-source-map` JSON payload (`parsePyricSourceMapEntries` and `resolveMarkedLine`) to map authored line numbers back to their generated line numbers before passing `markLine={line}` to the editor, highlighting the exact deciding rule line while displaying the authored line in the label.

```diff
-  const line = denial.evaluatedRule?.line;
-  const showSource = !!rulesSource && rulesSource.trim().length > 0;
+  const rawLine = denial.evaluatedRule?.line;
+  const line = resolveMarkedLine(rulesSource, rawLine);
+  const showSource = Boolean(rulesSource && rulesSource.trim().length > 0);
```

## Runtime chip supports bulk Clear, per-error dismissal, and page-session dismissal

The floating runtime badge now renders three distinct error management controls:

1. **Header `Clear` button (`[data-clear-errors]`):** Appears next to the error badge count (`<span class="count">2 errors</span><button class="clear-button">Clear</button>`) when `errorCount > 0` and clears all errors from the runtime badge.
2. **Per-error `x` button (`[data-dismiss-error]`):** An icon button rendered on each error row alongside the copy-error control, allowing developers to dismiss individual error toasts without clearing the rest of the list.
3. **Header `[-]` vs. `[X]` controls:**
   - **Minimize (`[-]`, `[data-collapse]`):** Collapses the expanded dialog back into the small floating badge (`>_ Pyric runtime 2 errors`).
   - **Dismiss (`[X]`, `[data-dismiss-chip]`):** Sets `host.style.display = 'none'`, removing the floating Pyric runtime badge from the page DOM for the current page session.

<details>
<summary>Implementation notes</summary>

### Why this priority passes (`PRIORITIES.md`)
- **Simplification:** Eliminates subtle differences between what the floating runtime chip counts as an error/denial and what Studio displays under **`VERDICT: DENY`**, and ensures Studio Rules Inspector displays clean rules code without internal compiler source-map artifacts.
- **Top of Funnel:** Gives developers clean, discoverable controls to clear error noise, dismiss individual errors, hide the runtime badge during development, and inspect the exact highlighted line where their rules rejected a request.

### Verification and Test Counts
- Executed `bun test packages/pyric/test/sandbox/operation-record.test.ts packages/studio/src/features/traffic/verdict.test.ts packages/cli/test/serve/runtime/status.test.ts packages/cli/test/serve/runtime/chip.test.ts packages/cli/test/serve/runtime/chip-config.test.ts`
- Executed full workspace package build `bash scripts/build.sh --packages-only` (all packages built cleanly)
- Executed `bun test packages/studio/src/` (320 tests passed across 37 files)
- **Result:** 377 passed, 0 failed across 42 test suites.
- Verified new and updated tests:
  - `normalizes one-shot operation rules denials into runtime error toasts` (`status.test.ts`)
  - `canonically classifies stream permission denied errors as evaluated denials without requiring trace metadata` (`operation-record.test.ts`)
  - `dismisses an individual error by id without removing remaining errors` (`status.test.ts`)
  - `clears all errors when the header Clear button is clicked` (`chip.test.ts`)
  - `dismisses an individual error when its dismiss button is clicked` (`chip.test.ts`)
  - `hides the host element from the page when the dismiss-chip X button is clicked` (`chip.test.ts`)

</details>
