### PR TITLE
fix(cli): enforce canonical realpath containment on studio workspace paths

### DIFF
--- a/packages/cli/src/serve/studio/disk-workspace.ts
+++ b/packages/cli/src/serve/studio/disk-workspace.ts
@@ -17,8 +17,16 @@ import {
   stat,
   writeFile,
 } from 'node:fs/promises';
-import { existsSync, mkdirSync, watch as fsWatch, type FSWatcher } from 'node:fs';
-import { dirname, join, posix, relative, resolve, sep } from 'node:path';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readlinkSync,
+  realpathSync,
+  watch as fsWatch,
+  type FSWatcher,
+} from 'node:fs';
+import { basename, dirname, join, posix, relative, resolve, sep } from 'node:path';
 
 import type {
   WorkspaceChange,
@@ -32,6 +40,54 @@ export class WorkspacePathError extends Error {
     super(`workspace path escapes root: '${path}'`);
     this.name = 'WorkspacePathError';
   }
+}
+
+/**
+ * Resolves the canonical realpath of a path, handling symlinks and non-existent
+ * terminal segments by resolving the nearest existing ancestor.
+ */
+function getCanonicalPath(targetPath: string, seen = new Set<string>()): string {
+  const abs = resolve(targetPath);
+  if (seen.has(abs)) {
+    throw new WorkspacePathError(targetPath);
+  }
+  seen.add(abs);
+
+  try {
+    return realpathSync(abs);
+  } catch (err: any) {
+    if (err?.code === 'ELOOP') {
+      throw new WorkspacePathError(targetPath);
+    }
+    if (err?.code !== 'ENOENT' && err?.code !== 'ENOTDIR') {
+      throw err;
+    }
+  }
+
+  try {
+    const st = lstatSync(abs);
+    if (st.isSymbolicLink()) {
+      const linkTarget = readlinkSync(abs);
+      const nextTarget = resolve(dirname(abs), linkTarget);
+      return getCanonicalPath(nextTarget, seen);
+    }
+  } catch {
+    // abs does not exist as a directory entry
+  }
+
+  const parent = dirname(abs);
+  if (parent === abs) {
+    return abs;
+  }
+  const canonicalParent = getCanonicalPath(parent, seen);
+  return join(canonicalParent, basename(abs));
+}
+
+/** Check whether canonical target is contained within canonical root. */
+function isContained(root: string, target: string): boolean {
+  if (target === root) return true;
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  return target.startsWith(prefix);
 }
 
 /**
@@ -52,6 +108,24 @@ export function resolveWorkspacePath(root: string, rel: string): string {
   if (abs !== root && !abs.startsWith(root + sep)) {
     throw new WorkspacePathError(rel);
   }
+
+  // Canonical realpath containment check:
+  // Reject symlinks that escape the workspace root.
+  const canonicalRoot = getCanonicalPath(root);
+  let canonicalTarget: string;
+  try {
+    canonicalTarget = getCanonicalPath(abs);
+  } catch (err) {
+    if (err instanceof WorkspacePathError) {
+      throw new WorkspacePathError(rel);
+    }
+    throw err;
+  }
+
+  if (!isContained(canonicalRoot, canonicalTarget)) {
+    throw new WorkspacePathError(rel);
+  }
+
   return abs;
 }
 

--- a/packages/cli/test/serve/studio/disk-workspace-symlink.test.ts
+++ b/packages/cli/test/serve/studio/disk-workspace-symlink.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Permanent regression tests for Finding 5 (P2):
+ * Studio Workspace Symbolic Link Boundary Traversal Protection.
+ *
+ * Verifies that resolveWorkspacePath and diskWorkspace operations (read, write,
+ * remove, list) reject symbolic links that escape the workspace root directory.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  diskWorkspace,
+  resolveWorkspacePath,
+  WorkspacePathError,
+} from '../../../src/serve/studio/disk-workspace.js';
+
+describe('diskWorkspace symlink boundary traversal protection (Finding 5)', () => {
+  let testDir: string;
+  let workspaceRoot: string;
+  let outsideDir: string;
+  let outsideFile: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'pyric-symlink-reg-'));
+    workspaceRoot = join(testDir, 'workspace');
+    mkdirSync(workspaceRoot);
+
+    outsideDir = join(testDir, 'outside');
+    mkdirSync(outsideDir);
+
+    outsideFile = join(outsideDir, 'sensitive.txt');
+    writeFileSync(outsideFile, 'CONFIDENTIAL_DATA', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('resolveWorkspacePath', () => {
+    it('throws WorkspacePathError when a symlink points to a file outside root', () => {
+      const symlinkPath = join(workspaceRoot, 'leak-file.txt');
+      symlinkSync(outsideFile, symlinkPath);
+
+      expect(() =>
+        resolveWorkspacePath(workspaceRoot, 'leak-file.txt'),
+      ).toThrow(WorkspacePathError);
+    });
+
+    it('throws WorkspacePathError when a symlink points to a directory outside root', () => {
+      const symlinkDir = join(workspaceRoot, 'leak-dir');
+      symlinkSync(outsideDir, symlinkDir);
+
+      expect(() =>
+        resolveWorkspacePath(workspaceRoot, 'leak-dir/sensitive.txt'),
+      ).toThrow(WorkspacePathError);
+
+      expect(() =>
+        resolveWorkspacePath(workspaceRoot, 'leak-dir/new-file.txt'),
+      ).toThrow(WorkspacePathError);
+    });
+
+    it('throws WorkspacePathError when a dangling symlink targets outside root', () => {
+      const danglingPath = join(workspaceRoot, 'dangling-escape.txt');
+      symlinkSync(join(outsideDir, 'non-existent.txt'), danglingPath);
+
+      expect(() =>
+        resolveWorkspacePath(workspaceRoot, 'dangling-escape.txt'),
+      ).toThrow(WorkspacePathError);
+    });
+
+    it('allows symlinks pointing to files strictly within workspace root', () => {
+      const internalFile = join(workspaceRoot, 'internal.txt');
+      writeFileSync(internalFile, 'INTERNAL_DATA', 'utf8');
+
+      const internalSymlink = join(workspaceRoot, 'internal-link.txt');
+      symlinkSync(internalFile, internalSymlink);
+
+      const resolved = resolveWorkspacePath(workspaceRoot, 'internal-link.txt');
+      expect(resolved).toBe(internalSymlink);
+    });
+
+    it('allows symlinks pointing to directories strictly within workspace root', () => {
+      const internalSubdir = join(workspaceRoot, 'subdir');
+      mkdirSync(internalSubdir);
+      writeFileSync(join(internalSubdir, 'subfile.txt'), 'SUB', 'utf8');
+
+      const internalDirSymlink = join(workspaceRoot, 'link-subdir');
+      symlinkSync(internalSubdir, internalDirSymlink);
+
+      const resolved = resolveWorkspacePath(
+        workspaceRoot,
+        'link-subdir/subfile.txt',
+      );
+      expect(resolved).toBe(join(internalDirSymlink, 'subfile.txt'));
+    });
+
+    it('allows creating new files inside workspace root when parent does not exist yet', () => {
+      const resolved = resolveWorkspacePath(
+        workspaceRoot,
+        'new/nested/path/file.txt',
+      );
+      expect(resolved).toBe(
+        join(workspaceRoot, 'new', 'nested', 'path', 'file.txt'),
+      );
+    });
+  });
+
+  describe('diskWorkspace store operations through symlinks', () => {
+    it('read rejects symlink pointing outside root and preserves confidential data', async () => {
+      const symlinkPath = join(workspaceRoot, 'secret-link.txt');
+      symlinkSync(outsideFile, symlinkPath);
+
+      const ws = diskWorkspace(workspaceRoot);
+      await expect(ws.read('secret-link.txt')).rejects.toThrow(
+        WorkspacePathError,
+      );
+    });
+
+    it('write rejects symlink pointing outside root and does not overwrite outside file', async () => {
+      const symlinkPath = join(workspaceRoot, 'overwrite-link.txt');
+      symlinkSync(outsideFile, symlinkPath);
+
+      const ws = diskWorkspace(workspaceRoot);
+      await expect(
+        ws.write('overwrite-link.txt', 'ATTACKER_OVERWRITE'),
+      ).rejects.toThrow(WorkspacePathError);
+
+      // Verify outside file was NOT modified
+      expect(readFileSync(outsideFile, 'utf8')).toBe('CONFIDENTIAL_DATA');
+    });
+
+    it('remove rejects symlink pointing outside root and does not delete outside file', async () => {
+      const symlinkPath = join(workspaceRoot, 'delete-link.txt');
+      symlinkSync(outsideFile, symlinkPath);
+
+      const ws = diskWorkspace(workspaceRoot);
+      await expect(ws.remove('delete-link.txt')).rejects.toThrow(
+        WorkspacePathError,
+      );
+
+      // Verify outside file still exists
+      expect(existsSync(outsideFile)).toBe(true);
+    });
+
+    it('list rejects traversing into a symlinked directory outside root', async () => {
+      const symlinkDir = join(workspaceRoot, 'outside-dir-link');
+      symlinkSync(outsideDir, symlinkDir);
+
+      const ws = diskWorkspace(workspaceRoot);
+      await expect(ws.list('outside-dir-link')).rejects.toThrow(
+        WorkspacePathError,
+      );
+    });
+
+    it('allows read and write through internal symlinks within workspace root', async () => {
+      const internalFile = join(workspaceRoot, 'target.txt');
+      writeFileSync(internalFile, 'ORIGINAL', 'utf8');
+
+      const symlinkPath = join(workspaceRoot, 'internal-alias.txt');
+      symlinkSync(internalFile, symlinkPath);
+
+      const ws = diskWorkspace(workspaceRoot);
+      expect(await ws.read('internal-alias.txt')).toBe('ORIGINAL');
+
+      await ws.write('internal-alias.txt', 'UPDATED');
+      expect(await ws.read('internal-alias.txt')).toBe('UPDATED');
+      expect(readFileSync(internalFile, 'utf8')).toBe('UPDATED');
+    });
+  });
+});


### PR DESCRIPTION
Resolves symbolic links against the canonical workspace root, throwing `WorkspacePathError` when a symlink targets a path outside the workspace.

```ts
import { resolveWorkspacePath, diskWorkspace, WorkspacePathError } from '@pyric/cli/serve/studio/disk-workspace.js';
import * as fs from 'node:fs';

// Setup: a workspace directory containing a symlink that points outside the root
const workspaceRoot = '/Users/deast/projects/my-app';
const outsideSecret = '/Users/deast/.ssh/id_rsa';
fs.symlinkSync(outsideSecret, `${workspaceRoot}/leak.txt`);

// Previously: returned "/Users/deast/projects/my-app/leak.txt" because the lexical prefix matched.
// Now: throws WorkspacePathError because the canonical target escapes the canonical root.
try {
  resolveWorkspacePath(workspaceRoot, 'leak.txt');
} catch (err) {
  console.log(err instanceof WorkspacePathError); // true
  console.log(err.message); // "workspace path escapes root: 'leak.txt'"
}

// diskWorkspace read, write, and delete operations fail closed before touching the filesystem:
const store = diskWorkspace(workspaceRoot);
await store.read('leak.txt');             // throws WorkspacePathError
await store.write('leak.txt', 'payload');  // throws WorkspacePathError
await store.remove('leak.txt');            // throws WorkspacePathError
```

## Risk

Workspaces that intentionally symlink files or directories from outside the project directory will now receive `WorkspacePathError` when accessed through Pyric Studio workspace endpoints. Symlinks pointing to locations within the workspace root continue to resolve and function normally.

## Canonical realpath resolution prevents symlink escapes from workspace root

`resolveWorkspacePath` previously relied on lexical POSIX path normalization (`posix.normalize`) and string prefix checking (`abs.startsWith(root + sep)`). When a symlink inside the workspace directory targeted an arbitrary outside file (e.g. `workspace/leak.txt -> /etc/passwd`), the lexical path began with `workspaceRoot`, passing validation and allowing the outside file to be read, modified, or deleted via the Studio API.

The path resolver now resolves canonical paths using `realpathSync` and checks `isContained(canonicalRoot, canonicalTarget)`. Any path whose canonical destination falls outside `canonicalRoot` immediately raises `WorkspacePathError`.

## Internal symlinks within the workspace directory remain supported

Symlinks that point to files or subdirectories located inside `workspaceRoot` (such as relative links between project packages or assets) resolve to canonical paths within `canonicalRoot` and continue to pass validation without interruption.

## Target paths for new files verify nearest-existing ancestor containment

When `diskWorkspace.write` creates a new file whose path does not yet exist on disk, `getCanonicalPath` walks up the directory hierarchy to resolve the nearest existing ancestor. If the non-existent file is nested inside a symlinked directory pointing outside the workspace, the ancestor escape is detected and rejected before file creation.

<details>
<summary>Implementation notes & verification</summary>

### Verification
- **Dedicated Regression Suite**: [`packages/cli/test/serve/studio/disk-workspace-symlink.test.ts`](file:///Users/deast/repos/davideast/pyric/packages/cli/test/serve/studio/disk-workspace-symlink.test.ts)
  - 11/11 tests pass covering outside file symlinks, outside directory symlinks, dangling symlinks, internal file/directory symlinks, non-existent file writes, and all `diskWorkspace` operations (`read`, `write`, `remove`, `list`).
- **Full CLI Suite**: `bun test packages/cli`
  - 1,760 passed, 21 skipped, 0 failed.
- **Oracle Assertion**: [`tmp/findings-evidence/falsifiable-assertions.test.ts`](file:///Users/deast/repos/davideast/pyric/tmp/findings-evidence/falsifiable-assertions.test.ts)
  - Check 5 (`Studio Workspace Symlink Traversal Protection`) passes Green.
- **Typecheck & Build**: `bun run --cwd packages/cli typecheck` passes with 0 errors.

</details>
