### PR TITLE
Use sandbox in public command documentation

### DIFF
--- a/packages/cli/src/next/with-pyric.ts
+++ b/packages/cli/src/next/with-pyric.ts
@@ -25,7 +25,7 @@ function applyPyricEnhancements(config: NextConfigObject, options?: PyricNextOpt
 /**
  * Higher-order configuration wrapper for Next.js (`next.config.js` or `next.config.mjs`).
  *
- * During development mode (`pyric dev` or non-production NODE_ENV):
+ * During development mode (`pyric sandbox` or non-production NODE_ENV):
  *   - Applies Webpack and Turbopack alias mappings to swap `firebase/*` imports
  *     for Pyric local sandbox mirrors on client components.
  *   - Adds `firebase` and `firebase-admin` to `serverExternalPackages` to prevent

--- a/packages/cli/src/serve/entries/bridge-url.ts
+++ b/packages/cli/src/serve/entries/bridge-url.ts
@@ -1,7 +1,7 @@
 /**
  * Re-anchor a bridge WebSocket URL to the page's own origin.
  *
- * `pyric dev` / the vite plugin bake their OWN host into the bridge URL it
+ * `pyric sandbox` / the vite plugin bake their OWN host into the bridge URL it
  * sends the page (e.g. `ws://localhost:5173/__pyric/sandbox`). But the page may
  * have been loaded over a different host (Tailscale, a LAN IP) or scheme
  * (`https` via `tailscale serve`, which then requires `wss`). Connecting to the

--- a/packages/cli/src/serve/vite-plugin.ts
+++ b/packages/cli/src/serve/vite-plugin.ts
@@ -1,18 +1,18 @@
 /**
  * `@pyric/cli/vite` — the firebase→pyric-sandbox swap as a Vite plugin.
  *
- * The serve analog for SOURCE-driven apps: instead of `vite build && pyric dev
+ * The serve analog for SOURCE-driven apps: instead of `vite build && pyric sandbox
  * dist`, a team keeps `vite dev` (HMR, source maps) with the in-process sandbox
  * standing in for Firebase. The app's `firebase/*` imports are UNCHANGED — the
  * plugin swaps them at the module-resolution layer (`resolveId`), the same way
- * `pyric dev` swaps via a runtime import map. (Design: `plans/pyric-vite-plugin.md`.)
+ * `pyric sandbox` swaps via a runtime import map. (Design: `plans/pyric-vite-plugin.md`.)
  *
  * Two flavors, one `apply` function. Under `vite dev` the swap is ALWAYS on.
  * For `vite build` the swap is MODE-gated: a plain `vite build` (mode
  * `production`) ships the real `firebase` package — the swap never reaches the
  * prod artifact — while `vite build --mode development` (any NON-production
  * mode) produces a SANDBOX build that bundles pyric's in-page adapters instead
- * of the real SDK: self-contained, meant to be previewed under `pyric dev`, and
+ * of the real SDK: self-contained, meant to be previewed under `pyric sandbox`, and
  * stamped with the sandbox-build marker so it can never be deployed (`pyric
  * deploy hosting` refuses it). `pyric({ swapInBuild })` forces the build
  * behavior on/off regardless of mode. See `sandbox-marker.ts`.
@@ -24,11 +24,11 @@
  *   - the host-neutral sandbox session — rules, fixtures, stores, live payload,
  *     Studio routes, `/__pyric/*` namespace, and owned cleanup;
  *   - the SharedWorker host — `bundleWorker` served at `/__pyric/sdk/worker.js`;
- *   - the bridge mount shared with `pyric dev --bridge`.
+ *   - the bridge mount shared with `pyric sandbox --bridge`.
  *
  * Scope = M1 (swap + rules) + M2 (SharedWorker multi-tab + persist/capture/seed)
  * + M3 (the MCP bridge fold — `{ bridge }`). M3 reuses `createBridgeMount` (the
- * proven serve-flavored bridge behind `pyric dev --bridge`), composing it into
+ * proven serve-flavored bridge behind `pyric sandbox --bridge`), composing it into
  * the same `/__pyric` middleware; on the worker path the bridge peer routes
  * agent tool-calls THROUGH the SharedWorker (`connectBridgePeer`), so the agent
  * and the app share one backend without forcing the page in-page.
@@ -82,7 +82,7 @@ export interface PyricOptions {
    *  only when the worker bundle itself fails, bridge or not. */
   bridge?: boolean | { project?: string; disableAuditLog?: boolean };
   /** Serve the **Pyric Studio** app at `/__pyric/ui/` on Vite's dev origin (the
-   *  `pyric dev --ui` equivalent). Mounts the disk-backed workspace/project
+   *  `pyric sandbox --ui` equivalent). Mounts the disk-backed workspace/project
    *  routes Studio's `local` mode talks to AND serves the unified Astro site
    *  (vendored in this package at `dist/serve/site-ui`). **On by default**,
    *  including under `bridge` (the bridge peer routes through the SharedWorker,
@@ -93,7 +93,7 @@ export interface PyricOptions {
    *  dev/builds. On by default. Pass `false` to hide it, or
    *  `{ initiallyOpen: true }` when actively debugging runtime errors. */
   runtimeChip?: PyricRuntimeChipOption;
-  /** RTDB-triggered Cloud Functions under this dev server (the `pyric dev`
+  /** RTDB-triggered Cloud Functions under this dev server (the `pyric sandbox`
    *  parity fold). By default a `functions` block in `firebase.json` is
    *  discovered automatically: its `onValueCreated` triggers run in an isolated
    *  node child against the shared sandbox (other trigger kinds warn and are
@@ -216,7 +216,7 @@ export function pyric(options: PyricOptions = {}): Plugin {
     // `vite build` keeps the real firebase package — the swap never reaches
     // production output. A sandbox build applies the same swap so the output
     // bundles pyric's in-page adapters (self-contained; preview it under
-    // `pyric dev`, never deploy it).
+    // `pyric sandbox`, never deploy it).
     apply(config, env) {
       void config;
       return pageRuntime.applies(env);

--- a/packages/cli/src/verify/fixture.ts
+++ b/packages/cli/src/verify/fixture.ts
@@ -27,7 +27,7 @@ export interface PyricVerifyFixture {
    *  SharedWorker's `instanceId`). Purely additive: `pyric verify` ignores it.
    *  Present only on captures written by the worker's capture flush; used by
    *  boot-time event hydration to SKIP priming a capture that belongs to a
-   *  DIFFERENT instance (e.g. another browser profile sharing one `pyric dev`),
+   *  DIFFERENT instance (e.g. another browser profile sharing one `pyric sandbox`),
    *  so someone else's session never shows up as yours. Absent on older /
    *  standalone captures → hydration primes best-effort. */
   capturedBy?: string;

--- a/packages/conformance/registry/firestore.ts
+++ b/packages/conformance/registry/firestore.ts
@@ -2023,7 +2023,7 @@ export const firestoreRegistry = {
           rowRef: "149",
           featureKeys: ["setLogLevel"],
           api: "setLogLevel",
-          behavior: "Accepted no-op — the sandbox has no modular-SDK-style logger to wire a level into; it uses host-level `console` logging directly, gated by `pyric dev`'s own flags, not this call",
+          behavior: "Accepted no-op. The sandbox has no modular-SDK-style logger to wire a level into. It uses host-level `console` logging directly, gated by `pyric sandbox`'s own flags, not this call",
           status: "diverged-documented",
           statusNote: "accepted no-op; no sandbox logger wired",
         }),

--- a/packages/pyric/src/database/controls.ts
+++ b/packages/pyric/src/database/controls.ts
@@ -69,7 +69,7 @@ export function forceWebSockets(): void {
  *
  * Accepted no-op: the sandbox has no modular-SDK-style logger to wire a
  * level/sink into (it uses host-level `console` logging directly, gated
- * by `pyric dev`'s own flags — matching `pyric/firestore`'s
+ * by `pyric sandbox`'s own flags — matching `pyric/firestore`'s
  * `setLogLevel`). Accepted so init code that calls it compiles + runs.
  */
 export function enableLogging(

--- a/packages/pyric/src/firestore/persistence.ts
+++ b/packages/pyric/src/firestore/persistence.ts
@@ -191,7 +191,7 @@ const TAB_MANAGER_SYMBOL: unique symbol = Symbol('pyric/firestore/tabManager');
 const GC_SYMBOL: unique symbol = Symbol('pyric/firestore/gc');
 
 /** Opaque tab-manager config token. Inert — persistence is always on,
- *  and the SharedWorker/`pyric dev` path already is the one shared
+ *  and the SharedWorker/`pyric sandbox` path already is the one shared
  *  store every tab talks to, so there is no separate multi-tab mode
  *  to opt into. Carries the requested kind only for debugging. */
 export interface PersistentTabManager {
@@ -409,7 +409,7 @@ export type LogLevel = 'debug' | 'verbose' | 'info' | 'warn' | 'error' | 'silent
 /**
  * Accepted no-op: the sandbox has no modular-SDK-style logger to wire
  * a level into (it uses host-level `console` logging directly, gated
- * by `pyric dev`'s own flags, not this call). Exists purely so app
+ * by `pyric sandbox`'s own flags, not this call). Exists purely so app
  * code that calls this defensively at startup doesn't crash on a
  * missing export.
  */

--- a/packages/pyric/src/sandbox/persistence/types.ts
+++ b/packages/pyric/src/sandbox/persistence/types.ts
@@ -15,7 +15,7 @@
 /**
  * Minimal web-storage-like contract the session persistence controller
  * reads/writes. Matches the `localStorage` / `sessionStorage` browser
- * API subset that `pyric dev`'s `SessionStore` already uses, so
+ * API subset that `pyric sandbox`'s `SessionStore` already uses, so
  * browsers pass real storages and tests pass in-memory Map-backed fakes.
  *
  * Why the minimal subset (get/set/remove) instead of the full

--- a/packages/pyric/src/sandbox/remote.ts
+++ b/packages/pyric/src/sandbox/remote.ts
@@ -78,7 +78,7 @@ export interface RemoteSandboxChannel {
  */
 export interface RemoteSandbox extends Sandbox {
   readonly [REMOTE_SANDBOX]: true;
-  /** Base URL of the `pyric dev` this handle is attached to (used in
+  /** Base URL of the `pyric sandbox` this handle is attached to (used in
    *  error guidance: "open <serveUrl> in a browser and retry"). */
   readonly serveUrl: string;
   /** The raw worker op/sub relay channel. */
@@ -100,7 +100,7 @@ export const REMOTE_SANDBOX_FACTORY = Symbol.for('pyric.remote.sandboxFactory');
 
 /** Options accepted by the ambient remote-sandbox factory. */
 export interface RemoteSandboxFactoryOptions {
-  /** Explicit `pyric dev` base URL (from `PYRIC_SANDBOX=remote:<url>`).
+  /** Explicit `pyric sandbox` base URL (from `PYRIC_SANDBOX=remote:<url>`).
    *  When omitted the factory discovers the running host itself (the
    *  `.pyric/serve.json` locator protocol). */
   url?: string;

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -124,7 +124,7 @@ export interface StorageOptions {
    * origin-scoped, so without this every project served on the same
    * localhost port shared one storage database (issue #359). Ignored when
    * an explicit `dbName` is given; only honored on the FIRST call per
-   * `Sandbox`. Hosts pass their project identity here (`pyric dev` passes
+   * `Sandbox`. Hosts pass their project identity here (`pyric sandbox` passes
    * the served project's key; app handles pass `options.projectId`).
    */
   projectId?: string;

--- a/packages/site-docs/src/content/reference/cli.md
+++ b/packages/site-docs/src/content/reference/cli.md
@@ -15,8 +15,6 @@ description: "Syntax, flags, configuration, and command selection for pyric sand
 pyric sandbox [flags] [--] [command...]
 ```
 
-`dev` and `serve` are not aliases. Use `sandbox`.
-
 Put every Pyric flag before the first child command token. After the first child command token, every remaining argument belongs to the child. A bare `--` makes the boundary explicit.
 
 ```bash

--- a/packages/site-docs/src/lib/loaders/api-reference.ts
+++ b/packages/site-docs/src/lib/loaders/api-reference.ts
@@ -1,20 +1,45 @@
 /**
  * Content-layer loader for the generated API reference. One in-process
- * TypeDoc conversion covers every released entry point (src/lib/api-reference)
- * — but only when a declaration actually changed: the loader digests every
- * entry's .d.ts up front and skips the conversion entirely when the digest
- * set matches the persisted store. Warm dev start: no TypeDoc at all.
+ * TypeDoc conversion covers every released entry point (src/lib/api-reference).
+ * The loader digests every declaration in each published package and skips the
+ * conversion when the digest set matches the persisted store. A warm dev start
+ * does not run TypeDoc.
  */
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import type { Loader } from 'astro/loaders';
 import {
   discoverApiDescriptors,
+  REPO_ROOT,
   renderAllApiPages,
 } from '../api-reference';
 
 /** Bumping this invalidates every cached entry (renderer/config changes). */
-const GENERATOR_VERSION = 'v1';
+const GENERATOR_VERSION = 'v2';
+
+function declarationFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...declarationFiles(path));
+    else if (entry.isFile() && entry.name.endsWith('.d.ts')) files.push(path);
+  }
+  return files.sort();
+}
+
+function packageDeclarationDigest(packageDir: string): string {
+  const distDir = join(REPO_ROOT, 'packages', packageDir, 'dist');
+  const files = declarationFiles(distDir);
+  if (files.length === 0) {
+    throw new Error(`api-reference loader: no declarations found in ${distDir}`);
+  }
+  const hash = createHash('sha256').update(GENERATOR_VERSION);
+  for (const file of files) {
+    hash.update(relative(distDir, file)).update('\0').update(readFileSync(file)).update('\0');
+  }
+  return hash.digest('hex');
+}
 
 export function apiReferenceLoader(): Loader {
   return {
@@ -22,10 +47,10 @@ export function apiReferenceLoader(): Loader {
     async load({ store, renderMarkdown, logger }) {
       const descriptors = discoverApiDescriptors();
       const digests = new Map<string, string>();
+      const packageDigests = new Map<string, string>();
       for (const d of descriptors) {
-        let declarations: string;
         try {
-          declarations = readFileSync(d.typesPath, 'utf8');
+          readFileSync(d.typesPath);
         } catch {
           throw new Error(
             'api-reference loader: packages are not built (missing ' +
@@ -33,9 +58,17 @@ export function apiReferenceLoader(): Loader {
               ').\nBuild packages first, from the repo root:\n\n  bun run build --packages-only\n',
           );
         }
+        let packageDigest = packageDigests.get(d.packageDir);
+        if (!packageDigest) {
+          packageDigest = packageDeclarationDigest(d.packageDir);
+          packageDigests.set(d.packageDir, packageDigest);
+        }
         digests.set(
           d.slug,
-          createHash('sha256').update(GENERATOR_VERSION).update(declarations).digest('hex'),
+          createHash('sha256')
+            .update(packageDigest)
+            .update(relative(REPO_ROOT, d.typesPath))
+            .digest('hex'),
         );
       }
       // The index digests the whole inventory (routes + order), so adding or

--- a/packages/ui/src/auth/authApi.ts
+++ b/packages/ui/src/auth/authApi.ts
@@ -59,7 +59,7 @@ export function useAuthApi(): AuthApi {
 /**
  * Provide an auth API bundle to the subtree. Pyric Studio supplies the
  * in-process bundle for dev-seed review and the SharedWorker client bundle under
- * `pyric dev --ui`.
+ * `pyric sandbox --ui`.
  */
 export function AuthApiProvider({
   value,

--- a/packages/ui/src/firestore/firestoreApi.ts
+++ b/packages/ui/src/firestore/firestoreApi.ts
@@ -73,7 +73,7 @@ export function useFirestoreApi(): FirestoreApi {
 /**
  * Provide a Firestore API bundle to the subtree. Pyric Studio wraps its data
  * surface with this, supplying the in-process bundle for dev-seed review and the
- * SharedWorker client bundle under `pyric dev --ui`.
+ * SharedWorker client bundle under `pyric sandbox --ui`.
  */
 export function FirestoreApiProvider({
   value,

--- a/pyric-plugin/skills/pyric/SKILL.md
+++ b/pyric-plugin/skills/pyric/SKILL.md
@@ -37,7 +37,7 @@ the project's package manager.
      `pyric({ bridge: true })` call. Do not add a second `plugins` property. Start the existing
      dev script, such as `npm run dev` or `bun run dev`. Do not also start `pyric sandbox`.
    - **Existing non-Vite app:** Preserve its development command. Replace any retired
-     `pyric dev` or `pyric serve` launcher with `pyric sandbox`. Put Pyric flags before the
+     Pyric launcher with `pyric sandbox`. Put Pyric flags before the
      first child command token. Use `--` to separate the child command when it could be
      mistaken for a Pyric flag. A complete command looks like
      `pyric sandbox --bridge --persist --json -- <command>`. If `pyric.json` defines


### PR DESCRIPTION
Updates the public CLI reference, generated API reference, and Pyric setup skill to use only `pyric sandbox`.

```bash
pyric sandbox --bridge -- npm run dev
```

## Public command examples now use sandbox

Generated API pages now describe the current `pyric sandbox` command. The CLI reference and setup skill lead with the current command without naming retired launchers. Valid child commands such as `npm run dev` and `next dev` remain unchanged.

The API reference cache now hashes every declaration file in each published package. A TSDoc change in a re-exported declaration therefore regenerates the affected API pages.

## Risk

The wider cache key can regenerate all API routes for a package after any declaration change. It does not change the generated API content or runtime packages.

<details>
<summary>Implementation notes</summary>

- `bun run build --packages-only` completed successfully.
- `bash scripts/build-site.sh` completed successfully and built 109 pages.
- A scan of rendered HTML, Markdown endpoints, JSON, and text output found zero `pyric dev` or `pyric serve` invocations.
- No documentation unit test was added.

</details>