### PR TITLE
feat(cli): export backend bundler presets and add dev tooling guide

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,6 +73,10 @@
       "types": "./dist/next/index.d.ts",
       "import": "./dist/next/index.js"
     },
+    "./bundler": {
+      "types": "./dist/bundler/index.d.ts",
+      "import": "./dist/bundler/index.js"
+    },
     "./serve/worker": {
       "types": "./dist/serve/worker/index.d.ts",
       "import": "./dist/serve/worker/index.js"

--- a/packages/cli/src/bundler/externals.ts
+++ b/packages/cli/src/bundler/externals.ts
@@ -39,13 +39,7 @@ export function isPyricExternal(id: string): boolean {
   if (typeof id !== 'string' || id.length === 0) {
     return false;
   }
-  return (
-    id === 'firebase-admin' ||
-    id.startsWith('firebase-admin/') ||
-    id === 'firebase' ||
-    id.startsWith('firebase/') ||
-    id.startsWith('@firebase/')
-  );
+  return pyricRollupExternals.some((regex) => regex.test(id));
 }
 
 /**
@@ -58,5 +52,4 @@ export const pyricExternals = Object.freeze({
   webpack: pyricRollupExternals,
   esbuild: pyricEsbuildExternals,
   tsup: pyricEsbuildExternals,
-  isExternal: isPyricExternal,
 });

--- a/packages/cli/src/bundler/externals.ts
+++ b/packages/cli/src/bundler/externals.ts
@@ -1,0 +1,62 @@
+/**
+ * Externalization presets and helpers for Node backend bundlers.
+ *
+ * Prevents backend bundlers (Rolldown, esbuild, tsup, Rollup, Vite, Webpack)
+ * from inlining Firebase and Firebase Admin SDKs into bundled server outputs,
+ * preserving runtime interception by `@pyric/cli/register` under `pyric sandbox`.
+ */
+
+/**
+ * RegExp patterns matching Firebase packages for bundlers that accept RegExp
+ * in their external configuration (Rolldown, Rollup, Vite, Webpack).
+ */
+export const pyricRollupExternals: readonly RegExp[] = Object.freeze([
+  /^firebase-admin(\/.*)?$/,
+  /^firebase(\/.*)?$/,
+  /^@firebase(\/.*)?$/,
+]);
+
+/**
+ * Wildcard string patterns matching Firebase packages for bundlers that require
+ * string arrays with glob wildcards (esbuild, tsup).
+ */
+export const pyricEsbuildExternals: readonly string[] = Object.freeze([
+  'firebase-admin',
+  'firebase-admin/*',
+  'firebase',
+  'firebase/*',
+  '@firebase/*',
+]);
+
+/**
+ * Universal predicate returning true if a module specifier belongs to Firebase
+ * or Firebase Admin SDK surfaces intercepted by Pyric.
+ *
+ * Compatible with bundlers that accept a function in their external setting
+ * (Rolldown, Rollup, Vite, Webpack).
+ */
+export function isPyricExternal(id: string): boolean {
+  if (typeof id !== 'string' || id.length === 0) {
+    return false;
+  }
+  return (
+    id === 'firebase-admin' ||
+    id.startsWith('firebase-admin/') ||
+    id === 'firebase' ||
+    id.startsWith('firebase/') ||
+    id.startsWith('@firebase/')
+  );
+}
+
+/**
+ * Convenience presets mapping bundler names to their supported external pattern format.
+ */
+export const pyricExternals = Object.freeze({
+  rolldown: pyricRollupExternals,
+  rollup: pyricRollupExternals,
+  vite: pyricRollupExternals,
+  webpack: pyricRollupExternals,
+  esbuild: pyricEsbuildExternals,
+  tsup: pyricEsbuildExternals,
+  isExternal: isPyricExternal,
+});

--- a/packages/cli/src/bundler/index.ts
+++ b/packages/cli/src/bundler/index.ts
@@ -1,0 +1,19 @@
+/**
+ * `@pyric/cli/bundler` — externalization presets and helpers for Node backend
+ * bundlers (Rolldown, esbuild, tsup, Rollup, Vite) to preserve `@pyric/cli/register`
+ * runtime sandbox interception.
+ *
+ *   // rolldown.config.ts / rollup.config.js / vite.config.ts
+ *   import { pyricExternals } from '@pyric/cli/bundler';
+ *   export default { external: pyricExternals.rolldown };
+ *
+ *   // tsup.config.ts / esbuild.config.mjs
+ *   import { pyricExternals } from '@pyric/cli/bundler';
+ *   export default { external: pyricExternals.esbuild };
+ */
+export {
+  pyricRollupExternals,
+  pyricEsbuildExternals,
+  isPyricExternal,
+  pyricExternals,
+} from './externals.js';

--- a/packages/cli/src/bundler/index.ts
+++ b/packages/cli/src/bundler/index.ts
@@ -3,12 +3,14 @@
  * bundlers (Rolldown, esbuild, tsup, Rollup, Vite) to preserve `@pyric/cli/register`
  * runtime sandbox interception.
  *
- *   // rolldown.config.ts / rollup.config.js / vite.config.ts
+ *   // rolldown.config.ts / rollup.config.js
  *   import { pyricExternals } from '@pyric/cli/bundler';
  *   export default { external: pyricExternals.rolldown };
  *
+ *   // vite.config.ts (SSR / Node backend builds)
+ *   export default { build: { rollupOptions: { external: pyricExternals.vite } } };
+ *
  *   // tsup.config.ts / esbuild.config.mjs
- *   import { pyricExternals } from '@pyric/cli/bundler';
  *   export default { external: pyricExternals.esbuild };
  */
 export {

--- a/packages/cli/test/bundler/externals.test.ts
+++ b/packages/cli/test/bundler/externals.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isPyricExternal,
+  pyricEsbuildExternals,
+  pyricExternals,
+  pyricRollupExternals,
+} from '../../src/bundler/externals.js';
+
+describe('bundler externalization presets and predicate', () => {
+  describe('isPyricExternal', () => {
+    test('returns true for firebase-admin root and subpaths', () => {
+      expect(isPyricExternal('firebase-admin')).toBe(true);
+      expect(isPyricExternal('firebase-admin/app')).toBe(true);
+      expect(isPyricExternal('firebase-admin/firestore')).toBe(true);
+      expect(isPyricExternal('firebase-admin/auth')).toBe(true);
+      expect(isPyricExternal('firebase-admin/database')).toBe(true);
+      expect(isPyricExternal('firebase-admin/messaging')).toBe(true);
+    });
+
+    test('returns true for firebase client root and subpaths', () => {
+      expect(isPyricExternal('firebase')).toBe(true);
+      expect(isPyricExternal('firebase/app')).toBe(true);
+      expect(isPyricExternal('firebase/firestore')).toBe(true);
+      expect(isPyricExternal('firebase/auth')).toBe(true);
+      expect(isPyricExternal('firebase/database')).toBe(true);
+      expect(isPyricExternal('firebase/storage')).toBe(true);
+    });
+
+    test('returns true for @firebase scoped packages', () => {
+      expect(isPyricExternal('@firebase/app')).toBe(true);
+      expect(isPyricExternal('@firebase/firestore')).toBe(true);
+      expect(isPyricExternal('@firebase/util')).toBe(true);
+    });
+
+    test('returns false for third-party libraries', () => {
+      expect(isPyricExternal('express')).toBe(false);
+      expect(isPyricExternal('hono')).toBe(false);
+      expect(isPyricExternal('pg')).toBe(false);
+      expect(isPyricExternal('dotenv')).toBe(false);
+      expect(isPyricExternal('lodash')).toBe(false);
+    });
+
+    test('returns false for unrelated google cloud libraries', () => {
+      expect(isPyricExternal('@google-cloud/storage')).toBe(false);
+      expect(isPyricExternal('@google-cloud/firestore')).toBe(false);
+      expect(isPyricExternal('@google/genai')).toBe(false);
+    });
+
+    test('returns false for partial name overlaps', () => {
+      expect(isPyricExternal('firebase-tools')).toBe(false);
+      expect(isPyricExternal('firebase-mock')).toBe(false);
+      expect(isPyricExternal('my-firebase-app')).toBe(false);
+    });
+
+    test('returns false for empty or non-string inputs', () => {
+      expect(isPyricExternal('')).toBe(false);
+      expect(isPyricExternal(null as unknown as string)).toBe(false);
+      expect(isPyricExternal(undefined as unknown as string)).toBe(false);
+    });
+  });
+
+  describe('pyricRollupExternals', () => {
+    test('matches firebase-admin, firebase, and @firebase packages', () => {
+      const matchesAny = (id: string): boolean =>
+        pyricRollupExternals.some((regex) => regex.test(id));
+
+      expect(matchesAny('firebase-admin')).toBe(true);
+      expect(matchesAny('firebase-admin/firestore')).toBe(true);
+      expect(matchesAny('firebase')).toBe(true);
+      expect(matchesAny('firebase/app')).toBe(true);
+      expect(matchesAny('@firebase/app')).toBe(true);
+    });
+
+    test('rejects unrelated packages and partial overlaps', () => {
+      const matchesAny = (id: string): boolean =>
+        pyricRollupExternals.some((regex) => regex.test(id));
+
+      expect(matchesAny('express')).toBe(false);
+      expect(matchesAny('firebase-tools')).toBe(false);
+      expect(matchesAny('@google-cloud/storage')).toBe(false);
+    });
+  });
+
+  describe('pyricEsbuildExternals', () => {
+    test('contains expected root and wildcard patterns for esbuild/tsup', () => {
+      expect(pyricEsbuildExternals).toContain('firebase-admin');
+      expect(pyricEsbuildExternals).toContain('firebase-admin/*');
+      expect(pyricEsbuildExternals).toContain('firebase');
+      expect(pyricEsbuildExternals).toContain('firebase/*');
+      expect(pyricEsbuildExternals).toContain('@firebase/*');
+    });
+  });
+
+  describe('pyricExternals presets', () => {
+    test('maps bundler aliases to their supported pattern formats', () => {
+      expect(pyricExternals.rolldown).toBe(pyricRollupExternals);
+      expect(pyricExternals.rollup).toBe(pyricRollupExternals);
+      expect(pyricExternals.vite).toBe(pyricRollupExternals);
+      expect(pyricExternals.webpack).toBe(pyricRollupExternals);
+      expect(pyricExternals.esbuild).toBe(pyricEsbuildExternals);
+      expect(pyricExternals.tsup).toBe(pyricEsbuildExternals);
+      expect(pyricExternals.isExternal).toBe(isPyricExternal);
+    });
+  });
+});

--- a/packages/cli/test/bundler/externals.test.ts
+++ b/packages/cli/test/bundler/externals.test.ts
@@ -99,7 +99,6 @@ describe('bundler externalization presets and predicate', () => {
       expect(pyricExternals.webpack).toBe(pyricRollupExternals);
       expect(pyricExternals.esbuild).toBe(pyricEsbuildExternals);
       expect(pyricExternals.tsup).toBe(pyricEsbuildExternals);
-      expect(pyricExternals.isExternal).toBe(isPyricExternal);
     });
   });
 });

--- a/packages/site-docs/src/content/get-started/backend-bundlers.md
+++ b/packages/site-docs/src/content/get-started/backend-bundlers.md
@@ -88,9 +88,42 @@ export default defineConfig({
 });
 ```
 
+### If you use Vite for Node backend builds (`vite.config.ts`)
+
+In Vite, external dependencies for SSR / Node backend builds are configured under `build.rollupOptions.external`:
+
+```ts
+import { defineConfig } from 'vite';
+import { pyricExternals } from '@pyric/cli/bundler';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: pyricExternals.vite,
+    },
+  },
+});
+```
+
+> [!NOTE]
+> For standard frontend Vite applications, use the dedicated [`@pyric/cli/vite`](/docs/get-started/vite) plugin instead, which handles dev-server interception automatically.
+
+### If you use Webpack (`webpack.config.js`)
+
+Webpack accepts regular expression arrays under `externals`:
+
+```js
+import { pyricExternals } from '@pyric/cli/bundler';
+
+export default {
+  target: 'node',
+  externals: pyricExternals.webpack,
+};
+```
+
 ### If you use a custom predicate
 
-For bundlers that support function-based external resolution (such as Rollup, Rolldown, Vite, or Webpack), use `isPyricExternal`:
+For bundlers that support function-based external resolution (such as Rollup or Rolldown), use `isPyricExternal`:
 
 ```ts
 import { isPyricExternal } from '@pyric/cli/bundler';

--- a/packages/site-docs/src/content/get-started/backend-bundlers.md
+++ b/packages/site-docs/src/content/get-started/backend-bundlers.md
@@ -1,0 +1,140 @@
+---
+title: "Backend bundlers & Node dev tools"
+navLabel: "Backend bundlers"
+group: "Get started"
+section: ""
+order: 35
+description: "Configure Rolldown, esbuild, tsup, and backend dev tooling to preserve local Pyric sandbox interception."
+---
+
+# Backend bundlers & Node dev tools
+
+When you run `pyric sandbox [command...]`, Pyric injects `NODE_OPTIONS="--import @pyric/cli/register"` into your development process. This Node.js runtime loader intercepts calls to `firebase-admin` and `firebase`, transparently routing them into your local sandbox.
+
+If your backend uses a bundler (such as Rolldown, esbuild, or tsup) during development, dependencies are compiled inline by default. When `firebase-admin` is bundled inline into an output file (such as `dist/server.js`), Node never resolves the package at runtime, and sandbox interception is bypassed.
+
+This guide shows you how to configure your bundler to keep Firebase packages external so that `pyric sandbox` intercepts your backend services.
+
+---
+
+## 1. Import the externalisation presets
+
+Install `@pyric/cli` as a development dependency if you have not already:
+
+```bash
+npm install -D @pyric/cli
+```
+
+Import `pyricExternals` from `@pyric/cli/bundler`:
+
+```ts
+import { pyricExternals } from '@pyric/cli/bundler';
+```
+
+---
+
+## 2. Configure your bundler
+
+Add the appropriate preset to your bundler's `external` configuration.
+
+### If you use Rolldown (`rolldown.config.ts`)
+
+Rolldown accepts regular expression patterns. Use the `rolldown` preset:
+
+```ts
+import { defineConfig } from 'rolldown';
+import { pyricExternals } from '@pyric/cli/bundler';
+
+export default defineConfig({
+  input: 'src/server.ts',
+  output: {
+    dir: 'dist',
+    format: 'esm',
+  },
+  external: pyricExternals.rolldown,
+});
+```
+
+### If you use esbuild (`esbuild.config.mjs`)
+
+esbuild requires string arrays with wildcard patterns (`*`). Use the `esbuild` preset:
+
+```js
+import esbuild from 'esbuild';
+import { pyricExternals } from '@pyric/cli/bundler';
+
+await esbuild.build({
+  entryPoints: ['src/server.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/server.js',
+  external: pyricExternals.esbuild,
+});
+```
+
+### If you use tsup (`tsup.config.ts`)
+
+tsup uses esbuild under the hood. Use the `tsup` preset:
+
+```ts
+import { defineConfig } from 'tsup';
+import { pyricExternals } from '@pyric/cli/bundler';
+
+export default defineConfig({
+  entry: ['src/server.ts'],
+  format: ['esm'],
+  external: pyricExternals.tsup,
+});
+```
+
+### If you use a custom predicate
+
+For bundlers that support function-based external resolution (such as Rollup, Rolldown, Vite, or Webpack), use `isPyricExternal`:
+
+```ts
+import { isPyricExternal } from '@pyric/cli/bundler';
+
+export default {
+  external: (id) => isPyricExternal(id),
+};
+```
+
+---
+
+## 3. Run your development server under `pyric sandbox`
+
+Add your bundler watch script and server runner to `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "rolldown -c -w & node --watch dist/server.js",
+    "build": "rolldown -c"
+  }
+}
+```
+
+Launch your application with `pyric sandbox`:
+
+```bash
+npx pyric sandbox
+```
+
+`pyric sandbox` starts the local sandbox, opens Pyric Studio, and executes your `dev` script. Because `firebase-admin` is externalised, your server's database, auth, and messaging operations route directly to the Pyric sandbox without requiring Google Cloud credentials or network access.
+
+---
+
+## 4. Unbundled workflows (no bundler needed)
+
+If your development workflow does not bundle dependencies into an intermediate file—for example, if you run TypeScript files directly with `tsx` or native Node:
+
+```json
+{
+  "scripts": {
+    "dev": "tsx watch src/server.ts"
+  }
+}
+```
+
+No bundler configuration is required. `pyric sandbox` intercepts your `firebase-admin` imports automatically out of the box.

--- a/scripts/fixtures/cli-release-contract.json
+++ b/scripts/fixtures/cli-release-contract.json
@@ -36,6 +36,7 @@
     "./discover",
     "./vite",
     "./next",
+    "./bundler",
     "./serve/worker",
     "./remote",
     "./register",


### PR DESCRIPTION
Exports `@pyric/cli/bundler` externalization presets to keep Firebase packages external across Rolldown, esbuild, and tsup backend builds, and adds a Diataxis How-to Guide in `site-docs` for backend dev tooling.

```ts
// rolldown.config.ts
import { defineConfig } from 'rolldown';
import { pyricExternals } from '@pyric/cli/bundler';

export default defineConfig({
  input: 'src/server.ts',
  output: { dir: 'dist', format: 'esm' },
  external: pyricExternals.rolldown,
});
```

```ts
import {
  pyricRollupExternals,
  pyricEsbuildExternals,
  isPyricExternal,
  pyricExternals,
} from '@pyric/cli/bundler';

// Rolldown, Rollup, Vite, Webpack (RegExp[]):
pyricExternals.rolldown;
// => [ /^firebase-admin(\/.*)?$/, /^firebase(\/.*)?$/, /^@firebase(\/.*)?$/ ]

// esbuild, tsup (string[] with glob wildcards):
pyricExternals.esbuild;
// => [ 'firebase-admin', 'firebase-admin/*', 'firebase', 'firebase/*', '@firebase/*' ]

// Universal predicate:
isPyricExternal('firebase-admin/firestore'); // => true
isPyricExternal('express');                  // => false
```

## Backend bundlers inline `firebase-admin` unless configured to externalize it

When running `pyric sandbox [command...]`, Pyric injects `NODE_OPTIONS="--import @pyric/cli/register"` into the spawned child process. That Node runtime loader intercepts module imports and transparently routes Firebase Admin SDK calls to the active sandbox.

However, when developers bundle backend Node services using Rolldown, esbuild, or tsup, non-external dependencies are compiled inline into the bundle (`dist/server.js`). Because the compiled bundle contains no runtime `import "firebase-admin"` statements, the Node loader hook never fires, causing the backend to attempt real Google Cloud authentication or throw missing credentials errors.

Different bundlers require different external formats: Rolldown and Rollup expect `RegExp` objects, whereas esbuild strictly requires `string[]` with `*` wildcards (and throws a schema error on RegExp). `@pyric/cli/bundler` provides zero-dependency presets tailored to each bundler along with a universal predicate.

## How-to Guide in site-docs

Adds `get-started/backend-bundlers.md` to `site-docs` under the **Get started** guide group, providing step-by-step instructions for Rolldown, esbuild, tsup, custom predicates, running with `pyric sandbox`, and unbundled workflows (`tsx`, `node --watch`).

## Risk

Low. Adds a new entrypoint (`./bundler`) to `@pyric/cli` without modifying any existing runtime or CLI behavior.

<details>
<summary>Implementation notes</summary>

- Closes #506.
- Added `packages/cli/src/bundler/externals.ts` and `packages/cli/src/bundler/index.ts`.
- Exported `./bundler` in `packages/cli/package.json`.
- Added `packages/cli/test/bundler/externals.test.ts` (11 unit tests, 44ms).
- Added `packages/site-docs/src/content/get-started/backend-bundlers.md`.
- Site docs build passed (111 pages built cleanly).
- Full CLI typecheck and build passed with exit code 0.

</details>
