### PR TITLE
docs: lead onboarding with the pyric-start skill

### DIFF
--- a/.agents/skills/readme-bookstore-test/SKILL.md
+++ b/.agents/skills/readme-bookstore-test/SKILL.md
@@ -239,6 +239,7 @@ starts where the last iteration ended.
 - **2026-07-08 — No manual line wrapping in markdown prose.** One line
   per paragraph; hard-wrapped prose is a diff and editing nuisance and an
   owner correction that should never recur.
+- **2026-07-27 — Make generator freshness explicit.** An unversioned package-generator command can reuse stale package-runner state and silently expose an older template set. User-facing onboarding commands should request the intended distribution tag explicitly, such as `npm create package@latest`; internal package identity, usage syntax, and implementation comments can remain unversioned.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Install the Pyric plugin:
 npx plugins add davideast/pyric
 ```
 
+Antigravity CLI and OpenCode use the standalone skill installer:
+
+```bash
+# Antigravity CLI
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent antigravity-cli
+
+# OpenCode
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent opencode
+```
+
 Then ask your agent:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -14,12 +14,28 @@ Pyric adds a development-only resolution layer to a Firebase application. Run th
 
 The mirrored data services do not connect to a production Firebase project. Local writes cannot delete production data or create Firebase usage charges, and local rules changes do not deploy. Pyric owns the development sandbox and verification workflow. Firebase owns production, with `firebase-tools` or the Firebase Console handling deployment.
 
-## Start a new Firebase application locally
+## Start with a coding agent
+
+Install the Pyric plugin:
+
+```bash
+npx plugins add davideast/pyric
+```
+
+Then ask your agent:
+
+```text
+Use the pyric-start skill to set up and run Pyric in this project.
+```
+
+The skill chooses the project launcher, starts one local sandbox bridge, opens the application, and confirms that the browser sandbox is connected.
+
+## Start from the terminal
 
 Create a Vite application with canonical Firebase imports, Firestore rules, and the Pyric development plugin already configured:
 
 ```bash
-npm create pyric my-app
+npm create pyric@latest my-app
 cd my-app
 npm install
 npm run dev

--- a/packages/create-pyric/README.md
+++ b/packages/create-pyric/README.md
@@ -3,7 +3,7 @@
 Scaffold a Pyric app. Used by:
 
 ```bash
-npm create pyric [dir]
+npm create pyric@latest [dir]
 ```
 
 Default template is **web**: a Vite app wired to `@pyric/cli/vite`. Then:

--- a/packages/site-docs/src/content/agent/set-up-your-agent.md
+++ b/packages/site-docs/src/content/agent/set-up-your-agent.md
@@ -11,21 +11,38 @@ description: "Connect Claude Code, Cursor, Codex, or any MCP client to your back
 
 One connection and your agent has the whole backend as tools. It can read and write documents as any user, run queries, lint and simulate rules, seed data, and inspect everything, against the same sandbox your app and Studio see. Nothing it does leaves your machine.
 
-The seam is one endpoint. `pyric dev --bridge` mounts an MCP server on your dev server at `/__pyric/mcp`, and every client below connects to it, directly or through a small stdio proxy that finds it for you.
+## Install the plugin
+
+Install the Pyric plugin from any terminal:
+
+```bash
+npx plugins add davideast/pyric
+```
+
+Then ask your coding agent:
+
+```text
+Use the pyric-start skill to set up and run Pyric in this project.
+```
+
+The skill scaffolds a project if needed, selects the correct launcher, starts the bridge, opens the app, and checks that the sandbox is connected. Ask for the skill by name because command syntax differs between coding agents. To expose the backend as tools, configure the client below.
+
+One requirement remains: the sandbox lives inside the served page, so keep the app open in a browser tab while the agent works. If data tools return nothing, open the page and try again.
+
+## Configure a client manually
+
+The seam is one endpoint. `pyric dev --bridge` mounts an MCP server on the development server at `/__pyric/mcp`. A client can connect directly or through the stdio proxy, which finds the running server.
+
+Start the bridge:
+
 ```bash
 pyric dev --bridge
 ```
-One requirement to know up front: the sandbox lives inside the served page, so keep the app open in a browser tab while the agent works. If data tools return nothing, the page is not open. Open it and try again.
 
-## Claude Code
+### Claude Code
 
-The plugin does the whole thing, including finding the port.
-```bash
-claude plugin install https://github.com/davideast/pyric   # path: pyric-plugin/
-```
-Then, inside Claude Code, run `/pyric:pyric-start`. It scaffolds a project if you need one, starts `pyric dev --bridge --persist`, opens the app so the sandbox connects, and wires MCP through a stdio proxy that discovers the running server on its own. There is no `claude mcp add` step and no port to configure.
+Register the stdio server:
 
-Prefer manual wiring? Register the stdio server:
 ```bash
 claude mcp add pyric -- npx --package @pyric/cli pyric mcp
 ```
@@ -36,7 +53,7 @@ claude mcp add pyric --transport http --url http://localhost:5173/__pyric/mcp
 ```
 First thing to ask: "Inspect the sandbox." One tool call comes back with the current rules, a lint summary, a document census, and recent denials.
 
-## Cursor
+### Cursor
 
 Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the port is never your problem:
 ```json
@@ -48,7 +65,7 @@ Cursor reads MCP servers from `.cursor/mcp.json`. Use the stdio server so the po
 ```
 Start `pyric dev --bridge`, open the app, then ask Cursor to inspect the sandbox.
 
-## Codex
+### Codex
 
 Same shape, Codex config. In `~/.codex/config.toml`:
 ```toml
@@ -58,7 +75,7 @@ args = ["--package", "@pyric/cli", "pyric", "mcp"]
 ```
 Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
 
-## Any MCP client
+### Any MCP client
 
 The generic recipe is two options, and every client above is one of them applied:
 

--- a/packages/site-docs/src/content/agent/set-up-your-agent.md
+++ b/packages/site-docs/src/content/agent/set-up-your-agent.md
@@ -4,7 +4,7 @@ navLabel: "Connect an agent"
 group: "Work with an agent"
 section: ""
 order: 10
-description: "Connect Claude Code, Cursor, Codex, or any MCP client to your backend in minutes."
+description: "Connect Claude Code, Cursor, Codex, Antigravity CLI, OpenCode, or any MCP client to your backend in minutes."
 ---
 
 # Connect an agent to the sandbox
@@ -17,6 +17,16 @@ Install the Pyric plugin from any terminal:
 
 ```bash
 npx plugins add davideast/pyric
+```
+
+Antigravity CLI and OpenCode use the standalone skill installer:
+
+```bash
+# Antigravity CLI
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent antigravity-cli
+
+# OpenCode
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent opencode
 ```
 
 Then ask your coding agent:
@@ -74,6 +84,42 @@ command = "npx"
 args = ["--package", "@pyric/cli", "pyric", "mcp"]
 ```
 Start `pyric dev --bridge`, open the app, and ask it to inspect the sandbox.
+
+### Antigravity CLI
+
+Antigravity CLI reads workspace MCP servers from `.agents/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "pyric": {
+      "command": "npx",
+      "args": ["--package", "@pyric/cli", "pyric", "mcp"]
+    }
+  }
+}
+```
+
+Start `pyric dev --bridge`, open the app, then use `/mcp` in Antigravity CLI to confirm that `pyric` is connected. Ask it to inspect the sandbox.
+
+### OpenCode
+
+Add Pyric to the workspace `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "pyric": {
+      "type": "local",
+      "command": ["npx", "--package", "@pyric/cli", "pyric", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Start `pyric dev --bridge`, open the app, then run `opencode mcp list` to confirm that `pyric` is connected. Ask it to inspect the sandbox.
 
 ### Any MCP client
 

--- a/packages/site-docs/src/content/get-started/start-building.md
+++ b/packages/site-docs/src/content/get-started/start-building.md
@@ -11,16 +11,32 @@ description: "Start a new Firebase application or add Pyric to an existing Vite 
 
 Pyric adds a development-only resolution layer to a Firebase application. During Vite development, supported `firebase/*` imports resolve to a browser-local backend. A normal production build resolves those imports to Firebase again.
 
-## Start a new application
+## Start with a coding agent
+
+Install the Pyric plugin:
+
+```bash
+npx plugins add davideast/pyric
+```
+
+Then ask your agent:
+
+```text
+Use the pyric-start skill to set up and run Pyric in this project.
+```
+
+The skill selects the project launcher, starts one local sandbox bridge, opens the application, and confirms that the browser sandbox is connected.
+
+## Start from the terminal
 
 Create a new Vite or Next.js application with canonical Firebase imports, Firestore rules, and Pyric already configured:
 
 ```bash
 # Start a Vite application
-npm create pyric my-app
+npm create pyric@latest my-app
 
 # Or start a Next.js application
-npm create pyric my-app -- --template nextjs
+npm create pyric@latest my-app -- --template nextjs
 
 cd my-app
 npm install

--- a/packages/site-docs/src/content/get-started/start-building.md
+++ b/packages/site-docs/src/content/get-started/start-building.md
@@ -19,6 +19,16 @@ Install the Pyric plugin:
 npx plugins add davideast/pyric
 ```
 
+Antigravity CLI and OpenCode use the standalone skill installer:
+
+```bash
+# Antigravity CLI
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent antigravity-cli
+
+# OpenCode
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent opencode
+```
+
 Then ask your agent:
 
 ```text

--- a/packages/site-docs/src/content/tutorial.md
+++ b/packages/site-docs/src/content/tutorial.md
@@ -17,6 +17,8 @@ Firebase provides the Emulator Suite, but it is Java-dependent, can be frustrati
 
 ## Meet Pyric
 
+For this tutorial, use the terminal path so every step starts from the same chat template:
+
 ```bash
 npm create pyric@latest my-chat -- --template chat
 cd my-chat


### PR DESCRIPTION
Leads greenfield onboarding with the plugin-installed `pyric-start` skill while keeping the package generator as the explicit terminal path.

```bash
npx plugins add davideast/pyric
```

Antigravity CLI and OpenCode use the standalone skills installer because they are not current `npx plugins` targets:

```bash
# Antigravity CLI
npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent antigravity-cli

# OpenCode
npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric-start --agent opencode
```

```text
Use the pyric-start skill to set up and run Pyric in this project.
```

## The agent path comes first without replacing the terminal path

```bash
npm create pyric@latest my-app
cd my-app
npm install
npm run dev
```

The root README and site Quickstart now present the plugin and skill before the manual path. The tutorial remains deterministic by naming the chat template explicitly, and every user-facing package-generator example requests `@latest` so stale package-runner state does not hide newer templates.

The agent setup page uses the cross-client plugin installer instead of a Claude-only installer. It now includes workspace-local MCP configuration for Antigravity CLI through `.agents/mcp_config.json` and for OpenCode through `opencode.json`. Client-specific MCP configuration remains documented because the current plugin bundle does not register MCP portably.

## Risk

This changes documentation only. The main review judgment is whether the pre-release `pyric-start` workflow is ready to become the first path readers see. The current skill still needs its launcher detection and empty-directory CLI assumptions brought up to date; this pull request does not change that implementation.

<details>
<summary>Implementation notes</summary>

- `bun run --cwd packages/site-docs test` — 43 passed
- `bun run --cwd packages/site-docs build` — 108 pages built
- `bun test --cwd packages/create-pyric` — 21 passed
- Direct `pyric-start` installation for `--agent antigravity-cli` — installed successfully in an isolated project
- Direct `pyric-start` installation for `--agent opencode` — installed successfully in an isolated project
- `npm create pyric@latest -- --help` — exited successfully
- `git diff --check` — passed
- Bare `npm create pyric` references remain only in package identity, CLI usage, provenance, implementation comments, and internal documentation.

</details>
