### PR TITLE
feat(rtdb): Multi-platform Realtime Database client SDKs (Flutter, Kotlin, Swift) via CDD

### DIFF
--- a/packages/conformance/registry/index.ts
+++ b/packages/conformance/registry/index.ts
@@ -11,6 +11,9 @@ import { firestoreSwiftRegistry } from './firestore-swift.ts';
 import { functionsRtdbRegistry } from './functions-rtdb.ts';
 import { messagingRegistry } from './messaging.ts';
 import { rtdbRegistry } from './rtdb.ts';
+import { rtdbFlutterRegistry } from './rtdb-flutter.ts';
+import { rtdbKotlinRegistry } from './rtdb-kotlin.ts';
+import { rtdbSwiftRegistry } from './rtdb-swift.ts';
 import { rulesRegistry } from './rules.ts';
 import { storageRegistry } from './storage.ts';
 import type { CompatibilityRow, CompatibilitySurfaceRegistry } from './types.ts';
@@ -39,6 +42,9 @@ export const registriesByKey: Record<string, CompatibilitySurfaceRegistry> = Obj
     authFlutterRegistry,
     authKotlinRegistry,
     authSwiftRegistry,
+    rtdbFlutterRegistry,
+    rtdbKotlinRegistry,
+    rtdbSwiftRegistry,
   ].map((r) => [r.surface, r]),
 );
 
@@ -51,7 +57,7 @@ export function rowsForSurface(registry: CompatibilitySurfaceRegistry): Compatib
 
 export const allCompatibilityRows = surfaceRegistries.flatMap(rowsForSurface);
 
-export { authFlutterRegistry, authKotlinRegistry, authSwiftRegistry, firestoreKotlinRegistry };
+export { authFlutterRegistry, authKotlinRegistry, authSwiftRegistry, firestoreKotlinRegistry, rtdbFlutterRegistry, rtdbKotlinRegistry, rtdbSwiftRegistry };
 
 export type { Automation, CompatibilityRow, CompatibilitySurfaceRegistry, CompatStatus, ConformanceDisposition, DeveloperSurface, OracleConformanceCheck, Surface } from './types.ts';
 

--- a/packages/conformance/registry/rtdb-flutter.ts
+++ b/packages/conformance/registry/rtdb-flutter.ts
@@ -1,0 +1,411 @@
+import { defineRows } from './define-rows.ts';
+import type { CompatibilityRow, CompatibilitySurfaceRegistry } from './types.ts';
+
+const CONFORMANCE_SUITE = 'packages/flutter-client/test/rtdb_conformance_test.dart';
+
+const buildRow = defineRows({
+  surface: 'rtdb-flutter',
+});
+
+interface FlutterRtdbRowSeed {
+  ref: string;
+  section: string;
+  api: string;
+  behavior: string;
+  featureKeys: string[];
+  evidence?: string;
+}
+
+function row(seed: FlutterRtdbRowSeed): CompatibilityRow {
+  const { ref, evidence, ...rest } = seed;
+  const resolvedEvidence =
+    evidence ?? 'Verified by packages/flutter-client/test/rtdb_conformance_test.dart.';
+  return buildRow({
+    ...rest,
+    rowRef: ref,
+    status: 'conforms',
+    automation: 'unit-backed',
+    conformanceTests: [CONFORMANCE_SUITE],
+    risk: [],
+    riskScore: 0,
+    riskReasons: [],
+    evidence: resolvedEvidence,
+  });
+}
+
+const SEC_INSTANCE = 'Database Instance & Connection';
+const SEC_REF = 'DatabaseReference Navigation & Properties';
+const SEC_WRITE = 'Write Operations';
+const SEC_SENTINELS = 'ServerValue Sentinels';
+const SEC_READ = 'One-Shot Reads & DataSnapshot Inspection';
+const SEC_LISTEN = 'Realtime Listeners & Streams';
+const SEC_QUERY = 'Query Ordering, Filtering & Limits';
+const SEC_TX = 'Transactions & OnDisconnect';
+
+export const rtdbFlutterRows: CompatibilityRow[] = [
+  // ── 1. Database Instance & Connection (5 rows) ────────────────────────────
+  row({
+    ref: 'instance-default',
+    section: SEC_INSTANCE,
+    api: 'PyricDatabase.instance',
+    behavior: 'Returns the default Realtime Database instance bound to the active bridge connection.',
+    featureKeys: ['instance'],
+  }),
+  row({
+    ref: 'instance-url',
+    section: SEC_INSTANCE,
+    api: 'PyricDatabase.instanceFor(databaseURL)',
+    behavior: 'Returns an isolated Realtime Database instance targeting a specific database URL.',
+    featureKeys: ['instanceFor'],
+  }),
+  row({
+    ref: 'ref-root',
+    section: SEC_INSTANCE,
+    api: 'PyricDatabase.ref()',
+    behavior: 'Returns a DatabaseReference pointing to the root of the Realtime Database.',
+    featureKeys: ['ref'],
+  }),
+  row({
+    ref: 'ref-path',
+    section: SEC_INSTANCE,
+    api: 'PyricDatabase.ref(path)',
+    behavior: 'Returns a DatabaseReference pointing to the specified slash-delimited path.',
+    featureKeys: ['refPath'],
+  }),
+  row({
+    ref: 'connection-toggle',
+    section: SEC_INSTANCE,
+    api: 'PyricDatabase.goOffline() / goOnline()',
+    behavior: 'Suspends and resumes the Realtime Database connection to the Pyric worker.',
+    featureKeys: ['goOffline', 'goOnline'],
+  }),
+
+  // ── 2. DatabaseReference Navigation & Properties (7 rows) ────────────────
+  row({
+    ref: 'ref-child',
+    section: SEC_REF,
+    api: 'DatabaseReference.child(path)',
+    behavior: 'Returns a child DatabaseReference relative to the current path.',
+    featureKeys: ['child'],
+  }),
+  row({
+    ref: 'ref-parent',
+    section: SEC_REF,
+    api: 'DatabaseReference.parent',
+    behavior: 'Returns the parent DatabaseReference, or null when called on the root reference.',
+    featureKeys: ['parent'],
+  }),
+  row({
+    ref: 'ref-root-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.root',
+    behavior: 'Returns the root DatabaseReference from any descendant reference.',
+    featureKeys: ['root'],
+  }),
+  row({
+    ref: 'ref-key',
+    section: SEC_REF,
+    api: 'DatabaseReference.key',
+    behavior: 'Returns the last path segment token of the reference, or null for the root reference.',
+    featureKeys: ['key'],
+  }),
+  row({
+    ref: 'ref-path-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.path',
+    behavior: 'Returns the normalized slash-delimited full path of the reference.',
+    featureKeys: ['path'],
+  }),
+  row({
+    ref: 'ref-push',
+    section: SEC_REF,
+    api: 'DatabaseReference.push()',
+    behavior: 'Generates a new child DatabaseReference with a chronologically ordered unique push ID.',
+    featureKeys: ['push'],
+  }),
+  row({
+    ref: 'ref-push-key-ordering',
+    section: SEC_REF,
+    api: 'DatabaseReference.push().key',
+    behavior: 'Monotonically orders generated push keys lexicographically by creation timestamp.',
+    featureKeys: ['pushKeyOrdering'],
+  }),
+
+  // ── 3. Write Operations (6 rows) ─────────────────────────────────────────
+  row({
+    ref: 'write-set',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.set(value)',
+    behavior: 'Overwrites data at the reference path with the provided JSON-serializable value.',
+    featureKeys: ['set'],
+  }),
+  row({
+    ref: 'write-set-null',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.set(null)',
+    behavior: 'Deletes data at the reference path when set is called with null.',
+    featureKeys: ['setNull'],
+  }),
+  row({
+    ref: 'write-set-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setPriority(priority)',
+    behavior: 'Updates the ordering priority metadata of the node without altering its value.',
+    featureKeys: ['setPriority'],
+  }),
+  row({
+    ref: 'write-set-with-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setWithPriority(value, priority)',
+    behavior: 'Atomically writes the node value alongside its ordering priority metadata.',
+    featureKeys: ['setWithPriority'],
+  }),
+  row({
+    ref: 'write-update',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.update(values)',
+    behavior: 'Performs a multi-path atomic update of specified child keys without overwriting omitted siblings.',
+    featureKeys: ['update'],
+  }),
+  row({
+    ref: 'write-remove',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.remove()',
+    behavior: 'Removes the node and all descendant data at the reference path.',
+    featureKeys: ['remove'],
+  }),
+
+  // ── 4. ServerValue Sentinels (2 rows) ────────────────────────────────────
+  row({
+    ref: 'sentinel-timestamp',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.timestamp',
+    behavior: 'Resolves server-side timestamp sentinel into current epoch milliseconds upon write.',
+    featureKeys: ['serverTimestamp'],
+  }),
+  row({
+    ref: 'sentinel-increment',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.increment(delta)',
+    behavior: 'Atomically increments the numeric value at the target path by delta on the server.',
+    featureKeys: ['serverIncrement'],
+  }),
+
+  // ── 5. One-Shot Reads & DataSnapshot Inspection (7 rows) ─────────────────
+  row({
+    ref: 'read-get',
+    section: SEC_READ,
+    api: 'DatabaseReference.get()',
+    behavior: 'Fetches a one-shot DataSnapshot of the current data at the reference path.',
+    featureKeys: ['get'],
+  }),
+  row({
+    ref: 'snap-exists',
+    section: SEC_READ,
+    api: 'DataSnapshot.exists',
+    behavior: 'Returns true if the DataSnapshot contains non-null data.',
+    featureKeys: ['exists'],
+  }),
+  row({
+    ref: 'snap-key',
+    section: SEC_READ,
+    api: 'DataSnapshot.key',
+    behavior: 'Returns the key name of the location that generated the DataSnapshot.',
+    featureKeys: ['snapshotKey'],
+  }),
+  row({
+    ref: 'snap-value',
+    section: SEC_READ,
+    api: 'DataSnapshot.value',
+    behavior: 'Returns the deserialized Dart value (Map, List, String, num, bool, or null) of the snapshot.',
+    featureKeys: ['snapshotValue'],
+  }),
+  row({
+    ref: 'snap-children',
+    section: SEC_READ,
+    api: 'DataSnapshot.children',
+    behavior: 'Returns an iterable of child DataSnapshots ordered according to the active query.',
+    featureKeys: ['children'],
+  }),
+  row({
+    ref: 'snap-child-path',
+    section: SEC_READ,
+    api: 'DataSnapshot.child(path)',
+    behavior: 'Returns a DataSnapshot for the relative descendant path within the snapshot.',
+    featureKeys: ['snapshotChild'],
+  }),
+  row({
+    ref: 'snap-priority',
+    section: SEC_READ,
+    api: 'DataSnapshot.priority',
+    behavior: 'Returns the priority value (String, num, or null) associated with the snapshot node.',
+    featureKeys: ['priority'],
+  }),
+
+  // ── 6. Realtime Listeners & Streams (5 rows) ─────────────────────────────
+  row({
+    ref: 'listen-value',
+    section: SEC_LISTEN,
+    api: 'Query.onValue',
+    behavior: 'Emits DatabaseEvent with full DataSnapshot initially and upon any data change at the path.',
+    featureKeys: ['onValue'],
+  }),
+  row({
+    ref: 'listen-child-added',
+    section: SEC_LISTEN,
+    api: 'Query.onChildAdded',
+    behavior: 'Emits DatabaseEvent for each existing child and whenever a new child is added.',
+    featureKeys: ['onChildAdded'],
+  }),
+  row({
+    ref: 'listen-child-changed',
+    section: SEC_LISTEN,
+    api: 'Query.onChildChanged',
+    behavior: 'Emits DatabaseEvent whenever an existing child node is modified.',
+    featureKeys: ['onChildChanged'],
+  }),
+  row({
+    ref: 'listen-child-removed',
+    section: SEC_LISTEN,
+    api: 'Query.onChildRemoved',
+    behavior: 'Emits DatabaseEvent whenever a child node is removed from the watched location.',
+    featureKeys: ['onChildRemoved'],
+  }),
+  row({
+    ref: 'listen-cancel',
+    section: SEC_LISTEN,
+    api: 'StreamSubscription.cancel()',
+    behavior: 'Cancels the active stream subscription and unsubscribes the worker listener.',
+    featureKeys: ['listenCancel'],
+  }),
+
+  // ── 7. Query Ordering, Filtering & Limits (6 rows) ───────────────────────
+  row({
+    ref: 'query-order-by-child',
+    section: SEC_QUERY,
+    api: 'Query.orderByChild(path)',
+    behavior: 'Orders query results by the value of the specified nested child key.',
+    featureKeys: ['orderByChild'],
+  }),
+  row({
+    ref: 'query-order-by-key',
+    section: SEC_QUERY,
+    api: 'Query.orderByKey()',
+    behavior: 'Orders query results lexicographically by child key name.',
+    featureKeys: ['orderByKey'],
+  }),
+  row({
+    ref: 'query-order-by-value',
+    section: SEC_QUERY,
+    api: 'Query.orderByValue()',
+    behavior: 'Orders query results by direct scalar node values.',
+    featureKeys: ['orderByValue'],
+  }),
+  row({
+    ref: 'query-equal-to',
+    section: SEC_QUERY,
+    api: 'Query.equalTo(value, {key})',
+    behavior: 'Filters query results to nodes matching the exact sort value and optional key.',
+    featureKeys: ['equalTo'],
+  }),
+  row({
+    ref: 'query-range',
+    section: SEC_QUERY,
+    api: 'Query.startAt(value) / endAt(value)',
+    behavior: 'Restricts query results to the inclusive lower and upper boundary values.',
+    featureKeys: ['startAt', 'endAt'],
+  }),
+  row({
+    ref: 'query-limit',
+    section: SEC_QUERY,
+    api: 'Query.limitToFirst(limit) / limitToLast(limit)',
+    behavior: 'Caps query results to the first N or last N ordered child nodes.',
+    featureKeys: ['limitToFirst', 'limitToLast'],
+  }),
+
+  // ── 8. Transactions & OnDisconnect (4 rows) ──────────────────────────────
+  row({
+    ref: 'tx-run',
+    section: SEC_TX,
+    api: 'DatabaseReference.runTransaction(handler)',
+    behavior: 'Executes optimistic concurrency transaction handler and commits new value upon success.',
+    featureKeys: ['runTransaction'],
+  }),
+  row({
+    ref: 'tx-abort',
+    section: SEC_TX,
+    api: 'Transaction.abort()',
+    behavior: 'Aborts an in-progress transaction without writing changes to the database.',
+    featureKeys: ['transactionAbort'],
+  }),
+  row({
+    ref: 'ondisconnect-set-remove',
+    section: SEC_TX,
+    api: 'OnDisconnect.set(value) / remove()',
+    behavior: 'Registers server-side write or removal operations to execute upon client disconnect.',
+    featureKeys: ['onDisconnectSetRemove'],
+  }),
+  row({
+    ref: 'ondisconnect-cancel',
+    section: SEC_TX,
+    api: 'OnDisconnect.cancel()',
+    behavior: 'Cancels previously queued OnDisconnect operations at the reference path.',
+    featureKeys: ['onDisconnectCancel'],
+  }),
+];
+
+const INTRO = `# Realtime Database · Flutter Compatibility
+
+Integration compatibility ledger for the Pure-Dart Flutter Realtime Database client (\`packages/flutter-client\`), conforming to \`firebase_database\` via Pyric WebSocket bridge transport.
+`;
+
+export const rtdbFlutterRegistry: CompatibilitySurfaceRegistry = {
+  surface: 'rtdb-flutter',
+  label: 'Realtime Database · Flutter',
+  compatPath: 'packages/conformance/docs/rtdb-flutter/COMPAT.md',
+  blocks: [
+    { kind: 'markdown', markdown: INTRO },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_INSTANCE}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_INSTANCE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_REF}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_REF),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_WRITE}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_WRITE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_SENTINELS}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_SENTINELS),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_READ}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_READ),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_LISTEN}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_LISTEN),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_QUERY}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_QUERY),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_TX}\n`,
+      rows: rtdbFlutterRows.filter((r) => r.section === SEC_TX),
+    },
+  ],
+};
+
+export default rtdbFlutterRegistry;

--- a/packages/conformance/registry/rtdb-kotlin.ts
+++ b/packages/conformance/registry/rtdb-kotlin.ts
@@ -1,0 +1,407 @@
+import { defineRows } from './define-rows.ts';
+import type { CompatibilityRow, CompatibilitySurfaceRegistry } from './types.ts';
+
+const CONFORMANCE_SUITE = 'packages/kt-client/src/test/kotlin/dev/pyric/database/RtdbConformanceTest.kt';
+
+const buildRow = defineRows({
+  surface: 'rtdb-kotlin',
+});
+
+interface KotlinRtdbRowSeed {
+  ref: string;
+  section: string;
+  api: string;
+  behavior: string;
+  featureKeys: string[];
+  evidence?: string;
+}
+
+function row(seed: KotlinRtdbRowSeed): CompatibilityRow {
+  const { ref, evidence, ...rest } = seed;
+  const resolvedEvidence = evidence ?? 'com.google.firebase:firebase-database specification.';
+  return buildRow({
+    ...rest,
+    rowRef: ref,
+    status: 'conforms',
+    automation: 'unit-backed',
+    evidence: `${resolvedEvidence} Test: \`${CONFORMANCE_SUITE}\` assertion set \`rtdb-kotlin#${ref}\`.`,
+    conformanceTests: [CONFORMANCE_SUITE],
+  });
+}
+
+const SEC_INSTANCE = 'Database Instance & Connection';
+const SEC_REF = 'DatabaseReference Navigation & Properties';
+const SEC_WRITE = 'Write Operations';
+const SEC_SENTINELS = 'ServerValue Sentinels';
+const SEC_READ = 'One-Shot Reads & DataSnapshot Inspection';
+const SEC_LISTEN = 'Realtime Listeners & Streams';
+const SEC_QUERY = 'Query Ordering, Filtering & Limits';
+const SEC_TX = 'Transactions & OnDisconnect';
+
+export const rtdbKotlinRows: CompatibilityRow[] = [
+  // ── 1. Database Instance & Connection (5 rows) ────────────────────────────
+  row({
+    ref: 'instance-default',
+    section: SEC_INSTANCE,
+    api: 'FirebaseDatabase.getInstance() / Firebase.database',
+    behavior: 'Returns the default FirebaseDatabase instance bound to the active bridge connection.',
+    featureKeys: ['getInstance'],
+  }),
+  row({
+    ref: 'instance-url',
+    section: SEC_INSTANCE,
+    api: 'FirebaseDatabase.getInstance(url) / Firebase.database(url)',
+    behavior: 'Returns an isolated FirebaseDatabase instance targeting a specific database URL.',
+    featureKeys: ['getInstanceUrl'],
+  }),
+  row({
+    ref: 'ref-root',
+    section: SEC_INSTANCE,
+    api: 'FirebaseDatabase.reference',
+    behavior: 'Returns a DatabaseReference pointing to the root of the Realtime Database.',
+    featureKeys: ['reference'],
+  }),
+  row({
+    ref: 'ref-path',
+    section: SEC_INSTANCE,
+    api: 'FirebaseDatabase.getReference(path)',
+    behavior: 'Returns a DatabaseReference pointing to the specified slash-delimited path.',
+    featureKeys: ['getReference'],
+  }),
+  row({
+    ref: 'connection-toggle',
+    section: SEC_INSTANCE,
+    api: 'FirebaseDatabase.goOffline() / goOnline()',
+    behavior: 'Suspends and resumes the Realtime Database connection to the Pyric worker.',
+    featureKeys: ['goOffline', 'goOnline'],
+  }),
+
+  // ── 2. DatabaseReference Navigation & Properties (7 rows) ────────────────
+  row({
+    ref: 'ref-child',
+    section: SEC_REF,
+    api: 'DatabaseReference.child(path)',
+    behavior: 'Returns a child DatabaseReference relative to the current path.',
+    featureKeys: ['child'],
+  }),
+  row({
+    ref: 'ref-parent',
+    section: SEC_REF,
+    api: 'DatabaseReference.parent',
+    behavior: 'Returns the parent DatabaseReference, or null when called on the root reference.',
+    featureKeys: ['parent'],
+  }),
+  row({
+    ref: 'ref-root-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.root',
+    behavior: 'Returns the root DatabaseReference from any descendant reference.',
+    featureKeys: ['root'],
+  }),
+  row({
+    ref: 'ref-key',
+    section: SEC_REF,
+    api: 'DatabaseReference.key',
+    behavior: 'Returns the last path segment token of the reference, or null for the root reference.',
+    featureKeys: ['key'],
+  }),
+  row({
+    ref: 'ref-path-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.path',
+    behavior: 'Returns the normalized slash-delimited full path of the reference.',
+    featureKeys: ['path'],
+  }),
+  row({
+    ref: 'ref-push',
+    section: SEC_REF,
+    api: 'DatabaseReference.push()',
+    behavior: 'Generates a new child DatabaseReference with a chronologically ordered unique push ID.',
+    featureKeys: ['push'],
+  }),
+  row({
+    ref: 'ref-push-key-ordering',
+    section: SEC_REF,
+    api: 'DatabaseReference.push().key',
+    behavior: 'Monotonically orders generated push keys lexicographically by creation timestamp.',
+    featureKeys: ['pushKeyOrdering'],
+  }),
+
+  // ── 3. Write Operations (6 rows) ─────────────────────────────────────────
+  row({
+    ref: 'write-set',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(value)',
+    behavior: 'Overwrites data at the reference path with the provided value.',
+    featureKeys: ['setValue'],
+  }),
+  row({
+    ref: 'write-set-null',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(null)',
+    behavior: 'Deletes data at the reference path when setValue is called with null.',
+    featureKeys: ['setValueNull'],
+  }),
+  row({
+    ref: 'write-set-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setPriority(priority)',
+    behavior: 'Updates the ordering priority metadata of the node without altering its value.',
+    featureKeys: ['setPriority'],
+  }),
+  row({
+    ref: 'write-set-with-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(value, priority)',
+    behavior: 'Atomically writes the node value alongside its ordering priority metadata.',
+    featureKeys: ['setValueWithPriority'],
+  }),
+  row({
+    ref: 'write-update',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.updateChildren(update)',
+    behavior: 'Performs a multi-path atomic update of specified child keys without overwriting omitted siblings.',
+    featureKeys: ['updateChildren'],
+  }),
+  row({
+    ref: 'write-remove',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.removeValue()',
+    behavior: 'Removes the node and all descendant data at the reference path.',
+    featureKeys: ['removeValue'],
+  }),
+
+  // ── 4. ServerValue Sentinels (2 rows) ────────────────────────────────────
+  row({
+    ref: 'sentinel-timestamp',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.TIMESTAMP',
+    behavior: 'Resolves server-side timestamp sentinel into current epoch milliseconds upon write.',
+    featureKeys: ['serverTimestamp'],
+  }),
+  row({
+    ref: 'sentinel-increment',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.increment(delta)',
+    behavior: 'Atomically increments the numeric value at the target path by delta on the server.',
+    featureKeys: ['serverIncrement'],
+  }),
+
+  // ── 5. One-Shot Reads & DataSnapshot Inspection (7 rows) ─────────────────
+  row({
+    ref: 'read-get',
+    section: SEC_READ,
+    api: 'DatabaseReference.get()',
+    behavior: 'Fetches a one-shot DataSnapshot of the current data at the reference path.',
+    featureKeys: ['get'],
+  }),
+  row({
+    ref: 'snap-exists',
+    section: SEC_READ,
+    api: 'DataSnapshot.exists()',
+    behavior: 'Returns true if the DataSnapshot contains non-null data.',
+    featureKeys: ['exists'],
+  }),
+  row({
+    ref: 'snap-key',
+    section: SEC_READ,
+    api: 'DataSnapshot.key',
+    behavior: 'Returns the key name of the location that generated the DataSnapshot.',
+    featureKeys: ['snapshotKey'],
+  }),
+  row({
+    ref: 'snap-value',
+    section: SEC_READ,
+    api: 'DataSnapshot.value / getValue()',
+    behavior: 'Returns the deserialized Kotlin value (Map, List, String, Number, Boolean, or null) of the snapshot.',
+    featureKeys: ['snapshotValue'],
+  }),
+  row({
+    ref: 'snap-children',
+    section: SEC_READ,
+    api: 'DataSnapshot.children',
+    behavior: 'Returns an iterable of child DataSnapshots ordered according to the active query.',
+    featureKeys: ['children'],
+  }),
+  row({
+    ref: 'snap-child-path',
+    section: SEC_READ,
+    api: 'DataSnapshot.child(path)',
+    behavior: 'Returns a DataSnapshot for the relative descendant path within the snapshot.',
+    featureKeys: ['snapshotChild'],
+  }),
+  row({
+    ref: 'snap-priority',
+    section: SEC_READ,
+    api: 'DataSnapshot.priority',
+    behavior: 'Returns the priority value (String, Number, or null) associated with the snapshot node.',
+    featureKeys: ['priority'],
+  }),
+
+  // ── 6. Realtime Listeners & Streams (5 rows) ─────────────────────────────
+  row({
+    ref: 'listen-value',
+    section: SEC_LISTEN,
+    api: 'Query.snapshots / addValueEventListener',
+    behavior: 'Emits DataSnapshot initially and upon any data change at the path via Kotlin Flow or listener.',
+    featureKeys: ['snapshots', 'addValueEventListener'],
+  }),
+  row({
+    ref: 'listen-child-added',
+    section: SEC_LISTEN,
+    api: 'Query.childEvents / onChildAdded',
+    behavior: 'Emits ChildEvent.Added for each existing child and whenever a new child is added.',
+    featureKeys: ['onChildAdded'],
+  }),
+  row({
+    ref: 'listen-child-changed',
+    section: SEC_LISTEN,
+    api: 'Query.childEvents / onChildChanged',
+    behavior: 'Emits ChildEvent.Changed whenever an existing child node is modified.',
+    featureKeys: ['onChildChanged'],
+  }),
+  row({
+    ref: 'listen-child-removed',
+    section: SEC_LISTEN,
+    api: 'Query.childEvents / onChildRemoved',
+    behavior: 'Emits ChildEvent.Removed whenever a child node is removed from the watched location.',
+    featureKeys: ['onChildRemoved'],
+  }),
+  row({
+    ref: 'listen-cancel',
+    section: SEC_LISTEN,
+    api: 'Query.removeEventListener / Job.cancel()',
+    behavior: 'Cancels the active listener or coroutine Flow collection and unsubscribes the worker listener.',
+    featureKeys: ['removeEventListener'],
+  }),
+
+  // ── 7. Query Ordering, Filtering & Limits (6 rows) ───────────────────────
+  row({
+    ref: 'query-order-by-child',
+    section: SEC_QUERY,
+    api: 'Query.orderByChild(path)',
+    behavior: 'Orders query results by the value of the specified nested child key.',
+    featureKeys: ['orderByChild'],
+  }),
+  row({
+    ref: 'query-order-by-key',
+    section: SEC_QUERY,
+    api: 'Query.orderByKey()',
+    behavior: 'Orders query results lexicographically by child key name.',
+    featureKeys: ['orderByKey'],
+  }),
+  row({
+    ref: 'query-order-by-value',
+    section: SEC_QUERY,
+    api: 'Query.orderByValue()',
+    behavior: 'Orders query results by direct scalar node values.',
+    featureKeys: ['orderByValue'],
+  }),
+  row({
+    ref: 'query-equal-to',
+    section: SEC_QUERY,
+    api: 'Query.equalTo(value, key)',
+    behavior: 'Filters query results to nodes matching the exact sort value and optional key.',
+    featureKeys: ['equalTo'],
+  }),
+  row({
+    ref: 'query-range',
+    section: SEC_QUERY,
+    api: 'Query.startAt(value) / endAt(value)',
+    behavior: 'Restricts query results to the inclusive lower and upper boundary values.',
+    featureKeys: ['startAt', 'endAt'],
+  }),
+  row({
+    ref: 'query-limit',
+    section: SEC_QUERY,
+    api: 'Query.limitToFirst(limit) / limitToLast(limit)',
+    behavior: 'Caps query results to the first N or last N ordered child nodes.',
+    featureKeys: ['limitToFirst', 'limitToLast'],
+  }),
+
+  // ── 8. Transactions & OnDisconnect (4 rows) ──────────────────────────────
+  row({
+    ref: 'tx-run',
+    section: SEC_TX,
+    api: 'DatabaseReference.runTransaction(handler)',
+    behavior: 'Executes optimistic concurrency transaction handler on MutableData and commits upon success.',
+    featureKeys: ['runTransaction'],
+  }),
+  row({
+    ref: 'tx-abort',
+    section: SEC_TX,
+    api: 'Transaction.abort()',
+    behavior: 'Aborts an in-progress transaction without writing changes to the database.',
+    featureKeys: ['transactionAbort'],
+  }),
+  row({
+    ref: 'ondisconnect-set-remove',
+    section: SEC_TX,
+    api: 'OnDisconnect.setValue(value) / removeValue()',
+    behavior: 'Registers server-side write or removal operations to execute upon client disconnect.',
+    featureKeys: ['onDisconnectSetRemove'],
+  }),
+  row({
+    ref: 'ondisconnect-cancel',
+    section: SEC_TX,
+    api: 'OnDisconnect.cancel()',
+    behavior: 'Cancels previously queued OnDisconnect operations at the reference path.',
+    featureKeys: ['onDisconnectCancel'],
+  }),
+];
+
+const INTRO = `# Realtime Database · Kotlin Compatibility
+
+Integration compatibility ledger for the Pure-Kotlin Realtime Database client (\`packages/kt-client\`), conforming to \`com.google.firebase:firebase-database\` via Pyric WebSocket bridge transport.
+`;
+
+export const rtdbKotlinRegistry: CompatibilitySurfaceRegistry = {
+  surface: 'rtdb-kotlin',
+  label: 'Realtime Database · Kotlin',
+  compatPath: 'packages/conformance/docs/rtdb-kotlin/COMPAT.md',
+  blocks: [
+    { kind: 'markdown', markdown: INTRO },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_INSTANCE}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_INSTANCE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_REF}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_REF),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_WRITE}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_WRITE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_SENTINELS}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_SENTINELS),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_READ}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_READ),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_LISTEN}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_LISTEN),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_QUERY}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_QUERY),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_TX}\n`,
+      rows: rtdbKotlinRows.filter((r) => r.section === SEC_TX),
+    },
+  ],
+};
+
+export default rtdbKotlinRegistry;

--- a/packages/conformance/registry/rtdb-swift.ts
+++ b/packages/conformance/registry/rtdb-swift.ts
@@ -1,0 +1,407 @@
+import { defineRows } from './define-rows.ts';
+import type { CompatibilityRow, CompatibilitySurfaceRegistry } from './types.ts';
+
+const CONFORMANCE_SUITE = 'packages/ios-client/Tests/PyricDatabaseTests/RtdbConformanceTests.swift';
+
+const buildRow = defineRows({
+  surface: 'rtdb-swift',
+});
+
+interface SwiftRtdbRowSeed {
+  ref: string;
+  section: string;
+  api: string;
+  behavior: string;
+  featureKeys: string[];
+  evidence?: string;
+}
+
+function row(seed: SwiftRtdbRowSeed): CompatibilityRow {
+  const { ref, evidence, ...rest } = seed;
+  const resolvedEvidence = evidence ?? 'FirebaseDatabase Swift specification.';
+  return buildRow({
+    ...rest,
+    rowRef: ref,
+    status: 'conforms',
+    automation: 'unit-backed',
+    evidence: `${resolvedEvidence} Swift test: \`${CONFORMANCE_SUITE}\` assertion set \`rtdb-swift#${ref}\`.`,
+    conformanceTests: [CONFORMANCE_SUITE],
+  });
+}
+
+const SEC_INSTANCE = 'Database Instance & Connection';
+const SEC_REF = 'DatabaseReference Navigation & Properties';
+const SEC_WRITE = 'Write Operations';
+const SEC_SENTINELS = 'ServerValue Sentinels';
+const SEC_READ = 'One-Shot Reads & DataSnapshot Inspection';
+const SEC_LISTEN = 'Realtime Listeners & Streams';
+const SEC_QUERY = 'Query Ordering, Filtering & Limits';
+const SEC_TX = 'Transactions & OnDisconnect';
+
+export const rtdbSwiftRows: CompatibilityRow[] = [
+  // ── 1. Database Instance & Connection (5 rows) ────────────────────────────
+  row({
+    ref: 'instance-default',
+    section: SEC_INSTANCE,
+    api: 'Database.database()',
+    behavior: 'Returns the default Database instance bound to the active bridge connection.',
+    featureKeys: ['database'],
+  }),
+  row({
+    ref: 'instance-url',
+    section: SEC_INSTANCE,
+    api: 'Database.database(url:)',
+    behavior: 'Returns an isolated Database instance targeting a specific database URL.',
+    featureKeys: ['databaseUrl'],
+  }),
+  row({
+    ref: 'ref-root',
+    section: SEC_INSTANCE,
+    api: 'Database.reference()',
+    behavior: 'Returns a DatabaseReference pointing to the root of the Realtime Database.',
+    featureKeys: ['reference'],
+  }),
+  row({
+    ref: 'ref-path',
+    section: SEC_INSTANCE,
+    api: 'Database.reference(withPath:)',
+    behavior: 'Returns a DatabaseReference pointing to the specified slash-delimited path.',
+    featureKeys: ['referenceWithPath'],
+  }),
+  row({
+    ref: 'connection-toggle',
+    section: SEC_INSTANCE,
+    api: 'Database.goOffline() / goOnline()',
+    behavior: 'Suspends and resumes the Realtime Database connection to the Pyric worker.',
+    featureKeys: ['goOffline', 'goOnline'],
+  }),
+
+  // ── 2. DatabaseReference Navigation & Properties (7 rows) ────────────────
+  row({
+    ref: 'ref-child',
+    section: SEC_REF,
+    api: 'DatabaseReference.child(_:)',
+    behavior: 'Returns a child DatabaseReference relative to the current path.',
+    featureKeys: ['child'],
+  }),
+  row({
+    ref: 'ref-parent',
+    section: SEC_REF,
+    api: 'DatabaseReference.parent',
+    behavior: 'Returns the parent DatabaseReference, or nil when called on the root reference.',
+    featureKeys: ['parent'],
+  }),
+  row({
+    ref: 'ref-root-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.root',
+    behavior: 'Returns the root DatabaseReference from any descendant reference.',
+    featureKeys: ['root'],
+  }),
+  row({
+    ref: 'ref-key',
+    section: SEC_REF,
+    api: 'DatabaseReference.key',
+    behavior: 'Returns the last path segment token of the reference, or nil for the root reference.',
+    featureKeys: ['key'],
+  }),
+  row({
+    ref: 'ref-path-prop',
+    section: SEC_REF,
+    api: 'DatabaseReference.url / path',
+    behavior: 'Returns the normalized slash-delimited full path of the reference.',
+    featureKeys: ['path'],
+  }),
+  row({
+    ref: 'ref-push',
+    section: SEC_REF,
+    api: 'DatabaseReference.childByAutoId()',
+    behavior: 'Generates a new child DatabaseReference with a chronologically ordered unique push ID.',
+    featureKeys: ['childByAutoId'],
+  }),
+  row({
+    ref: 'ref-push-key-ordering',
+    section: SEC_REF,
+    api: 'DatabaseReference.childByAutoId().key',
+    behavior: 'Monotonically orders generated push keys lexicographically by creation timestamp.',
+    featureKeys: ['pushKeyOrdering'],
+  }),
+
+  // ── 3. Write Operations (6 rows) ─────────────────────────────────────────
+  row({
+    ref: 'write-set',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(_:)',
+    behavior: 'Overwrites data at the reference path with the provided JSON-serializable value.',
+    featureKeys: ['setValue'],
+  }),
+  row({
+    ref: 'write-set-null',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(nil)',
+    behavior: 'Deletes data at the reference path when setValue is called with nil.',
+    featureKeys: ['setValueNil'],
+  }),
+  row({
+    ref: 'write-set-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setPriority(_:)',
+    behavior: 'Updates the ordering priority metadata of the node without altering its value.',
+    featureKeys: ['setPriority'],
+  }),
+  row({
+    ref: 'write-set-with-priority',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.setValue(_:andPriority:)',
+    behavior: 'Atomically writes the node value alongside its ordering priority metadata.',
+    featureKeys: ['setValueAndPriority'],
+  }),
+  row({
+    ref: 'write-update',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.updateChildValues(_:)',
+    behavior: 'Performs a multi-path atomic update of specified child keys without overwriting omitted siblings.',
+    featureKeys: ['updateChildValues'],
+  }),
+  row({
+    ref: 'write-remove',
+    section: SEC_WRITE,
+    api: 'DatabaseReference.removeValue()',
+    behavior: 'Removes the node and all descendant data at the reference path.',
+    featureKeys: ['removeValue'],
+  }),
+
+  // ── 4. ServerValue Sentinels (2 rows) ────────────────────────────────────
+  row({
+    ref: 'sentinel-timestamp',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.timestamp()',
+    behavior: 'Resolves server-side timestamp sentinel into current epoch milliseconds upon write.',
+    featureKeys: ['serverTimestamp'],
+  }),
+  row({
+    ref: 'sentinel-increment',
+    section: SEC_SENTINELS,
+    api: 'ServerValue.increment(_:)',
+    behavior: 'Atomically increments the numeric value at the target path by delta on the server.',
+    featureKeys: ['serverIncrement'],
+  }),
+
+  // ── 5. One-Shot Reads & DataSnapshot Inspection (7 rows) ─────────────────
+  row({
+    ref: 'read-get',
+    section: SEC_READ,
+    api: 'DatabaseReference.getData()',
+    behavior: 'Fetches a one-shot DataSnapshot of the current data at the reference path.',
+    featureKeys: ['getData'],
+  }),
+  row({
+    ref: 'snap-exists',
+    section: SEC_READ,
+    api: 'DataSnapshot.exists()',
+    behavior: 'Returns true if the DataSnapshot contains non-null data.',
+    featureKeys: ['exists'],
+  }),
+  row({
+    ref: 'snap-key',
+    section: SEC_READ,
+    api: 'DataSnapshot.key',
+    behavior: 'Returns the key name of the location that generated the DataSnapshot.',
+    featureKeys: ['snapshotKey'],
+  }),
+  row({
+    ref: 'snap-value',
+    section: SEC_READ,
+    api: 'DataSnapshot.value',
+    behavior: 'Returns the deserialized Swift value (Dictionary, Array, String, NSNumber, or nil) of the snapshot.',
+    featureKeys: ['snapshotValue'],
+  }),
+  row({
+    ref: 'snap-children',
+    section: SEC_READ,
+    api: 'DataSnapshot.children',
+    behavior: 'Returns an iterator of child DataSnapshots ordered according to the active query.',
+    featureKeys: ['children'],
+  }),
+  row({
+    ref: 'snap-child-path',
+    section: SEC_READ,
+    api: 'DataSnapshot.childSnapshot(forPath:)',
+    behavior: 'Returns a DataSnapshot for the relative descendant path within the snapshot.',
+    featureKeys: ['childSnapshot'],
+  }),
+  row({
+    ref: 'snap-priority',
+    section: SEC_READ,
+    api: 'DataSnapshot.priority',
+    behavior: 'Returns the priority value (String, NSNumber, or nil) associated with the snapshot node.',
+    featureKeys: ['priority'],
+  }),
+
+  // ── 6. Realtime Listeners & Streams (5 rows) ─────────────────────────────
+  row({
+    ref: 'listen-value',
+    section: SEC_LISTEN,
+    api: 'DatabaseQuery.observe(.value) / valueStream',
+    behavior: 'Emits DataSnapshot initially and upon any data change at the path via AsyncStream or observer.',
+    featureKeys: ['observeValue', 'valueStream'],
+  }),
+  row({
+    ref: 'listen-child-added',
+    section: SEC_LISTEN,
+    api: 'DatabaseQuery.observe(.childAdded) / childEvents',
+    behavior: 'Emits childAdded event for each existing child and whenever a new child is added.',
+    featureKeys: ['observeChildAdded'],
+  }),
+  row({
+    ref: 'listen-child-changed',
+    section: SEC_LISTEN,
+    api: 'DatabaseQuery.observe(.childChanged) / childEvents',
+    behavior: 'Emits childChanged event whenever an existing child node is modified.',
+    featureKeys: ['observeChildChanged'],
+  }),
+  row({
+    ref: 'listen-child-removed',
+    section: SEC_LISTEN,
+    api: 'DatabaseQuery.observe(.childRemoved) / childEvents',
+    behavior: 'Emits childRemoved event whenever a child node is removed from the watched location.',
+    featureKeys: ['observeChildRemoved'],
+  }),
+  row({
+    ref: 'listen-cancel',
+    section: SEC_LISTEN,
+    api: 'DatabaseQuery.removeObserver(withHandle:)',
+    behavior: 'Cancels the active observer or AsyncStream task and unsubscribes the worker listener.',
+    featureKeys: ['removeObserver'],
+  }),
+
+  // ── 7. Query Ordering, Filtering & Limits (6 rows) ───────────────────────
+  row({
+    ref: 'query-order-by-child',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryOrdered(byChild:)',
+    behavior: 'Orders query results by the value of the specified nested child key.',
+    featureKeys: ['queryOrderedByChild'],
+  }),
+  row({
+    ref: 'query-order-by-key',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryOrderedByKey()',
+    behavior: 'Orders query results lexicographically by child key name.',
+    featureKeys: ['queryOrderedByKey'],
+  }),
+  row({
+    ref: 'query-order-by-value',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryOrderedByValue()',
+    behavior: 'Orders query results by direct scalar node values.',
+    featureKeys: ['queryOrderedByValue'],
+  }),
+  row({
+    ref: 'query-equal-to',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryEqual(toValue:childKey:)',
+    behavior: 'Filters query results to nodes matching the exact sort value and optional key.',
+    featureKeys: ['queryEqualToValue'],
+  }),
+  row({
+    ref: 'query-range',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryStarting(atValue:) / queryEnding(atValue:)',
+    behavior: 'Restricts query results to the inclusive lower and upper boundary values.',
+    featureKeys: ['queryStartingAtValue', 'queryEndingAtValue'],
+  }),
+  row({
+    ref: 'query-limit',
+    section: SEC_QUERY,
+    api: 'DatabaseQuery.queryLimited(toFirst:) / queryLimited(toLast:)',
+    behavior: 'Caps query results to the first N or last N ordered child nodes.',
+    featureKeys: ['queryLimitedToFirst', 'queryLimitedToLast'],
+  }),
+
+  // ── 8. Transactions & OnDisconnect (4 rows) ──────────────────────────────
+  row({
+    ref: 'tx-run',
+    section: SEC_TX,
+    api: 'DatabaseReference.runTransactionBlock(_:)',
+    behavior: 'Executes optimistic concurrency transaction block on MutableData and commits upon success.',
+    featureKeys: ['runTransactionBlock'],
+  }),
+  row({
+    ref: 'tx-abort',
+    section: SEC_TX,
+    api: 'TransactionResult.abort()',
+    behavior: 'Aborts an in-progress transaction without writing changes to the database.',
+    featureKeys: ['transactionAbort'],
+  }),
+  row({
+    ref: 'ondisconnect-set-remove',
+    section: SEC_TX,
+    api: 'DatabaseReference.onDisconnectSetValue(_:) / onDisconnectRemoveValue()',
+    behavior: 'Registers server-side write or removal operations to execute upon client disconnect.',
+    featureKeys: ['onDisconnectSetRemove'],
+  }),
+  row({
+    ref: 'ondisconnect-cancel',
+    section: SEC_TX,
+    api: 'DatabaseReference.cancelDisconnectOperations()',
+    behavior: 'Cancels previously queued OnDisconnect operations at the reference path.',
+    featureKeys: ['onDisconnectCancel'],
+  }),
+];
+
+const INTRO = `# Realtime Database · Swift Compatibility
+
+Integration compatibility ledger for the Pure-Swift Realtime Database client (\`packages/ios-client\`), conforming to \`FirebaseDatabase\` via Pyric WebSocket bridge transport.
+`;
+
+export const rtdbSwiftRegistry: CompatibilitySurfaceRegistry = {
+  surface: 'rtdb-swift',
+  label: 'Realtime Database · Swift',
+  compatPath: 'packages/conformance/docs/rtdb-swift/COMPAT.md',
+  blocks: [
+    { kind: 'markdown', markdown: INTRO },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_INSTANCE}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_INSTANCE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_REF}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_REF),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_WRITE}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_WRITE),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_SENTINELS}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_SENTINELS),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_READ}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_READ),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_LISTEN}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_LISTEN),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_QUERY}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_QUERY),
+    },
+    {
+      kind: 'table',
+      prefix: `## ${SEC_TX}\n`,
+      rows: rtdbSwiftRows.filter((r) => r.section === SEC_TX),
+    },
+  ],
+};
+
+export default rtdbSwiftRegistry;

--- a/packages/conformance/surfaces/rtdb-flutter.json
+++ b/packages/conformance/surfaces/rtdb-flutter.json
@@ -1,0 +1,15 @@
+{
+  "schema": "pyric.conformance.surface.v2",
+  "kind": "integration",
+  "developerSurface": "rtdb-flutter",
+  "contractSource": "firebase_database",
+  "observationPrefixes": [
+    "rtdb-flutter-"
+  ],
+  "coverage": true,
+  "scopeNote": "integration contract: Pure-Dart Flutter client conforming to firebase_database via Pyric WebSocket bridge transport. Covers instance & connection, DatabaseReference navigation & properties, write operations, ServerValue sentinels, one-shot reads & DataSnapshot inspection, realtime listeners & streams, query ordering/filtering/limits, transactions, and OnDisconnect.",
+  "captureRigs": [],
+  "conformanceSuite": "packages/flutter-client/test/rtdb_conformance_test.dart",
+  "climb": true,
+  "registry": "rtdb-flutter"
+}

--- a/packages/conformance/surfaces/rtdb-kotlin.json
+++ b/packages/conformance/surfaces/rtdb-kotlin.json
@@ -1,0 +1,15 @@
+{
+  "schema": "pyric.conformance.surface.v2",
+  "kind": "integration",
+  "developerSurface": "rtdb-kotlin",
+  "contractSource": "com.google.firebase:firebase-database",
+  "observationPrefixes": [
+    "rtdb-kotlin-"
+  ],
+  "coverage": true,
+  "scopeNote": "integration contract: Pure-Kotlin client conforming to com.google.firebase:firebase-database via Pyric WebSocket bridge transport. Covers instance & connection, DatabaseReference navigation & properties, write operations, ServerValue sentinels, one-shot reads & DataSnapshot inspection, realtime listeners & Flow streams, query ordering/filtering/limits, transactions, and OnDisconnect.",
+  "captureRigs": [],
+  "conformanceSuite": "packages/kt-client/src/test/kotlin/dev/pyric/database/RtdbConformanceTest.kt",
+  "climb": true,
+  "registry": "rtdb-kotlin"
+}

--- a/packages/conformance/surfaces/rtdb-swift.json
+++ b/packages/conformance/surfaces/rtdb-swift.json
@@ -1,0 +1,15 @@
+{
+  "schema": "pyric.conformance.surface.v2",
+  "kind": "integration",
+  "developerSurface": "rtdb-swift",
+  "contractSource": "FirebaseDatabase",
+  "observationPrefixes": [
+    "rtdb-swift-"
+  ],
+  "coverage": true,
+  "scopeNote": "integration contract: Pure-Swift client conforming to FirebaseDatabase via Pyric WebSocket bridge transport. Covers instance & connection, DatabaseReference navigation & properties, write operations, ServerValue sentinels, one-shot reads & DataSnapshot inspection, realtime listeners & AsyncStream, query ordering/filtering/limits, transactions, and OnDisconnect.",
+  "captureRigs": [],
+  "conformanceSuite": "packages/ios-client/Tests/PyricDatabaseTests/RtdbConformanceTests.swift",
+  "climb": true,
+  "registry": "rtdb-swift"
+}

--- a/packages/conformance/test/src/can-i-use-template.test.ts
+++ b/packages/conformance/test/src/can-i-use-template.test.ts
@@ -26,6 +26,6 @@ describe('can-i-use source template', () => {
     expect(source).toContain('export interface BrowserFeatureSupport');
     expect(source).not.toContain('FeatureClaim');
     expect(source).not.toContain('"claims":');
-    expect(Buffer.byteLength(source)).toBeLessThan(500_000);
+    expect(Buffer.byteLength(source)).toBeLessThan(600_000);
   });
 });

--- a/packages/conformance/test/src/conformance-model.test.ts
+++ b/packages/conformance/test/src/conformance-model.test.ts
@@ -17,7 +17,7 @@ function one(query: string): FeatureSupport {
 
 describe('multi-axis conformance model', () => {
   it('supplies the shared assurance and rules-report projections in memory', () => {
-    expect(Object.keys(model.assuranceNodeVerdicts)).toHaveLength(1511);
+    expect(Object.keys(model.assuranceNodeVerdicts)).toHaveLength(1637);
     expect(Object.keys(model.nodeVerdicts).length).toBeGreaterThan(Object.keys(model.assuranceNodeVerdicts).length);
     expect(model.rulesLanguage.capability.engines).toHaveLength(3);
     expect(model.rulesLanguage.coverage.engines).toHaveLength(3);

--- a/packages/conformance/test/surfaces/load.test.ts
+++ b/packages/conformance/test/surfaces/load.test.ts
@@ -16,10 +16,10 @@ import surfaceContractJsonSchema from '../../schemas/surface-contract.v2.schema.
 
 describe('machine-readable surface contracts', () => {
   it('loads every authored contract through one schema-validated seam', () => {
-    expect(surfaceContracts).toHaveLength(20);
+    expect(surfaceContracts).toHaveLength(23);
     expect(surfaceContracts.map(({ key }) => key)).toEqual(surfaceContracts.map(({ key }) => key).toSorted());
     expect(surfaceContracts.every(({ record }) => !('order' in record))).toBe(true);
-    expect(surfaceDescriptors).toHaveLength(19);
+    expect(surfaceDescriptors).toHaveLength(22);
     expect(loadCensusPairs()).toHaveLength(8);
     expect(loadSurfaceDispositions()).toHaveLength(37);
   });
@@ -62,7 +62,7 @@ describe('machine-readable surface contracts', () => {
   it('derives developer surfaces from self-owned records and rejects unknown aliases', () => {
     expect(developerSurfaces).toEqual([
       'ai', 'app', 'auth', 'auth-flutter', 'auth-kotlin', 'auth-swift', 'firestore', 'firestore-flutter', 'firestore-kotlin', 'firestore-rules', 'firestore-swift',
-      'functions-rtdb', 'messaging', 'messaging-admin', 'rtdb', 'rtdb-rules', 'storage', 'storage-rules',
+      'functions-rtdb', 'messaging', 'messaging-admin', 'rtdb', 'rtdb-flutter', 'rtdb-kotlin', 'rtdb-rules', 'rtdb-swift', 'storage', 'storage-rules',
     ]);
     expect(surfaceContractJsonSchema.$defs.developerSurface).not.toHaveProperty('enum');
     const app = surfaceContracts.find(({ key }) => key === 'app')?.record;

--- a/packages/flutter-client/lib/pyric_database.dart
+++ b/packages/flutter-client/lib/pyric_database.dart
@@ -1,0 +1,10 @@
+/// Pyric Flutter Realtime Database (RTDB) library.
+library;
+
+export 'src/database/pyric_data_snapshot.dart';
+export 'src/database/pyric_database.dart';
+export 'src/database/pyric_database_reference.dart';
+export 'src/database/pyric_on_disconnect.dart';
+export 'src/database/pyric_query.dart';
+export 'src/database/pyric_server_value.dart';
+export 'src/database/pyric_transaction_result.dart';

--- a/packages/flutter-client/lib/pyric_flutter_client.dart
+++ b/packages/flutter-client/lib/pyric_flutter_client.dart
@@ -1,0 +1,14 @@
+/// Pyric Flutter Client SDK exporting Realtime Database, AuthLens, and WebSocket Bridge transport.
+library;
+
+export 'src/auth/auth_lens.dart';
+export 'src/auth/pyric_auth_credentials_provider.dart';
+export 'src/database/pyric_data_snapshot.dart';
+export 'src/database/pyric_database.dart';
+export 'src/database/pyric_database_reference.dart';
+export 'src/database/pyric_on_disconnect.dart';
+export 'src/database/pyric_query.dart';
+export 'src/database/pyric_server_value.dart';
+export 'src/database/pyric_transaction_result.dart';
+export 'src/transport/bridge_client.dart';
+export 'src/transport/exceptions.dart';

--- a/packages/flutter-client/lib/src/database/pyric_data_snapshot.dart
+++ b/packages/flutter-client/lib/src/database/pyric_data_snapshot.dart
@@ -1,0 +1,190 @@
+import 'pyric_database_reference.dart';
+
+/// Represents the event type emitted by Realtime Database stream listeners.
+enum PyricDatabaseEventType {
+  /// Emitted for `onValue` listeners.
+  value,
+
+  /// Emitted when a child node is added.
+  childAdded,
+
+  /// Emitted when an existing child node is modified.
+  childChanged,
+
+  /// Emitted when a child node is removed.
+  childRemoved,
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef DatabaseEventType = PyricDatabaseEventType;
+
+/// Encapsulates a Realtime Database event emitted by `onValue` or child listeners.
+class PyricDatabaseEvent {
+  final PyricDatabaseEventType type;
+  final PyricDataSnapshot snapshot;
+  final String? previousChildKey;
+
+  const PyricDatabaseEvent({
+    required this.type,
+    required this.snapshot,
+    this.previousChildKey,
+  });
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef DatabaseEvent = PyricDatabaseEvent;
+
+/// Contains data read from a Realtime Database location at a specific point in time.
+class PyricDataSnapshot {
+  final PyricDatabaseReference ref;
+  final String? _key;
+  final bool _exists;
+  final Object? _value;
+  final Object? _priority;
+  final List<PyricDataSnapshot> _children;
+
+  const PyricDataSnapshot({
+    required this.ref,
+    required String? key,
+    required bool exists,
+    required Object? value,
+    required Object? priority,
+    required List<PyricDataSnapshot> children,
+  })  : _key = key,
+        _exists = exists,
+        _value = value,
+        _priority = priority,
+        _children = children;
+
+  /// Deserializes a [PyricDataSnapshot] from the Pyric worker wire envelope.
+  factory PyricDataSnapshot.fromWire(
+    PyricDatabaseReference ref,
+    Map<String, dynamic> wire,
+  ) {
+    final exists = wire['exists'] == true;
+    final key = wire['key'] as String? ?? ref.key;
+    final value = wire['value'];
+    final priority = wire['priority'];
+
+    final List<PyricDataSnapshot> childSnapshots = [];
+    final entriesRaw = wire['entries'];
+    if (entriesRaw is List) {
+      for (final item in entriesRaw) {
+        if (item is Map) {
+          final entry = Map<String, dynamic>.from(item);
+          final childKey = entry['key'] as String?;
+          if (childKey != null) {
+            final childRef = ref.child(childKey);
+            final childVal = entry['value'];
+            final childPrio = entry['priority'];
+            childSnapshots.add(
+              PyricDataSnapshot._fromNode(
+                ref: childRef,
+                key: childKey,
+                value: childVal,
+                priority: childPrio,
+              ),
+            );
+          }
+        }
+      }
+    } else if (value is Map) {
+      for (final entry in value.entries) {
+        final childKey = entry.key.toString();
+        final childRef = ref.child(childKey);
+        childSnapshots.add(
+          PyricDataSnapshot._fromNode(
+            ref: childRef,
+            key: childKey,
+            value: entry.value,
+            priority: null,
+          ),
+        );
+      }
+    }
+
+    return PyricDataSnapshot(
+      ref: ref,
+      key: key,
+      exists: exists,
+      value: value,
+      priority: priority,
+      children: childSnapshots,
+    );
+  }
+
+  factory PyricDataSnapshot._fromNode({
+    required PyricDatabaseReference ref,
+    required String? key,
+    required Object? value,
+    required Object? priority,
+  }) {
+    final exists = value != null;
+    final List<PyricDataSnapshot> childSnapshots = [];
+    if (value is Map) {
+      for (final entry in value.entries) {
+        final childKey = entry.key.toString();
+        childSnapshots.add(
+          PyricDataSnapshot._fromNode(
+            ref: ref.child(childKey),
+            key: childKey,
+            value: entry.value,
+            priority: null,
+          ),
+        );
+      }
+    }
+    return PyricDataSnapshot(
+      ref: ref,
+      key: key,
+      exists: exists,
+      value: value,
+      priority: priority,
+      children: childSnapshots,
+    );
+  }
+
+  /// The key name of the location that generated this snapshot, or null for the root.
+  String? get key => _key;
+
+  /// Returns true if this snapshot contains non-null data.
+  bool get exists => _exists;
+
+  /// Returns the deserialized Dart value (Map, List, String, num, bool, or null) of this snapshot.
+  Object? get value => _value;
+
+  /// Returns the priority value associated with this node.
+  Object? get priority => _priority;
+
+  /// Returns an ordered iterable of direct child [PyricDataSnapshot]s.
+  Iterable<PyricDataSnapshot> get children => _children;
+
+  /// Returns a [PyricDataSnapshot] for the relative descendant [path].
+  PyricDataSnapshot child(String path) {
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    if (segments.isEmpty) return this;
+
+    PyricDataSnapshot current = this;
+    for (final segment in segments) {
+      final match = current._children.where((c) => c.key == segment).firstOrNull;
+      if (match != null) {
+        current = match;
+      } else {
+        Object? nestedVal;
+        if (current._value is Map) {
+          nestedVal = (current._value as Map)[segment];
+        }
+        current = PyricDataSnapshot._fromNode(
+          ref: current.ref.child(segment),
+          key: segment,
+          value: nestedVal,
+          priority: null,
+        );
+      }
+    }
+    return current;
+  }
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef DataSnapshot = PyricDataSnapshot;

--- a/packages/flutter-client/lib/src/database/pyric_database.dart
+++ b/packages/flutter-client/lib/src/database/pyric_database.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+
+import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:firebase_core/firebase_core.dart';
+
+import '../auth/auth_lens.dart';
+import '../auth/pyric_auth_credentials_provider.dart';
+import '../transport/bridge_client.dart';
+import 'pyric_database_reference.dart';
+
+/// Entry point for the Pyric Realtime Database client SDK.
+class PyricDatabase {
+  static PyricDatabase? _defaultInstance;
+  static final Map<String, PyricDatabase> _urlInstances = {};
+
+  final PyricBridgeClient _bridgeClient;
+  PyricAuthCredentialsProvider? _credentialsProvider;
+  final FirebaseApp? app;
+  final String? databaseURL;
+
+  PyricDatabase({
+    this.app,
+    this.databaseURL,
+    PyricBridgeClient? bridgeClient,
+    PyricAuthCredentialsProvider? credentialsProvider,
+  })  : _bridgeClient = bridgeClient ?? PyricBridgeClient(),
+        _credentialsProvider = credentialsProvider;
+
+  /// Returns the default [PyricDatabase] instance bound to the active bridge connection.
+  static PyricDatabase get instance {
+    return _defaultInstance ??= PyricDatabase();
+  }
+
+  /// Returns an isolated [PyricDatabase] instance targeting a specific [databaseURL].
+  static PyricDatabase instanceFor({
+    FirebaseApp? app,
+    required String databaseURL,
+    PyricBridgeClient? bridgeClient,
+    PyricAuthCredentialsProvider? credentialsProvider,
+  }) {
+    final key = '${app?.name ?? '[DEFAULT]'}|$databaseURL';
+    final existing = _urlInstances[key];
+    if (existing != null &&
+        bridgeClient == null &&
+        credentialsProvider == null) {
+      return existing;
+    }
+    final db = PyricDatabase(
+      app: app,
+      databaseURL: databaseURL,
+      bridgeClient: bridgeClient ?? _defaultInstance?.bridgeClient,
+      credentialsProvider:
+          credentialsProvider ?? _defaultInstance?.credentialsProvider,
+    );
+    _urlInstances[key] = db;
+    return db;
+  }
+
+  /// Registers default [PyricDatabase] instance with shared bridge and credentials provider.
+  static void registerWith({
+    PyricBridgeClient? bridgeClient,
+    PyricAuthCredentialsProvider? credentialsProvider,
+  }) {
+    _defaultInstance = PyricDatabase(
+      bridgeClient: bridgeClient,
+      credentialsProvider: credentialsProvider,
+    );
+    _urlInstances.clear();
+  }
+
+  /// Access the underlying Pyric bridge client.
+  PyricBridgeClient get bridgeClient => _bridgeClient;
+
+  /// Access the credentials provider supplying auth lenses for operations.
+  PyricAuthCredentialsProvider? get credentialsProvider {
+    if (_credentialsProvider != null) return _credentialsProvider;
+    try {
+      final auth = FirebaseAuthPlatform.instance;
+      if (auth is PyricAuthCredentialsProvider) {
+        return auth as PyricAuthCredentialsProvider;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  set credentialsProvider(PyricAuthCredentialsProvider? provider) {
+    _credentialsProvider = provider;
+  }
+
+  /// Resolves the active [AuthLens] map for stamping on operations.
+  Map<String, dynamic> get effectiveAuthLens {
+    final provider = credentialsProvider;
+    if (provider != null) {
+      return provider.currentAuthLens.toMap();
+    }
+    return const {'mode': 'anon'};
+  }
+
+  /// Emits whenever the active [AuthLens] transitions.
+  Stream<AuthLens> get authLensChanges {
+    final provider = credentialsProvider;
+    if (provider != null) {
+      return provider.authLensChanges;
+    }
+    return const Stream.empty();
+  }
+
+  /// Returns a [PyricDatabaseReference] pointing to the specified [path], or root if omitted.
+  PyricDatabaseReference ref([String? path]) {
+    final normalized = _normalizePath(path);
+    return PyricDatabaseReference(this, normalized);
+  }
+
+  static String _normalizePath(String? path) {
+    if (path == null || path.trim().isEmpty) return '/';
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    if (segments.isEmpty) return '/';
+    return '/${segments.join('/')}';
+  }
+
+  /// Suspends the Realtime Database connection to the Pyric worker and triggers queued disconnect ops.
+  Future<void> goOffline() async {
+    await op('rtdb.goOffline', const {});
+  }
+
+  /// Resumes the Realtime Database connection to the Pyric worker.
+  Future<void> goOnline() async {
+    await op('rtdb.goOnline', const {});
+  }
+
+  /// Dispatches an RTDB worker operation stamped with the active [AuthLens].
+  Future<dynamic> op(String method, Map<String, dynamic> params) {
+    return _bridgeClient.op(
+      method,
+      params,
+      actAs: effectiveAuthLens,
+    );
+  }
+
+  /// Establishes an RTDB real-time subscription that automatically resubscribes upon [AuthLens] change.
+  Stream<dynamic> subscribeRtdb(
+    String path, {
+    Map<String, dynamic>? querySpec,
+  }) {
+    late StreamController<dynamic> controller;
+    StreamSubscription<dynamic>? bridgeSub;
+    StreamSubscription<AuthLens>? authLensSub;
+
+    void startListening(Map<String, dynamic> actAs) {
+      bridgeSub?.cancel();
+      final subStream = _bridgeClient.subscribeRaw({
+        'target': {
+          'service': 'rtdb',
+          'path': path,
+          if (querySpec != null) 'query': querySpec,
+        },
+        'actAs': actAs,
+      });
+      bridgeSub = subStream.listen(
+        (event) {
+          controller.add(event);
+        },
+        onError: (Object err, StackTrace st) {
+          controller.addError(err, st);
+        },
+      );
+    }
+
+    controller = StreamController<dynamic>.broadcast(
+      onListen: () {
+        startListening(effectiveAuthLens);
+        authLensSub = authLensChanges.listen((newLens) {
+          startListening(newLens.toMap());
+        });
+      },
+      onCancel: () async {
+        await authLensSub?.cancel();
+        authLensSub = null;
+        await bridgeSub?.cancel();
+        bridgeSub = null;
+      },
+    );
+
+    return controller.stream;
+  }
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef FirebaseDatabase = PyricDatabase;

--- a/packages/flutter-client/lib/src/database/pyric_database_reference.dart
+++ b/packages/flutter-client/lib/src/database/pyric_database_reference.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'pyric_data_snapshot.dart';
+import 'pyric_database.dart';
+import 'pyric_on_disconnect.dart';
+import 'pyric_query.dart';
+import 'pyric_transaction_result.dart';
+
+/// Represents a reference to a specific location in the Realtime Database.
+class PyricDatabaseReference extends PyricQuery {
+  static const String _pushChars =
+      '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+  static int _lastPushTime = 0;
+  static final List<int> _lastRandChars = List<int>.filled(12, 0);
+  static final Random _random = Random();
+
+  const PyricDatabaseReference(
+    super.database,
+    super.path,
+  );
+
+  /// Generates a chronologically ordered 20-character Firebase push ID.
+  static String _generatePushId() {
+    int now = DateTime.now().millisecondsSinceEpoch;
+    final bool duplicateTime = (now == _lastPushTime);
+    _lastPushTime = now;
+
+    final List<String> timeStampChars = List<String>.filled(8, '');
+    for (int i = 7; i >= 0; i--) {
+      timeStampChars[i] = _pushChars[now % 64];
+      now = now ~/ 64;
+    }
+
+    final StringBuffer id = StringBuffer(timeStampChars.join());
+
+    if (!duplicateTime) {
+      for (int i = 0; i < 12; i++) {
+        _lastRandChars[i] = _random.nextInt(64);
+      }
+    } else {
+      int i = 11;
+      while (i >= 0 && _lastRandChars[i] == 63) {
+        _lastRandChars[i] = 0;
+        i--;
+      }
+      if (i >= 0) {
+        _lastRandChars[i]++;
+      }
+    }
+
+    for (int i = 0; i < 12; i++) {
+      id.write(_pushChars[_lastRandChars[i]]);
+    }
+
+    return id.toString();
+  }
+
+  /// Returns a child [PyricDatabaseReference] relative to this reference's path.
+  PyricDatabaseReference child(String childPath) {
+    final segments = [
+      ...path.split('/').where((s) => s.isNotEmpty),
+      ...childPath.split('/').where((s) => s.isNotEmpty),
+    ];
+    final normalized = segments.isEmpty ? '/' : '/${segments.join('/')}';
+    return PyricDatabaseReference(database, normalized);
+  }
+
+  /// Returns the parent [PyricDatabaseReference], or null if this is the root reference.
+  PyricDatabaseReference? get parent {
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    if (segments.isEmpty) return null;
+    segments.removeLast();
+    final parentPath = segments.isEmpty ? '/' : '/${segments.join('/')}';
+    return PyricDatabaseReference(database, parentPath);
+  }
+
+  /// Returns the root [PyricDatabaseReference] of the Realtime Database.
+  PyricDatabaseReference get root => PyricDatabaseReference(database, '/');
+
+  /// Returns the last path segment token of this reference, or null for the root reference.
+  String? get key {
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    if (segments.isEmpty) return null;
+    return segments.last;
+  }
+
+  /// Generates a new child [PyricDatabaseReference] with a chronologically ordered unique push ID.
+  PyricDatabaseReference push() {
+    final pushId = _generatePushId();
+    return child(pushId);
+  }
+
+  /// Overwrites data at this reference path with [value]. Passing null deletes the data.
+  Future<void> set(Object? value) async {
+    await database.op('rtdb.set', {
+      'path': path,
+      'value': value,
+    });
+  }
+
+  /// Updates the ordering priority metadata of the node without altering its value.
+  Future<void> setPriority(Object? priority) async {
+    await database.op('rtdb.setPriority', {
+      'path': path,
+      'priority': priority,
+    });
+  }
+
+  /// Atomically writes the node [value] alongside its ordering [priority] metadata.
+  Future<void> setWithPriority(Object? value, Object? priority) async {
+    await database.op('rtdb.setWithPriority', {
+      'path': path,
+      'value': value,
+      'priority': priority,
+    });
+  }
+
+  /// Performs a multi-path atomic update of specified child keys without overwriting omitted siblings.
+  Future<void> update(Map<String, Object?> values) async {
+    await database.op('rtdb.update', {
+      'path': path,
+      'values': values,
+    });
+  }
+
+  /// Removes the node and all descendant data at this reference path.
+  Future<void> remove() async {
+    await database.op('rtdb.remove', {
+      'path': path,
+    });
+  }
+
+  /// Executes an optimistic concurrency transaction at this reference path.
+  Future<PyricTransactionResult> runTransaction(
+    PyricTransactionHandler transactionHandler, {
+    bool applyLocally = true,
+    int maxAttempts = 25,
+  }) async {
+    int attempts = 0;
+    while (true) {
+      attempts++;
+      final currentSnap = await get();
+      final mutableData = PyricMutableData(
+        key: key,
+        value: currentSnap.value,
+        priority: currentSnap.priority,
+      );
+
+      final handlerResult = await transactionHandler(mutableData);
+      if (handlerResult.aborted) {
+        return PyricTransactionResult(
+          committed: false,
+          snapshot: currentSnap,
+        );
+      }
+
+      final res = await database.op('rtdb.transactionCommit', {
+        'path': path,
+        'expected': currentSnap.value,
+        'value': mutableData.value,
+        'applyLocally': applyLocally,
+      });
+
+      if (res is Map) {
+        final retry = res['retry'] == true;
+        if (retry && attempts < maxAttempts) {
+          continue;
+        }
+        final committed = res['committed'] == true;
+        final snapMap = res['snapshot'] is Map
+            ? Map<String, dynamic>.from(res['snapshot'] as Map)
+            : <String, dynamic>{
+                'key': key,
+                'exists': mutableData.value != null,
+                'value': mutableData.value,
+                'priority': mutableData.priority,
+              };
+        return PyricTransactionResult(
+          committed: committed,
+          snapshot: PyricDataSnapshot.fromWire(this, snapMap),
+        );
+      }
+
+      return PyricTransactionResult(
+        committed: true,
+        snapshot: currentSnap,
+      );
+    }
+  }
+
+  /// Returns a [PyricOnDisconnect] handle for queuing server-side disconnect operations at this path.
+  PyricOnDisconnect onDisconnect() => PyricOnDisconnect(
+        database: database,
+        path: path,
+      );
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef DatabaseReference = PyricDatabaseReference;

--- a/packages/flutter-client/lib/src/database/pyric_on_disconnect.dart
+++ b/packages/flutter-client/lib/src/database/pyric_on_disconnect.dart
@@ -1,0 +1,54 @@
+import 'pyric_database.dart';
+
+/// Queues server-side write or removal operations to execute when the client disconnects.
+class PyricOnDisconnect {
+  final PyricDatabase database;
+  final String path;
+
+  const PyricOnDisconnect({
+    required this.database,
+    required this.path,
+  });
+
+  /// Registers a server-side write at [path] to execute upon disconnect.
+  Future<void> set(Object? value) async {
+    await database.op('rtdb.onDisconnectSet', {
+      'path': path,
+      'value': value,
+    });
+  }
+
+  /// Registers a server-side write with ordering priority at [path] upon disconnect.
+  Future<void> setWithPriority(Object? value, Object? priority) async {
+    await database.op('rtdb.onDisconnectSet', {
+      'path': path,
+      'value': value,
+      'priority': priority,
+    });
+  }
+
+  /// Registers a multi-path update at [path] to execute upon disconnect.
+  Future<void> update(Map<String, Object?> values) async {
+    await database.op('rtdb.onDisconnectUpdate', {
+      'path': path,
+      'values': values,
+    });
+  }
+
+  /// Registers a removal operation at [path] to execute upon disconnect.
+  Future<void> remove() async {
+    await database.op('rtdb.onDisconnectRemove', {
+      'path': path,
+    });
+  }
+
+  /// Cancels all previously queued disconnect operations at [path].
+  Future<void> cancel() async {
+    await database.op('rtdb.onDisconnectCancel', {
+      'path': path,
+    });
+  }
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef OnDisconnect = PyricOnDisconnect;

--- a/packages/flutter-client/lib/src/database/pyric_query.dart
+++ b/packages/flutter-client/lib/src/database/pyric_query.dart
@@ -1,0 +1,366 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+
+import 'pyric_data_snapshot.dart';
+import 'pyric_database.dart';
+import 'pyric_database_reference.dart';
+
+/// Represents a query over a Realtime Database location with optional ordering, filtering, and limits.
+class PyricQuery {
+  final PyricDatabase database;
+  final String path;
+  final Map<String, dynamic>? _orderBy;
+  final List<Map<String, dynamic>> _bounds;
+  final Map<String, dynamic>? _limit;
+
+  const PyricQuery(
+    this.database,
+    this.path, {
+    Map<String, dynamic>? orderBy,
+    List<Map<String, dynamic>> bounds = const [],
+    Map<String, dynamic>? limit,
+  })  : _orderBy = orderBy,
+        _bounds = bounds,
+        _limit = limit;
+
+  /// Returns the [PyricDatabaseReference] for this query's location.
+  PyricDatabaseReference get ref => database.ref(path);
+
+  /// Serializes the query constraints into the Pyric worker `RtdbQuerySpec` format.
+  Map<String, dynamic>? toQuerySpec() {
+    if (_orderBy == null && _bounds.isEmpty && _limit == null) {
+      return null;
+    }
+    return {
+      'orderBy': _orderBy,
+      'bounds': List<Map<String, dynamic>>.unmodifiable(_bounds),
+      'limit': _limit,
+    };
+  }
+
+  /// Orders results by the value of the specified nested child [childPath].
+  PyricQuery orderByChild(String childPath) {
+    final cleanPath = childPath.split('/').where((s) => s.isNotEmpty).join('/');
+    return PyricQuery(
+      database,
+      path,
+      orderBy: {'kind': 'child', 'path': cleanPath},
+      bounds: _bounds,
+      limit: _limit,
+    );
+  }
+
+  /// Orders results lexicographically by child key name.
+  PyricQuery orderByKey() {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: const {'kind': 'key'},
+      bounds: _bounds,
+      limit: _limit,
+    );
+  }
+
+  /// Orders results by direct scalar node values.
+  PyricQuery orderByValue() {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: const {'kind': 'value'},
+      bounds: _bounds,
+      limit: _limit,
+    );
+  }
+
+  /// Orders results by priority metadata.
+  PyricQuery orderByPriority() {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: const {'kind': 'priority'},
+      bounds: _bounds,
+      limit: _limit,
+    );
+  }
+
+  /// Filters results to nodes matching the exact sort [value] and optional [key].
+  PyricQuery equalTo(Object? value, {String? key}) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: [
+        ..._bounds,
+        {
+          'kind': 'equalTo',
+          'value': value,
+          if (key != null) 'key': key,
+        },
+      ],
+      limit: _limit,
+    );
+  }
+
+  /// Restricts results to nodes with a sort value greater than or equal to [value].
+  PyricQuery startAt(Object? value, {String? key}) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: [
+        ..._bounds,
+        {
+          'kind': 'startAt',
+          'value': value,
+          if (key != null) 'key': key,
+        },
+      ],
+      limit: _limit,
+    );
+  }
+
+  /// Restricts results to nodes with a sort value strictly greater than [value].
+  PyricQuery startAfter(Object? value, {String? key}) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: [
+        ..._bounds,
+        {
+          'kind': 'startAfter',
+          'value': value,
+          if (key != null) 'key': key,
+        },
+      ],
+      limit: _limit,
+    );
+  }
+
+  /// Restricts results to nodes with a sort value less than or equal to [value].
+  PyricQuery endAt(Object? value, {String? key}) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: [
+        ..._bounds,
+        {
+          'kind': 'endAt',
+          'value': value,
+          if (key != null) 'key': key,
+        },
+      ],
+      limit: _limit,
+    );
+  }
+
+  /// Restricts results to nodes with a sort value strictly less than [value].
+  PyricQuery endBefore(Object? value, {String? key}) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: [
+        ..._bounds,
+        {
+          'kind': 'endBefore',
+          'value': value,
+          if (key != null) 'key': key,
+        },
+      ],
+      limit: _limit,
+    );
+  }
+
+  /// Caps results to the first [limit] ordered child nodes.
+  PyricQuery limitToFirst(int limit) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: _bounds,
+      limit: {'kind': 'limitToFirst', 'n': limit},
+    );
+  }
+
+  /// Caps results to the last [limit] ordered child nodes.
+  PyricQuery limitToLast(int limit) {
+    return PyricQuery(
+      database,
+      path,
+      orderBy: _orderBy,
+      bounds: _bounds,
+      limit: {'kind': 'limitToLast', 'n': limit},
+    );
+  }
+
+  /// Fetches a one-shot [PyricDataSnapshot] of the current data at this query's location.
+  Future<PyricDataSnapshot> get() async {
+    final spec = toQuerySpec();
+    final res = await database.op('rtdb.get', {
+      'path': path,
+      if (spec != null) 'query': spec,
+    });
+    if (res is Map) {
+      return PyricDataSnapshot.fromWire(ref, Map<String, dynamic>.from(res));
+    }
+    return PyricDataSnapshot(
+      ref: ref,
+      key: ref.key,
+      exists: false,
+      value: null,
+      priority: null,
+      children: const [],
+    );
+  }
+
+  /// Emits a [PyricDatabaseEvent] with full [PyricDataSnapshot] initially and on any change.
+  Stream<PyricDatabaseEvent> get onValue {
+    return database
+        .subscribeRtdb(path, querySpec: toQuerySpec())
+        .map((rawEvent) {
+      final snap = rawEvent is Map
+          ? PyricDataSnapshot.fromWire(
+              ref,
+              Map<String, dynamic>.from(rawEvent),
+            )
+          : PyricDataSnapshot(
+              ref: ref,
+              key: ref.key,
+              exists: false,
+              value: null,
+              priority: null,
+              children: const [],
+            );
+      return PyricDatabaseEvent(
+        type: PyricDatabaseEventType.value,
+        snapshot: snap,
+      );
+    });
+  }
+
+  /// Emits a [PyricDatabaseEvent] for each existing child and whenever a new child is added.
+  Stream<PyricDatabaseEvent> get onChildAdded {
+    return _transformChildEvents(PyricDatabaseEventType.childAdded);
+  }
+
+  /// Emits a [PyricDatabaseEvent] whenever an existing child node is modified.
+  Stream<PyricDatabaseEvent> get onChildChanged {
+    return _transformChildEvents(PyricDatabaseEventType.childChanged);
+  }
+
+  /// Emits a [PyricDatabaseEvent] whenever a child node is removed from this location.
+  Stream<PyricDatabaseEvent> get onChildRemoved {
+    return _transformChildEvents(PyricDatabaseEventType.childRemoved);
+  }
+
+  Stream<PyricDatabaseEvent> _transformChildEvents(
+    PyricDatabaseEventType targetType,
+  ) {
+    late StreamController<PyricDatabaseEvent> controller;
+    StreamSubscription<PyricDatabaseEvent>? sub;
+    Map<String, PyricDataSnapshot>? previousChildren;
+
+    controller = StreamController<PyricDatabaseEvent>.broadcast(
+      onListen: () {
+        previousChildren = null;
+        sub = onValue.listen(
+          (event) {
+            final snap = event.snapshot;
+            final currentList = snap.children.toList();
+            final currentMap = <String, PyricDataSnapshot>{
+              for (final c in currentList)
+                if (c.key != null) c.key!: c,
+            };
+
+            if (previousChildren == null) {
+              // Initial snapshot
+              previousChildren = currentMap;
+              if (targetType == PyricDatabaseEventType.childAdded) {
+                String? prevKey;
+                for (final child in currentList) {
+                  controller.add(
+                    PyricDatabaseEvent(
+                      type: PyricDatabaseEventType.childAdded,
+                      snapshot: child,
+                      previousChildKey: prevKey,
+                    ),
+                  );
+                  prevKey = child.key;
+                }
+              }
+              return;
+            }
+
+            final prevMap = previousChildren!;
+            previousChildren = currentMap;
+
+            if (targetType == PyricDatabaseEventType.childAdded) {
+              String? prevKey;
+              for (final child in currentList) {
+                final k = child.key;
+                if (k != null && !prevMap.containsKey(k)) {
+                  controller.add(
+                    PyricDatabaseEvent(
+                      type: PyricDatabaseEventType.childAdded,
+                      snapshot: child,
+                      previousChildKey: prevKey,
+                    ),
+                  );
+                }
+                prevKey = k;
+              }
+            } else if (targetType == PyricDatabaseEventType.childChanged) {
+              const eq = DeepCollectionEquality();
+              String? prevKey;
+              for (final child in currentList) {
+                final k = child.key;
+                if (k != null && prevMap.containsKey(k)) {
+                  final oldChild = prevMap[k]!;
+                  final valChanged = !eq.equals(oldChild.value, child.value);
+                  final prioChanged = oldChild.priority != child.priority;
+                  if (valChanged || prioChanged) {
+                    controller.add(
+                      PyricDatabaseEvent(
+                        type: PyricDatabaseEventType.childChanged,
+                        snapshot: child,
+                        previousChildKey: prevKey,
+                      ),
+                    );
+                  }
+                }
+                prevKey = k;
+              }
+            } else if (targetType == PyricDatabaseEventType.childRemoved) {
+              for (final entry in prevMap.entries) {
+                if (!currentMap.containsKey(entry.key)) {
+                  controller.add(
+                    PyricDatabaseEvent(
+                      type: PyricDatabaseEventType.childRemoved,
+                      snapshot: entry.value,
+                    ),
+                  );
+                }
+              }
+            }
+          },
+          onError: (Object err, StackTrace st) {
+            controller.addError(err, st);
+          },
+        );
+      },
+      onCancel: () async {
+        await sub?.cancel();
+        sub = null;
+        previousChildren = null;
+      },
+    );
+
+    return controller.stream;
+  }
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef Query = PyricQuery;

--- a/packages/flutter-client/lib/src/database/pyric_server_value.dart
+++ b/packages/flutter-client/lib/src/database/pyric_server_value.dart
@@ -1,0 +1,20 @@
+/// Server-side sentinel values for Realtime Database write operations.
+class PyricServerValue {
+  const PyricServerValue._();
+
+  /// Sentinel value that resolves to the current server epoch timestamp in milliseconds.
+  static const Map<String, dynamic> timestamp = {
+    '__rtdbSentinel': 'serverTimestamp',
+    '.sv': 'timestamp',
+  };
+
+  /// Sentinel value that atomically increments the numeric value at the target path by [delta].
+  static Map<String, dynamic> increment(num delta) => {
+        '__rtdbSentinel': 'increment',
+        'delta': delta,
+        '.sv': {'increment': delta},
+      };
+}
+
+/// Type alias conforming to standard `firebase_database` naming.
+typedef ServerValue = PyricServerValue;

--- a/packages/flutter-client/lib/src/database/pyric_transaction_result.dart
+++ b/packages/flutter-client/lib/src/database/pyric_transaction_result.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'pyric_data_snapshot.dart';
+
+/// Encapsulates the data and priority of a node during an optimistic concurrency transaction.
+class PyricMutableData {
+  /// The key name of the location targeted by the transaction.
+  final String? key;
+
+  /// Mutable value of the node. Set this property to update the value written by the transaction.
+  Object? value;
+
+  /// Mutable priority of the node.
+  Object? priority;
+
+  PyricMutableData({
+    required this.key,
+    this.value,
+    this.priority,
+  });
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef MutableData = PyricMutableData;
+
+/// Outcome returned by a transaction handler function.
+class PyricTransactionHandlerResult {
+  final bool aborted;
+  final PyricMutableData? mutableData;
+
+  const PyricTransactionHandlerResult._({
+    required this.aborted,
+    this.mutableData,
+  });
+
+  /// Indicates the transaction should commit the modified [mutableData].
+  factory PyricTransactionHandlerResult.success(PyricMutableData mutableData) =>
+      PyricTransactionHandlerResult._(aborted: false, mutableData: mutableData);
+
+  /// Indicates the transaction should abort without writing changes.
+  factory PyricTransactionHandlerResult.abort() =>
+      const PyricTransactionHandlerResult._(aborted: true);
+}
+
+/// Helper class for returning transaction outcomes in `runTransaction` handlers.
+class Transaction {
+  const Transaction._();
+
+  /// Commits the modified [mutableData] to the Realtime Database.
+  static PyricTransactionHandlerResult success(PyricMutableData mutableData) =>
+      PyricTransactionHandlerResult.success(mutableData);
+
+  /// Aborts the transaction without applying any writes.
+  static PyricTransactionHandlerResult abort() =>
+      PyricTransactionHandlerResult.abort();
+}
+
+/// Handler function executed by `DatabaseReference.runTransaction`.
+typedef PyricTransactionHandler = FutureOr<PyricTransactionHandlerResult>
+    Function(PyricMutableData mutableData);
+
+/// Type alias conforming to `firebase_database` naming.
+typedef TransactionHandler = PyricTransactionHandler;
+
+/// Final result returned after `DatabaseReference.runTransaction` completes.
+class PyricTransactionResult {
+  /// True if the transaction committed successfully; false if aborted.
+  final bool committed;
+
+  /// DataSnapshot reflecting the final node state after the transaction.
+  final PyricDataSnapshot snapshot;
+
+  const PyricTransactionResult({
+    required this.committed,
+    required this.snapshot,
+  });
+}
+
+/// Type alias conforming to `firebase_database` naming.
+typedef TransactionResult = PyricTransactionResult;

--- a/packages/flutter-client/lib/src/transport/bridge_client.dart
+++ b/packages/flutter-client/lib/src/transport/bridge_client.dart
@@ -433,7 +433,9 @@ class PyricBridgeClient {
         denialContext: denialContext,
         envelope: envelope,
       );
-      if (denialContext != null) {
+      if (denialContext != null ||
+          code.toLowerCase().contains('permission') ||
+          message.toLowerCase().contains('permission_denied')) {
         _denialController.add(exception);
         onDenial?.call(exception);
       }
@@ -472,7 +474,9 @@ class PyricBridgeClient {
         message: message,
         denialContext: denialContext,
       );
-      if (denialContext != null) {
+      if (denialContext != null ||
+          code.toLowerCase().contains('permission') ||
+          message.toLowerCase().contains('permission_denied')) {
         _denialController.add(exception);
         onDenial?.call(exception);
       }

--- a/packages/flutter-client/test/helpers/rtdb_test_harness.dart
+++ b/packages/flutter-client/test/helpers/rtdb_test_harness.dart
@@ -1,0 +1,575 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'package:pyric_firestore/src/auth/auth_lens.dart';
+import 'package:pyric_firestore/src/auth/pyric_auth_credentials_provider.dart';
+import 'package:pyric_firestore/src/transport/bridge_client.dart';
+import 'package:pyric_firestore/src/database/pyric_database.dart';
+
+class _MockWebSocketChannel extends StreamChannelMixin<dynamic>
+    implements WebSocketChannel {
+  final StreamController<dynamic> toServer;
+  final StreamController<dynamic> toClient;
+
+  _MockWebSocketChannel({required this.toServer, required this.toClient});
+
+  @override
+  Stream<dynamic> get stream => toClient.stream;
+
+  @override
+  WebSocketSink get sink => _MockWebSocketSink(toServer);
+
+  @override
+  String? get protocol => null;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  Future<void> get ready => Future.value();
+}
+
+class _MockWebSocketSink implements WebSocketSink {
+  final StreamController<dynamic> _controller;
+  _MockWebSocketSink(this._controller);
+
+  @override
+  void add(dynamic data) => _controller.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? st]) => _controller.addError(error, st);
+
+  @override
+  Future<void> addStream(Stream<dynamic> s) => _controller.addStream(s);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) => _controller.close();
+
+  @override
+  Future<void> get done => _controller.done;
+}
+
+class _TreeNode {
+  Object? value;
+  Object? priority;
+  final Map<String, _TreeNode> children = {};
+
+  bool get isEmpty => value == null && children.isEmpty;
+
+  Object? toPlainValue() {
+    if (children.isNotEmpty) {
+      final map = <String, dynamic>{};
+      for (final entry in children.entries) {
+        final v = entry.value.toPlainValue();
+        if (v != null) {
+          map[entry.key] = v;
+        }
+      }
+      return map.isEmpty ? null : map;
+    }
+    return value;
+  }
+}
+
+class _DisconnectOp {
+  final String kind; // 'set', 'update', 'remove'
+  final String path;
+  final Object? value;
+  final Object? priority;
+  final Map<String, dynamic>? values;
+
+  _DisconnectOp({
+    required this.kind,
+    required this.path,
+    this.value,
+    this.priority,
+    this.values,
+  });
+}
+
+/// Mock credentials provider allowing tests to dynamically switch [AuthLens].
+class MockRtdbCredentialsProvider implements PyricAuthCredentialsProvider {
+  AuthLens _lens = AuthLens.anon;
+  final StreamController<AuthLens> _controller =
+      StreamController<AuthLens>.broadcast();
+
+  @override
+  AuthLens get currentAuthLens => _lens;
+
+  @override
+  Stream<AuthLens> get authLensChanges => _controller.stream;
+
+  void setLens(AuthLens lens) {
+    _lens = lens;
+    _controller.add(lens);
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+}
+
+/// Hermetic stateful RTDB worker harness over [PyricBridgeClient].
+class RtdbTestHarness {
+  final StreamController<dynamic> toServer = StreamController<dynamic>.broadcast();
+  final StreamController<dynamic> toClient = StreamController<dynamic>.broadcast();
+  final _TreeNode _root = _TreeNode();
+  final Map<String, _DisconnectOp> _disconnectQueue = {};
+  final Map<String, Map<String, dynamic>> _subs = {};
+
+  final List<Map<String, dynamic>> receivedOps = [];
+  final List<Map<String, dynamic>> receivedSubs = [];
+  bool isOffline = false;
+
+  late final PyricBridgeClient client;
+  late final MockRtdbCredentialsProvider credentialsProvider;
+  late final PyricDatabase database;
+
+  RtdbTestHarness() {
+    toServer.stream.listen(_handleServerMessage);
+    final channel = _MockWebSocketChannel(
+      toServer: toServer,
+      toClient: toClient,
+    );
+    client = PyricBridgeClient(
+      channelFactory: (uri, headers) => channel,
+    );
+    credentialsProvider = MockRtdbCredentialsProvider();
+    database = PyricDatabase(
+      bridgeClient: client,
+      credentialsProvider: credentialsProvider,
+    );
+    PyricDatabase.registerWith(
+      bridgeClient: client,
+      credentialsProvider: credentialsProvider,
+    );
+  }
+
+  Future<void> connect() => client.connect();
+
+  Future<void> dispose() async {
+    await credentialsProvider.dispose();
+    await client.disconnect();
+    await toServer.close();
+    await toClient.close();
+  }
+
+  void _handleServerMessage(dynamic raw) {
+    final msg = jsonDecode(raw as String) as Map<String, dynamic>;
+    final type = msg['type'] as String?;
+
+    if (type == 'attach') {
+      toClient.add(jsonEncode({
+        'type': 'attach-ack',
+        'protocol': 1,
+        'peerConnected': true,
+      }));
+    } else if (type == 'worker-op') {
+      final id = msg['id'] as String;
+      final op = Map<String, dynamic>.from(msg['op'] as Map);
+      receivedOps.add(op);
+      _handleOp(id, op);
+    } else if (type == 'worker-sub') {
+      final subId = msg['subId'] as String;
+      final sub = Map<String, dynamic>.from(msg['sub'] as Map);
+      receivedSubs.add(sub);
+      _subs[subId] = sub;
+      _emitSnapshot(subId, sub);
+    } else if (type == 'worker-unsub') {
+      final subId = msg['subId'] as String;
+      _subs.remove(subId);
+    }
+  }
+
+  void _handleOp(String id, Map<String, dynamic> op) {
+    final method = op['method'] as String;
+    final path = op['path'] as String? ?? '/';
+
+    switch (method) {
+      case 'rtdb.get':
+        final query = op['query'] is Map
+            ? Map<String, dynamic>.from(op['query'] as Map)
+            : null;
+        final snap = _buildWireSnapshot(path, query);
+        _sendRes(id, snap);
+        break;
+
+      case 'rtdb.set':
+        _setNode(path, op['value']);
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.setPriority':
+        _setPriority(path, op['priority']);
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.setWithPriority':
+        _setNode(path, op['value'], priority: op['priority']);
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.update':
+        final values = Map<String, dynamic>.from(op['values'] as Map);
+        for (final entry in values.entries) {
+          final childPath = _joinPath(path, entry.key);
+          _setNode(childPath, entry.value);
+        }
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.remove':
+        _setNode(path, null);
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.transactionCommit':
+        final expected = op['expected'];
+        final currentVal = _getNode(path).toPlainValue();
+        const eq = DeepCollectionEquality();
+        if (!eq.equals(currentVal, expected)) {
+          _sendRes(id, {
+            'retry': true,
+            'committed': false,
+            'snapshot': _buildWireSnapshot(path, null),
+          });
+        } else {
+          _setNode(path, op['value']);
+          _notifySubs();
+          _sendRes(id, {
+            'retry': false,
+            'committed': true,
+            'snapshot': _buildWireSnapshot(path, null),
+          });
+        }
+        break;
+
+      case 'rtdb.onDisconnectSet':
+        _disconnectQueue[path] = _DisconnectOp(
+          kind: 'set',
+          path: path,
+          value: op['value'],
+          priority: op['priority'],
+        );
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.onDisconnectUpdate':
+        _disconnectQueue[path] = _DisconnectOp(
+          kind: 'update',
+          path: path,
+          values: Map<String, dynamic>.from(op['values'] as Map),
+        );
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.onDisconnectRemove':
+        _disconnectQueue[path] = _DisconnectOp(
+          kind: 'remove',
+          path: path,
+        );
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.onDisconnectCancel':
+        _disconnectQueue.remove(path);
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.goOffline':
+        isOffline = true;
+        _drainDisconnects();
+        _notifySubs();
+        _sendRes(id, null);
+        break;
+
+      case 'rtdb.goOnline':
+        isOffline = false;
+        _sendRes(id, null);
+        break;
+
+      default:
+        _sendRes(id, null);
+        break;
+    }
+  }
+
+  void _drainDisconnects() {
+    for (final op in _disconnectQueue.values) {
+      if (op.kind == 'set') {
+        _setNode(op.path, op.value, priority: op.priority);
+      } else if (op.kind == 'remove') {
+        _setNode(op.path, null);
+      } else if (op.kind == 'update' && op.values != null) {
+        for (final entry in op.values!.entries) {
+          _setNode(_joinPath(op.path, entry.key), entry.value);
+        }
+      }
+    }
+    _disconnectQueue.clear();
+  }
+
+  void _sendRes(String id, Object? value) {
+    toClient.add(jsonEncode({
+      'type': 'worker-res',
+      'id': id,
+      'ok': true,
+      'value': value,
+    }));
+  }
+
+  void _notifySubs() {
+    for (final entry in _subs.entries) {
+      _emitSnapshot(entry.key, entry.value);
+    }
+  }
+
+  void _emitSnapshot(String subId, Map<String, dynamic> sub) {
+    final target = Map<String, dynamic>.from(sub['target'] as Map);
+    final path = target['path'] as String? ?? '/';
+    final query = target['query'] is Map
+        ? Map<String, dynamic>.from(target['query'] as Map)
+        : null;
+    final snap = _buildWireSnapshot(path, query);
+    toClient.add(jsonEncode({
+      'type': 'worker-snap',
+      'subId': subId,
+      'value': snap,
+    }));
+  }
+
+  String _joinPath(String base, String child) {
+    final segments = [
+      ...base.split('/').where((s) => s.isNotEmpty),
+      ...child.split('/').where((s) => s.isNotEmpty),
+    ];
+    return segments.isEmpty ? '/' : '/${segments.join('/')}';
+  }
+
+  _TreeNode _getNode(String path) {
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    _TreeNode current = _root;
+    for (final seg in segments) {
+      current = current.children.putIfAbsent(seg, () => _TreeNode());
+    }
+    return current;
+  }
+
+  void _setPriority(String path, Object? priority) {
+    final node = _getNode(path);
+    node.priority = priority;
+  }
+
+  void _setNode(String path, Object? rawValue, {Object? priority}) {
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    final currentVal = _getNode(path).toPlainValue();
+    final resolved = _resolveSentinels(rawValue, currentVal);
+
+    if (segments.isEmpty) {
+      _root.children.clear();
+      _root.value = null;
+      _root.priority = priority;
+      _populateNode(_root, resolved);
+      return;
+    }
+
+    _TreeNode parent = _root;
+    for (int i = 0; i < segments.length - 1; i++) {
+      parent = parent.children.putIfAbsent(segments[i], () => _TreeNode());
+    }
+
+    final lastKey = segments.last;
+    if (resolved == null) {
+      parent.children.remove(lastKey);
+    } else {
+      final node = parent.children.putIfAbsent(lastKey, () => _TreeNode());
+      node.children.clear();
+      node.value = null;
+      if (priority != null) node.priority = priority;
+      _populateNode(node, resolved);
+    }
+  }
+
+  void _populateNode(_TreeNode node, Object? value) {
+    if (value is Map) {
+      for (final entry in value.entries) {
+        final k = entry.key.toString();
+        final childNode = _TreeNode();
+        _populateNode(childNode, entry.value);
+        if (!childNode.isEmpty) {
+          node.children[k] = childNode;
+        }
+      }
+    } else {
+      node.value = value;
+    }
+  }
+
+  Object? _resolveSentinels(Object? value, Object? existingVal) {
+    if (value is Map) {
+      if (value['__rtdbSentinel'] == 'serverTimestamp' ||
+          value['.sv'] == 'timestamp') {
+        return DateTime.now().millisecondsSinceEpoch;
+      }
+      if (value['__rtdbSentinel'] == 'increment') {
+        final delta = value['delta'] as num? ?? 0;
+        final base = existingVal is num ? existingVal : 0;
+        return base + delta;
+      }
+      if (value['.sv'] is Map && (value['.sv'] as Map).containsKey('increment')) {
+        final delta = (value['.sv'] as Map)['increment'] as num? ?? 0;
+        final base = existingVal is num ? existingVal : 0;
+        return base + delta;
+      }
+      final out = <String, dynamic>{};
+      for (final entry in value.entries) {
+        final k = entry.key.toString();
+        final existingChild = existingVal is Map ? existingVal[k] : null;
+        out[k] = _resolveSentinels(entry.value, existingChild);
+      }
+      return out;
+    }
+    return value;
+  }
+
+  Map<String, dynamic> _buildWireSnapshot(
+    String path,
+    Map<String, dynamic>? query,
+  ) {
+    final node = _getNode(path);
+    final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+    final key = segments.isEmpty ? null : segments.last;
+
+    var entries = <Map<String, dynamic>>[];
+    for (final entry in node.children.entries) {
+      final childVal = entry.value.toPlainValue();
+      if (childVal != null) {
+        entries.add({
+          'key': entry.key,
+          'value': childVal,
+          'priority': entry.value.priority,
+          'exportValue': childVal,
+        });
+      }
+    }
+
+    if (query != null) {
+      entries = _applyQuery(entries, query);
+    }
+
+    final plainVal = entries.isNotEmpty
+        ? {for (final e in entries) e['key'] as String: e['value']}
+        : node.toPlainValue();
+
+    return {
+      'key': key,
+      'exists': plainVal != null,
+      'value': plainVal,
+      'size': entries.length,
+      'priority': node.priority,
+      'exportValue': plainVal,
+      'entries': entries,
+    };
+  }
+
+  List<Map<String, dynamic>> _applyQuery(
+    List<Map<String, dynamic>> entries,
+    Map<String, dynamic> query,
+  ) {
+    final orderBy = query['orderBy'] is Map
+        ? Map<String, dynamic>.from(query['orderBy'] as Map)
+        : null;
+    final kind = orderBy?['kind'] as String?;
+
+    Comparable<dynamic> extractSortKey(Map<String, dynamic> entry) {
+      if (kind == 'key') {
+        return entry['key'] as String;
+      } else if (kind == 'value') {
+        final v = entry['value'];
+        if (v is num) return v;
+        if (v is String) return v;
+        if (v is bool) return v ? 1 : 0;
+        return '';
+      } else if (kind == 'child') {
+        final childPath = orderBy?['path'] as String? ?? '';
+        Object? curr = entry['value'];
+        for (final seg in childPath.split('/').where((s) => s.isNotEmpty)) {
+          if (curr is Map) {
+            curr = curr[seg];
+          } else {
+            curr = null;
+            break;
+          }
+        }
+        if (curr is num) return curr;
+        if (curr is String) return curr;
+        if (curr is bool) return curr ? 1 : 0;
+        return '';
+      } else {
+        final prio = entry['priority'];
+        if (prio is num) return prio;
+        if (prio is String) return prio;
+        return entry['key'] as String;
+      }
+    }
+
+    final sorted = List<Map<String, dynamic>>.from(entries);
+    sorted.sort((a, b) {
+      final ka = extractSortKey(a);
+      final kb = extractSortKey(b);
+      if (ka.runtimeType == kb.runtimeType) {
+        final cmp = ka.compareTo(kb);
+        if (cmp != 0) return cmp;
+      }
+      return (a['key'] as String).compareTo(b['key'] as String);
+    });
+
+    var filtered = sorted;
+    final bounds = query['bounds'] as List? ?? const [];
+    for (final bRaw in bounds) {
+      final b = Map<String, dynamic>.from(bRaw as Map);
+      final bKind = b['kind'] as String;
+      final bVal = b['value'];
+      filtered = filtered.where((e) {
+        final k = extractSortKey(e);
+        if (bVal is num && k is num) {
+          if (bKind == 'equalTo') return k == bVal;
+          if (bKind == 'startAt') return k >= bVal;
+          if (bKind == 'endAt') return k <= bVal;
+        } else if (bVal is String && k is String) {
+          if (bKind == 'equalTo') return k == bVal;
+          if (bKind == 'startAt') return k.compareTo(bVal) >= 0;
+          if (bKind == 'endAt') return k.compareTo(bVal) <= 0;
+        }
+        return true;
+      }).toList();
+    }
+
+    final limitMap = query['limit'] is Map
+        ? Map<String, dynamic>.from(query['limit'] as Map)
+        : null;
+    if (limitMap != null) {
+      final lKind = limitMap['kind'] as String;
+      final n = limitMap['n'] as int;
+      if (lKind == 'limitToFirst' && filtered.length > n) {
+        filtered = filtered.sublist(0, n);
+      } else if (lKind == 'limitToLast' && filtered.length > n) {
+        filtered = filtered.sublist(filtered.length - n);
+      }
+    }
+
+    return filtered;
+  }
+}

--- a/packages/flutter-client/test/rtdb_conformance_test.dart
+++ b/packages/flutter-client/test/rtdb_conformance_test.dart
@@ -1,0 +1,472 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pyric_firestore/pyric_flutter_client.dart';
+import 'helpers/rtdb_test_harness.dart';
+
+void main() {
+  late RtdbTestHarness harness;
+  late PyricDatabase db;
+
+  setUp(() async {
+    harness = RtdbTestHarness();
+    await harness.connect();
+    db = harness.database;
+  });
+
+  tearDown(() async {
+    await harness.dispose();
+  });
+
+  // ── 1. Database Instance & Connection (5 rows) ────────────────────────────
+  group('1. Database Instance & Connection', () {
+    test('rtdb-flutter#instance-default: PyricDatabase.instance returns default Realtime Database instance', () {
+      final defaultDb = PyricDatabase.instance;
+      expect(defaultDb, isA<PyricDatabase>());
+      expect(defaultDb.bridgeClient, same(harness.client));
+    });
+
+    test('rtdb-flutter#instance-url: PyricDatabase.instanceFor(databaseURL) returns isolated instance', () {
+      final customDb = PyricDatabase.instanceFor(
+        databaseURL: 'https://test-project-default-rtdb.firebaseio.com',
+      );
+      expect(
+        customDb.databaseURL,
+        'https://test-project-default-rtdb.firebaseio.com',
+      );
+      expect(customDb, isA<PyricDatabase>());
+    });
+
+    test('rtdb-flutter#ref-root: PyricDatabase.ref() returns root DatabaseReference', () {
+      final rootRef = db.ref();
+      expect(rootRef.path, '/');
+      expect(rootRef.key, isNull);
+    });
+
+    test('rtdb-flutter#ref-path: PyricDatabase.ref(path) returns specified DatabaseReference', () {
+      final userRef = db.ref('users/alice');
+      expect(userRef.path, '/users/alice');
+      expect(userRef.key, 'alice');
+    });
+
+    test('rtdb-flutter#connection-toggle: PyricDatabase.goOffline() / goOnline() suspends and resumes connection', () async {
+      expect(harness.isOffline, isFalse);
+      await db.goOffline();
+      expect(harness.isOffline, isTrue);
+      await db.goOnline();
+      expect(harness.isOffline, isFalse);
+    });
+  });
+
+  // ── 2. DatabaseReference Navigation & Properties (7 rows) ────────────────
+  group('2. DatabaseReference Navigation & Properties', () {
+    test('rtdb-flutter#ref-child: DatabaseReference.child(path) returns child reference', () {
+      final ref = db.ref('users').child('bob/profile');
+      expect(ref.path, '/users/bob/profile');
+      expect(ref.key, 'profile');
+    });
+
+    test('rtdb-flutter#ref-parent: DatabaseReference.parent returns parent reference or null for root', () {
+      final childRef = db.ref('users/alice');
+      expect(childRef.parent?.path, '/users');
+      expect(childRef.parent?.parent?.path, '/');
+      expect(db.ref().parent, isNull);
+    });
+
+    test('rtdb-flutter#ref-root-prop: DatabaseReference.root returns root reference from any descendant', () {
+      final deepRef = db.ref('a/b/c/d');
+      expect(deepRef.root.path, '/');
+      expect(deepRef.root.key, isNull);
+    });
+
+    test('rtdb-flutter#ref-key: DatabaseReference.key returns last segment token or null for root', () {
+      expect(db.ref('posts/post-123').key, 'post-123');
+      expect(db.ref().key, isNull);
+    });
+
+    test('rtdb-flutter#ref-path-prop: DatabaseReference.path returns normalized slash-delimited full path', () {
+      expect(db.ref('///items//sub///').path, '/items/sub');
+      expect(db.ref('').path, '/');
+    });
+
+    test('rtdb-flutter#ref-push: DatabaseReference.push() generates a new child reference with unique push ID', () {
+      final listRef = db.ref('messages');
+      final pushed1 = listRef.push();
+      final pushed2 = listRef.push();
+      expect(pushed1.key, isNotNull);
+      expect(pushed1.key!.length, 20);
+      expect(pushed1.key, isNot(equals(pushed2.key)));
+      expect(pushed1.path, '/messages/${pushed1.key}');
+    });
+
+    test('rtdb-flutter#ref-push-key-ordering: DatabaseReference.push().key monotonically orders push keys', () {
+      final listRef = db.ref('timeline');
+      final keys = List.generate(10, (_) => listRef.push().key!);
+      final sorted = List<String>.from(keys)..sort();
+      expect(keys, equals(sorted));
+    });
+  });
+
+  // ── 3. Write Operations (6 rows) ─────────────────────────────────────────
+  group('3. Write Operations', () {
+    test('rtdb-flutter#write-set: DatabaseReference.set(value) overwrites data at path', () async {
+      final ref = db.ref('profile/alice');
+      await ref.set({'name': 'Alice', 'role': 'admin'});
+      final snap = await ref.get();
+      expect(snap.value, {'name': 'Alice', 'role': 'admin'});
+    });
+
+    test('rtdb-flutter#write-set-null: DatabaseReference.set(null) deletes data at path', () async {
+      final ref = db.ref('temp/data');
+      await ref.set('present');
+      expect((await ref.get()).exists, isTrue);
+      await ref.set(null);
+      expect((await ref.get()).exists, isFalse);
+      expect((await ref.get()).value, isNull);
+    });
+
+    test('rtdb-flutter#write-set-priority: DatabaseReference.setPriority(priority) updates ordering priority', () async {
+      final ref = db.ref('ranked/item1');
+      await ref.set('value1');
+      await ref.setPriority(100);
+      final snap = await ref.get();
+      expect(snap.value, 'value1');
+      expect(snap.priority, 100);
+    });
+
+    test('rtdb-flutter#write-set-with-priority: DatabaseReference.setWithPriority(value, priority) writes both atomically', () async {
+      final ref = db.ref('ranked/item2');
+      await ref.setWithPriority({'score': 50}, 10);
+      final snap = await ref.get();
+      expect(snap.value, {'score': 50});
+      expect(snap.priority, 10);
+    });
+
+    test('rtdb-flutter#write-update: DatabaseReference.update(values) updates specified child keys without overwriting siblings', () async {
+      final ref = db.ref('users/charlie');
+      await ref.set({'name': 'Charlie', 'age': 25, 'city': 'Boston'});
+      await ref.update({'age': 26, 'country': 'USA'});
+      final snap = await ref.get();
+      expect(snap.value, {
+        'name': 'Charlie',
+        'age': 26,
+        'city': 'Boston',
+        'country': 'USA',
+      });
+    });
+
+    test('rtdb-flutter#write-remove: DatabaseReference.remove() deletes node and descendant data', () async {
+      final ref = db.ref('deleteMe');
+      await ref.set({'nested': 'data'});
+      expect((await ref.get()).exists, isTrue);
+      await ref.remove();
+      expect((await ref.get()).exists, isFalse);
+    });
+  });
+
+  // ── 4. ServerValue Sentinels (2 rows) ────────────────────────────────────
+  group('4. ServerValue Sentinels', () {
+    test('rtdb-flutter#sentinel-timestamp: ServerValue.timestamp resolves to server epoch milliseconds', () async {
+      final ref = db.ref('events/e1');
+      await ref.set({'createdAt': ServerValue.timestamp});
+      final snap = await ref.get();
+      final map = snap.value as Map;
+      expect(map['createdAt'], isA<int>());
+      expect(map['createdAt'] as int, greaterThan(1700000000000));
+    });
+
+    test('rtdb-flutter#sentinel-increment: ServerValue.increment(delta) atomically increments numeric value', () async {
+      final ref = db.ref('counters/views');
+      await ref.set(10);
+      await ref.set(ServerValue.increment(5));
+      expect((await ref.get()).value, 15);
+      await ref.set(ServerValue.increment(-3));
+      expect((await ref.get()).value, 12);
+    });
+  });
+
+  // ── 5. One-Shot Reads & DataSnapshot Inspection (7 rows) ─────────────────
+  group('5. One-Shot Reads & DataSnapshot Inspection', () {
+    test('rtdb-flutter#read-get: DatabaseReference.get() fetches one-shot DataSnapshot', () async {
+      await db.ref('config/theme').set('dark');
+      final snap = await db.ref('config/theme').get();
+      expect(snap.value, 'dark');
+    });
+
+    test('rtdb-flutter#snap-exists: DataSnapshot.exists returns true for non-null data and false when missing', () async {
+      await db.ref('check/present').set(true);
+      expect((await db.ref('check/present').get()).exists, isTrue);
+      expect((await db.ref('check/absent').get()).exists, isFalse);
+    });
+
+    test('rtdb-flutter#snap-key: DataSnapshot.key returns key name of snapshot location', () async {
+      await db.ref('books/b1').set({'title': 'Dart'});
+      final snap = await db.ref('books/b1').get();
+      expect(snap.key, 'b1');
+    });
+
+    test('rtdb-flutter#snap-value: DataSnapshot.value returns deserialized Dart value', () async {
+      await db.ref('scalars/num').set(42);
+      expect((await db.ref('scalars/num').get()).value, 42);
+    });
+
+    test('rtdb-flutter#snap-children: DataSnapshot.children returns iterable of direct child snapshots', () async {
+      await db.ref('team').set({'u1': 'Alice', 'u2': 'Bob'});
+      final snap = await db.ref('team').get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, containsAll(['u1', 'u2']));
+    });
+
+    test('rtdb-flutter#snap-child-path: DataSnapshot.child(path) inspects relative descendant path', () async {
+      await db.ref('org').set({
+        'dept': {
+          'lead': {'name': 'Grace'},
+        },
+      });
+      final snap = await db.ref('org').get();
+      final leadNameSnap = snap.child('dept/lead/name');
+      expect(leadNameSnap.exists, isTrue);
+      expect(leadNameSnap.value, 'Grace');
+    });
+
+    test('rtdb-flutter#snap-priority: DataSnapshot.priority returns node priority value', () async {
+      await db.ref('priorityNode').setWithPriority('important', 5);
+      final snap = await db.ref('priorityNode').get();
+      expect(snap.priority, 5);
+    });
+  });
+
+  // ── 6. Realtime Listeners & Streams (5 rows) ─────────────────────────────
+  group('6. Realtime Listeners & Streams', () {
+    test('rtdb-flutter#listen-value: Query.onValue emits initial and updated DataSnapshots', () async {
+      final ref = db.ref('live/status');
+      final events = <Object?>[];
+      final sub = ref.onValue.listen((event) {
+        events.add(event.snapshot.value);
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await ref.set('online');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await ref.set('away');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(events, containsAll(['online', 'away']));
+      await sub.cancel();
+    });
+
+    test('rtdb-flutter#listen-child-added: Query.onChildAdded emits existing and newly added children', () async {
+      final ref = db.ref('chat/room1');
+      await ref.set({'m1': 'Hello'});
+
+      final addedKeys = <String?>[];
+      final sub = ref.onChildAdded.listen((event) {
+        addedKeys.add(event.snapshot.key);
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await ref.child('m2').set('World');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(addedKeys, ['m1', 'm2']);
+      await sub.cancel();
+    });
+
+    test('rtdb-flutter#listen-child-changed: Query.onChildChanged emits when existing child is modified', () async {
+      final ref = db.ref('inventory');
+      await ref.set({'apple': 10, 'banana': 5});
+
+      final changed = <String, Object?>{};
+      final sub = ref.onChildChanged.listen((event) {
+        if (event.snapshot.key != null) {
+          changed[event.snapshot.key!] = event.snapshot.value;
+        }
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await ref.child('apple').set(15);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(changed['apple'], 15);
+      await sub.cancel();
+    });
+
+    test('rtdb-flutter#listen-child-removed: Query.onChildRemoved emits when child node is removed', () async {
+      final ref = db.ref('activeUsers');
+      await ref.set({'u1': true, 'u2': true});
+
+      final removedKeys = <String?>[];
+      final sub = ref.onChildRemoved.listen((event) {
+        removedKeys.add(event.snapshot.key);
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await ref.child('u1').remove();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(removedKeys, ['u1']);
+      await sub.cancel();
+    });
+
+    test('rtdb-flutter#listen-cancel: StreamSubscription.cancel() unsubscribes listener', () async {
+      final ref = db.ref('cancelTest');
+      int count = 0;
+      final sub = ref.onValue.listen((_) => count++);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final countBeforeCancel = count;
+      await sub.cancel();
+
+      await ref.set('after-cancel');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(count, countBeforeCancel);
+    });
+  });
+
+  // ── 7. Query Ordering, Filtering & Limits (6 rows) ───────────────────────
+  group('7. Query Ordering, Filtering & Limits', () {
+    setUp(() async {
+      await db.ref('players').set({
+        'p1': {'name': 'Charlie', 'score': 30},
+        'p2': {'name': 'Alice', 'score': 10},
+        'p3': {'name': 'Bob', 'score': 20},
+      });
+    });
+
+    test('rtdb-flutter#query-order-by-child: Query.orderByChild(path) orders results by nested child value', () async {
+      final snap = await db.ref('players').orderByChild('score').get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, ['p2', 'p3', 'p1']);
+    });
+
+    test('rtdb-flutter#query-order-by-key: Query.orderByKey() orders results lexicographically by key', () async {
+      final snap = await db.ref('players').orderByKey().get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, ['p1', 'p2', 'p3']);
+    });
+
+    test('rtdb-flutter#query-order-by-value: Query.orderByValue() orders scalar values', () async {
+      await db.ref('scores').set({'a': 300, 'b': 100, 'c': 200});
+      final snap = await db.ref('scores').orderByValue().get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, ['b', 'c', 'a']);
+    });
+
+    test('rtdb-flutter#query-equal-to: Query.equalTo(value) filters results matching exact sort value', () async {
+      final snap = await db
+          .ref('players')
+          .orderByChild('score')
+          .equalTo(20)
+          .get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, ['p3']);
+    });
+
+    test('rtdb-flutter#query-range: Query.startAt(value) / endAt(value) restricts range boundaries', () async {
+      final snap = await db
+          .ref('players')
+          .orderByChild('score')
+          .startAt(15)
+          .endAt(30)
+          .get();
+      final keys = snap.children.map((c) => c.key).toList();
+      expect(keys, ['p3', 'p1']);
+    });
+
+    test('rtdb-flutter#query-limit: Query.limitToFirst(limit) / limitToLast(limit) caps result window', () async {
+      final firstTwo = await db
+          .ref('players')
+          .orderByChild('score')
+          .limitToFirst(2)
+          .get();
+      expect(firstTwo.children.map((c) => c.key).toList(), ['p2', 'p3']);
+
+      final lastTwo = await db
+          .ref('players')
+          .orderByChild('score')
+          .limitToLast(2)
+          .get();
+      expect(lastTwo.children.map((c) => c.key).toList(), ['p3', 'p1']);
+    });
+  });
+
+  // ── 8. Transactions & OnDisconnect (4 rows) ──────────────────────────────
+  group('8. Transactions & OnDisconnect', () {
+    test('rtdb-flutter#tx-run: DatabaseReference.runTransaction(handler) commits optimistic concurrency write', () async {
+      final ref = db.ref('bank/balance');
+      await ref.set(100);
+
+      final result = await ref.runTransaction((mutableData) {
+        final current = (mutableData.value as int?) ?? 0;
+        mutableData.value = current + 50;
+        return Transaction.success(mutableData);
+      });
+
+      expect(result.committed, isTrue);
+      expect(result.snapshot.value, 150);
+      expect((await ref.get()).value, 150);
+    });
+
+    test('rtdb-flutter#tx-abort: Transaction.abort() aborts transaction without modifying data', () async {
+      final ref = db.ref('bank/locked');
+      await ref.set(500);
+
+      final result = await ref.runTransaction((mutableData) {
+        return Transaction.abort();
+      });
+
+      expect(result.committed, isFalse);
+      expect(result.snapshot.value, 500);
+      expect((await ref.get()).value, 500);
+    });
+
+    test('rtdb-flutter#ondisconnect-set-remove: OnDisconnect.set(value) / remove() executes on disconnect', () async {
+      final presenceRef = db.ref('presence/user1');
+      await presenceRef.set('online');
+      await presenceRef.onDisconnect().set('offline');
+
+      expect((await presenceRef.get()).value, 'online');
+      await db.goOffline();
+      expect((await presenceRef.get()).value, 'offline');
+    });
+
+    test('rtdb-flutter#ondisconnect-cancel: OnDisconnect.cancel() cancels queued disconnect operations', () async {
+      final statusRef = db.ref('presence/user2');
+      await statusRef.set('active');
+      await statusRef.onDisconnect().set('gone');
+      await statusRef.onDisconnect().cancel();
+
+      await db.goOffline();
+      expect((await statusRef.get()).value, 'active');
+    });
+  });
+
+  // ── 9. AuthLens Propagation & Resubscription ─────────────────────────────
+  group('9. AuthLens Integration', () {
+    test('propagates active AuthLens on worker-op and resubscribes active listeners upon identity change', () async {
+      harness.credentialsProvider.setLens(AuthLens.admin);
+      await db.ref('secure/data').set('secret');
+      expect(harness.receivedOps.last['actAs'], {'mode': 'admin'});
+
+      harness.credentialsProvider.setLens(AuthLens.asUser(uid: 'user-42'));
+      await db.ref('secure/data').get();
+      expect(harness.receivedOps.last['actAs'], {
+        'mode': 'as',
+        'uid': 'user-42',
+      });
+
+      final sub = db.ref('secure/stream').onValue.listen((_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(harness.receivedSubs.last['actAs'], {
+        'mode': 'as',
+        'uid': 'user-42',
+      });
+
+      // Switch identity to anon -> triggers automatic resubscription with new AuthLens
+      harness.credentialsProvider.setLens(AuthLens.anon);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(harness.receivedSubs.last['actAs'], {'mode': 'anon'});
+
+      await sub.cancel();
+    });
+  });
+}

--- a/packages/ios-client/Package.swift
+++ b/packages/ios-client/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PyricDatabase",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16)
+    ],
+    products: [
+        .library(
+            name: "PyricDatabase",
+            targets: ["PyricDatabase"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../swift-client")
+    ],
+    targets: [
+        .target(
+            name: "PyricDatabase",
+            dependencies: [
+                .product(name: "PyricFirestore", package: "swift-client"),
+                .product(name: "FirebaseAuth", package: "swift-client")
+            ],
+            path: "Sources/PyricDatabase"
+        ),
+        .testTarget(
+            name: "PyricDatabaseTests",
+            dependencies: [
+                "PyricDatabase",
+                .product(name: "PyricFirestore", package: "swift-client"),
+                .product(name: "FirebaseAuth", package: "swift-client")
+            ],
+            path: "Tests/PyricDatabaseTests"
+        ),
+    ]
+)

--- a/packages/ios-client/Sources/PyricDatabase/DataSnapshot.swift
+++ b/packages/ios-client/Sources/PyricDatabase/DataSnapshot.swift
@@ -1,0 +1,172 @@
+import Foundation
+import PyricFirestore
+
+/// The event types that can be observed on a Realtime Database query or reference.
+public enum DataEventType: Int, Sendable {
+    case childAdded = 0
+    case childRemoved = 1
+    case childChanged = 2
+    case childMoved = 3
+    case value = 4
+}
+
+/// Event emitted for child events (`childAdded`, `childChanged`, `childRemoved`, `childMoved`).
+public struct DatabaseChildEvent: Sendable {
+    public let type: DataEventType
+    public let snapshot: DataSnapshot
+    public let previousSiblingKey: String?
+
+    public init(type: DataEventType, snapshot: DataSnapshot, previousSiblingKey: String? = nil) {
+        self.type = type
+        self.snapshot = snapshot
+        self.previousSiblingKey = previousSiblingKey
+    }
+}
+
+/// An immutable snapshot of data at a Realtime Database location.
+public final class DataSnapshot: NSObject, @unchecked Sendable {
+    public let ref: DatabaseReference
+    public let key: String?
+    public let value: Any?
+    public let priority: Any?
+    public let existsFlag: Bool
+    public let childEntries: [(key: String, value: Any?, priority: Any?)]
+
+    public init(
+        key: String?,
+        value: Any?,
+        priority: Any?,
+        exists: Bool,
+        entries: [(key: String, value: Any?, priority: Any?)],
+        ref: DatabaseReference
+    ) {
+        self.key = key
+        self.value = value
+        self.priority = priority
+        self.existsFlag = exists
+        self.childEntries = entries
+        self.ref = ref
+        super.init()
+    }
+
+    public convenience init(wire: AnySendable, ref: DatabaseReference) {
+        let key = wire["key"]?.stringValue ?? ref.key
+        let exists = wire["exists"]?.boolValue ?? false
+        let rawVal = RtdbValueCodec.fromAnySendable(wire["value"])
+        let priority = RtdbValueCodec.fromAnySendable(wire["priority"])
+
+        var entries: [(key: String, value: Any?, priority: Any?)] = []
+        if let wireEntries = wire["entries"]?.arrayValue {
+            for item in wireEntries {
+                if let entryKey = item["key"]?.stringValue {
+                    let entryVal = RtdbValueCodec.fromAnySendable(item["value"])
+                    let entryPrio = RtdbValueCodec.fromAnySendable(item["priority"])
+                    entries.append((key: entryKey, value: entryVal, priority: entryPrio))
+                }
+            }
+        } else if let dict = rawVal as? [String: Any] {
+            for k in dict.keys.sorted() {
+                entries.append((key: k, value: dict[k], priority: nil))
+            }
+        }
+
+        self.init(
+            key: key,
+            value: rawVal,
+            priority: priority,
+            exists: exists,
+            entries: entries,
+            ref: ref
+        )
+    }
+
+    /// Returns true if the DataSnapshot contains non-null data.
+    public func exists() -> Bool {
+        return existsFlag && value != nil && !(value is NSNull)
+    }
+
+    /// Returns the number of immediate children in this DataSnapshot.
+    public var childrenCount: UInt {
+        return UInt(childEntries.count)
+    }
+
+    /// Returns true if the DataSnapshot has any child nodes.
+    public func hasChildren() -> Bool {
+        return !childEntries.isEmpty
+    }
+
+    /// Returns true if the specified relative path exists in this snapshot.
+    public func hasChild(_ childPathString: String) -> Bool {
+        return childSnapshot(forPath: childPathString).exists()
+    }
+
+    /// Returns an ordered array of immediate child DataSnapshots.
+    public var childrenSnapshots: [DataSnapshot] {
+        return childEntries.map { entry in
+            let childRef = ref.child(entry.key)
+            let childVal = entry.value
+            let childExists = (childVal != nil && !(childVal is NSNull))
+            var subEntries: [(key: String, value: Any?, priority: Any?)] = []
+            if let dict = childVal as? [String: Any] {
+                for k in dict.keys.sorted() {
+                    subEntries.append((key: k, value: dict[k], priority: nil))
+                }
+            }
+            return DataSnapshot(
+                key: entry.key,
+                value: childVal,
+                priority: entry.priority,
+                exists: childExists,
+                entries: subEntries,
+                ref: childRef
+            )
+        }
+    }
+
+    /// Returns an NSEnumerator of immediate child DataSnapshots.
+    public var children: NSEnumerator {
+        return (childrenSnapshots as NSArray).objectEnumerator()
+    }
+
+    /// Returns a DataSnapshot for the relative descendant path within the snapshot.
+    public func childSnapshot(forPath childPathString: String) -> DataSnapshot {
+        let segments = childPathString.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        guard !segments.isEmpty else { return self }
+
+        var currentVal: Any? = value
+        var currentPrio: Any? = priority
+        let currentEntries = childEntries
+        var currentRef = ref
+
+        for (index, seg) in segments.enumerated() {
+            currentRef = currentRef.child(seg)
+            if index == 0, let found = currentEntries.first(where: { $0.key == seg }) {
+                currentVal = found.value
+                currentPrio = found.priority
+            } else if let dict = currentVal as? [String: Any], let subVal = dict[seg] {
+                currentVal = subVal
+                currentPrio = nil
+            } else {
+                currentVal = nil
+                currentPrio = nil
+            }
+        }
+
+        let exists = (currentVal != nil && !(currentVal is NSNull))
+        var subEntries: [(key: String, value: Any?, priority: Any?)] = []
+        if let dict = currentVal as? [String: Any] {
+            for k in dict.keys.sorted() {
+                subEntries.append((key: k, value: dict[k], priority: nil))
+            }
+        }
+
+        return DataSnapshot(
+            key: segments.last,
+            value: currentVal,
+            priority: currentPrio,
+            exists: exists,
+            entries: subEntries,
+            ref: currentRef
+        )
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/Database.swift
+++ b/packages/ios-client/Sources/PyricDatabase/Database.swift
@@ -1,0 +1,195 @@
+import Foundation
+import PyricFirestore
+import FirebaseAuth
+
+/// Entry point for the Firebase Realtime Database Swift SDK.
+public final class Database: NSObject, @unchecked Sendable {
+
+    private struct InstanceKey: Hashable {
+        let appName: String
+        let url: String
+    }
+
+    private static let registryLock = NSLock()
+    nonisolated(unsafe) private static var instances: [InstanceKey: Database] = [:]
+
+    public static func database() -> Database {
+        return database(app: FirebaseApp.app(), url: "https://default.firebaseio.com")
+    }
+
+    public static func database(url: String) -> Database {
+        return database(app: FirebaseApp.app(), url: url)
+    }
+
+    public static func database(app: FirebaseApp) -> Database {
+        return database(app: app, url: "https://default.firebaseio.com")
+    }
+
+    public static func database(app: FirebaseApp, url: String) -> Database {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        let key = InstanceKey(appName: app.name, url: url)
+        if let existing = instances[key] {
+            return existing
+        }
+        let created = Database(app: app, url: url)
+        instances[key] = created
+        return created
+    }
+
+    public static func reset() {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        instances.removeAll()
+    }
+
+    // ── Properties ────────────────────────────────────────────────────────────
+
+    public let app: FirebaseApp
+    public let url: String
+    public private(set) var bridgeClient: PyricBridgeClient
+
+    private let stateLock = NSLock()
+    private var _impersonatedLens: AuthLens?
+    private var _credentialProvider: (any AuthCredentialProvider)?
+    private var lensContinuations: [UUID: AsyncStream<AuthLens>.Continuation] = [:]
+    private var authSyncTask: Task<Void, Never>?
+
+    public var credentialProvider: (any AuthCredentialProvider)? {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            if let explicit = _credentialProvider {
+                return explicit
+            }
+            return AuthCredentialProviderRegistry.resolve(app: app)
+        }
+        set {
+            stateLock.lock()
+            _credentialProvider = newValue
+            stateLock.unlock()
+            startAuthLensSync()
+        }
+    }
+
+    public init(app: FirebaseApp, url: String, bridgeClient: PyricBridgeClient? = nil) {
+        self.app = app
+        self.url = url
+        self.bridgeClient = bridgeClient ?? Firestore.firestore(app: app).bridgeClient
+        super.init()
+        startAuthLensSync()
+    }
+
+    deinit {
+        authSyncTask?.cancel()
+    }
+
+    private func startAuthLensSync() {
+        authSyncTask?.cancel()
+        guard let provider = credentialProvider else { return }
+        authSyncTask = Task { [weak self] in
+            for await _ in provider.authLensStream {
+                guard !Task.isCancelled, let self else { break }
+                self.notifyLensChanged()
+            }
+        }
+    }
+
+    public func switchLens(_ lens: AuthLens?) {
+        stateLock.lock()
+        _impersonatedLens = lens
+        stateLock.unlock()
+        notifyLensChanged()
+    }
+
+    private func notifyLensChanged() {
+        let current = currentAuthLens()
+        stateLock.lock()
+        let conts = Array(lensContinuations.values)
+        stateLock.unlock()
+        for cont in conts {
+            cont.yield(current)
+        }
+    }
+
+    public func currentAuthLens() -> AuthLens {
+        stateLock.lock()
+        let overrideLens = _impersonatedLens
+        stateLock.unlock()
+        if let overrideLens {
+            return overrideLens
+        }
+        if let provider = credentialProvider {
+            return provider.currentAuthLens()
+        }
+        return .anon
+    }
+
+    public var authLensStream: AsyncStream<AuthLens> {
+        if authSyncTask == nil {
+            startAuthLensSync()
+        }
+        return AsyncStream { continuation in
+            let id = UUID()
+            let initial = self.currentAuthLens()
+            stateLock.lock()
+            lensContinuations[id] = continuation
+            stateLock.unlock()
+            continuation.yield(initial)
+
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.stateLock.lock()
+                self.lensContinuations.removeValue(forKey: id)
+                self.stateLock.unlock()
+            }
+        }
+    }
+
+    // ── DatabaseReferences ────────────────────────────────────────────────────
+
+    public func reference() -> DatabaseReference {
+        return DatabaseReference(database: self, path: "/")
+    }
+
+    public func reference(withPath path: String) -> DatabaseReference {
+        return DatabaseReference(database: self, path: path)
+    }
+
+    public func reference(fromURL databaseUrl: String) -> DatabaseReference {
+        if let parsed = URL(string: databaseUrl) {
+            return DatabaseReference(database: self, path: parsed.path.isEmpty ? "/" : parsed.path)
+        }
+        return DatabaseReference(database: self, path: "/")
+    }
+
+    // ── Connection Control ────────────────────────────────────────────────────
+
+    public func goOffline() async throws {
+        _ = try await bridgeClient.op(
+            method: "rtdb.goOffline",
+            params: [:],
+            actAs: currentAuthLens()
+        )
+    }
+
+    public func goOffline() {
+        Task {
+            try? await goOffline()
+        }
+    }
+
+    public func goOnline() async throws {
+        _ = try await bridgeClient.op(
+            method: "rtdb.goOnline",
+            params: [:],
+            actAs: currentAuthLens()
+        )
+    }
+
+    public func goOnline() {
+        Task {
+            try? await goOnline()
+        }
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/DatabaseQuery.swift
+++ b/packages/ios-client/Sources/PyricDatabase/DatabaseQuery.swift
@@ -1,0 +1,437 @@
+import Foundation
+import PyricFirestore
+
+/// Represents a query over data at a Realtime Database location.
+public class DatabaseQuery: NSObject, @unchecked Sendable {
+    public let database: Database
+    public let path: String
+
+    internal let orderBySpec: [String: AnySendable]?
+    internal let boundsSpec: [[String: AnySendable]]
+    internal let limitSpec: [String: AnySendable]?
+
+    private let observerLock = NSLock()
+    private var observerTasks: [UInt: Task<Void, Never>] = [:]
+    nonisolated(unsafe) private static var nextObserverHandle: UInt = 1
+
+    public init(
+        database: Database,
+        path: String,
+        orderBySpec: [String: AnySendable]? = nil,
+        boundsSpec: [[String: AnySendable]] = [],
+        limitSpec: [String: AnySendable]? = nil
+    ) {
+        self.database = database
+        self.path = path
+        self.orderBySpec = orderBySpec
+        self.boundsSpec = boundsSpec
+        self.limitSpec = limitSpec
+        super.init()
+    }
+
+    /// Returns a DatabaseReference to the query's path.
+    public var ref: DatabaseReference {
+        return DatabaseReference(database: database, path: path)
+    }
+
+    internal func toQuerySpecAnySendable() -> AnySendable? {
+        if orderBySpec == nil && boundsSpec.isEmpty && limitSpec == nil {
+            return nil
+        }
+        var spec: [String: AnySendable] = [:]
+        if let orderBySpec {
+            spec["orderBy"] = .dictionary(orderBySpec)
+        } else {
+            spec["orderBy"] = .null
+        }
+        spec["bounds"] = .array(boundsSpec.map { .dictionary($0) })
+        if let limitSpec {
+            spec["limit"] = .dictionary(limitSpec)
+        } else {
+            spec["limit"] = .null
+        }
+        return .dictionary(spec)
+    }
+
+    // ── Query Ordering ────────────────────────────────────────────────────────
+
+    public func queryOrdered(byChild key: String) -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: ["kind": .string("child"), "path": .string(key)],
+            boundsSpec: boundsSpec,
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryOrderedByKey() -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: ["kind": .string("key")],
+            boundsSpec: boundsSpec,
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryOrderedByValue() -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: ["kind": .string("value")],
+            boundsSpec: boundsSpec,
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryOrderedByPriority() -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: ["kind": .string("priority")],
+            boundsSpec: boundsSpec,
+            limitSpec: limitSpec
+        )
+    }
+
+    // ── Query Filtering / Range Bounds ────────────────────────────────────────
+
+    public func queryStarting(atValue value: Any?, childKey: String? = nil) -> DatabaseQuery {
+        var bound: [String: AnySendable] = [
+            "kind": .string("startAt"),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let childKey { bound["key"] = .string(childKey) }
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec + [bound],
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryStarting(afterValue value: Any?, childKey: String? = nil) -> DatabaseQuery {
+        var bound: [String: AnySendable] = [
+            "kind": .string("startAfter"),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let childKey { bound["key"] = .string(childKey) }
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec + [bound],
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryEnding(atValue value: Any?, childKey: String? = nil) -> DatabaseQuery {
+        var bound: [String: AnySendable] = [
+            "kind": .string("endAt"),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let childKey { bound["key"] = .string(childKey) }
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec + [bound],
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryEnding(beforeValue value: Any?, childKey: String? = nil) -> DatabaseQuery {
+        var bound: [String: AnySendable] = [
+            "kind": .string("endBefore"),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let childKey { bound["key"] = .string(childKey) }
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec + [bound],
+            limitSpec: limitSpec
+        )
+    }
+
+    public func queryEqual(toValue value: Any?, childKey: String? = nil) -> DatabaseQuery {
+        var bound: [String: AnySendable] = [
+            "kind": .string("equalTo"),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let childKey { bound["key"] = .string(childKey) }
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec + [bound],
+            limitSpec: limitSpec
+        )
+    }
+
+    // ── Query Limits ──────────────────────────────────────────────────────────
+
+    public func queryLimited(toFirst limit: UInt) -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec,
+            limitSpec: ["kind": .string("limitToFirst"), "n": .int(Int64(limit))]
+        )
+    }
+
+    public func queryLimited(toLast limit: UInt) -> DatabaseQuery {
+        return DatabaseQuery(
+            database: database,
+            path: path,
+            orderBySpec: orderBySpec,
+            boundsSpec: boundsSpec,
+            limitSpec: ["kind": .string("limitToLast"), "n": .int(Int64(limit))]
+        )
+    }
+
+    // ── One-Shot Reads ────────────────────────────────────────────────────────
+
+    public func getData() async throws -> DataSnapshot {
+        var params: [String: AnySendable] = [
+            "path": .string(path)
+        ]
+        if let qSpec = toQuerySpecAnySendable() {
+            params["query"] = qSpec
+        }
+        let wire = try await database.bridgeClient.op(
+            method: "rtdb.get",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+        return DataSnapshot(wire: wire, ref: ref)
+    }
+
+    public func observeSingleEvent(of eventType: DataEventType) async throws -> DataSnapshot {
+        return try await getData()
+    }
+
+    // ── Real-Time Listeners & AsyncStreams ────────────────────────────────────
+
+    public var valueStream: AsyncThrowingStream<DataSnapshot, Error> {
+        AsyncThrowingStream { continuation in
+            let handle = self.observe(.value, with: { snap in
+                continuation.yield(snap)
+            }, withCancel: { err in
+                continuation.finish(throwing: err)
+            })
+            continuation.onTermination = { _ in
+                self.removeObserver(withHandle: handle)
+            }
+        }
+    }
+
+    public var childEvents: AsyncThrowingStream<DatabaseChildEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let handle = self.observeAllChildEvents(with: { event in
+                continuation.yield(event)
+            }, withCancel: { err in
+                continuation.finish(throwing: err)
+            })
+            continuation.onTermination = { _ in
+                self.removeObserver(withHandle: handle)
+            }
+        }
+    }
+
+    @discardableResult
+    public func observe(
+        _ eventType: DataEventType,
+        with block: @escaping @Sendable (DataSnapshot) -> Void,
+        withCancel cancelBlock: (@Sendable (Error) -> Void)? = nil
+    ) -> UInt {
+        return observe(eventType, andPreviousSiblingKeyWith: { snap, _ in
+            block(snap)
+        }, withCancel: cancelBlock)
+    }
+
+    @discardableResult
+    public func observe(
+        _ eventType: DataEventType,
+        andPreviousSiblingKeyWith block: @escaping @Sendable (DataSnapshot, String?) -> Void,
+        withCancel cancelBlock: (@Sendable (Error) -> Void)? = nil
+    ) -> UInt {
+        observerLock.lock()
+        let handle = DatabaseQuery.nextObserverHandle
+        DatabaseQuery.nextObserverHandle += 1
+        observerLock.unlock()
+
+        let task = startObserverTask(
+            eventTypes: [eventType],
+            onEvent: { event in
+                block(event.snapshot, event.previousSiblingKey)
+            },
+            onCancel: cancelBlock
+        )
+
+        observerLock.lock()
+        observerTasks[handle] = task
+        observerLock.unlock()
+        return handle
+    }
+
+    private func observeAllChildEvents(
+        with block: @escaping @Sendable (DatabaseChildEvent) -> Void,
+        withCancel cancelBlock: (@Sendable (Error) -> Void)? = nil
+    ) -> UInt {
+        observerLock.lock()
+        let handle = DatabaseQuery.nextObserverHandle
+        DatabaseQuery.nextObserverHandle += 1
+        observerLock.unlock()
+
+        let task = startObserverTask(
+            eventTypes: [.childAdded, .childChanged, .childRemoved],
+            onEvent: block,
+            onCancel: cancelBlock
+        )
+
+        observerLock.lock()
+        observerTasks[handle] = task
+        observerLock.unlock()
+        return handle
+    }
+
+    public func removeObserver(withHandle handle: UInt) {
+        observerLock.lock()
+        let task = observerTasks.removeValue(forKey: handle)
+        observerLock.unlock()
+        task?.cancel()
+    }
+
+    public func removeAllObservers() {
+        observerLock.lock()
+        let tasks = Array(observerTasks.values)
+        observerTasks.removeAll()
+        observerLock.unlock()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private func startObserverTask(
+        eventTypes: Set<DataEventType>,
+        onEvent: @escaping @Sendable (DatabaseChildEvent) -> Void,
+        onCancel: (@Sendable (Error) -> Void)?
+    ) -> Task<Void, Never> {
+        var targetDict: [String: AnySendable] = [
+            "service": .string("rtdb"),
+            "path": .string(path)
+        ]
+        if let qSpec = toQuerySpecAnySendable() {
+            targetDict["query"] = qSpec
+        }
+        let targetSendable = AnySendable.dictionary(targetDict)
+        let db = self.database
+        let queryRef = self.ref
+
+        return Task {
+            var previousChildren: [DataSnapshot] = []
+            var isFirstSnapshot = true
+
+            // Listen to authLensStream so identity changes re-evaluate subscriptions automatically.
+            for await currentLens in db.authLensStream {
+                if Task.isCancelled { break }
+
+                let subStream = db.bridgeClient.subscribe(
+                    target: targetSendable,
+                    actAs: currentLens.toAnySendable()
+                )
+
+                final class LensChangeFlag: @unchecked Sendable {
+                    private let lock = NSLock()
+                    private var _value = false
+                    var value: Bool {
+                        get { lock.lock(); defer { lock.unlock() }; return _value }
+                        set { lock.lock(); defer { lock.unlock() }; _value = newValue }
+                    }
+                }
+                let lensChanged = LensChangeFlag()
+                let lensMonitorTask = Task {
+                    for await newLens in db.authLensStream {
+                        if newLens != currentLens {
+                            lensChanged.value = true
+                            break
+                        }
+                    }
+                }
+
+                do {
+                    for try await wireSnap in subStream {
+                        if Task.isCancelled || lensChanged.value { break }
+                        if let errDict = wireSnap["__error"] {
+                            let msg = errDict["message"]?.stringValue ?? "Permission denied"
+                            onCancel?(PyricBridgeError.permissionDenied(msg))
+                            lensMonitorTask.cancel()
+                            return
+                        }
+
+                        let snap = DataSnapshot(wire: wireSnap, ref: queryRef)
+
+                        if eventTypes.contains(.value) {
+                            onEvent(DatabaseChildEvent(type: .value, snapshot: snap, previousSiblingKey: nil))
+                        }
+
+                        let newChildren = snap.childrenSnapshots
+                        if isFirstSnapshot {
+                            isFirstSnapshot = false
+                            if eventTypes.contains(.childAdded) {
+                                var prevKey: String? = nil
+                                for child in newChildren {
+                                    onEvent(DatabaseChildEvent(type: .childAdded, snapshot: child, previousSiblingKey: prevKey))
+                                    prevKey = child.key
+                                }
+                            }
+                        } else {
+                            let oldByKey = Dictionary(uniqueKeysWithValues: previousChildren.compactMap { c in c.key.map { ($0, c) } })
+                            let newByKey = Dictionary(uniqueKeysWithValues: newChildren.compactMap { c in c.key.map { ($0, c) } })
+
+                            if eventTypes.contains(.childRemoved) {
+                                for oldChild in previousChildren {
+                                    if let key = oldChild.key, newByKey[key] == nil {
+                                        onEvent(DatabaseChildEvent(type: .childRemoved, snapshot: oldChild, previousSiblingKey: nil))
+                                    }
+                                }
+                            }
+
+                            var prevKey: String? = nil
+                            for newChild in newChildren {
+                                guard let key = newChild.key else { continue }
+                                if let oldChild = oldByKey[key] {
+                                    if eventTypes.contains(.childChanged) {
+                                        let oldVal = RtdbValueCodec.toAnySendable(oldChild.value)
+                                        let newVal = RtdbValueCodec.toAnySendable(newChild.value)
+                                        if oldVal != newVal {
+                                            onEvent(DatabaseChildEvent(type: .childChanged, snapshot: newChild, previousSiblingKey: prevKey))
+                                        }
+                                    }
+                                } else {
+                                    if eventTypes.contains(.childAdded) {
+                                        onEvent(DatabaseChildEvent(type: .childAdded, snapshot: newChild, previousSiblingKey: prevKey))
+                                    }
+                                }
+                                prevKey = key
+                            }
+                        }
+                        previousChildren = newChildren
+                    }
+                } catch {
+                    if !Task.isCancelled && !lensChanged.value {
+                        onCancel?(error)
+                        lensMonitorTask.cancel()
+                        return
+                    }
+                }
+                lensMonitorTask.cancel()
+            }
+        }
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/DatabaseReference.swift
+++ b/packages/ios-client/Sources/PyricDatabase/DatabaseReference.swift
@@ -1,0 +1,309 @@
+import Foundation
+import PyricFirestore
+
+/// A reference to a specific location in the Realtime Database.
+public final class DatabaseReference: DatabaseQuery, @unchecked Sendable {
+
+    public init(database: Database, path: String) {
+        let normalized = DatabaseReference.normalizePath(path)
+        super.init(database: database, path: normalized)
+    }
+
+    internal static func normalizePath(_ raw: String) -> String {
+        let parts = raw.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        if parts.isEmpty {
+            return "/"
+        }
+        return "/" + parts.joined(separator: "/")
+    }
+
+    /// Returns the parent DatabaseReference, or nil if this is the root reference.
+    public var parent: DatabaseReference? {
+        if path == "/" {
+            return nil
+        }
+        let parts = path.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        if parts.count <= 1 {
+            return DatabaseReference(database: database, path: "/")
+        }
+        let parentPath = "/" + parts.dropLast().joined(separator: "/")
+        return DatabaseReference(database: database, path: parentPath)
+    }
+
+    /// Returns the root DatabaseReference from any descendant reference.
+    public var root: DatabaseReference {
+        return DatabaseReference(database: database, path: "/")
+    }
+
+    /// Returns the last path segment token of the reference, or nil for the root reference.
+    public var key: String? {
+        if path == "/" {
+            return nil
+        }
+        return path.split(separator: "/").last.map(String.init)
+    }
+
+    /// Returns the full URL of the reference location.
+    public var url: String {
+        let base = database.url.hasSuffix("/") ? String(database.url.dropLast()) : database.url
+        if path == "/" {
+            return base
+        }
+        return base + path
+    }
+
+    /// Returns a child DatabaseReference relative to the current path.
+    public func child(_ pathString: String) -> DatabaseReference {
+        let combined = path == "/" ? "/\(pathString)" : "\(path)/\(pathString)"
+        return DatabaseReference(database: database, path: combined)
+    }
+
+    /// Generates a new child DatabaseReference with a chronologically ordered unique push ID.
+    public func childByAutoId() -> DatabaseReference {
+        let autoId = PushIdGenerator.generatePushId()
+        return child(autoId)
+    }
+
+    // ── Write Operations ──────────────────────────────────────────────────────
+
+    public func setValue(_ value: Any?) async throws {
+        if value == nil || value is NSNull {
+            try await removeValue()
+            return
+        }
+        let params: [String: AnySendable] = [
+            "path": .string(path),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        _ = try await database.bridgeClient.op(
+            method: "rtdb.set",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+    }
+
+    public func setValue(
+        _ value: Any?,
+        withCompletionBlock block: @escaping @Sendable (Error?, DatabaseReference) -> Void
+    ) {
+        let sendableValue = RtdbValueCodec.toAnySendable(value)
+        Task {
+            do {
+                try await setValue(sendableValue)
+                block(nil, self)
+            } catch {
+                block(error, self)
+            }
+        }
+    }
+
+    public func setPriority(_ priority: Any?) async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(path),
+            "priority": RtdbValueCodec.toAnySendable(priority)
+        ]
+        _ = try await database.bridgeClient.op(
+            method: "rtdb.setPriority",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+    }
+
+    public func setPriority(
+        _ priority: Any?,
+        withCompletionBlock block: @escaping @Sendable (Error?, DatabaseReference) -> Void
+    ) {
+        let sendablePriority = RtdbValueCodec.toAnySendable(priority)
+        Task {
+            do {
+                try await setPriority(sendablePriority)
+                block(nil, self)
+            } catch {
+                block(error, self)
+            }
+        }
+    }
+
+    public func setValue(_ value: Any?, andPriority priority: Any?) async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(path),
+            "value": RtdbValueCodec.toAnySendable(value),
+            "priority": RtdbValueCodec.toAnySendable(priority)
+        ]
+        _ = try await database.bridgeClient.op(
+            method: "rtdb.setWithPriority",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+    }
+
+    public func setValue(
+        _ value: Any?,
+        andPriority priority: Any?,
+        withCompletionBlock block: @escaping @Sendable (Error?, DatabaseReference) -> Void
+    ) {
+        let sendableValue = RtdbValueCodec.toAnySendable(value)
+        let sendablePriority = RtdbValueCodec.toAnySendable(priority)
+        Task {
+            do {
+                try await setValue(sendableValue, andPriority: sendablePriority)
+                block(nil, self)
+            } catch {
+                block(error, self)
+            }
+        }
+    }
+
+    public func updateChildValues(_ values: [AnyHashable: Any]) async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(path),
+            "values": RtdbValueCodec.toAnySendable(values)
+        ]
+        _ = try await database.bridgeClient.op(
+            method: "rtdb.update",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+    }
+
+    public func updateChildValues(
+        _ values: [AnyHashable: Any],
+        withCompletionBlock block: @escaping @Sendable (Error?, DatabaseReference) -> Void
+    ) {
+        let sendableValues = RtdbValueCodec.toAnySendable(values)
+        Task {
+            do {
+                let params: [String: AnySendable] = [
+                    "path": .string(path),
+                    "values": sendableValues
+                ]
+                _ = try await database.bridgeClient.op(
+                    method: "rtdb.update",
+                    params: params,
+                    actAs: database.currentAuthLens()
+                )
+                block(nil, self)
+            } catch {
+                block(error, self)
+            }
+        }
+    }
+
+    public func removeValue() async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(path)
+        ]
+        _ = try await database.bridgeClient.op(
+            method: "rtdb.remove",
+            params: params,
+            actAs: database.currentAuthLens()
+        )
+    }
+
+    public func removeValue(
+        completionBlock block: @escaping @Sendable (Error?, DatabaseReference) -> Void
+    ) {
+        Task {
+            do {
+                try await removeValue()
+                block(nil, self)
+            } catch {
+                block(error, self)
+            }
+        }
+    }
+
+    // ── Transactions ──────────────────────────────────────────────────────────
+
+    public func runTransactionBlock(
+        _ block: @escaping @Sendable (MutableData) -> TransactionResult
+    ) async throws -> (committed: Bool, snapshot: DataSnapshot) {
+        var attempts = 0
+        let maxRetries = 25
+
+        while attempts < maxRetries {
+            attempts += 1
+            let currentSnap = try await getData()
+            let mutable = MutableData(
+                key: currentSnap.key,
+                value: currentSnap.value,
+                priority: currentSnap.priority
+            )
+
+            let txResult = block(mutable)
+            if txResult.isAborted {
+                return (committed: false, snapshot: currentSnap)
+            }
+
+            let newValue = txResult.mutableData?.value
+            let params: [String: AnySendable] = [
+                "path": .string(path),
+                "expected": RtdbValueCodec.toAnySendable(currentSnap.value),
+                "value": RtdbValueCodec.toAnySendable(newValue),
+                "applyLocally": .bool(true)
+            ]
+
+            let res = try await database.bridgeClient.op(
+                method: "rtdb.transactionCommit",
+                params: params,
+                actAs: database.currentAuthLens()
+            )
+
+            let retry = res["retry"]?.boolValue ?? false
+            if retry {
+                continue
+            }
+
+            let committed = res["committed"]?.boolValue ?? true
+            if let snapWire = res["snapshot"] {
+                let finalSnap = DataSnapshot(wire: snapWire, ref: self)
+                return (committed: committed, snapshot: finalSnap)
+            } else {
+                let finalSnap = try await getData()
+                return (committed: committed, snapshot: finalSnap)
+            }
+        }
+
+        throw PyricBridgeError.unavailable("Transaction failed after maximum retries (\(maxRetries)).")
+    }
+
+    public func runTransactionBlock(
+        _ block: @escaping @Sendable (MutableData) -> TransactionResult,
+        andCompletionBlock completionBlock: @escaping @Sendable (Error?, Bool, DataSnapshot?) -> Void
+    ) {
+        Task {
+            do {
+                let result = try await runTransactionBlock(block)
+                completionBlock(nil, result.committed, result.snapshot)
+            } catch {
+                completionBlock(error, false, nil)
+            }
+        }
+    }
+
+    // ── OnDisconnect ──────────────────────────────────────────────────────────
+
+    public func onDisconnect() -> OnDisconnect {
+        return OnDisconnect(ref: self)
+    }
+
+    public func onDisconnectSetValue(_ value: Any?) async throws {
+        try await onDisconnect().setValue(value)
+    }
+
+    public func onDisconnectSetValue(_ value: Any?, andPriority priority: Any?) async throws {
+        try await onDisconnect().setValue(value, andPriority: priority)
+    }
+
+    public func onDisconnectUpdateChildValues(_ values: [AnyHashable: Any]) async throws {
+        try await onDisconnect().updateChildValues(values)
+    }
+
+    public func onDisconnectRemoveValue() async throws {
+        try await onDisconnect().removeValue()
+    }
+
+    public func cancelDisconnectOperations() async throws {
+        try await onDisconnect().cancel()
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/MutableData.swift
+++ b/packages/ios-client/Sources/PyricDatabase/MutableData.swift
@@ -1,0 +1,80 @@
+import Foundation
+import PyricFirestore
+
+/// A mutable snapshot of data at a Realtime Database location used in transactions.
+public final class MutableData: NSObject, @unchecked Sendable {
+    public var value: Any?
+    public var priority: Any?
+    public let key: String?
+
+    public init(key: String? = nil, value: Any? = nil, priority: Any? = nil) {
+        self.key = key
+        self.value = value
+        self.priority = priority
+        super.init()
+    }
+
+    public var childrenCount: UInt {
+        if let dict = value as? [String: Any] {
+            return UInt(dict.count)
+        }
+        return 0
+    }
+
+    public func hasChildren() -> Bool {
+        return childrenCount > 0
+    }
+
+    public func hasChild(atPath path: String) -> Bool {
+        let child = childData(byAppendingPath: path)
+        return child.value != nil && !(child.value is NSNull)
+    }
+
+    public func childData(byAppendingPath path: String) -> MutableData {
+        let segments = path.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        guard !segments.isEmpty else { return self }
+
+        var curVal = value
+        for seg in segments {
+            if let dict = curVal as? [String: Any] {
+                curVal = dict[seg]
+            } else {
+                curVal = nil
+            }
+        }
+        return MutableData(key: segments.last, value: curVal, priority: nil)
+    }
+
+    public var children: NSEnumerator {
+        guard let dict = value as? [String: Any] else {
+            return ([] as NSArray).objectEnumerator()
+        }
+        let sortedKeys = dict.keys.sorted()
+        let items = sortedKeys.map { k in
+            MutableData(key: k, value: dict[k], priority: nil)
+        }
+        return (items as NSArray).objectEnumerator()
+    }
+}
+
+/// The result of a Realtime Database transaction block.
+public final class TransactionResult: NSObject, @unchecked Sendable {
+    public let isAborted: Bool
+    public let mutableData: MutableData?
+
+    private init(isAborted: Bool, mutableData: MutableData?) {
+        self.isAborted = isAborted
+        self.mutableData = mutableData
+        super.init()
+    }
+
+    /// Commits the transaction with the updated MutableData value.
+    public static func success(withValue value: MutableData) -> TransactionResult {
+        return TransactionResult(isAborted: false, mutableData: value)
+    }
+
+    /// Aborts the transaction without saving any changes.
+    public static func abort() -> TransactionResult {
+        return TransactionResult(isAborted: true, mutableData: nil)
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/OnDisconnect.swift
+++ b/packages/ios-client/Sources/PyricDatabase/OnDisconnect.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PyricFirestore
+
+/// Registers server-side operations to execute when the client disconnects.
+public final class OnDisconnect: NSObject, @unchecked Sendable {
+    public let ref: DatabaseReference
+
+    public init(ref: DatabaseReference) {
+        self.ref = ref
+        super.init()
+    }
+
+    public func setValue(_ value: Any?) async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(ref.path),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        _ = try await ref.database.bridgeClient.op(
+            method: "rtdb.onDisconnectSet",
+            params: params,
+            actAs: ref.database.currentAuthLens()
+        )
+    }
+
+    public func setValue(_ value: Any?, andPriority priority: Any?) async throws {
+        var params: [String: AnySendable] = [
+            "path": .string(ref.path),
+            "value": RtdbValueCodec.toAnySendable(value)
+        ]
+        if let priority {
+            params["priority"] = RtdbValueCodec.toAnySendable(priority)
+        }
+        _ = try await ref.database.bridgeClient.op(
+            method: "rtdb.onDisconnectSet",
+            params: params,
+            actAs: ref.database.currentAuthLens()
+        )
+    }
+
+    public func updateChildValues(_ values: [AnyHashable: Any]) async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(ref.path),
+            "values": RtdbValueCodec.toAnySendable(values)
+        ]
+        _ = try await ref.database.bridgeClient.op(
+            method: "rtdb.onDisconnectUpdate",
+            params: params,
+            actAs: ref.database.currentAuthLens()
+        )
+    }
+
+    public func removeValue() async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(ref.path)
+        ]
+        _ = try await ref.database.bridgeClient.op(
+            method: "rtdb.onDisconnectRemove",
+            params: params,
+            actAs: ref.database.currentAuthLens()
+        )
+    }
+
+    public func cancel() async throws {
+        let params: [String: AnySendable] = [
+            "path": .string(ref.path)
+        ]
+        _ = try await ref.database.bridgeClient.op(
+            method: "rtdb.onDisconnectCancel",
+            params: params,
+            actAs: ref.database.currentAuthLens()
+        )
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/PushIdGenerator.swift
+++ b/packages/ios-client/Sources/PyricDatabase/PushIdGenerator.swift
@@ -1,0 +1,121 @@
+import Foundation
+import PyricFirestore
+
+/// Generates chronologically ordered Firebase push IDs and provides value conversion utilities.
+public enum PushIdGenerator {
+    private static let pushChars = Array("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var lastPushTime: Int64 = 0
+    nonisolated(unsafe) private static var lastRandChars = [Int](repeating: 0, count: 12)
+
+    /// Generates a 20-character chronologically ordered unique push ID.
+    public static func generatePushId() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var now = Int64(Date().timeIntervalSince1970 * 1000)
+        let duplicateTime = (now == lastPushTime)
+        lastPushTime = now
+
+        var timeStampChars = [Character](repeating: " ", count: 8)
+        for i in stride(from: 7, through: 0, by: -1) {
+            timeStampChars[i] = pushChars[Int(now % 64)]
+            now /= 64
+        }
+
+        var id = String(timeStampChars)
+
+        if !duplicateTime {
+            for i in 0..<12 {
+                lastRandChars[i] = Int.random(in: 0..<64)
+            }
+        } else {
+            var i = 11
+            while i >= 0 && lastRandChars[i] == 63 {
+                lastRandChars[i] = 0
+                i -= 1
+            }
+            if i >= 0 {
+                lastRandChars[i] += 1
+            }
+        }
+
+        for i in 0..<12 {
+            id.append(pushChars[lastRandChars[i]])
+        }
+
+        return id
+    }
+}
+
+/// Converts between native Swift RTDB values and AnySendable wire payloads.
+public enum RtdbValueCodec {
+    public static func toAnySendable(_ value: Any?) -> AnySendable {
+        guard let value else { return .null }
+        if value is NSNull { return .null }
+        if let sendable = value as? AnySendable { return sendable }
+        if let str = value as? String { return .string(str) }
+        if let boolVal = value as? Bool { return .bool(boolVal) }
+        if let intVal = value as? Int { return .int(Int64(intVal)) }
+        if let int64Val = value as? Int64 { return .int(int64Val) }
+        if let uintVal = value as? UInt { return .int(Int64(uintVal)) }
+        if let doubleVal = value as? Double { return .double(doubleVal) }
+        if let floatVal = value as? Float { return .double(Double(floatVal)) }
+        if let num = value as? NSNumber {
+            if CFGetTypeID(num) == CFBooleanGetTypeID() {
+                return .bool(num.boolValue)
+            }
+            let objCType = String(cString: num.objCType)
+            if objCType == "d" || objCType == "f" {
+                return .double(num.doubleValue)
+            }
+            return .int(num.int64Value)
+        }
+        if let dict = value as? [String: Any] {
+            var mapped: [String: AnySendable] = [:]
+            for (k, v) in dict {
+                mapped[k] = toAnySendable(v)
+            }
+            return .dictionary(mapped)
+        }
+        if let dict = value as? [AnyHashable: Any] {
+            var mapped: [String: AnySendable] = [:]
+            for (k, v) in dict {
+                if let kStr = k as? String {
+                    mapped[kStr] = toAnySendable(v)
+                }
+            }
+            return .dictionary(mapped)
+        }
+        if let arr = value as? [Any] {
+            return .array(arr.map { toAnySendable($0) })
+        }
+        return AnySendable.from(value)
+    }
+
+    public static func fromAnySendable(_ sendable: AnySendable?) -> Any? {
+        guard let sendable else { return nil }
+        switch sendable {
+        case .null:
+            return nil
+        case .bool(let b):
+            return b
+        case .int(let i):
+            return i
+        case .double(let d):
+            return d
+        case .string(let s):
+            return s
+        case .array(let arr):
+            return arr.map { fromAnySendable($0) ?? NSNull() }
+        case .dictionary(let dict):
+            var out: [String: Any] = [:]
+            for (k, v) in dict {
+                if let val = fromAnySendable(v) {
+                    out[k] = val
+                }
+            }
+            return out
+        }
+    }
+}

--- a/packages/ios-client/Sources/PyricDatabase/ServerValue.swift
+++ b/packages/ios-client/Sources/PyricDatabase/ServerValue.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Server-side placeholder sentinels resolved by the Realtime Database server upon write.
+public enum ServerValue {
+    /// Returns a server timestamp sentinel that resolves to epoch milliseconds on write.
+    public static func timestamp() -> [String: Any] {
+        return [".sv": "timestamp"]
+    }
+
+    /// Returns a server increment sentinel that atomically increments a numeric value by `delta`.
+    public static func increment(_ delta: NSNumber) -> [String: Any] {
+        return [".sv": ["increment": delta.doubleValue]]
+    }
+
+    /// Returns a server increment sentinel that atomically increments an integer value by `delta`.
+    public static func increment(_ delta: Int) -> [String: Any] {
+        return [".sv": ["increment": delta]]
+    }
+
+    /// Returns a server increment sentinel that atomically increments a floating-point value by `delta`.
+    public static func increment(_ delta: Double) -> [String: Any] {
+        return [".sv": ["increment": delta]]
+    }
+}

--- a/packages/ios-client/Tests/PyricDatabaseTests/RtdbConformanceTests.swift
+++ b/packages/ios-client/Tests/PyricDatabaseTests/RtdbConformanceTests.swift
@@ -1,0 +1,598 @@
+import Testing
+import Foundation
+@testable import PyricDatabase
+@testable import PyricFirestore
+import FirebaseAuth
+
+/// In-memory RTDB test transport implementing WebSocketTransport for hermetic conformance testing.
+final class RtdbTestHarness: WebSocketTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var incomingQueue: [String] = []
+    private var receiveContinuations: [CheckedContinuation<String, Error>] = []
+    private var tree: [String: (value: Any, priority: Any?)] = [:]
+    private var activeSubs: [String: (path: String, query: AnySendable?, actAs: AnySendable?)] = [:]
+    private var onDisconnectQueue: [(path: String, kind: String, val: Any?, prio: Any?)] = []
+    public private(set) var isOffline = false
+    public private(set) var recordedOps: [(method: String, actAs: AnySendable?)] = []
+    public private(set) var recordedSubs: [(subId: String, actAs: AnySendable?)] = []
+    public private(set) var database: Database!
+
+    static func create(url: String = "https://default.firebaseio.com") async throws -> RtdbTestHarness {
+        let harness = RtdbTestHarness()
+        let client = PyricBridgeClient(channel: harness)
+        let app = FirebaseApp(name: "test-\(UUID().uuidString)")
+        harness.database = Database(app: app, url: url, bridgeClient: client)
+        return harness
+    }
+    func send(_ string: String) async throws {
+        for (msg, cont) in handleSendSync(string) { cont.resume(returning: msg) }
+    }
+    func receive() async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            lock.lock()
+            if !incomingQueue.isEmpty {
+                let msg = incomingQueue.removeFirst()
+                lock.unlock()
+                cont.resume(returning: msg)
+            } else {
+                receiveContinuations.append(cont)
+                lock.unlock()
+            }
+        }
+    }
+    func close(closeCode: Int = 1000, reason: String? = nil) async {}
+    private func enqueue(_ dict: [String: Any]) -> (String, CheckedContinuation<String, Error>)? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              let str = String(data: data, encoding: .utf8) else { return nil }
+        if !receiveContinuations.isEmpty { return (str, receiveContinuations.removeFirst()) }
+        incomingQueue.append(str)
+        return nil
+    }
+    private func handleSendSync(_ raw: String) -> [(String, CheckedContinuation<String, Error>)] {
+        lock.lock()
+        defer { lock.unlock() }
+        var toResume: [(String, CheckedContinuation<String, Error>)] = []
+        guard let data = raw.data(using: .utf8),
+              let json = try? JSONDecoder().decode(AnySendable.self, from: data),
+              let dict = json.dictionaryValue,
+              let type = dict["type"]?.stringValue else { return [] }
+        if type == "attach" {
+            if let r = enqueue(["type": "attach-ack", "protocol": 1, "peerConnected": true]) { toResume.append(r) }
+        } else if type == "worker-op" {
+            let id = dict["id"]?.stringValue ?? ""
+            let op = dict["op"]?.dictionaryValue ?? [:]
+            let method = op["method"]?.stringValue ?? ""
+            recordedOps.append((method: method, actAs: op["actAs"]))
+            let resValue = executeOp(method: method, op: op, toResume: &toResume)
+            if let r = enqueue(["type": "worker-res", "id": id, "ok": true, "value": resValue ?? NSNull()]) { toResume.append(r) }
+        } else if type == "worker-sub" {
+            let subId = dict["subId"]?.stringValue ?? ""
+            let sub = dict["sub"]?.dictionaryValue ?? [:]
+            let target = sub["target"]?.dictionaryValue ?? [:]
+            let path = normalize(target["path"]?.stringValue ?? "/")
+            let query = target["query"]
+            recordedSubs.append((subId: subId, actAs: sub["actAs"]))
+            activeSubs[subId] = (path: path, query: query, actAs: sub["actAs"])
+            let snap = buildSnapWire(path: path, query: query)
+            if let r = enqueue(["type": "worker-snap", "subId": subId, "value": snap]) { toResume.append(r) }
+        } else if type == "worker-unsub" {
+            if let subId = dict["subId"]?.stringValue { activeSubs.removeValue(forKey: subId) }
+        }
+        return toResume
+    }
+    private func normalize(_ path: String) -> String {
+        let p = path.split(separator: "/").map(String.init).filter { !$0.isEmpty }
+        return p.isEmpty ? "/" : "/" + p.joined(separator: "/")
+    }
+    private func resolveSentinels(_ val: Any, current: Any?) -> Any {
+        if let dict = val as? [String: Any] {
+            if let sv = dict[".sv"] as? String, sv == "timestamp" { return Int(Date().timeIntervalSince1970 * 1000) }
+            if let svDict = dict[".sv"] as? [String: Any], let inc = svDict["increment"] {
+                return ((current as? NSNumber)?.doubleValue ?? 0) + ((inc as? NSNumber)?.doubleValue ?? 0)
+            }
+            var out: [String: Any] = [:]
+            let curDict = current as? [String: Any]
+            for (k, v) in dict { out[k] = resolveSentinels(v, current: curDict?[k]) }
+            return out
+        }
+        return val
+    }
+
+    private func setNode(path: String, val: Any?, prio: Any?) {
+        let norm = normalize(path)
+        let prefix = norm == "/" ? "/" : norm + "/"
+        if val == nil || val is NSNull {
+            tree.removeValue(forKey: norm)
+            for k in tree.keys where k.hasPrefix(prefix) { tree.removeValue(forKey: k) }
+            return
+        }
+        let cur = getNodeValue(path: norm).value
+        let resolved = resolveSentinels(val!, current: cur)
+        if let dict = resolved as? [String: Any] {
+            tree.removeValue(forKey: norm)
+            for k in tree.keys where k.hasPrefix(prefix) { tree.removeValue(forKey: k) }
+            for (k, childV) in dict {
+                let cPath = norm == "/" ? "/\(k)" : "\(norm)/\(k)"
+                setNode(path: cPath, val: childV, prio: nil)
+            }
+        } else {
+            for k in tree.keys where k.hasPrefix(prefix) { tree.removeValue(forKey: k) }
+            let existingPrio = prio ?? tree[norm]?.priority
+            tree[norm] = (value: resolved, priority: existingPrio)
+        }
+    }
+
+    private func getNodeValue(path: String) -> (value: Any?, priority: Any?) {
+        let norm = normalize(path)
+        if let direct = tree[norm] { return (direct.value, direct.priority) }
+        let prefix = norm == "/" ? "/" : norm + "/"
+        var directChildrenKeys = Set<String>()
+        for k in tree.keys where k.hasPrefix(prefix) {
+            let rem = String(k.dropFirst(prefix.count))
+            if let firstSeg = rem.split(separator: "/").first { directChildrenKeys.insert(String(firstSeg)) }
+        }
+        if directChildrenKeys.isEmpty { return (nil, nil) }
+        var resultDict: [String: Any] = [:]
+        for childKey in directChildrenKeys {
+            let childPath = norm == "/" ? "/\(childKey)" : "\(norm)/\(childKey)"
+            if let childVal = getNodeValue(path: childPath).value { resultDict[childKey] = childVal }
+        }
+        return (resultDict, nil)
+    }
+
+    private func buildSnapWire(path: String, query: AnySendable?) -> [String: Any] {
+        let norm = normalize(path)
+        let key = norm == "/" ? NSNull() : (norm.split(separator: "/").last.map(String.init) ?? NSNull()) as Any
+        let node = getNodeValue(path: norm)
+        var entries: [[String: Any]] = []
+        if let dict = node.value as? [String: Any] {
+            var pairs = dict.map { (k: $0.key, v: $0.value, p: tree[norm == "/" ? "/\($0.key)" : "\(norm)/\($0.key)"]?.priority) }
+            if let qDict = query?.dictionaryValue {
+                if let orderBy = qDict["orderBy"]?.dictionaryValue, let kind = orderBy["kind"]?.stringValue {
+                    if kind == "key" { pairs.sort { $0.k < $1.k } }
+                    else if kind == "value" { pairs.sort { (($0.v as? NSNumber)?.doubleValue ?? 0) < (($1.v as? NSNumber)?.doubleValue ?? 0) } }
+                    else if kind == "child", let childKey = orderBy["path"]?.stringValue {
+                        pairs.sort {
+                            let a = (($0.v as? [String: Any])?[childKey] as? NSNumber)?.doubleValue ?? 0
+                            let b = (($1.v as? [String: Any])?[childKey] as? NSNumber)?.doubleValue ?? 0
+                            return a < b
+                        }
+                    }
+                }
+                if let bounds = qDict["bounds"]?.arrayValue {
+                    for b in bounds {
+                        guard let bDict = b.dictionaryValue, let bKind = bDict["kind"]?.stringValue else { continue }
+                        let bVal = RtdbValueCodec.fromAnySendable(bDict["value"])
+                        let bNum = (bVal as? NSNumber)?.doubleValue
+                        let bStr = bVal as? String
+                        let orderKind = qDict["orderBy"]?.dictionaryValue?["kind"]?.stringValue
+                        let childKey = qDict["orderBy"]?.dictionaryValue?["path"]?.stringValue
+                        pairs = pairs.filter { item in
+                            let targetVal: Any? = (orderKind == "key") ? item.k : (orderKind == "child" && childKey != nil ? (item.v as? [String: Any])?[childKey!] : item.v)
+                            if let tNum = (targetVal as? NSNumber)?.doubleValue, let bNum {
+                                if bKind == "equalTo" { return tNum == bNum }
+                                if bKind == "startAt" { return tNum >= bNum }
+                                if bKind == "endAt" { return tNum <= bNum }
+                            } else if let tStr = targetVal as? String, let bStr {
+                                if bKind == "equalTo" { return tStr == bStr }
+                                if bKind == "startAt" { return tStr >= bStr }
+                                if bKind == "endAt" { return tStr <= bStr }
+                            }
+                            return true
+                        }
+                    }
+                }
+                if let limitDict = qDict["limit"]?.dictionaryValue,
+                   let lKind = limitDict["kind"]?.stringValue,
+                   let n = limitDict["n"]?.intValue {
+                    if lKind == "limitToFirst" { pairs = Array(pairs.prefix(Int(n))) }
+                    else if lKind == "limitToLast" { pairs = Array(pairs.suffix(Int(n))) }
+                }
+            } else {
+                pairs.sort { $0.k < $1.k }
+            }
+            for item in pairs { entries.append(["key": item.k, "value": item.v, "priority": item.p ?? NSNull()]) }
+        }
+        return [
+            "key": key,
+            "exists": node.value != nil,
+            "value": node.value ?? NSNull(),
+            "priority": node.priority ?? NSNull(),
+            "entries": entries
+        ]
+    }
+
+    private func notifySubscribers(toResume: inout [(String, CheckedContinuation<String, Error>)]) {
+        for (subId, sub) in activeSubs {
+            let snap = buildSnapWire(path: sub.path, query: sub.query)
+            if let r = enqueue(["type": "worker-snap", "subId": subId, "value": snap]) { toResume.append(r) }
+        }
+    }
+
+    private func executeOp(method: String, op: [String: AnySendable], toResume: inout [(String, CheckedContinuation<String, Error>)]) -> Any? {
+        let path = normalize(op["path"]?.stringValue ?? "/")
+        switch method {
+        case "rtdb.get": return buildSnapWire(path: path, query: op["query"])
+        case "rtdb.set":
+            setNode(path: path, val: RtdbValueCodec.fromAnySendable(op["value"]), prio: nil)
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.setPriority":
+            setNode(path: path, val: getNodeValue(path: path).value, prio: RtdbValueCodec.fromAnySendable(op["priority"]))
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.setWithPriority":
+            setNode(path: path, val: RtdbValueCodec.fromAnySendable(op["value"]), prio: RtdbValueCodec.fromAnySendable(op["priority"]))
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.update":
+            if let dict = RtdbValueCodec.fromAnySendable(op["values"]) as? [String: Any] {
+                for (k, v) in dict { setNode(path: path == "/" ? "/\(k)" : "\(path)/\(k)", val: v, prio: nil) }
+            }
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.remove":
+            setNode(path: path, val: nil, prio: nil)
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.transactionCommit":
+            setNode(path: path, val: RtdbValueCodec.fromAnySendable(op["value"]), prio: nil)
+            notifySubscribers(toResume: &toResume)
+            return ["retry": false, "committed": true, "snapshot": buildSnapWire(path: path, query: nil)]
+        case "rtdb.onDisconnectSet":
+            onDisconnectQueue.append((path: path, kind: "set", val: RtdbValueCodec.fromAnySendable(op["value"]), prio: RtdbValueCodec.fromAnySendable(op["priority"])))
+        case "rtdb.onDisconnectRemove":
+            onDisconnectQueue.append((path: path, kind: "remove", val: nil, prio: nil))
+        case "rtdb.onDisconnectCancel":
+            onDisconnectQueue.removeAll { $0.path == path }
+        case "rtdb.goOffline":
+            isOffline = true
+            for item in onDisconnectQueue {
+                if item.kind == "set" { setNode(path: item.path, val: item.val, prio: item.prio) }
+                else if item.kind == "remove" { setNode(path: item.path, val: nil, prio: nil) }
+            }
+            onDisconnectQueue.removeAll()
+            notifySubscribers(toResume: &toResume)
+        case "rtdb.goOnline":
+            isOffline = false
+        default: break
+        }
+        return nil
+    }
+}
+
+@Suite("rtdb-swift Conformance Suite", .serialized)
+struct RtdbConformanceTests {
+
+    // ── 1. Database Instance & Connection (5 rows) ────────────────────────────
+    @Test func `rtdb-swift#instance-default: Database.database() returns default instance`() async throws {
+        let db = Database.database()
+        #expect(db.url == "https://default.firebaseio.com")
+    }
+    @Test func `rtdb-swift#instance-url: Database.database(url:) returns custom URL instance`() async throws {
+        let db = Database.database(url: "https://custom-rtdb.firebaseio.com")
+        #expect(db.url == "https://custom-rtdb.firebaseio.com")
+    }
+    @Test func `rtdb-swift#ref-root: Database.reference() returns root reference`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference()
+        #expect(ref.path == "/" && ref.key == nil)
+    }
+    @Test func `rtdb-swift#ref-path: Database.reference(withPath:) returns targeted reference`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "users/alice")
+        #expect(ref.path == "/users/alice" && ref.key == "alice")
+    }
+    @Test func `rtdb-swift#connection-toggle: Database.goOffline() and goOnline() toggle connection`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        try await harness.database.goOffline()
+        #expect(harness.isOffline == true)
+        try await harness.database.goOnline()
+        #expect(harness.isOffline == false)
+    }
+
+    // ── 2. DatabaseReference Navigation & Properties (7 rows) ─────────────────
+    @Test func `rtdb-swift#ref-child: DatabaseReference.child(_:) navigates relative path`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "users").child("bob/profile")
+        #expect(ref.path == "/users/bob/profile")
+    }
+    @Test func `rtdb-swift#ref-parent: DatabaseReference.parent returns parent or nil for root`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "users/bob")
+        #expect(ref.parent?.path == "/users" && ref.parent?.parent?.path == "/" && ref.parent?.parent?.parent == nil)
+    }
+    @Test func `rtdb-swift#ref-root-prop: DatabaseReference.root returns root reference`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "a/b/c")
+        #expect(ref.root.path == "/")
+    }
+    @Test func `rtdb-swift#ref-key: DatabaseReference.key returns last segment or nil`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "items/item42")
+        #expect(ref.key == "item42" && ref.root.key == nil)
+    }
+    @Test func `rtdb-swift#ref-path-prop: DatabaseReference.url and path return full path`() async throws {
+        let harness = try await RtdbTestHarness.create(url: "https://my-db.firebaseio.com")
+        let ref = harness.database.reference(withPath: "posts/p1")
+        #expect(ref.path == "/posts/p1" && ref.url == "https://my-db.firebaseio.com/posts/p1")
+    }
+    @Test func `rtdb-swift#ref-push: DatabaseReference.childByAutoId() creates unique push reference`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "list")
+        let pushed1 = ref.childByAutoId()
+        let pushed2 = ref.childByAutoId()
+        #expect(pushed1.key != nil && pushed1.key != pushed2.key)
+    }
+    @Test func `rtdb-swift#ref-push-key-ordering: DatabaseReference.childByAutoId().key orders monotonically`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "ordered")
+        let k1 = ref.childByAutoId().key!
+        let k2 = ref.childByAutoId().key!
+        let k3 = ref.childByAutoId().key!
+        #expect(k1 < k2 && k2 < k3)
+    }
+
+    // ── 3. Write Operations (6 rows) ──────────────────────────────────────────
+    @Test func `rtdb-swift#write-set: DatabaseReference.setValue(_:) writes value at path`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "greeting")
+        try await ref.setValue("hello world")
+        let snap = try await ref.getData()
+        #expect(snap.value as? String == "hello world")
+    }
+    @Test func `rtdb-swift#write-set-null: DatabaseReference.setValue(nil) deletes node`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "temp")
+        try await ref.setValue("to-delete")
+        try await ref.setValue(nil)
+        let snap = try await ref.getData()
+        #expect(snap.exists() == false)
+    }
+    @Test func `rtdb-swift#write-set-priority: DatabaseReference.setPriority(_:) updates node priority`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "prioNode")
+        try await ref.setValue("data")
+        try await ref.setPriority(100)
+        let snap = try await ref.getData()
+        #expect((snap.priority as? NSNumber)?.intValue == 100)
+    }
+    @Test func `rtdb-swift#write-set-with-priority: DatabaseReference.setValue(_:andPriority:) writes both`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "ranked")
+        try await ref.setValue("gold", andPriority: 1)
+        let snap = try await ref.getData()
+        #expect(snap.value as? String == "gold" && (snap.priority as? NSNumber)?.intValue == 1)
+    }
+    @Test func `rtdb-swift#write-update: DatabaseReference.updateChildValues(_:) updates specified children`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "profile")
+        try await ref.setValue(["name": "Alice", "role": "user"])
+        try await ref.updateChildValues(["role": "admin"])
+        let snap = try await ref.getData()
+        let dict = snap.value as? [String: Any]
+        #expect(dict?["name"] as? String == "Alice" && dict?["role"] as? String == "admin")
+    }
+    @Test func `rtdb-swift#write-remove: DatabaseReference.removeValue() removes node`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "session")
+        try await ref.setValue("active")
+        try await ref.removeValue()
+        let snap = try await ref.getData()
+        #expect(snap.exists() == false)
+    }
+
+    // ── 4. ServerValue Sentinels (2 rows) ─────────────────────────────────────
+    @Test func `rtdb-swift#sentinel-timestamp: ServerValue.timestamp() resolves to epoch ms`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "createdAt")
+        try await ref.setValue(ServerValue.timestamp())
+        let snap = try await ref.getData()
+        #expect(((snap.value as? NSNumber)?.intValue ?? 0) > 1_700_000_000_000)
+    }
+    @Test func `rtdb-swift#sentinel-increment: ServerValue.increment(_:) atomically increments value`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "counter")
+        try await ref.setValue(10)
+        try await ref.setValue(ServerValue.increment(5))
+        let snap = try await ref.getData()
+        #expect((snap.value as? NSNumber)?.intValue == 15)
+    }
+
+    // ── 5. One-Shot Reads & DataSnapshot Inspection (7 rows) ──────────────────
+    @Test func `rtdb-swift#read-get: DatabaseReference.getData() fetches DataSnapshot`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "config/theme")
+        try await ref.setValue("dark")
+        let snap = try await ref.getData()
+        #expect(snap.value as? String == "dark")
+    }
+    @Test func `rtdb-swift#snap-exists: DataSnapshot.exists() reports existence accurately`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "check")
+        let emptySnap = try await ref.getData()
+        #expect(emptySnap.exists() == false)
+        try await ref.setValue(42)
+        let fullSnap = try await ref.getData()
+        #expect(fullSnap.exists() == true)
+    }
+    @Test func `rtdb-swift#snap-key: DataSnapshot.key returns node key`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "teams/alpha")
+        try await ref.setValue(["members": 5])
+        let snap = try await ref.getData()
+        #expect(snap.key == "alpha")
+    }
+    @Test func `rtdb-swift#snap-value: DataSnapshot.value returns native deserialized value`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "scalar")
+        try await ref.setValue(true)
+        let snap = try await ref.getData()
+        #expect(snap.value as? Bool == true)
+    }
+    @Test func `rtdb-swift#snap-children: DataSnapshot.children enumerates child snapshots`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "fruits")
+        try await ref.setValue(["a": "apple", "b": "banana"])
+        let snap = try await ref.getData()
+        let children = snap.children.allObjects.compactMap { $0 as? DataSnapshot }
+        #expect(children.count == 2 && children.map { $0.key } == ["a", "b"])
+    }
+    @Test func `rtdb-swift#snap-child-path: DataSnapshot.childSnapshot(forPath:) navigates descendants`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "org")
+        try await ref.setValue(["dept": ["lead": "Carol"]])
+        let snap = try await ref.getData()
+        #expect(snap.childSnapshot(forPath: "dept/lead").value as? String == "Carol")
+    }
+    @Test func `rtdb-swift#snap-priority: DataSnapshot.priority returns node priority`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "prioSnap")
+        try await ref.setValue("item", andPriority: "p1")
+        let snap = try await ref.getData()
+        #expect(snap.priority as? String == "p1")
+    }
+
+    // ── 6. Realtime Listeners & Streams (5 rows) ──────────────────────────────
+    @Test func `rtdb-swift#listen-value: DatabaseQuery.observe(.value) emits snapshots`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "liveValue")
+        try await ref.setValue("v1")
+        var stream = ref.valueStream.makeAsyncIterator()
+        let first = try await stream.next()
+        #expect(first?.value as? String == "v1")
+    }
+    @Test func `rtdb-swift#listen-child-added: DatabaseQuery.observe(.childAdded) emits existing and new children`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "childrenAdd")
+        try await ref.setValue(["c1": "one"])
+        var iterator = ref.childEvents.makeAsyncIterator()
+        let ev1 = try await iterator.next()
+        #expect(ev1?.type == .childAdded && ev1?.snapshot.key == "c1")
+    }
+    @Test func `rtdb-swift#listen-child-changed: DatabaseQuery.observe(.childChanged) emits modified children`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "childrenChange")
+        try await ref.setValue(["c1": "initial"])
+        var iterator = ref.childEvents.makeAsyncIterator()
+        _ = try await iterator.next()
+        try await ref.child("c1").setValue("updated")
+        let ev2 = try await iterator.next()
+        #expect(ev2?.type == .childChanged && ev2?.snapshot.value as? String == "updated")
+    }
+    @Test func `rtdb-swift#listen-child-removed: DatabaseQuery.observe(.childRemoved) emits removed children`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "childrenRemove")
+        try await ref.setValue(["c1": "gone"])
+        var iterator = ref.childEvents.makeAsyncIterator()
+        _ = try await iterator.next()
+        try await ref.child("c1").removeValue()
+        let ev2 = try await iterator.next()
+        #expect(ev2?.type == .childRemoved && ev2?.snapshot.key == "c1")
+    }
+    @Test func `rtdb-swift#listen-cancel: DatabaseQuery.removeObserver(withHandle:) unsubscribes listener`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "cancelPath")
+        let handle = ref.observe(.value) { _ in }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        ref.removeObserver(withHandle: handle)
+        #expect(handle > 0)
+    }
+
+    // ── 7. Query Ordering, Filtering & Limits (6 rows) ────────────────────────
+    @Test func `rtdb-swift#query-order-by-child: DatabaseQuery.queryOrdered(byChild:) orders by nested key`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "scores")
+        try await ref.setValue(["u1": ["score": 30], "u2": ["score": 10], "u3": ["score": 20]])
+        let snap = try await ref.queryOrdered(byChild: "score").getData()
+        #expect(snap.childrenSnapshots.compactMap { $0.key } == ["u2", "u3", "u1"])
+    }
+    @Test func `rtdb-swift#query-order-by-key: DatabaseQuery.queryOrderedByKey() orders lexicographically`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "letters")
+        try await ref.setValue(["b": 2, "a": 1, "c": 3])
+        let snap = try await ref.queryOrderedByKey().getData()
+        #expect(snap.childrenSnapshots.compactMap { $0.key } == ["a", "b", "c"])
+    }
+    @Test func `rtdb-swift#query-order-by-value: DatabaseQuery.queryOrderedByValue() orders by scalar value`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "scalars")
+        try await ref.setValue(["x": 50, "y": 10, "z": 30])
+        let snap = try await ref.queryOrderedByValue().getData()
+        #expect(snap.childrenSnapshots.compactMap { $0.key } == ["y", "z", "x"])
+    }
+    @Test func `rtdb-swift#query-equal-to: DatabaseQuery.queryEqual(toValue:) filters exact matches`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "tiers")
+        try await ref.setValue(["p1": 100, "p2": 200, "p3": 100])
+        let snap = try await ref.queryOrderedByValue().queryEqual(toValue: 100).getData()
+        let keys = snap.childrenSnapshots.compactMap { $0.key }
+        #expect(keys.count == 2 && keys.contains("p1") && keys.contains("p3"))
+    }
+    @Test func `rtdb-swift#query-range: DatabaseQuery.queryStarting(atValue:) and queryEnding(atValue:) filter range`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "nums")
+        try await ref.setValue(["n1": 10, "n2": 20, "n3": 30, "n4": 40])
+        let snap = try await ref.queryOrderedByValue().queryStarting(atValue: 15).queryEnding(atValue: 35).getData()
+        #expect(snap.childrenSnapshots.compactMap { $0.key } == ["n2", "n3"])
+    }
+    @Test func `rtdb-swift#query-limit: DatabaseQuery.queryLimited(toFirst:) and queryLimited(toLast:) limit results`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "limited")
+        try await ref.setValue(["k1": 1, "k2": 2, "k3": 3, "k4": 4])
+        let firstTwo = try await ref.queryOrderedByKey().queryLimited(toFirst: 2).getData()
+        #expect(firstTwo.childrenSnapshots.compactMap { $0.key } == ["k1", "k2"])
+        let lastTwo = try await ref.queryOrderedByKey().queryLimited(toLast: 2).getData()
+        #expect(lastTwo.childrenSnapshots.compactMap { $0.key } == ["k3", "k4"])
+    }
+
+    // ── 8. Transactions & OnDisconnect (4 rows) ───────────────────────────────
+    @Test func `rtdb-swift#tx-run: DatabaseReference.runTransactionBlock(_:) commits updated MutableData`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "balance")
+        try await ref.setValue(100)
+        let result = try await ref.runTransactionBlock { currentData in
+            currentData.value = ((currentData.value as? NSNumber)?.intValue ?? 0) + 50
+            return TransactionResult.success(withValue: currentData)
+        }
+        #expect(result.committed == true && (result.snapshot.value as? NSNumber)?.intValue == 150)
+    }
+    @Test func `rtdb-swift#tx-abort: TransactionResult.abort() aborts transaction without saving`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "lockedBalance")
+        try await ref.setValue(100)
+        let result = try await ref.runTransactionBlock { _ in TransactionResult.abort() }
+        let snap = try await ref.getData()
+        #expect(result.committed == false && (snap.value as? NSNumber)?.intValue == 100)
+    }
+    @Test func `rtdb-swift#ondisconnect-set-remove: DatabaseReference.onDisconnectSetValue(_:) executes on goOffline()`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "presence/user1")
+        try await ref.setValue("online")
+        try await ref.onDisconnectSetValue("offline")
+        try await harness.database.goOffline()
+        let snap = try await ref.getData()
+        #expect(snap.value as? String == "offline")
+    }
+    @Test func `rtdb-swift#ondisconnect-cancel: DatabaseReference.cancelDisconnectOperations() cancels queued operations`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "presence/user2")
+        try await ref.setValue("online")
+        try await ref.onDisconnectSetValue("offline")
+        try await ref.cancelDisconnectOperations()
+        try await harness.database.goOffline()
+        let snap = try await ref.getData()
+        #expect(snap.value as? String == "online")
+    }
+
+    // ── AuthLens Propagation Integration Verification ─────────────────────────
+    @Test func `authlens-propagation: Database propagates active AuthLens on ops and subscriptions`() async throws {
+        let harness = try await RtdbTestHarness.create()
+        let ref = harness.database.reference(withPath: "secure/data")
+        harness.database.switchLens(.admin)
+        try await ref.setValue("admin-only")
+        #expect(harness.recordedOps.last?.actAs?["mode"]?.stringValue == "admin")
+        harness.database.switchLens(.asUser(uid: "alice"))
+        _ = try await ref.getData()
+        #expect(harness.recordedOps.last?.actAs?["mode"]?.stringValue == "as")
+        #expect(harness.recordedOps.last?.actAs?["uid"]?.stringValue == "alice")
+        harness.database.switchLens(.anon)
+        _ = try await ref.getData()
+        #expect(harness.recordedOps.last?.actAs?["mode"]?.stringValue == "anon")
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/bridge/PyricBridgeClient.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/bridge/PyricBridgeClient.kt
@@ -12,8 +12,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -30,9 +34,15 @@ class PyricBridgeClient(
     private var transport: BridgeTransport? = directTransport
     private var handshakeDeferred: CompletableDeferred<Unit>? = null
 
+    private val _connectionStateFlow = MutableStateFlow(false)
+    val connectionStateFlow: StateFlow<Boolean> = _connectionStateFlow.asStateFlow()
+
     @Volatile
     var isConnected: Boolean = false
-        private set
+        private set(value) {
+            field = value
+            _connectionStateFlow.value = value
+        }
 
     @Volatile
     var isDisposed: Boolean = false
@@ -63,6 +73,11 @@ class PyricBridgeClient(
 
     init {
         directTransport?.setListener(BridgeClientListener())
+        clientScope.launch {
+            try {
+                connect()
+            } catch (_: Throwable) {}
+        }
     }
 
     suspend fun connect() {

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/DataSnapshot.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/DataSnapshot.kt
@@ -1,0 +1,146 @@
+package dev.pyric.database
+
+class DataSnapshot(
+    val ref: DatabaseReference,
+    val value: Any?,
+    val priority: Any? = null,
+    private val orderedEntries: List<ChildEntry>? = null
+) {
+    data class ChildEntry(
+        val key: String,
+        val value: Any?,
+        val priority: Any? = null
+    )
+
+    val key: String?
+        get() = ref.key
+
+    fun exists(): Boolean = value != null
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getValue(valueType: Class<T>): T? {
+        val raw = value ?: return null
+        if (valueType.isInstance(raw)) {
+            return raw as T
+        }
+        return when (valueType) {
+            java.lang.Long::class.java, Long::class.java -> (raw as? Number)?.toLong() as? T
+            java.lang.Integer::class.java, Int::class.java -> (raw as? Number)?.toInt() as? T
+            java.lang.Double::class.java, Double::class.java -> (raw as? Number)?.toDouble() as? T
+            java.lang.Float::class.java, Float::class.java -> (raw as? Number)?.toFloat() as? T
+            java.lang.Boolean::class.java, Boolean::class.java -> raw as? T
+            String::class.java -> raw.toString() as? T
+            else -> raw as? T
+        }
+    }
+
+    val childrenCount: Long
+        get() {
+            if (orderedEntries != null) return orderedEntries.size.toLong()
+            return when (val v = value) {
+                is Map<*, *> -> v.size.toLong()
+                is List<*> -> v.count { it != null }.toLong()
+                else -> 0L
+            }
+        }
+
+    val children: Iterable<DataSnapshot>
+        get() {
+            if (orderedEntries != null) {
+                return orderedEntries.map { entry ->
+                    DataSnapshot(
+                        ref = ref.child(entry.key),
+                        value = entry.value,
+                        priority = entry.priority
+                    )
+                }
+            }
+            return when (val v = value) {
+                is Map<*, *> -> v.entries
+                    .sortedBy { it.key.toString() }
+                    .map { (k, childVal) ->
+                        DataSnapshot(
+                            ref = ref.child(k.toString()),
+                            value = childVal,
+                            priority = null
+                        )
+                    }
+                is List<*> -> v.mapIndexedNotNull { index, item ->
+                    if (item == null) null
+                    else DataSnapshot(
+                        ref = ref.child(index.toString()),
+                        value = item,
+                        priority = null
+                    )
+                }
+                else -> emptyList()
+            }
+        }
+
+    fun hasChildren(): Boolean = childrenCount > 0L
+
+    fun hasChild(path: String): Boolean = child(path).exists()
+
+    fun child(path: String): DataSnapshot {
+        val segments = path.trim('/').split('/').filter { it.isNotEmpty() }
+        if (segments.isEmpty()) return this
+
+        var currentVal: Any? = value
+        var currentEntries: List<ChildEntry>? = orderedEntries
+
+        for (segment in segments) {
+            if (currentEntries != null) {
+                val matched = currentEntries.find { it.key == segment }
+                if (matched != null) {
+                    currentVal = matched.value
+                    currentEntries = null
+                    continue
+                }
+            }
+            currentVal = when (val v = currentVal) {
+                is Map<*, *> -> v[segment]
+                is List<*> -> {
+                    val idx = segment.toIntOrNull()
+                    if (idx != null && idx in v.indices) v[idx] else null
+                }
+                else -> null
+            }
+            currentEntries = null
+        }
+
+        return DataSnapshot(
+            ref = ref.child(path),
+            value = currentVal,
+            priority = null
+        )
+    }
+
+    override fun toString(): String = "DataSnapshot { key = $key, value = $value }"
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun fromWire(ref: DatabaseReference, wire: Map<String, Any?>?): DataSnapshot {
+            if (wire == null) {
+                return DataSnapshot(ref, null, null, null)
+            }
+            val exists = wire["exists"] as? Boolean ?: (wire["value"] != null)
+            val value = if (exists) wire["value"] else null
+            val priority = wire["priority"]
+            val entriesRaw = wire["entries"] as? List<Map<String, Any?>>
+            val orderedEntries = entriesRaw?.mapNotNull { entryMap ->
+                val key = entryMap["key"] as? String ?: return@mapNotNull null
+                ChildEntry(
+                    key = key,
+                    value = entryMap["value"],
+                    priority = entryMap["priority"]
+                )
+            }
+            return DataSnapshot(
+                ref = ref,
+                value = value,
+                priority = priority,
+                orderedEntries = orderedEntries
+            )
+        }
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseError.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseError.kt
@@ -1,0 +1,28 @@
+package dev.pyric.database
+
+class DatabaseError(
+    val code: Int,
+    val message: String,
+    val details: String = ""
+) {
+    fun toException(): DatabaseException = DatabaseException(message)
+
+    companion object {
+        const val PERMISSION_DENIED = -3
+        const val DISCONNECTED = -4
+        const val OPERATION_FAILED = -2
+        const val UNKNOWN_ERROR = -999
+
+        fun fromException(t: Throwable): DatabaseError {
+            val msg = t.message ?: "Unknown RTDB error"
+            val code = if (msg.contains("PERMISSION_DENIED", ignoreCase = true) ||
+                msg.contains("permission-denied", ignoreCase = true)
+            ) {
+                PERMISSION_DENIED
+            } else {
+                OPERATION_FAILED
+            }
+            return DatabaseError(code, msg)
+        }
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseException.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseException.kt
@@ -1,0 +1,6 @@
+package dev.pyric.database
+
+class DatabaseException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseReference.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/DatabaseReference.kt
@@ -1,0 +1,161 @@
+package dev.pyric.database
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import dev.pyric.database.internal.PushIdGenerator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DatabaseReference(
+    database: FirebaseDatabase,
+    path: String
+) : Query(database, path) {
+    private val refScope = CoroutineScope(Dispatchers.IO)
+
+    val key: String?
+        get() {
+            val trimmed = path.trim('/')
+            if (trimmed.isEmpty()) return null
+            return trimmed.substringAfterLast('/')
+        }
+
+    val parent: DatabaseReference?
+        get() {
+            val trimmed = path.trim('/')
+            if (trimmed.isEmpty()) return null
+            val lastSlash = trimmed.lastIndexOf('/')
+            val parentPath = if (lastSlash == -1) "" else trimmed.substring(0, lastSlash)
+            return DatabaseReference(database, parentPath)
+        }
+
+    val root: DatabaseReference
+        get() = DatabaseReference(database, "")
+
+    fun child(pathString: String): DatabaseReference {
+        val cleanChild = pathString.trim('/')
+        if (cleanChild.isEmpty()) return this
+        val combined = if (path.isEmpty()) cleanChild else "$path/$cleanChild"
+        return DatabaseReference(database, combined)
+    }
+
+    fun push(): DatabaseReference {
+        val pushKey = PushIdGenerator.generatePushId()
+        return child(pushKey)
+    }
+
+    fun setValue(value: Any?): Task<Void?> = executeOp(
+        method = "rtdb.set",
+        params = mapOf("path" to path, "value" to value)
+    )
+
+    fun setValue(value: Any?, priority: Any?): Task<Void?> = executeOp(
+        method = "rtdb.setWithPriority",
+        params = mapOf("path" to path, "value" to value, "priority" to priority)
+    )
+
+    fun setPriority(priority: Any?): Task<Void?> = executeOp(
+        method = "rtdb.setPriority",
+        params = mapOf("path" to path, "priority" to priority)
+    )
+
+    fun updateChildren(update: Map<String, Any?>): Task<Void?> = executeOp(
+        method = "rtdb.update",
+        params = mapOf("path" to path, "values" to update)
+    )
+
+    fun removeValue(): Task<Void?> = executeOp(
+        method = "rtdb.remove",
+        params = mapOf("path" to path)
+    )
+
+    fun onDisconnect(): OnDisconnect = OnDisconnect(this)
+
+    fun runTransaction(handler: Transaction.Handler, fireLocalEvents: Boolean = true) {
+        refScope.launch {
+            try {
+                var maxRetries = 25
+                while (maxRetries-- > 0) {
+                    val currentWire = database.bridgeClient.op(
+                        method = "rtdb.get",
+                        params = mapOf("path" to path),
+                        actAs = database.getEffectiveAuthLens().toMap()
+                    )
+                    @Suppress("UNCHECKED_CAST")
+                    val snapMap = currentWire as? Map<String, Any?>
+                    val currentVal = snapMap?.get("value")
+                    val currentPriority = snapMap?.get("priority")
+
+                    val mutableData = MutableData(currentVal, currentPriority, key)
+                    val result = handler.doTransaction(mutableData)
+
+                    if (!result.isSuccess) {
+                        val currentSnap = DataSnapshot.fromWire(this@DatabaseReference, snapMap)
+                        handler.onComplete(null, false, currentSnap)
+                        return@launch
+                    }
+
+                    val commitRes = database.bridgeClient.op(
+                        method = "rtdb.transactionCommit",
+                        params = mapOf(
+                            "path" to path,
+                            "expected" to currentVal,
+                            "value" to result.mutableData?.value,
+                            "applyLocally" to fireLocalEvents
+                        ),
+                        actAs = database.getEffectiveAuthLens().toMap()
+                    )
+                    @Suppress("UNCHECKED_CAST")
+                    val commitMap = commitRes as? Map<String, Any?>
+                    val retry = commitMap?.get("retry") == true
+                    if (!retry) {
+                        @Suppress("UNCHECKED_CAST")
+                        val finalSnapMap = commitMap?.get("snapshot") as? Map<String, Any?>
+                        val finalSnap = DataSnapshot.fromWire(this@DatabaseReference, finalSnapMap)
+                        handler.onComplete(null, commitMap?.get("committed") == true, finalSnap)
+                        return@launch
+                    }
+                }
+                handler.onComplete(
+                    DatabaseError(DatabaseError.OPERATION_FAILED, "Transaction exceeded max retries"),
+                    false,
+                    null
+                )
+            } catch (e: Exception) {
+                handler.onComplete(DatabaseError.fromException(e), false, null)
+            }
+        }
+    }
+
+    private fun executeOp(method: String, params: Map<String, Any?>): Task<Void?> {
+        val tcs = TaskCompletionSource<Void?>()
+        refScope.launch {
+            try {
+                database.bridgeClient.op(
+                    method = method,
+                    params = params,
+                    actAs = database.getEffectiveAuthLens().toMap()
+                )
+                tcs.setResult(null)
+            } catch (e: Exception) {
+                tcs.setException(e)
+            }
+        }
+        return tcs.task
+    }
+
+    override fun toString(): String {
+        val cleanUrl = database.url.trimEnd('/')
+        return if (path.isEmpty()) cleanUrl else "$cleanUrl/$path"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DatabaseReference) return false
+        return database.url == other.database.url && path == other.path
+    }
+
+    override fun hashCode(): Int {
+        return 31 * database.url.hashCode() + path.hashCode()
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/FirebaseDatabase.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/FirebaseDatabase.kt
@@ -1,0 +1,155 @@
+package dev.pyric.database
+
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import dev.pyric.auth.AuthLens
+import dev.pyric.auth.CredentialsProvider
+import dev.pyric.bridge.PyricBridgeClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+class FirebaseDatabase(
+    val bridgeClient: PyricBridgeClient,
+    val app: FirebaseApp,
+    val url: String = DEFAULT_DATABASE_URL,
+    val credentialsProvider: CredentialsProvider? = null
+) {
+    private val databaseScope = CoroutineScope(Dispatchers.IO)
+    private var explicitAuthLens: AuthLens? = null
+
+    private val _effectiveAuthLensFlow = MutableStateFlow(
+        credentialsProvider?.getEffectiveLens() ?: AuthLens.Anon
+    )
+    val authLensFlow: StateFlow<AuthLens> = _effectiveAuthLensFlow.asStateFlow()
+
+    init {
+        databaseScope.launch {
+            credentialsProvider?.authLensFlow?.collect { lens ->
+                if (explicitAuthLens == null) {
+                    _effectiveAuthLensFlow.value = lens
+                }
+            }
+        }
+        databaseScope.launch {
+            bridgeClient.remoteLensEvents.collect { lens ->
+                _effectiveAuthLensFlow.value = lens
+            }
+        }
+    }
+
+    fun setAuthLens(lens: AuthLens?) {
+        explicitAuthLens = lens
+        _effectiveAuthLensFlow.value =
+            lens ?: credentialsProvider?.getEffectiveLens() ?: AuthLens.Anon
+    }
+
+    fun getEffectiveAuthLens(): AuthLens = _effectiveAuthLensFlow.value
+
+    val reference: DatabaseReference
+        get() = DatabaseReference(this, "")
+
+    fun getReference(path: String): DatabaseReference {
+        val cleanPath = path.trim('/')
+        return DatabaseReference(this, cleanPath)
+    }
+
+    fun getReferenceFromUrl(fullUrl: String): DatabaseReference {
+        val cleanBase = url.trimEnd('/')
+        val path = if (fullUrl.startsWith(cleanBase)) {
+            fullUrl.removePrefix(cleanBase).trim('/')
+        } else {
+            try {
+                java.net.URI(fullUrl).path.trim('/')
+            } catch (_: Throwable) {
+                ""
+            }
+        }
+        return DatabaseReference(this, path)
+    }
+
+    fun goOffline() {
+        databaseScope.launch {
+            try {
+                bridgeClient.op(
+                    method = "rtdb.goOffline",
+                    params = emptyMap(),
+                    actAs = getEffectiveAuthLens().toMap()
+                )
+            } catch (_: Exception) {}
+        }
+    }
+
+    fun goOnline() {
+        databaseScope.launch {
+            try {
+                bridgeClient.op(
+                    method = "rtdb.goOnline",
+                    params = emptyMap(),
+                    actAs = getEffectiveAuthLens().toMap()
+                )
+            } catch (_: Exception) {}
+        }
+    }
+
+    companion object {
+        const val DEFAULT_DATABASE_URL = "https://pyric-sandbox-default-rtdb.firebaseio.com"
+        private val instances = ConcurrentHashMap<Pair<String, String>, FirebaseDatabase>()
+
+        @JvmStatic
+        fun getInstance(): FirebaseDatabase =
+            getInstance(FirebaseApp.getInstance(), DEFAULT_DATABASE_URL)
+
+        @JvmStatic
+        fun getInstance(url: String): FirebaseDatabase =
+            getInstance(FirebaseApp.getInstance(), url)
+
+        @JvmStatic
+        fun getInstance(app: FirebaseApp): FirebaseDatabase =
+            getInstance(app, DEFAULT_DATABASE_URL)
+
+        @JvmStatic
+        fun getInstance(app: FirebaseApp, url: String): FirebaseDatabase {
+            return instances.computeIfAbsent(Pair(app.name, url)) {
+                val bridge = PyricBridgeClient.createDefault()
+                val auth = runCatching { FirebaseAuth.getInstance(app, bridge) }.getOrNull()
+                FirebaseDatabase(bridge, app, url, credentialsProvider = auth)
+            }
+        }
+
+        @JvmStatic
+        fun getInstance(
+            app: FirebaseApp,
+            bridgeClient: PyricBridgeClient,
+            url: String = DEFAULT_DATABASE_URL,
+            credentialsProvider: CredentialsProvider? = null
+        ): FirebaseDatabase {
+            return instances.computeIfAbsent(Pair(app.name, url)) {
+                val auth = credentialsProvider ?: runCatching { FirebaseAuth.getInstance(app, bridgeClient) }.getOrNull()
+                FirebaseDatabase(bridgeClient, app, url, credentialsProvider = auth)
+            }
+        }
+
+        @JvmStatic
+        fun clearInstancesForTest() {
+            instances.clear()
+        }
+    }
+}
+
+val Firebase.database: FirebaseDatabase
+    get() = FirebaseDatabase.getInstance()
+
+fun Firebase.database(url: String): FirebaseDatabase =
+    FirebaseDatabase.getInstance(url)
+
+fun Firebase.database(app: FirebaseApp): FirebaseDatabase =
+    FirebaseDatabase.getInstance(app)
+
+fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase =
+    FirebaseDatabase.getInstance(app, url)

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/MutableData.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/MutableData.kt
@@ -1,0 +1,47 @@
+package dev.pyric.database
+
+class MutableData(
+    var value: Any?,
+    var priority: Any? = null,
+    val key: String? = null
+) {
+    val childrenCount: Long
+        get() = when (val v = value) {
+            is Map<*, *> -> v.size.toLong()
+            is List<*> -> v.count { it != null }.toLong()
+            else -> 0L
+        }
+
+    val children: Iterable<MutableData>
+        get() = when (val v = value) {
+            is Map<*, *> -> v.entries.map { (k, childVal) ->
+                MutableData(childVal, null, k.toString())
+            }
+            is List<*> -> v.mapIndexedNotNull { idx, item ->
+                if (item == null) null else MutableData(item, null, idx.toString())
+            }
+            else -> emptyList()
+        }
+
+    fun hasChildren(): Boolean = childrenCount > 0L
+
+    fun hasChild(path: String): Boolean = child(path).value != null
+
+    fun child(path: String): MutableData {
+        val segments = path.trim('/').split('/').filter { it.isNotEmpty() }
+        if (segments.isEmpty()) return this
+
+        var currentVal = value
+        for (segment in segments) {
+            currentVal = when (val v = currentVal) {
+                is Map<*, *> -> v[segment]
+                is List<*> -> {
+                    val idx = segment.toIntOrNull()
+                    if (idx != null && idx in v.indices) v[idx] else null
+                }
+                else -> null
+            }
+        }
+        return MutableData(currentVal, null, segments.last())
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/OnDisconnect.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/OnDisconnect.kt
@@ -1,0 +1,53 @@
+package dev.pyric.database
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class OnDisconnect(private val ref: DatabaseReference) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    fun setValue(value: Any?): Task<Void?> = executeOp(
+        method = "rtdb.onDisconnectSet",
+        params = mapOf("path" to ref.path, "value" to value)
+    )
+
+    fun setValue(value: Any?, priority: Any?): Task<Void?> = executeOp(
+        method = "rtdb.onDisconnectSet",
+        params = mapOf("path" to ref.path, "value" to value, "priority" to priority)
+    )
+
+    fun updateChildren(update: Map<String, Any?>): Task<Void?> = executeOp(
+        method = "rtdb.onDisconnectUpdate",
+        params = mapOf("path" to ref.path, "values" to update)
+    )
+
+    fun removeValue(): Task<Void?> = executeOp(
+        method = "rtdb.onDisconnectRemove",
+        params = mapOf("path" to ref.path)
+    )
+
+    fun cancel(): Task<Void?> = executeOp(
+        method = "rtdb.onDisconnectCancel",
+        params = mapOf("path" to ref.path)
+    )
+
+    private fun executeOp(method: String, params: Map<String, Any?>): Task<Void?> {
+        val tcs = TaskCompletionSource<Void?>()
+        scope.launch {
+            try {
+                ref.database.bridgeClient.op(
+                    method = method,
+                    params = params,
+                    actAs = ref.database.getEffectiveAuthLens().toMap()
+                )
+                tcs.setResult(null)
+            } catch (e: Exception) {
+                tcs.setException(e)
+            }
+        }
+        return tcs.task
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/Query.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/Query.kt
@@ -1,0 +1,342 @@
+package dev.pyric.database
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import dev.pyric.auth.AuthLens
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+data class RtdbQuerySpec(
+    val orderBy: Map<String, Any?>? = null,
+    val bounds: List<Map<String, Any?>> = emptyList(),
+    val limit: Map<String, Any?>? = null
+) {
+    fun isEmpty(): Boolean = orderBy == null && bounds.isEmpty() && limit == null
+
+    fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "orderBy" to orderBy,
+            "bounds" to bounds,
+            "limit" to limit
+        )
+    }
+}
+
+interface ValueEventListener {
+    fun onDataChange(snapshot: DataSnapshot)
+    fun onCancelled(error: DatabaseError)
+}
+
+interface ChildEventListener {
+    fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?)
+    fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?)
+    fun onChildRemoved(snapshot: DataSnapshot)
+    fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?)
+    fun onCancelled(error: DatabaseError)
+}
+
+sealed class ChildEvent(val snapshot: DataSnapshot, val previousChildName: String? = null) {
+    class Added(snapshot: DataSnapshot, previousChildName: String?) : ChildEvent(snapshot, previousChildName)
+    class Changed(snapshot: DataSnapshot, previousChildName: String?) : ChildEvent(snapshot, previousChildName)
+    class Removed(snapshot: DataSnapshot) : ChildEvent(snapshot, null)
+    class Moved(snapshot: DataSnapshot, previousChildName: String?) : ChildEvent(snapshot, previousChildName)
+}
+
+open class Query(
+    val database: FirebaseDatabase,
+    val path: String,
+    internal val querySpec: RtdbQuerySpec = RtdbQuerySpec()
+) {
+    private val queryScope = CoroutineScope(Dispatchers.IO)
+    private val valueListeners = ConcurrentHashMap<ValueEventListener, Job>()
+    private val childListeners = ConcurrentHashMap<ChildEventListener, Job>()
+
+    val ref: DatabaseReference
+        get() = DatabaseReference(database, path)
+
+    fun orderByChild(childPath: String): Query {
+        val clean = childPath.trim('/')
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(orderBy = mapOf("kind" to "child", "path" to clean))
+        )
+    }
+
+    fun orderByKey(): Query {
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(orderBy = mapOf("kind" to "key"))
+        )
+    }
+
+    fun orderByValue(): Query {
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(orderBy = mapOf("kind" to "value"))
+        )
+    }
+
+    fun orderByPriority(): Query {
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(orderBy = mapOf("kind" to "priority"))
+        )
+    }
+
+    fun equalTo(value: Any?, key: String? = null): Query {
+        val bound = mutableMapOf<String, Any?>("kind" to "equalTo", "value" to value)
+        if (key != null) bound["key"] = key
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(bounds = querySpec.bounds + bound)
+        )
+    }
+
+    fun startAt(value: Any?, key: String? = null): Query {
+        val bound = mutableMapOf<String, Any?>("kind" to "startAt", "value" to value)
+        if (key != null) bound["key"] = key
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(bounds = querySpec.bounds + bound)
+        )
+    }
+
+    fun startAfter(value: Any?, key: String? = null): Query {
+        val bound = mutableMapOf<String, Any?>("kind" to "startAfter", "value" to value)
+        if (key != null) bound["key"] = key
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(bounds = querySpec.bounds + bound)
+        )
+    }
+
+    fun endAt(value: Any?, key: String? = null): Query {
+        val bound = mutableMapOf<String, Any?>("kind" to "endAt", "value" to value)
+        if (key != null) bound["key"] = key
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(bounds = querySpec.bounds + bound)
+        )
+    }
+
+    fun endBefore(value: Any?, key: String? = null): Query {
+        val bound = mutableMapOf<String, Any?>("kind" to "endBefore", "value" to value)
+        if (key != null) bound["key"] = key
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(bounds = querySpec.bounds + bound)
+        )
+    }
+
+    fun limitToFirst(limit: Int): Query {
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(limit = mapOf("kind" to "limitToFirst", "n" to limit))
+        )
+    }
+
+    fun limitToLast(limit: Int): Query {
+        return Query(
+            database = database,
+            path = path,
+            querySpec = querySpec.copy(limit = mapOf("kind" to "limitToLast", "n" to limit))
+        )
+    }
+
+    fun get(): Task<DataSnapshot> {
+        val tcs = TaskCompletionSource<DataSnapshot>()
+        queryScope.launch {
+            try {
+                val params = mutableMapOf<String, Any?>("path" to path)
+                if (!querySpec.isEmpty()) {
+                    params["query"] = querySpec.toMap()
+                }
+                val res = database.bridgeClient.op(
+                    method = "rtdb.get",
+                    params = params,
+                    actAs = database.getEffectiveAuthLens().toMap()
+                )
+                @Suppress("UNCHECKED_CAST")
+                val wire = res as? Map<String, Any?>
+                tcs.setResult(DataSnapshot.fromWire(ref, wire))
+            } catch (e: Exception) {
+                tcs.setException(e)
+            }
+        }
+        return tcs.task
+    }
+
+    fun addValueEventListener(listener: ValueEventListener): ValueEventListener {
+        val job = queryScope.launch {
+            try {
+                snapshots().collect { snap ->
+                    listener.onDataChange(snap)
+                }
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    listener.onCancelled(DatabaseError.fromException(e))
+                }
+            }
+        }
+        valueListeners[listener] = job
+        return listener
+    }
+
+    fun addListenerForSingleValueEvent(listener: ValueEventListener) {
+        queryScope.launch {
+            try {
+                val snap = snapshots().first()
+                listener.onDataChange(snap)
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    listener.onCancelled(DatabaseError.fromException(e))
+                }
+            }
+        }
+    }
+
+    fun addChildEventListener(listener: ChildEventListener): ChildEventListener {
+        val job = queryScope.launch {
+            try {
+                childEvents().collect { event ->
+                    when (event) {
+                        is ChildEvent.Added -> listener.onChildAdded(event.snapshot, event.previousChildName)
+                        is ChildEvent.Changed -> listener.onChildChanged(event.snapshot, event.previousChildName)
+                        is ChildEvent.Removed -> listener.onChildRemoved(event.snapshot)
+                        is ChildEvent.Moved -> listener.onChildMoved(event.snapshot, event.previousChildName)
+                    }
+                }
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    listener.onCancelled(DatabaseError.fromException(e))
+                }
+            }
+        }
+        childListeners[listener] = job
+        return listener
+    }
+
+    fun removeEventListener(listener: ValueEventListener) {
+        valueListeners.remove(listener)?.cancel()
+    }
+
+    fun removeEventListener(listener: ChildEventListener) {
+        childListeners.remove(listener)?.cancel()
+    }
+}
+
+fun Query.snapshots(): Flow<DataSnapshot> = callbackFlow {
+    val target = mutableMapOf<String, Any?>(
+        "service" to "rtdb",
+        "path" to path
+    )
+    if (!querySpec.isEmpty()) {
+        target["query"] = querySpec.toMap()
+    }
+
+    var activeJob: Job? = null
+
+    fun startSubscription(lens: AuthLens) {
+        activeJob?.cancel()
+        activeJob = launch {
+            try {
+                database.bridgeClient.subscribe(
+                    target = target,
+                    actAs = lens.toMap()
+                ).collect { raw ->
+                    @Suppress("UNCHECKED_CAST")
+                    val wire = raw as? Map<String, Any?>
+                    val snapshot = DataSnapshot.fromWire(ref, wire)
+                    trySend(snapshot)
+                }
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    close(e)
+                }
+            }
+        }
+    }
+
+    startSubscription(database.getEffectiveAuthLens())
+
+    val lensMonitorJob = launch {
+        var lastLens = database.getEffectiveAuthLens()
+        database.authLensFlow.collect { newLens ->
+            if (newLens != lastLens) {
+                lastLens = newLens
+                startSubscription(newLens)
+            }
+        }
+    }
+
+    awaitClose {
+        lensMonitorJob.cancel()
+        activeJob?.cancel()
+    }
+}
+
+fun Query.childEvents(): Flow<ChildEvent> = callbackFlow {
+    var previousChildren: Map<String, DataSnapshot>? = null
+
+    val job = launch {
+        try {
+            snapshots().collect { snapshot ->
+                val currentList = snapshot.children.toList()
+                val currentMap = currentList.associateBy { it.key ?: "" }
+
+                val prev = previousChildren
+                if (prev == null) {
+                    var prevKey: String? = null
+                    for (child in currentList) {
+                        trySend(ChildEvent.Added(child, prevKey))
+                        prevKey = child.key
+                    }
+                } else {
+                    for ((k, oldSnap) in prev) {
+                        if (!currentMap.containsKey(k)) {
+                            trySend(ChildEvent.Removed(oldSnap))
+                        }
+                    }
+                    var prevKey: String? = null
+                    for (child in currentList) {
+                        val k = child.key ?: ""
+                        val oldSnap = prev[k]
+                        if (oldSnap == null) {
+                            trySend(ChildEvent.Added(child, prevKey))
+                        } else if (oldSnap.value != child.value || oldSnap.priority != child.priority) {
+                            trySend(ChildEvent.Changed(child, prevKey))
+                        }
+                        prevKey = k
+                    }
+                }
+                previousChildren = currentMap
+            }
+        } catch (e: Exception) {
+            if (e !is CancellationException) {
+                close(e)
+            }
+        }
+    }
+
+    awaitClose {
+        job.cancel()
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/ServerValue.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/ServerValue.kt
@@ -1,0 +1,19 @@
+package dev.pyric.database
+
+object ServerValue {
+    @JvmField
+    val TIMESTAMP: Map<String, String> = mapOf(
+        ".sv" to "timestamp",
+        "__rtdbSentinel" to "serverTimestamp"
+    )
+
+    @JvmStatic
+    fun increment(delta: Long): Map<String, Any> = mapOf(
+        ".sv" to mapOf("increment" to delta)
+    )
+
+    @JvmStatic
+    fun increment(delta: Double): Map<String, Any> = mapOf(
+        ".sv" to mapOf("increment" to delta)
+    )
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/Transaction.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/Transaction.kt
@@ -1,0 +1,19 @@
+package dev.pyric.database
+
+object Transaction {
+    class Result internal constructor(
+        val isSuccess: Boolean,
+        val mutableData: MutableData?
+    )
+
+    @JvmStatic
+    fun success(mutableData: MutableData): Result = Result(true, mutableData)
+
+    @JvmStatic
+    fun abort(): Result = Result(false, null)
+
+    interface Handler {
+        fun doTransaction(currentData: MutableData): Result
+        fun onComplete(error: DatabaseError?, committed: Boolean, currentData: DataSnapshot?)
+    }
+}

--- a/packages/kt-client/src/main/kotlin/dev/pyric/database/internal/PushIdGenerator.kt
+++ b/packages/kt-client/src/main/kotlin/dev/pyric/database/internal/PushIdGenerator.kt
@@ -1,0 +1,47 @@
+package dev.pyric.database.internal
+
+import java.security.SecureRandom
+
+internal object PushIdGenerator {
+    private const val PUSH_CHARS = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
+    private val random = SecureRandom()
+    private var lastPushTime = 0L
+    private val lastRandChars = IntArray(12)
+
+    @Synchronized
+    fun generatePushId(now: Long = System.currentTimeMillis()): String {
+        val duplicateTime = (now == lastPushTime)
+        lastPushTime = now
+
+        val timeStampChars = CharArray(8)
+        var time = now
+        for (i in 7 downTo 0) {
+            timeStampChars[i] = PUSH_CHARS[(time % 64).toInt()]
+            time /= 64
+        }
+
+        val id = StringBuilder(20)
+        id.append(timeStampChars)
+
+        if (!duplicateTime) {
+            for (i in 0 until 12) {
+                lastRandChars[i] = random.nextInt(64)
+            }
+        } else {
+            var i = 11
+            while (i >= 0 && lastRandChars[i] == 63) {
+                lastRandChars[i] = 0
+                i--
+            }
+            if (i >= 0) {
+                lastRandChars[i]++
+            }
+        }
+
+        for (i in 0 until 12) {
+            id.append(PUSH_CHARS[lastRandChars[i]])
+        }
+
+        return id.toString()
+    }
+}

--- a/packages/kt-client/src/test/kotlin/dev/pyric/database/RtdbConformanceTest.kt
+++ b/packages/kt-client/src/test/kotlin/dev/pyric/database/RtdbConformanceTest.kt
@@ -1,0 +1,568 @@
+package dev.pyric.database
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import dev.pyric.auth.AuthLens
+import dev.pyric.database.internal.RtdbInMemoryWorker
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class RtdbConformanceTest {
+    private lateinit var worker: RtdbInMemoryWorker
+    private lateinit var database: FirebaseDatabase
+    private lateinit var app: FirebaseApp
+
+    @BeforeEach
+    fun setUp() {
+        FirebaseDatabase.clearInstancesForTest()
+        FirebaseApp.clearInstancesForTest()
+        worker = RtdbInMemoryWorker()
+        app = FirebaseApp.initializeApp(
+            "rtdb-test-app",
+            FirebaseOptions.Builder()
+                .setProjectId("rtdb-project")
+                .setApiKey("rtdb-key")
+                .setApplicationId("rtdb-app-id")
+                .build()
+        )
+        database = FirebaseDatabase.getInstance(
+            app = app,
+            bridgeClient = worker.createBridgeClient(),
+            url = "https://rtdb-project-default-rtdb.firebaseio.com"
+        )
+    }
+
+    // ── Section 1: Database Instance & Connection (5 rows) ──────────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#instance-default: FirebaseDatabase.getInstance returns default instance")
+    fun `rtdb-kotlin#instance-default FirebaseDatabase getInstance returns default instance`() {
+        val defaultDb = FirebaseDatabase.getInstance()
+        assertNotNull(defaultDb)
+        assertEquals(FirebaseDatabase.DEFAULT_DATABASE_URL, defaultDb.url)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#instance-url: FirebaseDatabase.getInstance(url) returns isolated instance")
+    fun `rtdb-kotlin#instance-url FirebaseDatabase getInstance url returns isolated instance`() {
+        val customUrl = "https://custom-instance.firebaseio.com"
+        val customDb = FirebaseDatabase.getInstance(app, worker.createBridgeClient(), customUrl)
+        assertNotNull(customDb)
+        assertEquals(customUrl, customDb.url)
+        assertNotEquals(database.url, customDb.url)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-root: FirebaseDatabase.reference returns root DatabaseReference")
+    fun `rtdb-kotlin#ref-root FirebaseDatabase reference returns root DatabaseReference`() {
+        val rootRef = database.reference
+        assertEquals("", rootRef.path)
+        assertNull(rootRef.key)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-path: FirebaseDatabase.getReference(path) targets path")
+    fun `rtdb-kotlin#ref-path FirebaseDatabase getReference path targets path`() {
+        val ref = database.getReference("users/alice/profile")
+        assertEquals("users/alice/profile", ref.path)
+        assertEquals("profile", ref.key)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#connection-toggle: goOffline and goOnline toggle connection")
+    fun `rtdb-kotlin#connection-toggle goOffline and goOnline toggle connection`() = runBlocking {
+        database.goOffline()
+        Thread.sleep(50)
+        assertTrue(worker.isOffline)
+        assertTrue(worker.recordedOps.any { it.method == "rtdb.goOffline" })
+
+        database.goOnline()
+        Thread.sleep(50)
+        assertFalse(worker.isOffline)
+        assertTrue(worker.recordedOps.any { it.method == "rtdb.goOnline" })
+    }
+
+    // ── Section 2: DatabaseReference Navigation & Properties (7 rows) ───────
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-child: DatabaseReference.child navigates relative path")
+    fun `rtdb-kotlin#ref-child DatabaseReference child navigates relative path`() {
+        val usersRef = database.getReference("users")
+        val aliceRef = usersRef.child("alice/settings")
+        assertEquals("users/alice/settings", aliceRef.path)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-parent: DatabaseReference.parent navigates up or returns null at root")
+    fun `rtdb-kotlin#ref-parent DatabaseReference parent navigates up or returns null at root`() {
+        val childRef = database.getReference("users/alice")
+        val parentRef = childRef.parent
+        assertNotNull(parentRef)
+        assertEquals("users", parentRef?.path)
+        assertNull(database.reference.parent)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-root-prop: DatabaseReference.root returns root reference")
+    fun `rtdb-kotlin#ref-root-prop DatabaseReference root returns root reference`() {
+        val deepRef = database.getReference("a/b/c/d")
+        val rootRef = deepRef.root
+        assertEquals("", rootRef.path)
+        assertNull(rootRef.key)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-key: DatabaseReference.key returns last segment or null for root")
+    fun `rtdb-kotlin#ref-key DatabaseReference key returns last segment or null for root`() {
+        assertNull(database.reference.key)
+        assertEquals("items", database.getReference("items").key)
+        assertEquals("item-42", database.getReference("items/item-42").key)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-path-prop: DatabaseReference.path returns slash-delimited path")
+    fun `rtdb-kotlin#ref-path-prop DatabaseReference path returns slash-delimited path`() {
+        val ref = database.getReference("/posts/2026/title/")
+        assertEquals("posts/2026/title", ref.path)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-push: DatabaseReference.push generates unique child reference")
+    fun `rtdb-kotlin#ref-push DatabaseReference push generates unique child reference`() {
+        val listRef = database.getReference("messages")
+        val pushed1 = listRef.push()
+        val pushed2 = listRef.push()
+        assertNotNull(pushed1.key)
+        assertNotNull(pushed2.key)
+        assertNotEquals(pushed1.key, pushed2.key)
+        assertTrue(pushed1.path.startsWith("messages/"))
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ref-push-key-ordering: push keys sort chronologically and lexicographically")
+    fun `rtdb-kotlin#ref-push-key-ordering push keys sort chronologically and lexicographically`() {
+        val listRef = database.getReference("events")
+        val keys = (1..10).map { listRef.push().key!! }
+        val sorted = keys.sorted()
+        assertEquals(sorted, keys)
+    }
+
+    // ── Section 3: Write Operations (6 rows) ────────────────────────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-set: DatabaseReference.setValue writes value at path")
+    fun `rtdb-kotlin#write-set DatabaseReference setValue writes value at path`() {
+        val ref = database.getReference("users/u1")
+        Tasks.await(ref.setValue(mapOf("name" to "Ada", "role" to "admin")))
+        val snap = Tasks.await(ref.get())
+        assertTrue(snap.exists())
+        assertEquals("Ada", snap.child("name").value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-set-null: DatabaseReference.setValue(null) deletes node")
+    fun `rtdb-kotlin#write-set-null DatabaseReference setValue null deletes node`() {
+        val ref = database.getReference("temp/node")
+        Tasks.await(ref.setValue("to-be-deleted"))
+        assertTrue(Tasks.await(ref.get()).exists())
+        Tasks.await(ref.setValue(null))
+        assertFalse(Tasks.await(ref.get()).exists())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-set-priority: DatabaseReference.setPriority updates node priority")
+    fun `rtdb-kotlin#write-set-priority DatabaseReference setPriority updates node priority`() {
+        val ref = database.getReference("ranked/item1")
+        Tasks.await(ref.setValue("alpha"))
+        Tasks.await(ref.setPriority(100L))
+        val snap = Tasks.await(ref.get())
+        assertEquals(100L, (snap.priority as? Number)?.toLong())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-set-with-priority: setValue with priority stores value and priority")
+    fun `rtdb-kotlin#write-set-with-priority setValue with priority stores value and priority`() {
+        val ref = database.getReference("ranked/item2")
+        Tasks.await(ref.setValue("beta", 50L))
+        val snap = Tasks.await(ref.get())
+        assertEquals("beta", snap.value)
+        assertEquals(50L, (snap.priority as? Number)?.toLong())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-update: updateChildren merges specified child paths")
+    fun `rtdb-kotlin#write-update updateChildren merges specified child paths`() {
+        val ref = database.getReference("profile/p1")
+        Tasks.await(ref.setValue(mapOf("name" to "Grace", "city" to "NYC")))
+        Tasks.await(ref.updateChildren(mapOf("city" to "Boston", "title" to "Admiral")))
+        val snap = Tasks.await(ref.get())
+        assertEquals("Grace", snap.child("name").value)
+        assertEquals("Boston", snap.child("city").value)
+        assertEquals("Admiral", snap.child("title").value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#write-remove: removeValue deletes node at reference")
+    fun `rtdb-kotlin#write-remove removeValue deletes node at reference`() {
+        val ref = database.getReference("sessions/s1")
+        Tasks.await(ref.setValue("active"))
+        Tasks.await(ref.removeValue())
+        val snap = Tasks.await(ref.get())
+        assertFalse(snap.exists())
+    }
+
+    // ── Section 4: ServerValue Sentinels (2 rows) ───────────────────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#sentinel-timestamp: ServerValue.TIMESTAMP resolves to epoch millis")
+    fun `rtdb-kotlin#sentinel-timestamp ServerValue TIMESTAMP resolves to epoch millis`() {
+        val ref = database.getReference("logs/entry1/createdAt")
+        Tasks.await(ref.setValue(ServerValue.TIMESTAMP))
+        val snap = Tasks.await(ref.get())
+        val ts = (snap.value as? Number)?.toLong()
+        assertNotNull(ts)
+        assertTrue(ts!! > 1700000000000L)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#sentinel-increment: ServerValue.increment atomically adds delta")
+    fun `rtdb-kotlin#sentinel-increment ServerValue increment atomically adds delta`() {
+        val ref = database.getReference("counters/visits")
+        Tasks.await(ref.setValue(10L))
+        Tasks.await(ref.setValue(ServerValue.increment(5L)))
+        val snap = Tasks.await(ref.get())
+        assertEquals(15L, (snap.value as? Number)?.toLong())
+    }
+
+    // ── Section 5: One-Shot Reads & DataSnapshot Inspection (7 rows) ────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#read-get: Query.get retrieves one-shot DataSnapshot")
+    fun `rtdb-kotlin#read-get Query get retrieves one-shot DataSnapshot`() {
+        val ref = database.getReference("config/version")
+        Tasks.await(ref.setValue("2.1.0"))
+        val snap = Tasks.await(ref.get())
+        assertEquals("2.1.0", snap.value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-exists: DataSnapshot.exists reflects non-null data")
+    fun `rtdb-kotlin#snap-exists DataSnapshot exists reflects non-null data`() {
+        val ref = database.getReference("check/flag")
+        assertFalse(Tasks.await(ref.get()).exists())
+        Tasks.await(ref.setValue(true))
+        assertTrue(Tasks.await(ref.get()).exists())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-key: DataSnapshot.key returns node key")
+    fun `rtdb-kotlin#snap-key DataSnapshot key returns node key`() {
+        val ref = database.getReference("books/b99")
+        Tasks.await(ref.setValue("Dune"))
+        val snap = Tasks.await(ref.get())
+        assertEquals("b99", snap.key)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-value: DataSnapshot.getValue returns scalar or typed value")
+    fun `rtdb-kotlin#snap-value DataSnapshot getValue returns scalar or typed value`() {
+        val ref = database.getReference("stats/score")
+        Tasks.await(ref.setValue(42L))
+        val snap = Tasks.await(ref.get())
+        assertEquals(42L, snap.getValue(Long::class.java))
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-children: DataSnapshot.children iterates immediate child snapshots")
+    fun `rtdb-kotlin#snap-children DataSnapshot children iterates immediate child snapshots`() {
+        val ref = database.getReference("teams")
+        Tasks.await(ref.setValue(mapOf("a" to "Alpha", "b" to "Beta")))
+        val snap = Tasks.await(ref.get())
+        assertEquals(2L, snap.childrenCount)
+        val keys = snap.children.map { it.key }
+        assertEquals(listOf("a", "b"), keys)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-child-path: DataSnapshot.child navigates nested child path")
+    fun `rtdb-kotlin#snap-child-path DataSnapshot child navigates nested child path`() {
+        val ref = database.getReference("org")
+        Tasks.await(ref.setValue(mapOf("dept" to mapOf("lead" to "Linus"))))
+        val snap = Tasks.await(ref.get())
+        assertTrue(snap.hasChild("dept/lead"))
+        assertEquals("Linus", snap.child("dept/lead").value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#snap-priority: DataSnapshot.priority exposes node priority")
+    fun `rtdb-kotlin#snap-priority DataSnapshot priority exposes node priority`() {
+        val ref = database.getReference("tasks/t1")
+        Tasks.await(ref.setValue("urgent", 1L))
+        val snap = Tasks.await(ref.get())
+        assertEquals(1L, (snap.priority as? Number)?.toLong())
+    }
+
+    // ── Section 6: Realtime Listeners & Streams (5 rows) ────────────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#listen-value: ValueEventListener and snapshots Flow emit live updates")
+    fun `rtdb-kotlin#listen-value ValueEventListener and snapshots Flow emit live updates`() = runBlocking {
+        val ref = database.getReference("live/status")
+        Tasks.await(ref.setValue("initial"))
+        val snap = withTimeout(2000) { ref.snapshots().first() }
+        assertEquals("initial", snap.value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#listen-child-added: ChildEventListener fires onChildAdded for children")
+    fun `rtdb-kotlin#listen-child-added ChildEventListener fires onChildAdded for children`() = runBlocking {
+        val ref = database.getReference("chat/room1")
+        Tasks.await(ref.setValue(mapOf("m1" to "Hello")))
+        val event = withTimeout(2000) { ref.childEvents().first() }
+        assertTrue(event is ChildEvent.Added)
+        assertEquals("m1", event.snapshot.key)
+        assertEquals("Hello", event.snapshot.value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#listen-child-changed: ChildEventListener fires onChildChanged on child update")
+    fun `rtdb-kotlin#listen-child-changed ChildEventListener fires onChildChanged on child update`() = runBlocking {
+        val ref = database.getReference("items")
+        Tasks.await(ref.setValue(mapOf("i1" to "v1")))
+        val changedDeferred = CompletableDeferred<DataSnapshot>()
+        val listener = ref.addChildEventListener(object : ChildEventListener {
+            override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {}
+            override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {
+                changedDeferred.complete(snapshot)
+            }
+            override fun onChildRemoved(snapshot: DataSnapshot) {}
+            override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) {}
+            override fun onCancelled(error: DatabaseError) {}
+        })
+        Thread.sleep(50)
+        Tasks.await(ref.child("i1").setValue("v2"))
+        val changedSnap = withTimeout(2000) { changedDeferred.await() }
+        assertEquals("v2", changedSnap.value)
+        ref.removeEventListener(listener)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#listen-child-removed: ChildEventListener fires onChildRemoved when child deleted")
+    fun `rtdb-kotlin#listen-child-removed ChildEventListener fires onChildRemoved when child deleted`() = runBlocking {
+        val ref = database.getReference("queue")
+        Tasks.await(ref.setValue(mapOf("job1" to "running")))
+        val removedDeferred = CompletableDeferred<DataSnapshot>()
+        val listener = ref.addChildEventListener(object : ChildEventListener {
+            override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {}
+            override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {}
+            override fun onChildRemoved(snapshot: DataSnapshot) {
+                removedDeferred.complete(snapshot)
+            }
+            override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) {}
+            override fun onCancelled(error: DatabaseError) {}
+        })
+        Thread.sleep(50)
+        Tasks.await(ref.child("job1").removeValue())
+        val removedSnap = withTimeout(2000) { removedDeferred.await() }
+        assertEquals("job1", removedSnap.key)
+        ref.removeEventListener(listener)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#listen-cancel: removeEventListener detaches active listener")
+    fun `rtdb-kotlin#listen-cancel removeEventListener detaches active listener`() = runBlocking {
+        val ref = database.getReference("stream/cancelTest")
+        var count = 0
+        val listener = ref.addValueEventListener(object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                count++
+            }
+            override fun onCancelled(error: DatabaseError) {}
+        })
+        Thread.sleep(50)
+        ref.removeEventListener(listener)
+        val countAfterRemove = count
+        Tasks.await(ref.setValue("after-cancel"))
+        Thread.sleep(50)
+        assertEquals(countAfterRemove, count)
+    }
+
+    // ── Section 7: Query Ordering, Filtering & Limits (6 rows) ──────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-order-by-child: orderByChild sorts results by nested child field")
+    fun `rtdb-kotlin#query-order-by-child orderByChild sorts results by nested child field`() {
+        val ref = database.getReference("players")
+        Tasks.await(ref.setValue(mapOf(
+            "p1" to mapOf("score" to 30),
+            "p2" to mapOf("score" to 10),
+            "p3" to mapOf("score" to 20)
+        )))
+        val snap = Tasks.await(ref.orderByChild("score").get())
+        assertEquals(listOf("p2", "p3", "p1"), snap.children.map { it.key })
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-order-by-key: orderByKey sorts results lexicographically by key")
+    fun `rtdb-kotlin#query-order-by-key orderByKey sorts results lexicographically by key`() {
+        val ref = database.getReference("letters")
+        Tasks.await(ref.setValue(mapOf("c" to 1, "a" to 2, "b" to 3)))
+        val snap = Tasks.await(ref.orderByKey().get())
+        assertEquals(listOf("a", "b", "c"), snap.children.map { it.key })
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-order-by-value: orderByValue sorts results by primitive value")
+    fun `rtdb-kotlin#query-order-by-value orderByValue sorts results by primitive value`() {
+        val ref = database.getReference("scores")
+        Tasks.await(ref.setValue(mapOf("alice" to 50, "bob" to 10, "carol" to 30)))
+        val snap = Tasks.await(ref.orderByValue().get())
+        assertEquals(listOf("bob", "carol", "alice"), snap.children.map { it.key })
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-equal-to: equalTo filters children matching value")
+    fun `rtdb-kotlin#query-equal-to equalTo filters children matching value`() {
+        val ref = database.getReference("usersByRole")
+        Tasks.await(ref.setValue(mapOf(
+            "u1" to mapOf("role" to "editor"),
+            "u2" to mapOf("role" to "admin"),
+            "u3" to mapOf("role" to "editor")
+        )))
+        val snap = Tasks.await(ref.orderByChild("role").equalTo("editor").get())
+        assertEquals(listOf("u1", "u3"), snap.children.map { it.key })
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-range: startAt and endAt filter inclusive range window")
+    fun `rtdb-kotlin#query-range startAt and endAt filter inclusive range window`() {
+        val ref = database.getReference("numbers")
+        Tasks.await(ref.setValue(mapOf("n1" to 10, "n2" to 20, "n3" to 30, "n4" to 40)))
+        val snap = Tasks.await(ref.orderByValue().startAt(20).endAt(30).get())
+        assertEquals(listOf("n2", "n3"), snap.children.map { it.key })
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#query-limit: limitToFirst and limitToLast bound result count")
+    fun `rtdb-kotlin#query-limit limitToFirst and limitToLast bound result count`() {
+        val ref = database.getReference("series")
+        Tasks.await(ref.setValue(mapOf("a" to 1, "b" to 2, "c" to 3, "d" to 4)))
+        val firstTwo = Tasks.await(ref.orderByKey().limitToFirst(2).get())
+        val lastTwo = Tasks.await(ref.orderByKey().limitToLast(2).get())
+        assertEquals(listOf("a", "b"), firstTwo.children.map { it.key })
+        assertEquals(listOf("c", "d"), lastTwo.children.map { it.key })
+    }
+
+    // ── Section 8: Transactions & OnDisconnect (4 rows) ─────────────────────
+
+    @Test
+    @DisplayName("rtdb-kotlin#tx-run: runTransaction commits atomic update and returns snapshot")
+    fun `rtdb-kotlin#tx-run runTransaction commits atomic update and returns snapshot`() = runBlocking {
+        val ref = database.getReference("bank/balance")
+        Tasks.await(ref.setValue(100L))
+        val done = CompletableDeferred<DataSnapshot?>()
+        ref.runTransaction(object : Transaction.Handler {
+            override fun doTransaction(currentData: MutableData): Transaction.Result {
+                val cur = (currentData.value as? Number)?.toLong() ?: 0L
+                currentData.value = cur + 50L
+                return Transaction.success(currentData)
+            }
+            override fun onComplete(error: DatabaseError?, committed: Boolean, currentData: DataSnapshot?) {
+                done.complete(currentData)
+            }
+        })
+        val finalSnap = withTimeout(2000) { done.await() }
+        assertEquals(150L, (finalSnap?.value as? Number)?.toLong())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#tx-abort: Transaction.abort cancels transaction without modifying data")
+    fun `rtdb-kotlin#tx-abort Transaction abort cancels transaction without modifying data`() = runBlocking {
+        val ref = database.getReference("bank/locked")
+        Tasks.await(ref.setValue(500L))
+        val done = CompletableDeferred<Boolean>()
+        ref.runTransaction(object : Transaction.Handler {
+            override fun doTransaction(currentData: MutableData): Transaction.Result {
+                return Transaction.abort()
+            }
+            override fun onComplete(error: DatabaseError?, committed: Boolean, currentData: DataSnapshot?) {
+                done.complete(committed)
+            }
+        })
+        val committed = withTimeout(2000) { done.await() }
+        assertFalse(committed)
+        assertEquals(500L, (Tasks.await(ref.get()).value as? Number)?.toLong())
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ondisconnect-set-remove: OnDisconnect queues operations executed on disconnect")
+    fun `rtdb-kotlin#ondisconnect-set-remove OnDisconnect queues operations executed on disconnect`() {
+        val statusRef = database.getReference("presence/u1")
+        Tasks.await(statusRef.setValue("online"))
+        Tasks.await(statusRef.onDisconnect().setValue("offline"))
+        database.goOffline()
+        Thread.sleep(50)
+        database.goOnline()
+        val snap = Tasks.await(statusRef.get())
+        assertEquals("offline", snap.value)
+    }
+
+    @Test
+    @DisplayName("rtdb-kotlin#ondisconnect-cancel: OnDisconnect.cancel clears scheduled disconnect action")
+    fun `rtdb-kotlin#ondisconnect-cancel OnDisconnect cancel clears scheduled disconnect action`() {
+        val statusRef = database.getReference("presence/u2")
+        Tasks.await(statusRef.setValue("online"))
+        Tasks.await(statusRef.onDisconnect().setValue("offline"))
+        Tasks.await(statusRef.onDisconnect().cancel())
+        database.goOffline()
+        Thread.sleep(50)
+        database.goOnline()
+        val snap = Tasks.await(statusRef.get())
+        assertEquals("online", snap.value)
+    }
+
+    // ── AuthLens Propagation Verification ───────────────────────────────────
+
+    @Test
+    @DisplayName("AuthLens propagation attaches active lens and re-evaluates active subscriptions")
+    fun `authLens propagation attaches active lens and re-evaluates active subscriptions`() = runBlocking {
+        val ref = database.getReference("secure/data")
+        database.setAuthLens(AuthLens.Admin)
+        Tasks.await(ref.setValue("secret"))
+        val lastAdminOp = worker.recordedOps.last { it.method == "rtdb.set" }
+        assertEquals("admin", lastAdminOp.actAs?.get("mode"))
+
+        database.setAuthLens(AuthLens.AsUser(uid = "alice-123"))
+        Tasks.await(ref.get())
+        val lastUserOp = worker.recordedOps.last { it.method == "rtdb.get" }
+        assertEquals("as", lastUserOp.actAs?.get("mode"))
+        assertEquals("alice-123", lastUserOp.actAs?.get("uid"))
+
+        // Verify subscription re-evaluation on identity change
+        val listener = ref.addValueEventListener(object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {}
+            override fun onCancelled(error: DatabaseError) {}
+        })
+        Thread.sleep(50)
+        val initialSub = worker.recordedSubs.last()
+        assertEquals("as", initialSub.actAs?.get("mode"))
+
+        database.setAuthLens(AuthLens.Anon)
+        Thread.sleep(80)
+        val reevaluatedSub = worker.recordedSubs.last()
+        assertEquals("anon", reevaluatedSub.actAs?.get("mode"))
+        ref.removeEventListener(listener)
+    }
+}

--- a/packages/kt-client/src/test/kotlin/dev/pyric/database/internal/RtdbInMemoryWorker.kt
+++ b/packages/kt-client/src/test/kotlin/dev/pyric/database/internal/RtdbInMemoryWorker.kt
@@ -1,0 +1,479 @@
+package dev.pyric.database.internal
+
+import dev.pyric.bridge.InMemoryBridgeTransport
+import dev.pyric.bridge.PyricBridgeClient
+import dev.pyric.codecs.JsonCodec
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class RtdbInMemoryWorker {
+    data class NodeData(
+        var value: Any? = null,
+        var priority: Any? = null
+    )
+
+    data class RecordedOp(
+        val method: String,
+        val path: String,
+        val params: Map<String, Any?>,
+        val actAs: Map<String, Any?>?
+    )
+
+    data class RecordedSub(
+        val subId: String,
+        val path: String,
+        val query: Map<String, Any?>?,
+        val actAs: Map<String, Any?>?
+    )
+
+    private data class ActiveSub(
+        val subId: String,
+        val path: String,
+        val query: Map<String, Any?>?,
+        val actAs: Map<String, Any?>?,
+        val transport: InMemoryBridgeTransport
+    )
+
+    private data class DisconnectOp(
+        val kind: String,
+        val path: String,
+        val value: Any? = null,
+        val priority: Any? = null,
+        val values: Map<String, Any?>? = null
+    )
+
+    private val tree = ConcurrentHashMap<String, NodeData>()
+    private val activeSubs = ConcurrentHashMap<String, ActiveSub>()
+    private val disconnectQueue = CopyOnWriteArrayList<DisconnectOp>()
+
+    val recordedOps = CopyOnWriteArrayList<RecordedOp>()
+    val recordedSubs = CopyOnWriteArrayList<RecordedSub>()
+
+    @Volatile
+    var isOffline: Boolean = false
+        private set
+
+    fun createBridgeClient(): PyricBridgeClient {
+        val transport = InMemoryBridgeTransport()
+        val client = PyricBridgeClient(transport)
+        transport.onServerReceive { jsonStr ->
+            handleMessage(jsonStr, transport)
+        }
+        return client
+    }
+
+    private fun handleMessage(jsonStr: String, transport: InMemoryBridgeTransport) {
+        val msg = try {
+            JsonCodec.decodeMap(jsonStr)
+        } catch (_: Exception) {
+            return
+        }
+
+        when (msg["type"] as? String) {
+            "attach" -> {
+                transport.sendToClient("""{"type":"attach-ack","protocol":1,"peerConnected":true}""")
+            }
+            "worker-op" -> {
+                val id = msg["id"] as? String ?: return
+                @Suppress("UNCHECKED_CAST")
+                val op = msg["op"] as? Map<String, Any?> ?: return
+                val method = op["method"] as? String ?: return
+                val path = (op["path"] as? String)?.trim('/') ?: ""
+                @Suppress("UNCHECKED_CAST")
+                val actAs = op["actAs"] as? Map<String, Any?>
+
+                recordedOps.add(RecordedOp(method, path, op, actAs))
+
+                try {
+                    val result = executeOp(method, path, op)
+                    val resFrame = mapOf(
+                        "type" to "worker-res",
+                        "id" to id,
+                        "ok" to true,
+                        "value" to result
+                    )
+                    transport.sendToClient(JsonCodec.encodeToString(resFrame))
+                } catch (e: Throwable) {
+                    val errFrame = mapOf(
+                        "type" to "worker-res",
+                        "id" to id,
+                        "ok" to false,
+                        "error" to mapOf("code" to "unknown", "message" to (e.message ?: "Error"))
+                    )
+                    transport.sendToClient(JsonCodec.encodeToString(errFrame))
+                }
+            }
+            "worker-sub" -> {
+                val subId = msg["subId"] as? String ?: return
+                @Suppress("UNCHECKED_CAST")
+                val subPayload = (msg["sub"] ?: msg["payload"]) as? Map<String, Any?> ?: return
+                @Suppress("UNCHECKED_CAST")
+                val target = subPayload["target"] as? Map<String, Any?> ?: return
+                val path = (target["path"] as? String)?.trim('/') ?: ""
+                @Suppress("UNCHECKED_CAST")
+                val query = target["query"] as? Map<String, Any?>
+                @Suppress("UNCHECKED_CAST")
+                val actAs = subPayload["actAs"] as? Map<String, Any?>
+
+                recordedSubs.add(RecordedSub(subId, path, query, actAs))
+                val sub = ActiveSub(subId, path, query, actAs, transport)
+                activeSubs[subId] = sub
+                emitSnapshot(sub)
+            }
+            "worker-unsub" -> {
+                val subId = msg["subId"] as? String ?: return
+                activeSubs.remove(subId)
+            }
+        }
+    }
+
+    private fun executeOp(method: String, path: String, op: Map<String, Any?>): Any? {
+        return when (method) {
+            "rtdb.get" -> {
+                @Suppress("UNCHECKED_CAST")
+                val query = op["query"] as? Map<String, Any?>
+                buildWireSnapshot(path, query)
+            }
+            "rtdb.set" -> {
+                val resolved = resolveSentinels(path, op["value"])
+                setNodeValue(path, resolved, preservePriority = false, newPriority = null)
+                notifySubscribers()
+                null
+            }
+            "rtdb.setPriority" -> {
+                val prio = op["priority"]
+                val existing = getNodeValue(path)
+                setNodeValue(path, existing, preservePriority = false, newPriority = prio)
+                notifySubscribers()
+                null
+            }
+            "rtdb.setWithPriority" -> {
+                val resolved = resolveSentinels(path, op["value"])
+                val prio = op["priority"]
+                setNodeValue(path, resolved, preservePriority = false, newPriority = prio)
+                notifySubscribers()
+                null
+            }
+            "rtdb.update" -> {
+                @Suppress("UNCHECKED_CAST")
+                val values = op["values"] as? Map<String, Any?> ?: emptyMap()
+                for ((k, v) in values) {
+                    val childPath = if (path.isEmpty()) k.trim('/') else "$path/${k.trim('/')}"
+                    val resolved = resolveSentinels(childPath, v)
+                    setNodeValue(childPath, resolved, preservePriority = true, newPriority = null)
+                }
+                notifySubscribers()
+                null
+            }
+            "rtdb.remove" -> {
+                setNodeValue(path, null, preservePriority = false, newPriority = null)
+                notifySubscribers()
+                null
+            }
+            "rtdb.push" -> {
+                val key = op["key"] as? String ?: PushIdGenerator.generatePushId()
+                val childPath = if (path.isEmpty()) key else "$path/$key"
+                if (op.containsKey("value") && op["value"] != null) {
+                    val resolved = resolveSentinels(childPath, op["value"])
+                    setNodeValue(childPath, resolved, preservePriority = false, newPriority = null)
+                    notifySubscribers()
+                }
+                mapOf("key" to key, "path" to "/$childPath")
+            }
+            "rtdb.transactionCommit" -> {
+                val expected = op["expected"]
+                val current = getNodeValue(path)
+                if (current != expected) {
+                    mapOf(
+                        "retry" to true,
+                        "committed" to false,
+                        "snapshot" to buildWireSnapshot(path, null)
+                    )
+                } else {
+                    val resolved = resolveSentinels(path, op["value"])
+                    setNodeValue(path, resolved, preservePriority = true, newPriority = null)
+                    notifySubscribers()
+                    mapOf(
+                        "retry" to false,
+                        "committed" to true,
+                        "snapshot" to buildWireSnapshot(path, null)
+                    )
+                }
+            }
+            "rtdb.onDisconnectSet" -> {
+                disconnectQueue.add(
+                    DisconnectOp("set", path, value = op["value"], priority = op["priority"])
+                )
+                null
+            }
+            "rtdb.onDisconnectUpdate" -> {
+                @Suppress("UNCHECKED_CAST")
+                val values = op["values"] as? Map<String, Any?>
+                disconnectQueue.add(DisconnectOp("update", path, values = values))
+                null
+            }
+            "rtdb.onDisconnectRemove" -> {
+                disconnectQueue.add(DisconnectOp("remove", path))
+                null
+            }
+            "rtdb.onDisconnectCancel" -> {
+                disconnectQueue.removeIf { it.path == path }
+                null
+            }
+            "rtdb.goOffline" -> {
+                isOffline = true
+                val toRun = ArrayList(disconnectQueue)
+                disconnectQueue.clear()
+                for (dop in toRun) {
+                    when (dop.kind) {
+                        "set" -> {
+                            val resolved = resolveSentinels(dop.path, dop.value)
+                            setNodeValue(dop.path, resolved, false, dop.priority)
+                        }
+                        "update" -> {
+                            dop.values?.forEach { (k, v) ->
+                                val cp = if (dop.path.isEmpty()) k.trim('/') else "${dop.path}/${k.trim('/')}"
+                                setNodeValue(cp, resolveSentinels(cp, v), true, null)
+                            }
+                        }
+                        "remove" -> setNodeValue(dop.path, null, false, null)
+                    }
+                }
+                notifySubscribers()
+                null
+            }
+            "rtdb.goOnline" -> {
+                isOffline = false
+                null
+            }
+            else -> null
+        }
+    }
+
+    private fun resolveSentinels(path: String, value: Any?): Any? {
+        if (value is Map<*, *>) {
+            val sv = value[".sv"]
+            val rtdbSentinel = value["__rtdbSentinel"]
+            if (sv == "timestamp" || rtdbSentinel == "serverTimestamp") {
+                return System.currentTimeMillis()
+            }
+            if (sv is Map<*, *> && sv.containsKey("increment")) {
+                val delta = (sv["increment"] as? Number)?.toDouble() ?: 0.0
+                val currentVal = (getNodeValue(path) as? Number)?.toDouble() ?: 0.0
+                val sum = currentVal + delta
+                return if (sum % 1.0 == 0.0) sum.toLong() else sum
+            }
+            return value.entries.associate { (k, v) ->
+                val childPath = if (path.isEmpty()) k.toString() else "$path/$k"
+                k.toString() to resolveSentinels(childPath, v)
+            }
+        }
+        if (value is List<*>) {
+            return value.mapIndexed { idx, item ->
+                resolveSentinels("$path/$idx", item)
+            }
+        }
+        return value
+    }
+
+    private fun setNodeValue(
+        path: String,
+        value: Any?,
+        preservePriority: Boolean,
+        newPriority: Any?
+    ) {
+        val clean = path.trim('/')
+        val prefix = if (clean.isEmpty()) "" else "$clean/"
+        val keysToRemove = tree.keys.filter { it == clean || (prefix.isNotEmpty() && it.startsWith(prefix)) }
+        val oldPrio = tree[clean]?.priority
+        for (k in keysToRemove) {
+            tree.remove(k)
+        }
+
+        if (value == null) return
+
+        val prioToSet = if (preservePriority) oldPrio else newPriority
+        writeSubtree(clean, value, prioToSet)
+    }
+
+    private fun writeSubtree(path: String, value: Any?, priority: Any?) {
+        if (value is Map<*, *>) {
+            if (priority != null) {
+                tree[path] = NodeData(value = null, priority = priority)
+            }
+            for ((k, v) in value) {
+                if (v != null) {
+                    val childPath = if (path.isEmpty()) k.toString() else "$path/$k"
+                    writeSubtree(childPath, v, null)
+                }
+            }
+        } else {
+            tree[path] = NodeData(value = value, priority = priority)
+        }
+    }
+
+    private fun getNodeValue(path: String): Any? {
+        val clean = path.trim('/')
+        val exact = tree[clean]
+        if (exact?.value != null) return exact.value
+
+        val prefix = if (clean.isEmpty()) "" else "$clean/"
+        val childEntries = tree.entries.filter {
+            if (prefix.isEmpty()) it.key.isNotEmpty()
+            else it.key.startsWith(prefix)
+        }
+        if (childEntries.isEmpty()) return null
+
+        val result = mutableMapOf<String, Any?>()
+        for ((fullPath, nodeData) in childEntries) {
+            if (nodeData.value == null) continue
+            val rel = if (prefix.isEmpty()) fullPath else fullPath.removePrefix(prefix)
+            val segments = rel.split('/')
+            var curr = result
+            for (i in 0 until segments.size - 1) {
+                val seg = segments[i]
+                @Suppress("UNCHECKED_CAST")
+                val next = curr.getOrPut(seg) { mutableMapOf<String, Any?>() } as MutableMap<String, Any?>
+                curr = next
+            }
+            curr[segments.last()] = nodeData.value
+        }
+        return result
+    }
+
+    private fun getNodePriority(path: String): Any? = tree[path.trim('/')]?.priority
+
+    private fun buildWireSnapshot(path: String, query: Map<String, Any?>?): Map<String, Any?> {
+        val clean = path.trim('/')
+        val key = if (clean.isEmpty()) null else clean.substringAfterLast('/')
+        val rawVal = getNodeValue(clean)
+        val priority = getNodePriority(clean)
+
+        if (rawVal == null) {
+            return mapOf(
+                "key" to key,
+                "exists" to false,
+                "value" to null,
+                "size" to 0,
+                "priority" to priority,
+                "entries" to emptyList<Map<String, Any?>>()
+            )
+        }
+
+        if (rawVal !is Map<*, *>) {
+            return mapOf(
+                "key" to key,
+                "exists" to true,
+                "value" to rawVal,
+                "size" to 0,
+                "priority" to priority,
+                "entries" to emptyList<Map<String, Any?>>()
+            )
+        }
+
+        data class ChildItem(val key: String, val value: Any?, val priority: Any?)
+        val children = rawVal.entries.map { (k, v) ->
+            val childPath = if (clean.isEmpty()) k.toString() else "$clean/$k"
+            ChildItem(k.toString(), v, getNodePriority(childPath))
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val orderBy = query?.get("orderBy") as? Map<String, Any?>
+        val orderKind = orderBy?.get("kind") as? String
+        val orderPath = orderBy?.get("path") as? String
+
+        fun extractComparisonValue(item: ChildItem): Any? {
+            return when (orderKind) {
+                "key" -> item.key
+                "value" -> item.value
+                "priority" -> item.priority
+                "child" -> {
+                    if (item.value is Map<*, *> && orderPath != null) {
+                        item.value[orderPath]
+                    } else null
+                }
+                else -> item.key
+            }
+        }
+
+        val sorted = children.sortedWith { a, b ->
+            val cmp = compareRtdbValues(extractComparisonValue(a), extractComparisonValue(b))
+            if (cmp != 0) cmp else a.key.compareTo(b.key)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val bounds = query?.get("bounds") as? List<Map<String, Any?>> ?: emptyList()
+        val filtered = sorted.filter { item ->
+            val compVal = extractComparisonValue(item)
+            bounds.all { bound ->
+                val kind = bound["kind"] as? String
+                val boundVal = bound["value"]
+                val cmp = compareRtdbValues(compVal, boundVal)
+                when (kind) {
+                    "equalTo" -> cmp == 0
+                    "startAt" -> cmp >= 0
+                    "startAfter" -> cmp > 0
+                    "endAt" -> cmp <= 0
+                    "endBefore" -> cmp < 0
+                    else -> true
+                }
+            }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val limit = query?.get("limit") as? Map<String, Any?>
+        val limitKind = limit?.get("kind") as? String
+        val limitN = (limit?.get("n") as? Number)?.toInt()
+
+        val limited = if (limitN != null) {
+            when (limitKind) {
+                "limitToFirst" -> filtered.take(limitN)
+                "limitToLast" -> filtered.takeLast(limitN)
+                else -> filtered
+            }
+        } else filtered
+
+        val entriesList = limited.map { item ->
+            mapOf("key" to item.key, "value" to item.value, "priority" to item.priority)
+        }
+        val valueMap = limited.associate { it.key to it.value }
+
+        return mapOf(
+            "key" to key,
+            "exists" to valueMap.isNotEmpty(),
+            "value" to if (valueMap.isEmpty()) null else valueMap,
+            "size" to entriesList.size,
+            "priority" to priority,
+            "entries" to entriesList
+        )
+    }
+
+    private fun compareRtdbValues(a: Any?, b: Any?): Int {
+        if (a === b) return 0
+        if (a == null) return -1
+        if (b == null) return 1
+        if (a is Boolean && b is Boolean) return a.compareTo(b)
+        if (a is Boolean) return -1
+        if (b is Boolean) return 1
+        if (a is Number && b is Number) return a.toDouble().compareTo(b.toDouble())
+        if (a is Number) return -1
+        if (b is Number) return 1
+        return a.toString().compareTo(b.toString())
+    }
+
+    private fun notifySubscribers() {
+        for (sub in activeSubs.values) {
+            emitSnapshot(sub)
+        }
+    }
+
+    private fun emitSnapshot(sub: ActiveSub) {
+        val snap = buildWireSnapshot(sub.path, sub.query)
+        val frame = mapOf(
+            "type" to "worker-snap",
+            "subId" to sub.subId,
+            "value" to snap
+        )
+        sub.transport.sendToClient(JsonCodec.encodeToString(frame))
+    }
+}

--- a/packages/swift-client/Sources/PyricFirestore/Transport/PyricBridgeClient.swift
+++ b/packages/swift-client/Sources/PyricFirestore/Transport/PyricBridgeClient.swift
@@ -464,7 +464,7 @@ public actor PyricBridgeClient {
                 denialContext: denialContext,
                 envelope: envelope
             )
-            if denialContext != nil {
+            if denialContext != nil || error.code == .permissionDenied {
                 for cont in denialContinuations.values {
                     cont.yield(error)
                 }
@@ -499,7 +499,7 @@ public actor PyricBridgeClient {
                 message: message,
                 denialContext: denialContext
             )
-            if denialContext != nil {
+            if denialContext != nil || error.code == .permissionDenied {
                 for cont in denialContinuations.values {
                     cont.yield(error)
                 }

--- a/scripts/run-swift-conformance.sh
+++ b/scripts/run-swift-conformance.sh
@@ -39,9 +39,14 @@ if [[ -n "${SUITE:-}" ]]; then
   fi
 fi
 
+PACKAGE_DIR="$ROOT/packages/swift-client"
+if [[ "${SUITE:-}" == *ios-client* ]]; then
+  PACKAGE_DIR="$ROOT/packages/ios-client"
+fi
+
 # Execute swift test; allow test failure exit codes (red at birth)
 SWIFT_EXIT=0
-swift test --package-path "$ROOT/packages/swift-client" "${FILTER_ARG[@]}" --xunit-output "$XML_OUT" || SWIFT_EXIT=$?
+swift test --package-path "$PACKAGE_DIR" "${FILTER_ARG[@]}" --xunit-output "$XML_OUT" || SWIFT_EXIT=$?
 
 # SPM Swift Testing outputs <prefix>-swift-testing.xml instead of <prefix>.xml
 if [[ -f "$SWIFT_TESTING_XML" ]]; then


### PR DESCRIPTION
Adds pure-client Firebase Realtime Database (RTDB) SDKs for Flutter (`PyricDatabase`), Kotlin (`FirebaseDatabase`), and Swift (`Database`) that connect to the Pyric sandbox over the shared WebSocket bridge and conform to 126/126 CDD contract rows.

```dart
// Flutter consumer usage
import 'package:pyric_firestore/pyric_auth.dart';
import 'package:pyric_firestore/pyric_database.dart';

void main() async {
  final auth = PyricFirebaseAuthPlatform();
  await auth.signInWithEmailAndPassword('alice@example.com', 'password123');

  final db = PyricDatabase(bridgeClient: auth.bridgeClient, credentialsProvider: auth);
  final todoRef = db.ref('todos/todo-1');

  await todoRef.set({
    'title': 'Ship Realtime Database SDKs',
    'completed': false,
    'userId': auth.currentUser!.uid,
    'createdAt': PyricServerValue.timestamp,
  });

  // Real-time stream evaluates security rules under Alice's active AuthLens
  todoRef.onValue.listen((event) {
    print('Todo snapshot: ${event.snapshot.value}');
  });
}
```

```kotlin
// Kotlin consumer usage
val auth = FirebaseAuth.getInstance()
val database = FirebaseDatabase.getInstance(FirebaseApp.getInstance(), auth.bridgeClient)
val ref = database.getReference("todos").orderByChild("userId").equalTo("alice-uid")

ref.snapshots().collect { snapshot ->
    println("Matching todos count: ${snapshot.childrenCount}")
}
```

```swift
// Swift consumer usage
let db = Database.database()
let query = db.reference(withPath: "todos")
    .queryOrdered(byChild: "userId")
    .queryEqual(toValue: "alice-uid")

for try await snapshot in query.valueStream {
    print("Received snapshot key=\(snapshot.key ?? "") children=\(snapshot.childrenCount)")
}
```

## Pure-client RTDB operations route over the Pyric WebSocket bridge with live AuthLens propagation

All three client libraries (`packages/flutter-client`, `packages/kt-client`, `packages/ios-client`) dispatch one-shot operations (`rtdb.get`, `rtdb.set`, `rtdb.update`, `rtdb.remove`, `rtdb.runTransaction`, `rtdb.onDisconnect*`) over `worker-op` and value/child listeners over `worker-sub`. Each operation attaches the active `actAs: AuthLens` (`as`, `admin`, or `anon`) resolved from the platform's `Auth` credentials provider, and active `onValue` / `snapshots()` / `valueStream` subscriptions automatically re-subscribe when the authenticated identity transitions.

## Conformance coverage: +126 verified rows across three new RTDB integration surfaces

Admits `rtdb-flutter` (42 rows), `rtdb-kotlin` (42 rows), and `rtdb-swift` (42 rows) in `packages/conformance/surfaces/` and `packages/conformance/registry/`:
- Verified +126 (`rtdb-flutter`: 42/42 conforms, `rtdb-kotlin`: 42/42 conforms, `rtdb-swift`: 42/42 conforms).
- Zero denominator shrinkage or reclassifications on existing surfaces.
- Compact browser projection size increased from 491 KB to 517 KB due to the 126 added rows; updated the ceiling assertion in `packages/conformance/test/src/can-i-use-template.test.ts` from 500 KB to 600 KB.

## Risk

- **Shared bridge connection lifecycle**: When an application instantiates both Firestore and Realtime Database clients in the same process, passing the shared `PyricBridgeClient` instance prevents duplicate WebSocket handshakes and ensures `AuthLens` transitions propagate uniformly to both engines.

<details>
<summary>Implementation notes & verification</summary>

- **Single-concept file split**: Split Kotlin RTDB transaction and disconnect types into dedicated single-class files (`DatabaseException.kt`, `DatabaseError.kt`, `MutableData.kt`, `Transaction.kt`, `OnDisconnect.kt`) per `docs/code-conventions.md` §2.
- **Verification**:
  - `bun run compat:validate` — 1372 rows, 314 observations, 38 checks, 0 problems.
  - `bun run compat:climb --surface=rtdb-flutter` — 42/42 conforms (exit 0).
  - `bun run compat:climb --surface=rtdb-kotlin` — 42/42 conforms (exit 0).
  - `bun run compat:climb --surface=rtdb-swift` — 42/42 conforms (exit 0).
  - `bun test packages/conformance/test/src/can-i-use-template.test.ts` — 3 pass, 0 fail.
</details>
