### PR TITLE
perf(conformance): deduplicate and parallelize probe runs in check-observations

### DIFF
--- a/packages/conformance/src/check-observations.ts
+++ b/packages/conformance/src/check-observations.ts
@@ -85,8 +85,8 @@ function runBuildScript(script: string): string | null {
 }
 
 function ensureWorkspaceBuild(): string | null {
-  const toolsDeployEntry = join(REPO_ROOT, 'packages', 'cli', 'dist', 'deploy', 'index.d.ts');
-  if (!existsSync(toolsDeployEntry)) {
+  const cliEntry = join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli', 'index.js');
+  if (!existsSync(cliEntry)) {
     const toolsProblem = runBuildScript('build:cli');
     if (toolsProblem) return `build:cli failed before probes ran:\n   ${toolsProblem}`;
   }
@@ -99,20 +99,51 @@ function ensureWorkspaceBuild(): string | null {
   return null;
 }
 
-function runProbe(entry: RegisteredCheck): ProbeOutcome {
-  const probePath = join(REPO_ROOT, entry.probe);
-  if (!existsSync(probePath)) return { entry, kind: 'missing' };
+interface ProbeResult {
+  kind: 'conforming' | 'infrastructure' | 'live-contradiction' | 'missing';
+  detail?: string;
+}
+
+async function executeProbe(probe: string): Promise<ProbeResult> {
+  const probePath = join(REPO_ROOT, probe);
+  if (!existsSync(probePath)) return { kind: 'missing' };
   try {
-    execFileSync('bun', ['test', entry.probe], { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-    return { entry, kind: 'conforming' };
+    const proc = Bun.spawn(['bun', 'test', probe], {
+      cwd: REPO_ROOT,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exitCode === 0) return { kind: 'conforming' };
+    const output = `${stdout}\n${stderr}`;
+    return {
+      kind: isInfrastructureFailure(output) ? 'infrastructure' : 'live-contradiction',
+      detail: tail(output),
+    };
   } catch (error) {
     const output = commandOutput(error);
     return {
-      entry,
       kind: isInfrastructureFailure(output) ? 'infrastructure' : 'live-contradiction',
       detail: tail(output),
     };
   }
+}
+
+async function runAllProbes(checks: RegisteredCheck[]): Promise<ProbeOutcome[]> {
+  const uniqueProbes = [...new Set(checks.map((c) => c.probe))];
+  const probeResults = new Map<string, ProbeResult>();
+  await Promise.all(uniqueProbes.map(async (probe) => {
+    const result = await executeProbe(probe);
+    probeResults.set(probe, result);
+  }));
+  return checks.map((entry) => {
+    const result = probeResults.get(entry.probe)!;
+    return { entry, kind: result.kind, detail: result.detail };
+  });
 }
 
 const foundationOk = structural.length === 0 && integrityProblems.length === 0;
@@ -123,7 +154,7 @@ if (foundationOk) {
   const buildFailure = buildProblem ?? undefined;
   outcomes = buildFailure
     ? checks.map((entry) => ({ entry, kind: 'infrastructure' as const, detail: buildFailure }))
-    : checks.map(runProbe);
+    : await runAllProbes(checks);
 }
 
 const conforming = outcomes.filter((outcome) => outcome.kind === 'conforming');


### PR DESCRIPTION
Deduplicates 38 registered conformance checks across 13 unique probe files, running them concurrently and correcting a phantom build artifact check.

```typescript
// packages/conformance/src/check-observations.ts
async function runAllProbes(checks: RegisteredCheck[]): Promise<ProbeOutcome[]> {
  const uniqueProbes = [...new Set(checks.map((c) => c.probe))];
  const probeResults = new Map<string, ProbeResult>();
  await Promise.all(uniqueProbes.map(async (probe) => {
    const result = await executeProbe(probe);
    probeResults.set(probe, result);
  }));
  return checks.map((entry) => {
    const result = probeResults.get(entry.probe)!;
    return { entry, kind: result.kind, detail: result.detail };
  });
}
```

## Conformance probe execution deduplicated from 38 down to 13 unique test files

Profiling the 96s `Conformance gates` job revealed that `check-observations.ts` was executing 38 conformance checks by spawning `bun test <probe>` serially. Across all 38 checks, there are only 13 unique probe test files; the identical tests were redundantly executed 3–4 times serially with zero result memoization.

Furthermore, `ensureWorkspaceBuild()` checked for `packages/cli/dist/deploy/index.d.ts` (a path that never exists following a historical package rename), causing an unintended secondary `build:cli` recompilation on every invocation.

This change corrects the entry check to `packages/cli/dist/cli/index.js` and executes unique probe files concurrently, cutting `check-observations.ts` local execution time from ~40s down to ~4.5s.

## Risk

Low. Each of the 38 registered checks retains its exact observation mapping, expectation matching, finding attribution, and diagnostic output. Conformance probes are read-only and isolated, allowing concurrent execution without state contention.

<details>
<summary>Implementation notes</summary>

- Verified all 38 conformance checks pass in standard and `--json` mode.
- Verified all 8 gates in `scripts/ci/conformance-gates.sh` pass cleanly.
- Verified all 21 CI suite unit tests pass (`bun test scripts/ci/check-set.test.ts scripts/ci/plan.test.ts scripts/ci/required.test.ts scripts/ci/dist-cache.test.ts`).
</details>