### PR TITLE
release: v0.1.0-alpha.20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.19",
+      "version": "0.1.0-alpha.20",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -153,7 +153,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.19",
+      "version": "0.1.0-alpha.20",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -273,7 +273,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.19",
+      "version": "0.1.0-alpha.20",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -291,7 +291,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.19",
+      "version": "0.1.0-alpha.20",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -360,7 +360,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.19",
+      "version": "0.1.0-alpha.20",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.20`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.19

- fix(release): align packaging gate with sandbox command (1848f168)
- docs: align sandbox command surface (677c4aab)
- docs: remove internal storage rules research page (39edded6)
- feat(plugin): rename pyric-start skill to pyric (129975dd)
- fix(conformance): resolve SDK package manifests via export-safe directory walk (81487bbc)
- test(e2e): configure auth-required database rules for e2e fixtures under default-deny (94a7773e)
- fix(cli): safely default databaseRulesHash to null in runtime diagnostics (13a3a9c3)
- fix(serve): address standards and spec review findings for rtdb default policy (e380eb30)
- fix(serve): dynamically reload newly created rules and support multi-database configs (039b7128)
- feat(rtdb): enforce production default-deny security when database rules are absent (6a40a09e)
- feat(ci): shard build-and-test CLI suite across 2 runner VMs (4dd7b2cc)
- fix(e2e): update playwright configs and soak harnesses to invoke sandbox command (67eacbca)
- fix(cli,admin): resolve standards and spec findings for sandbox command (2df80648)
- feat(cli): implement pyric sandbox command and pyric.json configuration (7105cfac)
- perf(conformance): deduplicate and parallelize probe runs in check-observations (d261ea71)
- feat(ci): decouple playwright browser cache from global lockfile with multi-tier restore (e4cc1d02)
- feat(ci): add upstream build-packages stage to eliminate parallel compilation fanout (fbacf7bf)
- docs(priorities): note proof selection activation under build velocity (e7dec9ee)
- feat(ci): activate enforced proof selection and expand docs fast-path (1007ac2d)
- refactor(serve): enforce code conventions, simplify route guards, and align test structure (16e55c15)
- fix(pyric): fix test argument order for bun test in types.test.ts (df9e8845)
- fix(cli,studio): isolate writer locks, secure event streams, and scope token cache (3c16f42c)
- fix(cli): guard writer lock header enforcement with opts.writerLock check (1ec9870e)
- feat(security): implement defense-in-depth authorization & mutation guard for local workspace REST and event streams (0581967e)
- fix(rtdb): support scientific notation and single-quoted string escapes in rules (cc8febef)
- priorities: add multi-tenancy and impersonation section to priorities (4125fd21)
- chore: remove stale root DESIGN.md and PRODUCT.md (beba2dc8)
- feat(site): share Home | Docs | Studio chrome and retire the in-browser slogan (c551aeea)
- fix(site): match studio wordmark to Neue Haas display (e26ce5fb)
- chore: pin @types/bun and bun-types to 1.3.14 (50d96bf3)
- chore: refresh bun.lock for @types/bun 1.4.0 (b98bcf58)
- lower cta (1da2d4fa)
- feat(site): redesign landing page with drafting-sheet hero, agent composer, and authored essay (cdb0c68d)
- chore(git): remove untracked impeccable skill files from repository index (2bb64124)
- refactor(cli): extract named boolean predicates in presence.ts per code conventions (ad9de7b5)
- fix(test): guard presence event listeners against partial window mocks and update static e2e urls to /firestore/ (5de5ea22)
- feat(site): redesign landing hero with single deep-dive IDE demo card and authentic stdlib rules (32f57363)
- docs: refresh CONTEXT.md against the tree at alpha.19 (afb79baa)
- feat(examples): add decoupled React 19 in-page sandbox task application (#516) (8b022513)
- feat(plugin): introduce pyric-inpage-sandbox skill for standalone browser prototypes and simulation drivers (50b1d9d8)
- feat(messaging): support bare sandbox targets in getMessaging with stable instance identity (a9216b15)
- fix(storage): add in-memory persistence fallback for blocked IndexedDB and fix bare sandbox dynamic auth (41272c46)
- fix(test): restrict process.env copying in loadViteAiEnv to API authentication keys to prevent test env leaks in CI (edac81f5)
- style(ui): right-align model-to-alias subline on runtime chip (c47dfb32)
- feat(ui): implement Option 1 primary row and muted full-width subline layout for AI engine on runtime chip (d8bf534c)
- fix(ai): attach loaded api key to engine wire and show detailed alias config on runtime chip (e6905494)
- fix(ai): map experimental flash-lite aliases to gemini-flash-lite-latest instead of deprecated gemini-1.5-flash (9cc04857)
- feat(ai): populate process.env with AI env keys and surface AI logic mode row in runtime chip (8a793c83)
- fix(ai): preserve gemini engine config in toEngineWire and fall back to pluginEngineWire in worker getAI (c8cf7d72)
- feat(ai): surface AI broker request rejections on runtime chip and alias experimental model IDs (09c04b8d)
- fix(ai): implement code review findings for ADC fallback, Vertex AI headers, SSE buffer draining, and code conventions (7d4dbdf6)
- feat(ai): proxy mode production through server broker via GeminiEngine to avoid browser auth errors (9064fe11)
- docs: audit AI Logic and Pyric configuration (8e7453bf)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.20` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.20` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.20 && git push origin v0.1.0-alpha.20` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
