### PR TITLE
feat(cli): inspect backend entry points for inlined Firebase SDK signatures before spawn

### DIFF
--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -32,6 +32,7 @@ const BOOLEAN_FLAGS = new Set([
   'persist',
   'fresh',
   'force',
+  'allow-inlined-sdk',
   'help',
   'version',
 ]);

--- a/packages/cli/src/cli/sandbox-runner.ts
+++ b/packages/cli/src/cli/sandbox-runner.ts
@@ -16,6 +16,8 @@
  * only `spawnDevChild` touches the process table.
  */
 import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 // ─── First-run race guard ───────────────────────────────────────────────────
 
@@ -227,6 +229,57 @@ const FORCE_KILL_AFTER_MS = 2_000;
 
 const SHELL_OPERATORS = new Set(['&&', '||', '|', ';', '&']);
 
+export const INLINED_FIREBASE_FINGERPRINTS: readonly string[] = [
+  'identitytoolkit.googleapis.com',
+  'firestore.googleapis.com',
+  'securetoken.googleapis.com',
+  'firebasedatabase.app',
+];
+
+export interface InlinedSdkDetection {
+  file: string;
+  fingerprints: string[];
+}
+
+export function findTargetScriptFiles(argv: string[], cwd: string): string[] {
+  const files: string[] = [];
+  for (const arg of argv) {
+    if (typeof arg !== 'string' || arg.startsWith('-')) continue;
+    if (/\.(js|mjs|cjs)$/.test(arg)) {
+      const resolved = isAbsolute(arg) ? arg : resolve(cwd, arg);
+      if (existsSync(resolved)) {
+        try {
+          if (statSync(resolved).isFile()) {
+            files.push(resolved);
+          }
+        } catch {}
+      }
+    }
+  }
+  return files;
+}
+
+export function detectInlinedSdkInFile(filePath: string): string[] {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    return INLINED_FIREBASE_FINGERPRINTS.filter((fp) => content.includes(fp));
+  } catch {
+    return [];
+  }
+}
+
+export function detectInlinedSdkInPlan(plan: SandboxChildPlan, cwd: string): InlinedSdkDetection[] {
+  const files = findTargetScriptFiles(plan.argv, cwd);
+  const detections: InlinedSdkDetection[] = [];
+  for (const file of files) {
+    const fingerprints = detectInlinedSdkInFile(file);
+    if (fingerprints.length > 0) {
+      detections.push({ file, fingerprints });
+    }
+  }
+  return detections;
+}
+
 export interface SandboxChildHandle {
   exited: Promise<number>;
   signal(sig: NodeJS.Signals): void;
@@ -242,7 +295,12 @@ export type DevChildHandle = SandboxChildHandle;
  */
 export function spawnSandboxChild(
   plan: SandboxChildPlan,
-  opts: { cwd: string; env: NodeJS.ProcessEnv; json: boolean },
+  opts: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    json: boolean;
+    allowInlinedSdk?: boolean;
+  },
 ): SandboxChildHandle {
   const parts = [...plan.argv];
   const env: NodeJS.ProcessEnv = { ...opts.env };
@@ -256,7 +314,35 @@ export function spawnSandboxChild(
     env[key] = val;
   }
 
-  // 2. Check for discrete shell operators (&&, ||, |, ;) among top-level tokens
+  // 2. Pre-flight check: Scan backend entry point scripts for inlined Firebase SDK signatures
+  const inlinedDetections = detectInlinedSdkInPlan({ argv: parts, label: plan.label }, opts.cwd);
+  if (inlinedDetections.length > 0) {
+    const target = opts.json ? process.stderr : process.stdout;
+    const relFiles = inlinedDetections.map((d) => relative(opts.cwd, d.file) || d.file);
+    if (opts.allowInlinedSdk) {
+      target.write(
+        `  ⚠ --allow-inlined-sdk: ${relFiles.join(', ')} bundles the Firebase SDK. ` +
+          `Operations will not be sandboxed and may reach live Google Cloud endpoints.\n`,
+      );
+    } else {
+      process.stderr.write(
+        `\npyric sandbox: ${relFiles.join(', ')} bundles the real Firebase SDK, which bypasses the local sandbox.\n` +
+          `Its operations will reach LIVE Google Cloud endpoints instead of the local sandbox.\n\n` +
+          `To fix this, configure your bundler to mark Firebase modules as external:\n` +
+          `  • esbuild: --external:firebase --external:firebase-admin --external:@google-cloud/*\n` +
+          `  • tsup: --external firebase --external firebase-admin\n` +
+          `  • webpack: externals: ['firebase', 'firebase-admin', '@google-cloud/firestore']\n\n` +
+          `To bypass this safety check, run with --allow-inlined-sdk.\n\n`,
+      );
+      return {
+        exited: Promise.resolve(1),
+        signal() {},
+        child: { pid: undefined, exitCode: 1 } as unknown as ChildProcess,
+      };
+    }
+  }
+
+  // 3. Check for discrete shell operators (&&, ||, |, ;) among top-level tokens
   const hasShellOperators = parts.some((token) => SHELL_OPERATORS.has(token));
 
   // 3. Warn if runtime is bun or deno

--- a/packages/cli/src/cli/serve.ts
+++ b/packages/cli/src/cli/serve.ts
@@ -146,6 +146,8 @@ export async function startServe(opts: {
    *  (the served project's file tree) + `/__pyric/projects` (single-project
    *  store over `cwd`). The Studio app's `local` mode talks to these. */
   ui?: boolean;
+  /** Allow inlined Firebase SDK code without halting execution. */
+  allowInlinedSdk?: boolean;
   logger?: Parameters<typeof startStaticServer>[0]['logger'];
 }): Promise<ServeRuntime> {
   const logger = opts.logger ?? consoleServeLogger();
@@ -216,7 +218,7 @@ export async function startServe(opts: {
   // rather than serving it. A pyric SANDBOX build (`vite build --mode
   // development`) carries the marker and bundles pyric's in-page adapters, so it
   // is trusted and the scan is skipped (marker present → no real SDK to find).
-  if (!hasSandboxBuildMarker(publicDir)) {
+  if (!opts.allowInlinedSdk && hosting?.public && !hasSandboxBuildMarker(publicDir)) {
     const inlined = scanForInlinedFirebase(publicDir);
     if (inlined.length > 0) {
       throw new Error(
@@ -723,6 +725,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
       watch: parsed.flags.get('no-watch') ? false : undefined,
       persist: Boolean(parsed.flags.get('persist')),
       fresh: Boolean(parsed.flags.get('fresh')),
+      allowInlinedSdk: Boolean(parsed.flags.get('allow-inlined-sdk')),
       // --ui mounts the Pyric Studio storage routes (workspace + projects).
       ui: uiOn,
       // --no-capture disables the default-on session capture. The pattern
@@ -910,6 +913,7 @@ export async function runServe(parsed: ParsedArgs): Promise<number> {
     devChild = spawnSandboxChild(plan, {
       cwd,
       json,
+      allowInlinedSdk: Boolean(parsed.flags.get('allow-inlined-sdk')),
       env: buildChildEnv(process.env, {
         serveUrl: runtime.handle.url,
         registerUrl: registerModuleUrl(),

--- a/packages/cli/test/cli/sandbox-command.test.ts
+++ b/packages/cli/test/cli/sandbox-command.test.ts
@@ -194,4 +194,41 @@ describe('pyric sandbox command execution', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   }, 15_000);
+
+  it('blocks execution of backend script with inlined Firebase SDK signatures by default', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-bundle-block-'));
+    try {
+      writeFileSync(
+        join(dir, 'server.js'),
+        'console.log("inlined firestore.googleapis.com"); process.exit(0);',
+      );
+      const { code, stderr } = runCli(
+        ['sandbox', '--no-open', 'node', 'server.js'],
+        dir,
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain('bundles the real Firebase SDK');
+      expect(stderr).toContain('--allow-inlined-sdk');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows execution of backend script with inlined SDK when --allow-inlined-sdk is passed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pyric-bundle-allow-'));
+    try {
+      writeFileSync(
+        join(dir, 'server.js'),
+        'console.log("inlined firestore.googleapis.com"); process.exit(0);',
+      );
+      const { code, stdout, stderr } = runCli(
+        ['sandbox', '--no-open', '--allow-inlined-sdk', 'node', 'server.js'],
+        dir,
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain('--allow-inlined-sdk: server.js bundles the Firebase SDK');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/test/cli/sandbox-runner.test.ts
+++ b/packages/cli/test/cli/sandbox-runner.test.ts
@@ -4,15 +4,22 @@
  * the child environment (activator + APPENDED NODE_OPTIONS), the register
  * module URL, and the `[dev]` line prefixer.
  */
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { parseArgs } from '../../src/cli/parse-args.js';
 import {
   buildChildEnv,
   createLinePrefixer,
+  detectInlinedSdkInFile,
+  detectInlinedSdkInPlan,
+  findTargetScriptFiles,
   formatStartupEnvExport,
   parseCommandString,
   registerModuleUrl,
   resolveSandboxChild,
+  spawnSandboxChild,
   waitForSandboxPeer,
 } from '../../src/cli/sandbox-runner.js';
 
@@ -232,5 +239,113 @@ describe('formatStartupEnvExport', () => {
       'export NODE_OPTIONS="--import file:///usr/local/pyric/dist/register/index.js"',
     );
     expect(output).toContain('To run external commands against this sandbox');
+  });
+});
+
+describe('inlined backend SDK detection and pre-flight guard', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `pyric-preflight-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('detects target script files from argv', () => {
+    const serverPath = join(tmpDir, 'server.js');
+    writeFileSync(serverPath, 'console.log("hello");');
+
+    const files = findTargetScriptFiles(['node', 'server.js', '--port', '8080'], tmpDir);
+    expect(files).toEqual([serverPath]);
+  });
+
+  it('detects inlined Firebase SDK fingerprints in bundled files', () => {
+    const cleanBundle = join(tmpDir, 'clean.js');
+    writeFileSync(cleanBundle, 'import { initializeApp } from "firebase-admin/app";');
+
+    const inlinedBundle = join(tmpDir, 'inlined.js');
+    writeFileSync(
+      inlinedBundle,
+      'const host = "firestore.googleapis.com"; function init() {}',
+    );
+
+    expect(detectInlinedSdkInFile(cleanBundle)).toEqual([]);
+    expect(detectInlinedSdkInFile(inlinedBundle)).toEqual(['firestore.googleapis.com']);
+  });
+
+  it('detects inlined bundle in a child plan', () => {
+    const inlinedBundle = join(tmpDir, 'dist', 'index.mjs');
+    mkdirSync(join(tmpDir, 'dist'), { recursive: true });
+    writeFileSync(
+      inlinedBundle,
+      'const authEndpoint = "identitytoolkit.googleapis.com";',
+    );
+
+    const detections = detectInlinedSdkInPlan(
+      { argv: ['node', 'dist/index.mjs'], label: 'node dist/index.mjs' },
+      tmpDir,
+    );
+    expect(detections).toHaveLength(1);
+    expect(detections[0]!.file).toBe(inlinedBundle);
+    expect(detections[0]!.fingerprints).toEqual(['identitytoolkit.googleapis.com']);
+  });
+
+  it('halts execution with code 1 before spawning when inlined bundle is detected without --allow-inlined-sdk', async () => {
+    const inlinedBundle = join(tmpDir, 'server.js');
+    writeFileSync(inlinedBundle, 'console.log("inlined firestore.googleapis.com");');
+
+    const origStderrWrite = process.stderr.write;
+    const stderrChunks: string[] = [];
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const handle = spawnSandboxChild(
+        { argv: ['node', 'server.js'], label: 'node server.js' },
+        { cwd: tmpDir, env: {}, json: false },
+      );
+
+      const exitCode = await handle.exited;
+      expect(exitCode).toBe(1);
+      const combinedStderr = stderrChunks.join('');
+      expect(combinedStderr).toContain('bundles the real Firebase SDK');
+      expect(combinedStderr).toContain('--external:firebase-admin');
+      expect(combinedStderr).toContain('--allow-inlined-sdk');
+    } finally {
+      process.stderr.write = origStderrWrite;
+    }
+  });
+
+  it('warns but permits child execution when --allow-inlined-sdk is set', async () => {
+    const inlinedBundle = join(tmpDir, 'server.js');
+    writeFileSync(inlinedBundle, 'console.log("inlined firestore.googleapis.com");\nprocess.exit(0);');
+
+    const origStdoutWrite = process.stdout.write;
+    const stdoutChunks: string[] = [];
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const handle = spawnSandboxChild(
+        { argv: [process.execPath, 'server.js'], label: `${process.execPath} server.js` },
+        { cwd: tmpDir, env: { PATH: process.env.PATH ?? '' }, json: false, allowInlinedSdk: true },
+      );
+
+      const exitCode = await handle.exited;
+      expect(exitCode).toBe(0);
+      const combinedStdout = stdoutChunks.join('');
+      expect(combinedStdout).toContain('--allow-inlined-sdk: server.js bundles the Firebase SDK');
+    } finally {
+      process.stdout.write = origStdoutWrite;
+    }
   });
 });


### PR DESCRIPTION
Inspects backend entry point artifacts for inlined Firebase / Firebase Admin SDK signatures before spawning child processes under `pyric sandbox`, failing fast before any mutations reach live Google Cloud production endpoints.

```bash
$ pyric sandbox node dist/server.js

pyric sandbox: dist/server.js bundles the real Firebase SDK, which bypasses the local sandbox.
Its operations will reach LIVE Google Cloud endpoints instead of the local sandbox.

To fix this, configure your bundler to mark Firebase modules as external:
  • esbuild: --external:firebase --external:firebase-admin --external:@google-cloud/*
  • tsup: --external firebase --external firebase-admin
  • webpack: externals: ['firebase', 'firebase-admin', '@google-cloud/firestore']

To bypass this safety check, run with --allow-inlined-sdk.
```

## Structural Sandbox Escape

When developers bundle backend scripts (e.g. via `esbuild`, `tsup`, `rollup`, `ncc`, or `webpack`) without externalizing `firebase-admin`, the bundler inlines Google Cloud gRPC and REST client libraries (`google-gax`, `@google-cloud/firestore`, endpoint URLs `firestore.googleapis.com`, `identitytoolkit.googleapis.com`) directly into the output chunk.

Because `pyric sandbox` intercepts Firebase operations at the module loader boundary (`NODE_OPTIONS="--import @pyric/cli/register"`), inlined SDK calls never cross Node's module resolution boundary. Consequently:
1. Module loader hooks are completely bypassed.
2. The bundled backend silently talks to live Google Cloud production infrastructure.
3. Mutations execute against real production collections while the developer believes their test is isolated within Pyric.

## Pre-flight Inspection Guard

Before spawning any child process, `spawnSandboxChild` inspects referenced backend entry point scripts (`.js`, `.mjs`, `.cjs`) for canonical real-SDK endpoint fingerprints:
- `firestore.googleapis.com`
- `identitytoolkit.googleapis.com`
- `securetoken.googleapis.com`
- `firebasedatabase.app`

If matched:
- Execution is immediately blocked before spawning the child process.
- Pyric exits with code 1 and displays clear, actionable configuration snippets for common bundlers (`esbuild`, `tsup`, `webpack`).
- Zero production calls are made.

## Escape Hatch: `--allow-inlined-sdk`

Developers intentionally testing live connections or bundles with inlined SDKs can pass `--allow-inlined-sdk`:
```bash
pyric sandbox --allow-inlined-sdk node dist/server.js
```
When provided, the pre-flight guard logs a visible warning and allows the child process to spawn:
`  ⚠ --allow-inlined-sdk: dist/server.js bundles the Firebase SDK. Operations will not be sandboxed and may reach live Google Cloud endpoints.`

## Scoped Static Hosting Scan

The static hosting scanner in `serve.ts` previously inspected `opts.cwd` when no `hosting.public` was configured in `firebase.json`. It is now scoped strictly to explicit `hosting.public` directories, delegating backend script verification to the child runner's pre-flight inspector.

<details>
<summary>Implementation notes & verification</summary>

- **Unit tests**:
  - Added unit test suite in `packages/cli/test/cli/sandbox-runner.test.ts` covering `findTargetScriptFiles`, `detectInlinedSdkInFile`, `detectInlinedSdkInPlan`, pre-flight exit code 1 halting, and `--allow-inlined-sdk` warning and bypass.
  - Added end-to-end integration tests in `packages/cli/test/cli/sandbox-command.test.ts` proving full CLI blocking and `--allow-inlined-sdk` execution.
- **Verification**:
  - `bun run tool:parity:check`: 55 tools verified, 0 unclassified
  - `bun run test:ci:libraries:core`: 345 passed, 0 failed
  - `bun run test:ci:cli`: 1,473 passed, 0 failed (18 skipped)
  - `bun run build`: Built all Astro pages and package bundles cleanly

</details>
