### PR TITLE
feat(rtdb): enforce production default-deny security when database rules are absent

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -158,6 +158,8 @@ CORE FLAGS (sandbox)
   --no-capture       Don't write the session capture. dev writes
                      .pyric/last-session.json by default so \`pyric verify\`
                      can replay your session; --no-capture disables it.
+  --permissive       Allow unauthenticated Realtime Database reads and writes when no
+                     rules file is present. For local prototyping only.
   --allowed-host H   Allow an extra Host header past the DNS-rebinding guard
                      (comma-separated; localhost/127.0.0.1 always allowed).
   --persist          Persist sandbox state (docs + auth users) to

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -32,6 +32,7 @@ const BOOLEAN_FLAGS = new Set([
   'persist',
   'fresh',
   'force',
+  'permissive',
   'help',
   'version',
 ]);

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -146,6 +146,8 @@ export async function startServe(opts: {
    *  (the served project's file tree) + `/__pyric/projects` (single-project
    *  store over `cwd`). The Studio app's `local` mode talks to these. */
   ui?: boolean;
+  /** Explicit opt-in to permissive mode (default-allow RTDB rules when unconfigured). */
+  permissive?: boolean;
   logger?: Parameters<typeof startStaticServer>[0]['logger'];
 }): Promise<ServeRuntime> {
   const logger = opts.logger ?? consoleServeLogger();
@@ -304,6 +306,7 @@ export async function startServe(opts: {
       studio: opts.ui ? { siteUiDir } : false,
       bridgeUrl: () => mount && origin.port > 0 ? mount.wsUrl(origin) : null,
       activity: (incident) => logger.note(formatActivityWarning(incident)),
+      permissive: opts.permissive,
       logger,
     });
   } catch (error) {
@@ -723,6 +726,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
       watch: parsed.flags.get('no-watch') ? false : undefined,
       persist: Boolean(parsed.flags.get('persist')),
       fresh: Boolean(parsed.flags.get('fresh')),
+      permissive: Boolean(parsed.flags.get('permissive')),
       // --ui mounts the Pyric Studio storage routes (workspace + projects).
       ui: uiOn,
       // --no-capture disables the default-on session capture. The pattern

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -140,10 +140,11 @@ if (!useWorker) try {
     diagnostics.rulesDeployed = true;
     diagnostics.rulesHash = payload.rulesHash;
   }
-  if (payload.databaseRules) {
-    rtdbSandbox.setRules(getDatabase(sandbox), payload.databaseRules);
+  const effectiveDatabaseRules = payload.databaseRules ?? (payload.permissive ? null : rtdbSandbox.DEFAULT_DENY_RULES);
+  if (effectiveDatabaseRules) {
+    rtdbSandbox.setRules(getDatabase(sandbox), effectiveDatabaseRules);
     diagnostics.databaseRulesDeployed = true;
-    diagnostics.databaseRulesHash = payload.databaseRulesHash ?? null;
+    diagnostics.databaseRulesHash = payload.databaseRulesHash ?? 'default-deny';
   }
   // Open the ONE per-sandbox storage service eagerly: the FIRST open wins the
   // rules AND the project-scoped IDB name (`pyric-storage:<projectKey>`,

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -140,11 +140,15 @@ if (!useWorker) try {
     diagnostics.rulesDeployed = true;
     diagnostics.rulesHash = payload.rulesHash;
   }
-  const effectiveDatabaseRules = payload.databaseRules ?? (payload.permissive ? null : rtdbSandbox.DEFAULT_DENY_RULES);
-  if (effectiveDatabaseRules) {
-    rtdbSandbox.setRules(getDatabase(sandbox), effectiveDatabaseRules);
+  const db = getDatabase(sandbox);
+  if (payload.databaseRules) {
+    rtdbSandbox.setRules(db, payload.databaseRules);
     diagnostics.databaseRulesDeployed = true;
-    diagnostics.databaseRulesHash = payload.databaseRulesHash ?? 'default-deny';
+    diagnostics.databaseRulesHash = payload.databaseRulesHash;
+  } else if (payload.permissive) {
+    rtdbSandbox.setDefaultPolicy(db, 'allow');
+  } else {
+    rtdbSandbox.setDefaultPolicy(db, 'deny');
   }
   // Open the ONE per-sandbox storage service eagerly: the FIRST open wins the
   // rules AND the project-scoped IDB name (`pyric-storage:<projectKey>`,

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -144,7 +144,7 @@ if (!useWorker) try {
   if (payload.databaseRules) {
     rtdbSandbox.setRules(db, payload.databaseRules);
     diagnostics.databaseRulesDeployed = true;
-    diagnostics.databaseRulesHash = payload.databaseRulesHash;
+    diagnostics.databaseRulesHash = payload.databaseRulesHash ?? null;
   } else if (payload.permissive) {
     rtdbSandbox.setDefaultPolicy(db, 'allow');
   } else {

--- a/packages/cli/src/serve/init-payload.ts
+++ b/packages/cli/src/serve/init-payload.ts
@@ -11,6 +11,8 @@ export interface InitPayload {
   databaseRules?: { rules: Record<string, unknown> } | null;
   databaseRulesHash?: string | null;
   databaseUrl?: string | null;
+  /** Explicit opt-in to permissive default access when rules are unconfigured. */
+  permissive?: boolean;
   /** Storage rules are installed once, before the first Storage operation. */
   storageRules: string | null;
   storageRulesHash: string | null;

--- a/packages/cli/src/serve/rules.ts
+++ b/packages/cli/src/serve/rules.ts
@@ -173,9 +173,13 @@ export async function loadProjectDatabaseRules(
   cwd: string,
   config: FirebaseJson | null,
 ): Promise<LoadedDatabaseRules> {
-  const configured = config?.database?.rules;
+  const block = config?.database;
+  const entries = block ? (Array.isArray(block) ? block : [block]) : [];
+  const configuredEntry = entries.find((e) => e && typeof e === 'object' && e.rules);
+  const configured = configuredEntry?.rules;
   const rel = configured ?? 'database.rules.json';
   const path = isAbsolute(rel) ? rel : join(cwd, rel);
+  const databaseUrl = entries.find((e) => e && typeof e === 'object' && e.url)?.url ?? null;
   let raw: string;
   try {
     raw = await readFile(path, 'utf8');
@@ -188,7 +192,7 @@ export async function loadProjectDatabaseRules(
         rules: null,
         rulesHash: null,
         sourcePath: null,
-        databaseUrl: config?.database?.url ?? null,
+        databaseUrl,
       };
     }
     throw e;
@@ -209,7 +213,7 @@ export async function loadProjectDatabaseRules(
     rules,
     rulesHash: rulesHashOf(raw),
     sourcePath: path,
-    databaseUrl: config?.database?.url ?? null,
+    databaseUrl,
   };
 }
 

--- a/packages/cli/src/serve/rules.ts
+++ b/packages/cli/src/serve/rules.ts
@@ -174,22 +174,22 @@ export async function loadProjectDatabaseRules(
   config: FirebaseJson | null,
 ): Promise<LoadedDatabaseRules> {
   const configured = config?.database?.rules;
-  if (!configured) {
-    return {
-      rules: null,
-      rulesHash: null,
-      sourcePath: null,
-      databaseUrl: config?.database?.url ?? null,
-    };
-  }
-
-  const path = isAbsolute(configured) ? configured : join(cwd, configured);
+  const rel = configured ?? 'database.rules.json';
+  const path = isAbsolute(rel) ? rel : join(cwd, rel);
   let raw: string;
   try {
     raw = await readFile(path, 'utf8');
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
-      throw new Error(`pyric dev: firebase.json points database.rules at ${path}, but it does not exist.`);
+      if (configured) {
+        throw new Error(`pyric dev: firebase.json points database.rules at ${path}, but it does not exist.`);
+      }
+      return {
+        rules: null,
+        rulesHash: null,
+        sourcePath: null,
+        databaseUrl: config?.database?.url ?? null,
+      };
     }
     throw e;
   }

--- a/packages/cli/src/serve/rules.ts
+++ b/packages/cli/src/serve/rules.ts
@@ -169,17 +169,38 @@ export async function loadProjectStorageRules(
   return { rules, rulesHash: rulesHashOf(rules), sourcePath: path };
 }
 
+function normalizeDatabaseEntries(block: unknown): Array<Record<string, unknown>> {
+  if (!block) {
+    return [];
+  }
+  if (Array.isArray(block)) {
+    return block.filter((item): item is Record<string, unknown> => typeof item === 'object' && item !== null);
+  }
+  if (typeof block === 'object' && block !== null) {
+    return [block as Record<string, unknown>];
+  }
+  return [];
+}
+
+function hasConfiguredRules(entry: Record<string, unknown>): entry is Record<string, unknown> & { rules: string } {
+  return typeof entry.rules === 'string';
+}
+
+function hasConfiguredUrl(entry: Record<string, unknown>): entry is Record<string, unknown> & { url: string } {
+  return typeof entry.url === 'string';
+}
+
 export async function loadProjectDatabaseRules(
   cwd: string,
   config: FirebaseJson | null,
 ): Promise<LoadedDatabaseRules> {
-  const block = config?.database;
-  const entries = block ? (Array.isArray(block) ? block : [block]) : [];
-  const configuredEntry = entries.find((e) => e && typeof e === 'object' && e.rules);
+  const entries = normalizeDatabaseEntries(config?.database);
+  const configuredEntry = entries.find(hasConfiguredRules);
   const configured = configuredEntry?.rules;
   const rel = configured ?? 'database.rules.json';
   const path = isAbsolute(rel) ? rel : join(cwd, rel);
-  const databaseUrl = entries.find((e) => e && typeof e === 'object' && e.url)?.url ?? null;
+  const urlEntry = entries.find(hasConfiguredUrl);
+  const databaseUrl = urlEntry?.url ?? null;
   let raw: string;
   try {
     raw = await readFile(path, 'utf8');

--- a/packages/cli/src/serve/sandbox-session.ts
+++ b/packages/cli/src/serve/sandbox-session.ts
@@ -216,16 +216,15 @@ export async function createSandboxSession(
   });
 
   const reloadFirestoreRules = async (): Promise<RulesReloadResult> => {
+    if (!firestore.sourcePath) return { kind: 'not-configured' };
     try {
-      const updated = await loadProjectRules(options.projectDir, options.firebaseConfig);
-      if (!updated.sourcePath || !updated.rules || !updated.rulesHash) {
-        return { kind: 'not-configured' };
-      }
-      firestore.sourcePath = updated.sourcePath;
-      live.rules = updated.rules;
-      live.rulesHash = updated.rulesHash;
-      events.broadcast('rules-changed', { rules: updated.rules, rulesHash: updated.rulesHash });
-      return { kind: 'reloaded', rulesHash: updated.rulesHash, clients: events.clientCount() };
+      const raw = await readFile(firestore.sourcePath, 'utf8');
+      const rules = prepareRulesSource(raw, firestore.sourcePath);
+      const rulesHash = rulesHashOf(rules);
+      live.rules = rules;
+      live.rulesHash = rulesHash;
+      events.broadcast('rules-changed', { rules, rulesHash });
+      return { kind: 'reloaded', rulesHash, clients: events.clientCount() };
     } catch (error) {
       return { kind: 'rejected', error: error instanceof Error ? error : new Error(String(error)) };
     }

--- a/packages/cli/src/serve/sandbox-session.ts
+++ b/packages/cli/src/serve/sandbox-session.ts
@@ -216,30 +216,28 @@ export async function createSandboxSession(
   });
 
   const reloadFirestoreRules = async (): Promise<RulesReloadResult> => {
-    if (!firestore.sourcePath) return { kind: 'not-configured' };
     try {
-      const raw = await readFile(firestore.sourcePath, 'utf8');
-      const rules = prepareRulesSource(raw, firestore.sourcePath);
-      const rulesHash = rulesHashOf(rules);
-      live.rules = rules;
-      live.rulesHash = rulesHash;
-      events.broadcast('rules-changed', { rules, rulesHash });
-      return { kind: 'reloaded', rulesHash, clients: events.clientCount() };
+      const updated = await loadProjectRules(options.projectDir, options.firebaseConfig);
+      if (!updated.sourcePath || !updated.rules || !updated.rulesHash) {
+        return { kind: 'not-configured' };
+      }
+      firestore.sourcePath = updated.sourcePath;
+      live.rules = updated.rules;
+      live.rulesHash = updated.rulesHash;
+      events.broadcast('rules-changed', { rules: updated.rules, rulesHash: updated.rulesHash });
+      return { kind: 'reloaded', rulesHash: updated.rulesHash, clients: events.clientCount() };
     } catch (error) {
       return { kind: 'rejected', error: error instanceof Error ? error : new Error(String(error)) };
     }
   };
   const reloadDatabaseRules = async (): Promise<RulesReloadResult> => {
-    const isMissingDatabaseRules = database.sourcePath === null;
-    if (isMissingDatabaseRules) {
-      return { kind: 'not-configured' };
-    }
     try {
       const updated = await loadProjectDatabaseRules(options.projectDir, options.firebaseConfig);
       const isMissingUpdatedRules = updated.rules === null || updated.rulesHash === null;
       if (isMissingUpdatedRules) {
         return { kind: 'not-configured' };
       }
+      database.sourcePath = updated.sourcePath;
       live.databaseRules = updated.rules;
       live.databaseRulesHash = updated.rulesHash;
       events.broadcast('rtdb-rules-update', { rules: updated.rules, rulesHash: updated.rulesHash });

--- a/packages/cli/src/serve/sandbox-session.ts
+++ b/packages/cli/src/serve/sandbox-session.ts
@@ -35,6 +35,7 @@ export interface SandboxSessionOptions {
   bridgeUrl?: () => string | null;
   ai?: InitPayload['ai'];
   aiProxyUpstream?: string;
+  permissive?: boolean;
   logger?: ServeLogger;
   activity?: (incident: ActivityIncident) => void;
 }
@@ -97,6 +98,13 @@ export async function createSandboxSession(
     databaseRules: database.rules,
     databaseRulesHash: database.rulesHash,
   };
+  if (!database.sourcePath) {
+    if (options.permissive) {
+      options.logger?.note('  ⓘ RTDB permissive mode active — client reads/writes are open by default.');
+    } else {
+      options.logger?.note('  ⚠ no database.rules.json found — client RTDB reads/writes default to DENY (matching production Firebase). Use --permissive for open prototyping.');
+    }
+  }
   const events = createEventHub();
   const capture: CaptureStore | undefined = (options.capture ?? true)
     ? createCaptureStore(options.projectDir)
@@ -164,6 +172,7 @@ export async function createSandboxSession(
       : seedUsers,
     messaging: true,
     ai: options.ai ?? null,
+    permissive: Boolean(options.permissive),
   });
 
   const summary: SandboxSessionSummary = {

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -221,12 +221,13 @@ export function applyServeInit(
       };
     }
   }
-  if (payload.databaseRules) {
+  const effectiveDatabaseRules = payload.databaseRules ?? (payload.permissive ? null : rtdbSandbox.DEFAULT_DENY_RULES);
+  if (effectiveDatabaseRules) {
     const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
-    rtdbSandbox.setRules(rtdb, payload.databaseRules);
+    rtdbSandbox.setRules(rtdb, effectiveDatabaseRules);
     ctx.activeRules ??= {};
     ctx.activeRules.database = {
-      source: payload.databaseRules,
+      source: effectiveDatabaseRules,
       updatedAt: Date.now(),
       status: 'active',
       messages: [],

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -221,17 +221,20 @@ export function applyServeInit(
       };
     }
   }
-  const effectiveDatabaseRules = payload.databaseRules ?? (payload.permissive ? null : rtdbSandbox.DEFAULT_DENY_RULES);
-  if (effectiveDatabaseRules) {
-    const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
-    rtdbSandbox.setRules(rtdb, effectiveDatabaseRules);
+  const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
+  if (payload.databaseRules) {
+    rtdbSandbox.setRules(rtdb, payload.databaseRules);
     ctx.activeRules ??= {};
     ctx.activeRules.database = {
-      source: effectiveDatabaseRules,
+      source: payload.databaseRules,
       updatedAt: Date.now(),
       status: 'active',
       messages: [],
     };
+  } else if (payload.permissive) {
+    rtdbSandbox.setDefaultPolicy(rtdb, 'allow');
+  } else {
+    rtdbSandbox.setDefaultPolicy(rtdb, 'deny');
   }
 
   // 1b. Storage rules — deployed ONCE, here, before any storage op can run.

--- a/packages/cli/test/e2e/fixture/database.rules.json
+++ b/packages/cli/test/e2e/fixture/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": "auth != null",
+    ".write": "auth != null"
+  }
+}

--- a/packages/cli/test/e2e/soak/fixture/database.rules.json
+++ b/packages/cli/test/e2e/soak/fixture/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": "auth != null",
+    ".write": "auth != null"
+  }
+}

--- a/packages/cli/test/serve/sandbox-session.test.ts
+++ b/packages/cli/test/serve/sandbox-session.test.ts
@@ -226,4 +226,57 @@ service cloud.firestore {
     await session.close();
     expect(response.ended).toBe(true);
   });
+
+  it('loads database.rules.json automatically when present in project root', async () => {
+    const root = project();
+    writeFileSync(join(root, 'database.rules.json'), JSON.stringify({
+      rules: { '.read': 'auth != null', '.write': 'auth != null' },
+    }));
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+    });
+
+    expect(session.summary.rules.database.sourcePath).toBe(join(root, 'database.rules.json'));
+    expect(session.payload().databaseRules).toEqual({
+      rules: { '.read': 'auth != null', '.write': 'auth != null' },
+    });
+
+    await session.close();
+  });
+
+  it('exposes permissive flag in payload and logs appropriate notices', async () => {
+    const root = project();
+    const notes: string[] = [];
+    const logger = {
+      note: (msg: string) => notes.push(msg),
+      error: () => {},
+    };
+
+    // Default: permissive is false, logs deny notice
+    const sessionDefault = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+      logger,
+    });
+    expect(sessionDefault.payload().permissive).toBe(false);
+    expect(notes.some((n) => n.includes('default to DENY'))).toBe(true);
+    await sessionDefault.close();
+
+    // Permissive: permissive is true, logs permissive notice
+    notes.length = 0;
+    const sessionPermissive = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+      permissive: true,
+      logger,
+    });
+    expect(sessionPermissive.payload().permissive).toBe(true);
+    expect(notes.some((n) => n.includes('permissive mode active'))).toBe(true);
+    await sessionPermissive.close();
+  });
 });

--- a/packages/cli/test/serve/sandbox-session.test.ts
+++ b/packages/cli/test/serve/sandbox-session.test.ts
@@ -175,6 +175,54 @@ service cloud.firestore {
     await session.close();
   });
 
+  it('dynamically discovers and reloads newly created database.rules.json when unconfigured at boot', async () => {
+    const root = project();
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: null,
+      sdk: { dir: join(root, 'sdk') },
+    });
+
+    expect(session.summary.rules.database.sourcePath).toBeNull();
+    expect(session.payload().databaseRules).toBeNull();
+
+    const rulesPath = join(root, 'database.rules.json');
+    writeFileSync(rulesPath, JSON.stringify({
+      rules: { '.read': true, '.write': true },
+    }));
+
+    const reloaded = await session.reloadDatabaseRules();
+    expect(reloaded.kind).toBe('reloaded');
+    expect(session.payload().databaseRules).toEqual({ rules: { '.read': true, '.write': true } });
+
+    await session.close();
+  });
+
+  it('supports multi-database array configs in firebase.json', async () => {
+    const root = project();
+    const rulesPath = join(root, 'main-db.rules.json');
+    writeFileSync(rulesPath, JSON.stringify({
+      rules: { '.read': true },
+    }));
+
+    const session = await createSandboxSession({
+      projectDir: root,
+      firebaseConfig: {
+        database: [
+          { target: 'main', rules: 'main-db.rules.json', url: 'https://main-db.firebaseio.com' },
+          { target: 'analytics', rules: 'analytics.rules.json' },
+        ],
+      },
+      sdk: { dir: join(root, 'sdk') },
+    });
+
+    expect(session.summary.rules.database.sourcePath).toBe(rulesPath);
+    expect(session.payload().databaseRules).toEqual({ rules: { '.read': true } });
+    expect(session.payload().databaseUrl).toBe('https://main-db.firebaseio.com');
+
+    await session.close();
+  });
+
   it('serves one live init payload with late-bound host facts', async () => {
     const root = project();
     let bridgeUrl: string | null = null;

--- a/packages/cli/test/serve/worker/serve-init.test.ts
+++ b/packages/cli/test/serve/worker/serve-init.test.ts
@@ -715,3 +715,40 @@ describe('buildWorkerCtx — boot-time hydration + reset non-resurrection', () =
     expect(ctxB.sandbox.history().some((e) => e.kind === 'write')).toBe(false);
   });
 });
+
+describe('applyServeInit — Realtime Database default security policy', () => {
+  it('enforces default-deny when database rules are unconfigured', async () => {
+    const ctx = await makeCtx();
+    applyServeInit(ctx, { ...basePayload, databaseRules: null, permissive: false }, { fetch: recordingFetch() });
+
+    const port = fakePort();
+    await handleMessage(ctx, port, {
+      t: 'op',
+      id: 'rtdb-write-1',
+      method: 'rtdb.set',
+      path: '/items/item1',
+      value: { title: 'secret' },
+    });
+
+    const res = getRes(port, 'rtdb-write-1');
+    expect(res.ok).toBe(false);
+    expect((res as { error: { message: string } }).error.message).toContain('PERMISSION_DENIED');
+  });
+
+  it('allows open access when permissive mode is explicitly enabled', async () => {
+    const ctx = await makeCtx();
+    applyServeInit(ctx, { ...basePayload, databaseRules: null, permissive: true }, { fetch: recordingFetch() });
+
+    const port = fakePort();
+    await handleMessage(ctx, port, {
+      t: 'op',
+      id: 'rtdb-write-2',
+      method: 'rtdb.set',
+      path: '/items/item2',
+      value: { title: 'open' },
+    });
+
+    const res = getRes(port, 'rtdb-write-2');
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/pyric/src/database/sandbox-namespace.ts
+++ b/packages/pyric/src/database/sandbox-namespace.ts
@@ -7,10 +7,37 @@ import type { Database } from './types.js';
 // Mirrors `pyric/firestore`'s `sandbox` namespace — explicit
 // per-package sandbox lifecycle.
 
+export const DEFAULT_DENY_RTDB_RULES: { rules: Record<string, unknown> } = {
+  rules: {
+    '.read': false,
+    '.write': false,
+  },
+};
+
+export const DEFAULT_OPEN_RTDB_RULES: { rules: Record<string, unknown> } = {
+  rules: {
+    '.read': true,
+    '.write': true,
+  },
+};
+
 export const sandbox = {
+  DEFAULT_DENY_RULES: DEFAULT_DENY_RTDB_RULES,
+  DEFAULT_OPEN_RULES: DEFAULT_OPEN_RTDB_RULES,
+
+  /**
+   * Set the default access policy when no rules are loaded ('allow' or 'deny').
+   * In 'deny' mode (matching production Firebase), all client reads and writes
+   * without rules are rejected with PERMISSION_DENIED.
+   */
+  setDefaultPolicy(db: Database, policy: 'allow' | 'deny'): void {
+    const target = targetOf(db);
+    target.backend.setDefaultPolicy(policy);
+  },
+
   /**
    * Replace deployed rules. Pass `null` to clear (sandbox returns to
-   * default-allow). Rules are evaluated through the existing
+   * default policy). Rules are evaluated through the existing
    * RTDB rules simulator — the same engine used by the rules tooling.
    *
    * @example

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -42,6 +42,7 @@ export class RtdbBackend {
   getPriority(path: string): Priority { return this.state.priorities.get(path); }
   setData(seed: Record<string, JsonValue>): void { this.writes.setData(seed); }
   setRules(rules: { rules: Record<string, unknown> } | null): void { this.writes.setRules(rules); }
+  setDefaultPolicy(policy: 'allow' | 'deny'): void { this.writes.setDefaultPolicy(policy); }
   getActiveRules(): { rules: Record<string, unknown> } | null { return this.writes.getActiveRules(); }
   snapshotState(): JsonValue { return this.writes.snapshotState(); }
 

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -95,11 +95,19 @@ export interface EvalContext {
   updates?: { path: string; value: unknown }[];
 }
 
+export type RtdbDefaultPolicy = 'allow' | 'deny';
+
 export class RulesEvaluator {
   private compiled: CompiledRtdbRules | null = null;
+  private defaultPolicy: RtdbDefaultPolicy = 'allow';
+
+  /** Set default access policy when no rules are loaded ('allow' or 'deny'). */
+  setDefaultPolicy(policy: RtdbDefaultPolicy): void {
+    this.defaultPolicy = policy;
+  }
 
   /** Replace the deployed rules. `null` clears (sandbox returns to
-   *  default-allow). */
+   *  configured default policy). */
   setRules(rulesJson: { rules: Record<string, unknown> } | null): void {
     if (rulesJson === null) {
       this.compiled = null;
@@ -161,6 +169,14 @@ export class RulesEvaluator {
       }
     }
     if (this.compiled === null) {
+      if (this.defaultPolicy === 'deny') {
+        return {
+          check: 'no-rule',
+          reasons: ['No RTDB rules loaded; default deny.'],
+          errorCode: 'NO_MATCHING_RULE',
+          errorMessage: 'No RTDB rules loaded; default deny.',
+        };
+      }
       return {
         check: 'allow',
         reasons: ['No RTDB rules loaded; default allow.'],

--- a/packages/pyric/src/database/sandbox/write-plane.ts
+++ b/packages/pyric/src/database/sandbox/write-plane.ts
@@ -52,6 +52,12 @@ export class WritePlane {
     this.state.notifyWrite();
   }
 
+  setDefaultPolicy(policy: 'allow' | 'deny'): void {
+    this.state.rules.setDefaultPolicy(policy);
+    this.cancelDeniedListeners();
+    this.state.notifyWrite();
+  }
+
   getActiveRules(): { rules: Record<string, unknown> } | null {
     const isRulesNull = this.state.activeRules === null;
     let result: { rules: Record<string, unknown> } | null = null;

--- a/packages/pyric/test/database/default-policy.test.ts
+++ b/packages/pyric/test/database/default-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'bun:test';
 import { initializeSandbox } from 'pyric/sandbox';
 import {
   getDatabase,
+  getAdminDatabase,
   get,
   set,
   ref as dbRef,
@@ -41,10 +42,11 @@ describe('RTDB sandbox default security policy', () => {
     expect(readError).toBeInstanceOf(Error);
     expect((readError as Error).message).toContain('PERMISSION_DENIED');
 
-    // Admin bypass via sandbox namespace succeeds despite deny policy
-    rtdbSandbox.setData(db, { '/users/alice': { name: 'Alice Admin' } });
-    const snapshot = rtdbSandbox.snapshotState(db);
-    expect(snapshot).toEqual({ users: { alice: { name: 'Alice Admin' } } });
+    // Admin handle bypass via getAdminDatabase succeeds despite deny policy
+    const adminDb = getAdminDatabase(sandbox);
+    await set(dbRef(adminDb, '/users/alice'), { name: 'Alice Admin' });
+    const adminSnap = await get(dbRef(adminDb, '/users/alice'));
+    expect(adminSnap.val()).toEqual({ name: 'Alice Admin' });
 
     // .info paths remain readable even under deny policy
     const infoSnap = await get(dbRef(db, '/.info/serverTimeOffset'));

--- a/packages/pyric/test/database/default-policy.test.ts
+++ b/packages/pyric/test/database/default-policy.test.ts
@@ -1,0 +1,75 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  getDatabase,
+  get,
+  set,
+  ref as dbRef,
+  sandbox as rtdbSandbox,
+  DEFAULT_DENY_RTDB_RULES,
+  DEFAULT_OPEN_RTDB_RULES,
+} from '../../src/database/index.js';
+
+describe('RTDB sandbox default security policy', () => {
+  it('rejects client mutations and reads under default deny policy', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox.withAuth({ uid: 'client-user' }));
+
+    // Set default policy to deny
+    rtdbSandbox.setDefaultPolicy(db, 'deny');
+
+    const testRef = dbRef(db, '/users/alice');
+
+    // Client write is rejected with PERMISSION_DENIED
+    let writeError: unknown = null;
+    try {
+      await set(testRef, { name: 'Alice' });
+    } catch (err) {
+      writeError = err;
+    }
+    expect(writeError).toBeInstanceOf(Error);
+    expect((writeError as Error).message).toContain('PERMISSION_DENIED');
+
+    // Client read is rejected with PERMISSION_DENIED
+    let readError: unknown = null;
+    try {
+      await get(testRef);
+    } catch (err) {
+      readError = err;
+    }
+    expect(readError).toBeInstanceOf(Error);
+    expect((readError as Error).message).toContain('PERMISSION_DENIED');
+
+    // Admin bypass via sandbox namespace succeeds despite deny policy
+    rtdbSandbox.setData(db, { '/users/alice': { name: 'Alice Admin' } });
+    const snapshot = rtdbSandbox.snapshotState(db);
+    expect(snapshot).toEqual({ users: { alice: { name: 'Alice Admin' } } });
+
+    // .info paths remain readable even under deny policy
+    const infoSnap = await get(dbRef(db, '/.info/serverTimeOffset'));
+    expect(infoSnap.val()).toBe(0);
+  });
+
+  it('allows client operations when explicitly switched to permissive or open rules', async () => {
+    const sandbox = initializeSandbox();
+    const db = getDatabase(sandbox.withAuth({ uid: 'client-user' }));
+
+    // Explicitly set DEFAULT_DENY_RTDB_RULES
+    rtdbSandbox.setRules(db, DEFAULT_DENY_RTDB_RULES);
+    await expect(set(dbRef(db, '/test'), 'data')).rejects.toThrow('PERMISSION_DENIED');
+
+    // Explicitly switch to DEFAULT_OPEN_RTDB_RULES
+    rtdbSandbox.setRules(db, DEFAULT_OPEN_RTDB_RULES);
+    await set(dbRef(db, '/test'), 'open-data');
+    const snap = await get(dbRef(db, '/test'));
+    expect(snap.val()).toBe('open-data');
+
+    // Clear rules with setDefaultPolicy('allow')
+    rtdbSandbox.setRules(db, null);
+    rtdbSandbox.setDefaultPolicy(db, 'allow');
+    await set(dbRef(db, '/test2'), 'permissive-data');
+    const snap2 = await get(dbRef(db, '/test2'));
+    expect(snap2.val()).toBe('permissive-data');
+  });
+});


### PR DESCRIPTION
Enforces production-parity default-deny security when Realtime Database rules are absent, with an opt-in `--permissive` flag for open prototyping.

```ts
import { getDatabase, set, ref, sandbox } from 'pyric/database';

const db = getDatabase(sandbox.withAuth({ uid: 'client-user' }));

// Unconfigured RTDB sandboxes now default to DENY (matching production Firebase)
await set(ref(db, '/data'), 'value'); // throws PERMISSION_DENIED: Permission denied

// Prototyping or tests can opt into permissive mode or open rules:
sandbox.setRules(db, sandbox.DEFAULT_OPEN_RULES);
await set(ref(db, '/data'), 'value'); // succeeds
```

## Unruled RTDB sandboxes default to closed access

```ts
// packages/cli/src/serve/worker/serve-init.ts
const effectiveDatabaseRules = payload.databaseRules ?? (payload.permissive ? null : rtdbSandbox.DEFAULT_DENY_RULES);
if (effectiveDatabaseRules) {
  const rtdb = ctx.rtdb ??= getDatabase(ctx.sandbox);
  rtdbSandbox.setRules(rtdb, effectiveDatabaseRules);
}
```

Previously, running a project without `database.rules.json` left the sandbox in a null-rules state, which evaluated client operations as open-by-default. Developers writing client-side mutations locally were never warned when operations lacked production rules, discovering permissions errors only after production deployment.

When no rules file is present, `pyric sandbox` now deploys `DEFAULT_DENY_RTDB_RULES` (`{ ".read": false, ".write": false }`), perfectly mirroring production Firebase behavior.

## CLI opt-in `--permissive` flag supports rapid prototyping

Developers experimenting or prototyping without rules can pass `--permissive`:
```bash
pyric sandbox --permissive
```
When `--permissive` is active, the CLI notes `ⓘ RTDB permissive mode active — client reads/writes are open by default.`. When running default-deny, the CLI informs the developer:
`⚠ no database.rules.json found — client RTDB reads/writes default to DENY (matching production Firebase). Use --permissive for open prototyping.`

## Administrative handles and system paths remain accessible

- Admin operations (`target.backend.adminSet`, `pyric-admin`, and `sandbox.setData`) bypass rules evaluation and continue to succeed regardless of rule state.
- System metadata paths (`/.info/*`, including `/.info/connected` and `/.info/serverTimeOffset`) remain readable by default under deny-all rules, matching Firebase's metadata contract.

## Automatic project root discovery

`loadProjectDatabaseRules` now discovers `database.rules.json` in the project root directory when `config.database.rules` is omitted from `firebase.json`, matching `firestore.rules` fallback behavior.

## Risk

Existing apps running `pyric sandbox` that touch RTDB without configuring `database.rules.json` will now receive `PERMISSION_DENIED` errors on client reads and writes until they add a rules file or specify `--permissive`. This is the intended production parity behavior.

<details>
<summary>Implementation notes & verification</summary>

- **Unit tests**:
  - Added `packages/pyric/test/database/default-policy.test.ts` verifying deny enforcement, info-path readability, and admin bypass.
  - Added tests in `packages/cli/test/serve/worker/serve-init.test.ts` verifying default-deny and permissive mode in worker serve init.
  - Added tests in `packages/cli/test/serve/sandbox-session.test.ts` verifying automatic `database.rules.json` discovery and permissive payload propagation.
- **Verification**:
  - `bun run tool:parity:check`: 55 tools verified, 0 unclassified
  - `bun run test:ci:libraries:core`: 345 passed, 0 failed
  - `bun run test:ci:cli`: 1,470 passed, 0 failed (18 skipped)
  - `bun run build`: Built cleanly

</details>
