### PR TITLE
docs: add impersonation and Flutter guides

### DIFF
--- a/packages/cli/test/tool-name-drift.test.ts
+++ b/packages/cli/test/tool-name-drift.test.ts
@@ -12,6 +12,7 @@ import { DEFAULT_MCP_TOOL_NAMES } from '../src/bridge/server/mcp-contract.js';
 const NON_TOOL_TOKENS = new Set<string>([
   'rules_version', // Firestore/RTDB rules file schema field, not a tool.
   'firestore_simulator_', // Prose stem ("firestore_simulator_*"), not a literal tool name.
+  'pyric_firestore', // Dart/Flutter package name, not a tool.
 ]);
 
 /**

--- a/packages/site-docs/src/content/build/authentication.md
+++ b/packages/site-docs/src/content/build/authentication.md
@@ -60,7 +60,7 @@ To flip between identities without a sign-in flow, `setUser` forces the current 
 authSandbox.setUser(auth, aliceUser);
 authSandbox.setUser(auth, null);
 ```
-Keep the `sandbox` namespace out of app source. The real `firebase/auth` has no equivalent, so it belongs in your harness and seed code, where switching users mid-test is the point. In the running app, the account picker and `pyric snapshot` cover the same ground: lived users can be promoted to a committable fixture and re-seeded on boot.
+Keep the `sandbox` namespace out of app source. The real `firebase/auth` has no equivalent, so it belongs in your harness and seed code, where switching users mid-test is the point. In the running app, the runtime chip embeds an impersonation dialog to switch users, filter by tenant, or bypass rules without reloading: see [Switch and impersonate identities in development](../observe/switch-and-impersonate-identities.md). Lived users can also be promoted to a committable fixture with `pyric snapshot` and re-seeded on boot.
 
 ## Design an identity model
 

--- a/packages/site-docs/src/content/build/cloud-firestore.md
+++ b/packages/site-docs/src/content/build/cloud-firestore.md
@@ -96,6 +96,10 @@ pyric firestore indexes generate src --out firestore.indexes.json
 
 Review the generated file with the query open, then deploy it with the rest of the Firebase configuration when you [ship to production](../ship/ship-to-production.md).
 
+## Use from Flutter apps
+
+If you are building with Flutter, `pyric_firestore` redirects standard FlutterFire `cloud_firestore` calls to the local Pyric sandbox bridge during development without changing your application data code. See [Flutter development setup](../get-started/flutter.md).
+
 ## And from an agent
 
 Ask a connected agent to inventory the Firestore queries in the application, derive their indexes, and compare each query with the Rules that govern list access. [Work with an agent](../agent/work-with-an-agent.md) shows how the agent connects to the same local backend.

--- a/packages/site-docs/src/content/get-started/flutter.md
+++ b/packages/site-docs/src/content/get-started/flutter.md
@@ -1,0 +1,113 @@
+---
+title: "Flutter development setup"
+navLabel: "Flutter"
+group: "Get started"
+section: ""
+order: 35
+description: "Route cloud_firestore calls from Flutter apps to a local Pyric sandbox bridge during development."
+---
+
+# Flutter development setup
+
+Use Pyric with Flutter and FlutterFire without modifying your application data code.
+
+`pyric_firestore` is a platform interface implementation for [`cloud_firestore`](https://pub.dev/packages/cloud_firestore). In debug mode, it routes standard Firestore reads, writes, queries, and listeners across a local WebSocket bridge to your Pyric sandbox. In release builds, normal Firebase Cloud Firestore executes unchanged.
+
+## Add the dependency
+
+Add `pyric_firestore` to your Flutter project's `pubspec.yaml`:
+
+```bash
+flutter pub add pyric_firestore
+```
+
+## Register the platform interface
+
+In your application entry point (`lib/main.dart`), register `PyricFirestorePlatform` inside a `kDebugMode` guard before initializing UI or accessing Firestore:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:pyric_firestore/pyric_firestore.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+
+  // In debug builds, redirect Firestore calls to the local Pyric sandbox
+  if (kDebugMode) {
+    PyricFirestorePlatform.registerWith(
+      bridgeClient: PyricBridgeClient(
+        uri: Uri.parse('ws://127.0.0.1:5174/__pyric/sandbox'),
+      ),
+    );
+  }
+
+  runApp(const MyApp());
+}
+```
+
+Every standard `FirebaseFirestore.instance` call (`collection()`, `doc()`, `snapshots()`, transactions, batches) now executes against the local Pyric backend.
+
+## Start the Pyric sandbox bridge
+
+Start the Pyric sandbox with the bridge enabled and listen on your designated port:
+
+```bash
+npx pyric sandbox --bridge --port 5174
+```
+
+Alternatively, if you run a Vite web application alongside Flutter, enable the bridge in `vite.config.ts`:
+
+```ts
+import { defineConfig } from 'vite';
+import { pyric } from '@pyric/cli/vite';
+
+export default defineConfig({
+  plugins: [
+    pyric({
+      bridge: true,
+    }),
+  ],
+});
+```
+
+The bridge accepts WebSocket connections at `/__pyric/sandbox` on the development server origin.
+
+## Connect from devices and emulators
+
+The connection URI depends on where your Flutter application is running:
+
+| Target Platform | Bridge URI | Setup Command |
+| :--- | :--- | :--- |
+| **macOS / Windows / Linux desktop** | `ws://127.0.0.1:5174/__pyric/sandbox` | None |
+| **iOS Simulator** | `ws://127.0.0.1:5174/__pyric/sandbox` | None |
+| **Android Emulator** | `ws://127.0.0.1:5174/__pyric/sandbox` | `adb reverse tcp:5174 tcp:5174` |
+| **Physical Device (iOS / Android)** | `ws://<HOST-LAN-IP>:5174/__pyric/sandbox` | Connect to same Wi-Fi / local network |
+
+### Android Emulator setup
+
+Pyric enforces a DNS-rebinding security guard on incoming HTTP and WebSocket requests. When an Android emulator connects through the standard virtual router (`10.0.2.2:5174`), the request header carries `Host: 10.0.2.2:5174`, which the guard rejects.
+
+Run `adb reverse` to forward port 5174 over the emulator's loopback interface:
+
+```bash
+adb reverse tcp:5174 tcp:5174
+```
+
+With reverse forwarding active, connect to `ws://127.0.0.1:5174/__pyric/sandbox`.
+
+## Supported Firestore capabilities
+
+`pyric_firestore` mirrors FlutterFire's core API surface:
+
+- **Documents & Collections**: `doc()`, `collection()`, `get()`, `set()`, `update()`, `delete()`, and real-time `snapshots()`.
+- **Queries**: `where()`, `whereFilter()` (`Filter.and`, `Filter.or`), `orderBy()`, `limit()`, `limitToLast()`, and cursor pagination (`startAt`, `startAfter`, `endAt`, `endBefore`).
+- **Aggregations**: `count()`, `aggregate()`.
+- **Field Values**: `FieldValue.serverTimestamp()`, `FieldValue.increment()`, `FieldValue.arrayUnion()`, `FieldValue.arrayRemove()`, and `FieldValue.delete()`.
+- **Batched Writes**: Atomic `FirebaseFirestore.instance.batch()` commits.
+- **Transactions**: Interactive `FirebaseFirestore.instance.runTransaction()` reads and writes.
+
+Check the [Flutter Firestore conformance scorecard](/docs/firestore-flutter-compat/) for detailed behavioral coverage and parity status.

--- a/packages/site-docs/src/content/observe/resolve-runtime-status.md
+++ b/packages/site-docs/src/content/observe/resolve-runtime-status.md
@@ -30,7 +30,9 @@ Vite can serve a newer Pyric worker while an older SharedWorker is still running
 
 The old worker stops taking new work, finishes operations it already accepted, flushes captured state, and then reloads its connected tabs onto the new worker generation. The update control always occupies the same place in the panel, but remains disabled when the running worker is current.
 
-If replacement fails, the panel records the failure as a copyable error and leaves the update available so you can try again. Resolve the reported cause first. If a stale worker remains after a failed recovery, close every tab for that development origin and reopen the application.
+## Switch identities and impersonate users
+
+The runtime chip also hosts the local identity and impersonation dialog. When active, the collapsed bar displays your current impersonation badge (such as `as: <uid>` or `bypass rules`). Open the chip and select the **Identity** row to search users, test multi-tenant boundaries, or toggle an administrative rules bypass. See [Switch and impersonate identities in development](./switch-and-impersonate-identities.md) for the complete guide.
 
 ## Configure the chip
 

--- a/packages/site-docs/src/content/observe/switch-and-impersonate-identities.md
+++ b/packages/site-docs/src/content/observe/switch-and-impersonate-identities.md
@@ -1,0 +1,142 @@
+---
+title: "Switch and impersonate identities in development"
+navLabel: "Impersonate & tenants"
+group: "Observe & shape"
+section: ""
+order: 16
+description: "Switch active users, impersonate tenant identities, and bypass Security Rules with zero page reloads."
+---
+
+# Switch and impersonate identities in development
+
+Testing role-based access control and multi-tenant security boundaries usually requires repeatedly logging out, completing login flows with test credentials, or manually mocking JWT claims.
+
+During local Vite development (`pyric dev` or the `pyric()` plugin), Pyric embeds an accessible impersonation dialog directly inside the runtime chip. You can switch between active sandbox users, test multi-tenant boundaries (`request.auth.token.firebase.tenant`), and toggle an administrative rules bypass without reloading the page or altering application code.
+
+## Open the impersonation modal
+
+1. Look for the Pyric runtime chip in the bottom-right corner of your browser window. While the application is idle, the collapsed bar displays `ready` or your active identity badge (such as `as: <uid>` or `bypass rules`).
+2. Click anywhere on the bar to expand the runtime panel.
+3. Select the **Identity** row (or the **Impersonate** button) to open the modal dialog.
+
+The dialog uses the native HTML `<dialog>` element with focus containment. Pressing `Escape` or clicking the close button (`×`) dismisses the dialog and restores keyboard focus to the chip.
+
+## Switch between sandbox users
+
+The modal displays the current authentication status in the banner at the top, followed by a list of all sandbox users.
+
+1. Browse the user list or type in the search box to find a user by display name, email, UID, provider, or custom claims.
+2. Click any user in the list.
+
+The application immediately switches its active identity to that user:
+
+- **Zero page reload**: The Pyric client transport updates the active `AuthLens` without refreshing the page or restarting your components.
+- **Direct auth transition**: Active `onAuthStateChanged` listeners fire immediately with the new user record. If you switch from Alice to Bob, your application transitions directly from Alice to Bob without an intermediate `null` (signed-out) flash.
+- **Rules evaluation**: All subsequent Firestore and Realtime Database reads and writes evaluate against your Security Rules using the impersonated user's UID, provider data, and custom claims.
+
+To return to a signed-out state, open the modal and click **Sign Out**.
+
+## Filter users by role, tenant, or provider
+
+When your sandbox contains many seeded users, use the horizontal filter chips above the search list:
+
+- **All**: Displays all users in the local database.
+- **Admins**: Isolates users holding administrative custom claims (e.g. `role: 'admin'`, `admin: true`).
+- **Multi-Tenant**: Shows users scoped to an Identity Platform tenant.
+- **Provider chips**: Filters by identity provider, such as `google.com`, `github.com`, or password credentials.
+
+Selected filters combine with your search query to narrow the list instantly.
+
+## Create a new user on the fly
+
+If you need an identity that does not yet exist in your seed data:
+
+1. Open the impersonation modal and click **+ Create New User**.
+2. Enter the user's email address and an optional display name or password.
+3. If testing multi-tenancy, specify the target **Tenant ID**.
+4. To test role-based rules, provide custom claims as JSON (for example, `{"role": "editor", "department": "billing"}`).
+5. Submit the form.
+
+The new identity is created in the sandbox user database and selected as the active user immediately.
+
+## Test multi-tenant boundaries
+
+Firebase projects serving SaaS or enterprise customers rely on Google Cloud Identity Platform multi-tenancy. Security Rules enforce tenant isolation using the canonical claim:
+
+```rules
+request.auth.token.firebase.tenant
+```
+
+Pyric normalises tenant identity claims across the sandbox runtime and Security Rules engine:
+
+```rules
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /tenants/{tenantId}/workspaces/{workspaceId} {
+      // Enforce strict tenant boundary isolation
+      allow read, write: if request.auth != null
+        && request.auth.token.firebase.tenant == tenantId;
+    }
+  }
+}
+```
+
+When you impersonate a user assigned to tenant `tenant-acme`, Pyric populates `request.auth.token.firebase.tenant = 'tenant-acme'`. Switching to a user in `tenant-globex` causes requests targeting `/tenants/tenant-acme/...` to fail with a Security Rules denial, allowing you to test cross-tenant isolation live.
+
+## Bypass Security Rules with Admin Mode
+
+When building UI components before your Security Rules are fully defined, or when inspecting data structures that user rules restrict:
+
+1. Open the impersonation modal.
+2. Click **Toggle Admin Bypass**.
+
+When Admin Mode is active:
+
+- The collapsed runtime chip displays the badge `bypass rules`.
+- Firestore and Realtime Database operations execute under an administrative lens (`mode: 'admin'`), bypassing Security Rules evaluation while preserving your local application session.
+- To re-enable Security Rules enforcement, open the modal and click **Toggle Admin Bypass** again.
+
+## Persistence across browser reloads
+
+Active impersonation is persisted in browser storage:
+
+- The active lens (`mode: 'as'` or `mode: 'admin'`) is stored in `sessionStorage` under the key `pyric:auth-lens`.
+- Refreshing the browser tab or opening additional tabs on the same development server hydrates the saved lens automatically.
+- Closing the session or clicking **Sign Out** clears the stored lens and restores the standard application session.
+
+## Programmatic identity switching in tests
+
+For automated test suites and seed scripts, you can switch identities directly in code using the sandbox auth namespace without interacting with the UI:
+
+```ts
+import { initializeSandbox } from 'pyric/sandbox';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
+
+const sandbox = initializeSandbox();
+const auth = getAuth(sandbox);
+
+// Seed users with roles and tenant identifiers
+authSandbox.seedUsers(auth, [
+  {
+    uid: 'alice',
+    email: 'alice@acme.com',
+    tenant: 'tenant-acme',
+    customClaims: { role: 'admin' },
+  },
+  {
+    uid: 'bob',
+    email: 'bob@globex.com',
+    tenant: 'tenant-globex',
+    customClaims: { role: 'member' },
+  },
+]);
+
+// Switch the active user synchronously in tests
+authSandbox.setUser(auth, aliceUser);
+
+// Sign out
+authSandbox.setUser(auth, null);
+```
+
+Programmatic switches trigger `onAuthStateChanged` callbacks and update rules evaluation context identical to UI impersonation.


### PR DESCRIPTION
## Summary
- Adds Diataxis how-to guide for impersonating identities, multi-tenant boundary rules testing, and administrative bypass: `packages/site-docs/src/content/observe/switch-and-impersonate-identities.md`
- Adds Flutter integration guide using `pyric_firestore`: `packages/site-docs/src/content/get-started/flutter.md`
- Links new guides from authentication, Cloud Firestore, and runtime status documentation
- Adds `pyric_firestore` to `NON_TOOL_TOKENS` in `packages/cli/test/tool-name-drift.test.ts`

## Conformance & Site Build
- Verified Astro site builds cleanly (120 pages)
- Verified tool-name-drift test passes