### PR TITLE
fix: close the Firebase subpath cliff, redact leaked API keys, harden CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,33 @@ jobs:
       predicted-check-set: ${{ steps.plan.outputs.predicted-check-set }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Fetch PR endpoints and resolve merge base
+        # plan.ts diffs base...head (git's triple-dot / merge-base form) so
+        # check-set.ts only sees files the PR itself introduces, not whatever
+        # moved on the base branch since the fork point. A depth-1 checkout
+        # has neither base.sha nor head.sha as fetchable objects (both are
+        # ancestors of the synthetic merge commit actions/checkout resolves
+        # for pull_request events), so fetch them directly by SHA, then widen
+        # only as far as needed to reach a common ancestor. Same self-heal
+        # shape as resolve_base() in scripts/ci/conformance-coupling-gate.sh:
+        # most PRs resolve after one or two small deepenings instead of
+        # paying for the whole repository's history on every run.
+        if: github.event_name == 'pull_request'
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$CI_BASE_SHA" "$CI_HEAD_SHA"
+          depth=50
+          until git merge-base "$CI_BASE_SHA" "$CI_HEAD_SHA" >/dev/null 2>&1; do
+            if [ "$depth" -gt 6400 ]; then
+              git fetch --no-tags --unshallow origin
+              break
+            fi
+            git fetch --no-tags --deepen="$depth" origin
+            depth=$((depth * 4))
+          done
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
@@ -65,8 +90,31 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Fetch PR endpoints and resolve merge base
+        # Same rationale and self-heal shape as the `plan` job's identically
+        # named step: knip-audit.ts also diffs base...head (falling back to
+        # origin/main...HEAD, then to "no changed paths") purely to bucket
+        # findings into PR-introduced vs. legacy. It's advisory and
+        # continue-on-error, so a resolution failure here just degrades the
+        # bucketing, but resolving it properly is nearly free and keeps the
+        # audit's PR/legacy split accurate without cloning full history.
+        if: github.event_name == 'pull_request'
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$CI_BASE_SHA" "$CI_HEAD_SHA"
+          depth=50
+          until git merge-base "$CI_BASE_SHA" "$CI_HEAD_SHA" >/dev/null 2>&1; do
+            if [ "$depth" -gt 6400 ]; then
+              git fetch --no-tags --unshallow origin
+              break
+            fi
+            git fetch --no-tags --deepen="$depth" origin
+            depth=$((depth * 4))
+          done
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
   plan:
     name: Select required proof
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       check-set: ${{ steps.plan.outputs.check-set }}
       predicted-check-set: ${{ steps.plan.outputs.predicted-check-set }}
@@ -58,6 +59,7 @@ jobs:
   knip-audit:
     name: Advisory Knip audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: plan
     if: needs.plan.outputs.check-set == 'full'
     continue-on-error: true
@@ -93,6 +95,7 @@ jobs:
   build-packages:
     name: Build workspace packages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: plan
     if: needs.plan.outputs.check-set == 'full'
     steps:
@@ -143,6 +146,7 @@ jobs:
   build-and-test:
     name: Build all packages + run tests (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     strategy:
@@ -184,6 +188,7 @@ jobs:
   library-tests:
     name: Run library + UI tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
@@ -224,6 +229,7 @@ jobs:
   conformance-suite:
     name: Conformance suite
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
@@ -255,6 +261,7 @@ jobs:
   browser-conformance:
     name: Served app + SharedWorker conformance
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
@@ -326,6 +333,7 @@ jobs:
   release-contract:
     name: Release wrapper contract
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: plan
     if: needs.plan.outputs.predicted-check-set == 'release-only'
     steps:
@@ -338,6 +346,7 @@ jobs:
   conformance-gates:
     name: Conformance gates
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [plan, build-packages]
     if: needs.plan.outputs.check-set == 'full'
     steps:
@@ -387,6 +396,7 @@ jobs:
   packaging:
     name: Packaging gate (pack + install + subpath resolution)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: plan
     # Cost: the publish-shape gate runs only when the PR carries the
     # `ci-packaging` label (apply it on release PRs or ones touching package
@@ -450,6 +460,7 @@ jobs:
   install-matrix:
     name: Install matrix (${{ matrix.pm }})
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [plan, packaging]
     # Cost: same as `packaging`, only runs under the `ci-packaging` label.
     if: needs.plan.outputs.check-set == 'full' && contains(github.event.pull_request.labels.*.name, 'ci-packaging')
@@ -507,6 +518,7 @@ jobs:
   standalone:
     name: Standalone binary smoke (compile + vendor)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: plan
     # Cost: compiling a host-target binary is heavy (~100 MB executable), so
     # this runs under the same `ci-packaging` label policy as `packaging` —
@@ -556,6 +568,7 @@ jobs:
   required:
     name: CI / required
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
     needs: [plan, build-packages, build-and-test, library-tests, conformance-suite, browser-conformance, conformance-gates, release-contract, packaging, install-matrix, standalone]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,16 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
 
@@ -91,6 +101,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install
         # Playground carries Firebase deployment tooling for local demos. None
@@ -136,6 +156,16 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
 
@@ -162,6 +192,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
@@ -191,6 +231,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
       - uses: ./.github/actions/restore-dist
@@ -213,6 +263,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
@@ -289,6 +349,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
       - name: Configure job-local surface census cache
@@ -328,6 +398,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - uses: actions/setup-node@v4
         with:
@@ -389,6 +469,16 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22.15'
@@ -429,6 +519,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/oracle-recapture.yml
+++ b/.github/workflows/oracle-recapture.yml
@@ -60,6 +60,7 @@ jobs:
   unattended:
     name: Unattended rigs (installed-SDK probes)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -90,6 +91,7 @@ jobs:
   credentialed:
     name: Credentialed rig (${{ matrix.rig }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       # One rig's drift or absent secret must not cancel the others.
       fail-fast: false

--- a/.github/workflows/oracle-recapture.yml
+++ b/.github/workflows/oracle-recapture.yml
@@ -65,6 +65,15 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         run: bun install --frozen-lockfile --filter '!@pyric/playground'
       - name: Re-capture admin-app observations
@@ -120,6 +129,18 @@ jobs:
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      # Gated like Install itself: no point restoring/saving a cache for a
+      # leg that skips installing because its secret is absent.
+      - name: Cache Bun dependencies
+        if: steps.secret-check.outputs.available == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         if: steps.secret-check.outputs.available == 'true'
         run: bun install --frozen-lockfile --filter '!@pyric/playground'

--- a/.github/workflows/playground-contract.yml
+++ b/.github/workflows/playground-contract.yml
@@ -40,6 +40,7 @@ jobs:
   playground-caniuse:
     name: Playground can-i-use browser contract
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/playground-contract.yml
+++ b/.github/workflows/playground-contract.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install browser workspace
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/simulator-parity.yml
+++ b/.github/workflows/simulator-parity.yml
@@ -37,6 +37,7 @@ jobs:
   simulator-tests:
     name: Unit suite
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -63,6 +64,7 @@ jobs:
   parity-stress:
     name: Parity stress (live Rules Test API)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     # Don't fail external-contributor PRs that can't access the secret.
     # When PARITY_SA_BASE64 is empty the test steps short-circuit and the
     # job reports success with a clear log line. (Restored per

--- a/.github/workflows/simulator-parity.yml
+++ b/.github/workflows/simulator-parity.yml
@@ -42,6 +42,15 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.11'
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         run: bun install --frozen-lockfile
       - name: Build pyric
@@ -76,6 +85,18 @@ jobs:
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
+      # Bun re-downloads every dependency from the registry without this;
+      # persisting its install cache lets `bun install` reuse prior downloads.
+      # Gated like Install itself: no point restoring/saving a cache for a
+      # run that skips installing because its secret is absent.
+      - name: Cache Bun dependencies
+        if: steps.secret-check.outputs.available == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - name: Install
         if: steps.secret-check.outputs.available == 'true'
         run: bun install --frozen-lockfile --filter pyric

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@pyric/cli": "workspace:*",
         "@types/bun": "1.3.14",
         "bun-types": "1.3.14",
-        "firebase": "^12.12.0",
+        "firebase": "12.13.0",
         "firebase-admin": "^13.0.0",
         "knip": "^6.22.0",
         "mdast-util-from-markdown": "^2.0.3",
@@ -393,7 +393,7 @@
     },
   },
   "overrides": {
-    "firebase": "^12.12.0",
+    "firebase": "12.13.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/bun.lock
+++ b/bun.lock
@@ -393,7 +393,7 @@
     },
   },
   "overrides": {
-    "firebase": "12.13.0",
+    "firebase": "^12.12.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -2678,9 +2678,9 @@
 
     "planck": ["planck@1.5.0", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g=="],
 
-    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
 
-    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
@@ -3438,8 +3438,6 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
 
-    "@playwright/test/playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
-
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "@pyric/site-docs/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
@@ -3629,8 +3627,6 @@
     "nearley/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "nextjs-sandbox-app/@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -3827,10 +3823,6 @@
     "@jimp/core/file-type/token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "@opentui/core/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "@playwright/test/playwright/playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
 
     "@pyric/studio/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "examples/inpage-todo-app"
   ],
   "overrides": {
-    "firebase": "12.13.0"
+    "firebase": "$firebase"
   },
   "scripts": {
     "build": "bash scripts/build.sh",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@pyric/cli": "workspace:*",
     "@types/bun": "1.3.14",
     "bun-types": "1.3.14",
-    "firebase": "^12.12.0",
+    "firebase": "12.13.0",
     "firebase-admin": "^13.0.0",
     "knip": "^6.22.0",
     "mdast-util-from-markdown": "^2.0.3",

--- a/packages/cli/src/next/runtime-env.ts
+++ b/packages/cli/src/next/runtime-env.ts
@@ -12,6 +12,11 @@ export function augmentRuntimeEnv(config: NextConfigObject, options?: PyricNextO
   const updatedConfig: NextConfigObject = Object.assign({}, config);
   const existingEnv = updatedConfig.env !== undefined ? Object.assign({}, updatedConfig.env) : {};
   const chipValue = runtimeChipMetaValue(options.runtimeChip);
+  // Next.js only inlines `.env`-sourced values into the browser bundle when the
+  // key carries the `NEXT_PUBLIC_` prefix, so client components must read the
+  // prefixed name. The unprefixed name is kept for backwards compatibility with
+  // any existing server-side or bundler-level readers of `PYRIC_RUNTIME_CHIP`.
+  existingEnv.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP = chipValue;
   existingEnv.PYRIC_RUNTIME_CHIP = chipValue;
   updatedConfig.env = existingEnv;
   return updatedConfig;

--- a/packages/cli/src/serve/runtime/chip-config.ts
+++ b/packages/cli/src/serve/runtime/chip-config.ts
@@ -17,8 +17,22 @@ interface RuntimeChipDocument {
   querySelector(selector: string): { getAttribute(name: string): string | null } | null;
 }
 
+/** Read the browser-inlined chip value, preferring the `NEXT_PUBLIC_`-prefixed
+ * name (the only one Next.js is guaranteed to expose to client bundles) and
+ * falling back to the unprefixed name for other bundlers/back-compat. */
+function bundlerRuntimeChipValue(): string | undefined {
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') return undefined;
+  if (typeof process.env.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP === 'string') {
+    return process.env.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP;
+  }
+  if (typeof process.env.PYRIC_RUNTIME_CHIP === 'string') {
+    return process.env.PYRIC_RUNTIME_CHIP;
+  }
+  return undefined;
+}
+
 function hasBundlerRuntimeChipConfig(): boolean {
-  return typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.PYRIC_RUNTIME_CHIP === 'string';
+  return bundlerRuntimeChipValue() !== undefined;
 }
 
 /** Read plugin-authored values from DOM metadata or bundler environment variables, defaulting to collapsed UI when omitted. */
@@ -31,7 +45,7 @@ export function readPyricRuntimeChipConfig(
 
   const shouldFallbackToEnv = !hasMetaTag && hasBundlerRuntimeChipConfig();
   if (shouldFallbackToEnv) {
-    value = process.env.PYRIC_RUNTIME_CHIP as string;
+    value = bundlerRuntimeChipValue() as string;
   }
   if (value === 'off') {
     return null;

--- a/packages/cli/test/serve/runtime/chip-config.test.ts
+++ b/packages/cli/test/serve/runtime/chip-config.test.ts
@@ -36,4 +36,19 @@ describe('Pyric runtime chip configuration', () => {
     delete process.env.PYRIC_RUNTIME_CHIP;
     expect(readPyricRuntimeChipConfig(emptyDoc)).toEqual({ initiallyOpen: false, studioEnabled: true });
   });
+
+  it('prefers the NEXT_PUBLIC_-prefixed environment variable over the unprefixed one', () => {
+    const emptyDoc = { querySelector: () => null };
+
+    process.env.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP = 'expanded';
+    delete process.env.PYRIC_RUNTIME_CHIP;
+    expect(readPyricRuntimeChipConfig(emptyDoc)).toEqual({ initiallyOpen: true, studioEnabled: true });
+
+    process.env.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP = 'off';
+    process.env.PYRIC_RUNTIME_CHIP = 'expanded';
+    expect(readPyricRuntimeChipConfig(emptyDoc)).toBeNull();
+
+    delete process.env.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP;
+    delete process.env.PYRIC_RUNTIME_CHIP;
+  });
 });

--- a/packages/cli/test/unit/next/with-pyric.test.ts
+++ b/packages/cli/test/unit/next/with-pyric.test.ts
@@ -183,4 +183,12 @@ describe('withPyric Next.js configuration wrapper', () => {
     const resOpen = withPyric({}, { runtimeChip: { initiallyOpen: true } }) as Record<string, any>;
     expect(resOpen.env?.PYRIC_RUNTIME_CHIP).toBe('expanded');
   });
+
+  it('also configures the NEXT_PUBLIC_-prefixed runtime chip variable so browser client components can read it', () => {
+    const resOff = withPyric({}, { runtimeChip: false }) as Record<string, any>;
+    expect(resOff.env?.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP).toBe('off');
+
+    const resOpen = withPyric({}, { runtimeChip: { initiallyOpen: true } }) as Record<string, any>;
+    expect(resOpen.env?.NEXT_PUBLIC_PYRIC_RUNTIME_CHIP).toBe('expanded');
+  });
 });

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -61,7 +61,12 @@ packages/conformance/
                      DELETING a baselined registry row. The coverage ratchet
                      fails on any baseline row that disappears — whatever its
                      status — unless it is listed here, so a `bug` row can never
-                     be quietly dropped to shrink the denominator.
+                     be quietly dropped to shrink the denominator. Each entry is
+                     a grant for ONE removal: it must be baselined and actually
+                     gone from the registry, and the ratchet fails on any entry
+                     that is stale (row still present, or an id the baseline
+                     never had). Delete the entry in the PR that spends it —
+                     a leftover grant silently pre-authorizes the next deletion.
   rules-language/    the per-engine Rules-language axis. One hand-enumerated
                      construct snapshot per engine (firestore.json, storage.json,
                      rtdb.json). Coverage and simulator capability are derived in

--- a/packages/conformance/src/coverage.ts
+++ b/packages/conformance/src/coverage.ts
@@ -371,7 +371,14 @@ export type RowRemovalAllowlist = Record<string, RowRemoval>;
 
 export function loadRowRemovalAllowlist(path: string = ROW_REMOVAL_ALLOWLIST_PATH): RowRemovalAllowlist {
   if (!existsSync(path)) return {};
-  const allowlist = JSON.parse(readFileSync(path, 'utf8')) as RowRemovalAllowlist;
+  let allowlist: RowRemovalAllowlist;
+  try {
+    allowlist = JSON.parse(readFileSync(path, 'utf8')) as RowRemovalAllowlist;
+  } catch (err) {
+    // A raw SyntaxError names neither the file nor the gate; this hatch is
+    // hand-authored, so the reader needs to be told exactly what to fix.
+    throw new Error(`Row-removal allowlist at ${path} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
   for (const [id, entry] of Object.entries(allowlist)) {
     if (typeof entry?.reason !== 'string' || entry.reason.trim() === '') {
       throw new Error(`Row-removal allowlist entry '${id}' needs a non-empty reason`);
@@ -453,6 +460,21 @@ export function findRegressions(
     }
     if (prevStatus === 'conforms' && CONFORMING_DEMOTION.has(currentStatus)) {
       problems.push(`${id}: was 'conforms', now '${currentStatus}'`);
+    }
+  }
+
+  // An allowlist entry is a grant for ONE removal, not a standing permission.
+  // Left behind after the removal lands (or the row's later re-addition), it
+  // silently pre-authorizes deleting that row again — the reviewer who approved
+  // the original reason never saw the second deletion. So every entry must be
+  // EXERCISED right now: named in the baseline and gone from the registry.
+  // Anything else is dead configuration and has to be deleted from the file.
+  for (const id of Object.keys(allowedRowRemovals)) {
+    if (report.rowStatuses[id] !== undefined) {
+      problems.push(`allowlist entry '${id}' is stale: row present in registry`);
+    }
+    if (baseline.rowStatuses[id] === undefined) {
+      problems.push(`allowlist entry '${id}' is stale: id not in baseline`);
     }
   }
 

--- a/packages/conformance/test/src/coverage.test.ts
+++ b/packages/conformance/test/src/coverage.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   findRegressions,
   loadRowRemovalAllowlist,
@@ -116,17 +119,66 @@ describe('findRegressions — removal allowlist (the reviewed escape hatch)', ()
 
   test('an allowlist entry never excuses a status flip off conforms', () => {
     const problems = regressions({ 'auth#2': 'conforms' }, { 'auth#2': 'bug' }, { 'auth#2': { reason: 'surface retired' } });
-    expect(problems).toEqual(["auth#2: was 'conforms', now 'bug'"]);
-  });
-
-  test('an allowlist entry for a row that is still present changes nothing', () => {
-    const problems = regressions({ 'firestore#1': 'bug' }, { 'firestore#1': 'bug' }, { 'firestore#1': { reason: 'planned' } });
-    expect(problems).toEqual([]);
+    expect(problems).toEqual([
+      "auth#2: was 'conforms', now 'bug'",
+      "allowlist entry 'auth#2' is stale: row present in registry",
+    ]);
   });
 
   test('an empty allowlist permits no removals', () => {
     expect(regressions({ 'firestore#1': 'bug' }, {}, {})).toEqual([
       "firestore#1: was 'bug', row removed from the registry",
+    ]);
+  });
+});
+
+/**
+ * A grant is spent when its removal lands. Leaving it in the file turns a
+ * one-time, reviewed deletion into a permanent licence to delete that row
+ * again — including a row someone re-added in the meantime, whose second
+ * deletion no reviewer ever saw.
+ */
+describe('findRegressions — allowlist entries must be exercised, not standing', () => {
+  test('an entry for a row that is still in the registry is stale', () => {
+    const problems = regressions({ 'firestore#1': 'bug' }, { 'firestore#1': 'bug' }, { 'firestore#1': { reason: 'planned' } });
+    expect(problems).toEqual(["allowlist entry 'firestore#1' is stale: row present in registry"]);
+  });
+
+  test('an entry for a row that was removed and later re-added is stale', () => {
+    const problems = regressions(
+      { 'firestore#1': 'bug' },
+      { 'firestore#1': 'conforms' },
+      { 'firestore#1': { reason: 'row folded into firestore#9' } },
+    );
+    expect(problems).toEqual(["allowlist entry 'firestore#1' is stale: row present in registry"]);
+  });
+
+  test('an entry naming an id the baseline never had is stale', () => {
+    const problems = regressions({ 'auth#2': 'conforms' }, { 'auth#2': 'conforms' }, { 'typo#404': { reason: 'mis-typed id' } });
+    expect(problems).toEqual(["allowlist entry 'typo#404' is stale: id not in baseline"]);
+  });
+
+  test('an entry unknown to both baseline and registry reports both faults', () => {
+    const problems = regressions({}, { 'ghost#1': 'bug' }, { 'ghost#1': { reason: 'stale grant' } });
+    expect(problems).toEqual([
+      "allowlist entry 'ghost#1' is stale: row present in registry",
+      "allowlist entry 'ghost#1' is stale: id not in baseline",
+    ]);
+  });
+
+  test('an entry that is actually being exercised right now is clean', () => {
+    expect(regressions({ 'firestore#1': 'bug' }, {}, { 'firestore#1': { reason: 'row folded into firestore#9' } })).toEqual([]);
+  });
+
+  test('every stale entry is reported, one problem each', () => {
+    const problems = regressions(
+      { 'firestore#1': 'bug', 'auth#2': 'conforms' },
+      { 'firestore#1': 'bug', 'auth#2': 'conforms' },
+      { 'firestore#1': { reason: 'planned' }, 'auth#2': { reason: 'planned' } },
+    );
+    expect(problems).toEqual([
+      "allowlist entry 'firestore#1' is stale: row present in registry",
+      "allowlist entry 'auth#2' is stale: row present in registry",
     ]);
   });
 });
@@ -138,5 +190,40 @@ describe('loadRowRemovalAllowlist — committed file', () => {
       expect(typeof id).toBe('string');
       expect(entry.reason.trim().length).toBeGreaterThan(0);
     }
+  });
+
+  test('the committed allowlist is empty — no removal is currently granted', () => {
+    expect(loadRowRemovalAllowlist()).toEqual({});
+  });
+});
+
+describe('loadRowRemovalAllowlist — malformed input', () => {
+  const scratch: string[] = [];
+
+  afterAll(() => {
+    for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function allowlistFile(contents: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'row-removal-allowlist-'));
+    scratch.push(dir);
+    const path = join(dir, 'row-removal-allowlist.json');
+    writeFileSync(path, contents);
+    return path;
+  }
+
+  test('malformed JSON names the offending file instead of throwing a bare SyntaxError', () => {
+    const path = allowlistFile('{ "firestore#1": { "reason": "oops", }\n');
+    expect(() => loadRowRemovalAllowlist(path)).toThrow(path);
+    expect(() => loadRowRemovalAllowlist(path)).toThrow(/not valid JSON/);
+  });
+
+  test('an entry without a reason is still rejected', () => {
+    const path = allowlistFile('{ "firestore#1": { "reason": "  " } }');
+    expect(() => loadRowRemovalAllowlist(path)).toThrow(/needs a non-empty reason/);
+  });
+
+  test('an absent file grants nothing', () => {
+    expect(loadRowRemovalAllowlist(join(tmpdir(), 'no-such-row-removal-allowlist.json'))).toEqual({});
   });
 });

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/firestore/internal/value-codec.d.ts",
       "import": "./dist/firestore/internal/value-codec.js"
     },
+    "./firestore/lite": {
+      "types": "./dist/firestore/lite.d.ts",
+      "import": "./dist/firestore/lite.js"
+    },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js"
@@ -125,6 +129,26 @@
     "./sandbox/admin-firestore": {
       "types": "./dist/sandbox/admin-firestore/index.d.ts",
       "import": "./dist/sandbox/admin-firestore/index.js"
+    },
+    "./app-check": {
+      "types": "./dist/app-check/index.d.ts",
+      "import": "./dist/app-check/index.js"
+    },
+    "./functions": {
+      "types": "./dist/functions/index.d.ts",
+      "import": "./dist/functions/index.js"
+    },
+    "./analytics": {
+      "types": "./dist/analytics/index.d.ts",
+      "import": "./dist/analytics/index.js"
+    },
+    "./performance": {
+      "types": "./dist/performance/index.d.ts",
+      "import": "./dist/performance/index.js"
+    },
+    "./remote-config": {
+      "types": "./dist/remote-config/index.d.ts",
+      "import": "./dist/remote-config/index.js"
     }
   },
   "files": [

--- a/packages/pyric/src/ai/broker/gemini-engine.ts
+++ b/packages/pyric/src/ai/broker/gemini-engine.ts
@@ -10,7 +10,7 @@
  * without exposing secrets to the browser.
  */
 
-import { AiBrokerError, errorEnvelope } from './synthesizer.js';
+import { AiBrokerError, errorEnvelope, redactUrl } from './synthesizer.js';
 import type {
   AnswerEngine,
   CountTokensRequest,
@@ -169,9 +169,18 @@ export class GeminiEngine implements AnswerEngine {
         body: JSON.stringify(body),
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // Redact both: `url` always carries the key when auth is a static key
+      // (not bearer/ADC); `message` is defensively redacted too in case the
+      // fetch implementation's own error text echoes the request URL.
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      const safeUrl = redactUrl(url);
+      const safeMessage = redactUrl(rawMessage);
       throw new AiBrokerError(
-        errorEnvelope(502, `Failed to connect to Gemini API at ${url}: ${message}`, 'UNAVAILABLE'),
+        errorEnvelope(
+          502,
+          `Failed to connect to Gemini API at ${safeUrl}: ${safeMessage}`,
+          'UNAVAILABLE',
+        ),
       );
     }
 

--- a/packages/pyric/src/ai/broker/gemini-engine.ts
+++ b/packages/pyric/src/ai/broker/gemini-engine.ts
@@ -190,7 +190,7 @@ export class GeminiEngine implements AnswerEngine {
       throw new AiBrokerError(
         errorEnvelope(
           response.status,
-          `Gemini API returned status ${response.status}: ${errorText}`,
+          `Gemini API returned status ${response.status}: ${redactUrl(errorText)}`,
           'INTERNAL',
         ),
       );

--- a/packages/pyric/src/ai/broker/index.ts
+++ b/packages/pyric/src/ai/broker/index.ts
@@ -37,6 +37,7 @@ export {
   estimateTokens,
   mintThoughtSignature,
   mintFunctionCallId,
+  redactUrl,
   type SynthesizeOptions,
 } from './synthesizer.js';
 export type {

--- a/packages/pyric/src/ai/broker/openai-engine.ts
+++ b/packages/pyric/src/ai/broker/openai-engine.ts
@@ -29,6 +29,7 @@ import {
   Synthesizer,
   errorEnvelope,
   estimateTokens,
+  redactUrl,
   resolveModelVersion,
 } from './synthesizer.js';
 import { promptTextOf } from './scripted-engine.js';
@@ -627,8 +628,17 @@ export class OpenAiEngine implements AnswerEngine {
         body: JSON.stringify(body),
       });
     } catch (err) {
+      // The openai engine has no key-in-URL auth mechanism today
+      // (`OpenAiEngineOptions` carries no `apiKey`), but a caller-supplied
+      // `baseUrl` could embed a credential in its query string, and some
+      // fetch implementations echo the request URL into their error text —
+      // redact defensively at this choke point (T1.7).
       throw new AiBrokerError(
-        errorEnvelope(502, `openai engine: upstream fetch failed: ${String(err)}`, 'UNAVAILABLE'),
+        errorEnvelope(
+          502,
+          `openai engine: upstream fetch failed: ${redactUrl(String(err))}`,
+          'UNAVAILABLE',
+        ),
       );
     }
     if (!res.ok) {

--- a/packages/pyric/src/ai/broker/synthesizer.ts
+++ b/packages/pyric/src/ai/broker/synthesizer.ts
@@ -117,6 +117,40 @@ export function errorEnvelope(code: number, message: string, status: string): Wi
   return { error: { code, message, status } };
 }
 
+// ── URL redaction (T1.7) ─────────────────────────────────────────────────
+
+/**
+ * Query-param names that carry plaintext credentials on upstream REST
+ * requests (Google AI Studio's `?key=...` auth is the known case; the rest
+ * are defensive for sibling engines / future upstreams).
+ *
+ * Matched with a direct regex over the raw string rather than
+ * `new URL(...).searchParams` — the streaming action string embeds its own
+ * `?alt=sse` before the `?key=` is appended (a pre-existing, unrelated
+ * quirk this fix does not touch), which the strict `URLSearchParams` parser
+ * would fold into a single malformed pair and fail to redact. A regex on
+ * "`[?&]<param>=`" catches the value regardless of how the surrounding
+ * query string is (mal)formed.
+ */
+const SENSITIVE_URL_PARAM_PATTERN = /([?&](?:key|apiKey|api_key|access_token)=)[^&\s]*/gi;
+
+/**
+ * Redacts credential-bearing query-string VALUES from a URL (or any string
+ * that may embed one) before it lands in an error message or log line —
+ * e.g. `?key=AIza...` becomes `?key=***`. Host and path are preserved so
+ * the message stays useful for diagnosing connectivity failures; only the
+ * secret value is masked.
+ *
+ * Used at every choke point where an upstream request URL is interpolated
+ * into a thrown error or logged text, so a leaked key never reaches
+ * terminal output, CI logs, or Studio traffic captures. Safe to apply
+ * defensively to values that are not themselves URLs (e.g. a raw fetch
+ * error message) — it is a no-op when no sensitive param is present.
+ */
+export function redactUrl(url: string): string {
+  return url.replace(SENSITIVE_URL_PARAM_PATTERN, '$1***');
+}
+
 /** `ai-error-unknown-model` (404 NOT_FOUND), captured text verbatim — including production's `v1main`. */
 export function unknownModel(name: string): WireErrorEnvelope {
   return errorEnvelope(

--- a/packages/pyric/src/analytics/index.ts
+++ b/packages/pyric/src/analytics/index.ts
@@ -18,10 +18,18 @@ import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
 export { PyricDeferredApiError } from '../deferred/entry.js';
 
 export const {
-  getAnalytics, getGoogleAnalyticsClientId, initializeAnalytics, isSupported, logEvent,
+  getAnalytics, getGoogleAnalyticsClientId, initializeAnalytics, logEvent,
   setAnalyticsCollectionEnabled, setConsent, setCurrentScreen, setDefaultEventParameters,
   setUserId, setUserProperties, settings,
 } = deferredEntry('analytics');
+
+/**
+ * The one deferred symbol that answers instead of throwing: the real SDK
+ * resolves a boolean, and a deferred entry IS unsupported, so the standard
+ * `isSupported().then(ok => ok && get…(app))` guard must run — not crash.
+ */
+export const isSupported = async (): Promise<boolean> => false;
+
 
 // Type declarations. Aliased to the deferred placeholder so a consumer's own
 // annotations keep type-checking: every deferred call returns `never`, which is

--- a/packages/pyric/src/analytics/index.ts
+++ b/packages/pyric/src/analytics/index.ts
@@ -1,0 +1,45 @@
+/**
+ * `pyric/analytics` — a DEFERRED mirror of `firebase/analytics`.
+ *
+ * Google Analytics for Firebase is a fire-and-forget telemetry pipe to
+ * Google servers. There is no observable local behavior for the sandbox to
+ * mirror, so it is deferred.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/analytics`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  getAnalytics, getGoogleAnalyticsClientId, initializeAnalytics, isSupported, logEvent,
+  setAnalyticsCollectionEnabled, setConsent, setCurrentScreen, setDefaultEventParameters,
+  setUserId, setUserProperties, settings,
+} = deferredEntry('analytics');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type Analytics = DeferredApi;
+export type AnalyticsCallOptions = DeferredApi;
+export type AnalyticsSettings = DeferredApi;
+export type ConsentSettings = DeferredApi;
+export type ConsentStatusString = DeferredApi;
+export type ControlParams = DeferredApi;
+export type Currency = DeferredApi;
+export type CustomEventName = DeferredApi;
+export type CustomParams = DeferredApi;
+export type EventNameString = DeferredApi;
+export type EventParams = DeferredApi;
+export type GtagConfigParams = DeferredApi;
+export type Item = DeferredApi;
+export type Promotion = DeferredApi;
+export type SettingsOptions = DeferredApi;

--- a/packages/pyric/src/app-check/index.ts
+++ b/packages/pyric/src/app-check/index.ts
@@ -1,0 +1,41 @@
+/**
+ * `pyric/app-check` — a DEFERRED mirror of `firebase/app-check`.
+ *
+ * App Check attests that a request comes from your app, via reCAPTCHA or a
+ * custom attestation provider talking to Google infrastructure. The sandbox
+ * has no attestation authority to model against, so the whole surface is
+ * deferred.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/app-check`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  CustomProvider, ReCaptchaEnterpriseProvider, ReCaptchaV3Provider, getLimitedUseToken,
+  getToken, initializeAppCheck, onTokenChanged, setTokenAutoRefreshEnabled,
+} = deferredEntry('app-check');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type AppCheck = DeferredApi;
+export type AppCheckOptions = DeferredApi;
+export type AppCheckToken = DeferredApi;
+export type AppCheckTokenListener = DeferredApi;
+export type AppCheckTokenResult = DeferredApi;
+export type CustomProvider = DeferredApi;
+export type CustomProviderOptions = DeferredApi;
+export type PartialObserver = DeferredApi;
+export type ReCaptchaEnterpriseProvider = DeferredApi;
+export type ReCaptchaV3Provider = DeferredApi;
+export type Unsubscribe = DeferredApi;

--- a/packages/pyric/src/deferred/entry.ts
+++ b/packages/pyric/src/deferred/entry.ts
@@ -1,0 +1,167 @@
+/**
+ * The shared factory behind pyric's *deferred* Firebase Web SDK subpaths —
+ * `pyric/functions`, `pyric/analytics`, `pyric/app-check`,
+ * `pyric/firestore/lite`, `pyric/performance` and `pyric/remote-config`.
+ *
+ * WHY THESE EXIST AT ALL. pyric is a symbol-for-symbol drop-in for the
+ * Firebase Web SDK: an app swaps the `firebase` specifier for `pyric` and its
+ * module graph must keep loading. A subpath that is simply absent from the
+ * package `exports` map fails at RESOLVE time — Node raises
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED`, bundlers raise their own variants — long
+ * before any pyric code runs. That error names neither pyric nor the reason,
+ * so a developer whose app merely *mentions* `firebase/functions` on a code
+ * path it never takes sees an unattributable build failure.
+ *
+ * THE CONTRACT. Resolution and linking succeed; *use* fails loudly.
+ *   - The subpath resolves, so the module graph loads.
+ *   - Every symbol the real Firebase entry exports is present as a value, so
+ *     named-import linking (which is static in ESM — a missing name is a link
+ *     error, not a runtime one) succeeds and bundlers can tree-shake.
+ *   - Calling, constructing, or reading a member off one of those values
+ *     throws {@link PyricDeferredApiError} with a message that names the
+ *     subpath and points at the conformance matrix.
+ *
+ * An app that imports but never calls therefore runs unchanged. An app that
+ * genuinely depends on a deferred service gets one clear, attributed error at
+ * the exact call site instead of a cryptic resolver failure.
+ *
+ * NOT a mirror. These entries deliberately implement nothing. They are marked
+ * deferred in the conformance surface story and must never be counted as
+ * implemented surface.
+ */
+
+/**
+ * Compose the single user-facing message every deferred entry raises.
+ *
+ * @param subpath - The Firebase subpath *without* the `firebase/` prefix, e.g.
+ *   `functions` or `firestore/lite`.
+ */
+function deferredApiMessage(subpath: string): string {
+  return (
+    `pyric: 'firebase/${subpath}' is not yet mirrored by the local sandbox. ` +
+    'This API is deferred — see the conformance matrix. Imports resolve so ' +
+    'module graphs load; calls fail with this message.'
+  );
+}
+
+/**
+ * The error thrown by every deferred Firebase entry. Carries the subpath and
+ * the symbol that was touched so tooling can group these without parsing the
+ * message.
+ */
+export class PyricDeferredApiError extends Error {
+  override readonly name = 'PyricDeferredApiError';
+
+  /** The Firebase subpath, without the `firebase/` prefix (e.g. `functions`). */
+  readonly subpath: string;
+
+  /** The exported symbol whose use triggered this error (e.g. `getFunctions`). */
+  readonly symbol: string;
+
+  constructor(subpath: string, symbol: string) {
+    super(deferredApiMessage(subpath));
+    this.subpath = subpath;
+    this.symbol = symbol;
+  }
+}
+
+/**
+ * The static type of a deferred export.
+ *
+ * It is callable, constructible, and indexable so a deferred symbol can stand
+ * in for any of the three shapes a Firebase entry exports — a factory function
+ * (`getFunctions`), a class (`ReCaptchaV3Provider`), or an enum-like constant
+ * object (`HarmCategory`). Every result is `never`, which is assignable to
+ * anything, so a consumer's own annotations keep type-checking.
+ */
+export interface DeferredApi {
+  (...args: readonly unknown[]): never;
+  new (...args: readonly unknown[]): never;
+  readonly [member: string]: never;
+}
+
+/**
+ * Property reads that must NOT throw.
+ *
+ * Bundlers, test runners, `console.log`, promise adoption and React all probe
+ * values with these keys as part of ordinary machinery, never as an intent to
+ * use the API. Throwing on `then` in particular would turn `await`-ing
+ * anything holding a deferred value into this error at the wrong site, and
+ * throwing on `$$typeof` would break React's element check. They read as
+ * `undefined`, exactly as they would on a real function.
+ */
+const INERT_PROPERTIES: ReadonlySet<string> = new Set([
+  '$$typeof',
+  '__esModule',
+  'constructor',
+  'displayName',
+  'inspect',
+  'length',
+  'name',
+  'nodeType',
+  'prototype',
+  'then',
+  'toJSON',
+  'toString',
+  'valueOf',
+]);
+
+/**
+ * Build one deferred export: a function that throws when called or
+ * constructed, wrapped in a proxy so member reads (the enum-constant shape)
+ * throw the same error.
+ */
+function deferredSymbol(subpath: string, symbol: string): DeferredApi {
+  const throwing = function deferred(): never {
+    throw new PyricDeferredApiError(subpath, symbol);
+  };
+  Object.defineProperty(throwing, 'name', { value: symbol, configurable: true });
+
+  return new Proxy(throwing, {
+    get(target, property, receiver) {
+      // Symbol-keyed reads are always machinery (Symbol.toPrimitive,
+      // Symbol.hasInstance, Symbol.toStringTag, the inspect hook, …) — never a
+      // user reaching for an API member.
+      if (typeof property === 'symbol' || INERT_PROPERTIES.has(property)) {
+        return Reflect.get(target, property, receiver);
+      }
+      throw new PyricDeferredApiError(subpath, `${symbol}.${property}`);
+    },
+    construct() {
+      throw new PyricDeferredApiError(subpath, symbol);
+    },
+  }) as unknown as DeferredApi;
+}
+
+/**
+ * The lazily-materialised export bag for one deferred subpath.
+ *
+ * Each entry module destructures the symbols it needs off this object:
+ *
+ * ```ts
+ * export const { getFunctions, httpsCallable } = deferredEntry('functions');
+ * ```
+ *
+ * Destructuring is what makes the names real ESM exports (and what keeps the
+ * generated `.d.ts` honest); the proxy just mints a correctly-attributed stub
+ * for whichever name is read.
+ *
+ * @param subpath - The Firebase subpath, without the `firebase/` prefix.
+ */
+export function deferredEntry(subpath: string): Record<string, DeferredApi> {
+  const minted = new Map<string, DeferredApi>();
+  return new Proxy(Object.create(null) as Record<string, DeferredApi>, {
+    get(_target, property) {
+      if (typeof property === 'symbol') return undefined as unknown as DeferredApi;
+      let api = minted.get(property);
+      if (!api) {
+        api = deferredSymbol(subpath, property);
+        minted.set(property, api);
+      }
+      return api;
+    },
+    has() {
+      return true;
+    },
+  });
+}

--- a/packages/pyric/src/firestore/lite.ts
+++ b/packages/pyric/src/firestore/lite.ts
@@ -1,0 +1,91 @@
+/**
+ * `pyric/firestore/lite` — a DEFERRED mirror of `firebase/firestore/lite`.
+ *
+ * The Lite SDK is a separate build of Firestore with no local cache, no
+ * listeners and no offline queue. pyric mirrors the full `firebase/firestore`
+ * surface against the in-process sandbox; the Lite build needs its own
+ * cache-free instance identity, so it is deferred rather than aliased — an
+ * alias would silently give Lite consumers listener-backed semantics the real
+ * Lite SDK does not have.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/firestore/lite`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  AggregateField, AggregateQuerySnapshot, Bytes, CollectionReference, DocumentReference,
+  DocumentSnapshot, FieldPath, FieldValue, Firestore, FirestoreError, GeoPoint, Query,
+  QueryCompositeFilterConstraint, QueryConstraint, QueryDocumentSnapshot, QueryEndAtConstraint,
+  QueryFieldFilterConstraint, QueryLimitConstraint, QueryOrderByConstraint, QuerySnapshot,
+  QueryStartAtConstraint, Timestamp, Transaction, VectorValue, WriteBatch, addDoc,
+  aggregateFieldEqual, aggregateQuerySnapshotEqual, and, arrayRemove, arrayUnion, average,
+  collection, collectionGroup, connectFirestoreEmulator, count, deleteDoc, deleteField, doc,
+  documentId, endAt, endBefore, getAggregate, getCount, getDoc, getDocs, getFirestore,
+  increment, initializeFirestore, limit, limitToLast, or, orderBy, query, queryEqual, refEqual,
+  runTransaction, serverTimestamp, setDoc, setLogLevel, snapshotEqual, startAfter, startAt,
+  sum, terminate, updateDoc, vector, where, writeBatch,
+} = deferredEntry('firestore/lite');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type AddPrefixToKeys = DeferredApi;
+export type AggregateField = DeferredApi;
+export type AggregateFieldType = DeferredApi;
+export type AggregateQuerySnapshot = DeferredApi;
+export type AggregateSpec = DeferredApi;
+export type AggregateSpecData = DeferredApi;
+export type AggregateType = DeferredApi;
+export type Bytes = DeferredApi;
+export type ChildUpdateFields = DeferredApi;
+export type CollectionReference = DeferredApi;
+export type DocumentData = DeferredApi;
+export type DocumentReference = DeferredApi;
+export type DocumentSnapshot = DeferredApi;
+export type EmulatorMockTokenOptions = DeferredApi;
+export type FieldPath = DeferredApi;
+export type FieldValue = DeferredApi;
+export type Firestore = DeferredApi;
+export type FirestoreDataConverter = DeferredApi;
+export type FirestoreError = DeferredApi;
+export type FirestoreErrorCode = DeferredApi;
+export type GeoPoint = DeferredApi;
+export type LogLevel = DeferredApi;
+export type NestedUpdateFields = DeferredApi;
+export type OrderByDirection = DeferredApi;
+export type PartialWithFieldValue = DeferredApi;
+export type Primitive = DeferredApi;
+export type Query = DeferredApi;
+export type QueryCompositeFilterConstraint = DeferredApi;
+export type QueryConstraint = DeferredApi;
+export type QueryConstraintType = DeferredApi;
+export type QueryDocumentSnapshot = DeferredApi;
+export type QueryEndAtConstraint = DeferredApi;
+export type QueryFieldFilterConstraint = DeferredApi;
+export type QueryFilterConstraint = DeferredApi;
+export type QueryLimitConstraint = DeferredApi;
+export type QueryNonFilterConstraint = DeferredApi;
+export type QueryOrderByConstraint = DeferredApi;
+export type QuerySnapshot = DeferredApi;
+export type QueryStartAtConstraint = DeferredApi;
+export type SetOptions = DeferredApi;
+export type Settings = DeferredApi;
+export type Timestamp = DeferredApi;
+export type Transaction = DeferredApi;
+export type TransactionOptions = DeferredApi;
+export type UnionToIntersection = DeferredApi;
+export type UpdateData = DeferredApi;
+export type VectorValue = DeferredApi;
+export type WhereFilterOp = DeferredApi;
+export type WithFieldValue = DeferredApi;
+export type WriteBatch = DeferredApi;

--- a/packages/pyric/src/functions/index.ts
+++ b/packages/pyric/src/functions/index.ts
@@ -1,0 +1,38 @@
+/**
+ * `pyric/functions` — a DEFERRED mirror of `firebase/functions`.
+ *
+ * Callable Cloud Functions dispatch to deployed server code. Mirroring this
+ * means running the user’s functions, which is the emulator’s job, not the
+ * in-process sandbox’s — deferred pending a decision on the function-host
+ * seam.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/functions`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  FunctionsError, connectFunctionsEmulator, getFunctions, httpsCallable, httpsCallableFromURL,
+} = deferredEntry('functions');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type Functions = DeferredApi;
+export type FunctionsError = DeferredApi;
+export type FunctionsErrorCode = DeferredApi;
+export type FunctionsErrorCodeCore = DeferredApi;
+export type HttpsCallable = DeferredApi;
+export type HttpsCallableOptions = DeferredApi;
+export type HttpsCallableResult = DeferredApi;
+export type HttpsCallableStreamOptions = DeferredApi;
+export type HttpsCallableStreamResult = DeferredApi;

--- a/packages/pyric/src/performance/index.ts
+++ b/packages/pyric/src/performance/index.ts
@@ -1,0 +1,31 @@
+/**
+ * `pyric/performance` — a DEFERRED mirror of `firebase/performance`.
+ *
+ * Performance Monitoring instruments real network and render timings and
+ * ships them to Google. Nothing about it is locally observable, so it is
+ * deferred.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/performance`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  getPerformance, initializePerformance, trace,
+} = deferredEntry('performance');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type FirebasePerformance = DeferredApi;
+export type PerformanceSettings = DeferredApi;
+export type PerformanceTrace = DeferredApi;

--- a/packages/pyric/src/remote-config/index.ts
+++ b/packages/pyric/src/remote-config/index.ts
@@ -1,0 +1,45 @@
+/**
+ * `pyric/remote-config` — a DEFERRED mirror of `firebase/remote-config`.
+ *
+ * Remote Config serves server-side parameter values with fetch/activate
+ * caching semantics. Mirroring it needs a sandbox-side config store and a
+ * model of the fetch throttle — buildable, not yet built.
+ *
+ * Every symbol below resolves and links so an app that swaps `firebase` for
+ * `pyric` still loads; touching one throws `PyricDeferredApiError` naming this
+ * subpath. See `../deferred/entry.ts` for the full rationale.
+ *
+ * The value list is the exact public runtime surface of `firebase/remote-config`
+ * (Firebase Web SDK 12.13.0). Keep it in sync when this entry graduates to a
+ * real mirror.
+ */
+import { deferredEntry, type DeferredApi } from '../deferred/entry.js';
+
+export { PyricDeferredApiError } from '../deferred/entry.js';
+
+export const {
+  activate, ensureInitialized, fetchAndActivate, fetchConfig, getAll, getBoolean, getNumber,
+  getRemoteConfig, getString, getValue, isSupported, onConfigUpdate, setCustomSignals,
+  setLogLevel,
+} = deferredEntry('remote-config');
+
+// Type declarations. Aliased to the deferred placeholder so a consumer's own
+// annotations keep type-checking: every deferred call returns `never`, which is
+// assignable to any of these. Names that Firebase exports as a CLASS appear both
+// here and above — a class is a value and a type, and both meanings must survive
+// the swap.
+export type ConfigUpdate = DeferredApi;
+export type ConfigUpdateObserver = DeferredApi;
+export type CustomSignals = DeferredApi;
+export type FetchResponse = DeferredApi;
+export type FetchStatus = DeferredApi;
+export type FetchType = DeferredApi;
+export type FirebaseExperimentDescription = DeferredApi;
+export type FirebaseRemoteConfigObject = DeferredApi;
+export type LogLevel = DeferredApi;
+export type RemoteConfig = DeferredApi;
+export type RemoteConfigOptions = DeferredApi;
+export type RemoteConfigSettings = DeferredApi;
+export type Unsubscribe = DeferredApi;
+export type Value = DeferredApi;
+export type ValueSource = DeferredApi;

--- a/packages/pyric/src/remote-config/index.ts
+++ b/packages/pyric/src/remote-config/index.ts
@@ -19,9 +19,17 @@ export { PyricDeferredApiError } from '../deferred/entry.js';
 
 export const {
   activate, ensureInitialized, fetchAndActivate, fetchConfig, getAll, getBoolean, getNumber,
-  getRemoteConfig, getString, getValue, isSupported, onConfigUpdate, setCustomSignals,
+  getRemoteConfig, getString, getValue, onConfigUpdate, setCustomSignals,
   setLogLevel,
 } = deferredEntry('remote-config');
+
+/**
+ * The one deferred symbol that answers instead of throwing: the real SDK
+ * resolves a boolean, and a deferred entry IS unsupported, so the standard
+ * `isSupported().then(ok => ok && get…(app))` guard must run — not crash.
+ */
+export const isSupported = async (): Promise<boolean> => false;
+
 
 // Type declarations. Aliased to the deferred placeholder so a consumer's own
 // annotations keep type-checking: every deferred call returns `never`, which is

--- a/packages/pyric/test/ai/gemini-engine-redaction.test.ts
+++ b/packages/pyric/test/ai/gemini-engine-redaction.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Security regression: the Gemini engine appends the API key as a
+ * `?key=...` query parameter on upstream REST requests (Google AI Studio
+ * auth). When the upstream fetch fails (network error, timeout, DNS
+ * failure), the thrown `AiBrokerError` must NOT leak the plaintext key in
+ * its message — that message flows into `AiBroker`'s `request_rejected`
+ * event, Studio traffic captures, and (via `toAIError`/`aiErrorFromEnvelope`)
+ * the public `AIError` surface, any of which can land in terminal output or
+ * CI logs.
+ *
+ * T1.7. Host + path are still expected in the message for diagnosability —
+ * only the key VALUE must be redacted.
+ */
+import { describe, expect, it } from 'bun:test';
+import { AiBrokerError, GeminiEngine } from '../../src/ai/broker/index.js';
+
+const FAKE_KEY = 'test-key-SECRET123';
+
+function engineWithFailingFetch(): GeminiEngine {
+  return new GeminiEngine({
+    apiKey: FAKE_KEY,
+    fetch: (async () => {
+      throw new Error('getaddrinfo ENOTFOUND generativelanguage.googleapis.com');
+    }) as unknown as typeof fetch,
+  });
+}
+
+async function captureError(fn: () => Promise<unknown>): Promise<AiBrokerError> {
+  try {
+    await fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(AiBrokerError);
+    return err as AiBrokerError;
+  }
+  throw new Error('expected fn() to reject');
+}
+
+describe('GeminiEngine: API key redaction on upstream failure', () => {
+  it('generateContent: does not leak the API key when the upstream connection fails', async () => {
+    const engine = engineWithFailingFetch();
+    const err = await captureError(() => engine.generateContent({ contents: [] } as any, 'gemini-2.5-flash'));
+
+    expect(err.message).not.toContain(FAKE_KEY);
+    expect(err.envelope.error.message).not.toContain(FAKE_KEY);
+    // Diagnosability: host + path should survive redaction.
+    expect(err.envelope.error.message).toContain('generativelanguage.googleapis.com');
+  });
+
+  it('streamGenerateContent: does not leak the API key when the upstream connection fails', async () => {
+    const engine = engineWithFailingFetch();
+    const stream = engine.streamGenerateContent({ contents: [] } as any, 'gemini-2.5-flash');
+    const err = await captureError(() => stream.next());
+
+    expect(err.message).not.toContain(FAKE_KEY);
+    expect(err.envelope.error.message).not.toContain(FAKE_KEY);
+  });
+
+  it('countTokens: does not leak the API key when the upstream connection fails', async () => {
+    const engine = engineWithFailingFetch();
+    const err = await captureError(() => engine.countTokens({ contents: [] } as any, 'gemini-2.5-flash'));
+
+    expect(err.message).not.toContain(FAKE_KEY);
+    expect(err.envelope.error.message).not.toContain(FAKE_KEY);
+  });
+});

--- a/packages/pyric/test/ai/gemini-engine-redaction.test.ts
+++ b/packages/pyric/test/ai/gemini-engine-redaction.test.ts
@@ -12,7 +12,9 @@
  * only the key VALUE must be redacted.
  */
 import { describe, expect, it } from 'bun:test';
-import { AiBrokerError, GeminiEngine } from '../../src/ai/broker/index.js';
+import { AiBrokerError, GeminiEngine, type GenerateContentRequest } from '../../src/ai/broker/index.js';
+
+const EMPTY_REQUEST: GenerateContentRequest = { contents: [] };
 
 const FAKE_KEY = 'test-key-SECRET123';
 
@@ -38,7 +40,7 @@ async function captureError(fn: () => Promise<unknown>): Promise<AiBrokerError> 
 describe('GeminiEngine: API key redaction on upstream failure', () => {
   it('generateContent: does not leak the API key when the upstream connection fails', async () => {
     const engine = engineWithFailingFetch();
-    const err = await captureError(() => engine.generateContent({ contents: [] } as any, 'gemini-2.5-flash'));
+    const err = await captureError(() => engine.generateContent(EMPTY_REQUEST, 'gemini-2.5-flash'));
 
     expect(err.message).not.toContain(FAKE_KEY);
     expect(err.envelope.error.message).not.toContain(FAKE_KEY);
@@ -48,7 +50,7 @@ describe('GeminiEngine: API key redaction on upstream failure', () => {
 
   it('streamGenerateContent: does not leak the API key when the upstream connection fails', async () => {
     const engine = engineWithFailingFetch();
-    const stream = engine.streamGenerateContent({ contents: [] } as any, 'gemini-2.5-flash');
+    const stream = engine.streamGenerateContent(EMPTY_REQUEST, 'gemini-2.5-flash');
     const err = await captureError(() => stream.next());
 
     expect(err.message).not.toContain(FAKE_KEY);
@@ -57,8 +59,26 @@ describe('GeminiEngine: API key redaction on upstream failure', () => {
 
   it('countTokens: does not leak the API key when the upstream connection fails', async () => {
     const engine = engineWithFailingFetch();
-    const err = await captureError(() => engine.countTokens({ contents: [] } as any, 'gemini-2.5-flash'));
+    const err = await captureError(() => engine.countTokens(EMPTY_REQUEST, 'gemini-2.5-flash'));
 
+    expect(err.message).not.toContain(FAKE_KEY);
+    expect(err.envelope.error.message).not.toContain(FAKE_KEY);
+  });
+
+  it('does not leak the API key when the upstream returns a non-OK status', async () => {
+    // A proxy or gateway error page can echo the key-bearing request URL back
+    // in its body; that body is interpolated into the thrown error message.
+    const engine = new GeminiEngine({
+      apiKey: FAKE_KEY,
+      fetch: (async () =>
+        new Response(
+          `upstream proxy error: https://generativelanguage.googleapis.com/v1beta/models/x:generateContent?key=${FAKE_KEY} refused`,
+          { status: 502 },
+        )) as unknown as typeof fetch,
+    });
+    const err = await captureError(() => engine.generateContent(EMPTY_REQUEST, 'gemini-2.5-flash'));
+
+    expect(err.message).toContain('status 502');
     expect(err.message).not.toContain(FAKE_KEY);
     expect(err.envelope.error.message).not.toContain(FAKE_KEY);
   });

--- a/packages/pyric/test/deferred/subpath-exports.test.ts
+++ b/packages/pyric/test/deferred/subpath-exports.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Resolve-time guard for the Firebase Web SDK subpaths pyric does not mirror
+ * yet.
+ *
+ * The drop-in promise is symbol-for-symbol: an app that swaps `firebase` for
+ * `pyric` must keep loading even when it touches a service the sandbox has not
+ * implemented. Before these entries existed, `import 'firebase/functions'`
+ * under the swap died at RESOLVE time with `ERR_PACKAGE_PATH_NOT_EXPORTED` —
+ * an error with no attribution to pyric and no hint about what to do.
+ *
+ * The contract these tests freeze:
+ *   - the subpath RESOLVES and the module graph loads (import never throws);
+ *   - every documented value export is present, so named-import linking and
+ *     bundler tree-shaking succeed;
+ *   - USING one (call, construct, or property read) throws a single, clearly
+ *     attributed pyric error.
+ */
+import { describe, expect, test } from 'bun:test';
+
+/** Subpath → representative exports that must exist on the namespace. */
+const DEFERRED_SUBPATHS: ReadonlyArray<readonly [string, readonly string[]]> = [
+  ['firestore/lite', ['getFirestore', 'collection', 'getDocs', 'writeBatch', 'Timestamp']],
+  ['app-check', ['initializeAppCheck', 'ReCaptchaV3Provider', 'getToken']],
+  ['functions', ['getFunctions', 'httpsCallable', 'connectFunctionsEmulator']],
+  ['analytics', ['getAnalytics', 'logEvent', 'setUserId']],
+  ['performance', ['getPerformance', 'trace']],
+  ['remote-config', ['getRemoteConfig', 'fetchAndActivate', 'getValue']],
+];
+
+/** The exact user-facing message every deferred entry raises. */
+function deferredMessage(subpath: string): string {
+  return (
+    `pyric: 'firebase/${subpath}' is not yet mirrored by the local sandbox. ` +
+    'This API is deferred — see the conformance matrix. Imports resolve so ' +
+    'module graphs load; calls fail with this message.'
+  );
+}
+
+/**
+ * Subpaths whose value surface can be diffed against the installed Firebase
+ * Web SDK. (`firebase/vertexai` was removed in v12 — renamed to `firebase/ai`,
+ * which pyric already mirrors — so pyric ships no `./vertexai` entry either:
+ * resolving it fails exactly as it does on the real SDK.)
+ */
+const DIFFABLE_SUBPATHS: readonly string[] = [
+  'firestore/lite',
+  'app-check',
+  'functions',
+  'analytics',
+  'performance',
+  'remote-config',
+];
+
+describe('deferred entries mirror the real Firebase value surface exactly', () => {
+  for (const subpath of DIFFABLE_SUBPATHS) {
+    // A named import that Firebase exports but pyric does not is an ESM LINK
+    // error — the app fails to load, which is the failure mode these entries
+    // exist to prevent. An extra name pyric invents is a lie about the mirror.
+    // Both directions matter, so compare the sorted sets.
+    test(`pyric/${subpath}`, async () => {
+      const mirror = (await import(`pyric/${subpath}`)) as Record<string, unknown>;
+      const upstream = (await import(`firebase/${subpath}`)) as Record<string, unknown>;
+      const mirrored = Object.keys(mirror)
+        .filter((name) => name !== 'PyricDeferredApiError')
+        .sort();
+      expect(mirrored).toEqual(Object.keys(upstream).sort());
+    });
+  }
+});
+
+describe('deferred firebase subpaths resolve but throw on use', () => {
+  for (const [subpath, symbols] of DEFERRED_SUBPATHS) {
+    const first = symbols[0]!;
+
+    describe(`pyric/${subpath}`, () => {
+      test('resolves through the package exports map', async () => {
+        const mod = await import(`pyric/${subpath}`);
+        expect(typeof mod).toBe('object');
+      });
+
+      test('exposes its documented value exports', async () => {
+        const mod = (await import(`pyric/${subpath}`)) as Record<string, unknown>;
+        for (const symbol of symbols) {
+          expect(typeof mod[symbol]).toBe('function');
+        }
+      });
+
+      test('throws an attributed pyric error when called', async () => {
+        const mod = (await import(`pyric/${subpath}`)) as Record<string, unknown>;
+        const call = mod[first] as (...args: unknown[]) => unknown;
+        expect(() => call()).toThrow(deferredMessage(subpath));
+      });
+
+      test('throws when constructed', async () => {
+        const mod = (await import(`pyric/${subpath}`)) as Record<string, unknown>;
+        const ctor = mod[first] as new (...args: unknown[]) => unknown;
+        expect(() => new ctor()).toThrow(deferredMessage(subpath));
+      });
+
+      test('throws when an enum-style member is read', async () => {
+        const mod = (await import(`pyric/${subpath}`)) as Record<string, unknown>;
+        const value = mod[first] as Record<string, unknown>;
+        expect(() => value.SOME_ENUM_MEMBER).toThrow(deferredMessage(subpath));
+      });
+    });
+  }
+});

--- a/packages/pyric/test/deferred/subpath-exports.test.ts
+++ b/packages/pyric/test/deferred/subpath-exports.test.ts
@@ -105,3 +105,17 @@ describe('deferred firebase subpaths resolve but throw on use', () => {
     });
   }
 });
+
+describe('isSupported guards resolve instead of throwing', () => {
+  // The standard Firebase pattern `isSupported().then(ok => ok && getX(app))`
+  // must not crash at the guard itself: the real SDK resolves a boolean, and a
+  // deferred entry IS unsupported, so the honest answer is `false`.
+  for (const subpath of ['analytics', 'remote-config'] as const) {
+    test(`pyric/${subpath} isSupported() resolves false`, async () => {
+      const mod = (await import(`pyric/${subpath}`)) as {
+        isSupported: () => Promise<boolean>;
+      };
+      await expect(mod.isSupported()).resolves.toBe(false);
+    });
+  }
+});

--- a/scripts/ci/conformance-coupling-gate.sh
+++ b/scripts/ci/conformance-coupling-gate.sh
@@ -31,6 +31,19 @@ say() {
   printf '%s\n' "$1" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
 }
 
+# ENGINE_PATHS is a hardcoded list, so a rename upstream would silently retire
+# the gate: nothing would ever match again and every engine change would sail
+# through. Fail loudly on drift instead. Paths are repo-relative, so anchor them
+# at the worktree top level rather than trusting the caller's cwd.
+REPO_TOP="$(git rev-parse --show-toplevel)"
+for path in "${ENGINE_PATHS[@]}"; do
+  if [ ! -e "${REPO_TOP}/${path%/}" ]; then
+    say "❌ CONFORMANCE COUPLING GATE — CONFIGURATION DRIFT"
+    say "ENGINE_PATHS entry '${path}' no longer exists — update the gate."
+    exit 1
+  fi
+done
+
 # CI checks out at depth 1 for most jobs; recover just enough history to reach
 # a merge base rather than requiring every caller to deepen the checkout.
 resolve_base() {
@@ -44,16 +57,29 @@ resolve_base() {
 }
 
 if ! resolve_base; then
+  # In CI an unreachable base means the checkout is wrong (fetch-depth) or the
+  # base ref is gone — never that the branch is clean. Passing there would make
+  # the gate advisory exactly when it is load-bearing, so fail closed. Locally,
+  # a detached or history-less checkout is routine: warn and stay out of the way.
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    say "❌ CONFORMANCE COUPLING GATE — UNRESOLVABLE BASE"
+    say "No merge base with '${BASE_REF}' is reachable, so this gate cannot verify anything."
+    say "Remedy: check out with 'fetch-depth: 0' and pass the PR base as BASE_REF."
+    exit 1
+  fi
   echo "conformance-coupling-gate: no merge base with '${BASE_REF}' is reachable; nothing to compare." >&2
   exit 0
 fi
 
 MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
-CHANGED="$(git diff --name-only "${MERGE_BASE}...HEAD")"
 
 engine_changed=()
 evidence_changed=0
-while IFS= read -r file; do
+# core.quotePath=false plus NUL-delimited output: a default `diff --name-only`
+# C-quotes any non-ASCII path ("packages/pyric/src/rules/\303\251valuate.ts"),
+# which matches no case arm and would let a renamed-to-Unicode engine file slip
+# past the gate entirely.
+while IFS= read -r -d '' file; do
   [ -n "$file" ] || continue
   case "$file" in
     "$EVIDENCE_PATH"*)
@@ -74,15 +100,29 @@ while IFS= read -r file; do
         ;;
     esac
   done
-done <<<"$CHANGED"
+done < <(git -c core.quotePath=false diff --name-only -z "${MERGE_BASE}...HEAD")
 
 # No engine movement, or evidence moved with it: nothing to say.
 if [ "${#engine_changed[@]}" -eq 0 ] || [ "$evidence_changed" -gt 0 ]; then
   exit 0
 fi
 
-EXEMPTION="$(git log --format='%B' "${MERGE_BASE}..HEAD" |
-  grep -E '^Conformance-Exempt:[[:space:]]*[^[:space:]]' | head -n 1 || true)"
+# A waiver must be a real git TRAILER, not any line that happens to start with
+# the token: grepping the raw body lets prose ("Conformance-Exempt: ..." pasted
+# mid-paragraph, a quoted review note, a revert of an exempt commit) waive the
+# gate. `git interpret-trailers --parse` applies git's own trailer-block rules,
+# so only the structured last-paragraph form counts. One commit at a time —
+# concatenated bodies would let one commit's prose join another's trailer block.
+EXEMPTION=''
+while IFS= read -r sha; do
+  [ -n "$sha" ] || continue
+  trailer="$(git show -s --format='%B' "$sha" | git interpret-trailers --parse |
+    grep -E '^Conformance-Exempt:[[:space:]]*[^[:space:]]' | head -n 1 || true)"
+  if [ -n "$trailer" ]; then
+    EXEMPTION="$trailer"
+    break
+  fi
+done < <(git rev-list "${MERGE_BASE}..HEAD")
 
 if [ -n "$EXEMPTION" ]; then
   say "⚠️ CONFORMANCE COUPLING GATE — EXEMPT"

--- a/scripts/ci/conformance-coupling-gate.test.ts
+++ b/scripts/ci/conformance-coupling-gate.test.ts
@@ -18,6 +18,8 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: 'ci@example.com',
 };
 
+type GateEnv = Record<string, string | undefined>;
+
 const scratch: string[] = [];
 
 afterAll(() => {
@@ -35,6 +37,22 @@ function write(cwd: string, relPath: string, contents: string): void {
 }
 
 /**
+ * One seed file per ENGINE_PATHS entry. The gate refuses to run when a
+ * configured engine path has vanished (a rename must not silently retire it),
+ * so every entry has to exist in a synthetic workspace too — which also keeps
+ * this list honest against the script's.
+ */
+const ENGINE_SEED_FILES = [
+  'packages/pyric/src/rules/evaluate.ts',
+  'packages/pyric/src/firestore/sandbox/local-state.ts',
+  'packages/pyric/src/database/sandbox/read.ts',
+  'packages/pyric/src/database/sandbox-controls.ts',
+  'packages/pyric/src/storage/sandbox/rules.ts',
+  'packages/pyric/src/storage/enforce.ts',
+  'packages/pyric/src/sandbox/session.ts',
+];
+
+/**
  * A synthetic workspace whose base commit already carries one file under every
  * category the gate reasons about, so a test's diff contains exactly what the
  * test writes.
@@ -44,10 +62,7 @@ function makeRepo(): string {
   scratch.push(dir);
   git(dir, 'init', '--quiet', '--initial-branch=main');
   write(dir, 'README.md', 'base\n');
-  write(dir, 'packages/pyric/src/rules/evaluate.ts', 'export const v = 0;\n');
-  write(dir, 'packages/pyric/src/firestore/sandbox/local-state.ts', 'export const v = 0;\n');
-  write(dir, 'packages/pyric/src/database/sandbox-controls.ts', 'export const v = 0;\n');
-  write(dir, 'packages/pyric/src/storage/enforce.ts', 'export const v = 0;\n');
+  for (const file of ENGINE_SEED_FILES) write(dir, file, 'export const v = 0;\n');
   write(dir, 'packages/conformance/matrix.json', '{"rows":0}\n');
   git(dir, 'add', '-A');
   git(dir, 'commit', '--quiet', '-m', 'base');
@@ -60,9 +75,16 @@ function commit(cwd: string, message: string): void {
   git(cwd, 'commit', '--quiet', '-m', message);
 }
 
-function runGate(cwd: string): { status: number; output: string } {
-  const env = { ...gitEnv, BASE_REF: 'main' };
-  delete (env as Record<string, string | undefined>).GITHUB_STEP_SUMMARY;
+/**
+ * Runs the gate against a synthetic repo. GITHUB_ACTIONS / GITHUB_STEP_SUMMARY
+ * are stripped unless a test opts in: both change the gate's behavior, and a
+ * real CI run of this suite would otherwise leak them in via process.env.
+ */
+function runGate(cwd: string, overrides: GateEnv = {}): { status: number; output: string } {
+  const env: GateEnv = { ...gitEnv };
+  delete env.GITHUB_STEP_SUMMARY;
+  delete env.GITHUB_ACTIONS;
+  Object.assign(env, { BASE_REF: 'main' }, overrides);
   const result = spawnSync('bash', [script], { cwd, encoding: 'utf8', env });
   return { status: result.status ?? -1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
 }
@@ -175,13 +197,120 @@ describe('conformance coupling gate', () => {
     git(repo, 'commit', '--quiet', '-m', 'refactor(rules): rename', '-m', 'Conformance-Exempt: rename only');
 
     const summaryPath = join(repo, 'step-summary.md');
-    const result = spawnSync('bash', [script], {
-      cwd: repo,
-      encoding: 'utf8',
-      env: { ...gitEnv, BASE_REF: 'main', GITHUB_STEP_SUMMARY: summaryPath },
-    });
-    expect(result.status).toBe(0);
+    const { status } = runGate(repo, { GITHUB_STEP_SUMMARY: summaryPath });
+    expect(status).toBe(0);
     expect(readFileSync(summaryPath, 'utf8')).toContain('rename only');
+  });
+
+  // A body line that merely LOOKS like a trailer is prose: quoted review notes,
+  // pasted policy text, a revert that carries the original body forward. Only
+  // git's own trailer block may waive the gate.
+  test('a body that only quotes the trailer token mid-message does not waive the gate', () => {
+    const repo = makeRepo();
+    write(repo, 'packages/pyric/src/rules/evaluate.ts', 'export const v = 1;\n');
+    git(repo, 'add', '-A');
+    git(
+      repo,
+      'commit',
+      '--quiet',
+      '-m',
+      'refactor(rules): rename internals',
+      '-m',
+      'A reviewer might paste a note like:\nConformance-Exempt: totally fine, trust me\nand that prose must never waive this gate.'
+    );
+
+    const { status, output } = runGate(repo);
+    expect(status).toBe(1);
+    expect(output).toContain('FAILED');
+    expect(output).toContain('packages/pyric/src/rules/evaluate.ts');
+    expect(output).not.toContain('EXEMPT');
+  });
+
+  test('a genuine trailer still waives even when the body also quotes the token in prose', () => {
+    const repo = makeRepo();
+    write(repo, 'packages/pyric/src/rules/evaluate.ts', 'export const v = 1;\n');
+    git(repo, 'add', '-A');
+    git(
+      repo,
+      'commit',
+      '--quiet',
+      '-m',
+      'refactor(rules): rename internals',
+      '-m',
+      'The docs say to write "Conformance-Exempt: <reason>" as a trailer.',
+      '-m',
+      'Conformance-Exempt: pure rename, no observable behavior change'
+    );
+
+    const { status, output } = runGate(repo);
+    expect(status).toBe(0);
+    expect(output).toContain('EXEMPT');
+    expect(output).toContain('pure rename, no observable behavior change');
+  });
+
+  // Default `diff --name-only` C-quotes non-ASCII paths
+  // ("packages/pyric/src/rules/\303\251valuate.ts"), which matches no prefix
+  // and would let the file through as if it were not an engine file at all.
+  test('a non-ASCII engine path is still recognized (no C-quoting bypass)', () => {
+    const repo = makeRepo();
+    write(repo, 'packages/pyric/src/rules/évaluate.ts', 'export const v = 1;\n');
+    commit(repo, 'feat(rules): add an accented module');
+
+    const { status, output } = runGate(repo);
+    expect(status).toBe(1);
+    expect(output).toContain('évaluate.ts');
+    expect(output).not.toContain('\\303\\251');
+  });
+
+  // A rename of any engine directory would otherwise retire the gate in
+  // silence: nothing matches, so every later engine change passes.
+  test.each([
+    ['packages/pyric/src/sandbox/', 'packages/pyric/src/sandbox'],
+    ['packages/pyric/src/storage/enforce.ts', 'packages/pyric/src/storage/enforce.ts'],
+  ])('a vanished ENGINE_PATHS entry (%s) fails the gate rather than disabling it', (entry, target) => {
+    const repo = makeRepo();
+    rmSync(join(repo, target), { recursive: true, force: true });
+    write(repo, 'README.md', 'unrelated edit\n');
+    commit(repo, 'chore: move the engine tree');
+
+    const { status, output } = runGate(repo);
+    expect(status).toBe(1);
+    expect(output).toContain(`ENGINE_PATHS entry '${entry}' no longer exists`);
+    expect(output).toContain('update the gate');
+  });
+
+  test('every ENGINE_PATHS entry in the script is seeded by this suite', () => {
+    const source = readFileSync(script, 'utf8');
+    const block = source.slice(source.indexOf('ENGINE_PATHS=('), source.indexOf(')', source.indexOf('ENGINE_PATHS=(')));
+    const configured = [...block.matchAll(/'([^']+)'/g)].map((m) => m[1]!);
+    expect(configured.length).toBeGreaterThan(0);
+    for (const entry of configured) {
+      expect(ENGINE_SEED_FILES.some((file) => (entry.endsWith('/') ? file.startsWith(entry) : file === entry))).toBe(true);
+    }
+  });
+
+  // An unreachable base in CI means a broken checkout, not a clean branch.
+  test('an unresolvable merge base fails closed under GITHUB_ACTIONS', () => {
+    const repo = makeRepo();
+    write(repo, 'packages/pyric/src/rules/evaluate.ts', 'export const v = 1;\n');
+    commit(repo, 'fix(rules): tighten evaluation');
+
+    const { status, output } = runGate(repo, { BASE_REF: 'origin/nonexistent', GITHUB_ACTIONS: 'true' });
+    expect(status).toBe(1);
+    expect(output).toContain('UNRESOLVABLE BASE');
+    expect(output).toContain('origin/nonexistent');
+    expect(output).toContain('fetch-depth: 0');
+  });
+
+  test('an unresolvable merge base only warns on a local run', () => {
+    const repo = makeRepo();
+    write(repo, 'packages/pyric/src/rules/evaluate.ts', 'export const v = 1;\n');
+    commit(repo, 'fix(rules): tighten evaluation');
+
+    const { status, output } = runGate(repo, { BASE_REF: 'origin/nonexistent' });
+    expect(status).toBe(0);
+    expect(output).toContain('no merge base');
+    expect(output).toContain('nothing to compare');
   });
 
   test('the gate is wired into the conformance-gates CI job', () => {


### PR DESCRIPTION
Seven fixes from the hardening queue, headlined by the drop-in cliff: importing an unmirrored Firebase subpath under the module swap died at resolve time before any app code ran.

```ts
import { getFunctions, httpsCallable } from 'firebase/functions';
// Before: ERR_PACKAGE_PATH_NOT_EXPORTED at import — cryptic, unattributable.

const fns = getFunctions(app);
// Now the module graph loads, and the first call says what's going on:
// Error: pyric: 'firebase/functions' is not yet mirrored by the local sandbox.
// This API is deferred — see the conformance matrix. Imports resolve so
// module graphs load; calls fail with this message.
```

## Six subpaths resolve to throwing stubs; `./vertexai` stays absent like the real SDK

`./firestore/lite`, `./app-check`, `./functions`, `./analytics`, `./performance`, `./remote-config` each export the exact named surface of `firebase@12.13.0` (extracted from its typings, so named imports link) as stubs that throw on call, construct, or member read — with an inert-property allowlist so `await`-ing or React's element checks don't misfire. No `./vertexai` entry ships: Firebase v12 removed that subpath (renamed to `firebase/ai`, already mirrored), so `pyric/vertexai` rejects with the same `ERR_PACKAGE_PATH_NOT_EXPORTED` the real SDK gives.

## Risk

- **Stacked on #551** (`loop/tier-0`) — merge that first.
- **The stubs are invisible to conformance.** A probe contract proved the census schema counts any public mirror export as *implemented* (the stubs would score 5/5 mapped) and fatally rejects `availability: deferred` alongside real exports. `compat:census` and `compat:coverage` output are byte-identical to main; making deferral expressible is a schema design decision held for review, not smuggled in here.
- **The lockfile refresh swept stale drift**: fixing the npm override forced a fresh resolve, which picked up Playwright `1.61.1 → 1.62.0` (the root already requested `^1.62.0`; the checked-in lock was stale). CI browsers change version.
- The Firebase v12 export map has seven *more* subpaths still uncovered (`installations`, `data-connect`, `firestore/pipelines`, `auth/cordova`, `auth/web-extension`, `compat/*`), and the browser/Vite alias tables still pass these subpaths through to real Firebase — both recorded as follow-ups, not addressed here.
- CI timeout values are structural heuristics; tune against real Actions telemetry when available.

## Upstream AI connection failures no longer print the API key

```text
# Before, in terminal output, CI logs, and Studio traffic captures:
Failed to connect to Gemini API at https://generativelanguage.googleapis.com/…:generateContent?key=AIza…SECRET: getaddrinfo ENOTFOUND

# Now:
Failed to connect to Gemini API at https://generativelanguage.googleapis.com/…:generateContent?key=***: getaddrinfo ENOTFOUND
```

`redactUrl()` strips `key`/`apiKey`/`api_key`/`access_token` query values at the Gemini `fetchUpstream` catch (the one live leak; the OpenAI engine's catch is redacted defensively — it has no key-in-URL auth today). Host and path survive for diagnosability.

## The runtime chip flag reaches Next.js client bundles

`withPyric` now writes `NEXT_PUBLIC_PYRIC_RUNTIME_CHIP` (keeping the unprefixed name), and the browser-side reader prefers the prefixed name with fallback. `readPyricRuntimeChipConfig`'s signature is unchanged, so #548's caller is unaffected (verified against its branch).

## CI jobs cache dependencies, bound their runtime, and stop cloning full history

- `actions/cache@v4` on `~/.bun/install/cache` keyed on `bun.lock` for all 15 jobs that run `bun install` across the four workflows; secret-gated installs get identically-gated cache steps.
- Every job now carries `timeout-minutes` (10/30/45/60 by shape) instead of GitHub's 360-minute default.
- `plan` and `knip-audit` drop `fetch-depth: 0` for a depth-1 checkout plus a fetch-by-SHA + progressive-deepen step that preserves their triple-dot diff semantics exactly; `conformance-gates` keeps full history deliberately (its gate diffs the merge base).
- `overrides.firebase` becomes `"$firebase"`, ending npm's `EOVERRIDE` abort — the override's purpose was single-copy dedup, which one registry entry for `firebase@12.13.0` confirms is preserved.

<details>
<summary>Implementation notes</summary>

- Full monorepo suite green in the worktree (`bun run test`, exit 0); `packages/pyric` 6011 tests / 0 fail; `packages/cli` 1503 pass / 18 skip / 0 fail; manifest lint (publint + attw + exports↔dist) PASS for all four packages.
- Red-first discrimination verified per item by the orchestrating session (e.g. restoring the pre-fix Gemini engine fails the 3 redaction tests; the stub subpaths fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` on the base commit).
- One queue item closed as stale rather than "fixed": the reported top-level `turbopack` config-key bug is wrong for Next 15.x (which stabilized the key), and pyric's only version signal is the scaffold example pinned `next: ^15.0.0` — no code changed.
- Found, not fixed: the Gemini streaming URL embeds `?alt=sse` and then appends a second `?key=…` — a malformed query string that upstream currently tolerates. Worth its own ticket; redaction handles it regardless.
- Work ledger: `ignored/loop-journal.md` entries 4–11.

</details>