### PR TITLE
release: v0.1.0-alpha.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -133,7 +133,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -253,7 +253,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -271,7 +271,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -343,7 +343,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.18`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.17

- docs: lead onboarding with the pyric-start skill (#504) (c6ebcf0a)
- fix: map authored rule lines to generated line numbers before stripping source map comments (64b2e3b4)
- fix: surface operation denials on runtime chip and map inspector lines without source map comments (98d37b25)
- fix(runtime): align stream PERMISSION_DENIED errors with Studio DENY verdict and add chip dismissal controls (d55e4786)
- docs(conformance): publish Rules construct scores (4810aaff)
- docs(readme): update pyric plugin name (6385493e)
- refactor(plugin): transition domain skills into improve-firebase reference handbooks (c6af6d1c)
- docs(ai): document production passthrough mode and project configuration requirements (ea8b07ce)
- fix: resolve Functions child config warning (#498) and Admin Messaging bridge dispatch (#403) (041b95ff)
- feat(plugin): promote Firebase domain skills into public Open-Plugin bundle (48b93b5d)
- Revert "fix(plugin): add required name field to pyric-start skill frontmatter" (c975f28b)
- Revert "feat(plugin): promote Firebase domain skills into public Open-Plugin bundle" (aa7645cb)
- feat(plugin): promote Firebase domain skills into public Open-Plugin bundle (4873beae)
- fix(plugin): add required name field to pyric-start skill frontmatter (5a662789)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.18` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.18` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.18 && git push origin v0.1.0-alpha.18` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
