### PR TITLE
release: v0.1.0-alpha.19

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.0-alpha.19",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -133,7 +133,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.0-alpha.19",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -253,7 +253,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.0-alpha.19",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -271,7 +271,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.0-alpha.19",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -340,7 +340,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.0-alpha.19",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Publishes the merged Standard Library workflow and agent-onboarding fixes as the lockstep `0.1.0-alpha.19` package set.

```json
{
  "pyric": "0.1.0-alpha.19",
  "pyric-admin": "0.1.0-alpha.19",
  "create-pyric": "0.1.0-alpha.19",
  "@pyric/cli": "0.1.0-alpha.19",
  "@pyric/ui": "0.1.0-alpha.19"
}
```

## Alpha.19 exposes the service-aware Rules workflow to installed agents

The release moves the five package manifests in lockstep and refreshes `bun.lock`. Once published, the agent plugin's `@pyric/cli@latest` MCP server will expose `rules_stdlib_list`, `rules_stdlib_get`, and `rules_resolve_modules`, including Storage support.

## Risk

The version bump itself has no runtime logic, but publishing is irreversible. The merged commit must pass the full release preflight before any package is uploaded, and all five packages must publish at the same version.

<details>
<summary>Changes since v0.1.0-alpha.18</summary>

- `test: parse worker output as a classic script` (`60db48d5`)
- `ci: classify service-neutral rules tools` (`e5696f1f`)
- `feat: make rules standard library service-aware` (`d640c3fb`)
- `ci: stop snapshotting scaffold documentation` (`d824332e`)
- `docs: correct agent plugin onboarding` (`b7198026`)
- `ci: stop testing documentation` (`1c815940`)
- `test: remove stale Firestore example checks` (`f3317b91`)
- `docs: simplify examples and explain chess rules` (`e98cacf9`)

</details>

<details>
<summary>Release checklist</summary>

- [x] Merge this version-only release PR after required checks pass.
- [x] Run `bun run release:preflight 0.1.0-alpha.19` from the clean merged `main` commit and confirm that no packages or dist-tags changed.
- [x] Run `bash scripts/publish-alpha.sh 0.1.0-alpha.19` from that same commit.
- [x] Verify all five npm versions and their expected dist-tags.
- [x] Tag the published commit with `v0.1.0-alpha.19` and push the tag.
- [ ] Deploy the public site only if it should track this release.

</details>
