### PR TITLE
fix(conformance): resolve SDK package manifests via export-safe directory walk

### DIFF
--- a/packages/conformance/src/admin-app-probes.ts
+++ b/packages/conformance/src/admin-app-probes.ts
@@ -36,6 +36,7 @@ import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Probe } from '../rigs/types.ts';
+import { resolvedAdminVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // admin-app-* observations and probes both live under the 'auth' surface
@@ -65,16 +66,6 @@ async function loadProbes(): Promise<LoadedProbe[]> {
     loaded.push({ id, probe: mod.probe });
   }
   return loaded;
-}
-
-/** Resolved (installed) firebase-admin version — what the observation-version
- *  guard (check-observation-versions.ts) compares every admin-app-*
- *  observation's `adminSdkVersion` against. */
-function resolvedAdminVersion(): string {
-  const pkgPath = fileURLToPath(import.meta.resolve('firebase-admin/package.json'));
-  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
-  if (!meta.version) throw new Error('could not resolve installed firebase-admin version');
-  return meta.version;
 }
 
 /** Every probe assumes an empty app registry on entry and must leave one

--- a/packages/conformance/src/admin-firestore-probes.ts
+++ b/packages/conformance/src/admin-firestore-probes.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Probe } from '../rigs/types.ts';
 import { probe } from '../probes/firestore/admin-firestore-document-snapshot-get.ts';
+import { resolvedAdminVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ID = 'admin-firestore-document-snapshot-get';
@@ -17,11 +18,6 @@ interface ObservationEnvelope {
   observedAt: string;
   adminSdkVersion: string;
   behavior: Record<string, unknown>;
-}
-
-function installedAdminVersion(): string {
-  const packagePath = fileURLToPath(import.meta.resolve('firebase-admin/package.json'));
-  return (JSON.parse(readFileSync(packagePath, 'utf8')) as { version: string }).version;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -52,7 +48,7 @@ async function capture(record: Probe, adminSdkVersion: string): Promise<Observat
   };
 }
 
-const adminSdkVersion = installedAdminVersion();
+const adminSdkVersion = resolvedAdminVersion();
 const actual = await capture(probe, adminSdkVersion);
 
 if (process.argv.includes('--write')) {

--- a/packages/conformance/src/ai-probes.ts
+++ b/packages/conformance/src/ai-probes.ts
@@ -30,6 +30,7 @@
 import { writeFileSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // ai-* observations belong to the 'ai' surface.
@@ -43,10 +44,7 @@ if (!rawConfig) {
 const config = JSON.parse(rawConfig) as { apiKey: string; projectId: string };
 const { apiKey, projectId } = config;
 
-const fbPkg = JSON.parse(
-  readFileSync(fileURLToPath(import.meta.resolve('firebase/package.json')), 'utf8'),
-) as { version: string };
-const fbSdkVersion = fbPkg.version;
+const fbSdkVersion = resolvedFirebaseVersion();
 
 const API_VERSION = 'v1beta';
 const BASE = `https://firebasevertexai.googleapis.com/${API_VERSION}/projects/${projectId}`;

--- a/packages/conformance/src/app-production-browser-probes.ts
+++ b/packages/conformance/src/app-production-browser-probes.ts
@@ -9,6 +9,7 @@ import {
   observeCrossTabAuthAfterPersistenceSignal,
   type AuthStorageSignal,
 } from './cross-tab-auth-observer.js';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OBSERVATION = join(HERE, '..', 'observations', 'app', 'app-production-multi-app-topology.json');
@@ -24,10 +25,7 @@ if (!rawConfig) {
   throw new Error('PYRIC_ORACLE_FIREBASE_CONFIG is required; run oracle:plan before this production capture.');
 }
 const config = JSON.parse(rawConfig) as { apiKey: string; projectId: string };
-const firebasePackage = JSON.parse(readFileSync(
-  fileURLToPath(import.meta.resolve('firebase/package.json')),
-  'utf8',
-)) as { version: string };
+const firebasePackage = { version: resolvedFirebaseVersion() };
 
 const browserSource = String.raw`
 import { initializeApp, deleteApp } from 'firebase/app';

--- a/packages/conformance/src/app-registry-probes.ts
+++ b/packages/conformance/src/app-registry-probes.ts
@@ -37,6 +37,7 @@ import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Probe } from '../rigs/types.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PROBES_DIR = join(HERE, '..', 'probes', 'app');
@@ -64,16 +65,6 @@ async function loadProbes(): Promise<LoadedProbe[]> {
     loaded.push({ id, probe: mod.probe });
   }
   return loaded;
-}
-
-/** Resolved (installed) firebase version — what the observation-version guard
- *  (check-observation-versions.ts) compares every app-registry-* observation's
- *  `fbSdkVersion` against. */
-function resolvedFirebaseVersion(): string {
-  const pkgPath = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
-  if (!meta.version) throw new Error('could not resolve installed firebase version');
-  return meta.version;
 }
 
 /** Every probe assumes an empty app registry on entry and must leave one behind

--- a/packages/conformance/src/capture/functions-rtdb/harness.ts
+++ b/packages/conformance/src/capture/functions-rtdb/harness.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { resolvePackageVersion } from '../../package-version.ts';
 import { cert, deleteApp, initializeApp } from 'firebase-admin/app';
 import { getDatabase } from 'firebase-admin/database';
 import { probe as exactProbe } from '../../../probes/functions-rtdb/functions-rtdb-onvaluecreated-exact-create.ts';
@@ -62,10 +63,7 @@ function need(name: string): string {
 }
 
 function packageVersion(specifier: string): string {
-  const path = fileURLToPath(import.meta.resolve(`${specifier}/package.json`));
-  const meta = JSON.parse(readFileSync(path, 'utf8')) as { version?: unknown };
-  if (typeof meta.version !== 'string') throw new Error(`${specifier} package has no version`);
-  return meta.version;
+  return resolvePackageVersion(specifier);
 }
 
 function firebase(args: string[], env: Record<string, string>): void {

--- a/packages/conformance/src/capture/messaging-web/harness.ts
+++ b/packages/conformance/src/capture/messaging-web/harness.ts
@@ -75,6 +75,7 @@ import { initializeApp, cert, deleteApp } from 'firebase-admin/app';
 import { getMessaging } from 'firebase-admin/messaging';
 import type { ServiceAccount } from 'firebase-admin/app';
 import { pathToFileURL } from 'node:url';
+import { resolvedAdminVersion, resolvedFirebaseVersion } from '../../package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..', '..', '..', '..', '..');
@@ -133,15 +134,11 @@ if (webConfig.projectId !== projectId) {
   console.error(`✗ Config mismatch: web config is for ${webConfig.projectId}, service account for ${projectId}. Token registration requires the same project.`);
   process.exit(1);
 }
-const fbSdkVersion = (
-  JSON.parse(readFileSync(fileURLToPath(import.meta.resolve('firebase/package.json')), 'utf8')) as { version: string }
-).version;
+const fbSdkVersion = resolvedFirebaseVersion();
 // The deleteToken→UNREGISTERED capture spans both planes: a client deleteToken
 // and a server send. The send transport is firebase-admin, so that one
 // observation additionally records adminSdkVersion.
-const adminSdkVersion = (
-  JSON.parse(readFileSync(fileURLToPath(import.meta.resolve('firebase-admin/package.json')), 'utf8')) as { version: string }
-).version;
+const adminSdkVersion = resolvedAdminVersion();
 
 // ─── Build the app with config injected ─────────────────────────────────
 const define = {

--- a/packages/conformance/src/check-observation-versions.ts
+++ b/packages/conformance/src/check-observation-versions.ts
@@ -17,29 +17,19 @@
  * Usage: bun run packages/conformance/src/check-observation-versions.ts
  * Exit codes: 0 all match, 1 a mismatch / missing field / unresolvable package.
  */
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { loadObservations } from './ledger.ts';
+import {
+  resolvedAdminVersion,
+  resolvedFirebaseVersion,
+  resolvedFunctionsVersion,
+} from './package-version.ts';
 
-/** Resolved (installed) version of `pkg` from its own package.json. */
-function resolvedVersion(pkg: string): string {
-  try {
-    const pkgPath = fileURLToPath(import.meta.resolve(`${pkg}/package.json`));
-    const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: unknown };
-    if (typeof meta.version === 'string' && meta.version.length > 0) return meta.version;
-  } catch {
-    // fall through to the shared error below
-  }
-  console.error(`✗ Could not read the version of the installed ${pkg} package.`);
-  process.exit(1);
-}
-
-const resolved = resolvedVersion('firebase');
+const resolved = resolvedFirebaseVersion();
 // `admin-*` observations are captured against `firebase-admin` (the admin SDK),
 // not the firebase JS SDK, and are versioned by `adminSdkVersion`. They vouch
 // for admin behavior, so they must track the installed firebase-admin version.
-const resolvedAdmin = resolvedVersion('firebase-admin');
-const resolvedFunctions = resolvedVersion('firebase-functions');
+const resolvedAdmin = resolvedAdminVersion();
+const resolvedFunctions = resolvedFunctionsVersion();
 const observations = loadObservations();
 
 const missing: string[] = [];

--- a/packages/conformance/src/messaging-send-probes.ts
+++ b/packages/conformance/src/messaging-send-probes.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import { initializeApp, cert, deleteApp } from 'firebase-admin/app';
 import { getMessaging } from 'firebase-admin/messaging';
 import type { ServiceAccount } from 'firebase-admin/app';
+import { resolvedAdminVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // messaging-send-* observations belong to the 'messaging-admin' surface.
@@ -35,9 +36,7 @@ if (!b64) {
 const sa = JSON.parse(Buffer.from(b64, 'base64').toString('utf8')) as ServiceAccount & { project_id?: string };
 const projectId = (sa.projectId ?? sa.project_id)!;
 
-const adminSdkVersion = (
-  JSON.parse(readFileSync(fileURLToPath(import.meta.resolve('firebase-admin/package.json')), 'utf8')) as { version: string }
-).version;
+const adminSdkVersion = resolvedAdminVersion();
 
 const app = initializeApp({ credential: cert(sa) }, 'messaging-send-probes');
 const ENDPOINT = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;

--- a/packages/conformance/src/package-version.test.ts
+++ b/packages/conformance/src/package-version.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  resolvePackageJsonPath,
+  resolvePackageVersion,
+  resolvedAdminVersion,
+  resolvedFirebaseVersion,
+  resolvedFunctionsVersion,
+} from './package-version.ts';
+
+describe('package-version utility (walk-up resolver)', () => {
+  test('resolves installed firebase client version', () => {
+    const version = resolvedFirebaseVersion();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test('resolves installed firebase-admin server version', () => {
+    const version = resolvedAdminVersion();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test('resolves installed firebase-functions version', () => {
+    const version = resolvedFunctionsVersion();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test('locates valid package.json on disk matching package name', () => {
+    const adminPath = resolvePackageJsonPath('firebase-admin');
+    expect(existsSync(adminPath)).toBe(true);
+    const content = JSON.parse(readFileSync(adminPath, 'utf8')) as { name: string; version: string };
+    expect(content.name).toBe('firebase-admin');
+    expect(content.version).toBe(resolvedAdminVersion());
+
+    const fbPath = resolvePackageJsonPath('firebase');
+    expect(existsSync(fbPath)).toBe(true);
+    const fbContent = JSON.parse(readFileSync(fbPath, 'utf8')) as { name: string; version: string };
+    expect(fbContent.name).toBe('firebase');
+    expect(fbContent.version).toBe(resolvedFirebaseVersion());
+  });
+
+  test('throws descriptive error on non-existent package', () => {
+    expect(() => resolvePackageVersion('non-existent-dummy-pkg-12345')).toThrow(
+      /Could not resolve any public entrypoint/,
+    );
+  });
+
+  test('returns cached version on repeated calls', () => {
+    const v1 = resolvePackageVersion('firebase');
+    const v2 = resolvePackageVersion('firebase');
+    expect(v1).toBe(v2);
+  });
+});

--- a/packages/conformance/src/package-version.ts
+++ b/packages/conformance/src/package-version.ts
@@ -1,0 +1,94 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const KNOWN_ENTRIES: Record<string, string[]> = {
+  firebase: ['firebase/app', 'firebase/auth', 'firebase/firestore'],
+  'firebase-admin': ['firebase-admin', 'firebase-admin/app'],
+  'firebase-functions': ['firebase-functions'],
+};
+
+const versionCache = new Map<string, string>();
+const pathCache = new Map<string, string>();
+
+/**
+ * Ascends from a resolved entrypoint file path to locate the enclosing package.json
+ * whose "name" matches `pkgName`.
+ */
+export function resolvePackageJsonPath(pkgName: string, parentUrl: string = import.meta.url): string {
+  const cacheKey = `${pkgName}::${parentUrl}`;
+  if (pathCache.has(cacheKey)) return pathCache.get(cacheKey)!;
+
+  const candidates = KNOWN_ENTRIES[pkgName] ?? [pkgName, `${pkgName}/app`];
+  let resolvedUrl: string | undefined;
+  let lastError: Error | undefined;
+
+  for (const entry of candidates) {
+    try {
+      resolvedUrl = import.meta.resolve(entry, parentUrl);
+      if (resolvedUrl) break;
+    } catch (err) {
+      lastError = err as Error;
+    }
+  }
+
+  if (!resolvedUrl) {
+    throw new Error(
+      `Could not resolve any public entrypoint for package "${pkgName}". Last error: ${lastError?.message}`,
+    );
+  }
+
+  const filePath = fileURLToPath(resolvedUrl);
+  let currentDir = dirname(filePath);
+
+  while (currentDir !== dirname(currentDir)) {
+    const candidate = join(currentDir, 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        const content = JSON.parse(readFileSync(candidate, 'utf8')) as { name?: string };
+        if (content.name === pkgName) {
+          pathCache.set(cacheKey, candidate);
+          return candidate;
+        }
+      } catch {
+        // Continue climbing if package.json is unparseable or irrelevant
+      }
+    }
+    currentDir = dirname(currentDir);
+  }
+
+  throw new Error(`Walked up to filesystem root without finding matching package.json for "${pkgName}".`);
+}
+
+/**
+ * Returns the parsed `version` string from the target package's `package.json`.
+ */
+export function resolvePackageVersion(pkgName: string, parentUrl: string = import.meta.url): string {
+  const cacheKey = `${pkgName}::${parentUrl}`;
+  if (versionCache.has(cacheKey)) return versionCache.get(cacheKey)!;
+
+  const pkgJsonPath = resolvePackageJsonPath(pkgName, parentUrl);
+  const meta = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as { version?: unknown };
+
+  if (typeof meta.version !== 'string' || meta.version.length === 0) {
+    throw new Error(`Package manifest at ${pkgJsonPath} missing valid "version" string.`);
+  }
+
+  versionCache.set(cacheKey, meta.version);
+  return meta.version;
+}
+
+/** Resolved (installed) `firebase` client SDK version. */
+export function resolvedFirebaseVersion(parentUrl?: string): string {
+  return resolvePackageVersion('firebase', parentUrl);
+}
+
+/** Resolved (installed) `firebase-admin` server SDK version. */
+export function resolvedAdminVersion(parentUrl?: string): string {
+  return resolvePackageVersion('firebase-admin', parentUrl);
+}
+
+/** Resolved (installed) `firebase-functions` SDK version. */
+export function resolvedFunctionsVersion(parentUrl?: string): string {
+  return resolvePackageVersion('firebase-functions', parentUrl);
+}

--- a/packages/conformance/src/run-firestore-real.ts
+++ b/packages/conformance/src/run-firestore-real.ts
@@ -20,6 +20,7 @@ import { getAuth as getAdminAuth } from 'firebase-admin/auth';
 import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
 import { chromium } from '@playwright/test';
 import { acquireRunLock } from './storage-stdlib-real-lock.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 import {
   FIREBASE_API,
   accessHeaders,
@@ -617,16 +618,14 @@ async function run(): Promise<void> {
     if (!behavior || !browserBehavior || !probeRulesetName || !restoreVerified) {
       throw new Error('probe did not complete with verified rules restoration');
     }
-    const firebasePackage = JSON.parse(
-      readFileSync(fileURLToPath(await import.meta.resolve('firebase/package.json')), 'utf8'),
-    ) as { version: string };
+    const fbSdkVersion = resolvedFirebaseVersion();
     const observation = {
       name: 'firestore-transaction-contention-retries',
       matrixRow: 'firestore #93',
       rowIds: ['firestore#93'],
       description: 'Two authenticated Web SDK clients contend on transaction read documents; captures callback retries, fresh reads, maxAttempts exhaustion, and the terminal error shape.',
       observedAt: new Date().toISOString(),
-      fbSdkVersion: firebasePackage.version,
+      fbSdkVersion,
       projectId: sa.project_id,
       inputDigest: createHash('sha256').update(content).digest('hex'),
       lifecycle: {
@@ -651,7 +650,7 @@ async function run(): Promise<void> {
       ],
       description: 'Real-Chromium production capture for persistence preconditions, offline pending writes, explicit cache behavior, snapshot synchronization, and Firestore-only termination.',
       observedAt: new Date().toISOString(),
-      fbSdkVersion: firebasePackage.version,
+      fbSdkVersion,
       projectId: sa.project_id,
       inputDigest: createHash('sha256').update(content).digest('hex'),
       lifecycle: {
@@ -673,7 +672,7 @@ async function run(): Promise<void> {
       ...previousRulesObservation,
       description: 'Authenticated Web SDK operations against temporarily deployed production rules verify getAfter()/existsAfter() target, existence, and cross-document atomic projection semantics. The hosted Rules Test API limitation is retained separately in diagnostics.',
       observedAt: new Date().toISOString(),
-      fbSdkVersion: firebasePackage.version,
+      fbSdkVersion,
       projectId: sa.project_id,
       lifecycle: {
         originalRulesetName: snapshot.release.rulesetName,

--- a/packages/conformance/src/run-rules-rtdb.ts
+++ b/packages/conformance/src/run-rules-rtdb.ts
@@ -63,6 +63,7 @@ import {
   type RtdbScenario,
   type RtdbTestCase,
 } from '../rules-corpus/rtdb/index.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, '..', '..', '..');
@@ -98,15 +99,6 @@ interface Observation {
 interface ObservationLinkage {
   matrixRow: string;
   rowIds: string[];
-}
-
-/** Resolved (installed) firebase version — the value check-observation-versions.ts
- *  compares every observation against. */
-function resolvedFirebaseVersion(): string {
-  const pkgPath = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
-  if (!meta.version) throw new Error('could not resolve installed firebase version');
-  return meta.version;
 }
 
 /** Absolute path an observation for `scenario` writes to. */

--- a/packages/conformance/src/run-rules-storage.ts
+++ b/packages/conformance/src/run-rules-storage.ts
@@ -45,19 +45,11 @@ import {
   type StorageScenario,
 } from '../rules-corpus/storage/index.ts';
 import { readObservationLinkage } from './observation-linkage.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // rules-storage-* observations belong to the native 'storage-rules' surface.
 const OBS_DIR = join(HERE, '..', 'observations', 'storage-rules');
-
-/** Resolved (installed) firebase version — the value the observation-version
- *  guard compares every observation against. */
-function resolvedFirebaseVersion(): string {
-  const pkgPath = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
-  if (!meta.version) throw new Error('could not resolve installed firebase version');
-  return meta.version;
-}
 
 interface Observation {
   name: string;

--- a/packages/conformance/src/run-rules.ts
+++ b/packages/conformance/src/run-rules.ts
@@ -49,22 +49,15 @@ import {
   firestoreScenarioInputDigest,
   type FirestoreScenarioInputDigest,
 } from './firestore-rules-input-digest.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // rules-firestore-* observations belong to the native 'firestore-rules' surface.
 const OBS_DIR = join(HERE, '..', 'observations', 'firestore-rules');
 
-/** Resolved (installed) firebase version — the value the observation-version
- *  guard (check-observation-versions.ts) compares every observation against.
- *  The Rules Test API is a REST surface with no client SDK, but the envelope
+/** The Rules Test API is a REST surface with no client SDK, but the envelope
  *  carries `fbSdkVersion` for consistency with the rest of the oracle and to
  *  keep the version guard green once captures land. */
-function resolvedFirebaseVersion(): string {
-  const pkgPath = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  const meta = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
-  if (!meta.version) throw new Error('could not resolve installed firebase version');
-  return meta.version;
-}
 
 interface Observation {
   name: string;

--- a/packages/conformance/src/run-storage-stdlib-discovery.ts
+++ b/packages/conformance/src/run-storage-stdlib-discovery.ts
@@ -11,6 +11,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolvedFirebaseVersion } from './package-version.ts';
 import type { ProjectScope } from '../../../packages/pyric/src/project-scope.ts';
 import {
   TestFirestoreRulesHandler,
@@ -30,11 +31,6 @@ type Diagnostic = { notes?: string[]; issues?: unknown[]; httpStatus?: number; e
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OBS_DIR = join(HERE, '..', 'observations', 'storage-rules');
 const REQUEST_COUNTS: Record<ProbeId, number> = { p0: 12, p1: 14, p2: 1 };
-
-function resolvedFirebaseVersion(): string {
-  const path = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  return (JSON.parse(readFileSync(path, 'utf8')) as { version: string }).version;
-}
 
 export function selectedProbes(args: string[]): ProbeId[] {
   const values = args.flatMap((arg, index) => {

--- a/packages/conformance/src/run-storage-stdlib-real.ts
+++ b/packages/conformance/src/run-storage-stdlib-real.ts
@@ -14,6 +14,7 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readObservationLinkage } from './observation-linkage.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 import {
   accessHeaders,
   FIREBASE_API,
@@ -452,7 +453,7 @@ async function run(): Promise<void> {
         ? 'Real-resource Storage-to-Firestore advanced behavior for return types, evaluation order, path boundaries, helper composition, and independence from the Firestore ruleset.'
         : 'Real-resource Storage-to-Firestore lookup behavior for one/two/three distinct documents, repeated paths, get+exists composition, short-circuiting, and missing documents.',
       observedAt: new Date().toISOString(),
-      fbSdkVersion: (JSON.parse(readFileSync(fileURLToPath(import.meta.resolve('firebase/package.json')), 'utf8')) as { version: string }).version,
+      fbSdkVersion: resolvedFirebaseVersion(),
       projectId: sa.project_id,
       bucket: config.storageBucket,
       behavior,

--- a/packages/conformance/src/run.ts
+++ b/packages/conformance/src/run.ts
@@ -179,6 +179,7 @@ import {
 } from 'pyric/rules/internal/rtdb';
 import { createRtdbDisconnectProbes } from './capture/rtdb-disconnect/probes.ts';
 import { loadRtdbClimbProbes } from './capture/rtdb-climb/load-probes.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 
 // ─── Setup ────────────────────────────────────────────────────────────
 
@@ -806,11 +807,8 @@ async function loadConfig(): Promise<FirebaseWebConfig> {
 }
 
 const config = await loadConfig();
-// Resolve the firebase package via Node's resolver so we don't care
-// where it's hoisted in the workspace.
-const fbPkgPath = await import.meta.resolve('firebase/package.json');
-const fbPkg = JSON.parse(readFileSync(fileURLToPath(fbPkgPath), 'utf8')) as { version: string };
-const FB_SDK_VERSION = fbPkg.version;
+// Resolve the firebase package version via the centralized walk-up resolver.
+const FB_SDK_VERSION = resolvedFirebaseVersion();
 
 const appName = `pyric-oracle-${Date.now()}`;
 const app = initializeApp(config, appName);

--- a/packages/conformance/src/storage-stdlib-real-observations.ts
+++ b/packages/conformance/src/storage-stdlib-real-observations.ts
@@ -2,15 +2,11 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readObservationLinkage } from './observation-linkage.ts';
+import { resolvedFirebaseVersion } from './package-version.ts';
 import { type RequestBudget } from './storage-stdlib-real-budget.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OBS_DIR = join(HERE, '..', 'observations', 'storage-rules');
-
-function resolvedFirebaseVersion(): string {
-  const packagePath = fileURLToPath(import.meta.resolve('firebase/package.json'));
-  return (JSON.parse(readFileSync(packagePath, 'utf8')) as { version: string }).version;
-}
 
 export function writeStorageObservations(values: Array<Record<string, unknown>>): void {
   mkdirSync(OBS_DIR, { recursive: true });


### PR DESCRIPTION
Resolves installed Firebase SDK versions across `@pyric/conformance` by ascending from public module entrypoints instead of querying unexported `package.json` subpaths directly.

```ts
import {
  resolvedFirebaseVersion,
  resolvedAdminVersion,
  resolvedFunctionsVersion,
} from './packages/conformance/src/package-version.ts';

// Resolves public entrypoints ('firebase/app', 'firebase-admin', 'firebase-functions')
// via import.meta.resolve, then walks up directory by directory to read package.json:
const fbVersion = resolvedFirebaseVersion();
// => "12.13.0"
const adminVersion = resolvedAdminVersion();
// => "13.10.0"
const functionsVersion = resolvedFunctionsVersion();
// => "7.2.5"
```

```ts
import {
  resolvePackageJsonPath,
  resolvePackageVersion,
} from './packages/conformance/src/package-version.ts';

// Dynamic resolution with explicit parent URL context and arbitrary package names:
const manifestPath = resolvePackageJsonPath('firebase-admin', import.meta.url);
// => "/path/to/node_modules/firebase-admin/package.json"

const customPkgVersion = resolvePackageVersion('firebase-functions', import.meta.url);
// => "7.2.5"
```

## Direct package.json resolution violates strict ESM export maps

In strict Node.js ESM environments, resolving `import.meta.resolve('firebase-admin/package.json')` or `import.meta.resolve('firebase-functions/package.json')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` because those packages do not expose `./package.json` in their `"exports"` map. Similarly, `import.meta.resolve('firebase')` throws `No "exports" main defined` because Firebase v9+ exposes modular subpaths (`firebase/app`, `firebase/firestore`) without a root `.` entry.

The new `package-version.ts` resolver maps packages to known public subpaths (`firebase/app`, `firebase-admin`, `firebase-functions`), resolves the physical entry file, and climbs the filesystem tree via `path.dirname` until it finds the matching `package.json` manifest.

## Risk

This change is scoped entirely within the private `@pyric/conformance` package and touches zero runtime code shipped to npm. The primary risk was potential performance overhead or directory traversal escapes on odd file trees, which is mitigated by:
1. Caching resolved paths and versions in module-level `Map` instances after the first hit.
2. Checking `manifest.name === pkgName` during ascent to prevent accidentally matching a parent monorepo `package.json`.
3. Terminating traversal with an explicit error when reaching the filesystem root (`dir === dirname(dir)`).

<details>
<summary>Implementation notes</summary>

- Replaced 18 manual `import.meta.resolve('*/package.json')` call sites across 17 files in `packages/conformance/src/`.
- `bun test packages/conformance/src/package-version.test.ts` — 6 passed, 0 failed.
- `bun test packages/conformance/src/` — 36 passed, 0 failed.
- `bun run packages/conformance/src/check-observation-versions.ts` — 313 observations checked, 0 mismatches.
- `bun run --cwd packages/conformance typecheck` — 0 errors.
- Verified under native Node.js v26.5.1 via `node --input-type=module` without ESM resolution flags.

</details>
