### PR TITLE
docs(readme): lead with the mirror claim and canonical code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,39 @@
   <img src="https://pyric.dev/pyric-logo.svg" alt="Pyric" width="180" />
 </p>
 
-<h1 align="center">A local first Firebase development framework built for Agents</h1>
+<h1 align="center">A Firebase that runs inside your app during development</h1>
 
-<p align="center">Keep the same <code>firebase/*</code> code. Pyric runs it against a local backend during development, then gets out of the way when the app ships to Firebase.</p>
+<p align="center">Keep the same <code>firebase/*</code> code. During <code>vite dev</code> those imports resolve to a local backend running in the page. A production build ships the real Firebase SDK, unchanged.</p>
 
 <p align="center"><a href="https://pyric.dev">pyric.dev</a></p>
 
 <br />
 
-Pyric adds a development-only resolution layer to a Firebase application. Run the Vite development server and supported Firebase imports resolve to a browser-local backend. Run a normal production build and those imports resolve to Firebase again. The application source does not branch between the two.
+Application code stays canonical Firebase:
 
-The mirrored data services do not connect to a production Firebase project. Local writes cannot delete production data or create Firebase usage charges, and local rules changes do not deploy. Pyric owns the development sandbox and verification workflow. Firebase owns production, with `firebase-tools` or the Firebase Console handling deployment.
+```ts
+// src/firebase.ts
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
-## Start with a coding agent
+const app = initializeApp({
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+});
 
-Install the Pyric plugin:
-
-```bash
-npx plugins add davideast/pyric
+export const auth = getAuth(app);
+export const db = getFirestore(app);
 ```
 
-Antigravity CLI and OpenCode use the standalone skill installer:
+Run the Vite development server and supported Firebase imports resolve to a browser-local backend: Auth, Firestore with Security Rules, persistence in IndexedDB, one SharedWorker backend shared by every tab on the dev origin. Run a normal production build and those imports resolve to Firebase again. The application source does not branch between the two, and the local mirror never connects to a production project.
 
-```bash
-# Antigravity CLI
-npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric --agent antigravity-cli
+Coding agents get the same backend. A [skill](#start-with-a-coding-agent) sets up the sandbox end to end (`npx plugins add davideast/pyric`, then `/pyric`), and an opt-in MCP bridge lets an agent seed, inspect, and change the backend the app is already running against. `can-i-use` answers what conforms to real Firebase before the agent builds on it.
 
-# OpenCode
-npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric --agent opencode
-```
+<img width="1512" height="947" alt="Pyric Studio showing local data, requests, authentication state, and Security Rules verdicts" src="https://github.com/user-attachments/assets/cb4a219c-c5f0-4fb7-8904-996416c0a79c" />
 
-Then invoke the skill:
-
-| Agent | Enter |
-|---|---|
-| Codex | `$pyric` |
-| Claude Code | `/pyric:pyric` |
-| Antigravity CLI | `/pyric` |
-| OpenCode | `/pyric` |
-
-The leading `$` or `/` is part of the command.
-
-The skill chooses the project launcher, starts one local sandbox bridge, opens the application, and confirms that the browser sandbox is connected.
-
-## Start from the terminal
+## Create a new app
 
 Create a Vite application with canonical Firebase imports, Firestore rules, and the Pyric development plugin already configured:
 
@@ -82,41 +71,54 @@ Start the normal development server:
 npm run dev
 ```
 
-During `vite dev`, the plugin swaps supported `firebase/*` modules at resolution time. The backend runs in a SharedWorker, so tabs on the same development origin use one local backend. Browser-local persistence uses IndexedDB.
-
-Pyric Studio is available on the Vite origin at `/__pyric/ui/studio`. It opens the same backend used by the application.
+During `vite dev`, the plugin swaps supported `firebase/*` modules at resolution time. Pyric Studio is available on the Vite origin at `/__pyric/ui/studio`. It opens the same backend used by the application.
 
 For a static application or a Node process, `pyric sandbox` provides the same development-only package swap without the Vite plugin. The [CLI reference](packages/site-docs/src/content/reference/cli.md) documents those paths and every command.
 
-## Keep using official Firebase SDKs
+## Start with a coding agent
 
-Application code continues to import Firebase:
+Install the Pyric plugin:
 
-```ts
-// src/firebase.ts
-import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-
-const app = initializeApp({
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-});
-
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+```bash
+npx plugins add davideast/pyric
 ```
 
-The Firebase configuration is accepted by the local mirror during development. The production build passes that same configuration to Firebase. Normal Auth, Firestore, Realtime Database, Storage, Messaging, and Firebase AI Logic usage still belongs in the [Firebase documentation](https://firebase.google.com/docs).
+Antigravity CLI and OpenCode use the standalone skill installer:
 
-Pyric documents the parts that differ locally, including supported behavior, Security Rules, persistence, inspection, verification, and known gaps. See [use the Vite plugin](packages/cli/docs/how-to/use-the-vite-plugin.md) for the complete plugin contract.
+```bash
+# Antigravity CLI
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric --agent antigravity-cli
+
+# OpenCode
+npx skills add https://github.com/davideast/pyric/tree/main/pyric-plugin/skills/pyric --agent opencode
+```
+
+Then invoke the skill:
+
+| Agent | Enter |
+|---|---|
+| Codex | `$pyric` |
+| Claude Code | `/pyric:pyric` |
+| Antigravity CLI | `/pyric` |
+| OpenCode | `/pyric` |
+
+The leading `$` or `/` is part of the command.
+
+The skill chooses the project launcher, starts one local sandbox bridge, opens the application, and confirms that the browser sandbox is connected.
+
+An agent can also work through the MCP bridge directly. It keeps writing the same Firebase code while inspecting and changing the backend the application is already using. Agent access is opt-in:
+
+```ts
+pyric({
+  bridge: true
+});
+```
+
+The bridge mounts on the Vite development origin and routes agent operations to the same SharedWorker backend used by the application and Studio. This protects the local workflow, not an independently credentialed process. A coding agent with production Firebase credentials or deployment access can still affect production outside Pyric.
 
 ## Monitor the local environment in Pyric Studio
 
 Pyric Studio shows local data, requests, authentication state, Security Rules verdicts, and denied operations. Open `/__pyric/ui/studio` on the development server and reproduce the failure. A denied request includes the path and verdict needed to correct the rule or the application code.
-
-<img width="1512" height="947" alt="image" src="https://github.com/user-attachments/assets/cb4a219c-c5f0-4fb7-8904-996416c0a79c" />
 
 The Vite plugin discovers the Firestore rules path from `firebase.json`, or falls back to `firestore.rules`. Saving that file replaces the active local ruleset without a production deploy. A parse failure leaves the last valid ruleset active and reports the error in the development server.
 
@@ -129,23 +131,9 @@ pyric({
 });
 ```
 
-See [persistence and multi-tab behavior](packages/cli/docs/how-to/serve-persistence-and-multi-tab.md) for reset and seed precedence.
+See [persistence and multi-tab behavior](packages/site-docs/src/content/observe/shape-your-data.md) for reset and seed precedence.
 
-## Connect Coding Agents to the Sandbox using the Pyric MCP server
-
-An agent can keep writing the same Firebase code while inspecting and changing the backend that the application is already using. Agent access is opt-in. Enable the MCP bridge in the Vite plugin:
-
-```ts
-pyric({ 
-  bridge: true 
-});
-```
-
-The bridge mounts on the Vite development origin and routes agent operations to the same SharedWorker backend used by the application and Studio.
-
-This protects the local workflow, not an independently credentialed process. A coding agent with production Firebase credentials or deployment access can still affect production outside Pyric.
-
-## Verify the rules against production 
+## Verify the rules against production
 
 Development sessions capture Firestore and Realtime Database operations in `.pyric/last-session.json` by default. Replay those requests against candidate rules before deployment:
 
@@ -153,7 +141,7 @@ Development sessions capture Firestore and Realtime Database operations in `.pyr
 npx pyric verify
 ```
 
-The default engine runs locally. The optional Firestore Rules Test API engine sends derived rule cases to Google's hosted evaluator when production-authority verification is needed. It verifies rules and does not deploy them. See [verify against a captured session](packages/cli/docs/how-to/verify-against-a-captured-session.md).
+The default engine runs locally. The optional Firestore Rules Test API engine sends derived rule cases to Google's hosted evaluator when production-authority verification is needed. It verifies rules and does not deploy them. See [verify against a captured session](packages/site-docs/src/content/ship/ship-to-production.md).
 
 ## Ship the same application code
 
@@ -165,37 +153,24 @@ npm run build
 
 The built application contains the real Firebase SDK and uses the Firebase configuration already present in the source. Deploy the build, rules, and indexes with `firebase-tools` or the Firebase Console. Pyric has no production deployment path.
 
+The mirrored data services do not connect to a production Firebase project. Local writes cannot delete production data or create Firebase usage charges, and local rules changes do not deploy. Pyric owns the development sandbox and verification workflow. Firebase owns production, with `firebase-tools` or the Firebase Console handling deployment.
+
+Normal Auth, Firestore, Realtime Database, Storage, Messaging, and Firebase AI Logic usage still belongs in the [Firebase documentation](https://firebase.google.com/docs). Pyric documents the parts that differ locally, including supported behavior, Security Rules, persistence, inspection, verification, and known gaps. See [use the Vite plugin](packages/site-docs/src/content/get-started/vite.md) for the complete plugin contract.
+
 ## Check what Pyric mirrors
 
 Pyric is an independent implementation of observable Firebase behavior. Conformance evidence records what has been compared with Firebase and keeps five outcomes distinct: conforms, documented divergence, bug, unsupported, and unverified. The evidence is a floor, not a claim that every Firebase behavior has been measured.
 
-Ask about a developer-facing feature without nesting discovery under rules verification:
+Ask about a developer-facing feature:
 
 ```bash
 npx pyric can-i-use getAfter
 npx pyric can-i-use firestore-rules/request.query --json
 ```
 
-The result reports availability, Firebase fidelity, and assurance eligibility as separate axes. Exact names succeed; a name shared by multiple surfaces asks you to qualify it, and fuzzy input prints labeled suggestions and exits nonzero instead of presenting a guess as a trust answer.
+The result reports availability, Firebase fidelity, and assurance eligibility as separate axes. Exact names succeed; fuzzy input prints labeled suggestions and exits nonzero instead of presenting a guess as a trust answer.
 
-Documentation and other Node consumers can bind the same feature name to the
-published import that exposes it, without maintaining a second surface map:
-
-```ts
-import { canIUse, canIUseImport } from '@pyric/cli/conformance';
-
-const result = canIUse('getDownloadURL', { importPath: 'pyric/storage' });
-const evidence = canIUseImport('pyric/storage');
-const evidencePage = evidence && `/docs/${evidence.evidenceSlug}/`;
-```
-
-Each support result carries only census-proven `importPaths`; registry ownership
-cannot invent package exports. `canIUseImport()` supplies the separate canonical
-import-to-evidence join used by generated API documentation. An unrelated
-import path returns no exact match rather than borrowing another surface's trust
-claim.
-
-Read the generated [conformance scores](https://pyric.dev/docs/conformance-scores/) and the service matrices in the site's Conformance section. They are built from the same canonical registry used by assurance and `canIUse`, without committing duplicate Markdown. The [versioning and compatibility policy](packages/pyric/docs/explanation/versioning-and-compatibility.md) explains the release boundary.
+Read the generated [conformance scores](https://pyric.dev/docs/conformance-scores/) and the service matrices in the site's Conformance section. They are built from the same canonical registry used by assurance and `canIUse`. Node consumers can query the same registry through [`@pyric/cli/conformance`](packages/site-docs/src/content/reference/cli.md). The [versioning and compatibility policy](packages/site-docs/src/content/trust/versioning-and-compatibility.md) explains the release boundary.
 
 ## Stability
 
@@ -212,4 +187,4 @@ bun run test
 bun run compat:check
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md), [CONTEXT.md](CONTEXT.md), and [AGENTS.md](AGENTS.md) before changing the codebase.
+See [CONTEXT.md](CONTEXT.md) and [AGENTS.md](AGENTS.md) before changing the codebase.


### PR DESCRIPTION
Reorders the README so a short first read reaches the core claim, the canonical code, and both start paths. One paragraph of new copy; everything else is existing prose moved or trimmed.

The first screen a reader now gets:

> # A Firebase that runs inside your app during development
>
> Keep the same `firebase/*` code. During `vite dev` those imports resolve to a local backend running in the page. A production build ships the real Firebase SDK, unchanged.

followed by the canonical `src/firebase.ts` block, one paragraph on dev/prod resolution, one paragraph on the agent path, and the Studio screenshot.

## The H1 changes from "A local first Firebase development framework built for Agents"

"local first" reads as the CRDT/sync-engine category, "framework" overstates a Vite plugin, and "built for Agents" filters out human readers. The new H1 states what Pyric is. The old subhead ("Keep the same `firebase/*` code...") stays as the subhead.

## Content that moved, with the reason

- The canonical imports code block moves from the "Keep using official Firebase SDKs" section to the top. It is the strongest proof of the core claim and was four screens down.
- The Studio screenshot moves from the Studio section to the first screen. The Studio section keeps its prose.
- The paragraph about production safety (no production connection, no usage charges, rules do not deploy) moves from position two to "Ship the same application code", next to the build step it explains.
- "Start with a coding agent" moves below the two human start paths. Its full content is kept (installers, agent table, skill behavior) and the MCP bridge section merges into it, so agent setup lives in one place.
- The `canIUseImport()` code block and the two paragraphs of registry mechanics are cut to one linked sentence. That content is reference documentation, not README material.
- "Keep using official Firebase SDKs" dissolves as a section: its code moved to the top and its documentation pointer merged into the ship section.

## New copy: one paragraph in the fold for agents

> Coding agents get the same backend. A skill sets up the sandbox end to end (`npx plugins add davideast/pyric`, then `/pyric`), and an opt-in MCP bridge lets an agent seed, inspect, and change the backend the app is already running against. `can-i-use` answers what conforms to real Firebase before the agent builds on it.

This keeps the agent claim visible in the first screen after the agent section moved down.

## Five relative links pointed at files that no longer exist

Pre-existing on main, fixed here because this PR touches every one of them:

- `packages/cli/docs/how-to/use-the-vite-plugin.md` now points at `packages/site-docs/src/content/get-started/vite.md`
- `packages/cli/docs/how-to/serve-persistence-and-multi-tab.md` now points at `packages/site-docs/src/content/observe/shape-your-data.md`
- `packages/cli/docs/how-to/verify-against-a-captured-session.md` now points at `packages/site-docs/src/content/ship/ship-to-production.md`
- `packages/pyric/docs/explanation/versioning-and-compatibility.md` now points at `packages/site-docs/src/content/trust/versioning-and-compatibility.md`
- The `CONTRIBUTING.md` reference is removed; the file does not exist.

## Risk

The H1 and the section order are positioning decisions, not corrections. If the launch funnel should lead agent-first, the "Start with a coding agent" section belongs above the human quick start and this ordering is wrong. The `canIUseImport` API is now reachable only through the conformance section link. The three replacement link targets for the how-to links are nearest-topic matches, not renames; check they cover the same ground.

<details>
<summary>Implementation notes</summary>

- Text-only change to README.md. No new capability claims: every statement in the reordered top exists in the current README except the agent paragraph quoted above.
- All relative links verified against files on this branch; the main README has five that resolve to nothing.
- No em dashes introduced; heading style matches the existing verb-first pattern.

</details>
