### PR TITLE
feat(ci): add upstream build-packages stage to eliminate parallel compilation fanout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
           CI_PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: bun scripts/ci/plan.ts
 
-  build-and-test:
-    name: Build all packages + run tests
+  build-packages:
+    name: Build workspace packages
     runs-on: ubuntu-latest
     needs: plan
     if: needs.plan.outputs.check-set == 'full'
@@ -95,6 +95,26 @@ jobs:
         # their annotations stale until the contract is updated deliberately.
         run: bun run tool:parity:check
 
+  build-and-test:
+    name: Build all packages + run tests
+    runs-on: ubuntu-latest
+    needs: [plan, build-packages]
+    if: needs.plan.outputs.check-set == 'full'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install
+        run: bun install --frozen-lockfile --filter '!@pyric/playground'
+
+      - name: Build packages (site omitted)
+        uses: ./.github/actions/restore-dist
+        with:
+          flavor: packages
+
       - name: Run CLI tests
         # Deliberately unpaired: the CLI suite is load-sensitive under CPU
         # contention (verify replays flip verdicts when the suite shares a
@@ -106,7 +126,7 @@ jobs:
   library-tests:
     name: Run library + UI tests
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
       - uses: actions/checkout@v4
@@ -136,7 +156,7 @@ jobs:
   conformance-suite:
     name: Conformance suite
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
       - uses: actions/checkout@v4
@@ -157,7 +177,7 @@ jobs:
   browser-conformance:
     name: Served app + SharedWorker conformance
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
       - uses: actions/checkout@v4
@@ -222,7 +242,7 @@ jobs:
   conformance-gates:
     name: Conformance gates
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
       - uses: actions/checkout@v4
@@ -389,7 +409,7 @@ jobs:
     name: CI / required
     runs-on: ubuntu-latest
     if: always()
-    needs: [plan, build-and-test, library-tests, conformance-suite, browser-conformance, conformance-gates, release-contract, packaging, install-matrix, standalone]
+    needs: [plan, build-packages, build-and-test, library-tests, conformance-suite, browser-conformance, conformance-gates, release-contract, packaging, install-matrix, standalone]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/scripts/ci/dist-cache.test.ts
+++ b/scripts/ci/dist-cache.test.ts
@@ -18,6 +18,7 @@ function jobBlock(id: string): string {
 describe('CI dist cache', () => {
   test('every always-on job that needs the build goes through restore-dist', () => {
     for (const id of [
+      'build-packages',
       'build-and-test',
       'library-tests',
       'conformance-suite',

--- a/scripts/ci/required.test.ts
+++ b/scripts/ci/required.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { requiredFailures } from './required.ts';
 
 const success = {
+  'build-packages': 'success',
   'build-and-test': 'success',
   'library-tests': 'success',
   'conformance-suite': 'success',
@@ -30,7 +31,7 @@ describe('required CI result', () => {
     expect(requiredFailures({
       checkSet: 'release-only',
       requirePackaging: false,
-      results: { ...success, 'build-and-test': 'skipped', 'library-tests': 'skipped', 'conformance-suite': 'skipped', 'browser-conformance': 'skipped', 'conformance-gates': 'skipped', 'release-contract': 'success' },
+      results: { ...success, 'build-packages': 'skipped', 'build-and-test': 'skipped', 'library-tests': 'skipped', 'conformance-suite': 'skipped', 'browser-conformance': 'skipped', 'conformance-gates': 'skipped', 'release-contract': 'success' },
     })).toEqual([]);
   });
 

--- a/scripts/ci/required.ts
+++ b/scripts/ci/required.ts
@@ -9,7 +9,7 @@ interface RequiredInput {
 }
 
 const CHECK_SET_JOBS: Record<PrCheckSet, readonly string[]> = {
-  full: ['build-and-test', 'library-tests', 'conformance-suite', 'browser-conformance', 'conformance-gates'],
+  full: ['build-packages', 'build-and-test', 'library-tests', 'conformance-suite', 'browser-conformance', 'conformance-gates'],
   'release-only': ['release-contract'],
   'docs-only': [],
 };


### PR DESCRIPTION
Introduces an upstream `build-packages` job that compiles packages once and populates the content-keyed dist cache, eliminating redundant package compilations across parallel test jobs.

```yaml
# .github/workflows/build.yml
build-packages:
  name: Build workspace packages
  runs-on: ubuntu-latest
  needs: plan
  if: needs.plan.outputs.check-set == 'full'
  steps:
    - uses: actions/checkout@v4
    - uses: oven-sh/setup-bun@v2
    - name: Install
      run: bun install --frozen-lockfile --filter '!@pyric/playground'
    - uses: ./.github/actions/restore-dist
      with:
        flavor: packages
```

## Upstream build stage eliminates 4x parallel compilation stampede on cache misses

Previously, four test jobs (`build-and-test`, `library-tests`, `conformance-suite`, and `conformance-gates`) all started simultaneously from `plan`. Whenever build inputs changed, all four jobs experienced a cache miss, ran `scripts/build.sh --packages-only` in parallel (taking 22–23s on average and 78–80s at P90), and raced to save identical cache entries.

Extracting package compilation into an upstream `build-packages` stage ensures the build runs exactly once. Downstream test jobs now receive guaranteed cache hits during `restore-dist` (~2s) and run their respective test suites immediately without duplicate compilation.

## Risk

Downstream test jobs now wait for `build-packages` to complete before starting. When build inputs change, `build-packages` takes ~22s, but each downstream job saves 22–78s of compilation and avoids cache upload contention. When build inputs are unchanged, `build-packages` restores in ~2s, adding negligible latency to cached runs.

<details>
<summary>Implementation notes</summary>

- Added `build-packages` to `.github/workflows/build.yml` and set `needs: [plan, build-packages]` on downstream test jobs.
- Added `build-packages` to `CHECK_SET_JOBS['full']` in `scripts/ci/required.ts`.
- Updated test assertions in `scripts/ci/required.test.ts` and `scripts/ci/dist-cache.test.ts`.
- All 21 CI suite unit tests pass (`bun test scripts/ci/check-set.test.ts scripts/ci/plan.test.ts scripts/ci/required.test.ts scripts/ci/dist-cache.test.ts`).
</details>