### PR TITLE
fix(rtdb): support scientific notation and single-quoted string escapes in rules

### DIFF
--- a/packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm
+++ b/packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm
@@ -59,8 +59,11 @@ RtdbExpr {
     | null
 
   number
-    = digit+ "." digit+  -- float
-    | digit+              -- int
+    = digit+ "." digit+ exponent?  -- float
+    | digit+ exponent              -- exp
+    | digit+                       -- int
+
+  exponent = ("e" | "E") ("+" | "-")? digit+
 
   string
     = "\"" doubleStringChar* "\""  -- double

--- a/packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm.generated.ts
+++ b/packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm.generated.ts
@@ -63,8 +63,11 @@ export const RTDB_EXPR_OHM_SOURCE = `RtdbExpr {
     | null
 
   number
-    = digit+ "." digit+  -- float
-    | digit+              -- int
+    = digit+ "." digit+ exponent?  -- float
+    | digit+ exponent              -- exp
+    | digit+                       -- int
+
+  exponent = ("e" | "E") ("+" | "-")? digit+
 
   string
     = "\\"" doubleStringChar* "\\""  -- double

--- a/packages/pyric/src/rules/rtdb/grammar/simulator.ts
+++ b/packages/pyric/src/rules/rtdb/grammar/simulator.ts
@@ -29,6 +29,32 @@ function safeMemberRead(recv: unknown, key: string): unknown {
   return (recv as Record<string, unknown>)[key] ?? null;
 }
 
+/** Process standard escape sequences in single-quoted string literals. */
+function processStringEscapes(raw: string): string {
+  let out = '';
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (c !== '\\' || i === raw.length - 1) {
+      out += c;
+      continue;
+    }
+    const next = raw[++i];
+    switch (next) {
+      case '\\': out += '\\'; break;
+      case '\'': out += '\''; break;
+      case '"':  out += '"';  break;
+      case 'n':  out += '\n'; break;
+      case 'r':  out += '\r'; break;
+      case 't':  out += '\t'; break;
+      case 'b':  out += '\b'; break;
+      case 'f':  out += '\f'; break;
+      case '/':  out += '/';  break;
+      default:   out += '\\' + next; break;
+    }
+  }
+  return out;
+}
+
 export interface EvalContext {
   auth: SimulatedAuth | null;
   data: DataSnapshot;
@@ -289,7 +315,8 @@ function getEvalSemantics(): Semantics {
 
     literal(node) { return (node as any).eval(); },
 
-    number_float(_int, _dot, _frac) { return parseFloat(this.sourceString); },
+    number_float(_int, _dot, _frac, _exp) { return parseFloat(this.sourceString); },
+    number_exp(_digits, _exp) { return parseFloat(this.sourceString); },
     number_int(_digits) { return parseInt(this.sourceString, 10); },
     number(node) { return (node as any).eval(); },
 
@@ -297,7 +324,7 @@ function getEvalSemantics(): Semantics {
       return JSON.parse(this.sourceString);
     },
     string_single(_open, chars, _close) {
-      return chars.children.map((c: any) => c.sourceString).join('');
+      return processStringEscapes(chars.sourceString);
     },
     string(node) { return (node as any).eval(); },
 

--- a/packages/pyric/test/rules/rtdb/grammar/RtdbExprParser.test.ts
+++ b/packages/pyric/test/rules/rtdb/grammar/RtdbExprParser.test.ts
@@ -109,4 +109,33 @@ describe('parseExpression', () => {
     expect(result.referencedIdentifiers).toContain('auth');
     expect(result.referencedIdentifiers).toContain('newData');
   });
+
+  describe('scientific notation parsing', () => {
+    test('parses integer with exponent', () => {
+      expect(parseExpression('data.val() < 1e3').valid).toBe(true);
+      expect(parseExpression('data.val() === 2E5').valid).toBe(true);
+      expect(parseExpression('data.val() > 10e0').valid).toBe(true);
+    });
+
+    test('parses scientific notation with negative exponent', () => {
+      expect(parseExpression('data.val() === 1e-3').valid).toBe(true);
+      expect(parseExpression('data.val() === 5E-2').valid).toBe(true);
+    });
+
+    test('parses scientific notation with positive exponent sign', () => {
+      expect(parseExpression('data.val() === 1e+3').valid).toBe(true);
+      expect(parseExpression('data.val() === 2E+4').valid).toBe(true);
+    });
+
+    test('parses float base with exponent', () => {
+      expect(parseExpression('newData.val() >= 1.5e-2').valid).toBe(true);
+      expect(parseExpression('newData.val() <= 2.0E+3').valid).toBe(true);
+    });
+
+    test('rejects incomplete exponent syntax cleanly', () => {
+      expect(parseExpression('1e').valid).toBe(false);
+      expect(parseExpression('1e+').valid).toBe(false);
+      expect(parseExpression('1.5e-').valid).toBe(false);
+    });
+  });
 });

--- a/packages/pyric/test/rules/rtdb/grammar/simulator.test.ts
+++ b/packages/pyric/test/rules/rtdb/grammar/simulator.test.ts
@@ -173,4 +173,58 @@ describe('evaluateRtdbExpression', () => {
     const missingBody = { ...baseCtx, newData: new DataSnapshot({ title: 't' }) };
     expect(evalExpr("newData.hasChildren(['title', 'body'])", missingBody)).toBe(false);
   });
+
+  describe('scientific notation evaluation', () => {
+    test('evaluates scientific notation comparisons correctly', () => {
+      const under1k = { ...baseCtx, data: new DataSnapshot(500) };
+      const over1k = { ...baseCtx, data: new DataSnapshot(1500) };
+      expect(evalExpr('data.val() < 1e3', under1k)).toBe(true);
+      expect(evalExpr('data.val() < 1e3', over1k)).toBe(false);
+    });
+
+    test('evaluates scientific notation with decimals and negative exponents', () => {
+      const smallVal = { ...baseCtx, data: new DataSnapshot(0.015) };
+      expect(evalExpr('data.val() === 1.5e-2', smallVal)).toBe(true);
+    });
+
+    test('preserves subtraction precedence with scientific notation', () => {
+      const fiveHundred = { ...baseCtx, data: new DataSnapshot(500) };
+      expect(evalExpr('data.val() === 1e3 - 500', fiveHundred)).toBe(true);
+    });
+  });
+
+  describe('single-quoted string escape resolution', () => {
+    test('resolves newline and tab escapes', () => {
+      const newlineData = { ...baseCtx, data: new DataSnapshot('hello\nworld') };
+      expect(evalExpr("data.val() === 'hello\\nworld'", newlineData)).toBe(true);
+
+      const tabData = { ...baseCtx, data: new DataSnapshot('col1\tcol2') };
+      expect(evalExpr("data.val() === 'col1\\tcol2'", tabData)).toBe(true);
+    });
+
+    test('resolves escaped single quotes and backslashes', () => {
+      const apostropheData = { ...baseCtx, data: new DataSnapshot("it's a test") };
+      expect(evalExpr("data.val() === 'it\\'s a test'", apostropheData)).toBe(true);
+
+      const slashData = { ...baseCtx, data: new DataSnapshot('a\\b') };
+      expect(evalExpr("data.val() === 'a\\\\b'", slashData)).toBe(true);
+    });
+
+    test('resolves carriage return and double quotes', () => {
+      const crData = { ...baseCtx, data: new DataSnapshot('line1\r\nline2') };
+      expect(evalExpr("data.val() === 'line1\\r\\nline2'", crData)).toBe(true);
+
+      const quoteData = { ...baseCtx, data: new DataSnapshot('he said "hi"') };
+      expect(evalExpr("data.val() === 'he said \\\"hi\\\"'", quoteData)).toBe(true);
+    });
+
+    test('single-quoted and double-quoted string literals evaluate to identical values', () => {
+      expect(evalExpr("'a\\nb\\tc'", baseCtx)).toBe(evalExpr('"a\\nb\\tc"', baseCtx));
+    });
+
+    test('preserves unrecognized escape sequences safely without throwing', () => {
+      const unrecognized = { ...baseCtx, data: new DataSnapshot('\\z') };
+      expect(evalExpr("data.val() === '\\z'", unrecognized)).toBe(true);
+    });
+  });
 });

--- a/packages/pyric/test/rules/rtdb/simulation/handler.test.ts
+++ b/packages/pyric/test/rules/rtdb/simulation/handler.test.ts
@@ -970,4 +970,44 @@ describe('SimulateHandler — atomic multi-path update projection', () => {
     });
     expect(partial.success && partial.data.allowed).toBe(false);
   });
+
+  test('enforces validate rule with single-quoted string escape sequence', () => {
+    const expr = (raw: string) => ({
+      raw,
+      parsed: { raw, valid: true, errors: [], warnings: [], referencedIdentifiers: ['newData'] },
+    });
+    const rules: RtdbNode = {
+      path: '/',
+      pathVariables: [],
+      children: [
+        {
+          path: '/logs',
+          pathVariables: [],
+          write: expr('true'),
+          validate: expr("newData.val() === 'line1\\nline2'"),
+          children: [],
+        },
+      ],
+    };
+
+    // Passing write with exact newline
+    const allowResult = handler.execute(rules, {
+      operation: 'write',
+      path: '/logs',
+      auth: { uid: 'user1', token: {} },
+      mockData: {},
+      newData: 'line1\nline2',
+    });
+    expect(allowResult.success && allowResult.data.allowed).toBe(true);
+
+    // Denied write with literal backslash n
+    const denyResult = handler.execute(rules, {
+      operation: 'write',
+      path: '/logs',
+      auth: { uid: 'user1', token: {} },
+      mockData: {},
+      newData: 'line1\\nline2',
+    });
+    expect(denyResult.success && denyResult.data.allowed).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes parsing of scientific notation numbers and escape resolution in single-quoted string literals within the RTDB rules engine.

```ts
import { rtdbRules } from 'pyric/rules/rtdb';

const rules = rtdbRules({
  rules: {
    sensors: {
      $id: {
        // Scientific notation numbers in comparisons now parse and evaluate
        ".write": "newData.child('threshold').val() < 1e3 && newData.child('ratio').val() >= 1.5e-2",
        // Single-quoted strings now unescape backslash sequences like \n and \'
        ".validate": "newData.child('notes').val() === 'line1\\nline2' && newData.child('tag').val() === 'it\\'s valid'"
      }
    }
  }
});

// A sensor payload satisfying both rules is allowed
const result = rules.simulate({
  operation: 'write',
  path: '/sensors/s1',
  auth: null,
  newData: {
    threshold: 500,           // 500 < 1000 -> true
    ratio: 0.02,              // 0.02 >= 0.015 -> true
    notes: "line1\nline2",    // matches unescaped newline -> true
    tag: "it's valid"         // matches unescaped single quote -> true
  }
});

console.log(result.allowed); // true (previously rejected by parse error and escape mismatch)
```

## RTDB expressions accept scientific notation in number literals

The Ohm grammar (`RtdbExpr.ohm`) previously defined `number` as only integer (`digit+`) or decimal float (`digit+ "." digit+`), rejecting scientific notation:

```ts
import { parseExpression } from 'packages/pyric/src/rules/rtdb/grammar/RtdbExprParser.js';

parseExpression('data.val() < 1e3');        // now valid: true (was valid: false)
parseExpression('newData.val() >= 1.5e-2'); // now valid: true (was valid: false)
```

The grammar extends `number` with an `exponent` production evaluated with PEG ordered choice (`float` with optional exponent, then integer `exp`, then `int`), ensuring decimal bases like `1.5e-2` are not shadowed and negative exponents like `1e-3` parse greedily without colliding with binary subtraction operators.

## Single-quoted string literals resolve backslash escapes during evaluation

While double-quoted strings were unescaped via `JSON.parse`, `string_single` in `simulator.ts` joined raw parsed character slices without escape processing. Backslash sequences (such as `\n`, `\t`, `\r`, `\'`, `\"`, and `\\`) remained literal escape characters instead of resolving to their unescaped characters during rule evaluation.

Single-quoted literals now pass through `processStringEscapes`, matching the behavior of double-quoted strings:

```ts
import { evaluateRtdbExpression, DataSnapshot } from 'packages/pyric/src/rules/rtdb/grammar/simulator.js';

const ctx = {
  auth: null,
  data: new DataSnapshot('hello\nworld'),
  newData: new DataSnapshot(null),
  root: new DataSnapshot(null),
  now: Date.now(),
  pathVariableBindings: {},
};

// Evaluates to true against string containing an actual newline
evaluateRtdbExpression("data.val() === 'hello\\nworld'", ctx); // true (was false)
```

## Risk

Low.
- **Ordered choice in grammar**: Exponent syntax requires at least one digit (`("e" | "E") ("+" | "-")? digit+`), ensuring incomplete tokens (e.g. `1e`) fail parsing cleanly as before rather than misparsing.
- **Operator precedence**: Expressions combining subtraction and exponents (such as `1e3 - 500 === 500`) remain unambiguous in the PEG grammar.
- **Scope**: Escape processing applies exclusively to single-quoted string literals (`string_single`). Regex literals (`/pattern/flags`) use distinct grammar rules and remain untouched.

<details>
<summary>Implementation notes</summary>

- Modified files:
  - `packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm`: Added `exponent` rule to `number`.
  - `packages/pyric/src/rules/rtdb/grammar/RtdbExpr.ohm.generated.ts`: Inlined grammar regenerated via `bun run inline-grammar`.
  - `packages/pyric/src/rules/rtdb/grammar/simulator.ts`: Added `processStringEscapes` helper and wired `number_exp` / `number_float` / `string_single` semantics.
- Tests added:
  - `packages/pyric/test/rules/rtdb/grammar/RtdbExprParser.test.ts`: Added positive and negative syntax parsing tests for scientific notation.
  - `packages/pyric/test/rules/rtdb/grammar/simulator.test.ts`: Added evaluation tests for scientific notation and single-quoted escapes (`\n`, `\t`, `\r`, `\'`, `\\`).
  - `packages/pyric/test/rules/rtdb/simulation/handler.test.ts`: Added end-to-end `.validate` rule simulation test.
- Verification:
  - `bun test packages/pyric/test/rules/rtdb/`: 286 pass, 0 fail (all 19 files).
  - `bun test packages/pyric/test/rules/rtdb/rules-conformance.test.ts`: 33 pass, 0 fail across all 15 production oracle scenarios.
  - `bun run compat:rules-score`: 56/56 RTDB rules constructs pass, matching baselines.
  - `bun run --cwd packages/pyric typecheck`: 0 errors.
  - `bun run --cwd packages/pyric build`: clean build.

</details>
