### PR TITLE
feat(cli): implement pyric sandbox command and pyric.json configuration

### DIFF
--- a/examples/nextjs-sandbox-app/package.json
+++ b/examples/nextjs-sandbox-app/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Reference example: a Next.js app wrapped with @pyric/cli/next — `pyric dev -- next dev` runs against the local sandbox, `next build` ships real Firebase. This is the shape `pyric init --template nextjs` scaffolds.",
   "scripts": {
-    "dev": "pyric dev -- next dev",
+    "dev": "pyric sandbox -- next dev",
     "dev:direct": "next dev",
     "build": "next build",
     "start": "next start",

--- a/examples/nextjs-sandbox-app/playwright.config.ts
+++ b/examples/nextjs-sandbox-app/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: `bun ${cli} dev --port 4288 --no-open -- bun x next dev --port 4289`,
+    command: `bun ${cli} sandbox --port 4288 --no-open -- bun x next dev --port 4289`,
     url: 'http://127.0.0.1:4289',
     reuseExistingServer: true,
     timeout: 60_000,

--- a/packages/cli/scripts/standalone-smoke.ts
+++ b/packages/cli/scripts/standalone-smoke.ts
@@ -57,7 +57,7 @@ check('firestore rules validate', validate.code === 0);
 // ── Embedded serve (the headline path) ────────────────────────────────
 writeFileSync(join(work, 'index.html'), '<!doctype html><html><body>smoke</body></html>');
 const PORT = 5310;
-const child = spawn(BIN, ['dev', '--port', String(PORT), '--no-open', '--no-watch', '--ui', '--json'], {
+const child = spawn(BIN, ['sandbox', '--port', String(PORT), '--no-open', '--no-watch', '--ui', '--json'], {
   cwd: work,
   stdio: ['ignore', 'pipe', 'pipe'],
 });

--- a/packages/cli/src/cli/dev-runner.ts
+++ b/packages/cli/src/cli/dev-runner.ts
@@ -94,36 +94,63 @@ export interface DevChildPlan {
 }
 
 /**
+ * Tokenize a command string into an argv array, preserving quoted strings.
+ */
+export function parseCommandString(cmd: string): string[] {
+  const parts: string[] = [];
+  const regex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(cmd)) !== null) {
+    if (match[1] !== undefined) {
+      parts.push(match[1]);
+    } else if (match[2] !== undefined) {
+      parts.push(match[2]);
+    } else {
+      parts.push(match[0]);
+    }
+  }
+  return parts;
+}
+
+/**
  * Decide what (if anything) to run after the host is up.
  *
- * Matrix:
- *   --no-run                → null, always
- *   `-- <cmd>`              → that command (wins over everything else)
- *   --json (no `--`)        → null (machine mode defaults to host-only)
- *   package.json dev script → `<pm> run dev`
- *   none of the above       → null (host-only, today's behavior)
- *
- * A `dev` script that itself invokes `pyric dev` is treated as absent —
- * running it would recurse forever (pyric dev → npm run dev → pyric dev …).
+ * Precedence:
+ *   --no-run                                → null, always
+ *   explicit CLI command (args or `--`)     → that command (wins over everything else)
+ *   --json (with no explicit command)       → null (machine mode defaults to host-only)
+ *   pyric.json `command`                    → parsed command argv
+ *   none of the above                       → null (host-only)
  */
-export function resolveDevChild(opts: {
-  passthrough: string[];
-  noRun: boolean;
-  json: boolean;
-  devScript: string | null;
-  packageManager: PackageManager;
+export function resolveSandboxChild(opts: {
+  explicitCommand?: string[] | null;
+  passthrough?: string[];
+  configCommand?: string | null;
+  noRun?: boolean;
+  json?: boolean;
+  devScript?: string | null;
+  packageManager?: PackageManager;
 }): DevChildPlan | null {
   if (opts.noRun) return null;
-  if (opts.passthrough.length > 0) {
-    return { argv: [...opts.passthrough], label: opts.passthrough.join(' ') };
+  const cmd =
+    opts.explicitCommand && opts.explicitCommand.length > 0
+      ? opts.explicitCommand
+      : opts.passthrough && opts.passthrough.length > 0
+        ? opts.passthrough
+        : null;
+  if (cmd) {
+    return { argv: [...cmd], label: cmd.join(' ') };
   }
   if (opts.json) return null;
-  if (opts.devScript && !/(^|[\s;&|])pyric\s+dev\b/.test(opts.devScript)) {
-    const label = `${opts.packageManager} run dev`;
-    return { argv: [opts.packageManager, 'run', 'dev'], label };
+  if (opts.configCommand && opts.configCommand.trim().length > 0) {
+    const trimmed = opts.configCommand.trim();
+    const argv = parseCommandString(trimmed);
+    return { argv, label: trimmed };
   }
   return null;
 }
+
+export const resolveDevChild = resolveSandboxChild;
 
 // ─── Environment for the child (pure) ──────────────────────────────────────
 
@@ -236,16 +263,52 @@ export function spawnDevChild(
   plan: DevChildPlan,
   opts: { cwd: string; env: NodeJS.ProcessEnv; json: boolean },
 ): DevChildHandle {
-  const [command, ...args] = plan.argv;
-  const child = spawn(command!, args, {
-    cwd: opts.cwd,
-    env: opts.env,
-    stdio: ['inherit', 'pipe', 'pipe'],
-    // Own a process group so shutdown reaches package-manager grandchildren
-    // (for example `bun run dev` -> `node server.js`) rather than orphaning
-    // the actual dev server when only the runner exits.
-    detached: process.platform !== 'win32',
-  });
+  const parts = [...plan.argv];
+  const env: NodeJS.ProcessEnv = { ...opts.env };
+
+  // 1. Extract leading KEY=VAL assignments (e.g. PORT=8080 node server.js)
+  while (parts.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(parts[0]!)) {
+    const token = parts.shift()!;
+    const eq = token.indexOf('=');
+    const key = token.slice(0, eq);
+    const val = token.slice(eq + 1);
+    env[key] = val;
+  }
+
+  // 2. Check for shell operators (&&, ||, |, ;) in the command
+  const hasShellOperators =
+    plan.label.includes('&&') ||
+    plan.label.includes('||') ||
+    plan.label.includes('|') ||
+    plan.label.includes(';');
+
+  // 3. Warn if runtime is bun or deno
+  if (parts.length > 0 && (parts[0] === 'bun' || parts[0] === 'deno')) {
+    const runner = parts[0];
+    const target = opts.json ? process.stderr : process.stdout;
+    target.write(
+      `  ⚠ ${runner} detected: pyric intercepts Firebase imports via Node.js module loader hooks (NODE_OPTIONS="--import ..."). ` +
+        `${runner} does not evaluate Node loader hooks — SDK calls in this process will not reach the pyric sandbox. ` +
+        `Use \`node\` (or \`npx tsx\`) to run with the sandbox swap.\n`,
+    );
+  }
+
+  const [command, ...args] = parts;
+  const child = hasShellOperators
+    ? spawn(plan.label, [], {
+        cwd: opts.cwd,
+        env,
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: true,
+        detached: process.platform !== 'win32',
+      })
+    : spawn(command!, args, {
+        cwd: opts.cwd,
+        env,
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: process.platform === 'win32',
+        detached: process.platform !== 'win32',
+      });
 
   const outTarget = opts.json ? process.stderr : process.stdout;
   const out = createLinePrefixer('[dev] ', (line) => outTarget.write(line));

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -4,7 +4,7 @@
  *
  * Subcommands:
  *   pyric bridge [--port N] [--project ID]
- *   pyric dev [--port N] [--host H] [--no-cache] [--bridge] [--ui] [--seed FILE] [--no-watch] [--no-open] [--no-capture] [--no-run] [--json] [--persist] [--fresh] [-- <cmd>]
+ *   pyric sandbox [command...] [--port N] [--host H] [--no-cache] [--bridge] [--ui] [--seed FILE] [--no-watch] [--no-open] [--no-capture] [--no-run] [--json] [--persist] [--fresh] [-- <cmd>]
  *   pyric init [dir] [--template web|node] [--name N] [--force] [--json]
  *   pyric vendor [dir] [--json]
  *   pyric snapshot [--out FILE] [--port N] [--force] [--json] [--include-passwords]
@@ -60,7 +60,7 @@ clients (Claude Code, Cursor, ...).
 
 USAGE
   pyric bridge [flags]
-  pyric dev [flags] [-- <cmd>]
+  pyric sandbox [command...] [flags]
   pyric init [dir] [--template=web|node]
   pyric snapshot [--out=FILE]
   pyric verify [fixture|dir] [--engine sandbox|rules-test-api|both]
@@ -83,16 +83,14 @@ USAGE
 
 COMMANDS
   bridge                     Start the HTTP+WebSocket bridge external MCP clients point at.
-  dev                        Serve the app locally with the pyric sandbox standing in for
-                             Firebase — unmodified firebase/* imports hit an in-page sandbox
-                             with your firestore.rules deployed. Also runs your own dev
-                             command (\`-- <cmd>\`, else the package.json \`dev\` script) with
-                             unchanged firebase-admin/firebase imports routed to the
-                             sandbox (PYRIC_SANDBOX + \`--import @pyric/cli/register\`). A
-                             firebase.json Functions source is discovered automatically;
+  sandbox [command...]       Run an application command or script inside the local Firebase sandbox
+                             with unmodified firebase/* and firebase-admin/* imports routed to the
+                             in-memory mirror. When [command...] is omitted, runs the command
+                             configured in pyric.json; if none is configured, runs the sandbox host only.
+                             A firebase.json Functions source is discovered automatically;
                              supported RTDB onValueCreated exports run in isolated Node.
   init [dir]                 Scaffold a pyric project. --template=web (default; Vite app
-                             on \`@pyric/cli/vite\`), static (\`pyric dev\`), or node.
+                             on \`@pyric/cli/vite\`), static (\`pyric sandbox\`), or node.
                              --name=NAME --force (overwrite scaffold files) --json (machine
                              output on stdout). Never prompts; rerunning is safe.
                              Greenfield shortcut: \`npm create pyric [dir]\`.
@@ -102,15 +100,15 @@ COMMANDS
                              bun install. Standalone binary only.
   mcp                        Stdio MCP server for editors (Cursor / Claude /
                              Antigravity). Hosts a headless in-process sandbox,
-                             or attaches to a running \`pyric dev --bridge\`
+                             or attaches to a running \`pyric sandbox --bridge\`
                              (found via .pyric/serve.json) for shared-live Studio.
   snapshot [--out=FILE]      Promote lived sandbox state (live dev --persist, else
                              .pyric/state/state.json) to a committable fixture that
-                             \`pyric dev --seed FILE\` re-serves. Passwords are redacted
+                             \`pyric sandbox --seed FILE\` re-serves. Passwords are redacted
                              by default (--include-passwords keeps them). --port, --force, --json.
   verify [fixture|dir]       Replay a captured sandbox session against candidate rules
                              for the Firestore/RTDB services present in the fixture.
-                             No arg replays the latest \`pyric dev\` capture
+                             No arg replays the latest \`pyric sandbox\` capture
                              (.pyric/last-session.json). --service filters services.
                              --engine sandbox (default), rules-test-api, or both.
                              Hosted Rules Test API verification is Firestore-only
@@ -135,7 +133,7 @@ COMMANDS
   database rules validate    Validate Realtime Database rules expressions.
   database rules simulate    Run the local Realtime Database rules simulator.
   database rules generate    Compile a constraints module to database.rules.json.
-CORE FLAGS (dev)
+CORE FLAGS (sandbox)
   --port             Port to serve on. Default 3473 — "FIRE" on a phone keypad (scans forward when taken;
                      macOS AirPlay squats 5000).
   --host             Host to bind. Default localhost.
@@ -337,7 +335,7 @@ export async function dispatch(parsed: ParsedArgs): Promise<number> {
       return parsed.subcommand === null ? 0 : 1;
     case 'bridge':
       return await runBridge(parsed);
-    case 'dev':
+    case 'sandbox':
       const { runServe } = await import('./serve.js');
       return runServe(parsed);
     case 'snapshot':

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -40,11 +40,25 @@ function isBooleanFlag(key: string): boolean {
   return BOOLEAN_FLAGS.has(key) || key.startsWith('no-');
 }
 
-const SHORT_ALIASES: ReadonlyMap<string, { key: string; takesValue: boolean }> = new Map([
-  ['p', { key: 'port', takesValue: true }],
-  ['h', { key: 'help', takesValue: false }],
-  ['v', { key: 'version', takesValue: false }],
+const SHORT_VALUE_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['p', 'port'],
 ]);
+
+function consumeFlag(
+  flags: Map<string, FlagValue>,
+  key: string,
+  argv: string[],
+  currentIndex: number,
+  canTakeValue: boolean,
+): number {
+  const next = argv[currentIndex + 1];
+  if (canTakeValue && next !== undefined && !next.startsWith('-')) {
+    setFlag(flags, key, next);
+    return currentIndex + 1;
+  }
+  setFlag(flags, key, true);
+  return currentIndex;
+}
 
 export function parseArgs(argv: string[]): ParsedArgs {
   const flags = new Map<string, FlagValue>();
@@ -60,7 +74,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === '--') {
       // Everything after a bare `--` belongs to the child command, verbatim
-      // — never parsed as flags (`pyric dev -- npm start --port 3000`).
+      // — never parsed as flags (`pyric sandbox -- npm start --port 3000`).
       passthrough.push(...argv.slice(i + 1).filter((a): a is string => a !== undefined));
       break;
     }
@@ -75,29 +89,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
         setFlag(flags, arg.slice(2, eq), arg.slice(eq + 1));
       } else {
         const key = arg.slice(2);
-        const next = argv[i + 1];
-        if (!isBooleanFlag(key) && next && !next.startsWith('-')) {
-          setFlag(flags, key, next);
-          i += 1;
-        } else {
-          setFlag(flags, key, true);
-        }
+        i = consumeFlag(flags, key, argv, i, !isBooleanFlag(key));
       }
     } else if (arg.startsWith('-') && arg !== '-') {
       const raw = arg.slice(1);
-      const alias = SHORT_ALIASES.get(raw);
-      if (alias) {
-        if (alias.takesValue) {
-          const next = argv[i + 1];
-          if (next && !next.startsWith('-')) {
-            setFlag(flags, alias.key, next);
-            i += 1;
-          } else {
-            setFlag(flags, alias.key, true);
-          }
-        } else {
-          setFlag(flags, alias.key, true);
-        }
+      const longKey = SHORT_VALUE_ALIASES.get(raw);
+      if (longKey !== undefined) {
+        i = consumeFlag(flags, longKey, argv, i, true);
       } else {
         setFlag(flags, raw, true);
       }
@@ -112,7 +110,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 function isExecutionSubcommand(subcommand: string | null): boolean {
-  return subcommand === 'sandbox' || subcommand === 'dev';
+  return subcommand === 'sandbox';
 }
 
 function setFlag(flags: Map<string, FlagValue>, key: string, value: string | boolean): void {

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -19,10 +19,32 @@ export interface ParsedArgs {
 
 export type FlagValue = string | boolean | Array<string | boolean>;
 
-// Flags whose command contract is boolean must not consume a following
-// positional. Value-bearing flags retain the Firebase-style `--flag value`
-// form, while explicit boolean values remain available as `--json=true`.
-const BOOLEAN_FLAGS = new Set(['json']);
+const BOOLEAN_FLAGS = new Set([
+  'json',
+  'bridge',
+  'ui',
+  'no-ui',
+  'no-open',
+  'no-run',
+  'no-cache',
+  'no-watch',
+  'no-capture',
+  'persist',
+  'fresh',
+  'force',
+  'help',
+  'version',
+]);
+
+function isBooleanFlag(key: string): boolean {
+  return BOOLEAN_FLAGS.has(key) || key.startsWith('no-');
+}
+
+const SHORT_ALIASES: ReadonlyMap<string, { key: string; takesValue: boolean }> = new Map([
+  ['p', { key: 'port', takesValue: true }],
+  ['h', { key: 'help', takesValue: false }],
+  ['v', { key: 'version', takesValue: false }],
+]);
 
 export function parseArgs(argv: string[]): ParsedArgs {
   const flags = new Map<string, FlagValue>();
@@ -42,6 +64,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
       passthrough.push(...argv.slice(i + 1).filter((a): a is string => a !== undefined));
       break;
     }
+    if (isExecutionSubcommand(subcommand) && positional.length > 0) {
+      positional.push(arg);
+      i += 1;
+      continue;
+    }
     if (arg.startsWith('--')) {
       const eq = arg.indexOf('=');
       if (eq !== -1) {
@@ -49,15 +76,31 @@ export function parseArgs(argv: string[]): ParsedArgs {
       } else {
         const key = arg.slice(2);
         const next = argv[i + 1];
-        if (!BOOLEAN_FLAGS.has(key) && next && !next.startsWith('-')) {
+        if (!isBooleanFlag(key) && next && !next.startsWith('-')) {
           setFlag(flags, key, next);
           i += 1;
         } else {
           setFlag(flags, key, true);
         }
       }
-    } else if (arg.startsWith('-')) {
-      setFlag(flags, arg.slice(1), true);
+    } else if (arg.startsWith('-') && arg !== '-') {
+      const raw = arg.slice(1);
+      const alias = SHORT_ALIASES.get(raw);
+      if (alias) {
+        if (alias.takesValue) {
+          const next = argv[i + 1];
+          if (next && !next.startsWith('-')) {
+            setFlag(flags, alias.key, next);
+            i += 1;
+          } else {
+            setFlag(flags, alias.key, true);
+          }
+        } else {
+          setFlag(flags, alias.key, true);
+        }
+      } else {
+        setFlag(flags, raw, true);
+      }
     } else if (subcommand === null) {
       subcommand = arg;
     } else {
@@ -66,6 +109,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     i += 1;
   }
   return { subcommand, flags, positional, passthrough };
+}
+
+function isExecutionSubcommand(subcommand: string | null): boolean {
+  return subcommand === 'sandbox' || subcommand === 'dev';
 }
 
 function setFlag(flags: Map<string, FlagValue>, key: string, value: string | boolean): void {

--- a/packages/cli/src/cli/pyric-config.ts
+++ b/packages/cli/src/cli/pyric-config.ts
@@ -7,7 +7,6 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export interface PyricRulesConfig {
@@ -37,19 +36,6 @@ export async function readPyricConfig(cwd: string = process.cwd()): Promise<Pyri
     throw e;
   }
   try {
-    return JSON.parse(raw) as PyricConfig;
-  } catch (e) {
-    throw new Error(
-      `pyric: failed to parse pyric.json: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-}
-
-export function readPyricConfigSync(cwd: string = process.cwd()): PyricConfig {
-  const path = join(cwd, 'pyric.json');
-  if (!existsSync(path)) return {};
-  try {
-    const raw = readFileSync(path, 'utf-8');
     return JSON.parse(raw) as PyricConfig;
   } catch (e) {
     throw new Error(

--- a/packages/cli/src/cli/pyric-config.ts
+++ b/packages/cli/src/cli/pyric-config.ts
@@ -1,0 +1,59 @@
+/**
+ * Reader for the optional project-level `pyric.json` configuration file.
+ *
+ * Configures defaults for `pyric sandbox` (such as a default `command`,
+ * custom `port`, or explicit `rules` paths) without requiring CLI flags
+ * or magic process sniffing.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface PyricRulesConfig {
+  firestore?: string;
+  database?: string;
+  storage?: string;
+}
+
+export interface PyricConfig {
+  /** Default command to execute under the sandbox if none is passed on CLI. */
+  command?: string;
+  /** Local port to bind the Pyric sandbox host. */
+  port?: number;
+  /** Path to Firestore, RTDB, or Storage rules files. */
+  rules?: string | PyricRulesConfig;
+  /** Project ID label for emulation. */
+  project?: string;
+}
+
+export async function readPyricConfig(cwd: string = process.cwd()): Promise<PyricConfig> {
+  const path = join(cwd, 'pyric.json');
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw e;
+  }
+  try {
+    return JSON.parse(raw) as PyricConfig;
+  } catch (e) {
+    throw new Error(
+      `pyric: failed to parse pyric.json: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+export function readPyricConfigSync(cwd: string = process.cwd()): PyricConfig {
+  const path = join(cwd, 'pyric.json');
+  if (!existsSync(path)) return {};
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    return JSON.parse(raw) as PyricConfig;
+  } catch (e) {
+    throw new Error(
+      `pyric: failed to parse pyric.json: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}

--- a/packages/cli/src/cli/sandbox-runner.ts
+++ b/packages/cli/src/cli/sandbox-runner.ts
@@ -16,8 +16,6 @@
  * only `spawnDevChild` touches the process table.
  */
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 // ─── First-run race guard ───────────────────────────────────────────────────
 
@@ -63,35 +61,14 @@ export async function waitForSandboxPeer(
 
 // ─── Child-command resolution (pure) ───────────────────────────────────────
 
-export type PackageManager = 'bun' | 'pnpm' | 'yarn' | 'npm';
-
-/** Lockfile sniff, mirroring how init/vendor pick their install hints. */
-export function detectPackageManager(cwd: string): PackageManager {
-  if (existsSync(join(cwd, 'bun.lock')) || existsSync(join(cwd, 'bun.lockb'))) return 'bun';
-  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
-  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
-  return 'npm';
-}
-
-/** The project's `dev` script, or null (no package.json / no script). */
-export function readDevScript(cwd: string): string | null {
-  try {
-    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8')) as {
-      scripts?: Record<string, unknown>;
-    };
-    const dev = pkg.scripts?.dev;
-    return typeof dev === 'string' && dev.trim().length > 0 ? dev : null;
-  } catch {
-    return null;
-  }
-}
-
-export interface DevChildPlan {
-  /** argv to spawn — argv[0] is the executable, no shell. */
+export interface SandboxChildPlan {
+  /** argv to spawn — argv[0] is the executable. */
   argv: string[];
   /** Human-readable command for the pre-spawn line. */
   label: string;
 }
+
+export type DevChildPlan = SandboxChildPlan;
 
 /**
  * Tokenize a command string into an argv array, preserving quoted strings.
@@ -112,6 +89,14 @@ export function parseCommandString(cmd: string): string[] {
   return parts;
 }
 
+export interface ResolveSandboxChildOptions {
+  explicitCommand?: string[] | null;
+  passthrough?: string[];
+  configCommand?: string | null;
+  noRun?: boolean;
+  json?: boolean;
+}
+
 /**
  * Decide what (if anything) to run after the host is up.
  *
@@ -122,35 +107,30 @@ export function parseCommandString(cmd: string): string[] {
  *   pyric.json `command`                    → parsed command argv
  *   none of the above                       → null (host-only)
  */
-export function resolveSandboxChild(opts: {
-  explicitCommand?: string[] | null;
-  passthrough?: string[];
-  configCommand?: string | null;
-  noRun?: boolean;
-  json?: boolean;
-  devScript?: string | null;
-  packageManager?: PackageManager;
-}): DevChildPlan | null {
+export function resolveSandboxChild(opts: ResolveSandboxChildOptions): SandboxChildPlan | null {
   if (opts.noRun) return null;
-  const cmd =
-    opts.explicitCommand && opts.explicitCommand.length > 0
-      ? opts.explicitCommand
-      : opts.passthrough && opts.passthrough.length > 0
-        ? opts.passthrough
-        : null;
-  if (cmd) {
-    return { argv: [...cmd], label: cmd.join(' ') };
+
+  let activeCommand: string[] | null = null;
+  if (opts.explicitCommand && opts.explicitCommand.length > 0) {
+    activeCommand = opts.explicitCommand;
+  } else if (opts.passthrough && opts.passthrough.length > 0) {
+    activeCommand = opts.passthrough;
   }
+
+  if (activeCommand !== null) {
+    return { argv: [...activeCommand], label: activeCommand.join(' ') };
+  }
+
   if (opts.json) return null;
+
   if (opts.configCommand && opts.configCommand.trim().length > 0) {
     const trimmed = opts.configCommand.trim();
     const argv = parseCommandString(trimmed);
     return { argv, label: trimmed };
   }
+
   return null;
 }
-
-export const resolveDevChild = resolveSandboxChild;
 
 // ─── Environment for the child (pure) ──────────────────────────────────────
 
@@ -242,27 +222,28 @@ export function createLinePrefixer(
 
 // ─── Spawn + lifecycle ─────────────────────────────────────────────────────
 
-export interface DevChildHandle {
-  /** Resolves with the exit code to propagate once the child is gone. */
+/** How long a signalled child may linger before SIGKILL. */
+const FORCE_KILL_AFTER_MS = 2_000;
+
+const SHELL_OPERATORS = new Set(['&&', '||', '|', ';', '&']);
+
+export interface SandboxChildHandle {
   exited: Promise<number>;
-  /** Forward a signal (Ctrl-C / SIGTERM). Marks the exit as user-initiated
-   *  so the propagated code is 0, and SIGKILLs a child that lingers. */
   signal(sig: NodeJS.Signals): void;
   child: ChildProcess;
 }
 
-/** How long a signalled child may linger before SIGKILL. */
-const FORCE_KILL_AFTER_MS = 2_000;
+export type DevChildHandle = SandboxChildHandle;
 
 /**
  * Spawn the child with inherited stdin and `[dev]`-prefixed stdout/stderr.
  * In `--json` mode ALL child output goes to stderr — stdout carries exactly
  * the one machine line (the serve --json contract).
  */
-export function spawnDevChild(
-  plan: DevChildPlan,
+export function spawnSandboxChild(
+  plan: SandboxChildPlan,
   opts: { cwd: string; env: NodeJS.ProcessEnv; json: boolean },
-): DevChildHandle {
+): SandboxChildHandle {
   const parts = [...plan.argv];
   const env: NodeJS.ProcessEnv = { ...opts.env };
 
@@ -275,12 +256,8 @@ export function spawnDevChild(
     env[key] = val;
   }
 
-  // 2. Check for shell operators (&&, ||, |, ;) in the command
-  const hasShellOperators =
-    plan.label.includes('&&') ||
-    plan.label.includes('||') ||
-    plan.label.includes('|') ||
-    plan.label.includes(';');
+  // 2. Check for discrete shell operators (&&, ||, |, ;) among top-level tokens
+  const hasShellOperators = parts.some((token) => SHELL_OPERATORS.has(token));
 
   // 3. Warn if runtime is bun or deno
   if (parts.length > 0 && (parts[0] === 'bun' || parts[0] === 'deno')) {
@@ -294,21 +271,24 @@ export function spawnDevChild(
   }
 
   const [command, ...args] = parts;
-  const child = hasShellOperators
-    ? spawn(plan.label, [], {
-        cwd: opts.cwd,
-        env,
-        stdio: ['inherit', 'pipe', 'pipe'],
-        shell: true,
-        detached: process.platform !== 'win32',
-      })
-    : spawn(command!, args, {
-        cwd: opts.cwd,
-        env,
-        stdio: ['inherit', 'pipe', 'pipe'],
-        shell: process.platform === 'win32',
-        detached: process.platform !== 'win32',
-      });
+  let child: ChildProcess;
+  if (hasShellOperators) {
+    child = spawn(plan.label, [], {
+      cwd: opts.cwd,
+      env,
+      stdio: ['inherit', 'pipe', 'pipe'],
+      shell: true,
+      detached: process.platform !== 'win32',
+    });
+  } else {
+    child = spawn(command!, args, {
+      cwd: opts.cwd,
+      env,
+      stdio: ['inherit', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+      detached: process.platform !== 'win32',
+    });
+  }
 
   const outTarget = opts.json ? process.stderr : process.stdout;
   const out = createLinePrefixer('[dev] ', (line) => outTarget.write(line));
@@ -330,7 +310,7 @@ export function spawnDevChild(
 
   const exited = new Promise<number>((resolve) => {
     child.once('error', (e) => {
-      process.stderr.write(`pyric dev: failed to run \`${plan.label}\`: ${e.message}\n`);
+      process.stderr.write(`pyric sandbox: failed to run \`${plan.label}\`: ${e.message}\n`);
       resolve(1);
     });
     child.once('exit', (code, signal) => {
@@ -364,3 +344,5 @@ export function spawnDevChild(
     },
   };
 }
+
+export const spawnDevChild = spawnSandboxChild;

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -31,16 +31,13 @@ import { openBrowser, shouldAutoOpen } from '../serve/open-browser.js';
 import { readPyricConfig, type PyricConfig } from './pyric-config.js';
 import {
   buildChildEnv,
-  detectPackageManager,
   formatStartupEnvExport,
-  readDevScript,
   registerModuleUrl,
-  resolveDevChild,
   resolveSandboxChild,
-  spawnDevChild,
+  spawnSandboxChild,
   waitForSandboxPeer,
-  type DevChildHandle,
-} from './dev-runner.js';
+  type SandboxChildHandle,
+} from './sandbox-runner.js';
 import {
   createFunctionsDevelopmentRuntime,
   createHttpFunctionsPeerReadiness,
@@ -178,19 +175,18 @@ export async function startServe(opts: {
   if (pyricConfig.rules) {
     if (!config) config = {};
     if (typeof pyricConfig.rules === 'string') {
-      config.firestore = { rules: pyricConfig.rules, ...config.firestore };
+      config.firestore = { ...config.firestore, rules: pyricConfig.rules };
     } else {
       if (pyricConfig.rules.firestore) {
-        config.firestore = { rules: pyricConfig.rules.firestore, ...config.firestore };
+        config.firestore = { ...config.firestore, rules: pyricConfig.rules.firestore };
       }
       if (pyricConfig.rules.database) {
-        config.database = { rules: pyricConfig.rules.database, ...config.database };
+        config.database = { ...config.database, rules: pyricConfig.rules.database };
       }
       if (pyricConfig.rules.storage) {
-        config.storage = {
-          rules: pyricConfig.rules.storage,
-          ...(typeof config.storage === 'object' && !Array.isArray(config.storage) ? config.storage : {}),
-        };
+        const baseStorage =
+          typeof config.storage === 'object' && !Array.isArray(config.storage) ? config.storage : {};
+        config.storage = { ...baseStorage, rules: pyricConfig.rules.storage };
       }
     }
   }
@@ -619,6 +615,36 @@ export function installServeProcessGuard(
   };
 }
 
+function resolveServePort(flagPort: unknown, configPort?: number): number {
+  if (typeof flagPort === 'string') return Number(flagPort);
+  if (typeof flagPort === 'number') return flagPort;
+  if (typeof configPort === 'number') return configPort;
+  return 3473;
+}
+
+function resolveProjectIdentifier(
+  flagProject?: unknown,
+  envProject?: string,
+  configProject?: string,
+  rcDefault?: string,
+): string {
+  if (typeof flagProject === 'string' && flagProject.length > 0) return flagProject;
+  if (typeof envProject === 'string' && envProject.length > 0) return envProject;
+  if (typeof configProject === 'string' && configProject.length > 0) return configProject;
+  if (typeof rcDefault === 'string' && rcDefault.length > 0) return rcDefault;
+  return 'demo-project';
+}
+
+function resolveExplicitCommand(parsed: ParsedArgs): string[] | null {
+  if (parsed.passthrough && parsed.passthrough.length > 0) {
+    return parsed.passthrough;
+  }
+  if (parsed.positional.length > 0) {
+    return parsed.positional;
+  }
+  return null;
+}
+
 /** CLI entry. Resolves on SIGINT/SIGTERM after a clean stop. */
 export async function runServe(parsed: ParsedArgs): Promise<number> {
   const cwd = process.cwd();
@@ -631,12 +657,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   }
 
   const flagPort = parsed.flags.get('port');
-  const port =
-    typeof flagPort === 'string'
-      ? Number(flagPort)
-      : typeof flagPort === 'number'
-        ? flagPort
-        : pyricConfig.port ?? 3473;
+  const port = resolveServePort(flagPort, pyricConfig.port);
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     process.stderr.write(`pyric: invalid --port '${flagPort}'.\n`);
     return 1;
@@ -667,24 +688,19 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     if (functionsProject) {
       const flagProject = parsed.flags.get('project');
       const rc = await readFirebaseRc(cwd);
-      functionsProjectId =
-        (typeof flagProject === 'string' ? flagProject : undefined) ??
-        process.env.PYRIC_PROJECT ??
-        pyricConfig.project ??
-        rc?.projects?.default ??
-        'demo-project';
+      functionsProjectId = resolveProjectIdentifier(
+        flagProject,
+        process.env.PYRIC_PROJECT,
+        pyricConfig.project,
+        rc?.projects?.default,
+      );
     }
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
 
-  const explicitCommand =
-    parsed.passthrough && parsed.passthrough.length > 0
-      ? parsed.passthrough
-      : parsed.positional.length > 0
-        ? parsed.positional
-        : null;
+  const explicitCommand = resolveExplicitCommand(parsed);
 
   const plan = resolveSandboxChild({
     explicitCommand,
@@ -758,7 +774,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     void openBrowser(targetUrl);
   }
 
-  let devChild: DevChildHandle | null = null;
+  let devChild: SandboxChildHandle | null = null;
   let functionsRuntime: FunctionsDevelopmentRuntime | null = null;
   let resolveFunctionsExit!: (code: number) => void;
   const functionsExited = new Promise<number>((resolve) => { resolveFunctionsExit = resolve; });
@@ -891,7 +907,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     info.write(
       `✔ run      \`${plan.label}\` — firebase-admin/firebase imports are routed to the sandbox at ${runtime.handle.url}\n`,
     );
-    devChild = spawnDevChild(plan, {
+    devChild = spawnSandboxChild(plan, {
       cwd,
       json,
       env: buildChildEnv(process.env, {

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -28,6 +28,7 @@ import { formatActivityWarning } from '../serve/activity-warning.js';
 import { consoleServeLogger, startStaticServer, stderrServeLogger, type ServeHandle } from '../serve/server.js';
 import { createBridgeMount } from '../serve/bridge-mount.js';
 import { openBrowser, shouldAutoOpen } from '../serve/open-browser.js';
+import { readPyricConfig, type PyricConfig } from './pyric-config.js';
 import {
   buildChildEnv,
   detectPackageManager,
@@ -35,6 +36,7 @@ import {
   readDevScript,
   registerModuleUrl,
   resolveDevChild,
+  resolveSandboxChild,
   spawnDevChild,
   waitForSandboxPeer,
   type DevChildHandle,
@@ -170,6 +172,27 @@ export async function startServe(opts: {
   } catch (e) {
     if (!(e instanceof Error) || !e.message.includes('no firebase.json')) throw e;
     logger.note('  ⚠ no firebase.json found — serving the current directory without hosting config');
+  }
+
+  const pyricConfig = await readPyricConfig(opts.cwd);
+  if (pyricConfig.rules) {
+    if (!config) config = {};
+    if (typeof pyricConfig.rules === 'string') {
+      config.firestore = { rules: pyricConfig.rules, ...config.firestore };
+    } else {
+      if (pyricConfig.rules.firestore) {
+        config.firestore = { rules: pyricConfig.rules.firestore, ...config.firestore };
+      }
+      if (pyricConfig.rules.database) {
+        config.database = { rules: pyricConfig.rules.database, ...config.database };
+      }
+      if (pyricConfig.rules.storage) {
+        config.storage = {
+          rules: pyricConfig.rules.storage,
+          ...(typeof config.storage === 'object' && !Array.isArray(config.storage) ? config.storage : {}),
+        };
+      }
+    }
   }
 
   const hosting = extractHosting(config);
@@ -598,8 +621,22 @@ export function installServeProcessGuard(
 
 /** CLI entry. Resolves on SIGINT/SIGTERM after a clean stop. */
 export async function runServe(parsed: ParsedArgs): Promise<number> {
+  const cwd = process.cwd();
+  let pyricConfig: PyricConfig = {};
+  try {
+    pyricConfig = await readPyricConfig(cwd);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
+
   const flagPort = parsed.flags.get('port');
-  const port = typeof flagPort === 'string' ? Number(flagPort) : 3473;
+  const port =
+    typeof flagPort === 'string'
+      ? Number(flagPort)
+      : typeof flagPort === 'number'
+        ? flagPort
+        : pyricConfig.port ?? 3473;
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     process.stderr.write(`pyric: invalid --port '${flagPort}'.\n`);
     return 1;
@@ -610,7 +647,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   const only = parsed.flags.get('only');
   if (typeof only === 'string' && only !== 'hosting') {
     process.stderr.write(
-      `pyric: --only '${only}' is not supported — pyric dev v1 serves hosting (with the in-page sandbox standing in for firestore/auth).\n`,
+      `pyric: --only '${only}' is not supported — pyric sandbox serves hosting (with the in-page sandbox standing in for firestore/auth).\n`,
     );
     return 1;
   }
@@ -623,7 +660,6 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
   // Resolve the child plan BEFORE the server starts: a planned child implies
   // the bridge (see bridgeEnabledFor) — the child's injected PYRIC_SANDBOX
   // is useless without the /__pyric/sandbox WS mount.
-  const cwd = process.cwd();
   let functionsProject: FunctionsRtdbProject | null;
   let functionsProjectId: string | null = null;
   try {
@@ -634,6 +670,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
       functionsProjectId =
         (typeof flagProject === 'string' ? flagProject : undefined) ??
         process.env.PYRIC_PROJECT ??
+        pyricConfig.project ??
         rc?.projects?.default ??
         'demo-project';
     }
@@ -641,12 +678,19 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const plan = resolveDevChild({
-    passthrough: parsed.passthrough ?? [],
+
+  const explicitCommand =
+    parsed.passthrough && parsed.passthrough.length > 0
+      ? parsed.passthrough
+      : parsed.positional.length > 0
+        ? parsed.positional
+        : null;
+
+  const plan = resolveSandboxChild({
+    explicitCommand,
+    configCommand: pyricConfig.command,
     noRun: Boolean(parsed.flags.get('no-run')),
     json,
-    devScript: readDevScript(cwd),
-    packageManager: detectPackageManager(cwd),
   });
   const bridgeOn = bridgeEnabledFor(parsed.flags, plan, functionsProject);
 
@@ -675,7 +719,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
       project:
         typeof parsed.flags.get('project') === 'string'
           ? (parsed.flags.get('project') as string)
-          : process.env.PYRIC_PROJECT ?? functionsProjectId ?? undefined,
+          : process.env.PYRIC_PROJECT ?? pyricConfig.project ?? functionsProjectId ?? undefined,
     });
   } catch (e) {
     process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
@@ -838,6 +882,11 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
           `  ⚠ no browser tab connected after 30s — starting your command anyway; sandbox ops will fail until ${runtime.handle.url} is open.\n`,
         );
       }
+    } else if (!json) {
+      info.write(
+        `  ⓘ Auto-open is disabled (--no-open/CI). The pyric sandbox is browser-resident: ` +
+          `open ${runtime.handle.url} to connect if your command performs Firebase operations.\n`,
+      );
     }
     info.write(
       `✔ run      \`${plan.label}\` — firebase-admin/firebase imports are routed to the sandbox at ${runtime.handle.url}\n`,

--- a/packages/cli/src/functions-rtdb/development-runtime.ts
+++ b/packages/cli/src/functions-rtdb/development-runtime.ts
@@ -6,7 +6,7 @@ import {
   type FunctionsRtdbChildReady,
   type SpawnFunctionsRtdbChildOptions,
 } from './child.js';
-import { buildChildEnv, createLinePrefixer } from '../cli/dev-runner.js';
+import { buildChildEnv, createLinePrefixer } from '../cli/sandbox-runner.js';
 
 const INITIAL_PEER_TIMEOUT_MS = 30_000;
 const RELOAD_PEER_TIMEOUT_MS = 5_000;

--- a/packages/cli/src/serve/vite-sandbox-generation.ts
+++ b/packages/cli/src/serve/vite-sandbox-generation.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import type { ViteDevServer } from 'vite';
 import { readFirebaseJson, readFirebaseRc, type FirebaseJson } from '../cli/firebase-json.js';
-import { registerModuleUrl } from '../cli/dev-runner.js';
+import { registerModuleUrl } from '../cli/sandbox-runner.js';
 import {
   discoverFunctionsRtdbProject,
   type FunctionsRtdbProject,

--- a/packages/cli/test/cli/dev-runner.test.ts
+++ b/packages/cli/test/cli/dev-runner.test.ts
@@ -14,9 +14,11 @@ import {
   createLinePrefixer,
   detectPackageManager,
   formatStartupEnvExport,
+  parseCommandString,
   readDevScript,
   registerModuleUrl,
   resolveDevChild,
+  resolveSandboxChild,
   waitForSandboxPeer,
 } from '../../src/cli/dev-runner.js';
 
@@ -33,52 +35,107 @@ describe('parseArgs `--` passthrough', () => {
     expect(parseArgs(['dev', '--json']).passthrough).toEqual([]);
   });
 
-  it('handles a trailing bare --', () => {
-    expect(parseArgs(['dev', '--']).passthrough).toEqual([]);
+  it('collects positional command and arguments under sandbox without --', () => {
+    const parsed = parseArgs(['sandbox', '--port', '4000', 'next', 'dev', '--turbo']);
+    expect(parsed.subcommand).toBe('sandbox');
+    expect(parsed.flags.get('port')).toBe('4000');
+    expect(parsed.positional).toEqual(['next', 'dev', '--turbo']);
+    expect(parsed.flags.has('turbo')).toBe(false);
+  });
+
+  it('collects node flags under sandbox without --', () => {
+    const parsed = parseArgs(['sandbox', 'node', '-e', 'console.log(1)']);
+    expect(parsed.subcommand).toBe('sandbox');
+    expect(parsed.positional).toEqual(['node', '-e', 'console.log(1)']);
+    expect(parsed.flags.has('e')).toBe(false);
+  });
+
+  it('maps -p 4000 to port flag and preserves child command', () => {
+    const parsed = parseArgs(['sandbox', '-p', '4000', 'next', 'dev']);
+    expect(parsed.subcommand).toBe('sandbox');
+    expect(parsed.flags.get('port')).toBe('4000');
+    expect(parsed.positional).toEqual(['next', 'dev']);
   });
 });
 
-describe('resolveDevChild precedence', () => {
+describe('parseCommandString', () => {
+  it('tokenizes standard commands by space', () => {
+    expect(parseCommandString('next dev')).toEqual(['next', 'dev']);
+    expect(parseCommandString('npm run dev:server')).toEqual(['npm', 'run', 'dev:server']);
+  });
+
+  it('preserves double and single quoted strings', () => {
+    expect(parseCommandString('node -e "console.log(1)"')).toEqual([
+      'node',
+      '-e',
+      'console.log(1)',
+    ]);
+    expect(parseCommandString("node -e 'console.log(2)'")).toEqual([
+      'node',
+      '-e',
+      'console.log(2)',
+    ]);
+  });
+});
+
+describe('resolveSandboxChild precedence', () => {
   const base = {
+    explicitCommand: null as string[] | null,
     passthrough: [] as string[],
+    configCommand: null as string | null,
     noRun: false,
     json: false,
-    devScript: null as string | null,
-    packageManager: 'npm' as const,
   };
 
-  it('explicit -- command wins over the dev script', () => {
-    const plan = resolveDevChild({ ...base, passthrough: ['node', 'server.js'], devScript: 'vite' });
+  it('explicit CLI command wins over pyric.json config command', () => {
+    const plan = resolveSandboxChild({
+      ...base,
+      explicitCommand: ['node', 'server.js'],
+      configCommand: 'next dev',
+    });
     expect(plan).toEqual({ argv: ['node', 'server.js'], label: 'node server.js' });
   });
 
-  it('falls back to the dev script via the detected package manager', () => {
-    const plan = resolveDevChild({ ...base, devScript: 'vite dev', packageManager: 'bun' });
-    expect(plan).toEqual({ argv: ['bun', 'run', 'dev'], label: 'bun run dev' });
+  it('passthrough -- command wins over pyric.json config command', () => {
+    const plan = resolveSandboxChild({
+      ...base,
+      passthrough: ['node', 'server.js'],
+      configCommand: 'next dev',
+    });
+    expect(plan).toEqual({ argv: ['node', 'server.js'], label: 'node server.js' });
   });
 
-  it('no -- and no dev script → host-only', () => {
-    expect(resolveDevChild(base)).toBeNull();
+  it('falls back to pyric.json configCommand when no CLI command is given', () => {
+    const plan = resolveSandboxChild({ ...base, configCommand: 'next dev --port 3000' });
+    expect(plan).toEqual({ argv: ['next', 'dev', '--port', '3000'], label: 'next dev --port 3000' });
   });
 
-  it('--no-run forces host-only, even with -- and a dev script', () => {
+  it('no explicit command and no config command → host-only (null)', () => {
+    expect(resolveSandboxChild(base)).toBeNull();
+  });
+
+  it('--no-run forces host-only, even with an explicit command and config', () => {
     expect(
-      resolveDevChild({ ...base, noRun: true, passthrough: ['npm', 'start'], devScript: 'vite' }),
+      resolveSandboxChild({
+        ...base,
+        noRun: true,
+        explicitCommand: ['npm', 'start'],
+        configCommand: 'next dev',
+      }),
     ).toBeNull();
   });
 
-  it('--json defaults to host-only (skips the dev script)', () => {
-    expect(resolveDevChild({ ...base, json: true, devScript: 'vite' })).toBeNull();
+  it('--json defaults to host-only (skips configCommand)', () => {
+    expect(resolveSandboxChild({ ...base, json: true, configCommand: 'next dev' })).toBeNull();
   });
 
-  it('--json with an explicit -- command still runs it', () => {
-    const plan = resolveDevChild({ ...base, json: true, passthrough: ['node', 'x.js'] });
+  it('--json with an explicit command still runs it', () => {
+    const plan = resolveSandboxChild({
+      ...base,
+      json: true,
+      explicitCommand: ['node', 'x.js'],
+    });
     expect(plan?.argv).toEqual(['node', 'x.js']);
-  });
-
-  it('a dev script that itself runs pyric dev is skipped (no recursion)', () => {
-    expect(resolveDevChild({ ...base, devScript: 'pyric dev --bridge' })).toBeNull();
-    expect(resolveDevChild({ ...base, devScript: 'rimraf dist && pyric dev' })).toBeNull();
   });
 });
 

--- a/packages/cli/test/cli/index.test.ts
+++ b/packages/cli/test/cli/index.test.ts
@@ -67,7 +67,7 @@ describe('retained pyric command surface', () => {
 
     expect(code).toBe(0);
     expect(stderr).toBe('');
-    for (const command of ['init', 'dev', 'bridge', 'mcp', 'snapshot', 'verify', 'vendor']) {
+    for (const command of ['init', 'sandbox', 'bridge', 'mcp', 'snapshot', 'verify', 'vendor']) {
       expect(stdout).toMatch(new RegExp(`^\\s+(?:pyric )?${command}\\b`, 'm'));
     }
   });
@@ -337,15 +337,16 @@ describe('service command hierarchy', () => {
   });
 });
 
-describe('pyric dev command surface', () => {
-  it('rejects the removed serve spelling instead of retaining an alias', async () => {
-    expect((await runDispatch(['serve'])).code).toBe(1);
+describe('pyric sandbox command surface', () => {
+  it('rejects the removed dev spelling instead of retaining an alias', async () => {
+    expect((await runDispatch(['dev'])).code).toBe(1);
   });
 
-  it('advertises dev and never serve', async () => {
+  it('advertises sandbox and never dev or serve', async () => {
     const { code, stdout } = await runDispatch(['--help']);
     expect(code).toBe(0);
-    expect(stdout).toContain('pyric dev [flags]');
+    expect(stdout).toContain('pyric sandbox [command...]');
+    expect(stdout).not.toContain('pyric dev');
     expect(stdout).not.toContain('pyric serve');
   });
 });

--- a/packages/cli/test/cli/pyric-config.test.ts
+++ b/packages/cli/test/cli/pyric-config.test.ts
@@ -2,23 +2,13 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readPyricConfig, readPyricConfigSync } from '../../src/cli/pyric-config.js';
+import { readPyricConfig } from '../../src/cli/pyric-config.js';
 
 describe('pyric-config', () => {
-  it('returns empty defaults when pyric.json does not exist (async)', async () => {
+  it('returns empty defaults when pyric.json does not exist', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-none-'));
     try {
       const config = await readPyricConfig(tmp);
-      expect(config).toEqual({});
-    } finally {
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  it('returns empty defaults when pyric.json does not exist (sync)', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-none-'));
-    try {
-      const config = readPyricConfigSync(tmp);
       expect(config).toEqual({});
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -42,9 +32,6 @@ describe('pyric-config', () => {
       expect(config.port).toBe(4400);
       expect(config.rules).toBe('security/firestore.rules');
       expect(config.project).toBe('my-project');
-
-      const configSync = readPyricConfigSync(tmp);
-      expect(configSync).toEqual(config);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -77,7 +64,6 @@ describe('pyric-config', () => {
     try {
       writeFileSync(join(tmp, 'pyric.json'), '{ malformed');
       expect(readPyricConfig(tmp)).rejects.toThrow('pyric: failed to parse pyric.json');
-      expect(() => readPyricConfigSync(tmp)).toThrow('pyric: failed to parse pyric.json');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/packages/cli/test/cli/pyric-config.test.ts
+++ b/packages/cli/test/cli/pyric-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readPyricConfig, readPyricConfigSync } from '../../src/cli/pyric-config.js';
+
+describe('pyric-config', () => {
+  it('returns empty defaults when pyric.json does not exist (async)', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-none-'));
+    try {
+      const config = await readPyricConfig(tmp);
+      expect(config).toEqual({});
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty defaults when pyric.json does not exist (sync)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-none-'));
+    try {
+      const config = readPyricConfigSync(tmp);
+      expect(config).toEqual({});
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('parses valid pyric.json with command and port', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-valid-'));
+    try {
+      writeFileSync(
+        join(tmp, 'pyric.json'),
+        JSON.stringify({
+          command: 'next dev',
+          port: 4400,
+          rules: 'security/firestore.rules',
+          project: 'my-project',
+        }),
+      );
+      const config = await readPyricConfig(tmp);
+      expect(config.command).toBe('next dev');
+      expect(config.port).toBe(4400);
+      expect(config.rules).toBe('security/firestore.rules');
+      expect(config.project).toBe('my-project');
+
+      const configSync = readPyricConfigSync(tmp);
+      expect(configSync).toEqual(config);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('parses rules as an object', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-rules-'));
+    try {
+      writeFileSync(
+        join(tmp, 'pyric.json'),
+        JSON.stringify({
+          rules: {
+            firestore: 'firestore.rules',
+            database: 'database.rules.json',
+          },
+        }),
+      );
+      const config = await readPyricConfig(tmp);
+      expect(config.rules).toEqual({
+        firestore: 'firestore.rules',
+        database: 'database.rules.json',
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('throws descriptive error on malformed JSON', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-config-malformed-'));
+    try {
+      writeFileSync(join(tmp, 'pyric.json'), '{ malformed');
+      expect(readPyricConfig(tmp)).rejects.toThrow('pyric: failed to parse pyric.json');
+      expect(() => readPyricConfigSync(tmp)).toThrow('pyric: failed to parse pyric.json');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/test/cli/sandbox-command.test.ts
+++ b/packages/cli/test/cli/sandbox-command.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
+const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'cli', 'index.ts');
+
+function runCli(
+  args: string[],
+  cwd?: string,
+): { code: number; stdout: string; stderr: string } {
+  const dir = cwd ?? mkdtempSync(join(tmpdir(), 'pyric-cli-test-'));
+  try {
+    const result = spawnSync('bun', [CLI_ENTRY, ...args], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    return {
+      code: result.status ?? -1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    };
+  } finally {
+    if (!cwd) rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('pyric sandbox command execution', () => {
+  it('executes a short-lived node script and cleanly exits with code 0', () => {
+    const { code, stdout, stderr } = runCli([
+      'sandbox',
+      '--no-open',
+      'node',
+      '-e',
+      'console.log("SANDBOX_CHILD_HELLO")',
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain('SANDBOX_CHILD_HELLO');
+  });
+
+  it('propagates the child script non-zero exit code to the parent CLI process', () => {
+    const { code } = runCli([
+      'sandbox',
+      '--no-open',
+      'node',
+      '-e',
+      'process.exit(42)',
+    ]);
+    expect(code).toBe(42);
+  });
+
+  it('runs the command configured in pyric.json when no CLI command is provided', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-sandbox-cmd-'));
+    try {
+      writeFileSync(
+        join(tmp, 'pyric.json'),
+        JSON.stringify({
+          command: 'node -e "console.log(\'CONFIG_COMMAND_FIRED\')"',
+        }),
+      );
+      const { code, stdout } = runCli(['sandbox', '--no-open'], tmp);
+      expect(code).toBe(0);
+      expect(stdout).toContain('CONFIG_COMMAND_FIRED');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('explicit CLI command takes precedence over pyric.json command', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-sandbox-precedence-'));
+    try {
+      writeFileSync(
+        join(tmp, 'pyric.json'),
+        JSON.stringify({
+          command: 'node -e "console.log(\'FROM_CONFIG\')"',
+        }),
+      );
+      const { code, stdout } = runCli(
+        ['sandbox', '--no-open', 'node', '-e', 'console.log("FROM_CLI")'],
+        tmp,
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain('FROM_CLI');
+      expect(stdout).not.toContain('FROM_CONFIG');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('respects port from pyric.json and injects matching PYRIC_SANDBOX into child', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-sandbox-port-'));
+    try {
+      writeFileSync(
+        join(tmp, 'pyric.json'),
+        JSON.stringify({
+          port: 4892,
+          command: 'node -e "console.log(\'URL:\' + process.env.PYRIC_SANDBOX)"',
+        }),
+      );
+      const { code, stdout } = runCli(['sandbox', '--no-open'], tmp);
+      expect(code).toBe(0);
+      expect(stdout).toContain('URL:remote:http://localhost:4892');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('supports root import from firebase-admin under pyric sandbox', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'pyric-sandbox-admin-root-'));
+    try {
+      writeFileSync(
+        join(tmp, 'script.mjs'),
+        `import admin from 'firebase-admin';
+         console.log('ADMIN_INITIALIZE_FN:', typeof admin.initializeApp);
+         console.log('ADMIN_FIRESTORE_FN:', typeof admin.firestore);`,
+      );
+      writeFileSync(join(tmp, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { code, stdout } = runCli(['sandbox', '--no-open', 'node', 'script.mjs'], tmp);
+      expect(code).toBe(0);
+      expect(stdout).toContain('ADMIN_INITIALIZE_FN: function');
+      expect(stdout).toContain('ADMIN_FIRESTORE_FN: function');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts short flag -p 4912 to customize port without breaking child command', () => {
+    const { code, stdout } = runCli([
+      'sandbox',
+      '-p',
+      '4912',
+      '--no-open',
+      'node',
+      '-e',
+      'console.log("PORT_URL:" + process.env.PYRIC_SANDBOX)',
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain('PORT_URL:remote:http://localhost:4912');
+  });
+
+  it('extracts inline environment variables from child command', () => {
+    const { code, stdout } = runCli([
+      'sandbox',
+      '--no-open',
+      'CUSTOM_ENV=alpha123',
+      'node',
+      '-e',
+      'console.log("READ_ENV:" + process.env.CUSTOM_ENV)',
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain('READ_ENV:alpha123');
+  });
+});

--- a/packages/cli/test/cli/sandbox-command.test.ts
+++ b/packages/cli/test/cli/sandbox-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -153,4 +153,45 @@ describe('pyric sandbox command execution', () => {
     expect(code).toBe(0);
     expect(stdout).toContain('READ_ENV:alpha123');
   });
+
+  it('executes inline code containing logical operators (||) without breaking arguments', () => {
+    const { code, stdout } = runCli([
+      'sandbox',
+      '--no-open',
+      'node',
+      '-e',
+      'console.log("OPERATOR_TEST:" + (false || "fallback_value"))',
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain('OPERATOR_TEST:fallback_value');
+  });
+
+  it('runs in host-only mode when no command or config is provided', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-cli-host-'));
+    try {
+      const child = spawn('bun', [CLI_ENTRY, 'sandbox', '--no-open', '--no-run', '--port', '4933'], {
+        cwd: dir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout?.setEncoding('utf8');
+      let stdout = '';
+      child.stdout?.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+
+      const start = Date.now();
+      while (!stdout.includes('export PYRIC_SANDBOX="remote:http://localhost:4933"') && Date.now() - start < 10_000) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(stdout).toContain('export PYRIC_SANDBOX="remote:http://localhost:4933"');
+      child.kill('SIGINT');
+      const code = await new Promise<number>((resolve) => {
+        child.once('exit', (exit) => resolve(exit ?? 0));
+      });
+      expect(code).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });

--- a/packages/cli/test/cli/sandbox-runner.test.ts
+++ b/packages/cli/test/cli/sandbox-runner.test.ts
@@ -5,34 +5,28 @@
  * module URL, and the `[dev]` line prefixer.
  */
 import { describe, it, expect } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { parseArgs } from '../../src/cli/parse-args.js';
 import {
   buildChildEnv,
   createLinePrefixer,
-  detectPackageManager,
   formatStartupEnvExport,
   parseCommandString,
-  readDevScript,
   registerModuleUrl,
-  resolveDevChild,
   resolveSandboxChild,
   waitForSandboxPeer,
-} from '../../src/cli/dev-runner.js';
+} from '../../src/cli/sandbox-runner.js';
 
 describe('parseArgs `--` passthrough', () => {
   it('collects everything after -- verbatim, never as flags', () => {
-    const parsed = parseArgs(['dev', '--bridge', '--', 'npm', 'start', '--port', '3000']);
-    expect(parsed.subcommand).toBe('dev');
+    const parsed = parseArgs(['sandbox', '--bridge', '--', 'npm', 'start', '--port', '3000']);
+    expect(parsed.subcommand).toBe('sandbox');
     expect(parsed.flags.get('bridge')).toBe(true);
     expect(parsed.passthrough).toEqual(['npm', 'start', '--port', '3000']);
     expect(parsed.flags.has('port')).toBe(false);
   });
 
   it('is empty without --', () => {
-    expect(parseArgs(['dev', '--json']).passthrough).toEqual([]);
+    expect(parseArgs(['sandbox', '--json']).passthrough).toEqual([]);
   });
 
   it('collects positional command and arguments under sandbox without --', () => {
@@ -136,36 +130,6 @@ describe('resolveSandboxChild precedence', () => {
       explicitCommand: ['node', 'x.js'],
     });
     expect(plan?.argv).toEqual(['node', 'x.js']);
-  });
-});
-
-describe('detectPackageManager / readDevScript', () => {
-  it('sniffs lockfiles, defaulting to npm', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'pyric-pm-'));
-    try {
-      expect(detectPackageManager(dir)).toBe('npm');
-      writeFileSync(join(dir, 'yarn.lock'), '');
-      expect(detectPackageManager(dir)).toBe('yarn');
-      writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
-      expect(detectPackageManager(dir)).toBe('pnpm');
-      writeFileSync(join(dir, 'bun.lock'), '');
-      expect(detectPackageManager(dir)).toBe('bun');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reads scripts.dev, tolerating missing/invalid package.json', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'pyric-devscript-'));
-    try {
-      expect(readDevScript(dir)).toBeNull();
-      writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { dev: 'vite dev' } }));
-      expect(readDevScript(dir)).toBe('vite dev');
-      writeFileSync(join(dir, 'package.json'), '{not json');
-      expect(readDevScript(dir)).toBeNull();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
   });
 });
 

--- a/packages/cli/test/e2e/ai-demo.pw.ts
+++ b/packages/cli/test/e2e/ai-demo.pw.ts
@@ -52,7 +52,7 @@ test.beforeAll(async () => {
   const proc = spawn(
     process.execPath,
     // --no-cache: test the worker/entry bundles as built, never a warm cache.
-    [CLI_PATH, 'dev', '--no-open', '--port', '0', '--json', '--no-cache'],
+    [CLI_PATH, 'sandbox', '--no-open', '--port', '0', '--json', '--no-cache'],
     { cwd: DEMO_DIR, env: { ...process.env, CI: '1' }, stdio: ['ignore', 'pipe', 'pipe'] },
   );
   child = proc;

--- a/packages/cli/test/e2e/playwright.config.ts
+++ b/packages/cli/test/e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   webServer: process.env.E2E_BASE
     ? undefined
     : {
-        command: 'node ../../../dist/cli/index.js dev --port 5180 --no-open --no-cache',
+        command: 'node ../../../dist/cli/index.js sandbox --port 5180 --no-open --no-cache',
         cwd: 'fixture',
         url: 'http://127.0.0.1:5180',
         reuseExistingServer: true,

--- a/packages/cli/test/e2e/site-cli/playwright.config.ts
+++ b/packages/cli/test/e2e/site-cli/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: `bun ${cli} dev --ui --no-open --no-capture --no-watch --host 127.0.0.1 --port 5201`,
+    command: `bun ${cli} sandbox --ui --no-open --no-capture --no-watch --host 127.0.0.1 --port 5201`,
     cwd: fixture,
     env: { ...process.env, HOME: testHome, USERPROFILE: testHome },
     url: 'http://127.0.0.1:5201/__pyric/ui/',

--- a/packages/cli/test/e2e/soak/harness.ts
+++ b/packages/cli/test/e2e/soak/harness.ts
@@ -94,7 +94,7 @@ export async function startSoakServe(
 
   const args = [
     CLI_PATH,
-    'dev',
+    'sandbox',
     '--ui',
     '--bridge',
     '--no-open',

--- a/packages/cli/test/functions-rtdb/child.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/child.integration.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   buildChildEnv,
   registerModuleUrl,
-} from '../../src/cli/dev-runner.js';
+} from '../../src/cli/sandbox-runner.js';
 import { startServe, type ServeRuntime } from '../../src/cli/serve.js';
 import { connectRemoteSandbox, type RemoteSandbox } from '../../src/remote/index.js';
 import { silentServeLogger } from '../../src/serve/server.js';

--- a/packages/cli/test/functions-rtdb/dev.e2e.test.ts
+++ b/packages/cli/test/functions-rtdb/dev.e2e.test.ts
@@ -102,7 +102,7 @@ exports.makeUppercase = onValueCreated(
       let stderr = '';
       command = spawn('node', [
         cliEntry,
-        'dev',
+        'sandbox',
         '--port=0',
         '--host=127.0.0.1',
         '--no-open',
@@ -202,7 +202,7 @@ export const makeUppercase = onValueCreated(
     let stdout = '';
     let stderr = '';
     command = spawn('node', [
-      cliEntry, 'dev', '--port=0', '--host=127.0.0.1', '--no-open', '--no-capture',
+      cliEntry, 'sandbox', '--port=0', '--host=127.0.0.1', '--no-open', '--no-capture',
     ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
     command.stdout?.setEncoding('utf8');
     command.stderr?.setEncoding('utf8');
@@ -303,7 +303,7 @@ exports.stampPresence = onValueCreated('/presence/{uid}/state', async (event) =>
     let stdout = '';
     let stderr = '';
     command = spawn('node', [
-      cliEntry, 'dev', '--port=0', '--host=127.0.0.1', '--no-open', '--no-capture',
+      cliEntry, 'sandbox', '--port=0', '--host=127.0.0.1', '--no-open', '--no-capture',
     ], { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
     command.stdout?.setEncoding('utf8');
     command.stderr?.setEncoding('utf8');
@@ -401,7 +401,7 @@ require('node:child_process').execFileSync(process.execPath, ['-e', 'setTimeout(
     let stdout = '';
     const blockedCommand = spawn('node', [
       cliEntry,
-      'dev',
+      'sandbox',
       '--port=0',
       '--host=127.0.0.1',
       '--no-open',
@@ -465,11 +465,8 @@ require('node:child_process').execFileSync(process.execPath, ['-e', 'setTimeout(
       hosting: { public: 'public' },
       functions: { source: 'functions' },
     }));
-    writeFileSync(join(cwd, 'package.json'), JSON.stringify({
-      private: true,
-      scripts: {
-        dev: `node -e "require('node:fs').writeFileSync('dev-child.pid', String(process.pid)); setTimeout(() => {}, 60000)"`,
-      },
+    writeFileSync(join(cwd, 'pyric.json'), JSON.stringify({
+      command: `node -e "require('node:fs').writeFileSync('dev-child.pid', String(process.pid)); setTimeout(() => {}, 60000)"`,
     }));
     writeFileSync(join(cwd, 'functions/package.json'), JSON.stringify({
       name: 'fatal-functions',
@@ -482,7 +479,7 @@ require('node:child_process').execFileSync(process.execPath, ['-e', 'setTimeout(
     let stderr = '';
     const fatalCommand = spawn('node', [
       cliEntry,
-      'dev',
+      'sandbox',
       '--port=0',
       '--host=127.0.0.1',
       '--no-open',

--- a/packages/cli/test/functions-rtdb/messaging-bridge.integration.test.ts
+++ b/packages/cli/test/functions-rtdb/messaging-bridge.integration.test.ts
@@ -18,7 +18,7 @@ import {
 import {
   buildChildEnv,
   registerModuleUrl,
-} from '../../src/cli/dev-runner.js';
+} from '../../src/cli/sandbox-runner.js';
 import { startServe, type ServeRuntime } from '../../src/cli/serve.js';
 import { connectRemoteSandbox, type RemoteSandbox } from '../../src/remote/index.js';
 import { silentServeLogger } from '../../src/serve/server.js';

--- a/packages/cli/test/functions-rtdb/oracle-conformance.test.ts
+++ b/packages/cli/test/functions-rtdb/oracle-conformance.test.ts
@@ -28,7 +28,7 @@ import {
   spawnFunctionsRtdbChild,
   type FunctionsRtdbChildEvent,
 } from '../../src/functions-rtdb/child.js';
-import { buildChildEnv, registerModuleUrl } from '../../src/cli/dev-runner.js';
+import { buildChildEnv, registerModuleUrl } from '../../src/cli/sandbox-runner.js';
 import { startServe } from '../../src/cli/serve.js';
 import { connectRemoteSandbox } from '../../src/remote/index.js';
 import { silentServeLogger } from '../../src/serve/server.js';

--- a/packages/cli/test/serve/canonical-url.test.ts
+++ b/packages/cli/test/serve/canonical-url.test.ts
@@ -22,7 +22,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startServe, serveJsonLine, type ServeRuntime } from '../../src/cli/serve.js';
-import { buildChildEnv } from '../../src/cli/dev-runner.js';
+import { buildChildEnv } from '../../src/cli/sandbox-runner.js';
 import { silentServeLogger } from '../../src/serve/server.js';
 import { discoverServe, canonicalServeUrl } from '../../src/serve/discovery.js';
 

--- a/packages/cli/test/serve/integration.test.ts
+++ b/packages/cli/test/serve/integration.test.ts
@@ -333,7 +333,7 @@ describe('runServe host-only environment export', () => {
       return true;
     }) as typeof process.stdout.write;
     try {
-      const parsed = parseArgs(['dev', '--port', '0', '--no-open', '--no-run', '--no-cache']);
+      const parsed = parseArgs(['sandbox', '--port', '0', '--no-open', '--no-run', '--no-cache']);
       const code = await runServe(parsed);
       expect(code).toBe(0);
       expect(stdout).toContain('export PYRIC_SANDBOX="remote:http://');

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -13,7 +13,13 @@
   },
   "description": "Firebase Admin-shaped adapters for the Pyric development sandbox.",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./app": {
       "types": "./dist/app/index.d.ts",
       "import": "./dist/app/index.js"

--- a/packages/pyric-admin/src/admin.ts
+++ b/packages/pyric-admin/src/admin.ts
@@ -1,0 +1,40 @@
+/**
+ * Root `firebase-admin` compatibility facade.
+ *
+ * Implements top-level service accessors (admin.firestore(), admin.auth(), etc.)
+ * and re-exports app lifecycle helpers so standard `import admin from 'firebase-admin'`
+ * and `const admin = require('firebase-admin')` work out of the box in the sandbox.
+ */
+import * as appModule from './app/index.js';
+import { getFirestore } from './firestore/index.js';
+import { getAuth } from './auth/index.js';
+import { getDatabase } from './database/index.js';
+import { getStorage } from './storage/index.js';
+import { getMessaging } from './messaging/index.js';
+
+export const credential = {
+  cert: appModule.cert,
+  applicationDefault: appModule.applicationDefault,
+  refreshToken: (token: string) => ({
+    [Symbol.for('pyric.admin.credential')]: 'refreshToken',
+    token,
+  }),
+};
+
+export const firestore = (app?: appModule.PyricAdminApp) => getFirestore(app);
+export const auth = (app?: appModule.PyricAdminApp) => getAuth(app);
+export const database = (app?: appModule.PyricAdminApp) => getDatabase(app);
+export const storage = (app?: appModule.PyricAdminApp) => getStorage(app);
+export const messaging = (app?: appModule.PyricAdminApp) => getMessaging(app);
+
+const admin = {
+  ...appModule,
+  credential,
+  firestore,
+  auth,
+  database,
+  storage,
+  messaging,
+};
+
+export default admin;

--- a/packages/pyric-admin/src/index.ts
+++ b/packages/pyric-admin/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Root `pyric-admin` entry point — mirrors `firebase-admin`'s root package export.
+ *
+ * Exposes top-level modular helpers as well as the default `admin` namespace,
+ * allowing unmodified `import admin from 'firebase-admin'` and
+ * `import { initializeApp, firestore, auth } from 'firebase-admin'` to resolve cleanly.
+ */
+import * as appModule from './app/index.js';
+import { getFirestore } from './firestore/index.js';
+import { getAuth } from './auth/index.js';
+import { getDatabase } from './database/index.js';
+import { getStorage } from './storage/index.js';
+import { getMessaging } from './messaging/index.js';
+
+export * from './app/index.js';
+export { getFirestore } from './firestore/index.js';
+export { getAuth } from './auth/index.js';
+export { getDatabase } from './database/index.js';
+export { getStorage } from './storage/index.js';
+export { getMessaging } from './messaging/index.js';
+
+export const credential = {
+  cert: appModule.cert,
+  applicationDefault: appModule.applicationDefault,
+  refreshToken: (token: string) => ({
+    [Symbol.for('pyric.admin.credential')]: 'refreshToken',
+    token,
+  }),
+};
+
+export const firestore = (app?: appModule.PyricAdminApp) => getFirestore(app);
+export const auth = (app?: appModule.PyricAdminApp) => getAuth(app);
+export const database = (app?: appModule.PyricAdminApp) => getDatabase(app);
+export const storage = (app?: appModule.PyricAdminApp) => getStorage(app);
+export const messaging = (app?: appModule.PyricAdminApp) => getMessaging(app);
+
+const admin = {
+  ...appModule,
+  credential,
+  firestore,
+  auth,
+  database,
+  storage,
+  messaging,
+};
+
+export default admin;

--- a/packages/pyric-admin/src/index.ts
+++ b/packages/pyric-admin/src/index.ts
@@ -1,47 +1,8 @@
 /**
- * Root `pyric-admin` entry point — mirrors `firebase-admin`'s root package export.
+ * Root `pyric-admin` entry point — pure re-export barrel.
  *
- * Exposes top-level modular helpers as well as the default `admin` namespace,
- * allowing unmodified `import admin from 'firebase-admin'` and
- * `import { initializeApp, firestore, auth } from 'firebase-admin'` to resolve cleanly.
+ * Exposes the root admin facade and modular app exports.
  */
-import * as appModule from './app/index.js';
-import { getFirestore } from './firestore/index.js';
-import { getAuth } from './auth/index.js';
-import { getDatabase } from './database/index.js';
-import { getStorage } from './storage/index.js';
-import { getMessaging } from './messaging/index.js';
-
 export * from './app/index.js';
-export { getFirestore } from './firestore/index.js';
-export { getAuth } from './auth/index.js';
-export { getDatabase } from './database/index.js';
-export { getStorage } from './storage/index.js';
-export { getMessaging } from './messaging/index.js';
-
-export const credential = {
-  cert: appModule.cert,
-  applicationDefault: appModule.applicationDefault,
-  refreshToken: (token: string) => ({
-    [Symbol.for('pyric.admin.credential')]: 'refreshToken',
-    token,
-  }),
-};
-
-export const firestore = (app?: appModule.PyricAdminApp) => getFirestore(app);
-export const auth = (app?: appModule.PyricAdminApp) => getAuth(app);
-export const database = (app?: appModule.PyricAdminApp) => getDatabase(app);
-export const storage = (app?: appModule.PyricAdminApp) => getStorage(app);
-export const messaging = (app?: appModule.PyricAdminApp) => getMessaging(app);
-
-const admin = {
-  ...appModule,
-  credential,
-  firestore,
-  auth,
-  database,
-  storage,
-  messaging,
-};
-
-export default admin;
+export * from './admin.js';
+export { default } from './admin.js';

--- a/packages/pyric/test/app/app-service-types.test.ts
+++ b/packages/pyric/test/app/app-service-types.test.ts
@@ -24,4 +24,4 @@ it('app-backed service factories expose a required .app to downstream TypeScript
   });
   const output = `${result.stdout.toString()}${result.stderr.toString()}`;
   expect(result.exitCode, output).toBe(0);
-});
+}, 30_000);

--- a/scripts/fixtures/cli-release-contract.json
+++ b/scripts/fixtures/cli-release-contract.json
@@ -2,7 +2,7 @@
   "schema": "pyric.cli.release-contract.v1",
   "commands": [
     "bridge",
-    "dev",
+    "sandbox",
     "init",
     "vendor",
     "mcp",


### PR DESCRIPTION
Replaces `pyric dev` with `pyric sandbox`, a single command that runs the browser-resident Pyric sandbox daemon and optionally wraps a child command with injected environment variables and loader hooks.

```bash
# Run any child command inside the sandbox without configuration or flags
$ pyric sandbox next dev

# Positional arguments pass through directly to the child
$ pyric sandbox vitest run --watch=false

# Inline environment variables and short port flag work transparently
$ pyric sandbox -p 4000 PORT=3000 node server.js
```

## `sandbox` replaces `dev` without legacy command aliases

```bash
# The CLI router dispatches sandbox directly
$ pyric sandbox --port 4000
```

`dev` is completely removed from the CLI routing switch and command parser in favor of `sandbox`. Positional arguments following `pyric sandbox` are captured directly as the child command without requiring a bare `--` separator, though `--` remains supported for explicit argument demarcation.

## Child command precedence is explicit and eliminates `package.json` sniffing

```json
// pyric.json (optional)
{
  "command": "next dev",
  "port": 4000,
  "rules": {
    "firestore": "firestore.rules",
    "database": "database.rules.json"
  },
  "project": "demo-project"
}
```

```bash
# Runs the command configured in pyric.json when no CLI argument is given
$ pyric sandbox

# An explicit CLI argument overrides pyric.json
$ pyric sandbox node custom-script.js

# Machine mode (--json) or explicit --no-run starts the host daemon without spawning a child
$ pyric sandbox --no-run
```

`pyric sandbox` resolves the child execution plan strictly by:
1. Explicit CLI arguments (`pyric sandbox <cmd...>`) or passthrough (`pyric sandbox -- <cmd...>`)
2. `command` property in `pyric.json`
3. Host-only daemon mode (no child process) if neither is provided, or if `--no-run` / `--json` is specified

Automatic inspection of `package.json` `scripts.dev` is eliminated.

## `pyric-admin` exposes a root facade while preserving barrel purity

```ts
// Consumer child process: standard firebase-admin root import works without changes
import admin from 'firebase-admin';

admin.initializeApp();
const db = admin.firestore();
await db.collection('posts').doc('intro').set({ title: 'Hello Sandbox' });
```

`packages/pyric-admin/package.json` exports `.` pointing to `src/index.ts`, which acts as a pure re-export barrel delegating to `src/admin.ts`. Standard `import admin from 'firebase-admin'` resolves top-level accessors (`admin.firestore()`, `admin.auth()`, `admin.credential`) without modifying user imports.

## Shell chaining operators execute via shell while quoted inline scripts run directly

```bash
# Discrete shell operators trigger shell execution
$ pyric sandbox npm run build && npm run dev

# Quoted scripts with logical operators spawn directly without shell mangling
$ pyric sandbox node -e 'console.log(false || "fallback")'
```

Command tokens are inspected for discrete shell operators (`&&`, `||`, `|`, `;`, `&`). Commands containing unquoted operators run via the system shell, while commands with quoted scripts spawn directly with preserved arguments.

## Risk

- Workflows or scripts invoking `pyric dev` will fail with an unknown command error; they must invoke `pyric sandbox`.
- Projects that previously relied on implicit execution of `package.json`'s `dev` script must now specify their command either positionally (`pyric sandbox npm run dev`) or via `pyric.json` (`{ "command": "npm run dev" }`).

<details>
<summary>Implementation notes & verification</summary>

- **Barrel Purity (`docs/code-conventions.md` §4)**: `packages/pyric-admin/src/index.ts` is purely re-exports; implementation logic resides in `packages/pyric-admin/src/admin.ts`.
- **Explicit Branching (§3b, §3c)**: Replaced nested ternaries with `resolveServePort` and `resolveExplicitCommand`; replaced multi-tier nullish coalescing with `resolveProjectIdentifier`; eliminated conditional object spreads in `serve.ts`.
- **Suite Migration**:
  - Migrated `packages/cli/test/functions-rtdb/dev.e2e.test.ts` and `serve/integration.test.ts` to `sandbox`.
  - Updated `scripts/fixtures/cli-release-contract.json` to pin `sandbox`.
- **Verification Commands**:
  - `bun test packages/cli/test/cli/`: 150 passed, 0 failed
  - `bun run test:ci:cli`: 1,466 passed, 0 failed (18 skipped)
  - `bun run tool:parity:check`: Passed cleanly (50 deliberate, 5 gap, 0 unclassified)
  - `bun run test:ci:libraries:core`: 378 passed, 0 failed (3 skipped)
  - `bun run build`: Full monorepo and Astro documentation built cleanly

</details>
