### PR TITLE
fix(cli): enforce sandbox isolation and explicit fallback policy in functions child metadata

### DIFF
--- a/packages/cli/src/functions-rtdb/child.ts
+++ b/packages/cli/src/functions-rtdb/child.ts
@@ -97,34 +97,128 @@ function isChildMessage(value: unknown): value is FunctionsRtdbChildMessage {
   return typeof value === 'object' && value !== null && 'type' in value;
 }
 
+export interface FunctionsChildEnvOptions {
+  baseEnv: NodeJS.ProcessEnv;
+  entry: string;
+  instance: string;
+  location: string;
+  databaseHost: string;
+  projectId: string;
+}
+
+/**
+ * Resolve the project identifier for the functions child process.
+ *
+ * Precedence:
+ * 1. Explicit options.projectId
+ * 2. baseEnv.PYRIC_PROJECT
+ * 3. Instance prefix when formatted as `<projectId>-default-rtdb`
+ * 4. Default fallback to 'demo-project'
+ */
+export function resolveChildProjectId(
+  explicitProjectId?: string,
+  instance?: string,
+  baseEnv?: NodeJS.ProcessEnv,
+): string {
+  if (typeof explicitProjectId === 'string' && explicitProjectId.length > 0) {
+    return explicitProjectId;
+  }
+
+  const pyricProject = baseEnv?.PYRIC_PROJECT;
+  if (typeof pyricProject === 'string' && pyricProject.length > 0) {
+    return pyricProject;
+  }
+
+  if (typeof instance === 'string' && instance.length > 0) {
+    const stripped = instance.replace(/-default-rtdb$/, '');
+    if (stripped.length > 0) {
+      return stripped;
+    }
+  }
+
+  return 'demo-project';
+}
+
+/**
+ * Resolve the database host, defaulting to 'firebasedatabase.app'.
+ */
+export function resolveChildDatabaseHost(databaseHost?: string): string {
+  if (typeof databaseHost === 'string' && databaseHost.length > 0) {
+    return databaseHost;
+  }
+  return 'firebasedatabase.app';
+}
+
+/**
+ * Resolve the filesystem path to the child entrypoint module.
+ */
+export function resolveChildModulePath(childModuleUrl?: string | URL): string {
+  if (!childModuleUrl) {
+    return fileURLToPath(new URL('./child.js', import.meta.url));
+  }
+  if (typeof childModuleUrl === 'string' && !childModuleUrl.startsWith('file:')) {
+    return resolve(childModuleUrl);
+  }
+  return fileURLToPath(childModuleUrl);
+}
+
+/**
+ * Assemble the child process environment variables.
+ *
+ * Guaranteed child-only synthetic sandbox metadata:
+ * - GCLOUD_PROJECT is set to the resolved sandbox project ID
+ * - FIREBASE_CONFIG is set to synthetic JSON with projectId, databaseURL, and storageBucket
+ *
+ * Explicit control flow ensures that host environment cannot pollute or route
+ * sandbox functions execution to a production Firebase/GCP project.
+ */
+export function buildFunctionsChildEnv(options: FunctionsChildEnvOptions): NodeJS.ProcessEnv {
+  const { baseEnv, entry, instance, location, databaseHost, projectId } = options;
+
+  const resolvedEntry = resolve(entry);
+  const databaseURL = `https://${instance}.${databaseHost}`;
+  const storageBucket = `${projectId}.appspot.com`;
+
+  const syntheticFirebaseConfig = JSON.stringify({
+    projectId,
+    databaseURL,
+    storageBucket,
+  });
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    PYRIC_FUNCTIONS_RTDB_CHILD: '1',
+    PYRIC_FUNCTIONS_ENTRY: resolvedEntry,
+    PYRIC_FUNCTIONS_INSTANCE: instance,
+    PYRIC_FUNCTIONS_LOCATION: location,
+    PYRIC_FUNCTIONS_DATABASE_HOST: databaseHost,
+    GCLOUD_PROJECT: projectId,
+    FIREBASE_CONFIG: syntheticFirebaseConfig,
+  };
+
+  return childEnv;
+}
+
 /** Spawn the real Firebase Functions SDK in an isolated Node process. */
 export function spawnFunctionsRtdbChild(
   options: SpawnFunctionsRtdbChildOptions,
 ): FunctionsRtdbChildHandle {
-  const childModuleUrl = options.childModuleUrl ?? new URL('./child.js', import.meta.url);
-  const childModulePath = typeof childModuleUrl === 'string' && !childModuleUrl.startsWith('file:')
-    ? resolve(childModuleUrl)
-    : fileURLToPath(childModuleUrl);
-  const projectId = options.projectId ?? options.instance.replace(/-default-rtdb$/, '') ?? 'demo-project';
-  const databaseHost = options.databaseHost ?? 'firebasedatabase.app';
-  const databaseURL = `https://${options.instance}.${databaseHost}`;
-  const firebaseConfig = JSON.stringify({
+  const childModulePath = resolveChildModulePath(options.childModuleUrl);
+  const projectId = resolveChildProjectId(options.projectId, options.instance, options.env);
+  const databaseHost = resolveChildDatabaseHost(options.databaseHost);
+  const childEnv = buildFunctionsChildEnv({
+    baseEnv: options.env,
+    entry: options.entry,
+    instance: options.instance,
+    location: options.location,
+    databaseHost,
     projectId,
-    databaseURL,
-    storageBucket: `${projectId}.appspot.com`,
   });
-  const child = spawn(options.nodeExecutable ?? 'node', [childModulePath], {
+
+  const nodeExecutable = options.nodeExecutable ?? 'node';
+  const child = spawn(nodeExecutable, [childModulePath], {
     cwd: options.cwd,
-    env: {
-      ...options.env,
-      PYRIC_FUNCTIONS_RTDB_CHILD: '1',
-      PYRIC_FUNCTIONS_ENTRY: resolve(options.entry),
-      PYRIC_FUNCTIONS_INSTANCE: options.instance,
-      PYRIC_FUNCTIONS_LOCATION: options.location,
-      PYRIC_FUNCTIONS_DATABASE_HOST: databaseHost,
-      GCLOUD_PROJECT: options.env.GCLOUD_PROJECT ?? projectId,
-      FIREBASE_CONFIG: options.env.FIREBASE_CONFIG ?? firebaseConfig,
-    },
+    env: childEnv,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
   });
 

--- a/packages/cli/test/functions-rtdb/child.test.ts
+++ b/packages/cli/test/functions-rtdb/child.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import {
+  buildFunctionsChildEnv,
+  resolveChildDatabaseHost,
+  resolveChildModulePath,
+  resolveChildProjectId,
+} from '../../src/functions-rtdb/child.js';
+
+describe('functions child metadata and environment resolution', () => {
+  describe('resolveChildProjectId', () => {
+    test('prefers explicit projectId when provided', () => {
+      const resolved = resolveChildProjectId('custom-proj', 'other-default-rtdb', {
+        PYRIC_PROJECT: 'env-proj',
+      });
+      expect(resolved).toBe('custom-proj');
+    });
+
+    test('prefers PYRIC_PROJECT from environment when explicit projectId is omitted', () => {
+      const resolved = resolveChildProjectId(undefined, 'instance-default-rtdb', {
+        PYRIC_PROJECT: 'env-proj',
+      });
+      expect(resolved).toBe('env-proj');
+    });
+
+    test('strips -default-rtdb from instance when explicit options are absent', () => {
+      const resolved = resolveChildProjectId(undefined, 'my-app-default-rtdb', {});
+      expect(resolved).toBe('my-app');
+    });
+
+    test('preserves instance without -default-rtdb suffix', () => {
+      const resolved = resolveChildProjectId(undefined, 'my-custom-instance', {});
+      expect(resolved).toBe('my-custom-instance');
+    });
+
+    test('falls back to demo-project when instance is empty', () => {
+      const resolved = resolveChildProjectId(undefined, '', {});
+      expect(resolved).toBe('demo-project');
+    });
+
+    test('falls back to demo-project when all arguments are undefined', () => {
+      const resolved = resolveChildProjectId();
+      expect(resolved).toBe('demo-project');
+    });
+  });
+
+  describe('resolveChildDatabaseHost', () => {
+    test('returns custom host when provided', () => {
+      expect(resolveChildDatabaseHost('custom-host.local')).toBe('custom-host.local');
+    });
+
+    test('defaults to firebasedatabase.app when omitted or empty', () => {
+      expect(resolveChildDatabaseHost()).toBe('firebasedatabase.app');
+      expect(resolveChildDatabaseHost('')).toBe('firebasedatabase.app');
+    });
+  });
+
+  describe('resolveChildModulePath', () => {
+    test('defaults to child.js module path when omitted', () => {
+      const path = resolveChildModulePath();
+      expect(path).toMatch(/child\.js$/);
+    });
+
+    test('converts file: URL to filesystem path', () => {
+      const url = new URL('file:///tmp/custom-child.js');
+      expect(resolveChildModulePath(url)).toBe(fileURLToPath(url));
+    });
+  });
+
+  describe('buildFunctionsChildEnv', () => {
+    test('injects synthetic GCLOUD_PROJECT and FIREBASE_CONFIG matching sandbox metadata', () => {
+      const childEnv = buildFunctionsChildEnv({
+        baseEnv: { PATH: '/usr/bin', NODE_OPTIONS: '--inspect' },
+        entry: '/app/functions/index.js',
+        instance: 'my-sandbox-default-rtdb',
+        location: 'us-central1',
+        databaseHost: 'firebasedatabase.app',
+        projectId: 'my-sandbox',
+      });
+
+      expect(childEnv.GCLOUD_PROJECT).toBe('my-sandbox');
+      expect(childEnv.PYRIC_FUNCTIONS_RTDB_CHILD).toBe('1');
+      expect(childEnv.PYRIC_FUNCTIONS_ENTRY).toBe('/app/functions/index.js');
+      expect(childEnv.PYRIC_FUNCTIONS_INSTANCE).toBe('my-sandbox-default-rtdb');
+      expect(childEnv.PYRIC_FUNCTIONS_LOCATION).toBe('us-central1');
+      expect(childEnv.PYRIC_FUNCTIONS_DATABASE_HOST).toBe('firebasedatabase.app');
+      expect(childEnv.PATH).toBe('/usr/bin');
+      expect(childEnv.NODE_OPTIONS).toBe('--inspect');
+
+      const config = JSON.parse(childEnv.FIREBASE_CONFIG ?? '{}');
+      expect(config).toEqual({
+        projectId: 'my-sandbox',
+        databaseURL: 'https://my-sandbox-default-rtdb.firebasedatabase.app',
+        storageBucket: 'my-sandbox.appspot.com',
+      });
+    });
+
+    test('overrides host GCLOUD_PROJECT and FIREBASE_CONFIG to guarantee sandbox isolation', () => {
+      const dirtyHostEnv = {
+        GCLOUD_PROJECT: 'corp-production-gcp-project',
+        FIREBASE_CONFIG: JSON.stringify({
+          projectId: 'corp-production-gcp-project',
+          databaseURL: 'https://corp-production-gcp-project.firebaseio.com',
+        }),
+        SOME_OTHER_VAR: 'preserved',
+      };
+
+      const childEnv = buildFunctionsChildEnv({
+        baseEnv: dirtyHostEnv,
+        entry: '/app/functions/index.js',
+        instance: 'sandbox-app-default-rtdb',
+        location: 'europe-west1',
+        databaseHost: 'firebasedatabase.app',
+        projectId: 'sandbox-app',
+      });
+
+      // Crucial security guarantee: host production variables must NOT bleed into sandbox child
+      expect(childEnv.GCLOUD_PROJECT).toBe('sandbox-app');
+      expect(childEnv.SOME_OTHER_VAR).toBe('preserved');
+
+      const config = JSON.parse(childEnv.FIREBASE_CONFIG ?? '{}');
+      expect(config.projectId).toBe('sandbox-app');
+      expect(config.databaseURL).toBe('https://sandbox-app-default-rtdb.firebasedatabase.app');
+      expect(config.storageBucket).toBe('sandbox-app.appspot.com');
+    });
+  });
+});

--- a/packages/cli/test/functions-rtdb/dev.e2e.test.ts
+++ b/packages/cli/test/functions-rtdb/dev.e2e.test.ts
@@ -142,6 +142,7 @@ exports.makeUppercase = onValueCreated(
         expect(code).toBe(0);
         expect(stdout).toContain('Shutting down...');
         expect(stderr).not.toContain('Functions child exited unexpectedly');
+        expect(stderr).not.toContain('FIREBASE_CONFIG and GCLOUD_PROJECT environment variables are missing');
       } finally {
         observer?.close();
         observer = undefined;


### PR DESCRIPTION
Guarantees that the isolated Functions RTDB child process always receives synthetic sandbox project metadata (`GCLOUD_PROJECT` and `FIREBASE_CONFIG`), preventing false missing-configuration warnings and isolating local execution from developer host environment credentials.

```ts
import { buildFunctionsChildEnv, resolveChildProjectId } from './packages/cli/src/functions-rtdb/child.js';

// When a developer has production GCP credentials or project IDs in their shell,
// the child environment strictly overrides them with synthetic sandbox metadata:
const childEnv = buildFunctionsChildEnv({
  baseEnv: { GCLOUD_PROJECT: 'corp-production-gcp-project', PATH: '/usr/bin' },
  entry: '/path/to/functions/index.js',
  instance: 'my-app-default-rtdb',
  location: 'us-central1',
  databaseHost: 'firebasedatabase.app',
  projectId: resolveChildProjectId(undefined, 'my-app-default-rtdb', process.env),
});

console.log(childEnv.GCLOUD_PROJECT);
// => "my-app" (never leaks "corp-production-gcp-project")

console.log(JSON.parse(childEnv.FIREBASE_CONFIG!));
// => {
//   projectId: "my-app",
//   databaseURL: "https://my-app-default-rtdb.firebasedatabase.app",
//   storageBucket: "my-app.appspot.com"
// }
```

```ts
import {
  resolveChildProjectId,
  resolveChildDatabaseHost,
  resolveChildModulePath,
} from './packages/cli/src/functions-rtdb/child.js';

// Explicit branch-based project ID resolution:
const explicit = resolveChildProjectId('custom-id', 'ignored-default-rtdb');
// => "custom-id"

const fromInstance = resolveChildProjectId(undefined, 'chat-app-default-rtdb');
// => "chat-app"

const fallback = resolveChildProjectId(undefined, '');
// => "demo-project" (empty string no longer short-circuits)

const host = resolveChildDatabaseHost();
// => "firebasedatabase.app"

const modulePath = resolveChildModulePath();
// => "/path/to/dist/functions-rtdb/child.js"
```

## Functions child enforces sandbox metadata over host shell environment

`firebase-functions` inspects `GCLOUD_PROJECT` and `FIREBASE_CONFIG` during startup. Previously, `spawnFunctionsRtdbChild` passed `options.env.GCLOUD_PROJECT ?? projectId`, meaning any developer with GCP credentials or a production project in their shell had those values bleed into the local Functions child process, creating risk of accidental cloud operations. Furthermore, line 108 used an inline nullish chain with `.replace()` that evaluated empty instances `""` to `""` instead of `'demo-project'`.

The child setup now separates computation, decision, and assembly into explicit domain helpers conforming to `docs/code-conventions.md` Sections 3b and 3c, guaranteeing that child processes always run under isolated sandbox metadata.

## Risk

Low. The change is internal to the CLI's Functions child process launcher. Host environment variables that are unrelated to Firebase (`PATH`, `NODE_OPTIONS`, user env vars) continue to be preserved; only `GCLOUD_PROJECT` and `FIREBASE_CONFIG` are pinned to the sandbox project descriptor.

<details>
<summary>Implementation notes</summary>

- Closes #498.
- Conforms to `docs/code-conventions.md` (Sections 3, 3b, 3c).
- Added `packages/cli/test/functions-rtdb/child.test.ts` (12 unit tests, 73ms).
- Added warning-absence assertion to `packages/cli/test/functions-rtdb/dev.e2e.test.ts`.
- Full suite `bun test packages/cli/test/functions-rtdb/` (62 passed, 13 skipped, 0 failed).
- Typecheck & build passed with exit code 0.

</details>
