### PR TITLE
docs(readme): trim the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://pyric.dev/pyric-logo.svg" alt="Pyric" width="180" />
 </p>
 
-<h1 align="center">A Firebase that runs inside your app during development</h1>
+<h1 align="center">A Firebase that runs inside your app</h1>
 
 <p align="center">Keep the same <code>firebase/*</code> code. During <code>vite dev</code> those imports resolve to a local backend running in the page. A production build ships the real Firebase SDK, unchanged.</p>
 


### PR DESCRIPTION
Trims the README H1. The reader now sees:

> # A Firebase that runs inside your app
>
> Keep the same `firebase/*` code. During `vite dev` those imports resolve to a local backend running in the page. A production build ships the real Firebase SDK, unchanged.

## "during development" moves entirely to the subhead

The subhead already states when the swap is active and what a production build ships, so the H1 repeated it. One word-level change; nothing else touched.
