### PR TITLE
feat(rules): formalize multi-tenant priority and normalize tenant claims

### DIFF
--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -3,7 +3,20 @@
 As of 2026-07-14. pyric shipped its npm alpha and the feature set works — that is the problem. The first real user, a Firebase expert, loved the prototype tab, opened the docs, and backed off: overwhelmed by how much was there. They wanted a Vite plugin and didn't know one already existed; they later asked for a verify-before-production capability that also already existed. The system is objectively strong and subjectively too much. This season is not about building more. It is about making what exists easy to enter, simple to hold in your head, and safe to trust — and nothing else. When a proposal doesn't serve one of the three, it waits.
 
 ## Multi-tenancy and Impersonation
-- Supporting utilities and features that make it easier for pyric to support multi-tenancy and for users to have features to enable impersonation.
+
+**Test:** Does this enable developers to test multi-tenant boundaries or switch and impersonate authenticated tenant identities during local development and testing without manual token manipulation?
+
+The multi-tenant and impersonation capability: Firebase projects serving enterprise or SaaS customers rely on Google Cloud Identity Platform multi-tenancy (`request.auth.token.firebase.tenant`) and rapid user switching. Developers need the local runtime and security rules engine to natively isolate tenant scopes, evaluate tenant claims without verbose manual token mocking, and seamlessly switch active impersonation identities in the UI.
+
+**Counts:** normalizing tenant identity claims (`request.auth.token.firebase.tenant`) across the rules engine and sandbox; runtime UI controls and accessible modals to switch, impersonate, or inspect tenant identities; persisting active impersonation lenses across reloads; characterization tests for multi-tenant rules evaluation.
+**Doesn't count:** server-side multi-tenant provisioning outside the local dev sandbox; custom identity providers or OAuth redirection flows; aesthetic UI redesigns that do not advance identity switching.
+
+**Now:**
+- Token normalization: support explicit `tenant` on `AuthState` and `AuthLens` and normalize `request.auth.token.firebase.tenant` in sandbox context assembly (assessment e3fc2b8d)
+- Accessible Modal primitive: promote and harden focus-trapping `Modal` in `@pyric/ui/primitives` with focus restoration
+- Client transport lens persistence: hydrate and persist auth lens in `sessionStorage` (`pyric:auth-lens`) and provide reactive subscription API
+- Runtime chip impersonation: embed accessible dialog in runtime chip Shadow DOM to switch between App Session, Admin Bypass, and Impersonated User with tenant and claims
+
 
 ## Top of Funnel
 

--- a/packages/pyric/src/sandbox/admin-firestore/get-firestore.ts
+++ b/packages/pyric/src/sandbox/admin-firestore/get-firestore.ts
@@ -67,7 +67,23 @@ export function getFirestore(ctx: SandboxContext): SandboxFirestore {
  *  arm pins on every op/sub. Never absent — see {@link getFirestore}. */
 export function lensForAuth(auth: AuthState): AuthLens {
   if (auth === null || auth === undefined) return { mode: 'anon' };
-  return auth.token === undefined
-    ? { mode: 'as', uid: auth.uid }
-    : { mode: 'as', uid: auth.uid, token: auth.token };
+  const lens: Extract<AuthLens, { mode: 'as' }> = { mode: 'as', uid: auth.uid };
+  if (auth.token !== undefined) lens.token = auth.token;
+  if (auth.tenant !== undefined) lens.tenant = auth.tenant;
+  return lens;
 }
+
+export function authStateForLens(actAs: Extract<AuthLens, { mode: 'as' }>): AuthState {
+  const state: Extract<AuthState, { uid: string }> = { uid: actAs.uid };
+  if (actAs.token !== undefined) state.token = actAs.token;
+  if (actAs.tenant !== undefined) state.tenant = actAs.tenant;
+  return state;
+}
+
+export function lensCacheKey(actAs: Extract<AuthLens, { mode: 'as' }>): string {
+  const parts = [actAs.uid];
+  if (actAs.tenant !== undefined) parts.push(`tenant:${actAs.tenant}`);
+  if (actAs.token !== undefined) parts.push(JSON.stringify(actAs.token));
+  return parts.join(':');
+}
+

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -51,7 +51,11 @@ export type {
   WriteSandboxEvent,
 } from './types/index.js';
 export { SandboxError } from './types/index.js';
-export { SandboxContextImpl } from './sandbox-context.js';
+export {
+  SandboxContextImpl,
+  normalizeAuthState,
+  validateAuthState,
+} from './sandbox-context.js';
 export {
   isOperationEvent,
   operationContextFor,

--- a/packages/pyric/src/sandbox/sandbox-context.ts
+++ b/packages/pyric/src/sandbox/sandbox-context.ts
@@ -27,32 +27,84 @@ import { SandboxError } from './types/errors.js';
 import type { Sandbox } from './types/service.js';
 import { immutableOperationContext } from './operation-record.js';
 
+/**
+ * Normalize AuthState during SandboxContextImpl context assembly.
+ * Automatically projects top-level `tenant` into `token.firebase.tenant`
+ * while preserving custom claims and explicit nested token overrides.
+ * Never mutates original input.
+ */
+export function normalizeAuthState(auth: AuthState): AuthState {
+  if (auth === null) return null;
+
+  if (auth.tenant === undefined) {
+    if (auth.token === undefined) {
+      return { uid: auth.uid };
+    }
+    return {
+      uid: auth.uid,
+      token: structuredClone(auth.token),
+    };
+  }
+
+  const token = auth.token !== undefined ? structuredClone(auth.token) : {};
+  const existingFirebase = token.firebase;
+
+  let normalizedFirebase: Record<string, unknown>;
+  if (
+    typeof existingFirebase === 'object' &&
+    existingFirebase !== null &&
+    !Array.isArray(existingFirebase)
+  ) {
+    const fbObj = existingFirebase as Record<string, unknown>;
+    normalizedFirebase = {
+      ...fbObj,
+      tenant: fbObj.tenant !== undefined ? fbObj.tenant : auth.tenant,
+    };
+  } else {
+    normalizedFirebase = { tenant: auth.tenant };
+  }
+
+  token.firebase = normalizedFirebase;
+
+  return {
+    uid: auth.uid,
+    tenant: auth.tenant,
+    token,
+  };
+}
+
 function authLensFor(auth: AuthState): AuthLens {
   if (auth === null) return { mode: 'anon' };
-  return auth.token === undefined
-    ? { mode: 'as', uid: auth.uid }
-    : { mode: 'as', uid: auth.uid, token: auth.token };
+  const lens: Extract<AuthLens, { mode: 'as' }> = { mode: 'as', uid: auth.uid };
+  if (auth.token !== undefined) lens.token = auth.token;
+  if (auth.tenant !== undefined) lens.tenant = auth.tenant;
+  return lens;
 }
 
 export class SandboxContextImpl implements SandboxContext {
+  public readonly auth: AuthState;
+  public readonly operationContext: OperationContext;
+
   constructor(
     public readonly sandbox: Sandbox,
-    public readonly auth: AuthState,
+    auth: AuthState,
     operationContext?: OperationContext,
   ) {
+    validateAuthState(auth);
+    const normalized = normalizeAuthState(auth);
+    this.auth = normalized;
     this.operationContext = immutableOperationContext(operationContext ?? {
       source: { kind: 'unattributed' },
-      authLens: authLensFor(auth),
+      authLens: authLensFor(normalized),
     });
   }
 
-  public readonly operationContext: OperationContext;
-
   withAuth(auth: AuthState): SandboxContext {
     validateAuthState(auth);
-    return new SandboxContextImpl(this.sandbox, auth, {
+    const normalized = normalizeAuthState(auth);
+    return new SandboxContextImpl(this.sandbox, normalized, {
       source: this.operationContext.source,
-      authLens: authLensFor(auth),
+      authLens: authLensFor(normalized),
       ...(this.operationContext.planId === undefined
         ? {}
         : { planId: this.operationContext.planId }),
@@ -105,6 +157,14 @@ export function validateAuthState(auth: unknown): asserts auth is AuthState {
       'invalid-argument',
       'withAuth() requires `uid` to be a non-empty string.',
     );
+  }
+  if ('tenant' in obj && obj.tenant !== undefined) {
+    if (typeof obj.tenant !== 'string' || obj.tenant.length === 0) {
+      throw new SandboxError(
+        'invalid-argument',
+        'withAuth() requires `tenant` (when present) to be a non-empty string.',
+      );
+    }
   }
   if ('token' in obj && obj.token !== undefined) {
     if (obj.token === null || typeof obj.token !== 'object' || Array.isArray(obj.token)) {

--- a/packages/pyric/src/sandbox/types/auth-state.ts
+++ b/packages/pyric/src/sandbox/types/auth-state.ts
@@ -18,5 +18,5 @@
  * names should reflect that.
  */
 export type AuthState =
-  | { uid: string; token?: Record<string, unknown> }
+  | { uid: string; token?: Record<string, unknown>; tenant?: string }
   | null;

--- a/packages/pyric/src/sandbox/types/operation.ts
+++ b/packages/pyric/src/sandbox/types/operation.ts
@@ -15,7 +15,7 @@ export type EventActor =
 /** The identity/rules lens an operation actually ran under. */
 export type AuthLens =
   | { mode: 'admin' }
-  | { mode: 'as'; uid: string; token?: Record<string, unknown> }
+  | { mode: 'as'; uid: string; tenant?: string; token?: Record<string, unknown> }
   | { mode: 'app-session' }
   | { mode: 'anon' };
 

--- a/packages/pyric/test/firestore/multi-tenant-rules-challenge.test.ts
+++ b/packages/pyric/test/firestore/multi-tenant-rules-challenge.test.ts
@@ -1,0 +1,559 @@
+/**
+ * Multi-Tenant Security Rules Evaluation Stress Harness & Challenge Suite
+ *
+ * Empirical verification of Firestore security rules evaluation with multi-tenant tokens,
+ * custom claims coexistence, and concurrent cross-handle isolation.
+ */
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import { setRules } from 'pyric/sandbox/firestore';
+import {
+  actingAs,
+  doc,
+  collection,
+  setDoc,
+  getDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  addDoc,
+  writeBatch,
+  runTransaction,
+  onSnapshot,
+  type DocumentSnapshot,
+} from '../../src/firestore/index.js';
+
+
+// ─── Rulesets ─────────────────────────────────────────────────────────────
+
+const EXACT_TENANT_RULE = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /tenant_scoped/{docId} {
+      allow read: if request.auth.token.firebase.tenant == 'tenant-123';
+      allow write: if request.auth.token.firebase.tenant == 'tenant-123';
+    }
+  }
+}`;
+
+const CLAIMS_COEXISTENCE_RULE = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /admin_tenant/{docId} {
+      allow read, write: if request.auth.token.role == 'admin'
+        && request.auth.token.firebase.tenant == 'tenant-123';
+    }
+    match /multi_claims/{docId} {
+      allow read, write: if request.auth.token.firebase.tenant == 'tenant-123'
+        && request.auth.token.role == 'admin'
+        && request.auth.token.dept == 'platform'
+        && request.auth.token.level == 4;
+    }
+  }
+}`;
+
+const PARTITIONED_TENANTS_RULE = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /tenants/{tenantId}/data/{docId} {
+      allow read, write: if request.auth != null
+        && request.auth.token.firebase.tenant == tenantId;
+    }
+  }
+}`;
+
+const HELPER_FUNCTIONS_RULE = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    function hasValidTenant(expectedTenant) {
+      return request.auth != null
+        && request.auth.token != null
+        && request.auth.token.firebase != null
+        && request.auth.token.firebase.tenant == expectedTenant;
+    }
+
+    function isTenantRole(expectedTenant, expectedRole) {
+      return hasValidTenant(expectedTenant)
+        && request.auth.token.role == expectedRole;
+    }
+
+    match /projects/{tId}/docs/{dId} {
+      allow read: if hasValidTenant(tId);
+      allow write: if isTenantRole(tId, 'editor');
+    }
+  }
+}`;
+
+// ─── Test Suites ──────────────────────────────────────────────────────────
+
+describe('Challenge 1: Exact tenant rule evaluation (request.auth.token.firebase.tenant == "tenant-123")', () => {
+  it('allows read via getDoc when tenant matches', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/doc1', { value: 'authorized' });
+
+    const matchingUser = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-123' });
+    const snap = await getDoc(doc(matchingUser, 'tenant_scoped/doc1'));
+    expect(snap.exists()).toBe(true);
+    expect(snap.data()).toEqual({ value: 'authorized' });
+  });
+
+  it('denies read via getDoc when tenant does not match', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/doc1', { value: 'secret' });
+
+    const wrongTenantUser = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-999' });
+    await expect(getDoc(doc(wrongTenantUser, 'tenant_scoped/doc1'))).rejects.toThrow();
+  });
+
+  it('denies read via getDoc when tenant is missing', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/doc1', { value: 'secret' });
+
+    const noTenantUser = actingAs(sandbox, { uid: 'charlie' });
+    await expect(getDoc(doc(noTenantUser, 'tenant_scoped/doc1'))).rejects.toThrow();
+  });
+
+  it('denies read via getDoc when unauthenticated (null auth)', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/doc1', { value: 'secret' });
+
+    const anonUser = actingAs(sandbox, null);
+    await expect(getDoc(doc(anonUser, 'tenant_scoped/doc1'))).rejects.toThrow();
+  });
+
+  it('evaluates getDocs collection query with tenant matching vs mismatching', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/item1', { name: 'Item 1' });
+    sandbox.admin.setDocument('tenant_scoped/item2', { name: 'Item 2' });
+
+    const matchingUser = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-123' });
+    const wrongTenantUser = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-other' });
+    const noTenantUser = actingAs(sandbox, { uid: 'charlie' });
+
+    // Matching tenant can list collection
+    const querySnap = await getDocs(collection(matchingUser, 'tenant_scoped'));
+    expect(querySnap.size).toBe(2);
+
+    // Mismatched or missing tenant gets permission-denied
+    await expect(getDocs(collection(wrongTenantUser, 'tenant_scoped'))).rejects.toThrow();
+    await expect(getDocs(collection(noTenantUser, 'tenant_scoped'))).rejects.toThrow();
+  });
+
+  it('evaluates writes (setDoc, updateDoc, deleteDoc, addDoc) with tenant matching vs mismatching', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+
+    const matchingUser = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-123' });
+    const wrongTenantUser = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-wrong' });
+    const noTenantUser = actingAs(sandbox, { uid: 'charlie' });
+
+    // setDoc: allowed for match, denied for mismatch/missing
+    await expect(setDoc(doc(matchingUser, 'tenant_scoped/w1'), { created: true })).resolves.toBeUndefined();
+    await expect(setDoc(doc(wrongTenantUser, 'tenant_scoped/w2'), { created: true })).rejects.toThrow();
+    await expect(setDoc(doc(noTenantUser, 'tenant_scoped/w3'), { created: true })).rejects.toThrow();
+
+    // updateDoc: allowed for match, denied for mismatch/missing
+    await expect(updateDoc(doc(matchingUser, 'tenant_scoped/w1'), { updated: true })).resolves.toBeUndefined();
+    await expect(updateDoc(doc(wrongTenantUser, 'tenant_scoped/w1'), { updated: true })).rejects.toThrow();
+    await expect(updateDoc(doc(noTenantUser, 'tenant_scoped/w1'), { updated: true })).rejects.toThrow();
+
+    // addDoc: allowed for match, denied for mismatch/missing
+    await expect(addDoc(collection(matchingUser, 'tenant_scoped'), { auto: true })).resolves.toBeDefined();
+    await expect(addDoc(collection(wrongTenantUser, 'tenant_scoped'), { auto: true })).rejects.toThrow();
+    await expect(addDoc(collection(noTenantUser, 'tenant_scoped'), { auto: true })).rejects.toThrow();
+
+    // deleteDoc: allowed for match, denied for mismatch/missing
+    await expect(deleteDoc(doc(wrongTenantUser, 'tenant_scoped/w1'))).rejects.toThrow();
+    await expect(deleteDoc(doc(noTenantUser, 'tenant_scoped/w1'))).rejects.toThrow();
+    await expect(deleteDoc(doc(matchingUser, 'tenant_scoped/w1'))).resolves.toBeUndefined();
+  });
+
+  it('evaluates onSnapshot listener registration: allowed for match, denied for mismatch', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, EXACT_TENANT_RULE);
+    sandbox.admin.setDocument('tenant_scoped/live1', { v: 1 });
+
+    const matchingUser = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-123' });
+    const wrongTenantUser = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-456' });
+
+    // Matching user receives live snapshots
+    let seenVal: unknown;
+    const unsub = onSnapshot(doc(matchingUser, 'tenant_scoped/live1'), (snap) => {
+      seenVal = snap.data()?.v;
+    });
+
+    await setDoc(doc(matchingUser, 'tenant_scoped/live1'), { v: 2 });
+    expect(seenVal).toBe(2);
+    unsub();
+
+    // Wrong tenant receives permission-denied error callback
+    let errorReceived: unknown;
+    const unsubWrong = onSnapshot(
+      doc(wrongTenantUser, 'tenant_scoped/live1'),
+      {
+        error: (err) => { errorReceived = err; },
+      },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(errorReceived).toBeDefined();
+    unsubWrong();
+  });
+});
+
+describe('Challenge 2: Custom claims coexistence (role == "admin" && tenant == "tenant-123")', () => {
+  it('satisfies truth table across role and tenant permutations', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, CLAIMS_COEXISTENCE_RULE);
+
+    // 1. Both match (role=admin, tenant=tenant-123) -> ALLOW
+    const fullMatch = actingAs(sandbox, {
+      uid: 'u-both-match',
+      tenant: 'tenant-123',
+      token: { role: 'admin' },
+    });
+    await expect(
+      setDoc(doc(fullMatch, 'admin_tenant/d1'), { ok: 1 }),
+    ).resolves.toBeUndefined();
+
+    // 2. Role matches ('admin'), tenant mismatches ('tenant-999') -> DENY
+    const wrongTenant = actingAs(sandbox, {
+      uid: 'u-wrong-tenant',
+      tenant: 'tenant-999',
+      token: { role: 'admin' },
+    });
+    await expect(
+      setDoc(doc(wrongTenant, 'admin_tenant/d2'), { ok: 1 }),
+    ).rejects.toThrow();
+
+    // 3. Tenant matches ('tenant-123'), role mismatches ('viewer') -> DENY
+    const wrongRole = actingAs(sandbox, {
+      uid: 'u-wrong-role',
+      tenant: 'tenant-123',
+      token: { role: 'viewer' },
+    });
+    await expect(
+      setDoc(doc(wrongRole, 'admin_tenant/d3'), { ok: 1 }),
+    ).rejects.toThrow();
+
+    // 4. Neither matches -> DENY
+    const neitherMatch = actingAs(sandbox, {
+      uid: 'u-neither',
+      tenant: 'tenant-wrong',
+      token: { role: 'viewer' },
+    });
+    await expect(
+      setDoc(doc(neitherMatch, 'admin_tenant/d4'), { ok: 1 }),
+    ).rejects.toThrow();
+
+    // 5. Missing role claim, matching tenant -> DENY
+    const missingRole = actingAs(sandbox, {
+      uid: 'u-no-role',
+      tenant: 'tenant-123',
+    });
+    await expect(
+      setDoc(doc(missingRole, 'admin_tenant/d5'), { ok: 1 }),
+    ).rejects.toThrow();
+
+    // 6. Matching role, missing tenant -> DENY
+    const missingTenant = actingAs(sandbox, {
+      uid: 'u-no-tenant',
+      token: { role: 'admin' },
+    });
+    await expect(
+      setDoc(doc(missingTenant, 'admin_tenant/d6'), { ok: 1 }),
+    ).rejects.toThrow();
+  });
+
+  it('coexists with arbitrary multi-field custom claims without interference', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, CLAIMS_COEXISTENCE_RULE);
+
+    const multiClaimUser = actingAs(sandbox, {
+      uid: 'lead-dev',
+      tenant: 'tenant-123',
+      token: {
+        role: 'admin',
+        dept: 'platform',
+        level: 4,
+        extraFlag: true,
+        nested: { inner: 'val' },
+      },
+    });
+
+    await expect(
+      setDoc(doc(multiClaimUser, 'multi_claims/c1'), { data: 'pass' }),
+    ).resolves.toBeUndefined();
+
+    const readSnap = await getDoc(doc(multiClaimUser, 'multi_claims/c1'));
+    expect(readSnap.data()).toEqual({ data: 'pass' });
+
+    // Slight variance in one claim causes denial
+    const partialUser = actingAs(sandbox, {
+      uid: 'lead-dev-2',
+      tenant: 'tenant-123',
+      token: {
+        role: 'admin',
+        dept: 'platform',
+        level: 3, // Level 3 instead of 4
+      },
+    });
+    await expect(
+      setDoc(doc(partialUser, 'multi_claims/c2'), { data: 'fail' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('Challenge 3: Concurrency and Cross-Handle Isolation Stress Test', () => {
+  it('executes 300 interleaved concurrent operations across 5 tenant handles with zero cross-leakage', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, PARTITIONED_TENANTS_RULE);
+
+    // 5 handles sharing the EXACT SAME UID on the SAME sandbox, but differing tenants
+    const tenants = ['tenant-alpha', 'tenant-beta', 'tenant-gamma', 'tenant-delta', 'tenant-epsilon'];
+    const handles = new Map(
+      tenants.map((tid) => [tid, actingAs(sandbox, { uid: 'shared-agent-worker', tenant: tid })]),
+    );
+
+    // Untenanted handle with same UID
+    const untenantedHandle = actingAs(sandbox, { uid: 'shared-agent-worker' });
+
+    // Seed baseline documents for each tenant
+    for (const tid of tenants) {
+      sandbox.admin.setDocument(`tenants/${tid}/data/baseline`, { tenant: tid, count: 0 });
+    }
+
+    // Build 300 concurrent tasks:
+    // - 150 authorized operations (each handle reads/writes its own partition)
+    // - 150 unauthorized cross-tenant operations (handles attempting to read/write other partitions)
+    const tasks: Promise<void>[] = [];
+
+    for (let i = 0; i < 30; i++) {
+      for (const tid of tenants) {
+        const handle = handles.get(tid)!;
+        const otherTid = tenants[(tenants.indexOf(tid) + 1) % tenants.length];
+
+        // Authorized write to own partition
+        tasks.push(
+          (async () => {
+            await setDoc(doc(handle, `tenants/${tid}/data/run-${i}`), {
+              writtenBy: tid,
+              iteration: i,
+            });
+            const snap = await getDoc(doc(handle, `tenants/${tid}/data/run-${i}`));
+            expect(snap.exists()).toBe(true);
+            expect(snap.data()?.writtenBy).toBe(tid);
+          })(),
+        );
+
+        // Unauthorized write to another tenant's partition (MUST reject)
+        tasks.push(
+          (async () => {
+            let threw = false;
+            try {
+              await setDoc(doc(handle, `tenants/${otherTid}/data/attack-${i}`), {
+                breachedBy: tid,
+              });
+            } catch {
+              threw = true;
+            }
+            expect(threw).toBe(true);
+          })(),
+        );
+
+        // Unauthorized read from another tenant's baseline document (MUST reject)
+        tasks.push(
+          (async () => {
+            let threw = false;
+            try {
+              await getDoc(doc(handle, `tenants/${otherTid}/data/baseline`));
+            } catch {
+              threw = true;
+            }
+            expect(threw).toBe(true);
+          })(),
+        );
+      }
+
+      // Untenanted handle attempting access on all partitions (MUST reject)
+      tasks.push(
+        (async () => {
+          const targetTid = tenants[i % tenants.length];
+          let threw = false;
+          try {
+            await getDoc(doc(untenantedHandle, `tenants/${targetTid}/data/baseline`));
+          } catch {
+            threw = true;
+          }
+          expect(threw).toBe(true);
+        })(),
+      );
+    }
+
+    // Await all concurrent tasks simultaneously
+    await Promise.all(tasks);
+
+    // Verify all authorized documents were written without corruption
+    for (const tid of tenants) {
+      for (let i = 0; i < 30; i++) {
+        const docData = sandbox.admin.getDocument(`tenants/${tid}/data/run-${i}`);
+        expect(docData).toEqual({ writtenBy: tid, iteration: i });
+      }
+    }
+  });
+
+  it('guarantees atomicity and tenant boundaries during batched writes and transactions', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, PARTITIONED_TENANTS_RULE);
+
+    const handleA = actingAs(sandbox, { uid: 'userA', tenant: 'tenant-alpha' });
+
+    // 1. Valid batch wholly inside tenant-alpha -> succeeds
+    const goodBatch = writeBatch(handleA);
+    goodBatch.set(doc(handleA, 'tenants/tenant-alpha/data/b1'), { n: 1 });
+    goodBatch.set(doc(handleA, 'tenants/tenant-alpha/data/b2'), { n: 2 });
+    await expect(goodBatch.commit()).resolves.toBeUndefined();
+
+    // 2. Poisoned batch containing one cross-tenant write -> entire batch fails
+    const badBatch = writeBatch(handleA);
+    badBatch.set(doc(handleA, 'tenants/tenant-alpha/data/b3'), { n: 3 });
+    badBatch.set(doc(handleA, 'tenants/tenant-beta/data/breach'), { bad: true });
+    await expect(badBatch.commit()).rejects.toThrow();
+    expect(sandbox.admin.getDocument('tenants/tenant-alpha/data/b3')).toBeNull();
+
+    // 3. Valid transaction wholly inside tenant-alpha -> succeeds
+    await expect(
+      runTransaction(handleA, async (tx) => {
+        const r1 = await tx.get(doc(handleA, 'tenants/tenant-alpha/data/b1'));
+        tx.update(doc(handleA, 'tenants/tenant-alpha/data/b1'), { n: (r1.data()?.n as number) + 10 });
+      }),
+    ).resolves.toBeUndefined();
+    expect(sandbox.admin.getDocument('tenants/tenant-alpha/data/b1')?.n).toBe(11);
+
+    // 4. Transaction attempting write to cross-tenant document -> fails at commit
+    await expect(
+      runTransaction(handleA, async (tx) => {
+        await tx.get(doc(handleA, 'tenants/tenant-alpha/data/b1'));
+        tx.set(doc(handleA, 'tenants/tenant-beta/data/breach'), { bad: true });
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('Challenge 4: Rules helper functions and expression evaluation', () => {
+  it('correctly passes tenant arguments through rules functions for reads and role-based writes', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, HELPER_FUNCTIONS_RULE);
+
+    const projectEditor = actingAs(sandbox, {
+      uid: 'editor-1',
+      tenant: 'proj-omega',
+      token: { role: 'editor' },
+    });
+
+    const projectViewer = actingAs(sandbox, {
+      uid: 'viewer-1',
+      tenant: 'proj-omega',
+      token: { role: 'viewer' },
+    });
+
+    const outsiderEditor = actingAs(sandbox, {
+      uid: 'outsider-1',
+      tenant: 'proj-other',
+      token: { role: 'editor' },
+    });
+
+    // Editor on matching project: can read and write
+    await expect(
+      setDoc(doc(projectEditor, 'projects/proj-omega/docs/d1'), { title: 'Spec' }),
+    ).resolves.toBeUndefined();
+    const readSnap = await getDoc(doc(projectEditor, 'projects/proj-omega/docs/d1'));
+    expect(readSnap.exists()).toBe(true);
+
+    // Viewer on matching project: can read, but CANNOT write
+    const viewerReadSnap = await getDoc(doc(projectViewer, 'projects/proj-omega/docs/d1'));
+    expect(viewerReadSnap.exists()).toBe(true);
+    await expect(
+      setDoc(doc(projectViewer, 'projects/proj-omega/docs/d2'), { title: 'Hacked' }),
+    ).rejects.toThrow();
+
+    // Editor on wrong project: CANNOT read and CANNOT write
+    await expect(
+      getDoc(doc(outsiderEditor, 'projects/proj-omega/docs/d1')),
+    ).rejects.toThrow();
+    await expect(
+      setDoc(doc(outsiderEditor, 'projects/proj-omega/docs/d3'), { title: 'Intrusion' }),
+    ).rejects.toThrow();
+  });
+});
+
+
+
+describe('Challenge 6: Boundary & Structural Edge Cases in Rules Evaluation', () => {
+  const BOUNDARY_RULES = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /dynamic_tenants/{docId} {
+      allow read: if request.auth != null
+        && 'tenant' in request.auth.token.firebase
+        && request.auth.token.firebase.tenant == resource.data.tenantId;
+      allow create: if request.auth != null
+        && request.auth.token.firebase.tenant == request.resource.data.tenantId;
+    }
+    match /bracket_access/{docId} {
+      allow read: if request.auth.token.firebase['tenant'] == 'complex:tenant_id.v1@prod';
+    }
+  }
+}`;
+
+  it('evaluates resource.data binding against request.auth.token.firebase.tenant', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, BOUNDARY_RULES);
+
+    sandbox.admin.setDocument('dynamic_tenants/d1', { tenantId: 'tenant-dynamic-1', secret: 'abc' });
+    sandbox.admin.setDocument('dynamic_tenants/d2', { tenantId: 'tenant-dynamic-2', secret: 'xyz' });
+
+    const user1 = actingAs(sandbox, { uid: 'u1', tenant: 'tenant-dynamic-1' });
+    const user2 = actingAs(sandbox, { uid: 'u2', tenant: 'tenant-dynamic-2' });
+
+    // User 1 can read d1, but not d2
+    const s1 = await getDoc(doc(user1, 'dynamic_tenants/d1'));
+    expect(s1.exists()).toBe(true);
+    await expect(getDoc(doc(user1, 'dynamic_tenants/d2'))).rejects.toThrow();
+
+    // User 2 can read d2, but not d1
+    const s2 = await getDoc(doc(user2, 'dynamic_tenants/d2'));
+    expect(s2.exists()).toBe(true);
+    await expect(getDoc(doc(user2, 'dynamic_tenants/d1'))).rejects.toThrow();
+
+    // Create enforces request.resource.data.tenantId == request.auth.token.firebase.tenant
+    await expect(
+      setDoc(doc(user1, 'dynamic_tenants/new1'), { tenantId: 'tenant-dynamic-1', text: 'ok' }),
+    ).resolves.toBeUndefined();
+    await expect(
+      setDoc(doc(user1, 'dynamic_tenants/new2'), { tenantId: 'tenant-dynamic-2', text: 'illegal' }),
+    ).rejects.toThrow();
+  });
+
+  it('evaluates bracket access and complex strings in tenant identifiers', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, BOUNDARY_RULES);
+
+    const complexTenant = 'complex:tenant_id.v1@prod';
+    const complexUser = actingAs(sandbox, { uid: 'u-complex', tenant: complexTenant });
+    const normalUser = actingAs(sandbox, { uid: 'u-normal', tenant: 'normal-tenant' });
+
+    sandbox.admin.setDocument('bracket_access/b1', { payload: 'hello' });
+
+    const snap = await getDoc(doc(complexUser, 'bracket_access/b1'));
+    expect(snap.exists()).toBe(true);
+    expect(snap.data()).toEqual({ payload: 'hello' });
+
+    await expect(getDoc(doc(normalUser, 'bracket_access/b1'))).rejects.toThrow();
+  });
+});
+

--- a/packages/pyric/test/firestore/multi-user.test.ts
+++ b/packages/pyric/test/firestore/multi-user.test.ts
@@ -38,6 +38,17 @@ service cloud.firestore {
   }
 }`;
 
+// Multi-tenant isolated: only users whose token.firebase.tenant matches the path tenantId can access.
+const TENANT_ISOLATED = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /tenants/{tenantId}/records/{recordId} {
+      allow read, write: if request.auth != null
+        && request.auth.token.firebase.tenant == tenantId;
+    }
+  }
+}`;
+
 describe('multi-user (programmatic): one sandbox, distinct identities', () => {
   it('a write by one identity reaches another identity onSnapshot (shared store)', async () => {
     const sandbox = initializeSandbox();
@@ -86,3 +97,109 @@ describe('multi-user (programmatic): one sandbox, distinct identities', () => {
     await expect(setDoc(doc(anon, 'rooms/r2'), { x: 1 })).rejects.toThrow();
   });
 });
+
+describe('multi-tenant rules evaluation (request.auth.token.firebase.tenant)', () => {
+  it('allows access when tenant matches security rule condition', async () => {
+    const sandbox = initializeSandbox();
+    const aliceAlpha = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-alpha' });
+    setRules(sandbox, TENANT_ISOLATED);
+
+    await expect(
+      setDoc(doc(aliceAlpha, 'tenants/tenant-alpha/records/r1'), { title: 'Secret Doc' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('denies access when tenant does not match security rule condition', async () => {
+    const sandbox = initializeSandbox();
+    const bobBeta = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-beta' });
+    setRules(sandbox, TENANT_ISOLATED);
+
+    await expect(
+      setDoc(doc(bobBeta, 'tenants/tenant-alpha/records/r1'), { title: 'Intrusion' }),
+    ).rejects.toThrow();
+  });
+
+  it('denies access when user has no tenant configured', async () => {
+    const sandbox = initializeSandbox();
+    const charlie = actingAs(sandbox, { uid: 'charlie' });
+    setRules(sandbox, TENANT_ISOLATED);
+
+    await expect(
+      setDoc(doc(charlie, 'tenants/tenant-alpha/records/r1'), { title: 'No Tenant' }),
+    ).rejects.toThrow();
+  });
+
+  it('respects explicit nested token.firebase.tenant override in rules evaluation', async () => {
+    const sandbox = initializeSandbox();
+    const userWithOverride = actingAs(sandbox, {
+      uid: 'david',
+      tenant: 'tenant-alpha',
+      token: {
+        firebase: { tenant: 'tenant-override' },
+      },
+    });
+    setRules(sandbox, TENANT_ISOLATED);
+
+    // Can access tenant-override
+    await expect(
+      setDoc(doc(userWithOverride, 'tenants/tenant-override/records/r1'), { title: 'Overridden' }),
+    ).resolves.toBeUndefined();
+
+    // Denied on tenant-alpha
+    await expect(
+      setDoc(doc(userWithOverride, 'tenants/tenant-alpha/records/r1'), { title: 'Mismatch' }),
+    ).rejects.toThrow();
+  });
+
+  it('preserves custom claims alongside tenant during rules evaluation', async () => {
+    const CLAIMS_AND_TENANT = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /tenants/{tenantId}/admin_records/{docId} {
+      allow read, write: if request.auth != null
+        && request.auth.token.firebase.tenant == tenantId
+        && request.auth.token.role == 'admin';
+    }
+  }
+}`;
+    const sandbox = initializeSandbox();
+    setRules(sandbox, CLAIMS_AND_TENANT);
+
+    const admin = actingAs(sandbox, {
+      uid: 'admin-1',
+      tenant: 'tenant-acme',
+      token: { role: 'admin' },
+    });
+    const regularUser = actingAs(sandbox, {
+      uid: 'user-1',
+      tenant: 'tenant-acme',
+      token: { role: 'viewer' },
+    });
+
+    await expect(
+      setDoc(doc(admin, 'tenants/tenant-acme/admin_records/a1'), { confidential: true }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      setDoc(doc(regularUser, 'tenants/tenant-acme/admin_records/a1'), { confidential: true }),
+    ).rejects.toThrow();
+  });
+
+  it('delivers writes across identities within same tenant via onSnapshot', async () => {
+    const sandbox = initializeSandbox();
+    const aliceAlpha = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-alpha' });
+    const bobAlpha = actingAs(sandbox, { uid: 'bob', tenant: 'tenant-alpha' });
+    setRules(sandbox, TENANT_ISOLATED);
+
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const unsub = onSnapshot(doc(bobAlpha, 'tenants/tenant-alpha/records/shared'), (snap: DocumentSnapshot) => {
+      seen.push(snap.data() as Record<string, unknown> | undefined);
+    });
+
+    await setDoc(doc(aliceAlpha, 'tenants/tenant-alpha/records/shared'), { text: 'hello tenant' });
+
+    expect(seen.at(-1)).toEqual({ text: 'hello tenant' });
+    unsub();
+  });
+});
+

--- a/packages/pyric/test/sandbox/multi-tenant-adversarial.test.ts
+++ b/packages/pyric/test/sandbox/multi-tenant-adversarial.test.ts
@@ -1,0 +1,601 @@
+/**
+ * Adversarial Empirical Stress Suite for Multi-Tenant Impersonation (Milestone 1).
+ *
+ * Tests:
+ * 1. Edge-case tenant strings (dashes, numbers, unicode, emoji, CJK, RTL, special chars, high length).
+ * 2. Strict rejection of invalid types (empty string, non-string, null, boolean, object, array, function, symbol, NaN, BigInt).
+ * 3. Deep immutability and isolation (frozen inputs, post-call tampering resistance, chained context independence).
+ * 4. Explicit nested token override precedence (token.firebase.tenant vs top-level tenant, sub-claim preservation).
+ * 5. Clean non-tenant identity ({ uid: 'alice' } has no tenant/firebase properties).
+ * 6. Object.create(null) edge cases.
+ * 7. End-to-end Firestore security rules evaluation with multi-tenant edge cases.
+ * 8. Host lensCacheKey collision characterization.
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+  initializeSandbox,
+  SandboxContextImpl,
+  SandboxError,
+  normalizeAuthState,
+  validateAuthState,
+  type AuthState,
+} from 'pyric/sandbox';
+import { setRules } from 'pyric/sandbox/firestore';
+import {
+  actingAs,
+  doc,
+  setDoc,
+  getDoc,
+  type DocumentSnapshot,
+} from '../../src/firestore/index.js';
+import {
+  lensForAuth,
+  authStateForLens,
+  lensCacheKey,
+} from '../../src/sandbox/admin-firestore/get-firestore.js';
+
+// Multi-tenant path-isolated rule
+const TENANT_PATH_ISOLATED = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /tenants/{tenantId}/records/{recordId} {
+      allow read, write: if request.auth != null
+        && request.auth.token.firebase.tenant == tenantId;
+    }
+  }
+}`;
+
+// Explicit equality rule without path-wildcard constraints
+const TENANT_EQUALITY_RULE = `rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /system/status {
+      allow read: if request.auth != null
+        && request.auth.token.firebase.tenant == 'tenant:engineering@corp.internal/v1#special';
+    }
+    match /unicode/doc {
+      allow read: if request.auth != null
+        && request.auth.token.firebase.tenant == '租户-东京-42-🔥';
+    }
+    match /numbers/doc {
+      allow read: if request.auth != null
+        && request.auth.token.firebase.tenant == '9876543210';
+    }
+  }
+}`;
+
+describe('Adversarial Stress: 1. Tenant String Varieties & Unicode', () => {
+  const edgeCases = [
+    { name: 'dashes and hyphens', tenant: 'tenant-prod-us-east-1-alpha' },
+    { name: 'pure numeric string', tenant: '9876543210' },
+    { name: 'alphanumeric with underscores', tenant: 'tenant_enterprise_2026_v2' },
+    { name: 'CJK characters (Chinese/Japanese)', tenant: '租户-东京-42' },
+    { name: 'European diacritics and accents', tenant: 'ténant-élégant-über-straß' },
+    { name: 'Unicode Emoji', tenant: 'tenant-🚀-corp-🔥' },
+    { name: 'Right-to-Left (Arabic / Hebrew)', tenant: 'مستأجر-فرعي-10' },
+    { name: 'Dots and subdomains', tenant: 'tenant.sub.dept.domain.io' },
+    { name: 'Special punctuation symbols', tenant: 'tenant+team=omega~star!2' },
+    { name: 'Colon and at-sign', tenant: 'tenant:ops@cloud.dev' },
+    { name: 'High-length tenant string (1000 chars)', tenant: 'tenant-' + 'x'.repeat(1000) },
+  ];
+
+  for (const { name, tenant } of edgeCases) {
+    it(`normalizes correctly for: ${name}`, () => {
+      const sandbox = initializeSandbox();
+      const ctx = sandbox.withAuth({ uid: 'test-user', tenant });
+      expect(ctx.auth).toEqual({
+        uid: 'test-user',
+        tenant,
+        token: {
+          firebase: {
+            tenant,
+          },
+        },
+      });
+      expect(ctx.operationContext.authLens).toEqual({
+        mode: 'as',
+        uid: 'test-user',
+        tenant,
+        token: {
+          firebase: {
+            tenant,
+          },
+        },
+      });
+    });
+  }
+
+  it('evaluates unicode and emoji tenant in security rules', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_EQUALITY_RULE);
+
+    const validUnicodeUser = actingAs(sandbox, {
+      uid: 'user-cjk',
+      tenant: '租户-东京-42-🔥',
+    });
+    const invalidUnicodeUser = actingAs(sandbox, {
+      uid: 'user-cjk-wrong',
+      tenant: '租户-东京-42-💧', // wrong emoji
+    });
+
+    // Allowed for exact match
+    await expect(getDoc(doc(validUnicodeUser, 'unicode/doc'))).resolves.toBeDefined();
+    // Denied for mismatch
+    await expect(getDoc(doc(invalidUnicodeUser, 'unicode/doc'))).rejects.toThrow();
+  });
+
+  it('evaluates pure numeric string tenant in security rules', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_EQUALITY_RULE);
+
+    const numUser = actingAs(sandbox, {
+      uid: 'user-num',
+      tenant: '9876543210',
+    });
+    const wrongNumUser = actingAs(sandbox, {
+      uid: 'user-num-wrong',
+      tenant: '9876543211',
+    });
+
+    await expect(getDoc(doc(numUser, 'numbers/doc'))).resolves.toBeDefined();
+    await expect(getDoc(doc(wrongNumUser, 'numbers/doc'))).rejects.toThrow();
+  });
+
+  it('evaluates complex special characters with colons, slashes, hashes in equality rules', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_EQUALITY_RULE);
+
+    const specialUser = actingAs(sandbox, {
+      uid: 'user-special',
+      tenant: 'tenant:engineering@corp.internal/v1#special',
+    });
+    const wrongSpecialUser = actingAs(sandbox, {
+      uid: 'user-special-wrong',
+      tenant: 'tenant:engineering@corp.internal/v1#other',
+    });
+
+    await expect(getDoc(doc(specialUser, 'system/status'))).resolves.toBeDefined();
+    await expect(getDoc(doc(wrongSpecialUser, 'system/status'))).rejects.toThrow();
+  });
+
+  it('evaluates path-wildcard rules with dashed and unicode tenants', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_PATH_ISOLATED);
+
+    const dashedUser = actingAs(sandbox, {
+      uid: 'alice',
+      tenant: 'tenant-alpha-123',
+    });
+    await expect(
+      setDoc(doc(dashedUser, 'tenants/tenant-alpha-123/records/r1'), { ok: true }),
+    ).resolves.toBeUndefined();
+
+    // Unicode in path
+    const unicodeUser = actingAs(sandbox, {
+      uid: 'tanaka',
+      tenant: '租户-东京',
+    });
+    await expect(
+      setDoc(doc(unicodeUser, 'tenants/租户-东京/records/r1'), { ok: true }),
+    ).resolves.toBeUndefined();
+
+    // Mismatched access denied
+    await expect(
+      setDoc(doc(dashedUser, 'tenants/租户-东京/records/r1'), { hack: true }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('Adversarial Stress: 2. Rejection of Invalid Types', () => {
+  const invalidTenants: Array<[string, unknown]> = [
+    ['empty string', ''],
+    ['number positive', 42],
+    ['number zero', 0],
+    ['number negative', -1],
+    ['number float', 3.14159],
+    ['number NaN', NaN],
+    ['number Infinity', Infinity],
+    ['boolean true', true],
+    ['boolean false', false],
+    ['null', null],
+    ['empty object', {}],
+    ['non-empty object', { tenantId: 't1' }],
+    ['empty array', []],
+    ['string array', ['tenant-1']],
+    ['function', () => 'tenant-1'],
+    ['symbol', Symbol('tenant-1')],
+    ['bigint', 100n],
+  ];
+
+  for (const [desc, badTenant] of invalidTenants) {
+    it(`rejects ${desc} tenant on initializeSandbox().withAuth`, () => {
+      const sandbox = initializeSandbox();
+      expect(() => {
+        // @ts-expect-error — testing runtime invalid input
+        sandbox.withAuth({ uid: 'alice', tenant: badTenant });
+      }).toThrow(SandboxError);
+
+      try {
+        // @ts-expect-error — testing runtime invalid input
+        sandbox.withAuth({ uid: 'alice', tenant: badTenant });
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(SandboxError);
+        expect(err.code).toBe('invalid-argument');
+        expect(err.message).toContain('tenant');
+      }
+    });
+
+    it(`rejects ${desc} tenant on ctx.withAuth chaining`, () => {
+      const sandbox = initializeSandbox();
+      const ctx = sandbox.withAuth({ uid: 'alice' });
+      expect(() => {
+        // @ts-expect-error — testing runtime invalid input
+        ctx.withAuth({ uid: 'bob', tenant: badTenant });
+      }).toThrow(SandboxError);
+    });
+
+    it(`rejects ${desc} tenant on validateAuthState directly`, () => {
+      expect(() => {
+        validateAuthState({ uid: 'alice', tenant: badTenant });
+      }).toThrow(SandboxError);
+    });
+  }
+
+  it('rejects invalid combinations: empty uid with valid tenant', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      sandbox.withAuth({ uid: '', tenant: 'valid-tenant' });
+    }).toThrow(SandboxError);
+  });
+
+  it('rejects invalid combinations: non-string uid with valid tenant', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      // @ts-expect-error — testing runtime invalid input
+      sandbox.withAuth({ uid: 12345, tenant: 'valid-tenant' });
+    }).toThrow(SandboxError);
+  });
+
+  it('rejects invalid token: array token with valid tenant', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      // @ts-expect-error — testing runtime invalid input
+      sandbox.withAuth({ uid: 'alice', tenant: 'valid-tenant', token: ['bad'] });
+    }).toThrow(SandboxError);
+  });
+
+  it('rejects invalid token: null token with valid tenant', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      // @ts-expect-error — testing runtime invalid input
+      sandbox.withAuth({ uid: 'alice', tenant: 'valid-tenant', token: null });
+    }).toThrow(SandboxError);
+  });
+
+  it('rejects non-object auth argument', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      // @ts-expect-error — testing runtime invalid input
+      sandbox.withAuth('alice');
+    }).toThrow(SandboxError);
+    expect(() => {
+      // @ts-expect-error — testing runtime invalid input
+      sandbox.withAuth(12345);
+    }).toThrow(SandboxError);
+  });
+});
+
+describe('Adversarial Stress: 3. Immutability & Tamper-Resistance', () => {
+  it('does not mutate deeply frozen input object', () => {
+    const sandbox = initializeSandbox();
+    const frozenInput = Object.freeze({
+      uid: 'alice',
+      tenant: 'tenant-secure',
+      token: Object.freeze({
+        role: 'admin',
+        firebase: Object.freeze({
+          sign_in_provider: 'password',
+        }),
+      }),
+    });
+
+    // Should not throw TypeError for trying to assign to frozen object
+    let ctx!: SandboxContextImpl;
+    expect(() => {
+      ctx = sandbox.withAuth(frozenInput) as SandboxContextImpl;
+    }).not.toThrow();
+
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-secure',
+      token: {
+        role: 'admin',
+        firebase: {
+          sign_in_provider: 'password',
+          tenant: 'tenant-secure',
+        },
+      },
+    });
+
+    // Input remains frozen and unaltered
+    expect(Object.isFrozen(frozenInput)).toBe(true);
+    expect(Object.isFrozen(frozenInput.token)).toBe(true);
+    expect(Object.isFrozen(frozenInput.token.firebase)).toBe(true);
+    expect('tenant' in frozenInput.token.firebase).toBe(false);
+  });
+
+  it('resists tampering with input object after withAuth call', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_PATH_ISOLATED);
+
+    const mutableToken: Record<string, any> = {
+      firebase: { sign_in_provider: 'google.com' },
+      plan: 'free',
+    };
+    const mutableAuth: { uid: string; tenant: string; token: Record<string, any> } = {
+      uid: 'alice',
+      tenant: 'tenant-alpha',
+      token: mutableToken,
+    };
+
+    const aliceHandle = actingAs(sandbox, mutableAuth);
+    const ctx = sandbox.withAuth(mutableAuth);
+
+    // Caller maliciously tampers with their original object afterwards
+    mutableAuth.uid = 'hacked-uid';
+    mutableAuth.tenant = 'tenant-hacked';
+    mutableToken.plan = 'enterprise';
+    mutableToken.firebase.tenant = 'tenant-hacked';
+    mutableToken.firebase.sign_in_provider = 'anonymous';
+
+    // Context auth must be completely untouched
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-alpha',
+      token: {
+        firebase: {
+          sign_in_provider: 'google.com',
+          tenant: 'tenant-alpha',
+        },
+        plan: 'free',
+      },
+    });
+
+    // Firestore rule evaluation must use the original un-tampered identity
+    await expect(
+      setDoc(doc(aliceHandle, 'tenants/tenant-alpha/records/r1'), { data: 'safe' }),
+    ).resolves.toBeUndefined();
+
+    // Denied on the tampered tenant
+    await expect(
+      setDoc(doc(aliceHandle, 'tenants/tenant-hacked/records/r1'), { data: 'exploit' }),
+    ).rejects.toThrow();
+  });
+
+  it('guarantees context chaining independence (no state bleed)', () => {
+    const sandbox = initializeSandbox();
+
+    const ctx1 = sandbox.withAuth({ uid: 'user1', tenant: 'tenant-1' });
+    const ctx2 = ctx1.withAuth({ uid: 'user2', tenant: 'tenant-2' });
+    const ctx3 = ctx2.withAuth({ uid: 'user3' }); // non-tenant
+    const ctx4 = ctx3.withAuth(null); // anon
+
+    expect(ctx1.auth).toEqual({
+      uid: 'user1',
+      tenant: 'tenant-1',
+      token: { firebase: { tenant: 'tenant-1' } },
+    });
+    expect(ctx2.auth).toEqual({
+      uid: 'user2',
+      tenant: 'tenant-2',
+      token: { firebase: { tenant: 'tenant-2' } },
+    });
+    expect(ctx3.auth).toEqual({ uid: 'user3' });
+    expect('tenant' in (ctx3.auth ?? {})).toBe(false);
+    expect('token' in (ctx3.auth ?? {})).toBe(false);
+    expect(ctx4.auth).toBeNull();
+  });
+});
+
+describe('Adversarial Stress: 4. Explicit Nested Token Override Precedence', () => {
+  it('token.firebase.tenant strictly wins over top-level tenant in context and rules', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_PATH_ISOLATED);
+
+    const conflictingIdentity = {
+      uid: 'charlie',
+      tenant: 'tenant-declared-bar',
+      token: {
+        firebase: {
+          tenant: 'tenant-override-foo',
+          identities: { 'google.com': ['12345'] },
+        },
+        tier: 'gold',
+      },
+    };
+
+    const ctx = sandbox.withAuth(conflictingIdentity);
+
+    // ctx.auth retains top-level tenant field but token.firebase.tenant is the override
+    expect(ctx.auth?.tenant).toBe('tenant-declared-bar');
+    expect((ctx.auth?.token?.firebase as any)?.tenant).toBe('tenant-override-foo');
+    expect((ctx.auth?.token?.firebase as any)?.identities).toEqual({ 'google.com': ['12345'] });
+    expect(ctx.auth?.token?.tier).toBe('gold');
+
+    // Rule evaluation check:
+    const handle = actingAs(sandbox, conflictingIdentity);
+
+    // Must be ALLOWED on override tenant
+    await expect(
+      setDoc(doc(handle, 'tenants/tenant-override-foo/records/doc1'), { test: 1 }),
+    ).resolves.toBeUndefined();
+
+    // Must be DENIED on top-level tenant
+    await expect(
+      setDoc(doc(handle, 'tenants/tenant-declared-bar/records/doc1'), { test: 2 }),
+    ).rejects.toThrow();
+  });
+
+  it('empty string in explicit token.firebase.tenant is preserved over top-level tenant', () => {
+    const result = normalizeAuthState({
+      uid: 'david',
+      tenant: 'tenant-declared',
+      token: {
+        firebase: { tenant: '' },
+      },
+    });
+
+    // Explicit empty string in token.firebase.tenant is preserved (not overwritten by top-level tenant)
+    expect((result?.token?.firebase as any)?.tenant).toBe('');
+  });
+
+  it('explicit non-object firebase property in token is replaced with object containing tenant', () => {
+    const result = normalizeAuthState({
+      uid: 'david',
+      tenant: 'tenant-declared',
+      // @ts-expect-error — testing non-standard token shape
+      token: {
+        firebase: 'invalid-string-firebase',
+      },
+    });
+
+    expect(result?.token?.firebase).toEqual({ tenant: 'tenant-declared' });
+  });
+
+  it('explicit array firebase property in token is replaced with object containing tenant', () => {
+    const result = normalizeAuthState({
+      uid: 'david',
+      tenant: 'tenant-declared',
+      // @ts-expect-error — testing non-standard token shape
+      token: {
+        firebase: ['not', 'an', 'object'],
+      },
+    });
+
+    expect(result?.token?.firebase).toEqual({ tenant: 'tenant-declared' });
+  });
+});
+
+describe('Adversarial Stress: 5. Clean Non-Tenant Identity', () => {
+  it('strictly contains only uid when only uid is provided', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({ uid: 'plain-alice' });
+
+    expect(ctx.auth).toEqual({ uid: 'plain-alice' });
+    expect(Object.keys(ctx.auth ?? {})).toEqual(['uid']);
+    expect('tenant' in (ctx.auth ?? {})).toBe(false);
+    expect('token' in (ctx.auth ?? {})).toBe(false);
+
+    expect(ctx.operationContext.authLens).toEqual({
+      mode: 'as',
+      uid: 'plain-alice',
+    });
+    expect('tenant' in ctx.operationContext.authLens).toBe(false);
+    expect('token' in ctx.operationContext.authLens).toBe(false);
+  });
+
+  it('does not synthesize firebase or tenant in token when custom claims exist without tenant', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({
+      uid: 'plain-bob',
+      token: { role: 'editor', dept: 'eng' },
+    });
+
+    expect(ctx.auth).toEqual({
+      uid: 'plain-bob',
+      token: { role: 'editor', dept: 'eng' },
+    });
+    expect('tenant' in (ctx.auth ?? {})).toBe(false);
+    expect('firebase' in (ctx.auth?.token ?? {})).toBe(false);
+  });
+
+  it('denies access to tenant-isolated rules when identity is non-tenant', async () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, TENANT_PATH_ISOLATED);
+
+    const nonTenantUser = actingAs(sandbox, { uid: 'plain-charlie' });
+    await expect(
+      setDoc(doc(nonTenantUser, 'tenants/any-tenant/records/doc1'), { test: 1 }),
+    ).rejects.toThrow();
+  });
+
+  it('anonymous identity (null) has null auth and anon lens', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth(null);
+
+    expect(ctx.auth).toBeNull();
+    expect(ctx.operationContext.authLens).toEqual({ mode: 'anon' });
+  });
+});
+
+describe('Adversarial Stress: 6. Object.create(null) & Prototype Pollution', () => {
+  it('handles auth created via Object.create(null)', () => {
+    const sandbox = initializeSandbox();
+    const bareAuth: any = Object.create(null);
+    bareAuth.uid = 'bare-uid';
+    bareAuth.tenant = 'bare-tenant';
+
+    const ctx = sandbox.withAuth(bareAuth);
+    expect(ctx.auth?.uid).toBe('bare-uid');
+    expect(ctx.auth?.tenant).toBe('bare-tenant');
+    expect((ctx.auth?.token?.firebase as any)?.tenant).toBe('bare-tenant');
+  });
+
+  it('does not pollute Object prototype', () => {
+    const sandbox = initializeSandbox();
+    sandbox.withAuth({
+      uid: 'attacker',
+      tenant: 'tenant-evil',
+      token: {
+        // @ts-expect-error — testing prototype pollution
+        __proto__: { polluted: true },
+      },
+    });
+
+    expect((Object.prototype as any).polluted).toBeUndefined();
+    expect(({} as any).polluted).toBeUndefined();
+  });
+});
+
+describe('Adversarial Stress: 7. Host Lens and Cache Key Edge Cases', () => {
+  it('lensForAuth and authStateForLens round-trip identity with tenant', () => {
+    const authWithTenant: AuthState = {
+      uid: 'alice',
+      tenant: 'tenant-t1',
+      token: { role: 'admin' },
+    };
+    const lens = lensForAuth(authWithTenant);
+    expect(lens).toEqual({
+      mode: 'as',
+      uid: 'alice',
+      tenant: 'tenant-t1',
+      token: { role: 'admin' },
+    });
+
+    const recoveredAuth = authStateForLens(lens as Extract<typeof lens, { mode: 'as' }>);
+    expect(recoveredAuth).toEqual(authWithTenant);
+  });
+
+  it('characterizes lensCacheKey collision boundary (Finding)', () => {
+    // Lens 1: User with uid containing colon and 'tenant:' prefix
+    const lens1 = {
+      mode: 'as' as const,
+      uid: 'user:tenant:alpha',
+    };
+
+    // Lens 2: User with uid 'user' and tenant 'alpha'
+    const lens2 = {
+      mode: 'as' as const,
+      uid: 'user',
+      tenant: 'alpha',
+    };
+
+    const key1 = lensCacheKey(lens1);
+    const key2 = lensCacheKey(lens2);
+
+    // Both join with ':' resulting in 'user:tenant:alpha'
+    expect(key1).toBe('user:tenant:alpha');
+    expect(key2).toBe('user:tenant:alpha');
+    expect(key1).toBe(key2); // Collision characterized
+  });
+});

--- a/packages/pyric/test/sandbox/sandbox.test.ts
+++ b/packages/pyric/test/sandbox/sandbox.test.ts
@@ -11,6 +11,7 @@ import {
   initializeSandbox,
   SandboxContextImpl,
   SandboxError,
+  normalizeAuthState,
   type Sandbox,
 } from '../../src/sandbox/index.js';
 
@@ -89,6 +90,169 @@ describe('Sandbox.withAuth', () => {
     }
     expect(err).toBeInstanceOf(SandboxError);
     expect((err as SandboxError).code).toBe('invalid-argument');
+  });
+
+  it('normalizes top-level tenant into token.firebase.tenant', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({ uid: 'alice', tenant: 'tenant-123' });
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-123',
+      token: {
+        firebase: { tenant: 'tenant-123' },
+      },
+    });
+    expect(ctx.operationContext.authLens).toEqual({
+      mode: 'as',
+      uid: 'alice',
+      tenant: 'tenant-123',
+      token: {
+        firebase: { tenant: 'tenant-123' },
+      },
+    });
+  });
+
+  it('preserves custom claims alongside tenant in token', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({
+      uid: 'alice',
+      tenant: 'tenant-123',
+      token: { role: 'admin', tier: 'enterprise' },
+    });
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-123',
+      token: {
+        role: 'admin',
+        tier: 'enterprise',
+        firebase: { tenant: 'tenant-123' },
+      },
+    });
+  });
+
+  it('preserves explicit nested token.firebase.tenant over top-level tenant', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({
+      uid: 'alice',
+      tenant: 'tenant-top',
+      token: {
+        firebase: { tenant: 'tenant-override', sign_in_provider: 'google.com' },
+      },
+    });
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-top',
+      token: {
+        firebase: { tenant: 'tenant-override', sign_in_provider: 'google.com' },
+      },
+    });
+  });
+
+  it('preserves explicit non-tenant firebase sub-claims while adding tenant', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({
+      uid: 'alice',
+      tenant: 'tenant-alpha',
+      token: {
+        firebase: { sign_in_provider: 'password' },
+      },
+    });
+    expect(ctx.auth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-alpha',
+      token: {
+        firebase: { sign_in_provider: 'password', tenant: 'tenant-alpha' },
+      },
+    });
+  });
+
+  it('does not synthesize empty firebase or tenant when tenant is omitted', () => {
+    const sandbox = initializeSandbox();
+    const ctx = sandbox.withAuth({ uid: 'alice' });
+    expect(ctx.auth).toEqual({ uid: 'alice' });
+    expect('tenant' in (ctx.auth ?? {})).toBe(false);
+    expect('token' in (ctx.auth ?? {})).toBe(false);
+  });
+
+  it('does not mutate caller input objects', () => {
+    const sandbox = initializeSandbox();
+    const inputToken = { role: 'editor' };
+    const inputAuth = { uid: 'alice', tenant: 'tenant-xyz', token: inputToken };
+
+    const ctx = sandbox.withAuth(inputAuth);
+
+    // Input object and nested token remain unmodified
+    expect(inputToken).toEqual({ role: 'editor' });
+    expect('firebase' in inputToken).toBe(false);
+    expect(inputAuth).toEqual({
+      uid: 'alice',
+      tenant: 'tenant-xyz',
+      token: { role: 'editor' },
+    });
+
+    // Mutating inputToken afterwards does not affect context
+    inputToken.role = 'tampered';
+    expect((ctx.auth?.token as Record<string, unknown>).role).toBe('editor');
+  });
+
+  it('throws when tenant is empty string or non-string', () => {
+    const sandbox = initializeSandbox();
+    expect(() => {
+      sandbox.withAuth({ uid: 'alice', tenant: '' });
+    }).toThrow(SandboxError);
+
+    expect(() => {
+      // @ts-expect-error — exercising bad argument
+      sandbox.withAuth({ uid: 'alice', tenant: 123 });
+    }).toThrow(SandboxError);
+  });
+});
+
+describe('normalizeAuthState', () => {
+  it('returns null when input is null', () => {
+    expect(normalizeAuthState(null)).toBeNull();
+  });
+
+  it('leaves non-tenant auth intact without synthesizing firebase token', () => {
+    const result = normalizeAuthState({ uid: 'bob' });
+    expect(result).toEqual({ uid: 'bob' });
+    expect('tenant' in (result ?? {})).toBe(false);
+    expect('token' in (result ?? {})).toBe(false);
+  });
+
+  it('clones token on non-tenant auth to guarantee isolation', () => {
+    const token = { admin: true };
+    const result = normalizeAuthState({ uid: 'admin', token });
+    expect(result).toEqual({ uid: 'admin', token: { admin: true } });
+    expect(result?.token).not.toBe(token);
+  });
+
+  it('projects tenant to token.firebase.tenant when tenant is provided', () => {
+    const result = normalizeAuthState({ uid: 'carol', tenant: 'tenant-acme' });
+    expect(result).toEqual({
+      uid: 'carol',
+      tenant: 'tenant-acme',
+      token: {
+        firebase: { tenant: 'tenant-acme' },
+      },
+    });
+  });
+
+  it('explicit nested token.firebase.tenant overrides top-level tenant', () => {
+    const result = normalizeAuthState({
+      uid: 'carol',
+      tenant: 'tenant-acme',
+      token: {
+        firebase: { tenant: 'explicit-override', provider: 'saml' },
+      },
+    });
+    expect(result).toEqual({
+      uid: 'carol',
+      tenant: 'tenant-acme',
+      token: {
+        firebase: { tenant: 'explicit-override', provider: 'saml' },
+      },
+    });
   });
 });
 


### PR DESCRIPTION
Adds `tenant?: string` to `AuthState` and `AuthLens`, automatically projecting `request.auth.token.firebase.tenant` into Security Rules evaluation contexts without manual claim nesting.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { actingAs, doc, getDoc } from 'pyric/firestore';

const sandbox = initializeSandbox();

// Rules: allow read: if request.auth.token.firebase.tenant == 'tenant-alpha';
const user = actingAs(sandbox, { uid: 'alice', tenant: 'tenant-alpha' });
const snap = await getDoc(doc(user, 'organizations/tenant-alpha/data/report'));
console.log(snap.data());
```

### Stack
- **#546 (This PR: Base)**: Priority formalization & tenant token normalization
  - ↳ #548 (PR 3: Stacked on #546): Runtime chip impersonation modal & transport hydration
- #547 (PR 2: Headless Modal primitive in `@pyric/ui/primitives` - independent)

## `request.auth.token.firebase.tenant` is automatically projected from tenant identity

Previously, multi-tenant Security Rules that inspect `request.auth.token.firebase.tenant` evaluated to `null` unless callers manually constructed nested dictionary claims (`{ token: { firebase: { tenant: '...' } } }`). 

This change introduces an explicit, top-level `tenant` property to `AuthState` and `AuthLens`. During context assembly in `SandboxContextImpl`, top-level `tenant` values are projected into `token.firebase.tenant`, preserving existing custom claims and giving precedence to explicit nested overrides.

## Formalized repo priority in PRIORITIES.md

Formalized the `## Multi-tenancy and Impersonation` priority with its one-sentence test:
> *Does this make it possible or materially easier for a developer to verify multi-tenant data boundaries and impersonate end-user security contexts during local development?*

## Risk

Low. Single-tenant identities omitting `tenant` continue to produce unnested tokens without synthetic claims. Explicit nested overrides (`token.firebase.tenant`) are preserved without mutation.

<details>
<summary>Implementation notes</summary>

- Verified with 86 adversarial stress tests and 14 multi-tenant rules challenge tests.
- Deep freeze immutability enforced on caller auth objects.
- All CI test suites pass cleanly (`bun test scripts/ci/`, 27/27 pass).

</details>
