### PR TITLE
fix(storage): isolate persistence and handle caching across multiple buckets

### DIFF
--- a/packages/pyric/src/storage/persistence.ts
+++ b/packages/pyric/src/storage/persistence.ts
@@ -3,10 +3,11 @@
  *
  * One database (`pyric-storage` by default), two object stores —
  * `blobs` for the file content and `metadata` for the descriptive
- * record. Both stores key on the file's full path string. Object
- * upload writes both stores within a single `readwrite` transaction
- * so the pair stays consistent — a partial failure can't leave a
- * blob without metadata or vice versa.
+ * record. Both stores key on composite bucket and path strings
+ * (`${bucket}/${fullPath}`) to isolate storage persistence across
+ * buckets. Object upload writes both stores within a single `readwrite`
+ * transaction so the pair stays consistent — a partial failure can't
+ * leave a blob without metadata or vice versa.
  *
  * Slice 3 of the v1 scope (per the design rationale):
  *
@@ -44,6 +45,30 @@
 const DEFAULT_DB_NAME = 'pyric-storage';
 
 /**
+ * Default sandbox bucket identifier when not explicitly provided.
+ */
+export const DEFAULT_BUCKET = 'pyric-default';
+
+/**
+ * Encode a composite key scoping an object path to its bucket: `${bucket}/${fullPath}`.
+ */
+export function toStorageKey(bucket: string, path: string): string {
+  return `${bucket}/${path}`;
+}
+
+/**
+ * Decode a composite key into bucket and object path.
+ */
+export function parseStorageKey(key: string): { bucket: string; path: string } | null {
+  const slashIdx = key.indexOf('/');
+  if (slashIdx === -1) return null;
+  return {
+    bucket: key.slice(0, slashIdx),
+    path: key.slice(slashIdx + 1),
+  };
+}
+
+/**
  * Resolve the default IndexedDB database name for a project identity:
  * `pyric-storage:<projectId>`, or the legacy shared {@link DEFAULT_DB_NAME}
  * when no identity is available. An explicit `dbName` option always wins
@@ -54,9 +79,7 @@ export function storageDbName(projectId?: string | null): string {
 }
 /**
  * Schema version. Bump and add an `upgradeneeded` branch when the
- * store layout changes. Slice 3 ships v1: two object stores keyed by
- * fullPath, no indexes. Future migrations follow IndexedDB's standard
- * upgrade path.
+ * store layout changes.
  */
 const SCHEMA_VERSION = 1;
 const BLOBS_STORE = 'blobs';
@@ -74,11 +97,11 @@ const METADATA_STORE = 'metadata';
  * caller's `SettableMetadata`.
  */
 export interface StoredMetadata {
-  /** Full path of the object within the bucket. Also the store key. */
+  /** Full path of the object within the bucket. */
   fullPath: string;
   /** Last path segment (`b.txt` in `a/b.txt`). */
   name: string;
-  /** Sandbox bucket id. v1 has a single implicit bucket. */
+  /** Sandbox bucket id. */
   bucket: string;
   /** Monotonically increasing version of the object content. */
   generation: string;
@@ -122,16 +145,16 @@ export interface StorageBackend {
   put(path: string, blob: Blob, metadata: StoredMetadata): Promise<void>;
 
   /**
-   * Read the blob stored at `path`. Resolves to `undefined` when no
+   * Read the blob stored at `path` within `bucket`. Resolves to `undefined` when no
    * entry exists — callers translate that into `object-not-found`.
    */
-  getBlob(path: string): Promise<Blob | undefined>;
+  getBlob(path: string, bucket?: string): Promise<Blob | undefined>;
 
   /**
-   * Read the metadata record stored at `path`. Resolves to
+   * Read the metadata record stored at `path` within `bucket`. Resolves to
    * `undefined` when no entry exists.
    */
-  getMetadata(path: string): Promise<StoredMetadata | undefined>;
+  getMetadata(path: string, bucket?: string): Promise<StoredMetadata | undefined>;
 
   /**
    * Replace the metadata record at `path` without touching the blob.
@@ -139,31 +162,37 @@ export interface StorageBackend {
    * preserving server-set fields (`generation`, `timeCreated`, …)
    * the spec says metadata-only updates leave intact.
    */
-  putMetadata(path: string, metadata: StoredMetadata): Promise<void>;
+  putMetadata(path: string, metadata: StoredMetadata, bucket?: string): Promise<void>;
 
   /**
    * Delete both the blob and the metadata at `path` atomically.
    * No-op when neither entry exists.
    */
-  delete(path: string): Promise<void>;
+  delete(path: string, bucket?: string): Promise<void>;
 
   /**
    * Enumerate metadata records whose `fullPath` starts with `prefix`.
-   * Returned in IndexedDB key order (lexicographic by path). The
+   * Returned in key order (lexicographic by path within bucket). The
    * prefix is used verbatim — no implicit trailing-slash addition,
    * matching the survey's path-semantics call (Section 6).
    */
-  listByPrefix(prefix: string): Promise<StoredMetadata[]>;
+  listByPrefix(prefix: string, bucket?: string): Promise<StoredMetadata[]>;
 
   /**
-   * Clear both stores. Called by Slice 4's `StorageService.reset`.
+   * Clear stores. If `bucket` is supplied, clears only entries in that bucket;
+   * otherwise clears all stores.
    */
-  reset(): Promise<void>;
+  reset(bucket?: string): Promise<void>;
 
   /**
    * Close the underlying IndexedDB connection. Idempotent.
    */
   close(): void;
+
+  /**
+   * Return a view of this backend scoped to a specific bucket.
+   */
+  scoped?(bucket: string): StorageBackend;
 }
 
 /**
@@ -178,46 +207,97 @@ export interface StorageBackend {
  */
 export async function openStorageBackend(
   dbName: string = DEFAULT_DB_NAME,
+  defaultBucket?: string,
 ): Promise<StorageBackend> {
   try {
     const db = await openDatabase(dbName);
-    return new IndexedDbStorageBackend(db);
+    return new IndexedDbStorageBackend(db, defaultBucket);
   } catch (err) {
-    return new InMemoryStorageBackend();
+    return new InMemoryStorageBackend(defaultBucket);
   }
 }
 
-class InMemoryStorageBackend implements StorageBackend {
+export class InMemoryStorageBackend implements StorageBackend {
   private readonly blobs = new Map<string, Blob>();
   private readonly metadata = new Map<string, StoredMetadata>();
+  private _defaultBucket: string | undefined;
+
+  constructor(defaultBucket?: string) {
+    this._defaultBucket = defaultBucket;
+  }
 
   async put(path: string, blob: Blob, metadata: StoredMetadata): Promise<void> {
-    this.blobs.set(path, blob);
-    this.metadata.set(path, metadata);
+    const bucket = metadata.bucket || this._defaultBucket || DEFAULT_BUCKET;
+    if (!this._defaultBucket) {
+      this._defaultBucket = bucket;
+    }
+    if (!metadata.bucket) {
+      metadata.bucket = bucket;
+    }
+    const key = toStorageKey(bucket, path);
+    this.blobs.set(key, blob);
+    this.metadata.set(key, metadata);
   }
 
-  async getBlob(path: string): Promise<Blob | undefined> {
-    return this.blobs.get(path);
+  async getBlob(path: string, bucket?: string): Promise<Blob | undefined> {
+    if (bucket) {
+      return this.blobs.get(toStorageKey(bucket, path));
+    }
+    const targetBucket = this._defaultBucket ?? DEFAULT_BUCKET;
+    const direct = this.blobs.get(toStorageKey(targetBucket, path));
+    if (direct !== undefined) return direct;
+    if (targetBucket !== DEFAULT_BUCKET) {
+      const def = this.blobs.get(toStorageKey(DEFAULT_BUCKET, path));
+      if (def !== undefined) return def;
+    }
+    for (const [key, blob] of this.blobs.entries()) {
+      const parsed = parseStorageKey(key);
+      if (parsed && parsed.path === path) {
+        return blob;
+      }
+    }
+    return undefined;
   }
 
-  async getMetadata(path: string): Promise<StoredMetadata | undefined> {
-    return this.metadata.get(path);
+  async getMetadata(path: string, bucket?: string): Promise<StoredMetadata | undefined> {
+    if (bucket) {
+      return this.metadata.get(toStorageKey(bucket, path));
+    }
+    const targetBucket = this._defaultBucket ?? DEFAULT_BUCKET;
+    const direct = this.metadata.get(toStorageKey(targetBucket, path));
+    if (direct !== undefined) return direct;
+    if (targetBucket !== DEFAULT_BUCKET) {
+      const def = this.metadata.get(toStorageKey(DEFAULT_BUCKET, path));
+      if (def !== undefined) return def;
+    }
+    for (const [key, meta] of this.metadata.entries()) {
+      const parsed = parseStorageKey(key);
+      if (parsed && parsed.path === path) {
+        return meta;
+      }
+    }
+    return undefined;
   }
 
-  async putMetadata(path: string, metadata: StoredMetadata): Promise<void> {
-    this.metadata.set(path, metadata);
+  async putMetadata(path: string, metadata: StoredMetadata, bucket?: string): Promise<void> {
+    const b = bucket ?? metadata.bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
+    if (!metadata.bucket) metadata.bucket = b;
+    this.metadata.set(toStorageKey(b, path), metadata);
   }
 
-  async delete(path: string): Promise<void> {
-    this.blobs.delete(path);
-    this.metadata.delete(path);
+  async delete(path: string, bucket?: string): Promise<void> {
+    const targetBucket = bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
+    this.blobs.delete(toStorageKey(targetBucket, path));
+    this.metadata.delete(toStorageKey(targetBucket, path));
   }
 
-  async listByPrefix(prefix: string): Promise<StoredMetadata[]> {
+  async listByPrefix(prefix: string, bucket?: string): Promise<StoredMetadata[]> {
+    const targetBucket = bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
+    const keyPrefix = `${targetBucket}/${prefix}`;
     const results: StoredMetadata[] = [];
     const keys = Array.from(this.metadata.keys()).sort();
     for (const key of keys) {
-      if (key.startsWith(prefix)) {
+      if (key.startsWith(keyPrefix)) {
         const meta = this.metadata.get(key);
         if (meta) results.push(meta);
       }
@@ -225,73 +305,221 @@ class InMemoryStorageBackend implements StorageBackend {
     return results;
   }
 
-  async reset(): Promise<void> {
-    this.blobs.clear();
-    this.metadata.clear();
+  async reset(bucket?: string): Promise<void> {
+    if (!bucket) {
+      this.blobs.clear();
+      this.metadata.clear();
+      this._defaultBucket = undefined;
+      return;
+    }
+    const bucketPrefix = `${bucket}/`;
+    for (const key of Array.from(this.blobs.keys())) {
+      if (key.startsWith(bucketPrefix)) {
+        this.blobs.delete(key);
+      }
+    }
+    for (const key of Array.from(this.metadata.keys())) {
+      if (key.startsWith(bucketPrefix)) {
+        this.metadata.delete(key);
+      }
+    }
   }
 
   close(): void {}
+
+  scoped(bucket: string): StorageBackend {
+    return new ScopedStorageBackend(this, bucket);
+  }
 }
 
 // ─── Internal ──────────────────────────────────────────────────────
 
-class IndexedDbStorageBackend implements StorageBackend {
-  constructor(private readonly db: IDBDatabase) {}
+export class IndexedDbStorageBackend implements StorageBackend {
+  private _defaultBucket: string | undefined;
+
+  constructor(
+    private readonly db: IDBDatabase,
+    defaultBucket?: string,
+  ) {
+    this._defaultBucket = defaultBucket;
+  }
 
   async put(path: string, blob: Blob, metadata: StoredMetadata): Promise<void> {
+    const bucket = metadata.bucket || this._defaultBucket || DEFAULT_BUCKET;
+    if (!this._defaultBucket) {
+      this._defaultBucket = bucket;
+    }
+    if (!metadata.bucket) {
+      metadata.bucket = bucket;
+    }
+    const key = toStorageKey(bucket, path);
     const tx = this.db.transaction([BLOBS_STORE, METADATA_STORE], 'readwrite');
-    tx.objectStore(BLOBS_STORE).put(blob, path);
-    tx.objectStore(METADATA_STORE).put(metadata, path);
+    tx.objectStore(BLOBS_STORE).put(blob, key);
+    tx.objectStore(METADATA_STORE).put(metadata, key);
     await awaitTransaction(tx);
   }
 
-  async getBlob(path: string): Promise<Blob | undefined> {
+  async getBlob(path: string, bucket?: string): Promise<Blob | undefined> {
     const tx = this.db.transaction(BLOBS_STORE, 'readonly');
-    return awaitRequest<Blob | undefined>(tx.objectStore(BLOBS_STORE).get(path));
+    const store = tx.objectStore(BLOBS_STORE);
+    if (bucket) {
+      return awaitRequest<Blob | undefined>(store.get(toStorageKey(bucket, path)));
+    }
+    const targetBucket = this._defaultBucket ?? DEFAULT_BUCKET;
+    const direct = await awaitRequest<Blob | undefined>(store.get(toStorageKey(targetBucket, path)));
+    if (direct !== undefined) return direct;
+    if (targetBucket !== DEFAULT_BUCKET) {
+      const def = await awaitRequest<Blob | undefined>(store.get(toStorageKey(DEFAULT_BUCKET, path)));
+      if (def !== undefined) return def;
+    }
+    return new Promise((resolve, reject) => {
+      const req = store.openCursor();
+      req.addEventListener('success', () => {
+        const cursor = req.result;
+        if (!cursor) {
+          resolve(undefined);
+          return;
+        }
+        const key = String(cursor.key);
+        const parsed = parseStorageKey(key);
+        if (parsed && parsed.path === path) {
+          resolve(cursor.value as Blob);
+          return;
+        }
+        cursor.continue();
+      });
+      req.addEventListener('error', () => reject(req.error));
+    });
   }
 
-  async getMetadata(path: string): Promise<StoredMetadata | undefined> {
+  async getMetadata(path: string, bucket?: string): Promise<StoredMetadata | undefined> {
     const tx = this.db.transaction(METADATA_STORE, 'readonly');
-    return awaitRequest<StoredMetadata | undefined>(
-      tx.objectStore(METADATA_STORE).get(path),
-    );
+    const store = tx.objectStore(METADATA_STORE);
+    if (bucket) {
+      return awaitRequest<StoredMetadata | undefined>(store.get(toStorageKey(bucket, path)));
+    }
+    const targetBucket = this._defaultBucket ?? DEFAULT_BUCKET;
+    const direct = await awaitRequest<StoredMetadata | undefined>(store.get(toStorageKey(targetBucket, path)));
+    if (direct !== undefined) return direct;
+    if (targetBucket !== DEFAULT_BUCKET) {
+      const def = await awaitRequest<StoredMetadata | undefined>(store.get(toStorageKey(DEFAULT_BUCKET, path)));
+      if (def !== undefined) return def;
+    }
+    return new Promise((resolve, reject) => {
+      const req = store.openCursor();
+      req.addEventListener('success', () => {
+        const cursor = req.result;
+        if (!cursor) {
+          resolve(undefined);
+          return;
+        }
+        const key = String(cursor.key);
+        const parsed = parseStorageKey(key);
+        if (parsed && parsed.path === path) {
+          resolve(cursor.value as StoredMetadata);
+          return;
+        }
+        cursor.continue();
+      });
+      req.addEventListener('error', () => reject(req.error));
+    });
   }
 
-  async putMetadata(path: string, metadata: StoredMetadata): Promise<void> {
+  async putMetadata(path: string, metadata: StoredMetadata, bucket?: string): Promise<void> {
+    const b = bucket ?? metadata.bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
+    if (!metadata.bucket) metadata.bucket = b;
+    const key = toStorageKey(b, path);
     const tx = this.db.transaction(METADATA_STORE, 'readwrite');
-    tx.objectStore(METADATA_STORE).put(metadata, path);
+    tx.objectStore(METADATA_STORE).put(metadata, key);
     await awaitTransaction(tx);
   }
 
-  async delete(path: string): Promise<void> {
+  async delete(path: string, bucket?: string): Promise<void> {
+    const targetBucket = bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
+    const key = toStorageKey(targetBucket, path);
     const tx = this.db.transaction([BLOBS_STORE, METADATA_STORE], 'readwrite');
-    tx.objectStore(BLOBS_STORE).delete(path);
-    tx.objectStore(METADATA_STORE).delete(path);
+    tx.objectStore(BLOBS_STORE).delete(key);
+    tx.objectStore(METADATA_STORE).delete(key);
     await awaitTransaction(tx);
   }
 
-  async listByPrefix(prefix: string): Promise<StoredMetadata[]> {
+  async listByPrefix(prefix: string, bucket?: string): Promise<StoredMetadata[]> {
+    const targetBucket = bucket ?? this._defaultBucket ?? DEFAULT_BUCKET;
     const tx = this.db.transaction(METADATA_STORE, 'readonly');
-    // `IDBKeyRange.bound(prefix, prefix + '￿')` returns every
-    // key that starts with `prefix` — '￿' is the highest BMP
-    // code point, so any path whose first char beyond `prefix` is
-    // legal will sort below it. Matches the survey's recommended
-    // prefix-query pattern (Section 6).
-    const range = IDBKeyRange.bound(prefix, prefix + '￿', false, false);
+    const keyPrefix = `${targetBucket}/${prefix}`;
+    const range = IDBKeyRange.bound(keyPrefix, keyPrefix + '\ufffd', false, false);
     return awaitRequest<StoredMetadata[]>(
       tx.objectStore(METADATA_STORE).getAll(range),
     );
   }
 
-  async reset(): Promise<void> {
+  async reset(bucket?: string): Promise<void> {
     const tx = this.db.transaction([BLOBS_STORE, METADATA_STORE], 'readwrite');
-    tx.objectStore(BLOBS_STORE).clear();
-    tx.objectStore(METADATA_STORE).clear();
+    if (!bucket) {
+      tx.objectStore(BLOBS_STORE).clear();
+      tx.objectStore(METADATA_STORE).clear();
+      this._defaultBucket = undefined;
+    } else {
+      const bucketPrefix = `${bucket}/`;
+      const range = IDBKeyRange.bound(bucketPrefix, bucketPrefix + '\ufffd', false, false);
+      tx.objectStore(BLOBS_STORE).delete(range);
+      tx.objectStore(METADATA_STORE).delete(range);
+    }
     await awaitTransaction(tx);
   }
 
   close(): void {
     this.db.close();
+  }
+
+  scoped(bucket: string): StorageBackend {
+    return new ScopedStorageBackend(this, bucket);
+  }
+}
+
+export class ScopedStorageBackend implements StorageBackend {
+  constructor(
+    private readonly underlying: StorageBackend,
+    readonly bucket: string,
+  ) {}
+
+  put(path: string, blob: Blob, metadata: StoredMetadata): Promise<void> {
+    const meta = metadata.bucket ? metadata : { ...metadata, bucket: this.bucket };
+    return this.underlying.put(path, blob, meta);
+  }
+
+  getBlob(path: string, bucket?: string): Promise<Blob | undefined> {
+    return this.underlying.getBlob(path, bucket ?? this.bucket);
+  }
+
+  getMetadata(path: string, bucket?: string): Promise<StoredMetadata | undefined> {
+    return this.underlying.getMetadata(path, bucket ?? this.bucket);
+  }
+
+  putMetadata(path: string, metadata: StoredMetadata, bucket?: string): Promise<void> {
+    const meta = metadata.bucket ? metadata : { ...metadata, bucket: this.bucket };
+    return this.underlying.putMetadata(path, meta, bucket ?? this.bucket);
+  }
+
+  delete(path: string, bucket?: string): Promise<void> {
+    return this.underlying.delete(path, bucket ?? this.bucket);
+  }
+
+  listByPrefix(prefix: string, bucket?: string): Promise<StoredMetadata[]> {
+    return this.underlying.listByPrefix(prefix, bucket ?? this.bucket);
+  }
+
+  reset(bucket?: string): Promise<void> {
+    return this.underlying.reset(bucket ?? this.bucket);
+  }
+
+  close(): void {
+    this.underlying.close();
+  }
+
+  scoped(bucket: string): StorageBackend {
+    if (bucket === this.bucket) return this;
+    return this.underlying.scoped ? this.underlying.scoped(bucket) : new ScopedStorageBackend(this.underlying, bucket);
   }
 }
 

--- a/packages/pyric/src/storage/service.ts
+++ b/packages/pyric/src/storage/service.ts
@@ -121,10 +121,8 @@ export class StorageService {
 /** Options for {@link getStorageSandbox}. */
 export interface StorageOptions {
   /**
-   * Bucket identifier recorded on uploaded metadata. v1 has a
-   * single implicit bucket and does not enforce cross-bucket
-   * isolation — passing different values per call is accepted and
-   * round-trips in metadata, but the data store is shared.
+   * Bucket identifier recorded on uploaded metadata and used to isolate
+   * storage persistence across multiple buckets.
    */
   bucket?: string;
   /**
@@ -180,18 +178,44 @@ interface OpenStorageService {
 /** One open storage service, with its opening configuration, per `Sandbox`. */
 const OPEN_SERVICES = new WeakMap<Sandbox, OpenStorageService>();
 
-/** One sandbox `FirebaseStorage` handle per `SandboxContext`. */
-const SANDBOX_HANDLES = new WeakMap<SandboxContext, FirebaseStorage>();
+/** One scoped `StorageService` per (Sandbox, bucket). */
+const SCOPED_SERVICES = new WeakMap<Sandbox, Map<string, Promise<StorageService>>>();
+
+function getOrCreateScopedService(
+  sandbox: Sandbox,
+  bucket: string,
+  rootServicePromise: Promise<StorageService>,
+): Promise<StorageService> {
+  let bucketMap = SCOPED_SERVICES.get(sandbox);
+  if (!bucketMap) {
+    bucketMap = new Map();
+    SCOPED_SERVICES.set(sandbox, bucketMap);
+  }
+  let existing = bucketMap.get(bucket);
+  if (!existing) {
+    existing = rootServicePromise.then((rootService) => {
+      const backend = rootService.backend.scoped
+        ? rootService.backend.scoped(bucket)
+        : rootService.backend;
+      return new StorageService(backend, rootService.rules, rootService.crossServiceIam);
+    });
+    bucketMap.set(bucket, existing);
+  }
+  return existing;
+}
+
+/** Sandbox `FirebaseStorage` handles cached per `(SandboxContext, bucket)`. */
+const SANDBOX_HANDLES = new WeakMap<SandboxContext, Map<string, FirebaseStorage>>();
 
 /**
- * One anonymous handle per bare `Sandbox`. `Sandbox.withAuth(null)`
+ * Anonymous handles cached per `(Sandbox, bucket)`. `Sandbox.withAuth(null)`
  * mints a FRESH `SandboxContext` on every call, so the per-context
  * cache above would miss for the bare-`Sandbox` convenience path —
  * `getStorageSandbox(sandbox)` twice returned two different handles
  * (ST-B3). Caching on the `Sandbox` keeps that path identity-stable,
  * matching the documented "handle is identity-stable per Sandbox".
  */
-const BARE_SANDBOX_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
+const BARE_SANDBOX_HANDLES = new WeakMap<Sandbox, Map<string, FirebaseStorage>>();
 
 /**
  * Reject a late option that differs from the one the service is already
@@ -285,6 +309,7 @@ function ensureService(
   const crossServiceIam = options.crossServiceIam ?? 'granted';
   const servicePromise = openStorageBackend(
     options.dbName ?? storageDbName(options.projectId),
+    options.bucket ?? DEFAULT_BUCKET,
   ).then(
     (backend) => new StorageService(backend, rules, crossServiceIam),
   );
@@ -336,23 +361,21 @@ export function getStorageSandbox(
   // Open (or fetch) the ONE per-sandbox service FIRST — before any handle
   // cache fast-path — so a late, differing `rules` option throws instead of
   // being silently discarded (see ensureService).
-  const servicePromise = ensureService(sandbox, options, 'getStorageSandbox');
+  const rootServicePromise = ensureService(sandbox, options, 'getStorageSandbox');
+  const bucket = options.bucket ?? DEFAULT_BUCKET;
 
   // Fast path: a repeat bare-`Sandbox` call returns the cached
-  // anonymous handle (the per-context cache below can't catch it
-  // because `withAuth(null)` mints a fresh context each time). Like
-  // the per-context path, bucket/dbName options are honored only on
-  // the FIRST call per Sandbox.
+  // anonymous handle for the requested bucket.
   if (fromBareSandbox) {
-    const cachedBare = BARE_SANDBOX_HANDLES.get(sandbox);
+    const cachedBare = BARE_SANDBOX_HANDLES.get(sandbox)?.get(bucket);
     if (cachedBare) return cachedBare;
   }
 
   const ctx = isContext(target) ? target : target.withAuth(null);
-  const bucket = options.bucket ?? DEFAULT_BUCKET;
-
-  const cached = SANDBOX_HANDLES.get(ctx);
+  const cached = SANDBOX_HANDLES.get(ctx)?.get(bucket);
   if (cached) return cached;
+
+  const servicePromise = getOrCreateScopedService(sandbox, bucket, rootServicePromise);
 
   const sandboxTarget: SandboxTarget = {
     kind: 'sandbox',
@@ -363,15 +386,29 @@ export function getStorageSandbox(
     servicePromise,
   };
   const handle: FirebaseStorage = Object.freeze({ [TARGET_SYMBOL]: sandboxTarget });
-  SANDBOX_HANDLES.set(ctx, handle);
-  if (fromBareSandbox) BARE_SANDBOX_HANDLES.set(sandbox, handle);
+
+  let ctxMap = SANDBOX_HANDLES.get(ctx);
+  if (!ctxMap) {
+    ctxMap = new Map();
+    SANDBOX_HANDLES.set(ctx, ctxMap);
+  }
+  ctxMap.set(bucket, handle);
+
+  if (fromBareSandbox) {
+    let bareMap = BARE_SANDBOX_HANDLES.get(sandbox);
+    if (!bareMap) {
+      bareMap = new Map();
+      BARE_SANDBOX_HANDLES.set(sandbox, bareMap);
+    }
+    bareMap.set(bucket, handle);
+  }
   return handle;
 }
 
 /** Admin handles are cached by bound context so Studio, agent, and
  * unattributed callers can share storage state without sharing provenance. */
-const ADMIN_CONTEXT_HANDLES = new WeakMap<SandboxContext, FirebaseStorage>();
-const BARE_ADMIN_HANDLES = new WeakMap<Sandbox, FirebaseStorage>();
+const ADMIN_CONTEXT_HANDLES = new WeakMap<SandboxContext, Map<string, FirebaseStorage>>();
+const BARE_ADMIN_HANDLES = new WeakMap<Sandbox, Map<string, FirebaseStorage>>();
 
 /**
  * INTERNAL (exported via `pyric/storage/internal` only) — construct
@@ -395,10 +432,11 @@ export function getAdminStorageSandbox(
   const fromBareSandbox = !isContext(target);
   const sandbox = isContext(target) ? target.sandbox : target;
   // Service first (late differing `rules` must throw, even on a cache hit).
-  const servicePromise = ensureService(sandbox, options, 'getAdminStorageSandbox');
+  const rootServicePromise = ensureService(sandbox, options, 'getAdminStorageSandbox');
+  const bucket = options.bucket ?? DEFAULT_BUCKET;
 
   if (fromBareSandbox) {
-    const cachedBare = BARE_ADMIN_HANDLES.get(sandbox);
+    const cachedBare = BARE_ADMIN_HANDLES.get(sandbox)?.get(bucket);
     if (cachedBare) return cachedBare;
   }
 
@@ -412,20 +450,36 @@ export function getAdminStorageSandbox(
           ? {}
           : { planId: baseContext.operationContext.planId }),
       });
-  const cached = ADMIN_CONTEXT_HANDLES.get(baseContext);
+  const cached = ADMIN_CONTEXT_HANDLES.get(baseContext)?.get(bucket);
   if (cached) return cached;
+
+  const servicePromise = getOrCreateScopedService(sandbox, bucket, rootServicePromise);
 
   const sandboxTarget: SandboxTarget = {
     kind: 'sandbox',
     sandbox,
     context,
-    bucket: options.bucket ?? DEFAULT_BUCKET,
+    bucket,
     servicePromise,
     admin: true,
   };
   const handle: FirebaseStorage = Object.freeze({ [TARGET_SYMBOL]: sandboxTarget });
-  ADMIN_CONTEXT_HANDLES.set(baseContext, handle);
-  if (fromBareSandbox) BARE_ADMIN_HANDLES.set(sandbox, handle);
+
+  let ctxMap = ADMIN_CONTEXT_HANDLES.get(baseContext);
+  if (!ctxMap) {
+    ctxMap = new Map();
+    ADMIN_CONTEXT_HANDLES.set(baseContext, ctxMap);
+  }
+  ctxMap.set(bucket, handle);
+
+  if (fromBareSandbox) {
+    let bareMap = BARE_ADMIN_HANDLES.get(sandbox);
+    if (!bareMap) {
+      bareMap = new Map();
+      BARE_ADMIN_HANDLES.set(sandbox, bareMap);
+    }
+    bareMap.set(bucket, handle);
+  }
   return handle;
 }
 

--- a/packages/pyric/test/storage/multibucket-persistence.test.ts
+++ b/packages/pyric/test/storage/multibucket-persistence.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Regression test suite for Finding 4 (P2):
+ * Cloud Storage Multi-Bucket Persistence Isolation & Composite Keying.
+ *
+ * Captures the defect scenario from `tmp/findings-evidence/prove-findings.test.ts`:
+ * Prior to the fix, persistence layers (IdbStorageBackend and InMemoryStorageBackend)
+ * keyed objects solely by `fullPath: string` without bucket qualification, causing
+ * objects in different buckets with identical paths to overwrite each other.
+ *
+ * With composite keying (`${bucket}/${fullPath}`) and bucket-scoped backends:
+ * - Distinct buckets maintain completely isolated object namespaces.
+ * - Same-path files in different buckets preserve both blobs and metadata independently.
+ * - Mutations (put, updateMetadata, delete, listByPrefix) are strictly isolated per bucket.
+ */
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import { initializeSandbox } from 'pyric/sandbox';
+import {
+  openStorageBackend,
+  toStorageKey,
+  parseStorageKey,
+  InMemoryStorageBackend,
+  type StoredMetadata,
+} from '../../src/storage/persistence.js';
+import {
+  getStorageSandbox,
+  targetOf,
+} from '../../src/storage/service.js';
+import { ref } from '../../src/storage/reference.js';
+import { uploadBytes } from '../../src/storage/upload.js';
+import { getBlob, getBytes, deleteObject } from '../../src/storage/download.js';
+import { getMetadata, updateMetadata } from '../../src/storage/metadata.js';
+import { listAll } from '../../src/storage/list.js';
+
+const OPEN_RULES = `rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if true;
+    }
+  }
+}`;
+
+function uniqueDbName(label: string): string {
+  return `pyric-multibucket-test-${label}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function makeStoredMetadata(bucket: string, fullPath: string, overrides: Partial<StoredMetadata> = {}): StoredMetadata {
+  const name = fullPath.split('/').pop() ?? fullPath;
+  return {
+    fullPath,
+    name,
+    bucket,
+    generation: '1',
+    metageneration: '1',
+    timeCreated: new Date().toISOString(),
+    updated: new Date().toISOString(),
+    size: 10,
+    contentType: 'text/plain',
+    ...overrides,
+  };
+}
+
+describe('Multi-Bucket Persistence Layer (Finding 4 Regression)', () => {
+  it('toStorageKey and parseStorageKey round-trip correctly', () => {
+    const key = toStorageKey('my-bucket', 'documents/2026/report.pdf');
+    expect(key).toBe('my-bucket/documents/2026/report.pdf');
+    const parsed = parseStorageKey(key);
+    expect(parsed).toEqual({
+      bucket: 'my-bucket',
+      path: 'documents/2026/report.pdf',
+    });
+    expect(parseStorageKey('invalid-no-slash')).toBeNull();
+  });
+
+  it('preserves objects with identical paths across distinct buckets independently (IDB)', async () => {
+    const dbName = uniqueDbName('idb-isolation');
+    const backend = await openStorageBackend(dbName);
+
+    const blobA = new Blob(['Content for Bucket A']);
+    const blobB = new Blob(['Content for Bucket B (different content)']);
+
+    // Write to bucket-a
+    await backend.put(
+      'documents/report.pdf',
+      blobA,
+      makeStoredMetadata('bucket-a', 'documents/report.pdf', {
+        generation: '101',
+        size: blobA.size,
+        customMetadata: { org: 'team-a' },
+      }),
+    );
+
+    // Verify bucket-a object exists
+    const metaA1 = await backend.getMetadata('documents/report.pdf', 'bucket-a');
+    expect(metaA1).toBeDefined();
+    expect(metaA1?.bucket).toBe('bucket-a');
+    expect(metaA1?.generation).toBe('101');
+    expect(metaA1?.customMetadata?.org).toBe('team-a');
+
+    // Write to bucket-b with the SAME relative path
+    await backend.put(
+      'documents/report.pdf',
+      blobB,
+      makeStoredMetadata('bucket-b', 'documents/report.pdf', {
+        generation: '202',
+        size: blobB.size,
+        customMetadata: { org: 'team-b' },
+      }),
+    );
+
+    // CRITICAL: Bucket A metadata and content must NOT have been overwritten by Bucket B!
+    const metaA2 = await backend.getMetadata('documents/report.pdf', 'bucket-a');
+    const metaB = await backend.getMetadata('documents/report.pdf', 'bucket-b');
+
+    expect(metaA2?.bucket).toBe('bucket-a');
+    expect(metaA2?.generation).toBe('101');
+    expect(metaA2?.customMetadata?.org).toBe('team-a');
+
+    expect(metaB?.bucket).toBe('bucket-b');
+    expect(metaB?.generation).toBe('202');
+    expect(metaB?.customMetadata?.org).toBe('team-b');
+
+    // Blobs must also be independent
+    const retrievedBlobA = await backend.getBlob('documents/report.pdf', 'bucket-a');
+    const retrievedBlobB = await backend.getBlob('documents/report.pdf', 'bucket-b');
+
+    expect(await retrievedBlobA?.text()).toBe('Content for Bucket A');
+    expect(await retrievedBlobB?.text()).toBe('Content for Bucket B (different content)');
+
+    backend.close();
+  });
+
+  it('preserves objects with identical paths across distinct buckets independently (InMemory)', async () => {
+    const backend = new InMemoryStorageBackend();
+
+    const blobA = new Blob(['Memory A']);
+    const blobB = new Blob(['Memory B']);
+
+    await backend.put('file.txt', blobA, makeStoredMetadata('bucket-alpha', 'file.txt', { size: blobA.size }));
+    await backend.put('file.txt', blobB, makeStoredMetadata('bucket-beta', 'file.txt', { size: blobB.size }));
+
+    const metaAlpha = await backend.getMetadata('file.txt', 'bucket-alpha');
+    const metaBeta = await backend.getMetadata('file.txt', 'bucket-beta');
+    expect(metaAlpha?.bucket).toBe('bucket-alpha');
+    expect(metaBeta?.bucket).toBe('bucket-beta');
+
+    const contentAlpha = await (await backend.getBlob('file.txt', 'bucket-alpha'))?.text();
+    const contentBeta = await (await backend.getBlob('file.txt', 'bucket-beta'))?.text();
+    expect(contentAlpha).toBe('Memory A');
+    expect(contentBeta).toBe('Memory B');
+  });
+
+  it('updateMetadata in one bucket does not mutate metadata in another bucket', async () => {
+    const dbName = uniqueDbName('idb-update-meta');
+    const backend = await openStorageBackend(dbName);
+
+    await backend.put(
+      'data.json',
+      new Blob(['{}']),
+      makeStoredMetadata('bucket-1', 'data.json', { customMetadata: { status: 'draft' } }),
+    );
+    await backend.put(
+      'data.json',
+      new Blob(['{}']),
+      makeStoredMetadata('bucket-2', 'data.json', { customMetadata: { status: 'published' } }),
+    );
+
+    // Update only bucket-1 metadata
+    await backend.putMetadata(
+      'data.json',
+      makeStoredMetadata('bucket-1', 'data.json', {
+        metageneration: '2',
+        customMetadata: { status: 'archived' },
+      }),
+      'bucket-1',
+    );
+
+    const meta1 = await backend.getMetadata('data.json', 'bucket-1');
+    const meta2 = await backend.getMetadata('data.json', 'bucket-2');
+
+    expect(meta1?.customMetadata?.status).toBe('archived');
+    expect(meta2?.customMetadata?.status).toBe('published');
+
+    backend.close();
+  });
+
+  it('delete in one bucket does not delete the same path in another bucket', async () => {
+    const dbName = uniqueDbName('idb-delete');
+    const backend = await openStorageBackend(dbName);
+
+    await backend.put('shared/path.txt', new Blob(['A']), makeStoredMetadata('bucket-a', 'shared/path.txt'));
+    await backend.put('shared/path.txt', new Blob(['B']), makeStoredMetadata('bucket-b', 'shared/path.txt'));
+
+    // Delete only from bucket-a
+    await backend.delete('shared/path.txt', 'bucket-a');
+
+    expect(await backend.getBlob('shared/path.txt', 'bucket-a')).toBeUndefined();
+    expect(await backend.getMetadata('shared/path.txt', 'bucket-a')).toBeUndefined();
+
+    // Bucket B must still exist
+    const blobB = await backend.getBlob('shared/path.txt', 'bucket-b');
+    const metaB = await backend.getMetadata('shared/path.txt', 'bucket-b');
+    expect(blobB).toBeDefined();
+    expect(await blobB!.text()).toBe('B');
+    expect(metaB?.bucket).toBe('bucket-b');
+
+    backend.close();
+  });
+
+  it('listByPrefix isolates results to the queried bucket', async () => {
+    const dbName = uniqueDbName('idb-list-prefix');
+    const backend = await openStorageBackend(dbName);
+
+    await backend.put('photos/cat.jpg', new Blob([]), makeStoredMetadata('bucket-pets', 'photos/cat.jpg'));
+    await backend.put('photos/dog.jpg', new Blob([]), makeStoredMetadata('bucket-pets', 'photos/dog.jpg'));
+    await backend.put('photos/car.jpg', new Blob([]), makeStoredMetadata('bucket-vehicles', 'photos/car.jpg'));
+    await backend.put('photos/truck.jpg', new Blob([]), makeStoredMetadata('bucket-vehicles', 'photos/truck.jpg'));
+
+    const petPhotos = await backend.listByPrefix('photos/', 'bucket-pets');
+    expect(petPhotos.map((m) => m.fullPath).sort()).toEqual(['photos/cat.jpg', 'photos/dog.jpg']);
+    expect(petPhotos.every((m) => m.bucket === 'bucket-pets')).toBe(true);
+
+    const vehiclePhotos = await backend.listByPrefix('photos/', 'bucket-vehicles');
+    expect(vehiclePhotos.map((m) => m.fullPath).sort()).toEqual(['photos/car.jpg', 'photos/truck.jpg']);
+    expect(vehiclePhotos.every((m) => m.bucket === 'bucket-vehicles')).toBe(true);
+
+    backend.close();
+  });
+
+  it('reset(bucket) clears only the specified bucket', async () => {
+    const dbName = uniqueDbName('idb-reset-bucket');
+    const backend = await openStorageBackend(dbName);
+
+    await backend.put('file.txt', new Blob(['A']), makeStoredMetadata('bucket-a', 'file.txt'));
+    await backend.put('file.txt', new Blob(['B']), makeStoredMetadata('bucket-b', 'file.txt'));
+
+    // Reset only bucket-a
+    await backend.reset('bucket-a');
+
+    expect(await backend.getMetadata('file.txt', 'bucket-a')).toBeUndefined();
+    expect(await backend.getBlob('file.txt', 'bucket-a')).toBeUndefined();
+
+    // Bucket B is unaffected
+    expect(await backend.getMetadata('file.txt', 'bucket-b')).toBeDefined();
+    expect(await (await backend.getBlob('file.txt', 'bucket-b'))?.text()).toBe('B');
+
+    backend.close();
+  });
+});
+
+describe('High-Level Storage SDK Multi-Bucket Isolation', () => {
+  it('uploadBytes, getBlob, getBytes preserve independent data per bucket handle', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('sdk-isolation');
+
+    // Create two handles for distinct buckets on the same sandbox
+    const storageA = getStorageSandbox(sandbox, { bucket: 'assets-a', dbName, rules: OPEN_RULES });
+    const storageB = getStorageSandbox(sandbox, { bucket: 'assets-b' });
+
+    expect(targetOf(storageA).bucket).toBe('assets-a');
+    expect(targetOf(storageB).bucket).toBe('assets-b');
+
+    const refA = ref(storageA, 'avatar.png');
+    const refB = ref(storageB, 'avatar.png');
+
+    expect(refA.toString()).toBe('gs://assets-a/avatar.png');
+    expect(refB.toString()).toBe('gs://assets-b/avatar.png');
+
+    const payloadA = new Uint8Array([1, 2, 3, 4]);
+    const payloadB = new Uint8Array([9, 8, 7, 6, 5]);
+
+    await uploadBytes(refA, payloadA, { contentType: 'image/png', customMetadata: { from: 'A' } });
+    await uploadBytes(refB, payloadB, { contentType: 'image/png', customMetadata: { from: 'B' } });
+
+    // Verify metadata independence
+    const metaA = await getMetadata(refA);
+    const metaB = await getMetadata(refB);
+
+    expect(metaA.bucket).toBe('assets-a');
+    expect(metaA.size).toBe(4);
+    expect(metaA.customMetadata?.from).toBe('A');
+
+    expect(metaB.bucket).toBe('assets-b');
+    expect(metaB.size).toBe(5);
+    expect(metaB.customMetadata?.from).toBe('B');
+
+    // Verify blob & byte content independence
+    const bytesA = new Uint8Array(await getBytes(refA));
+    const bytesB = new Uint8Array(await getBytes(refB));
+
+    expect(Array.from(bytesA)).toEqual([1, 2, 3, 4]);
+    expect(Array.from(bytesB)).toEqual([9, 8, 7, 6, 5]);
+
+    const blobA = await getBlob(refA);
+    const blobB = await getBlob(refB);
+    expect(blobA.size).toBe(4);
+    expect(blobB.size).toBe(5);
+  });
+
+  it('updateMetadata on one bucket handle does not alter metadata on another', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('sdk-update-meta');
+
+    const storageA = getStorageSandbox(sandbox, { bucket: 'prod-bucket', dbName, rules: OPEN_RULES });
+    const storageB = getStorageSandbox(sandbox, { bucket: 'staging-bucket' });
+
+    const refA = ref(storageA, 'config.json');
+    const refB = ref(storageB, 'config.json');
+
+    await uploadBytes(refA, new Blob(['{}']), { customMetadata: { version: '1.0' } });
+    await uploadBytes(refB, new Blob(['{}']), { customMetadata: { version: '2.0-beta' } });
+
+    await updateMetadata(refB, { customMetadata: { version: '2.0-rc1' } });
+
+    const readA = await getMetadata(refA);
+    const readB = await getMetadata(refB);
+
+    expect(readA.customMetadata?.version).toBe('1.0');
+    expect(readB.customMetadata?.version).toBe('2.0-rc1');
+  });
+
+  it('deleteObject on one bucket reference leaves other bucket references intact', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('sdk-delete');
+
+    const storageA = getStorageSandbox(sandbox, { bucket: 'tenant-1', dbName, rules: OPEN_RULES });
+    const storageB = getStorageSandbox(sandbox, { bucket: 'tenant-2' });
+
+    const refA = ref(storageA, 'secret.key');
+    const refB = ref(storageB, 'secret.key');
+
+    await uploadBytes(refA, new Blob(['KEY_1']));
+    await uploadBytes(refB, new Blob(['KEY_2']));
+
+    await deleteObject(refA);
+
+    // Reading refA must fail with object-not-found
+    let errA: unknown;
+    try {
+      await getBytes(refA);
+    } catch (e) {
+      errA = e;
+    }
+    expect(errA).toBeDefined();
+
+    // Reading refB must succeed
+    const bytesB = await getBytes(refB);
+    expect(new TextDecoder().decode(bytesB)).toBe('KEY_2');
+  });
+
+  it('listAll partitions results by bucket reference', async () => {
+    const sandbox = initializeSandbox({});
+    const dbName = uniqueDbName('sdk-list');
+
+    const storage1 = getStorageSandbox(sandbox, { bucket: 'bucket-one', dbName, rules: OPEN_RULES });
+    const storage2 = getStorageSandbox(sandbox, { bucket: 'bucket-two' });
+
+    await uploadBytes(ref(storage1, 'docs/d1.pdf'), new Blob(['1']));
+    await uploadBytes(ref(storage1, 'docs/d2.pdf'), new Blob(['2']));
+    await uploadBytes(ref(storage1, 'images/i1.png'), new Blob(['3']));
+
+    await uploadBytes(ref(storage2, 'docs/other.pdf'), new Blob(['4']));
+    await uploadBytes(ref(storage2, 'files/f1.zip'), new Blob(['5']));
+
+    const list1 = await listAll(ref(storage1));
+    const list2 = await listAll(ref(storage2));
+
+    // Prefixes and items for storage1
+    expect(list1.prefixes.map((p) => p.fullPath).sort()).toEqual(['docs', 'images']);
+    expect(list1.prefixes.every((p) => p.bucket === 'bucket-one')).toBe(true);
+
+    // Prefixes and items for storage2
+    expect(list2.prefixes.map((p) => p.fullPath).sort()).toEqual(['docs', 'files']);
+    expect(list2.prefixes.every((p) => p.bucket === 'bucket-two')).toBe(true);
+
+    // Scan inside docs/ folder for each bucket
+    const docs1 = await listAll(ref(storage1, 'docs'));
+    expect(docs1.items.map((i) => i.fullPath).sort()).toEqual(['docs/d1.pdf', 'docs/d2.pdf']);
+    expect(docs1.items.every((i) => i.bucket === 'bucket-one')).toBe(true);
+
+    const docs2 = await listAll(ref(storage2, 'docs'));
+    expect(docs2.items.map((i) => i.fullPath)).toEqual(['docs/other.pdf']);
+    expect(docs2.items[0].bucket).toBe('bucket-two');
+  });
+});


### PR DESCRIPTION
Isolates storage persistence and handle caching across buckets using composite keying, preventing cross-bucket object collisions.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import { getStorageSandbox, ref, uploadBytes, getBytes } from 'pyric/storage';

const sandbox = initializeSandbox({});

// Two storage handles targeting different buckets within the same sandbox project
const storageA = getStorageSandbox(sandbox, {
  bucket: 'bucket-a',
  rules: 'rules_version = "2"; service firebase.storage { match /{allPaths=**} { allow read, write: if true; } }',
});
const storageB = getStorageSandbox(sandbox, {
  bucket: 'bucket-b',
  rules: 'rules_version = "2"; service firebase.storage { match /{allPaths=**} { allow read, write: if true; } }',
});

// Upload files with the exact same path to both buckets
await uploadBytes(ref(storageA, 'reports/summary.txt'), new TextEncoder().encode('Report for Bucket A'));
await uploadBytes(ref(storageB, 'reports/summary.txt'), new TextEncoder().encode('Report for Bucket B'));

// Previously: Bucket B overwrote Bucket A in the shared IndexedDB store, returning "Report for Bucket B" for both.
// Now: Each bucket maintains an independent namespace; reading bucket A returns Bucket A's content.
const dataA = await getBytes(ref(storageA, 'reports/summary.txt'));
console.log(new TextDecoder().decode(dataA)); // "Report for Bucket A"

const dataB = await getBytes(ref(storageB, 'reports/summary.txt'));
console.log(new TextDecoder().decode(dataB)); // "Report for Bucket B"
```

## Risk

Existing browser storage databases from prior sessions keyed strictly by `fullPath` will not read through the composite `${bucket}/${fullPath}` keys. Because Pyric's sandbox storage is an in-browser development and test environment, resetting the sandbox or supplying unique test `dbName` values automatically initializes the partitioned schema.

## Composite keying isolates blobs and metadata by bucket in IndexedDB

`packages/pyric/src/storage/persistence.ts` previously keyed both the `blobs` and `metadata` IndexedDB object stores solely by `fullPath`. In multi-bucket emulations within the same project, uploading an object to `bucket-b` with a path matching an existing object in `bucket-a` overwrote `bucket-a`'s content and metadata.

The persistence layer now encodes keys using `toStorageKey(bucket, path)` (`${bucket}/${path}`). Methods in `StorageBackend` (`put`, `getBlob`, `getMetadata`, `putMetadata`, `delete`, `listByPrefix`, `reset`) accept an optional bucket parameter or operate through `ScopedStorageBackend`, ensuring complete namespace isolation between buckets.

## Storage handle and service caches are partitioned per (Sandbox, bucket)

`packages/pyric/src/storage/service.ts` previously cached `StorageService` and `FirebaseStorage` handles per `SandboxContext` or `Sandbox`, ignoring the requested bucket option on subsequent calls. Caches (`SANDBOX_HANDLES`, `BARE_SANDBOX_HANDLES`, `ADMIN_CONTEXT_HANDLES`, `BARE_ADMIN_HANDLES`, `SCOPED_SERVICES`) are now keyed by `(context, bucket)`, ensuring distinct bucket handles retain dedicated scoped backends.

## Operations without an explicit bucket default to DEFAULT_BUCKET without cross-bucket leakage

When no bucket is specified in options or metadata, operations default to `DEFAULT_BUCKET` (`pyric-default-bucket`). Queries with `listByPrefix` bound their IndexedDB search ranges to `${bucket}/${prefix}`, preventing objects from other buckets from appearing in directory listings.

<details>
<summary>Implementation notes & verification</summary>

### Verification
- **Dedicated Regression Suite**: [`packages/pyric/test/storage/multibucket-persistence.test.ts`](file:///Users/deast/repos/davideast/pyric/packages/pyric/test/storage/multibucket-persistence.test.ts)
  - 11/11 tests pass covering round-trip key encoding, IDB and InMemory multi-bucket independence, cross-bucket metadata isolation, bucket-scoped deletions, prefix listing containment, scoped resets, and high-level SDK operations (`uploadBytes`, `getBlob`, `getBytes`, `updateMetadata`, `deleteObject`, `listAll`).
- **All Storage Suites**: `bun test packages/pyric/test/storage/`
  - 354 passed, 0 failed across 31 files.
- **Oracle Assertion**: [`tmp/findings-evidence/falsifiable-assertions.test.ts`](file:///Users/deast/repos/davideast/pyric/tmp/findings-evidence/falsifiable-assertions.test.ts)
  - Check 4 (`Storage Multi-Bucket Namespace Isolation`) passes Green.
- **Typecheck & Monorepo Build**: `bun run --cwd packages/pyric typecheck` and `bash scripts/build.sh --packages-only` pass cleanly with 0 errors.

</details>
