### PR TITLE
release: v0.1.0-alpha.22

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "@pyric/cli",
-      "version": "0.1.0-alpha.21",
+      "version": "0.1.0-alpha.22",
       "bin": {
         "pyric": "./dist/cli/index.js",
       },
@@ -153,7 +153,7 @@
     },
     "packages/create-pyric": {
       "name": "create-pyric",
-      "version": "0.1.0-alpha.21",
+      "version": "0.1.0-alpha.22",
       "bin": {
         "create-pyric": "./dist/bin.js",
       },
@@ -273,7 +273,7 @@
     },
     "packages/pyric": {
       "name": "pyric",
-      "version": "0.1.0-alpha.21",
+      "version": "0.1.0-alpha.22",
       "dependencies": {
         "@inbrowser/agent": "0.4.2",
         "fake-indexeddb": "^6.0.0",
@@ -291,7 +291,7 @@
     },
     "packages/pyric-admin": {
       "name": "pyric-admin",
-      "version": "0.1.0-alpha.21",
+      "version": "0.1.0-alpha.22",
       "dependencies": {
         "pyric": "workspace:*",
       },
@@ -360,7 +360,7 @@
     },
     "packages/ui": {
       "name": "@pyric/ui",
-      "version": "0.1.0-alpha.21",
+      "version": "0.1.0-alpha.22",
       "dependencies": {
         "@tanstack/react-virtual": "3.13.24",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/cli",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/create-pyric/package.json
+++ b/packages/create-pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pyric",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric-admin/package.json
+++ b/packages/pyric-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric-admin",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/pyric/package.json
+++ b/packages/pyric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyric",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyric/ui",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "license": "Apache-2.0",
   "homepage": "https://pyric.dev",
   "repository": {


### PR DESCRIPTION
Release cut for `0.1.0-alpha.22`. Merging this PR marks the release; the changelog below is the record.

## Changes since v0.1.0-alpha.20

- docs: add impersonation and Flutter guides (#570) (8a6ffcd7)
- fix(storage): isolate persistence and handle caching across multiple buckets (3b0c51fd)
- feat(swift): Pure-Swift Firestore client library and CDD conformance suite (0e6365ae)
- feat(kotlin): Pure-Kotlin Pyric Firestore client and conformance suite (26b96668)
- release: v0.1.0-alpha.21 (#566) (86134989)
- fix(cli): enforce canonical realpath containment on studio workspace paths (#565) (032909c0)
- refactor(bridge): compose MCP tools from records and guard tool names in skills and docs (#559) (cd1d527a)
- chore(flutter): prepare pyric_firestore package for pub.dev (b3c32eb9)
- fix(flutter): resolve CI blocker, standards violations, and spec defects (4772ae7d)
- feat(flutter): Pure-Dart Pyric platform interface and conformance suite (2dbcce68)
- feat(cli): the production guard, a layered interlock against silent live-Firebase egress (#556) (1380aeca)
- feat(serve): AI diagnostics reach the terminal: failures, rejections, blocks, substitutions, status (#555) (a8c93685)
- fix(rules): fail-closed parity phase 2: budgets, absorption, rejection, IAM (#554) (99f8acc8)
- docs(readme): trim the tagline (#558) (e7ecdaed)
- docs(readme): lead with the mirror claim and canonical code (#557) (c26e0e30)
- fix: close the Firebase subpath cliff, redact leaked API keys, harden CI (#552) (518652e0)
- fix(conformance): self-defending ratchet and engine↔evidence coupling gate (#551) (259c0293)
- fix(rules): enforce fail-closed security invariants across Firestore, RTDB, and Storage (#550) (1e013481)
- feat(ui): promote headless Modal primitive with focus containment (#547) (d1792c2b)
- feat(cli): add multi-tenant impersonation modal and user typeahead to runtime chip (#548) (1c34e789)
- feat(rules): formalize multi-tenant priority and normalize tenant claims (#546) (421e48f1)
- ci: add advisory Knip audit step to pull request workflow (#544) (ed46a8f9)
- fix(cli): ratify ./bundler release contract and refine externals and docs (1cbfb68d)
- feat(cli): export backend bundler presets and add dev tooling guide (#506) (aa08a265)
- fix(cli): enforce sandbox isolation and explicit fallback policy in functions child metadata (f6d94bbe)
- fix docs sandbox command references (85a04959)
- fix(worker): address lifecycle review findings (8f534151)
- fix(worker): eagerly initialize on connection and maintain closed port tombstone (d1fc8cf3)
- fix(worker): drain ports closing during in-flight context initialization (dd12a8f7)
- fix(worker): prevent SharedWorker singleton context poisoning on bootstrap failure (13273551)

## After merging

- [ ] `bun run release:preflight 0.1.0-alpha.22` from a clean merged-main checkout; confirm it reports that no packages or dist-tags changed
- [ ] `bash scripts/publish-alpha.sh 0.1.0-alpha.22` from that same clean merged-main commit after the preflight succeeds
- [ ] `git tag v0.1.0-alpha.22 && git push origin v0.1.0-alpha.22` on the published commit
- [ ] Site deploy (`bash scripts/deploy-site.sh`) if the site should track the release
