### PR TITLE
fix(worker): prevent SharedWorker singleton context poisoning on bootstrap failure

### DIFF
--- a/packages/cli/src/serve/worker/context-resolver.ts
+++ b/packages/cli/src/serve/worker/context-resolver.ts
@@ -1,0 +1,70 @@
+/**
+ * SharedWorker context resolver.
+ *
+ * Coordinates asynchronous initialization of a singleton resource across
+ * concurrent inbound connection requests or burst messages.
+ *
+ * Invariants:
+ * 1. Single In-Flight Attempt: When multiple callers request the context
+ *    concurrently while initialization is in flight, all callers share the
+ *    single in-flight promise rather than starting parallel initializations.
+ * 2. Unpoisoned on Rejection: If initialization rejects, the memoized promise
+ *    is cleared immediately, allowing subsequent requests to retry initialization
+ *    rather than permanently caching the rejection.
+ * 3. Synchronous Retrieval: Once successfully resolved, the resource is
+ *    available synchronously for shutdown and cleanup handlers.
+ */
+
+export interface ContextResolver<T> {
+  /**
+   * Return the resolved resource or the in-flight initialization promise.
+   * If a previous attempt rejected, starts a new attempt.
+   */
+  get(): Promise<T>;
+
+  /**
+   * Return the successfully resolved resource, or null if not yet resolved
+   * or currently in-flight.
+   */
+  current(): T | null;
+
+  /**
+   * Reset the resolver state. Useful for test isolation or worker teardown.
+   */
+  reset(): void;
+}
+
+export function createContextResolver<T>(factory: () => Promise<T>): ContextResolver<T> {
+  let value: T | null = null;
+  let inFlight: Promise<T> | null = null;
+
+  return {
+    async get(): Promise<T> {
+      if (value !== null) {
+        return value;
+      }
+      if (inFlight === null) {
+        inFlight = factory()
+          .then((resolved) => {
+            value = resolved;
+            return resolved;
+          })
+          .catch((error: unknown) => {
+            inFlight = null;
+            value = null;
+            throw error;
+          });
+      }
+      return inFlight;
+    },
+
+    current(): T | null {
+      return value;
+    },
+
+    reset(): void {
+      value = null;
+      inFlight = null;
+    },
+  };
+}

--- a/packages/cli/src/serve/worker/context-resolver.ts
+++ b/packages/cli/src/serve/worker/context-resolver.ts
@@ -27,11 +27,6 @@ export interface ContextResolver<T> {
    * or currently in-flight.
    */
   current(): T | null;
-
-  /**
-   * Reset the resolver state. Useful for test isolation or worker teardown.
-   */
-  reset(): void;
 }
 
 export function createContextResolver<T>(factory: () => Promise<T>): ContextResolver<T> {
@@ -60,11 +55,6 @@ export function createContextResolver<T>(factory: () => Promise<T>): ContextReso
 
     current(): T | null {
       return value;
-    },
-
-    reset(): void {
-      value = null;
-      inFlight = null;
     },
   };
 }

--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -68,6 +68,7 @@ import {
 import { createServiceWorkerRelay } from './service-worker-relay.js';
 import { createWorkerRetirement } from './retirement.js';
 import { createContextResolver } from './context-resolver.js';
+import { createPortLifecycleManager } from './port-lifecycle.js';
 
 declare const __PYRIC_WORKER_VERSION__: string;
 const workerEpoch = typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
@@ -75,6 +76,7 @@ const workerEpoch = typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
   : 'dev';
 const workerScope = self as unknown as SharedWorkerGlobalScope;
 const contextResolver = createContextResolver(buildCtx);
+const portLifecycle = createPortLifecycleManager();
 const retirement = createWorkerRetirement({
   closeWorker: () => workerScope.close(),
   beforeAnnounce: async () => { await contextResolver.current()?.captureFlush?.(); },
@@ -86,9 +88,12 @@ const retirement = createWorkerRetirement({
  * Return the shared context, memoizing the in-flight init promise so
  * concurrent first messages await ONE build. If initialization rejects,
  * the rejection is cleared so subsequent connection attempts can retry.
+ * Any ports that closed while initialization was in flight are drained immediately.
  */
-function getCtx(): Promise<HostCtx> {
-  return contextResolver.get();
+async function getCtx(): Promise<HostCtx> {
+  const ctx = await contextResolver.get();
+  portLifecycle.drainClosedPorts(ctx);
+  return ctx;
 }
 
 /**
@@ -163,9 +168,16 @@ workerScope.onconnect = (e: MessageEvent) => {
     // cannot overtake an already-posted mutation, and later frames see the
     // disconnected-port tombstone instead of touching the shared backend.
     messageQueue = messageQueue.then(async () => {
+      const portLike = port as unknown as PortLike;
+      if (portLifecycle.isPortClosed(portLike)) {
+        return;
+      }
       try {
         const ctx = await getCtx();
-        await handleMessage(ctx, port as unknown as PortLike, ev.data);
+        if (portLifecycle.isPortClosed(portLike)) {
+          return;
+        }
+        await handleMessage(ctx, portLike, ev.data);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error('[pyric worker] message handler error:', (e as Error)?.stack ?? e, 'msg:', ev.data);
@@ -179,8 +191,7 @@ workerScope.onconnect = (e: MessageEvent) => {
   // best-effort; subscriptions also GC when the worker itself dies.
   port.addEventListener('close', () => {
     retirement.disconnect(port);
-    const resolvedCtx = contextResolver.current();
-    if (resolvedCtx) void cleanupPortWithDisconnect(resolvedCtx, port as unknown as PortLike).catch(() => undefined);
+    portLifecycle.onPortClosed(port as unknown as PortLike, contextResolver.current());
   });
 };
 

--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -67,36 +67,28 @@ import {
 } from './service-worker-channel.js';
 import { createServiceWorkerRelay } from './service-worker-relay.js';
 import { createWorkerRetirement } from './retirement.js';
+import { createContextResolver } from './context-resolver.js';
 
 declare const __PYRIC_WORKER_VERSION__: string;
 const workerEpoch = typeof __PYRIC_WORKER_VERSION__ !== 'undefined'
   ? __PYRIC_WORKER_VERSION__
   : 'dev';
 const workerScope = self as unknown as SharedWorkerGlobalScope;
+const contextResolver = createContextResolver(buildCtx);
 const retirement = createWorkerRetirement({
   closeWorker: () => workerScope.close(),
-  beforeAnnounce: async () => { await _ctx?.captureFlush?.(); },
+  beforeAnnounce: async () => { await contextResolver.current()?.captureFlush?.(); },
 });
 
 // ─── Singleton context ────────────────────────────────────────────────────
 
-// `_ctx` is the RESOLVED context, kept for the synchronous `close` handler.
-// The build is memoized as a PROMISE (`_ctxPromise`) — NOT as the resolved
-// value — because init is async (it awaits `/__pyric/init.json` + persistence
-// restore). The first messages arrive in a BURST (the authState sub, the first
-// firestore sub, an op — possibly across two tabs at once); if each re-checked
-// only the resolved `_ctx` they would every one start a fresh init and build a
-// SEPARATE sandbox, so a listener and a write could bind to different
-// instances and never see each other. The promise memo guarantees ONE init.
-let _ctx: HostCtx | null = null;
-let _ctxPromise: Promise<HostCtx> | null = null;
-
 /**
  * Return the shared context, memoizing the in-flight init promise so
- * concurrent first messages await ONE build (see `_ctxPromise` above).
+ * concurrent first messages await ONE build. If initialization rejects,
+ * the rejection is cleared so subsequent connection attempts can retry.
  */
 function getCtx(): Promise<HostCtx> {
-  return (_ctxPromise ??= buildCtx());
+  return contextResolver.get();
 }
 
 /**
@@ -125,7 +117,6 @@ async function buildCtx(): Promise<HostCtx> {
         ? (url) => new EventSource(url) as unknown as EventSourceLike
         : null,
   });
-  _ctx = ctx; // publish the resolved ctx for the synchronous close handler
   return ctx;
 }
 
@@ -188,7 +179,8 @@ workerScope.onconnect = (e: MessageEvent) => {
   // best-effort; subscriptions also GC when the worker itself dies.
   port.addEventListener('close', () => {
     retirement.disconnect(port);
-    if (_ctx) void cleanupPortWithDisconnect(_ctx, port as unknown as PortLike).catch(() => undefined);
+    const resolvedCtx = contextResolver.current();
+    if (resolvedCtx) void cleanupPortWithDisconnect(resolvedCtx, port as unknown as PortLike).catch(() => undefined);
   });
 };
 

--- a/packages/cli/src/serve/worker/entry.ts
+++ b/packages/cli/src/serve/worker/entry.ts
@@ -137,6 +137,7 @@ workerScope.onconnect = (e: MessageEvent) => {
   const port = e.ports[0];
   port.start();
   retirement.connect(port);
+  void getCtx().catch(() => undefined);
 
   let messageQueue = Promise.resolve();
   port.onmessage = (ev: MessageEvent<InboundMessage>) => {

--- a/packages/cli/src/serve/worker/port-lifecycle.ts
+++ b/packages/cli/src/serve/worker/port-lifecycle.ts
@@ -1,0 +1,49 @@
+import { cleanupPortWithDisconnect, type HostCtx, type PortLike } from './host.js';
+
+/**
+ * SharedWorker port lifecycle manager.
+ *
+ * Tracks ports that close before asynchronous worker context initialization
+ * finishes, preventing dead-port leaks and ensuring that port cleanup / disconnect
+ * operations are drained as soon as the context becomes available.
+ */
+export interface PortLifecycleManager {
+  /** Record port closure. Cleans up immediately if context is ready, or defers until resolution. */
+  onPortClosed(port: PortLike, currentCtx: HostCtx | null): void;
+  /** Drain all deferred closed ports against the newly resolved context. */
+  drainClosedPorts(ctx: HostCtx): void;
+  /** Check whether a port has already closed before processing queued messages. */
+  isPortClosed(port: PortLike): boolean;
+  /** Reset all tracked closed ports (for testing or worker teardown). */
+  clear(): void;
+}
+
+export function createPortLifecycleManager(): PortLifecycleManager {
+  const pendingClosedPorts = new Set<PortLike>();
+
+  return {
+    onPortClosed(port: PortLike, currentCtx: HostCtx | null): void {
+      if (currentCtx !== null) {
+        void cleanupPortWithDisconnect(currentCtx, port).catch(() => undefined);
+      } else {
+        pendingClosedPorts.add(port);
+      }
+    },
+
+    drainClosedPorts(ctx: HostCtx): void {
+      if (pendingClosedPorts.size === 0) return;
+      for (const port of pendingClosedPorts) {
+        void cleanupPortWithDisconnect(ctx, port).catch(() => undefined);
+      }
+      pendingClosedPorts.clear();
+    },
+
+    isPortClosed(port: PortLike): boolean {
+      return pendingClosedPorts.has(port);
+    },
+
+    clear(): void {
+      pendingClosedPorts.clear();
+    },
+  };
+}

--- a/packages/cli/src/serve/worker/port-lifecycle.ts
+++ b/packages/cli/src/serve/worker/port-lifecycle.ts
@@ -17,7 +17,7 @@ export interface PortLifecycleManager {
 }
 
 export function createPortLifecycleManager(): PortLifecycleManager {
-  const closedPorts = new Set<PortLike>();
+  const closedPorts = new WeakSet<PortLike>();
   const pendingClosedPorts = new Set<PortLike>();
 
   return {

--- a/packages/cli/src/serve/worker/port-lifecycle.ts
+++ b/packages/cli/src/serve/worker/port-lifecycle.ts
@@ -14,15 +14,15 @@ export interface PortLifecycleManager {
   drainClosedPorts(ctx: HostCtx): void;
   /** Check whether a port has already closed before processing queued messages. */
   isPortClosed(port: PortLike): boolean;
-  /** Reset all tracked closed ports (for testing or worker teardown). */
-  clear(): void;
 }
 
 export function createPortLifecycleManager(): PortLifecycleManager {
+  const closedPorts = new Set<PortLike>();
   const pendingClosedPorts = new Set<PortLike>();
 
   return {
     onPortClosed(port: PortLike, currentCtx: HostCtx | null): void {
+      closedPorts.add(port);
       if (currentCtx !== null) {
         void cleanupPortWithDisconnect(currentCtx, port).catch(() => undefined);
       } else {
@@ -39,11 +39,7 @@ export function createPortLifecycleManager(): PortLifecycleManager {
     },
 
     isPortClosed(port: PortLike): boolean {
-      return pendingClosedPorts.has(port);
-    },
-
-    clear(): void {
-      pendingClosedPorts.clear();
+      return closedPorts.has(port);
     },
   };
 }

--- a/packages/cli/test/serve/worker/context-resolver.test.ts
+++ b/packages/cli/test/serve/worker/context-resolver.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test';
+import { createContextResolver } from '../../../src/serve/worker/context-resolver.js';
+
+describe('context-resolver', () => {
+  it('resolves successfully and memoizes the resolved context', async () => {
+    let factoryCalls = 0;
+    const resolver = createContextResolver(async () => {
+      factoryCalls++;
+      return { id: 'ctx-1' };
+    });
+
+    expect(resolver.current()).toBeNull();
+
+    const first = await resolver.get();
+    expect(first).toEqual({ id: 'ctx-1' });
+    expect(factoryCalls).toBe(1);
+    expect(resolver.current()).toBe(first);
+
+    const second = await resolver.get();
+    expect(second).toBe(first);
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('coalesces concurrent in-flight calls to a single factory invocation', async () => {
+    let factoryCalls = 0;
+    let finish: ((val: { id: string }) => void) | null = null;
+
+    const resolver = createContextResolver(() => {
+      factoryCalls++;
+      return new Promise<{ id: string }>((resolve) => {
+        finish = resolve;
+      });
+    });
+
+    const promise1 = resolver.get();
+    const promise2 = resolver.get();
+    const promise3 = resolver.get();
+
+    expect(factoryCalls).toBe(1);
+    finish!({ id: 'concurrent-ctx' });
+
+    const [r1, r2, r3] = await Promise.all([promise1, promise2, promise3]);
+    expect(r1).toEqual({ id: 'concurrent-ctx' });
+    expect(r2).toBe(r1);
+    expect(r3).toBe(r1);
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('does not permanently poison on rejection; subsequent call retries factory', async () => {
+    let attempts = 0;
+    const resolver = createContextResolver(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new Error('transient IDB or network failure');
+      }
+      return { id: `recovered-ctx-${attempts}` };
+    });
+
+    // First attempt rejects
+    await expect(resolver.get()).rejects.toThrow('transient IDB or network failure');
+    expect(attempts).toBe(1);
+    expect(resolver.current()).toBeNull();
+
+    // Second attempt retries factory and succeeds instead of rethrowing cached rejection
+    const recovered = await resolver.get();
+    expect(recovered).toEqual({ id: 'recovered-ctx-2' });
+    expect(attempts).toBe(2);
+    expect(resolver.current()).toBe(recovered);
+
+    // Third call reuses successfully resolved instance
+    const cached = await resolver.get();
+    expect(cached).toBe(recovered);
+    expect(attempts).toBe(2);
+  });
+
+  it('resets memoized state on reset()', async () => {
+    let counter = 0;
+    const resolver = createContextResolver(async () => {
+      counter++;
+      return { count: counter };
+    });
+
+    const first = await resolver.get();
+    expect(first.count).toBe(1);
+
+    resolver.reset();
+    expect(resolver.current()).toBeNull();
+
+    const second = await resolver.get();
+    expect(second.count).toBe(2);
+  });
+});

--- a/packages/cli/test/serve/worker/context-resolver.test.ts
+++ b/packages/cli/test/serve/worker/context-resolver.test.ts
@@ -72,21 +72,4 @@ describe('context-resolver', () => {
     expect(cached).toBe(recovered);
     expect(attempts).toBe(2);
   });
-
-  it('resets memoized state on reset()', async () => {
-    let counter = 0;
-    const resolver = createContextResolver(async () => {
-      counter++;
-      return { count: counter };
-    });
-
-    const first = await resolver.get();
-    expect(first.count).toBe(1);
-
-    resolver.reset();
-    expect(resolver.current()).toBeNull();
-
-    const second = await resolver.get();
-    expect(second.count).toBe(2);
-  });
 });

--- a/packages/cli/test/serve/worker/port-lifecycle.test.ts
+++ b/packages/cli/test/serve/worker/port-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test';
+import type { HostCtx, PortLike } from '../../../src/serve/worker/host.js';
+import { createPortLifecycleManager } from '../../../src/serve/worker/port-lifecycle.js';
+
+describe('PortLifecycleManager', () => {
+  it('cleans up port immediately when context is already resolved', async () => {
+    let cleanedPort: PortLike | null = null;
+    const ctx = {
+      subs: new Map(),
+      disconnect: new Map(),
+    } as unknown as HostCtx;
+
+    const manager = createPortLifecycleManager();
+    const port: PortLike = { postMessage() {} };
+
+    // Register a subscription to verify cleanup
+    let unsubscribed = false;
+    ctx.subs.set(port, new Map([['sub1', () => { unsubscribed = true; }]]));
+
+    manager.onPortClosed(port, ctx);
+
+    // Wait a tick for void promise
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(unsubscribed).toBe(true);
+    expect(ctx.subs.has(port)).toBe(false);
+    expect(manager.isPortClosed(port)).toBe(false);
+  });
+
+  it('queues closed port when context is null and drains it upon resolution', async () => {
+    const manager = createPortLifecycleManager();
+    const port: PortLike = { postMessage() {} };
+
+    // Tab closes while context is still in flight (currentCtx === null)
+    manager.onPortClosed(port, null);
+    expect(manager.isPortClosed(port)).toBe(true);
+
+    const ctx = {
+      subs: new Map(),
+      disconnect: new Map(),
+    } as unknown as HostCtx;
+
+    let unsubscribed = false;
+    ctx.subs.set(port, new Map([['sub1', () => { unsubscribed = true; }]]));
+
+    // Context finishes loading and drains deferred closed ports
+    manager.drainClosedPorts(ctx);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(unsubscribed).toBe(true);
+    expect(ctx.subs.has(port)).toBe(false);
+    expect(manager.isPortClosed(port)).toBe(false);
+  });
+
+  it('drops messages when isPortClosed is true', () => {
+    const manager = createPortLifecycleManager();
+    const port: PortLike = { postMessage() {} };
+
+    expect(manager.isPortClosed(port)).toBe(false);
+    manager.onPortClosed(port, null);
+    expect(manager.isPortClosed(port)).toBe(true);
+
+    manager.clear();
+    expect(manager.isPortClosed(port)).toBe(false);
+  });
+});

--- a/packages/cli/test/serve/worker/port-lifecycle.test.ts
+++ b/packages/cli/test/serve/worker/port-lifecycle.test.ts
@@ -4,7 +4,6 @@ import { createPortLifecycleManager } from '../../../src/serve/worker/port-lifec
 
 describe('PortLifecycleManager', () => {
   it('cleans up port immediately when context is already resolved', async () => {
-    let cleanedPort: PortLike | null = null;
     const ctx = {
       subs: new Map(),
       disconnect: new Map(),
@@ -22,7 +21,6 @@ describe('PortLifecycleManager', () => {
     // Wait a tick for void promise
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(unsubscribed).toBe(true);
     expect(unsubscribed).toBe(true);
     expect(ctx.subs.has(port)).toBe(false);
     expect(manager.isPortClosed(port)).toBe(true);

--- a/packages/cli/test/serve/worker/port-lifecycle.test.ts
+++ b/packages/cli/test/serve/worker/port-lifecycle.test.ts
@@ -23,8 +23,9 @@ describe('PortLifecycleManager', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(unsubscribed).toBe(true);
+    expect(unsubscribed).toBe(true);
     expect(ctx.subs.has(port)).toBe(false);
-    expect(manager.isPortClosed(port)).toBe(false);
+    expect(manager.isPortClosed(port)).toBe(true);
   });
 
   it('queues closed port when context is null and drains it upon resolution', async () => {
@@ -50,7 +51,8 @@ describe('PortLifecycleManager', () => {
 
     expect(unsubscribed).toBe(true);
     expect(ctx.subs.has(port)).toBe(false);
-    expect(manager.isPortClosed(port)).toBe(false);
+    // Port remains permanently marked closed so in-flight queued frames are ignored
+    expect(manager.isPortClosed(port)).toBe(true);
   });
 
   it('drops messages when isPortClosed is true', () => {
@@ -60,8 +62,5 @@ describe('PortLifecycleManager', () => {
     expect(manager.isPortClosed(port)).toBe(false);
     manager.onPortClosed(port, null);
     expect(manager.isPortClosed(port)).toBe(true);
-
-    manager.clear();
-    expect(manager.isPortClosed(port)).toBe(false);
   });
 });


### PR DESCRIPTION
Makes a SharedWorker recover from a transient bootstrap failure and safely forget closed ports after cleanup.

```ts
import { createContextResolver } from './context-resolver.js';

let attempts = 0;
const resolver = createContextResolver(async () => {
  attempts += 1;
  if (attempts === 1) throw new Error('temporary startup failure');
  return { id: 'worker-context' };
});

await resolver.get().catch(() => undefined);
const context = await resolver.get();

console.log(context.id); // worker-context
```

## Rejected bootstrap promises no longer poison the worker

`entry.ts` previously cached the first `buildCtx()` promise for the SharedWorker lifetime. A temporary initialization failure left every later tab connected to the same rejected promise.

`createContextResolver` now coalesces concurrent initialization calls, memoizes a successful context, and clears a rejected attempt so a later connection or message can retry. The worker begins initialization when a port connects instead of waiting for the first message.

## Closed ports are cleaned after initialization without lifetime retention

```ts
const closedPorts = new WeakSet<PortLike>();
const pendingClosedPorts = new Set<PortLike>();
```

A port that closes while initialization is running remains in `pendingClosedPorts` until the context is ready. Cleanup then drains that set. The `WeakSet` preserves the closed-port tombstone check without keeping every closed `MessagePort` alive for the remaining SharedWorker lifetime.

## Risk

This changes SharedWorker initialization timing and connection cleanup. Initialization now starts for every new connection, even if the port has not sent a message. A failed attempt is retried by a later caller. Closed-port checks depend on object identity, which matches the existing `MessagePort` lifecycle.

Review should confirm that eager initialization is the intended connection behavior and that deferred cleanup runs once the first successful context resolves.

<details>
<summary>Implementation notes</summary>

- Removed the unused `ContextResolver.reset()` surface because it could race with an in-flight initialization.
- Removed an unused test variable and a duplicate assertion.
- Targeted worker lifecycle tests: 6 passed, 0 failed.
- CLI TypeScript check: passed.
- Packages-only build: passed.
- Full CLI suite: 1,469 passed, 21 skipped, 0 failed.
- Final Standards review: no findings.
- Final Spec review: no findings.

</details>
