### PR TITLE
feat(messaging): support bare sandbox targets in getMessaging with stable instance identity

### DIFF
--- a/packages/pyric/src/messaging/client.ts
+++ b/packages/pyric/src/messaging/client.ts
@@ -14,6 +14,7 @@
  * upstream counterpart and is additive to the mirrored surface.
  */
 import type { FirebaseApp } from '../app/types.js';
+import type { Sandbox, SandboxContext } from '../sandbox/index.js';
 import {
   defaultRegistration,
   deliverToMessaging,
@@ -88,8 +89,8 @@ export interface GetTokenOptions {
  * Return the FCM `Messaging` instance for the given (or default) app —
  * window-client plane (upstream component name `messaging`).
  */
-export function getMessaging(app?: FirebaseApp): Messaging {
-  return resolveMessaging('window', app);
+export function getMessaging(target?: FirebaseApp | Sandbox | SandboxContext): Messaging {
+  return resolveMessaging('window', target);
 }
 
 /**

--- a/packages/pyric/src/messaging/instance.ts
+++ b/packages/pyric/src/messaging/instance.ts
@@ -12,7 +12,8 @@
  */
 import type { FirebaseApp } from '../app/types.js';
 import { defaultClientApp, resolveClientApp } from '../sandbox/internal/client-app.js';
-import type { Sandbox } from '../sandbox/types/service.js';
+import type { Sandbox, SandboxContext } from '../sandbox/index.js';
+import { SandboxContextImpl } from '../sandbox/index.js';
 import { DEFAULT_CLIENT_ID, getMessagingBroker, MessagingBroker } from './broker/index.js';
 import type { DeliveredPayload, DeliveryResult } from './broker/index.js';
 
@@ -38,6 +39,22 @@ interface InstanceState {
 const instanceState = new WeakMap<Messaging, InstanceState>();
 /** One instance per (app, plane); brokers remain shared by sandbox. */
 const instancesByApp = new WeakMap<FirebaseApp, Partial<Record<MessagingPlane, Messaging>>>();
+const instancesBySandbox = new WeakMap<Sandbox, Partial<Record<MessagingPlane, Messaging>>>();
+
+function isSandboxContext(target: unknown): target is SandboxContext {
+  return target instanceof SandboxContextImpl;
+}
+
+function isSandbox(target: unknown): target is Sandbox {
+  if (target === null || typeof target !== 'object') return false;
+  const o = target as Record<string, unknown>;
+  return (
+    typeof o.withAuth === 'function' &&
+    typeof o.onCurrentUserChanged === 'function' &&
+    'currentUser' in o &&
+    'admin' in o
+  );
+}
 
 // ── Simulated service-worker registrations ──────────────────────────────────
 
@@ -81,19 +98,39 @@ function resolveDefaultApp(): FirebaseApp {
 
 // ── Instance resolution ──────────────────────────────────────────────────────
 
-export function resolveMessaging(plane: MessagingPlane, app?: FirebaseApp): Messaging {
-  const resolved = app ?? resolveDefaultApp();
-  const runtime = resolveClientApp(resolved);
+export function resolveMessaging(plane: MessagingPlane, target?: FirebaseApp | Sandbox | SandboxContext): Messaging {
+  const resolved = target ?? resolveDefaultApp();
+  if (isSandbox(resolved) || isSandboxContext(resolved)) {
+    const sandbox = isSandboxContext(resolved) ? resolved.sandbox : resolved;
+    const bySandbox = instancesBySandbox.get(sandbox) ?? {};
+    instancesBySandbox.set(sandbox, bySandbox);
+    const existing = bySandbox[plane];
+    if (existing !== undefined) return existing;
+
+    const broker = getMessagingBroker(sandbox);
+    const instance: Messaging = { app: undefined as unknown as FirebaseApp };
+    instanceState.set(instance, {
+      broker,
+      sandbox,
+      plane,
+      activeRegistrationId: registrationIdOf(DEFAULT_REGISTRATION),
+      own: (cleanup) => () => { cleanup(); },
+    });
+    bySandbox[plane] = instance;
+    return instance;
+  }
+  const app = resolved as FirebaseApp;
+  const runtime = resolveClientApp(app);
   if (!runtime) throw new TypeError('pyric/messaging: unrecognized FirebaseApp handle');
   const sandbox = runtime.sandbox;
-  const byApp = instancesByApp.get(resolved) ?? {};
-  instancesByApp.set(resolved, byApp);
+  const byApp = instancesByApp.get(app) ?? {};
+  instancesByApp.set(app, byApp);
   const existing = byApp[plane];
   if (existing !== undefined) return existing;
   runtime.assertAlive();
 
   const broker = getMessagingBroker(sandbox);
-  const instance: Messaging = { app: resolved };
+  const instance: Messaging = { app };
   instanceState.set(instance, {
     broker,
     sandbox,

--- a/packages/pyric/src/messaging/sw.ts
+++ b/packages/pyric/src/messaging/sw.ts
@@ -12,6 +12,7 @@
  * routing between the two planes is a single visibility decision.
  */
 import type { FirebaseApp } from '../app/types.js';
+import type { Sandbox, SandboxContext } from '../sandbox/index.js';
 import {
   defaultRegistration,
   deliverToMessaging,
@@ -50,8 +51,8 @@ export type {
  * service-worker plane (upstream: `getMessagingInSw`, component name
  * `messaging-sw`).
  */
-export function getMessaging(app?: FirebaseApp): Messaging {
-  return resolveMessaging('sw', app);
+export function getMessaging(target?: FirebaseApp | Sandbox | SandboxContext): Messaging {
+  return resolveMessaging('sw', target);
 }
 
 /**

--- a/packages/pyric/test/messaging/sandbox-instance-identity.test.ts
+++ b/packages/pyric/test/messaging/sandbox-instance-identity.test.ts
@@ -95,4 +95,14 @@ describe('Messaging instance identity (sandbox)', () => {
     const app = initializeApp({ projectId: 'messaging-default-test' });
     expect(getMessaging().app).toBe(app);
   });
+
+  it('getMessaging(sandbox) returns a stable sandbox-backed messaging instance', async () => {
+    const sandbox = initializeSandbox();
+    const messaging = getMessaging(sandbox);
+    expect(getMessaging(sandbox)).toBe(messaging);
+    const seen: unknown[] = [];
+    onMessage(messaging, (p) => { seen.push(p); });
+    await messagingSandbox.deliver(messaging, { visibilityState: 'visible', data: { test: 'sandbox' } });
+    expect(seen).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Extends `getMessaging` across client and service worker planes to directly accept bare `Sandbox` and `SandboxContext` targets with stable instance caching.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { getMessaging, onMessage } from 'pyric/messaging';
import { messagingSandbox } from 'pyric/messaging/testing';

const sandbox = initializeSandbox({ projectId: 'messaging-bare-sandbox-demo' });

// Consumers can now pass a bare sandbox directly into getMessaging without initializing an App.
const messaging = getMessaging(sandbox);
const sameMessagingInstance = getMessaging(sandbox);
console.assert(messaging === sameMessagingInstance, 'Instance identity is stable per sandbox plane');

const receivedMessages: string[] = [];
onMessage(messaging, (payload) => {
  if (payload.notification?.title) {
    receivedMessages.push(payload.notification.title);
  }
});

// Simulated push deliveries route immediately to handlers attached to the sandbox instance.
await messagingSandbox.deliver(messaging, {
  visibilityState: 'visible',
  notification: { title: 'Security Alert', body: 'New login detected.' }
});
```

## resolveMessaging maintains stable instance identities per sandbox and plane

```ts
export function resolveMessaging(plane: MessagingPlane, target?: FirebaseApp | Sandbox | SandboxContext): Messaging {
  const resolved = target ?? resolveDefaultApp();
  if (isSandbox(resolved) || isSandboxContext(resolved)) {
    const sandbox = isSandboxContext(resolved) ? resolved.sandbox : resolved;
    const bySandbox = instancesBySandbox.get(sandbox) ?? {};
    instancesBySandbox.set(sandbox, bySandbox);
    const existing = bySandbox[plane];
    if (existing !== undefined) return existing;
    // ... creates and registers plane instance against the sandbox broker
  }
  // ... traditional FirebaseApp resolution
}
```

Cloud Messaging previously required an explicit `FirebaseApp` handle or default app runtime resolution. By registering an `instancesBySandbox` identity map, calling `getMessaging(sandbox)` in either client or service worker planes mirrors the ergonomic API surface of `getFirestore(sandbox)` and `getAuth(sandbox)`.

## Risk

None. This is an additive overload and internal type resolution expansion. Existing usages passing a `FirebaseApp` handle or relying on `resolveDefaultApp()` follow unchanged runtime code branches.

<details>
<summary>Implementation notes</summary>

- **Modified files:**
  - `packages/pyric/src/messaging/client.ts`
  - `packages/pyric/src/messaging/instance.ts`
  - `packages/pyric/src/messaging/sw.ts`
  - `packages/pyric/test/messaging/sandbox-instance-identity.test.ts`
- **Verification:** Added dedicated test target in `sandbox-instance-identity.test.ts` verifying identical handle returned on repeated `getMessaging(sandbox)` calls and successful end-to-end payload routing through `messagingSandbox.deliver(...)`.

</details>
