### PR TITLE
fix(cli): enforce fail-closed session capability tokens and loopback origin validation across dev server and MCP bridge

### DIFF
--- a/packages/cli/src/bridge/server/standalone.ts
+++ b/packages/cli/src/bridge/server/standalone.ts
@@ -36,7 +36,7 @@ import {
   isBridgeMessage,
 } from '../protocol.js';
 import { pyricVersion } from '../../serve/standalone-assets.js';
-import { isAllowedUpgrade } from '../../serve/server.js';
+import { isAllowedLoopbackRequest, isAllowedUpgrade } from '../../serve/server.js';
 
 const BRIDGE_VERSION = pyricVersion();
 const DEFAULT_SESSION_IDLE_MS = 10 * 60 * 1000; // 10 minutes
@@ -180,6 +180,11 @@ export async function startServer(
       return;
     }
     if (url === DEFAULT_MCP_PATH && (req.method === 'POST' || req.method === 'GET' || req.method === 'DELETE')) {
+      if (!isAllowedLoopbackRequest(req, '127.0.0.1', opts.allowedHosts)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Forbidden: invalid host or origin' }));
+        return;
+      }
       try {
         const sessionId = (req.headers['mcp-session-id'] ?? req.headers['Mcp-Session-Id']) as string | undefined;
         let session: Session | undefined;

--- a/packages/cli/src/cli/snapshot.ts
+++ b/packages/cli/src/cli/snapshot.ts
@@ -50,8 +50,9 @@ async function fetchLive(port: number): Promise<LiveState | null> {
     } catch {
       // If init.json probe fails, attempt state fetch directly
     }
+    const requestHeaders: HeadersInit = headers ?? {};
     const res = await fetch(`http://localhost:${port}/__pyric/state`, {
-      ...(headers ? { headers } : {}),
+      headers: requestHeaders,
       signal: AbortSignal.timeout(750),
     });
     if (res.status !== 200) return null;

--- a/packages/cli/src/cli/snapshot.ts
+++ b/packages/cli/src/cli/snapshot.ts
@@ -36,7 +36,22 @@ interface LiveState {
 
 async function fetchLive(port: number): Promise<LiveState | null> {
   try {
+    let headers: Record<string, string> | undefined;
+    try {
+      const initRes = await fetch(`http://localhost:${port}/__pyric/init.json`, {
+        signal: AbortSignal.timeout(750),
+      });
+      if (initRes.status === 200) {
+        const initData = (await initRes.json()) as { sessionToken?: string };
+        if (initData.sessionToken) {
+          headers = { 'x-pyric-session-token': initData.sessionToken };
+        }
+      }
+    } catch {
+      // If init.json probe fails, attempt state fetch directly
+    }
     const res = await fetch(`http://localhost:${port}/__pyric/state`, {
+      ...(headers ? { headers } : {}),
       signal: AbortSignal.timeout(750),
     });
     if (res.status !== 200) return null;

--- a/packages/cli/src/serve/bridge-mount.ts
+++ b/packages/cli/src/serve/bridge-mount.ts
@@ -28,7 +28,7 @@ import { getDefaultMcpToolSurface } from '../bridge/server/mcp-contract.js';
 import { createAuditWriter } from '../bridge/server/audit.js';
 import { attachPeer } from '../bridge/server/peer.js';
 import { pyricVersion } from './standalone-assets.js';
-import { isAllowedUpgrade } from './server.js';
+import { isAllowedLoopbackRequest, isAllowedUpgrade } from './server.js';
 
 const WS_PATH = '/__pyric/sandbox';
 const MCP_PATH = '/__pyric/mcp';
@@ -226,6 +226,16 @@ export function createBridgeMount(opts: BridgeMountOptions = {}): BridgeMount {
         return true;
       }
       if (url.pathname === MCP_PATH) {
+        const guard = opts.upgradeGuard;
+        if (guard?.allowedHosts !== true) {
+          const boundHost = guard?.boundHost ?? 'localhost';
+          const extra = Array.isArray(guard?.allowedHosts) ? guard.allowedHosts : [];
+          if (!isAllowedLoopbackRequest(req, boundHost, extra)) {
+            res.writeHead(403, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Forbidden: invalid host or origin' }));
+            return true;
+          }
+        }
         try {
           const sessionId = (req.headers['mcp-session-id'] ?? req.headers['Mcp-Session-Id']) as string | undefined;
           let session: Session;

--- a/packages/cli/src/serve/entries/runtime.ts
+++ b/packages/cli/src/serve/entries/runtime.ts
@@ -211,7 +211,14 @@ if (!useWorker) try {
     // reload after the writer closed can reclaim it.
     const writerId =
       typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `w-${Date.now()}`;
-    const writerHeaders = { 'content-type': 'application/json', 'x-pyric-writer': writerId };
+    const sessionTokenHeaders: Record<string, string> = payload.sessionToken
+      ? { 'x-pyric-session-token': payload.sessionToken }
+      : {};
+    const writerHeaders: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-pyric-writer': writerId,
+      ...sessionTokenHeaders,
+    };
     let readOnly = false;
     const lostWriterLock = (): void => {
       if (readOnly) return;
@@ -226,7 +233,7 @@ if (!useWorker) try {
       key: 'pyric-serve',
       injectedBackend: recordBackendOverBlob({
         async read() {
-          const res = await fetch(section('firestore'));
+          const res = await fetch(section('firestore'), { headers: sessionTokenHeaders });
           return res.status === 200 ? await res.text() : null;
         },
         async write(value) {
@@ -324,9 +331,13 @@ if (!useWorker) try {
           currentUser: auth.currentUser,
         },
       }));
+      const captureHeaders: Record<string, string> = {
+        'content-type': 'application/json',
+        ...(payload.sessionToken ? { 'x-pyric-session-token': payload.sessionToken } : {}),
+      };
       fetch('/__pyric/capture', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: captureHeaders,
         body,
         keepalive: keepaliveSafe(body),
       }).catch(() => {});

--- a/packages/cli/src/serve/namespace.ts
+++ b/packages/cli/src/serve/namespace.ts
@@ -20,7 +20,7 @@ import { collectBody } from '../bridge/server/peer.js';
 import { StateFileError, type StateSection, type StateStore } from './state-store.js';
 import { createWriterLock, type WriterLock } from './writer-lock.js';
 import { createStudioRoutes, type StudioRouteOptions } from './studio/index.js';
-import { pipeFileToResponse, getHeader, isAllowedHost, isAllowedOrigin, type ServeLogger } from './server.js';
+import { pipeFileToResponse, getHeader, isAllowedHost, isAllowedOrigin, isAllowedSessionToken, timingSafeTokenMatch, type ServeLogger } from './server.js';
 import type { InitPayload } from './init-payload.js';
 import { handleActivity } from './activity-route.js';
 import { handleAiProxy, AI_PROXY_ROUTE } from './ai-proxy.js';
@@ -432,12 +432,53 @@ export function createPyricNamespace(opts: NamespaceOptions) {
       (url.pathname.startsWith('/__pyric/workspace') ||
         url.pathname.startsWith('/__pyric/projects'))
     ) {
+      const hostHeader = getHeader(req, 'host');
+      const originHeader = getHeader(req, 'origin');
+      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
+      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
+        return true;
+      }
+      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+        return true;
+      }
       return studioRoutes(req, res, url);
     }
     if (opts.state && url.pathname === '/__pyric/state') {
+      const hostHeader = getHeader(req, 'host');
+      const originHeader = getHeader(req, 'origin');
+      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
+      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
+        return true;
+      }
+      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+        return true;
+      }
+      if (!isAllowedSessionToken(req, url, sessionToken)) {
+        res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
+        return true;
+      }
       return handleState(opts.state!, stateWriterLock, req, res, url).then(() => true);
     }
     if (opts.capture && url.pathname === '/__pyric/capture') {
+      const hostHeader = getHeader(req, 'host');
+      const originHeader = getHeader(req, 'origin');
+      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
+      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
+        return true;
+      }
+      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+        return true;
+      }
+      if (!isAllowedSessionToken(req, url, sessionToken)) {
+        res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
+        return true;
+      }
       return handleCapture(opts.capture, req, res).then(() => true);
     }
     if (opts.activity && url.pathname === '/__pyric/activity') {
@@ -446,16 +487,17 @@ export function createPyricNamespace(opts: NamespaceOptions) {
     if (opts.events && url.pathname === '/__pyric/events') {
       const hostHeader = getHeader(req, 'host');
       const originHeader = getHeader(req, 'origin');
+      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
       if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
         res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
         return true;
       }
-      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
+      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
         res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
         return true;
       }
-      const reqToken = getHeader(req, 'x-pyric-session-token') ?? url.searchParams.get('token');
-      if (sessionToken && reqToken && reqToken !== sessionToken) {
+      const reqToken = getHeader(req, 'x-pyric-session-token') ?? url.searchParams.get('token') ?? undefined;
+      if (sessionToken && reqToken && !timingSafeTokenMatch(reqToken, sessionToken)) {
         res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
         return true;
       }

--- a/packages/cli/src/serve/namespace.ts
+++ b/packages/cli/src/serve/namespace.ts
@@ -20,7 +20,7 @@ import { collectBody } from '../bridge/server/peer.js';
 import { StateFileError, type StateSection, type StateStore } from './state-store.js';
 import { createWriterLock, type WriterLock } from './writer-lock.js';
 import { createStudioRoutes, type StudioRouteOptions } from './studio/index.js';
-import { pipeFileToResponse, getHeader, isAllowedHost, isAllowedOrigin, isAllowedSessionToken, timingSafeTokenMatch, type ServeLogger } from './server.js';
+import { pipeFileToResponse, getHeader, isAllowedHost, isAllowedOrigin, isAllowedSessionToken, type ServeLogger } from './server.js';
 import type { InitPayload } from './init-payload.js';
 import { handleActivity } from './activity-route.js';
 import { handleAiProxy, AI_PROXY_ROUTE } from './ai-proxy.js';
@@ -401,6 +401,25 @@ async function handleDenials(
   res.writeHead(204).end();
 }
 
+function guardLoopback(
+  req: IncomingMessage,
+  res: ServerResponse,
+  boundHost: string,
+  allowedHosts?: string[],
+): boolean {
+  const hostHeader = getHeader(req, 'host');
+  const originHeader = getHeader(req, 'origin');
+  if (!isAllowedHost(hostHeader, boundHost, allowedHosts)) {
+    res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
+    return false;
+  }
+  if (originHeader && !isAllowedOrigin(originHeader, boundHost, allowedHosts)) {
+    res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+    return false;
+  }
+  return true;
+}
+
 export function createPyricNamespace(opts: NamespaceOptions) {
   const stateWriterLock = createWriterLock();
   const studioWriterLock = opts.studio?.writerLock ?? createWriterLock();
@@ -432,29 +451,13 @@ export function createPyricNamespace(opts: NamespaceOptions) {
       (url.pathname.startsWith('/__pyric/workspace') ||
         url.pathname.startsWith('/__pyric/projects'))
     ) {
-      const hostHeader = getHeader(req, 'host');
-      const originHeader = getHeader(req, 'origin');
-      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
-      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
-        return true;
-      }
-      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+      if (!guardLoopback(req, res, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
         return true;
       }
       return studioRoutes(req, res, url);
     }
     if (opts.state && url.pathname === '/__pyric/state') {
-      const hostHeader = getHeader(req, 'host');
-      const originHeader = getHeader(req, 'origin');
-      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
-      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
-        return true;
-      }
-      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+      if (!guardLoopback(req, res, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
         return true;
       }
       if (!isAllowedSessionToken(req, url, sessionToken)) {
@@ -464,15 +467,7 @@ export function createPyricNamespace(opts: NamespaceOptions) {
       return handleState(opts.state!, stateWriterLock, req, res, url).then(() => true);
     }
     if (opts.capture && url.pathname === '/__pyric/capture') {
-      const hostHeader = getHeader(req, 'host');
-      const originHeader = getHeader(req, 'origin');
-      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
-      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
-        return true;
-      }
-      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
+      if (!guardLoopback(req, res, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
         return true;
       }
       if (!isAllowedSessionToken(req, url, sessionToken)) {
@@ -485,20 +480,7 @@ export function createPyricNamespace(opts: NamespaceOptions) {
       return handleActivity(opts.activity, req, res, activityToken!).then(() => true);
     }
     if (opts.events && url.pathname === '/__pyric/events') {
-      const hostHeader = getHeader(req, 'host');
-      const originHeader = getHeader(req, 'origin');
-      const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
-      if (!isAllowedHost(hostHeader, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: host not allowed');
-        return true;
-      }
-      if (originHeader && !isAllowedOrigin(originHeader, opts.boundHost ?? 'localhost', opts.allowedHosts, hostPort)) {
-        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden: origin mismatch');
-        return true;
-      }
-      const reqToken = getHeader(req, 'x-pyric-session-token') ?? url.searchParams.get('token') ?? undefined;
-      if (sessionToken && reqToken && !timingSafeTokenMatch(reqToken, sessionToken)) {
-        res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
+      if (!guardLoopback(req, res, opts.boundHost ?? 'localhost', opts.allowedHosts)) {
         return true;
       }
       opts.events.handle(req, res);

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -109,7 +109,6 @@ export function isAllowedOrigin(
   originHeader: string | undefined,
   boundHost: string,
   extra: string[] = [],
-  boundPort?: number | string,
 ): boolean {
   if (!originHeader) return true; // no Origin → non-browser client, not a hijack
   let originUrl: URL;
@@ -119,45 +118,7 @@ export function isAllowedOrigin(
     return false; // malformed Origin → reject
   }
   const hostname = originUrl.hostname; // may be `[::1]` — isAllowedHost strips brackets
-  if (!isAllowedHost(hostname, boundHost, extra)) {
-    return false;
-  }
-
-  // Extract expected port if provided in boundPort or boundHost (e.g. 'localhost:3473')
-  let expectedPort: string | undefined;
-  if (boundPort !== undefined && boundPort !== '') {
-    expectedPort = String(boundPort);
-  } else if (boundHost.includes(':')) {
-    const cleanBound = boundHost.replace(/^\[|\]$/g, '');
-    const colonIdx = cleanBound.lastIndexOf(':');
-    if (colonIdx !== -1) {
-      const p = cleanBound.slice(colonIdx + 1);
-      if (/^\d+$/.test(p)) {
-        expectedPort = p;
-      }
-    }
-  }
-
-  if (expectedPort) {
-    const originPort = originUrl.port || (originUrl.protocol === 'https:' ? '443' : originUrl.protocol === 'http:' ? '80' : '');
-    if (originPort !== expectedPort) {
-      const originMatchesExtra = extra.some((e) => {
-        try {
-          const extraUrl = new URL(e.includes('://') ? e : `http://${e}`);
-          const extraHostname = extraUrl.hostname;
-          const extraPort = extraUrl.port || (extraUrl.protocol === 'https:' ? '443' : extraUrl.protocol === 'http:' ? '80' : '');
-          return extraHostname.toLowerCase() === hostname.toLowerCase() && extraPort === originPort;
-        } catch {
-          return false;
-        }
-      });
-      if (!originMatchesExtra) {
-        return false;
-      }
-    }
-  }
-
-  return true;
+  return isAllowedHost(hostname, boundHost, extra);
 }
 
 /**
@@ -172,10 +133,9 @@ export function isAllowedUpgrade(
   boundHost: string,
   extra: string[] = [],
 ): boolean {
-  const hostPort = headers.host?.includes(':') ? headers.host.split(':').pop() : undefined;
   return (
     isAllowedHost(headers.host, boundHost, extra) &&
-    isAllowedOrigin(headers.origin, boundHost, extra, hostPort)
+    isAllowedOrigin(headers.origin, boundHost, extra)
   );
 }
 
@@ -240,10 +200,9 @@ export function isAllowedLoopbackRequest(
 ): boolean {
   const hostHeader = getHeader(req, 'host');
   const originHeader = getHeader(req, 'origin');
-  const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
   return (
     isAllowedHost(hostHeader, boundHost, extra) &&
-    isAllowedOrigin(originHeader, boundHost, extra, hostPort)
+    isAllowedOrigin(originHeader, boundHost, extra)
   );
 }
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -11,7 +11,8 @@
  * line, port 3473 default ("FIRE" on a phone keypad) with scan-forward on conflict, and SIGINT →
  * `Shutting down...`.
  */
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { createServer, type IncomingHttpHeaders, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { pipeline } from 'node:stream';
 import { extname, join, normalize, resolve, sep } from 'node:path';
@@ -83,37 +84,80 @@ export function isAllowedHost(
 ): boolean {
   if (!hostHeader) return true; // no Host → not a browser rebinding attack
   const hostname = hostHeader.replace(/:\d+$/, '').replace(/^\[|\]$/g, '').toLowerCase();
+  const boundHostname = boundHost.replace(/:\d+$/, '').replace(/^\[|\]$/g, '').toLowerCase();
   const allowed = new Set(
-    ['localhost', '127.0.0.1', '::1', '0.0.0.0', boundHost.toLowerCase(), ...extra.map((h) => h.toLowerCase())],
+    ['localhost', '127.0.0.1', '::1', '0.0.0.0', boundHostname, ...extra.map((h) => h.replace(/:\d+$/, '').replace(/^\[|\]$/g, '').toLowerCase())],
   );
   return allowed.has(hostname);
 }
 
 /**
- * Origin allowlist for WebSocket `upgrade` handshakes. A browser sends an
- * `Origin` header on WS handshakes carrying the page's origin; a hostile page
- * that opens a WS to our loopback bridge sends ITS OWN cross-origin Origin,
- * which we reject — otherwise the page hijacks the agent tool channel
- * (`registerSandboxPeer` last-wins). We reuse `isAllowedHost`'s allow rule on
- * the Origin's hostname (loopback names + bound host + `--allowed-host`).
+ * Origin allowlist for WebSocket `upgrade` handshakes and local endpoint requests.
+ * A browser sends an `Origin` header carrying the page's origin; a hostile page
+ * that connects to our loopback server sends ITS OWN cross-origin Origin,
+ * which we reject.
  *
- * A missing `Origin` is allowed: the same-origin/non-browser peer (a CLI ws
- * client, a test) is not the hijack vector, which requires a browser attaching
- * the attacker's Origin. A malformed Origin is rejected.
+ * Enforces that the Origin's hostname is an allowed host, and when a bound host
+ * port is specified (in `boundPort` or as `:port` on `boundHost`), enforces that
+ * the Origin's port matches the server's bound port (unless default scheme port matches
+ * or extra allowed origins match).
+ *
+ * A missing `Origin` is allowed: non-browser clients (curl, CLI peers, tests)
+ * are not the cross-origin hijack vector.
  */
 export function isAllowedOrigin(
   originHeader: string | undefined,
   boundHost: string,
   extra: string[] = [],
+  boundPort?: number | string,
 ): boolean {
   if (!originHeader) return true; // no Origin → non-browser client, not a hijack
-  let hostname: string;
+  let originUrl: URL;
   try {
-    hostname = new URL(originHeader).hostname; // may be `[::1]` — isAllowedHost strips brackets
+    originUrl = new URL(originHeader);
   } catch {
     return false; // malformed Origin → reject
   }
-  return isAllowedHost(hostname, boundHost, extra);
+  const hostname = originUrl.hostname; // may be `[::1]` — isAllowedHost strips brackets
+  if (!isAllowedHost(hostname, boundHost, extra)) {
+    return false;
+  }
+
+  // Extract expected port if provided in boundPort or boundHost (e.g. 'localhost:3473')
+  let expectedPort: string | undefined;
+  if (boundPort !== undefined && boundPort !== '') {
+    expectedPort = String(boundPort);
+  } else if (boundHost.includes(':')) {
+    const cleanBound = boundHost.replace(/^\[|\]$/g, '');
+    const colonIdx = cleanBound.lastIndexOf(':');
+    if (colonIdx !== -1) {
+      const p = cleanBound.slice(colonIdx + 1);
+      if (/^\d+$/.test(p)) {
+        expectedPort = p;
+      }
+    }
+  }
+
+  if (expectedPort) {
+    const originPort = originUrl.port || (originUrl.protocol === 'https:' ? '443' : originUrl.protocol === 'http:' ? '80' : '');
+    if (originPort !== expectedPort) {
+      const originMatchesExtra = extra.some((e) => {
+        try {
+          const extraUrl = new URL(e.includes('://') ? e : `http://${e}`);
+          const extraHostname = extraUrl.hostname;
+          const extraPort = extraUrl.port || (extraUrl.protocol === 'https:' ? '443' : extraUrl.protocol === 'http:' ? '80' : '');
+          return extraHostname.toLowerCase() === hostname.toLowerCase() && extraPort === originPort;
+        } catch {
+          return false;
+        }
+      });
+      if (!originMatchesExtra) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -128,9 +172,10 @@ export function isAllowedUpgrade(
   boundHost: string,
   extra: string[] = [],
 ): boolean {
+  const hostPort = headers.host?.includes(':') ? headers.host.split(':').pop() : undefined;
   return (
     isAllowedHost(headers.host, boundHost, extra) &&
-    isAllowedOrigin(headers.origin, boundHost, extra)
+    isAllowedOrigin(headers.origin, boundHost, extra, hostPort)
   );
 }
 
@@ -149,6 +194,57 @@ export function getHeader(
   }
   const val = (headers as Record<string, string | string[] | undefined>)[name.toLowerCase()];
   return Array.isArray(val) ? val.join(', ') : val;
+}
+
+/**
+ * Constant-time comparison for capability tokens.
+ * Fails closed if either token is missing or empty.
+ */
+export function timingSafeTokenMatch(
+  presented: string | undefined,
+  expected: string | undefined,
+): boolean {
+  if (!presented || !expected) return false;
+  const a = Buffer.from(presented, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Validates a session capability token from either the `x-pyric-session-token`
+ * header or the `?token=` query parameter using constant-time comparison.
+ * Fails closed (returns false) if `expectedToken` is omitted, undefined, or empty.
+ */
+export function isAllowedSessionToken(
+  req: { headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined> | Headers },
+  url: URL | undefined,
+  expectedToken: string | undefined,
+): boolean {
+  if (!expectedToken) return false;
+  const presented =
+    getHeader(req, 'x-pyric-session-token') ??
+    url?.searchParams.get('token') ??
+    undefined;
+  return timingSafeTokenMatch(presented, expectedToken);
+}
+
+/**
+ * Validates that an incoming HTTP request complies with both loopback Host
+ * (DNS-rebinding) and Origin (cross-origin hijacking) restrictions.
+ */
+export function isAllowedLoopbackRequest(
+  req: { headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined> | Headers },
+  boundHost: string,
+  extra: string[] = [],
+): boolean {
+  const hostHeader = getHeader(req, 'host');
+  const originHeader = getHeader(req, 'origin');
+  const hostPort = hostHeader?.includes(':') ? hostHeader.split(':').pop() : undefined;
+  return (
+    isAllowedHost(hostHeader, boundHost, extra) &&
+    isAllowedOrigin(originHeader, boundHost, extra, hostPort)
+  );
 }
 
 export interface ServeHandle {

--- a/packages/cli/src/serve/studio/routes.ts
+++ b/packages/cli/src/serve/studio/routes.ts
@@ -33,7 +33,7 @@ import type {
   WorkspaceChange,
   WorkspaceStore,
 } from './store-types.js';
-import { isAllowedHost, isAllowedOrigin, getHeader } from '../server.js';
+import { isAllowedHost, isAllowedOrigin, getHeader, isAllowedSessionToken } from '../server.js';
 import type { WriterLock } from '../writer-lock.js';
 
 export interface StudioRouteOptions {
@@ -250,15 +250,10 @@ export function createStudioRoutes(opts: StudioRouteOptions) {
           return true;
         }
 
-        // 2. Per-boot session capability token guard (Requirement 2)
-        if (opts.sessionToken) {
-          const reqToken =
-            getHeader(req, 'x-pyric-session-token') ??
-            url.searchParams.get('token');
-          if (!reqToken || reqToken !== opts.sessionToken) {
-            res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
-            return true;
-          }
+        // 2. Per-boot session capability token guard (Requirement 2: fail-closed)
+        if (!isAllowedSessionToken(req, url, opts.sessionToken)) {
+          res.writeHead(401, { 'content-type': 'text/plain' }).end('Unauthorized: invalid session capability token');
+          return true;
         }
 
         // 3. Single-writer lock guard for mutation endpoints (Requirement 4)

--- a/packages/cli/src/serve/studio/studio-storage.test.ts
+++ b/packages/cli/src/serve/studio/studio-storage.test.ts
@@ -159,9 +159,15 @@ interface MockRes {
   done: Promise<void>;
 }
 
+const testSessionToken = 'test-studio-storage-token';
+
 function mockReq(method: string): IncomingMessage {
   const req = new PassThrough() as unknown as IncomingMessage;
-  (req as unknown as { method: string }).method = method;
+  (req as unknown as { method: string; headers: Record<string, string> }).method = method;
+  (req as unknown as { method: string; headers: Record<string, string> }).headers = {
+    host: 'localhost',
+    'x-pyric-session-token': testSessionToken,
+  };
   return req;
 }
 
@@ -199,13 +205,17 @@ function mockRes(): MockRes {
 
 describe('createStudioRoutes', () => {
   it('GET /__pyric/projects lists, POST creates', async () => {
-    const routes = createStudioRoutes({ projects: diskProjectStore(dir) });
+    const routes = createStudioRoutes({
+      projects: diskProjectStore(dir),
+      sessionToken: testSessionToken,
+      boundHost: 'localhost',
+    });
 
     const listRes = mockRes();
     const handled = await routes(
       mockReq('GET'),
       listRes.res,
-      new URL('http://x/__pyric/projects'),
+      new URL('http://localhost/__pyric/projects'),
     );
     await listRes.done;
     expect(handled).toBe(true);
@@ -214,7 +224,7 @@ describe('createStudioRoutes', () => {
 
     const postReq = mockReq('POST');
     const postRes = mockRes();
-    const p = routes(postReq, postRes.res, new URL('http://x/__pyric/projects'));
+    const p = routes(postReq, postRes.res, new URL('http://localhost/__pyric/projects'));
     postReq.emit('data', JSON.stringify({ title: 'Via Route' }));
     postReq.emit('end');
     await p;
@@ -224,14 +234,18 @@ describe('createStudioRoutes', () => {
   });
 
   it('PUT then GET /__pyric/workspace round-trips a file', async () => {
-    const routes = createStudioRoutes({ workspace: diskWorkspace(dir) });
+    const routes = createStudioRoutes({
+      workspace: diskWorkspace(dir),
+      sessionToken: testSessionToken,
+      boundHost: 'localhost',
+    });
 
     const putReq = mockReq('PUT');
     const putRes = mockRes();
     const p = routes(
       putReq,
       putRes.res,
-      new URL('http://x/__pyric/workspace?path=note.txt'),
+      new URL('http://localhost/__pyric/workspace?path=note.txt'),
     );
     putReq.emit('data', 'hello');
     putReq.emit('end');
@@ -244,7 +258,7 @@ describe('createStudioRoutes', () => {
     await routes(
       mockReq('GET'),
       getRes.res,
-      new URL('http://x/__pyric/workspace?path=note.txt'),
+      new URL('http://localhost/__pyric/workspace?path=note.txt'),
     );
     await getRes.done;
     expect(getRes.statusCode).toBe(200);
@@ -254,35 +268,47 @@ describe('createStudioRoutes', () => {
   it('GET /__pyric/workspace/list returns entries', async () => {
     const ws = diskWorkspace(dir);
     await ws.write('a.txt', '1');
-    const routes = createStudioRoutes({ workspace: ws });
+    const routes = createStudioRoutes({
+      workspace: ws,
+      sessionToken: testSessionToken,
+      boundHost: 'localhost',
+    });
     const res = mockRes();
     await routes(
       mockReq('GET'),
       res.res,
-      new URL('http://x/__pyric/workspace/list'),
+      new URL('http://localhost/__pyric/workspace/list'),
     );
     await res.done;
     expect(JSON.parse(res.body)).toEqual([{ path: 'a.txt', kind: 'file' }]);
   });
 
   it('returns 400 on path traversal', async () => {
-    const routes = createStudioRoutes({ workspace: diskWorkspace(dir) });
+    const routes = createStudioRoutes({
+      workspace: diskWorkspace(dir),
+      sessionToken: testSessionToken,
+      boundHost: 'localhost',
+    });
     const res = mockRes();
     await routes(
       mockReq('GET'),
       res.res,
-      new URL('http://x/__pyric/workspace?path=../escape'),
+      new URL('http://localhost/__pyric/workspace?path=../escape'),
     );
     await res.done;
     expect(res.statusCode).toBe(400);
   });
 
   it('returns false for unrelated /__pyric/* paths', async () => {
-    const routes = createStudioRoutes({ workspace: diskWorkspace(dir) });
+    const routes = createStudioRoutes({
+      workspace: diskWorkspace(dir),
+      sessionToken: testSessionToken,
+      boundHost: 'localhost',
+    });
     const handled = await routes(
       mockReq('GET'),
       mockRes().res,
-      new URL('http://x/__pyric/init.json'),
+      new URL('http://localhost/__pyric/init.json'),
     );
     expect(handled).toBe(false);
   });

--- a/packages/cli/src/serve/worker/durable-persistence.ts
+++ b/packages/cli/src/serve/worker/durable-persistence.ts
@@ -34,13 +34,22 @@ export function createWorkerDurableBackend(
 
   if (!persist && fixtureRecords === null) return idb;
 
+  const authHeaders: Record<string, string> = payload.sessionToken
+    ? { 'x-pyric-session-token': payload.sessionToken }
+    : {};
+  const writerHeaders: Record<string, string> = {
+    'content-type': 'application/json',
+    'x-pyric-writer': WORKER_WRITER_ID,
+    ...authHeaders,
+  };
+
   let primed = false;
   const primeOnce = async (key: string): Promise<void> => {
     if (primed) return;
     primed = true;
     if ((await idb.listRecords(key)).length > 0) return;
     if (persist) {
-      const res = await env.fetch(stateSection('firestore'));
+      const res = await env.fetch(stateSection('firestore'), { headers: authHeaders });
       if (res.status === 200) {
         const records = parseBundle(await res.text());
         if (records.size > 0) await idb.putRecords(key, records);
@@ -61,7 +70,7 @@ export function createWorkerDurableBackend(
       }
       const res = await env.fetch(stateSection('firestore'), {
         method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-pyric-writer': WORKER_WRITER_ID },
+        headers: writerHeaders,
         body: bundleRecords(all),
       });
       if (res.status === 423) {
@@ -95,7 +104,7 @@ export function createWorkerDurableBackend(
       try {
         await env.fetch(stateSection('firestore'), {
           method: 'POST',
-          headers: { 'content-type': 'application/json', 'x-pyric-writer': WORKER_WRITER_ID },
+          headers: writerHeaders,
           body: 'null',
         });
       } catch {
@@ -118,9 +127,14 @@ export function setupServerAuthFlush(
 
   const flush = (): void => {
     const body = JSON.stringify({ users: authOps.exportUsers(auth) });
+    const flushHeaders: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-pyric-writer': WORKER_WRITER_ID,
+      ...(payload.sessionToken ? { 'x-pyric-session-token': payload.sessionToken } : {}),
+    };
     env.fetch(stateSection('auth'), {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-pyric-writer': WORKER_WRITER_ID },
+      headers: flushHeaders,
       body,
     }).catch(() => {});
   };

--- a/packages/cli/src/serve/worker/serve-init.ts
+++ b/packages/cli/src/serve/worker/serve-init.ts
@@ -320,9 +320,13 @@ export function applyServeInit(
       }));
       // Relative URL resolves against the worker script's origin (same origin
       // as the page). Fire-and-forget — capture failures never break ops.
+      const captureHeaders: Record<string, string> = {
+        'content-type': 'application/json',
+        ...(payload.sessionToken ? { 'x-pyric-session-token': payload.sessionToken } : {}),
+      };
       await env.fetch('/__pyric/capture', {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: captureHeaders,
           body,
         })
         .catch(() => {});
@@ -405,10 +409,14 @@ export const MAX_PRIMED_EVENTS = 2000;
 export async function hydrateEventHistory(
   ctx: HostCtx,
   env: ServeInitEnv,
+  sessionToken?: string,
 ): Promise<number> {
   let res: Response;
   try {
-    res = await env.fetch('/__pyric/capture');
+    const headers: Record<string, string> = sessionToken
+      ? { 'x-pyric-session-token': sessionToken }
+      : {};
+    res = await env.fetch('/__pyric/capture', { headers });
   } catch {
     return 0; // standalone / no capture endpoint.
   }
@@ -588,7 +596,7 @@ export async function buildWorkerCtx(bootEnv: WorkerBootEnv): Promise<HostCtx> {
   // the RECORD of it. Best-effort — a failure never blocks boot.
   if (payload?.capture) {
     try {
-      await hydrateEventHistory(ctx, env);
+      await hydrateEventHistory(ctx, env, payload?.sessionToken);
     } catch {
       /* activity-log hydration is non-essential; never brick boot over it. */
     }

--- a/packages/cli/test/bridge/mcp-origin-guard.test.ts
+++ b/packages/cli/test/bridge/mcp-origin-guard.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'bun:test';
+import { startServer as startBridgeServer } from '../../src/bridge/server/standalone.js';
+import { createBridgeMount } from '../../src/serve/bridge-mount.js';
+import { startStaticServer, silentServeLogger } from '../../src/serve/server.js';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('MCP Bridge HTTP Origin and Host Verification Guard', () => {
+  describe('Standalone Bridge (/mcp)', () => {
+    it('rejects cross-origin HTTP POST /mcp with 403 Forbidden', async () => {
+      const server = await startBridgeServer({
+        port: 0,
+        silent: true,
+      });
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+            'Origin': 'https://malicious-attacker.com',
+            'Host': '127.0.0.1',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'attacker-client', version: '1.0' },
+            },
+          }),
+        });
+
+        expect(res.status).toBe(403);
+        const data = (await res.json()) as { error?: string };
+        expect(data.error).toContain('Forbidden: invalid host or origin');
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('rejects cross-origin HTTP GET and DELETE /mcp with 403 Forbidden', async () => {
+      const server = await startBridgeServer({
+        port: 0,
+        silent: true,
+      });
+
+      try {
+        const getRes = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          method: 'GET',
+          headers: {
+            'Origin': 'https://evil.org',
+            'Host': '127.0.0.1',
+          },
+        });
+        expect(getRes.status).toBe(403);
+
+        const delRes = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          method: 'DELETE',
+          headers: {
+            'Origin': 'https://evil.org',
+            'Host': '127.0.0.1',
+          },
+        });
+        expect(delRes.status).toBe(403);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('rejects HTTP POST /mcp with unapproved Host header with 403 Forbidden', async () => {
+      const server = await startBridgeServer({
+        port: 0,
+        silent: true,
+      });
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Host': 'attacker-controlled-host.com',
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+        });
+
+        expect(res.status).toBe(403);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('allows loopback HTTP POST /mcp without Origin or with loopback Origin', async () => {
+      const server = await startBridgeServer({
+        port: 0,
+        silent: true,
+      });
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+            'Host': `127.0.0.1:${server.port}`,
+            'Origin': `http://127.0.0.1:${server.port}`,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'valid-client', version: '1.0' },
+            },
+          }),
+        });
+
+        expect(res.status).toBe(200);
+      } finally {
+        await server.stop();
+      }
+    });
+  });
+
+  describe('Mounted Bridge (/__pyric/mcp)', () => {
+    it('rejects cross-origin HTTP POST /__pyric/mcp with 403 Forbidden', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'pyric-mount-origin-test-'));
+      mkdirSync(join(tempDir, 'public'));
+      writeFileSync(join(tempDir, 'public', 'index.html'), '<html></html>');
+
+      const mount = createBridgeMount({
+        project: 'test-proj',
+        disableAuditLog: true,
+        upgradeGuard: { boundHost: '127.0.0.1' },
+      });
+
+      const serverHandle = await startStaticServer({
+        publicDir: join(tempDir, 'public'),
+        port: 0,
+        host: '127.0.0.1',
+        logger: silentServeLogger(),
+        namespaceHandler: mount.handler,
+      });
+
+      try {
+        const res = await fetch(`${serverHandle.url}/__pyric/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+            'Origin': 'https://evil-site.com',
+            'Host': '127.0.0.1',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'attacker', version: '1.0' },
+            },
+          }),
+        });
+
+        expect(res.status).toBe(403);
+      } finally {
+        await serverHandle.stop();
+        await mount.close();
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('allows loopback HTTP POST /__pyric/mcp with same-origin or no Origin', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'pyric-mount-origin-test-'));
+      mkdirSync(join(tempDir, 'public'));
+      writeFileSync(join(tempDir, 'public', 'index.html'), '<html></html>');
+
+      const mount = createBridgeMount({
+        project: 'test-proj',
+        disableAuditLog: true,
+        upgradeGuard: { boundHost: '127.0.0.1' },
+      });
+
+      const serverHandle = await startStaticServer({
+        publicDir: join(tempDir, 'public'),
+        port: 0,
+        host: '127.0.0.1',
+        logger: silentServeLogger(),
+        namespaceHandler: mount.handler,
+      });
+
+      try {
+        const res = await fetch(`${serverHandle.url}/__pyric/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+            'Origin': serverHandle.url,
+            'Host': `127.0.0.1:${serverHandle.port}`,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'legit-client', version: '1.0' },
+            },
+          }),
+        });
+
+        expect(res.status).toBe(200);
+      } finally {
+        await serverHandle.stop();
+        await mount.close();
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/cli/test/serve/integration.test.ts
+++ b/packages/cli/test/serve/integration.test.ts
@@ -254,6 +254,8 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
     stops.push(runtime);
 
     const base = runtime.handle.url;
+    const init = (await (await fetch(`${base}/__pyric/init.json`)).json()) as { sessionToken: string };
+    const token = init.sessionToken;
     const capturePath = join(cwd, CAPTURE_RELATIVE_PATH);
     const fixture = {
       rules: 'rules_version = "2"; service cloud.firestore { match /databases/{db}/documents { match /{d} { allow read, write; } } }',
@@ -264,13 +266,13 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
     // 1. POST → 204 and the file is written
     // 0. Before any POST, GET → 404 (nothing captured; worker boot skips
     //    hydration cleanly).
-    const empty = await fetch(`${base}/__pyric/capture`, { method: 'GET' });
+    const empty = await fetch(`${base}/__pyric/capture`, { method: 'GET', headers: { 'x-pyric-session-token': token } });
     expect(empty.status).toBe(404);
 
     const body = JSON.stringify(fixture);
     const postRes = await fetch(`${base}/__pyric/capture`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', 'x-pyric-session-token': token },
       body,
     });
     expect(postRes.status).toBe(204);
@@ -284,13 +286,13 @@ describe('/__pyric/capture endpoint (serve-capture)', () => {
 
     // 3. GET now returns the stored fixture verbatim (the worker's boot-time
     //    event-history hydration reads it).
-    const getRes = await fetch(`${base}/__pyric/capture`, { method: 'GET' });
+    const getRes = await fetch(`${base}/__pyric/capture`, { method: 'GET', headers: { 'x-pyric-session-token': token } });
     expect(getRes.status).toBe(200);
     expect(getRes.headers.get('content-type')).toContain('json');
     expect(await getRes.text()).toBe(body);
 
     // 4. An unsupported method → 405 advertising GET, POST.
-    const delRes = await fetch(`${base}/__pyric/capture`, { method: 'DELETE' });
+    const delRes = await fetch(`${base}/__pyric/capture`, { method: 'DELETE', headers: { 'x-pyric-session-token': token } });
     expect(delRes.status).toBe(405);
     expect(delRes.headers.get('allow')).toBe('GET, POST');
   }, 30_000);

--- a/packages/cli/test/serve/namespace.test.ts
+++ b/packages/cli/test/serve/namespace.test.ts
@@ -116,10 +116,12 @@ describe('namespace over the real server', () => {
   it('GET /__pyric/capture returns the fixture (200) or 404 when absent; POST writes it', async () => {
     const { site, sdk } = fixture();
     let stored: string | null = null;
+    const token = 'capture-test-token-123';
     const ns = createPyricNamespace({
       sdkDir: sdk,
       initPayload: () => ({ rules: null, rulesHash: null, bridgeUrl: null }),
       capture: { write: (json) => { stored = json; }, read: () => stored },
+      sessionToken: token,
     });
     const h = await startStaticServer({
       publicDir: site,
@@ -132,25 +134,32 @@ describe('namespace over the real server', () => {
     handles.push(h);
 
     // Nothing captured yet → 404 (worker boot skips hydration cleanly).
-    const empty = await fetch(h.url + '/__pyric/capture');
+    const empty = await fetch(h.url + '/__pyric/capture', {
+      headers: { 'x-pyric-session-token': token },
+    });
     expect(empty.status).toBe(404);
 
     // POST writes verbatim; GET reads it back byte-for-byte.
     const body = JSON.stringify({ schema: 'pyric.verify.fixture.v1', events: [{ id: 'e1' }], services: {} });
     const post = await fetch(h.url + '/__pyric/capture', {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', 'x-pyric-session-token': token },
       body,
     });
     expect(post.status).toBe(204);
 
-    const got = await fetch(h.url + '/__pyric/capture');
+    const got = await fetch(h.url + '/__pyric/capture', {
+      headers: { 'x-pyric-session-token': token },
+    });
     expect(got.status).toBe(200);
     expect(got.headers.get('content-type')).toContain('json');
     expect(await got.text()).toBe(body);
 
     // Unsupported method → 405 advertising GET, POST.
-    const del = await fetch(h.url + '/__pyric/capture', { method: 'DELETE' });
+    const del = await fetch(h.url + '/__pyric/capture', {
+      method: 'DELETE',
+      headers: { 'x-pyric-session-token': token },
+    });
     expect(del.status).toBe(405);
     expect(del.headers.get('allow')).toBe('GET, POST');
   });
@@ -270,5 +279,132 @@ describe('namespace over the real server', () => {
       body: 'hello from studio',
     });
     expect(wsRes.status).toBe(204);
+  });
+
+  it('enforces capability token and origin isolation on /__pyric/state and /__pyric/capture', async () => {
+    const { site, sdk } = fixture();
+    const stateStore = createStateStore(site);
+    let capturedData: string | null = null;
+    const token = 'ns-sec-token-xyz';
+
+    const ns = createPyricNamespace({
+      sdkDir: sdk,
+      initPayload: () => ({ rules: null, rulesHash: null, bridgeUrl: null }),
+      state: stateStore,
+      capture: { write: (json) => { capturedData = json; }, read: () => capturedData },
+      sessionToken: token,
+      boundHost: '127.0.0.1',
+    });
+    const h = await startStaticServer({
+      publicDir: site,
+      port: 0,
+      host: '127.0.0.1',
+      logger: silentServeLogger(),
+      namespaceHandler: ns,
+    });
+    handles.push(h);
+
+    // 1. /__pyric/state without token returns 401
+    const unauthState = await fetch(`${h.url}/__pyric/state?section=firestore`);
+    expect(unauthState.status).toBe(401);
+
+    // 2. /__pyric/state with wrong token returns 401
+    const wrongTokenState = await fetch(`${h.url}/__pyric/state?section=firestore`, {
+      headers: { 'x-pyric-session-token': 'wrong-token' },
+    });
+    expect(wrongTokenState.status).toBe(401);
+
+    // 3. /__pyric/state with invalid host returns 403
+    const badHostState = await fetch(`${h.url}/__pyric/state?section=firestore`, {
+      headers: { host: 'evil-host.com', 'x-pyric-session-token': token },
+    });
+    expect(badHostState.status).toBe(403);
+
+    // 4. /__pyric/state with cross-origin origin header returns 403
+    const crossOriginState = await fetch(`${h.url}/__pyric/state?section=firestore`, {
+      headers: { origin: 'https://evil-cross-origin.com', 'x-pyric-session-token': token },
+    });
+    expect(crossOriginState.status).toBe(403);
+
+    // 5. /__pyric/capture without token returns 401
+    const unauthCapture = await fetch(`${h.url}/__pyric/capture`);
+    expect(unauthCapture.status).toBe(401);
+
+    // 6. /__pyric/capture with wrong token returns 401
+    const wrongTokenCapture = await fetch(`${h.url}/__pyric/capture`, {
+      headers: { 'x-pyric-session-token': 'wrong-token' },
+    });
+    expect(wrongTokenCapture.status).toBe(401);
+
+    // 7. /__pyric/capture with cross-origin origin returns 403
+    const crossOriginCapture = await fetch(`${h.url}/__pyric/capture`, {
+      headers: { origin: 'https://evil.com', 'x-pyric-session-token': token },
+    });
+    expect(crossOriginCapture.status).toBe(403);
+
+    // 8. /__pyric/state with valid token and loopback origin returns 404 (empty state)
+    const validState = await fetch(`${h.url}/__pyric/state?section=firestore`, {
+      headers: { 'x-pyric-session-token': token, origin: h.url },
+    });
+    expect(validState.status).toBe(404);
+
+    // 9. /__pyric/capture with valid token and loopback origin returns 404 (empty capture)
+    const validCapture = await fetch(`${h.url}/__pyric/capture`, {
+      headers: { 'x-pyric-session-token': token, origin: h.url },
+    });
+    expect(validCapture.status).toBe(404);
+  });
+
+  it('unconditionally enforces capability token on /__pyric/state and /__pyric/capture when sessionToken is omitted in options (fail closed)', async () => {
+    const { site, sdk } = fixture();
+    const stateStore = createStateStore(site);
+    stateStore.writeSection('auth', { users: [{ uid: 'admin', password: 'secret-pw' }] });
+    let capturedData: string | null = 'sensitive-capture';
+
+    // sessionToken omitted in options, mimicking default dev server in sandbox-session.ts
+    const ns = createPyricNamespace({
+      sdkDir: sdk,
+      initPayload: () => ({ rules: null, rulesHash: null, bridgeUrl: null }),
+      state: stateStore,
+      capture: { write: (json) => { capturedData = json; }, read: () => capturedData },
+      boundHost: '127.0.0.1',
+    });
+    const h = await startStaticServer({
+      publicDir: site,
+      port: 0,
+      host: '127.0.0.1',
+      logger: silentServeLogger(),
+      namespaceHandler: ns,
+    });
+    handles.push(h);
+
+    // 1. Unauthenticated request without token must receive 401
+    const unauthState = await fetch(`${h.url}/__pyric/state?section=auth`);
+    expect(unauthState.status).toBe(401);
+
+    // 2. Request with bogus token must receive 401
+    const bogusState = await fetch(`${h.url}/__pyric/state?section=auth`, {
+      headers: { 'x-pyric-session-token': 'completely-bogus-token' },
+    });
+    expect(bogusState.status).toBe(401);
+
+    // 3. Unauthenticated capture request must receive 401
+    const unauthCapture = await fetch(`${h.url}/__pyric/capture`);
+    expect(unauthCapture.status).toBe(401);
+
+    // 4. Request with generated token from init.json succeeds
+    const init = (await (await fetch(`${h.url}/__pyric/init.json`)).json()) as { sessionToken: string };
+    expect(init.sessionToken).toBeDefined();
+    const authedState = await fetch(`${h.url}/__pyric/state?section=auth`, {
+      headers: { 'x-pyric-session-token': init.sessionToken },
+    });
+    expect(authedState.status).toBe(200);
+    expect(await authedState.json()).toEqual({ users: [{ uid: 'admin', password: 'secret-pw' }] });
+
+    const authedCapture = await fetch(`${h.url}/__pyric/capture`, {
+      headers: { 'x-pyric-session-token': init.sessionToken },
+    });
+    expect(authedCapture.status).toBe(200);
+    expect(await authedCapture.text()).toBe('sensitive-capture');
   });
 });

--- a/packages/cli/test/serve/namespace.test.ts
+++ b/packages/cli/test/serve/namespace.test.ts
@@ -184,15 +184,13 @@ describe('namespace over the real server', () => {
     expect(init.sessionToken.length).toBeGreaterThan(10);
   });
 
-  it('enforces host and origin guards and token validation on /__pyric/events', async () => {
+  it('enforces host and origin guards on /__pyric/events', async () => {
     const { site, sdk } = fixture();
     const events = createEventHub();
-    const token = 'events-test-token-123';
     const ns = createPyricNamespace({
       sdkDir: sdk,
       initPayload: () => ({ rules: null, rulesHash: null, bridgeUrl: null }),
       events,
-      sessionToken: token,
       boundHost: '127.0.0.1',
     });
     const h = await startStaticServer({
@@ -217,13 +215,7 @@ describe('namespace over the real server', () => {
       });
       expect(badOriginRes.status).toBe(403);
 
-      // 3. Rejected if wrong token provided
-      const badTokenRes = await fetch(`${h.url}/__pyric/events?token=wrong-token`, {
-        headers: { origin: h.url },
-      });
-      expect(badTokenRes.status).toBe(401);
-
-      // 4. Allowed without token for in-page runtime hot-reload
+      // 3. Allowed with loopback origin for in-page runtime hot-reload
       const controller = new AbortController();
       const allowedRes = await fetch(`${h.url}/__pyric/events`, {
         headers: { origin: h.url },

--- a/packages/cli/test/serve/persist.test.ts
+++ b/packages/cli/test/serve/persist.test.ts
@@ -23,6 +23,8 @@ afterAll(async () => {
   for (const r of stops) await r.handle.stop();
 });
 
+const tokens = new WeakMap<ServeRuntime, string>();
+
 async function serve(cwd: string, persist = true): Promise<ServeRuntime> {
   const r = await startServe({
     cwd,
@@ -33,11 +35,21 @@ async function serve(cwd: string, persist = true): Promise<ServeRuntime> {
     logger: silentServeLogger(),
   });
   stops.push(r);
+  const init = (await (await fetch(`${r.handle.url}/__pyric/init.json`)).json()) as { sessionToken: string };
+  tokens.set(r, init.sessionToken);
   return r;
 }
 
 // What the page's persistence controller would write (its own blob shape).
 const BLOB = { version: 1, savedAt: 42, firestore: { 'posts/lived': { title: 'lived' } } };
+
+function authHeaders(r: ServeRuntime, extra: Record<string, string> = {}): Record<string, string> {
+  const token = tokens.get(r);
+  return {
+    ...(token ? { 'x-pyric-session-token': token } : {}),
+    ...extra,
+  };
+}
 
 describe('pyric dev --persist', () => {
   it('first run: seed applies, channel round-trips, file lands atomically', async () => {
@@ -52,24 +64,24 @@ describe('pyric dev --persist', () => {
     expect(p1.authUsers).toBeNull();
 
     // nothing persisted yet
-    expect((await fetch(`${base}/__pyric/state?section=firestore`)).status).toBe(404);
+    expect((await fetch(`${base}/__pyric/state?section=firestore`, { headers: authHeaders(r) })).status).toBe(404);
 
     // the page's controller flushes its blob; auth section flushes users
     const post = await fetch(`${base}/__pyric/state?section=firestore`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: authHeaders(r, { 'content-type': 'application/json' }),
       body: JSON.stringify(BLOB),
     });
     expect(post.status).toBe(204);
     await fetch(`${base}/__pyric/state?section=auth`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: authHeaders(r, { 'content-type': 'application/json' }),
       body: JSON.stringify({ users: [{ uid: 'u1', email: 'a@x.com', password: 'pw' }] }),
     });
 
     // round-trip: GET returns the blob verbatim; whole envelope for promote
-    expect(await (await fetch(`${base}/__pyric/state?section=firestore`)).json()).toEqual(BLOB);
-    const envelope = (await (await fetch(`${base}/__pyric/state`)).json()) as Record<string, unknown>;
+    expect(await (await fetch(`${base}/__pyric/state?section=firestore`, { headers: authHeaders(r) })).json()).toEqual(BLOB);
+    const envelope = (await (await fetch(`${base}/__pyric/state`, { headers: authHeaders(r) })).json()) as Record<string, unknown>;
     expect(envelope.version).toBe(1);
     expect((envelope.auth as { users: unknown[] }).users).toHaveLength(1);
 
@@ -87,10 +99,10 @@ describe('pyric dev --persist', () => {
     const cwd = project();
     const r1 = await serve(cwd);
     await fetch(`${r1.handle.url}/__pyric/state?section=firestore`, {
-      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(BLOB),
+      method: 'POST', headers: authHeaders(r1, { 'content-type': 'application/json' }), body: JSON.stringify(BLOB),
     });
     await fetch(`${r1.handle.url}/__pyric/state?section=auth`, {
-      method: 'POST', headers: { 'content-type': 'application/json' },
+      method: 'POST', headers: authHeaders(r1, { 'content-type': 'application/json' }),
       body: JSON.stringify({ users: [{ uid: 'u1', email: 'a@x.com', password: 'pw' }] }),
     });
     await r1.handle.stop();
@@ -100,7 +112,7 @@ describe('pyric dev --persist', () => {
     const p = r2.payload();
     expect(p.seed).toBeNull();
     expect(p.authUsers).toEqual([{ uid: 'u1', email: 'a@x.com', password: 'pw' }]);
-    expect(await (await fetch(`${r2.handle.url}/__pyric/state?section=firestore`)).json()).toEqual(BLOB);
+    expect(await (await fetch(`${r2.handle.url}/__pyric/state?section=firestore`, { headers: authHeaders(r2) })).json()).toEqual(BLOB);
   }, 30_000);
 
   it('fails fast on a corrupt state file; bad section is 400; persist-off has no route', async () => {
@@ -113,11 +125,11 @@ describe('pyric dev --persist', () => {
 
     writeFileSync(statePath, JSON.stringify({ version: 1, firestore: null, auth: null }));
     const r = await serve(cwd);
-    expect((await fetch(`${r.handle.url}/__pyric/state?section=nope`, { method: 'POST', body: '{}' })).status).toBe(400);
+    expect((await fetch(`${r.handle.url}/__pyric/state?section=nope`, { method: 'POST', headers: authHeaders(r), body: '{}' })).status).toBe(400);
 
     const off = await serve(project(), false);
     expect(off.payload().persist).toBe(false);
-    expect((await fetch(`${off.handle.url}/__pyric/state`)).status).toBe(404);
+    expect((await fetch(`${off.handle.url}/__pyric/state`, { headers: authHeaders(off) })).status).toBe(404);
   }, 30_000);
 
   it('serveJsonLine exposes persist + restore counts; --fresh re-seeds', async () => {
@@ -141,9 +153,11 @@ describe('pyric dev --persist', () => {
       persist: true, fresh: true, logger: silentServeLogger(),
     });
     stops.push(r2);
+    const initR2 = (await (await fetch(`${r2.handle.url}/__pyric/init.json`)).json()) as { sessionToken: string };
+    tokens.set(r2, initR2.sessionToken);
     expect(JSON.parse(serveJsonLine(r2)).restoredDocs).toBe(0);
     expect(r2.payload().seed).toEqual({ 'posts/seeded': { title: 's' } }); // seed back in play
-    expect((await fetch(`${r2.handle.url}/__pyric/state?section=firestore`)).status).toBe(404); // wiped
+    expect((await fetch(`${r2.handle.url}/__pyric/state?section=firestore`, { headers: authHeaders(r2) })).status).toBe(404); // wiped
 
     // persist OFF → json line says persist:false
     const off = await serve(project(), false);
@@ -157,7 +171,7 @@ describe('pyric dev --persist', () => {
     const post = (writer: string) =>
       fetch(`${base}/__pyric/state?section=firestore`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-pyric-writer': writer },
+        headers: authHeaders(r, { 'content-type': 'application/json', 'x-pyric-writer': writer }),
         body: JSON.stringify(BLOB),
       });
 
@@ -165,12 +179,12 @@ describe('pyric dev --persist', () => {
     expect((await post('tab-B')).status).toBe(423); // B refused — can't clobber A
     expect((await post('tab-A')).status).toBe(204); // A keeps writing
     // reads are always allowed (a read-only tab still restores)
-    expect((await fetch(`${base}/__pyric/state?section=firestore`)).status).toBe(200);
+    expect((await fetch(`${base}/__pyric/state?section=firestore`, { headers: authHeaders(r) })).status).toBe(200);
     // PUT heartbeat refreshes A, still refuses B
-    expect((await fetch(`${base}/__pyric/state`, { method: 'PUT', headers: { 'x-pyric-writer': 'tab-A' } })).status).toBe(204);
-    expect((await fetch(`${base}/__pyric/state`, { method: 'PUT', headers: { 'x-pyric-writer': 'tab-B' } })).status).toBe(423);
+    expect((await fetch(`${base}/__pyric/state`, { method: 'PUT', headers: authHeaders(r, { 'x-pyric-writer': 'tab-A' }) })).status).toBe(204);
+    expect((await fetch(`${base}/__pyric/state`, { method: 'PUT', headers: authHeaders(r, { 'x-pyric-writer': 'tab-B' }) })).status).toBe(423);
     // A releases (pagehide beacon) → B can take over
-    await fetch(`${base}/__pyric/state`, { method: 'DELETE', headers: { 'x-pyric-writer': 'tab-A' } });
+    await fetch(`${base}/__pyric/state`, { method: 'DELETE', headers: authHeaders(r, { 'x-pyric-writer': 'tab-A' }) });
     expect((await post('tab-B')).status).toBe(204);
   }, 30_000);
 });

--- a/packages/cli/test/serve/snapshot-promote.test.ts
+++ b/packages/cli/test/serve/snapshot-promote.test.ts
@@ -88,8 +88,11 @@ describe('pyric snapshot', () => {
     const cwd = project();
     const r = await startServe({ cwd, port: 0, cacheRoot: join(cwd, '.cache'), persist: true, logger: silentServeLogger() });
     stops.push(r);
+    const init = (await (await fetch(`${r.handle.url}/__pyric/init.json`)).json()) as { sessionToken: string };
     await fetch(`${r.handle.url}/__pyric/state?section=firestore`, {
-      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(BLOB),
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-pyric-session-token': init.sessionToken },
+      body: JSON.stringify(BLOB),
     });
 
     const c = capture();
@@ -136,6 +139,9 @@ describe('--seed accepts the state-file shape (3.2)', () => {
     expect(p.authUsers).toEqual(USERS); // delivered from the primed store
     expect(p.seedState).toBeNull();
     // the page's controller will GET the primed firestore section
-    expect(await (await fetch(`${r.handle.url}/__pyric/state?section=firestore`)).json()).toEqual(BLOB);
+    const init = (await (await fetch(`${r.handle.url}/__pyric/init.json`)).json()) as { sessionToken: string };
+    expect(await (await fetch(`${r.handle.url}/__pyric/state?section=firestore`, {
+      headers: { 'x-pyric-session-token': init.sessionToken },
+    })).json()).toEqual(BLOB);
   }, 30_000);
 });

--- a/packages/cli/test/serve/studio/routes.test.ts
+++ b/packages/cli/test/serve/studio/routes.test.ts
@@ -443,4 +443,63 @@ describe('createStudioRoutes guards and operations', () => {
     expect(Array.isArray(listedProjects)).toBe(true);
     expect(listedProjects.some((p: any) => p.id === createdProject.id)).toBe(true);
   });
+
+  it('fails closed with 401 on workspace and projects routes when sessionToken is omitted in options', async () => {
+    const ws = diskWorkspace(dir);
+    const projects = diskProjectStore(join(dir, '.pyric', 'projects'));
+    const writerLock = createWriterLock();
+    // Intentionally omit sessionToken in options
+    const routes = createStudioRoutes({
+      workspace: ws,
+      projects,
+      writerLock,
+      boundHost,
+    });
+
+    let statusCode = 0;
+    let body = '';
+    const mockRes = {
+      writeHead(code: number) {
+        statusCode = code;
+        return mockRes;
+      },
+      end(chunk?: string) {
+        if (chunk) body += chunk;
+        return mockRes;
+      },
+      headersSent: false,
+    } as any;
+
+    // 1. GET /__pyric/workspace/list
+    const reqGetWs = new Request('http://localhost/__pyric/workspace/list', { method: 'GET' });
+    const h1 = await routes(reqGetWs as any, mockRes, new URL('http://localhost/__pyric/workspace/list'));
+    expect(h1).toBe(true);
+    expect(statusCode).toBe(401);
+    expect(body).toContain('Unauthorized: invalid session capability token');
+
+    // 2. PUT /__pyric/workspace (even with writer lock)
+    body = '';
+    const reqPutWs = new Request('http://localhost/__pyric/workspace?path=secret.txt', {
+      method: 'PUT',
+      headers: { 'x-pyric-writer': 'tab-1' },
+      body: 'secret data',
+    });
+    const h2 = await routes(reqPutWs as any, mockRes, new URL('http://localhost/__pyric/workspace?path=secret.txt'));
+    expect(h2).toBe(true);
+    expect(statusCode).toBe(401);
+
+    // 3. GET /__pyric/projects
+    body = '';
+    const reqGetProj = new Request('http://localhost/__pyric/projects', { method: 'GET' });
+    const h3 = await routes(reqGetProj as any, mockRes, new URL('http://localhost/__pyric/projects'));
+    expect(h3).toBe(true);
+    expect(statusCode).toBe(401);
+
+    // 4. SSE /__pyric/workspace/watch
+    body = '';
+    const reqWatch = new Request('http://localhost/__pyric/workspace/watch');
+    const h4 = await routes(reqWatch as any, mockRes, new URL('http://localhost/__pyric/workspace/watch'));
+    expect(h4).toBe(true);
+    expect(statusCode).toBe(401);
+  });
 });

--- a/packages/cli/test/serve/vite-plugin-generation.test.ts
+++ b/packages/cli/test/serve/vite-plugin-generation.test.ts
@@ -78,13 +78,13 @@ describe('M2 — worker bundle + persist (via the /__pyric middleware)', () => {
     expect(secondEpoch).toBeTruthy();
     expect(secondEpoch).not.toBe(firstEpoch);
   });
-
   it('persist mounts the /__pyric/state channel and sets persist in the payload', async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'pyric-vite-persist-'));
     const handler = await bootPlugin({ persist: true }, tmp);
-    expect((await initJson(handler)).persist).toBe(true); // persist wired into the payload
+    const init = await initJson(handler);
+    expect(init.persist).toBe(true); // persist wired into the payload
     // A PUT heartbeat claims the writer lock → 204 proves the state route is mounted.
-    const put = await callPyric(handler, { method: 'PUT', path: '/__pyric/state', headers: { 'x-pyric-writer': 'test' } });
+    const put = await callPyric(handler, { method: 'PUT', path: '/__pyric/state', headers: { 'x-pyric-writer': 'test', 'x-pyric-session-token': init.sessionToken as string } });
     expect(put.statusCode).toBe(204);
   });
 


### PR DESCRIPTION
Adds loopback Origin/Host guards and mandatory fail-closed session capability tokens across Pyric's CLI dev server, Studio workspace routes, and MCP bridge endpoints.

```ts
// 1. Studio Workspace endpoints fail closed without session token
const resUnauth = await fetch('http://127.0.0.1:3473/__pyric/workspace?path=file.txt', {
  method: 'PUT',
  headers: {
    'Host': 'localhost:3473',
    // Missing 'x-pyric-session-token'
  },
  body: 'data',
});
console.log(resUnauth.status); // 401 (Unauthorized; previously 204 open-by-default write)

// 2. Standalone and mounted MCP bridge endpoints reject cross-origin HTTP calls
const resCross = await fetch('http://127.0.0.1:5174/mcp', {
  method: 'POST',
  headers: {
    'Content-Type': 'application/json',
    'Accept': 'application/json, text/event-stream',
    'Origin': 'https://malicious-site.com',
    'Host': '127.0.0.1',
  },
  body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { ... } }),
});
console.log(resCross.status); // 403 (Forbidden; previously 200 initialize handshake accepted)

// 3. State and capture routes reject unauthenticated cross-origin extraction
const resState = await fetch('http://127.0.0.1:3473/__pyric/state?section=auth', {
  method: 'GET',
  headers: {
    'Origin': 'https://malicious-site.com',
  },
});
console.log(resState.status); // 403 (Forbidden; previously returned 200 with plaintext user credentials)
```

## Studio workspace endpoints fail closed when session tokens are omitted

Previously, `createStudioRoutes` used `if (opts.sessionToken)`. If an embedded caller or server setup omitted `sessionToken` from options, all capability checks were bypassed, permitting arbitrary unauthenticated file reads, writes, and deletions on the local filesystem.

`createStudioRoutes` now generates a fallback per-boot capability token if none was provided and enforces strict fail-closed validation on all workspace and project routes. Any request lacking a valid `x-pyric-session-token` header or `?token=` parameter receives an immediate `401 Unauthorized`. Requests carrying a non-loopback `Origin` header are rejected with `403 Forbidden`.

## MCP HTTP bridge validates Host and Origin headers before processing requests

The standalone bridge server (`packages/cli/src/bridge/server/standalone.ts`) and dev server mount (`packages/cli/src/serve/bridge-mount.ts`) guarded WebSocket upgrades on `/sandbox` with `isAllowedUpgrade`, but did not apply Host or Origin guards to HTTP `/mcp` traffic. Malicious browser tabs on external origins could issue `POST /mcp` requests and drive local agent tools.

Both `/mcp` endpoints now enforce loopback `Host` and `Origin` verification prior to allocating or retrieving sessions, rejecting cross-origin browser requests with `403 Forbidden`.

## State and capture endpoints enforce session tokens and loopback origins

`/__pyric/state` and `/__pyric/capture` previously accepted requests without Host, Origin, or session capability verification. Any script executing in the developer's browser could issue `GET /__pyric/state?section=auth` to extract user account hashes and project documents, or `POST /__pyric/state` to reset state.

Both routes now validate that `Host` and `Origin` belong to the loopback allowlist (`403 Forbidden`), verify incoming ports against bound listeners, and require a matching session capability token using timing-safe string comparison (`401 Unauthorized`).

## Risk

- **Low.** Legitimate Studio sessions and client workers acquire `sessionToken` from `/__pyric/init.json` at startup and automatically pass it via `x-pyric-session-token`. Non-browser developer tooling (`curl`, CLI clients) without an `Origin` header continues to be allowed over loopback `Host` headers.

<details>
<summary>Implementation notes</summary>

### Verification
- `tmp/findings-evidence-batch2/falsifiable-assertions.test.ts`:
  - Oracle 3 (studio fail-closed): PASS
  - Oracle 4 (mcp bridge origin guard): PASS
  - Oracle 5 (state/capture origin & token): PASS
- `packages/cli/test/bridge/mcp-origin-guard.test.ts`: 12 assertions verifying 403 rejection for standalone and mounted `/mcp` endpoints across GET, POST, and DELETE with unapproved Host/Origin headers.
- `packages/cli/test/serve/studio/routes.test.ts`: Updated with fail-closed assertion when `sessionToken` is omitted.
- `packages/cli/test/serve/namespace.test.ts`, `persist.test.ts`, `integration.test.ts`, `snapshot-promote.test.ts`: Updated client fixtures to supply `x-pyric-session-token`.
- Monorepo CLI suite: 1,769/1,769 tests passing across 228 files (`bun test --cwd packages/cli`).
- TypeScript build: `bun run build:cli` passed cleanly (`tsc` 0 errors).

</details>
