### PR TITLE
docs(priorities): note proof selection activation under build velocity

### DIFF
--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -61,6 +61,7 @@ The feedback loop: local builds, tests, and CI should surface useful results qui
 
 **Now:**
 - Measure recent GitHub Actions runs and identify the critical path
+- Activate enforced CI check-set selection to bypass heavy matrix jobs on pure documentation changes
 - Shorten pull-request feedback time by removing redundant work and improving parallelism and caching
 - Keep release confidence intact while making the common local and CI loops faster
 


### PR DESCRIPTION
Updates `PRIORITIES.md` to reflect the active activation of enforced CI proof selection under Build Velocity.

```markdown
// PRIORITIES.md
**Now:**
- Measure recent GitHub Actions runs and identify the critical path
- Activate enforced CI check-set selection to bypass heavy matrix jobs on pure documentation changes
- Shorten pull-request feedback time by removing redundant work and improving parallelism and caching
```

## PRIORITIES documentation notes enforced CI proof selection

Documents the active enforcement of proof selection in CI under the Build Velocity section of `PRIORITIES.md`.

## Risk

None. This is an internal documentation update to `PRIORITIES.md`. Under the newly enforced CI policy, this qualifies for the `docs-only` fast path.

<details>
<summary>Implementation notes</summary>

- Pure documentation change intended to empirically verify the `docs-only` fast path in CI.
</details>