### PR TITLE
fix(storage): add in-memory persistence fallback for blocked IndexedDB and fix bare sandbox dynamic auth

### DIFF
--- a/packages/pyric/src/storage/persistence.ts
+++ b/packages/pyric/src/storage/persistence.ts
@@ -176,10 +176,61 @@ export interface StorageBackend {
  * production, callers pass nothing and inherit the default
  * `pyric-storage`.
  */
-export function openStorageBackend(
+export async function openStorageBackend(
   dbName: string = DEFAULT_DB_NAME,
 ): Promise<StorageBackend> {
-  return openDatabase(dbName).then((db) => new IndexedDbStorageBackend(db));
+  try {
+    const db = await openDatabase(dbName);
+    return new IndexedDbStorageBackend(db);
+  } catch (err) {
+    return new InMemoryStorageBackend();
+  }
+}
+
+class InMemoryStorageBackend implements StorageBackend {
+  private readonly blobs = new Map<string, Blob>();
+  private readonly metadata = new Map<string, StoredMetadata>();
+
+  async put(path: string, blob: Blob, metadata: StoredMetadata): Promise<void> {
+    this.blobs.set(path, blob);
+    this.metadata.set(path, metadata);
+  }
+
+  async getBlob(path: string): Promise<Blob | undefined> {
+    return this.blobs.get(path);
+  }
+
+  async getMetadata(path: string): Promise<StoredMetadata | undefined> {
+    return this.metadata.get(path);
+  }
+
+  async putMetadata(path: string, metadata: StoredMetadata): Promise<void> {
+    this.metadata.set(path, metadata);
+  }
+
+  async delete(path: string): Promise<void> {
+    this.blobs.delete(path);
+    this.metadata.delete(path);
+  }
+
+  async listByPrefix(prefix: string): Promise<StoredMetadata[]> {
+    const results: StoredMetadata[] = [];
+    const keys = Array.from(this.metadata.keys()).sort();
+    for (const key of keys) {
+      if (key.startsWith(prefix)) {
+        const meta = this.metadata.get(key);
+        if (meta) results.push(meta);
+      }
+    }
+    return results;
+  }
+
+  async reset(): Promise<void> {
+    this.blobs.clear();
+    this.metadata.clear();
+  }
+
+  close(): void {}
 }
 
 // ─── Internal ──────────────────────────────────────────────────────
@@ -246,21 +297,28 @@ class IndexedDbStorageBackend implements StorageBackend {
 
 function openDatabase(dbName: string): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(dbName, SCHEMA_VERSION);
-    req.addEventListener('upgradeneeded', () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(BLOBS_STORE)) {
-        db.createObjectStore(BLOBS_STORE);
+    try {
+      if (typeof indexedDB === 'undefined' || !indexedDB.open) {
+        return reject(new Error('IndexedDB not available'));
       }
-      if (!db.objectStoreNames.contains(METADATA_STORE)) {
-        db.createObjectStore(METADATA_STORE);
-      }
-    });
-    req.addEventListener('success', () => resolve(req.result));
-    req.addEventListener('error', () => reject(req.error));
-    req.addEventListener('blocked', () =>
-      reject(new Error(`IndexedDB open blocked for db "${dbName}"`)),
-    );
+      const req = indexedDB.open(dbName, SCHEMA_VERSION);
+      req.addEventListener('upgradeneeded', () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(BLOBS_STORE)) {
+          db.createObjectStore(BLOBS_STORE);
+        }
+        if (!db.objectStoreNames.contains(METADATA_STORE)) {
+          db.createObjectStore(METADATA_STORE);
+        }
+      });
+      req.addEventListener('success', () => resolve(req.result));
+      req.addEventListener('error', () => reject(req.error));
+      req.addEventListener('blocked', () =>
+        reject(new Error(`IndexedDB open blocked for db "${dbName}"`)),
+      );
+    } catch (err) {
+      reject(err);
+    }
   });
 }
 

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -293,6 +293,7 @@ export function getStorageSandbox(
     kind: 'sandbox',
     sandbox,
     context: ctx,
+    currentAuth: fromBareSandbox ? () => sandbox.currentUser : undefined,
     bucket,
     servicePromise,
   };


### PR DESCRIPTION
Adds an in-memory storage persistence fallback when IndexedDB is unavailable and binds dynamic user credentials on bare sandbox storage handles.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { getAuthSandbox } from 'pyric/auth';
import { getStorageSandbox, ref, uploadBytes } from 'pyric/storage';

// In an about:srcdoc preview iframe or headless test harness where indexedDB is undefined or blocked,
// openStorageBackend automatically falls back to an in-memory Blob and metadata store without throwing.
const sandbox = initializeSandbox({ projectId: 'storage-resilience-demo' });
const storage = getStorageSandbox(sandbox);
const auth = getAuthSandbox(sandbox);

// Storage handles initialized from bare sandboxes now resolve currentAuth dynamically against
// sandbox.currentUser, ensuring rule verifications evaluate against live authentication mutations.
await auth.signInWithEmailAndPassword('alice@example.com', 'secure-password-123');

const avatarRef = ref(storage, 'users/alice/avatar.png');
const fileBlob = new Blob(['PNG-DATA'], { type: 'image/png' });

// Succeeds against storage rules expecting request.auth.uid == 'alice'
await uploadBytes(avatarRef, fileBlob);
```

## openStorageBackend catches IndexedDB initialization exceptions and falls back to memory

```ts
export async function openStorageBackend(dbName: string = DEFAULT_DB_NAME): Promise<StorageBackend> {
  try {
    const db = await openDatabase(dbName);
    return new IndexedDbStorageBackend(db);
  } catch (err) {
    return new InMemoryStorageBackend();
  }
}
```

When `indexedDB.open` is restricted by browser security policies (such as in private browsing modes, third-party sandboxed preview frames, or server-side test environments), initialization no longer throws an uncaught rejection. `InMemoryStorageBackend` maintains identically structured Blob and metadata Maps for the lifetime of the session.

## getStorageSandbox on a bare sandbox evaluates rules against live auth mutations

When a caller initializes storage directly from a bare sandbox (`getStorageSandbox(sandbox)` rather than via a wrapped `FirebaseApp`), the internal driver directly registers `currentAuth: () => sandbox.currentUser`. Subsequent sign-in, sign-out, or user switching events reflect immediately in `request.auth` evaluations during file uploads and downloads.

## Risk

If a production consumer accidentally runs an app with blocked IndexedDB permissions in a standard web browser session, storage persistence will silently degrade to temporary in-memory session storage without emitting a hard console warning.

<details>
<summary>Implementation notes</summary>

- **Modified files:** 
  - `packages/pyric/src/storage/persistence.ts`
  - `packages/pyric/src/storage/service.ts`
- **Findings & decisions:** Implemented `InMemoryStorageBackend` complying fully with `StorageBackend` interface (`put`, `getBlob`, `getMetadata`, `putMetadata`, `delete`, `listByPrefix`, `reset`, `close`). Added safety try-catch checking for `typeof indexedDB === 'undefined'` before calling open.

</details>
