### PR TITLE
fix(release): align packaging gate with sandbox command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ During `vite dev`, the plugin swaps supported `firebase/*` modules at resolution
 
 Pyric Studio is available on the Vite origin at `/__pyric/ui/studio`. It opens the same backend used by the application.
 
-For a static application or a Node process, `pyric dev` provides the same development-only package swap without the Vite plugin. The [CLI reference](packages/cli/docs/reference/cli.md) documents those paths and every command.
+For a static application or a Node process, `pyric sandbox` provides the same development-only package swap without the Vite plugin. The [CLI reference](packages/site-docs/src/content/reference/cli.md) documents those paths and every command.
 
 ## Keep using official Firebase SDKs
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -2,7 +2,7 @@
 
 The data-management and debugging console for the pyric sandbox — the "Firebase
 console for Pyric". Astro consumes Studio as a React application and serves it
-from the public site or from `pyric dev --ui`.
+from the public site or from `pyric sandbox --ui`.
 
 Studio is **cross-service** (Firestore / Auth / Storage / RTDB over one event
 stream) and **agentic-dev-focused**: an Action Center digest of what changed,
@@ -27,7 +27,7 @@ builds. The standalone agent Playground is developed separately.
 
 `createStudioEnvironment(mode)` is the single wiring seam:
 
-- **`local`** — `pyric dev --ui`: disk via the pyric devr. Ships first.
+- **`local`**: `pyric sandbox --ui`, with disk access through the Pyric sandbox server. Ships first.
 - **`browser`** — browser-persisted state over the same ports. Future.
 - **`hosted`** — a remote API behind the same ports. Future.
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pyric/studio",
   "version": "0.0.0",
-  "description": "Pyric Studio \u2014 the data-management and debugging console for the pyric sandbox, served by `pyric dev --ui`. Cross-service viewer/editor, action center, traffic, rules-failure debugging, and the agentic build flow over one event stream.",
+  "description": "Pyric Studio is the data-management and debugging console for the pyric sandbox, served by `pyric sandbox --ui`. Cross-service viewer/editor, action center, traffic, rules-failure debugging, and the agentic build flow over one event stream.",
   "type": "module",
   "exports": {
     "./app": {

--- a/scripts/manifest-lint.sh
+++ b/scripts/manifest-lint.sh
@@ -23,7 +23,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 # The four publishable libraries. @pyric/studio is embedded into @pyric/cli for
-# `pyric dev --ui`, not published as part of this pack gate.
+# `pyric sandbox --ui`, not published as part of this pack gate.
 PACKAGES=(pyric pyric-admin cli ui)
 ATTW="$ROOT/node_modules/.bin/attw"
 PUBLINT="$ROOT/node_modules/.bin/publint"

--- a/scripts/packaging-test.sh
+++ b/scripts/packaging-test.sh
@@ -62,7 +62,7 @@ PYRIC_ADMIN_SUBPATHS=( $(exported_subpaths packages/pyric-admin) )
 PYRIC_CLI_SUBPATHS=( $(exported_subpaths packages/cli) )
 PYRIC_UI_SUBPATHS=( $(exported_subpaths packages/ui) )
 
-# Tracks the backgrounded `pyric dev` (Phase 5.5) so a failure mid-smoke
+# Tracks the backgrounded `pyric sandbox` (Phase 5.5) so a failure mid-smoke
 # doesn't leave it listening; killed in the error trap and after the probe.
 SERVE_PID=""
 cleanup_on_error() {
@@ -223,7 +223,7 @@ assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/README\.md$' "cre
 assert_tar_has "$TARBALL_CREATE_PYRIC" 'package/templates/chat/\.env\.example$' "create-pyric ships the chat environment example"
 assert_tar_lacks "$TARBALL_CREATE_PYRIC" 'package/templates/chat/dist/' "create-pyric excludes the built chat dist/ tree"
 assert_tar_has "$TARBALL_PYRIC_CLI" 'package/dist/cli/index\.js$' "@pyric/cli ships the pyric CLI bin"
-# The Vite plugin's `ui` option + `pyric dev --ui` resolve Studio and docs from
+# The Vite plugin's `ui` option + `pyric sandbox --ui` resolve Studio and docs from
 # one Astro tree at dist/serve/site-ui. The plugin's firebase swap resolves the
 # entries from dist/serve/entries. Both are `files:["dist"]`-whitelisted assets that
 # import fine but 404 / break the swap for installed users if the build drops them.
@@ -600,7 +600,7 @@ test -f "$CREATE_NEXTJS_OUT/next.config.mjs"
 grep -q "@pyric/cli/next" "$CREATE_NEXTJS_OUT/next.config.mjs"
 grep -q "withPyric(nextConfig)" "$CREATE_NEXTJS_OUT/next.config.mjs"
 test -f "$CREATE_NEXTJS_OUT/package.json"
-grep -q '"dev": "pyric dev -- next dev"' "$CREATE_NEXTJS_OUT/package.json"
+grep -q '"dev": "pyric sandbox -- next dev"' "$CREATE_NEXTJS_OUT/package.json"
 grep -q '"name": "packed-nextjs"' "$CREATE_NEXTJS_OUT/package.json"
 grep -q '# packed-nextjs' "$CREATE_NEXTJS_OUT/README.md"
 test -f "$CREATE_NEXTJS_OUT/src/app/page.tsx"
@@ -643,17 +643,17 @@ echo "  ✓ packed chat Functions module boots through @pyric/cli/register"
 
 # ─── Phase 5.5: serve smoke (init + serve from the packed bin) ─────────
 # The subpath + bin checks above prove imports resolve, but they never boot
-# the in-page sandbox runtime. A post-install `pyric dev`/bundler break
+# the in-page sandbox runtime. A post-install `pyric sandbox`/bundler break
 # (e.g. a dist path the tarball doesn't ship, or an esbuild plugin that can't
 # resolve pyric's SDK from node_modules) would pass everything above yet fail
 # the moment a user runs serve. This phase scaffolds a fresh app with the
-# packed `pyric init`, starts `pyric dev` headless on an ephemeral port, and
+# packed `pyric init`, starts `pyric sandbox` headless on an ephemeral port, and
 # probes the readiness endpoint — the one thing that exercises the real serve
 # path from the published tarball.
 #
 # Uses `--template static`: the default `web` template scaffolds a Vite app
 # (served by `vite dev`, `hosting.public` → `dist` which doesn't exist until a
-# build), so it isn't what `pyric dev` consumes. The `static` template is the
+# build), so it isn't what `pyric sandbox` consumes. The `static` template is the
 # serve-era no-bundler scaffold (a ready `public/` dir) — exactly the path this
 # smoke exercises. (The Vite-plugin path is covered by @pyric/cli' own tests.)
 echo ""
@@ -666,7 +666,7 @@ echo "  ✓ pyric init scaffolded a static app from the tarball"
 # Start serve in the background. `--json` puts the machine-readable line on
 # stdout AND suppresses the browser auto-open (no TTY/CI also suppress it);
 # `--port 0` binds an ephemeral port so the gate never collides with a real one.
-( cd "$SMOKE" && "$PYRIC_BIN" dev --port 0 --json ) > "$SMOKE/serve.out" 2> "$SMOKE/serve.err" &
+( cd "$SMOKE" && "$PYRIC_BIN" sandbox --port 0 --json ) > "$SMOKE/serve.out" 2> "$SMOKE/serve.err" &
 SERVE_PID=$!
 
 # Poll for the JSON contract line (printed once the server is listening).
@@ -681,7 +681,7 @@ for _ in $(seq 1 80); do
   sleep 0.5
 done
 if [ -z "$SERVE_URL" ]; then
-  echo "  ✗ pyric dev never reported a ready URL"
+  echo "  ✗ pyric sandbox never reported a ready URL"
   echo "    stderr:"; sed 's/^/      /' "$SMOKE/serve.err"
   exit 1
 fi
@@ -692,7 +692,7 @@ if ! curl -fsS "$SERVE_URL/__pyric/init.json" 2>/dev/null | jq -e 'has("rulesHas
   echo "  ✗ GET $SERVE_URL/__pyric/init.json did not return a valid init payload"
   exit 1
 fi
-echo "  ✓ pyric dev booted ($SERVE_URL) and /__pyric/init.json resolved"
+echo "  ✓ pyric sandbox booted ($SERVE_URL) and /__pyric/init.json resolved"
 
 kill "$SERVE_PID" 2>/dev/null
 wait "$SERVE_PID" 2>/dev/null || true

--- a/scripts/site/build.ts
+++ b/scripts/site/build.ts
@@ -92,7 +92,7 @@ async function bundleSdkAndWorker(): Promise<string> {
   // bundleSdk computes its OWN outDir under a cache root (keyed by content
   // hash) — it doesn't take an arbitrary target dir. Point its cache root at
   // a scratch dir under dist/, build once (noCache: true, this is a one-shot
-  // site build, not `pyric dev`'s warm-start path), then copy the bundle's
+  // site build, not `pyric sandbox`'s warm-start path), then copy the bundle's
   // files into the site's __pyric/sdk/.
   const scratchCache = join(ROOT, 'dist', '.site-sdk-cache');
   rmSync(scratchCache, { recursive: true, force: true });


### PR DESCRIPTION
Summary:
- update the packed Next.js assertion to require pyric sandbox
- run the packed server smoke through pyric sandbox
- correct stale release comments, Studio text, and the root CLI reference link

Verification:
- bun run test:packaging
- bun run test
- git diff --check
- bash syntax validation

Release status:
- no package was published
- npm authentication was verified separately with a temporary credential configuration
- after this PR merges, prepare the lockstep 0.1.0-alpha.20 release PR