### PR TITLE
feat(examples): Dual-engine (RTDB + Firestore) Auth sample apps for Flutter, Swift, and Android

### DIFF
--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/FirestoreTodoRepository.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/FirestoreTodoRepository.kt
@@ -4,67 +4,157 @@ import com.google.android.gms.tasks.await
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.snapshots
+import dev.pyric.database.FirebaseDatabase
+import dev.pyric.database.ServerValue
+import dev.pyric.database.snapshots
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 
 /**
- * Firestore-backed implementation of [TodoRepository] using Pyric's pure-Kotlin SDK.
+ * Multi-engine implementation of [TodoRepository] supporting both Realtime Database (RTDB)
+ * and Cloud Firestore using Pyric's pure-Kotlin SDKs.
  */
 class FirestoreTodoRepository(
-    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
+    private val database: FirebaseDatabase = FirebaseDatabase.getInstance(
+        com.google.firebase.FirebaseApp.getInstance(),
+        firestore.bridgeClient
+    )
 ) : TodoRepository {
+
+    private val _activeEngine = MutableStateFlow(DatabaseEngine.RTDB)
+    override val activeEngine: StateFlow<DatabaseEngine> = _activeEngine.asStateFlow()
+
+    override fun setEngine(engine: DatabaseEngine) {
+        _activeEngine.value = engine
+    }
 
     private val collection = firestore.collection(COLLECTION_NAME)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun getTodosStream(userId: String): Flow<List<Todo>> {
-        return collection
-            .whereEqualTo(FIELD_USER_ID, userId)
-            .snapshots()
-            .map { snapshot ->
-                snapshot.documents
-                    .map { doc -> Todo.fromSnapshot(doc) }
-                    .sortedWith(
-                        compareByDescending<Todo> { it.createdAt?.seconds ?: Long.MAX_VALUE }
-                            .thenByDescending { it.id }
-                    )
+        return _activeEngine.flatMapLatest { engine ->
+            when (engine) {
+                DatabaseEngine.RTDB -> {
+                    database.getReference(COLLECTION_NAME)
+                        .orderByChild(FIELD_USER_ID)
+                        .equalTo(userId)
+                        .snapshots()
+                        .map { snapshot ->
+                            snapshot.children
+                                .map { childSnap -> Todo.fromRtdbSnapshot(childSnap) }
+                                .sortedWith(
+                                    compareByDescending<Todo> { it.createdAt?.seconds ?: Long.MAX_VALUE }
+                                        .thenByDescending { it.id }
+                                )
+                        }
+                }
+                DatabaseEngine.FIRESTORE -> {
+                    collection
+                        .whereEqualTo(FIELD_USER_ID, userId)
+                        .snapshots()
+                        .map { snapshot ->
+                            snapshot.documents
+                                .map { doc -> Todo.fromSnapshot(doc) }
+                                .sortedWith(
+                                    compareByDescending<Todo> { it.createdAt?.seconds ?: Long.MAX_VALUE }
+                                        .thenByDescending { it.id }
+                                )
+                        }
+                }
             }
+        }
     }
 
     override suspend fun addTodo(title: String, userId: String) {
         val trimmed = title.trim()
         require(trimmed.isNotEmpty()) { "Todo title cannot be blank" }
 
-        val documentData = mapOf(
-            FIELD_TITLE to trimmed,
-            FIELD_COMPLETED to false,
-            FIELD_USER_ID to userId,
-            FIELD_CREATED_AT to FieldValue.serverTimestamp()
-        )
-        collection.add(documentData).await()
+        when (_activeEngine.value) {
+            DatabaseEngine.RTDB -> {
+                val data = mapOf(
+                    FIELD_TITLE to trimmed,
+                    FIELD_COMPLETED to false,
+                    FIELD_USER_ID to userId,
+                    FIELD_CREATED_AT to ServerValue.TIMESTAMP
+                )
+                database.getReference(COLLECTION_NAME).push().setValue(data).await()
+            }
+            DatabaseEngine.FIRESTORE -> {
+                val documentData = mapOf(
+                    FIELD_TITLE to trimmed,
+                    FIELD_COMPLETED to false,
+                    FIELD_USER_ID to userId,
+                    FIELD_CREATED_AT to FieldValue.serverTimestamp()
+                )
+                collection.add(documentData).await()
+            }
+        }
     }
 
     override suspend fun triggerUnauthorizedWrite() {
-        val documentData = mapOf(
-            FIELD_TITLE to "Unauthorized Hacker Todo",
-            FIELD_COMPLETED to false,
-            FIELD_USER_ID to "attacker-wrong-uid-999",
-            FIELD_CREATED_AT to FieldValue.serverTimestamp()
-        )
-        collection.add(documentData).await()
+        when (_activeEngine.value) {
+            DatabaseEngine.RTDB -> {
+                val data = mapOf(
+                    FIELD_TITLE to "Unauthorized Hacker Todo (RTDB)",
+                    FIELD_COMPLETED to false,
+                    FIELD_USER_ID to "attacker-wrong-uid-999",
+                    FIELD_CREATED_AT to ServerValue.TIMESTAMP
+                )
+                database.getReference(COLLECTION_NAME).push().setValue(data).await()
+            }
+            DatabaseEngine.FIRESTORE -> {
+                val documentData = mapOf(
+                    FIELD_TITLE to "Unauthorized Hacker Todo",
+                    FIELD_COMPLETED to false,
+                    FIELD_USER_ID to "attacker-wrong-uid-999",
+                    FIELD_CREATED_AT to FieldValue.serverTimestamp()
+                )
+                collection.add(documentData).await()
+            }
+        }
     }
 
     override suspend fun toggleTodo(id: String, completed: Boolean) {
         require(id.isNotEmpty()) { "Todo ID cannot be empty" }
-        collection.document(id).update(FIELD_COMPLETED, !completed).await()
+        when (_activeEngine.value) {
+            DatabaseEngine.RTDB -> {
+                database.getReference("$COLLECTION_NAME/$id")
+                    .updateChildren(mapOf(FIELD_COMPLETED to !completed))
+                    .await()
+            }
+            DatabaseEngine.FIRESTORE -> {
+                collection.document(id).update(FIELD_COMPLETED, !completed).await()
+            }
+        }
     }
 
     override suspend fun deleteTodo(id: String) {
         require(id.isNotEmpty()) { "Todo ID cannot be empty" }
-        collection.document(id).delete().await()
+        when (_activeEngine.value) {
+            DatabaseEngine.RTDB -> {
+                database.getReference("$COLLECTION_NAME/$id").removeValue().await()
+            }
+            DatabaseEngine.FIRESTORE -> {
+                collection.document(id).delete().await()
+            }
+        }
     }
 
     override fun isBridgeConnected(): Boolean {
-        return firestore.bridgeClient.isConnected
+        return database.bridgeClient.isConnected || firestore.bridgeClient.isConnected
+    }
+
+    override fun bridgeConnectionFlow(): Flow<Boolean> {
+        return kotlinx.coroutines.flow.combine(
+            database.bridgeClient.connectionStateFlow,
+            firestore.bridgeClient.connectionStateFlow
+        ) { dbConn, fsConn -> dbConn || fsConn }
     }
 
     companion object {

--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/Todo.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/Todo.kt
@@ -27,5 +27,25 @@ data class Todo(
                 createdAt = snapshot.getTimestamp("createdAt")
             )
         }
+
+        fun fromRtdbSnapshot(snapshot: dev.pyric.database.DataSnapshot): Todo {
+            val map = snapshot.value as? Map<*, *>
+            val rawCreatedAt = map?.get("createdAt")
+            val timestamp = when (rawCreatedAt) {
+                is Number -> {
+                    val millis = rawCreatedAt.toLong()
+                    Timestamp(millis / 1000L, ((millis % 1000L) * 1_000_000L).toInt())
+                }
+                is Timestamp -> rawCreatedAt
+                else -> null
+            }
+            return Todo(
+                id = snapshot.key.orEmpty(),
+                title = (map?.get("title") as? String).orEmpty(),
+                completed = (map?.get("completed") as? Boolean) ?: false,
+                userId = (map?.get("userId") as? String).orEmpty(),
+                createdAt = timestamp
+            )
+        }
     }
 }

--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/TodoRepository.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/data/TodoRepository.kt
@@ -1,12 +1,24 @@
 package dev.pyric.example.todo.data
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 
+enum class DatabaseEngine(val label: String) {
+    RTDB("Realtime Database (RTDB)"),
+    FIRESTORE("Cloud Firestore")
+}
+
 /**
- * Contract for managing Todo data operations.
+ * Contract for managing Todo data operations across Realtime Database (RTDB) and Cloud Firestore.
  */
 interface TodoRepository {
+    val activeEngine: StateFlow<DatabaseEngine>
+        get() = MutableStateFlow(DatabaseEngine.RTDB)
+
+    fun setEngine(engine: DatabaseEngine) {}
+
     /**
      * Real-time stream of todos filtered by user ID, ordered by creation time descending.
      */
@@ -43,7 +55,12 @@ interface TodoRepository {
     suspend fun deleteTodo(id: String)
 
     /**
-     * Returns whether the underlying Firestore bridge client is currently connected.
+     * Returns whether the underlying Pyric bridge client is currently connected.
      */
     fun isBridgeConnected(): Boolean
+
+    /**
+     * Reactive stream of bridge connection state.
+     */
+    fun bridgeConnectionFlow(): Flow<Boolean> = MutableStateFlow(isBridgeConnected())
 }

--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/screens/TodoScreen.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/screens/TodoScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +27,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import dev.pyric.example.todo.data.DatabaseEngine
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -98,6 +100,14 @@ fun TodoScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 6.dp)
+                )
+
+                DatabaseEngineRow(
+                    selectedEngine = state.activeEngine,
+                    onEngineSelected = viewModel::setEngine,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp)
                 )
 
                 TodoFilterRow(
@@ -244,5 +254,26 @@ private fun UnauthenticatedContent(
             color = MaterialTheme.colorScheme.outline,
             textAlign = TextAlign.Center
         )
+    }
+}
+
+@Composable
+private fun DatabaseEngineRow(
+    selectedEngine: DatabaseEngine,
+    onEngineSelected: (DatabaseEngine) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        DatabaseEngine.entries.forEach { engine ->
+            FilterChip(
+                selected = selectedEngine == engine,
+                onClick = { onEngineSelected(engine) },
+                label = { Text(engine.label) },
+                modifier = Modifier.weight(1f)
+            )
+        }
     }
 }

--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/viewmodel/TodoUiState.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/viewmodel/TodoUiState.kt
@@ -1,5 +1,6 @@
 package dev.pyric.example.todo.ui.viewmodel
 
+import dev.pyric.example.todo.data.DatabaseEngine
 import dev.pyric.example.todo.data.Todo
 import dev.pyric.example.todo.data.TodoFilter
 
@@ -10,6 +11,7 @@ data class TodoUiState(
     val todos: List<Todo> = emptyList(),
     val filteredTodos: List<Todo> = emptyList(),
     val filter: TodoFilter = TodoFilter.ALL,
+    val activeEngine: DatabaseEngine = DatabaseEngine.RTDB,
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
     val isConnected: Boolean = false,

--- a/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/viewmodel/TodoViewModel.kt
+++ b/examples/android-todo-app/app/src/main/kotlin/dev/pyric/example/todo/ui/viewmodel/TodoViewModel.kt
@@ -65,9 +65,13 @@ class TodoViewModel(
         todosStream,
         effectiveUserFlow,
         _filter,
-        _errorMessage,
-        _isOperationInProgress
-    ) { todos, (uid, email), filter, error, inProgress ->
+        repository.activeEngine,
+        combine(
+            _errorMessage,
+            _isOperationInProgress,
+            repository.bridgeConnectionFlow()
+        ) { error, inProgress, connected -> Triple(error, inProgress, connected) }
+    ) { todos, (uid, email), filter, engine, (error, inProgress, connected) ->
         val filtered = when (filter) {
             TodoFilter.ALL -> todos
             TodoFilter.ACTIVE -> todos.filter { !it.completed }
@@ -80,9 +84,10 @@ class TodoViewModel(
             todos = todos,
             filteredTodos = filtered,
             filter = filter,
+            activeEngine = engine,
             isLoading = inProgress && todos.isEmpty(),
             errorMessage = error,
-            isConnected = repository.isBridgeConnected() && error == null,
+            isConnected = connected && error == null,
             currentUserId = uid,
             currentUserEmail = email,
             activeCount = activeCount,
@@ -93,6 +98,10 @@ class TodoViewModel(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = TodoUiState(isLoading = true)
     )
+
+    fun setEngine(engine: dev.pyric.example.todo.data.DatabaseEngine) {
+        repository.setEngine(engine)
+    }
 
     fun setFilter(filter: TodoFilter) {
         _filter.value = filter

--- a/examples/android-todo-app/app/src/test/kotlin/dev/pyric/example/todo/data/FirestoreTodoRepositoryTest.kt
+++ b/examples/android-todo-app/app/src/test/kotlin/dev/pyric/example/todo/data/FirestoreTodoRepositoryTest.kt
@@ -1,11 +1,9 @@
 package dev.pyric.example.todo.data
 
-import com.google.firebase.FirebaseApp
-import com.google.firebase.FirebaseOptions
 import com.google.firebase.firestore.FirebaseFirestore
 import dev.pyric.bridge.InMemoryBridgeTransport
-import dev.pyric.bridge.PyricBridgeClient
 import dev.pyric.codecs.JsonCodec
+import dev.pyric.database.FirebaseDatabase
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -21,6 +19,7 @@ class FirestoreTodoRepositoryTest {
 
     private lateinit var transport: InMemoryBridgeTransport
     private lateinit var firestore: FirebaseFirestore
+    private lateinit var database: FirebaseDatabase
     private lateinit var repository: FirestoreTodoRepository
     private val recordedOps = CopyOnWriteArrayList<Map<String, Any?>>()
 
@@ -29,7 +28,9 @@ class FirestoreTodoRepositoryTest {
         recordedOps.clear()
         transport = InMemoryBridgeTransport()
         firestore = dev.pyric.example.todo.TestFirestoreFactory.create(transport)
-        repository = FirestoreTodoRepository(firestore)
+        database = FirebaseDatabase(firestore.bridgeClient, firestore.app)
+        repository = FirestoreTodoRepository(firestore, database)
+        repository.setEngine(DatabaseEngine.FIRESTORE)
 
         transport.onServerReceive { json ->
             val map = JsonCodec.decodeMap(json)
@@ -47,7 +48,7 @@ class FirestoreTodoRepositoryTest {
                     val method = op["method"] as String
 
                     when (method) {
-                        "setDoc", "updateDoc", "deleteDoc" -> {
+                        "setDoc", "updateDoc", "deleteDoc", "rtdb.set", "rtdb.update", "rtdb.remove" -> {
                             transport.sendToClient("""{"type":"worker-res","id":"$id","ok":true}""")
                         }
                         else -> {
@@ -80,6 +81,17 @@ class FirestoreTodoRepositoryTest {
         assertEquals("Buy groceries", data["title"])
         assertEquals(false, data["completed"])
         assertNotNull(data["createdAt"])
+    }
+
+    @Test
+    fun testRtdbAddTodoDispatchesRtdbSetOp() = runBlocking {
+        repository.setEngine(DatabaseEngine.RTDB)
+        repository.addTodo("Buy milk via RTDB", "user-1")
+
+        val op = recordedOps.find { it["method"] == "rtdb.set" }
+        assertNotNull("Expected rtdb.set operation", op)
+        val path = op!!["path"] as String
+        assertTrue("Expected path to start with todos/", path.startsWith("todos/"))
     }
 
     @Test

--- a/examples/android-todo-app/database.rules.json
+++ b/examples/android-todo-app/database.rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "todos": {
+      ".indexOn": ["userId"],
+      ".read": "auth != null && query.orderByChild == 'userId' && query.equalTo == auth.uid",
+      "$todoId": {
+        ".read": "auth != null && (!data.exists() || data.child('userId').val() == auth.uid)",
+        ".write": "auth != null && ((!data.exists() && newData.child('userId').val() == auth.uid) || (data.exists() && data.child('userId').val() == auth.uid && (!newData.exists() || newData.child('userId').val() == auth.uid)))"
+      }
+    }
+  }
+}

--- a/examples/flutter-todo-app/database.rules.json
+++ b/examples/flutter-todo-app/database.rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "todos": {
+      ".indexOn": ["userId"],
+      ".read": "auth != null && query.orderByChild == 'userId' && query.equalTo == auth.uid",
+      "$todoId": {
+        ".read": "auth != null && (!data.exists() || data.child('userId').val() == auth.uid)",
+        ".write": "auth != null && ((!data.exists() && newData.child('userId').val() == auth.uid) || (data.exists() && data.child('userId').val() == auth.uid && (!newData.exists() || newData.child('userId').val() == auth.uid)))"
+      }
+    }
+  }
+}

--- a/examples/flutter-todo-app/lib/main.dart
+++ b/examples/flutter-todo-app/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pyric_firestore/pyric_auth.dart';
+import 'package:pyric_firestore/pyric_database.dart';
 import 'package:pyric_firestore/pyric_debug.dart';
 import 'package:pyric_firestore/pyric_firestore.dart';
 import 'screens/todo_screen.dart';
@@ -8,9 +9,17 @@ import 'services/todo_repository.dart';
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Initialize Pyric pure-Dart platform adapters
-  PyricFirebaseAuthPlatform.registerWith();
-  PyricFirestorePlatform.registerWith();
+  // Initialize Pyric pure-Dart platform adapters with a shared bridge client
+  final auth = PyricFirebaseAuthPlatform();
+  FirebaseAuthPlatform.instance = auth;
+  PyricFirestorePlatform.registerWith(
+    bridgeClient: auth.bridgeClient,
+    credentialsProvider: auth,
+  );
+  PyricDatabase.registerWith(
+    bridgeClient: auth.bridgeClient,
+    credentialsProvider: auth,
+  );
 
   final debugController = PyricDebugController();
   final repository = TodoRepository();

--- a/examples/flutter-todo-app/lib/models/todo_item.dart
+++ b/examples/flutter-todo-app/lib/models/todo_item.dart
@@ -20,6 +20,8 @@ class TodoItem {
     final rawDate = data['createdAt'];
     if (rawDate is DateTime) {
       parsedDate = rawDate;
+    } else if (rawDate is num) {
+      parsedDate = DateTime.fromMillisecondsSinceEpoch(rawDate.toInt());
     } else if (rawDate is Map && rawDate['_seconds'] is num) {
       final seconds = (rawDate['_seconds'] as num).toInt();
       parsedDate = DateTime.fromMillisecondsSinceEpoch(seconds * 1000);

--- a/examples/flutter-todo-app/lib/screens/todo_screen.dart
+++ b/examples/flutter-todo-app/lib/screens/todo_screen.dart
@@ -25,6 +25,20 @@ class _TodoScreenState extends State<TodoScreen> {
   void initState() {
     super.initState();
     _initAuthListener();
+    widget.repository.engineNotifier.addListener(_onEngineChanged);
+  }
+
+  void _onEngineChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.repository.engineNotifier.removeListener(_onEngineChanged);
+    _textController.dispose();
+    super.dispose();
   }
 
   void _initAuthListener() {
@@ -208,10 +222,45 @@ class _TodoScreenState extends State<TodoScreen> {
                 ),
               ),
               TextButton(
-                onPressed: () => FirebaseAuthPlatform.instance.signOut(),
+                onPressed: () async {
+                  final auth = FirebaseAuthPlatform.instance;
+                  if (auth is PyricFirebaseAuthPlatform) {
+                    auth.switchAuthLens(null);
+                  }
+                  await auth.signOut();
+                  if (mounted) {
+                    setState(() {
+                      _effectiveUid = null;
+                      _userDisplay = null;
+                    });
+                  }
+                },
                 child: const Text('Sign Out'),
               ),
             ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+          child: SegmentedButton<DatabaseEngine>(
+            segments: const [
+              ButtonSegment<DatabaseEngine>(
+                value: DatabaseEngine.rtdb,
+                label: Text('Realtime DB (RTDB)'),
+                icon: Icon(Icons.storage_rounded),
+              ),
+              ButtonSegment<DatabaseEngine>(
+                value: DatabaseEngine.firestore,
+                label: Text('Cloud Firestore'),
+                icon: Icon(Icons.cloud_outlined),
+              ),
+            ],
+            selected: {widget.repository.currentEngine},
+            onSelectionChanged: (Set<DatabaseEngine> selection) {
+              if (selection.isNotEmpty) {
+                widget.repository.setEngine(selection.first);
+              }
+            },
           ),
         ),
         Padding(

--- a/examples/flutter-todo-app/lib/services/todo_repository.dart
+++ b/examples/flutter-todo-app/lib/services/todo_repository.dart
@@ -1,16 +1,67 @@
 import 'dart:async';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pyric_firestore/pyric_database.dart';
 import '../models/todo_item.dart';
 
-/// Repository managing Firestore operations for the Todo app.
+enum DatabaseEngine {
+  rtdb('Realtime Database (RTDB)'),
+  firestore('Cloud Firestore');
+
+  final String label;
+  const DatabaseEngine(this.label);
+}
+
+/// Repository managing both Realtime Database (RTDB) and Firestore operations for the Todo app.
 class TodoRepository {
   final FirebaseFirestorePlatform _firestore;
+  final PyricDatabase _rtdb;
+  final ValueNotifier<DatabaseEngine> engineNotifier =
+      ValueNotifier<DatabaseEngine>(DatabaseEngine.rtdb);
 
-  TodoRepository({FirebaseFirestorePlatform? firestore})
-      : _firestore = firestore ?? FirebaseFirestorePlatform.instance;
+  TodoRepository({
+    FirebaseFirestorePlatform? firestore,
+    PyricDatabase? rtdb,
+  })  : _firestore = firestore ?? FirebaseFirestorePlatform.instance,
+        _rtdb = rtdb ?? PyricDatabase.instance;
 
-  /// Emits real-time stream of todos filtered by user ID.
+  DatabaseEngine get currentEngine => engineNotifier.value;
+
+  void setEngine(DatabaseEngine engine) {
+    if (engineNotifier.value != engine) {
+      engineNotifier.value = engine;
+    }
+  }
+
+  /// Emits real-time stream of todos filtered by user ID from the active database engine.
   Stream<List<TodoItem>> getTodosStream(String userId) {
+    if (currentEngine == DatabaseEngine.rtdb) {
+      return _rtdb
+          .ref('todos')
+          .orderByChild('userId')
+          .equalTo(userId)
+          .onValue
+          .map((event) {
+        final raw = event.snapshot.value;
+        if (raw == null || raw is! Map) return <TodoItem>[];
+        final map = Map<String, dynamic>.from(raw);
+        final items = map.entries.map((entry) {
+          final valueMap = entry.value is Map
+              ? Map<String, dynamic>.from(entry.value as Map)
+              : <String, dynamic>{};
+          return TodoItem.fromMap(entry.key, valueMap);
+        }).toList();
+
+        items.sort((a, b) {
+          if (a.createdAt == null) return 1;
+          if (b.createdAt == null) return -1;
+          return b.createdAt!.compareTo(a.createdAt!);
+        });
+
+        return items;
+      });
+    }
+
     return _firestore
         .collection('todos')
         .where([
@@ -32,10 +83,21 @@ class TodoRepository {
     });
   }
 
-  /// Adds a new todo document stamped with the current user ID.
+  /// Adds a new todo item stamped with the current user ID.
   Future<void> addTodo(String title, String userId) async {
     final trimmed = title.trim();
     if (trimmed.isEmpty) return;
+
+    if (currentEngine == DatabaseEngine.rtdb) {
+      final newRef = _rtdb.ref('todos').push();
+      await newRef.set({
+        'title': trimmed,
+        'completed': false,
+        'userId': userId,
+        'createdAt': DateTime.now().millisecondsSinceEpoch,
+      });
+      return;
+    }
 
     final docRef = _firestore.collection('todos').doc();
     await docRef.set({
@@ -48,6 +110,17 @@ class TodoRepository {
 
   /// Deliberately attempts an unauthorized write (mismatched userId) to verify security rules.
   Future<void> triggerUnauthorizedWrite() async {
+    if (currentEngine == DatabaseEngine.rtdb) {
+      final newRef = _rtdb.ref('todos').push();
+      await newRef.set({
+        'title': 'Unauthorized Hacker Todo (RTDB)',
+        'completed': false,
+        'userId': 'attacker-wrong-uid-999',
+        'createdAt': DateTime.now().millisecondsSinceEpoch,
+      });
+      return;
+    }
+
     final docRef = _firestore.collection('todos').doc();
     await docRef.set({
       'title': 'Unauthorized Hacker Todo',
@@ -57,15 +130,27 @@ class TodoRepository {
     });
   }
 
-  /// Toggles the completed status of a todo document.
+  /// Toggles the completed status of a todo item.
   Future<void> toggleTodo(String id, bool completed) async {
+    if (currentEngine == DatabaseEngine.rtdb) {
+      await _rtdb.ref('todos/$id').update({
+        'completed': !completed,
+      });
+      return;
+    }
+
     await _firestore.collection('todos').doc(id).update({
       FieldPath(const ['completed']): !completed,
     });
   }
 
-  /// Deletes a todo document from Firestore.
+  /// Deletes a todo item from the active database engine.
   Future<void> deleteTodo(String id) async {
+    if (currentEngine == DatabaseEngine.rtdb) {
+      await _rtdb.ref('todos/$id').remove();
+      return;
+    }
+
     await _firestore.collection('todos').doc(id).delete();
   }
 }

--- a/examples/flutter-todo-app/pubspec.yaml
+++ b/examples/flutter-todo-app/pubspec.yaml
@@ -12,11 +12,14 @@ dependencies:
     sdk: flutter
   pyric_firestore:
     path: ../../packages/flutter-client
+  cloud_firestore_platform_interface: ^8.0.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  stream_channel: ^2.1.2
+  web_socket_channel: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/examples/shared/database.rules.json
+++ b/examples/shared/database.rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "todos": {
+      ".indexOn": ["userId"],
+      ".read": "auth != null && query.orderByChild == 'userId' && query.equalTo == auth.uid",
+      "$todoId": {
+        ".read": "auth != null && (!data.exists() || data.child('userId').val() == auth.uid)",
+        ".write": "auth != null && ((!data.exists() && newData.child('userId').val() == auth.uid) || (data.exists() && data.child('userId').val() == auth.uid && (!newData.exists() || newData.child('userId').val() == auth.uid)))"
+      }
+    }
+  }
+}

--- a/examples/swift-todo-app/Package.swift
+++ b/examples/swift-todo-app/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../../packages/swift-client")
+        .package(path: "../../packages/swift-client"),
+        .package(path: "../../packages/ios-client")
     ],
     targets: [
         .executableTarget(
@@ -23,6 +24,7 @@ let package = Package(
                 .product(name: "PyricFirestore", package: "swift-client"),
                 .product(name: "FirebaseAuth", package: "swift-client"),
                 .product(name: "PyricDebugUI", package: "swift-client"),
+                .product(name: "PyricDatabase", package: "ios-client")
             ],
             path: "Sources"
         )

--- a/examples/swift-todo-app/Sources/Models/TodoItem.swift
+++ b/examples/swift-todo-app/Sources/Models/TodoItem.swift
@@ -46,6 +46,9 @@ public struct TodoItem: Identifiable, Sendable, Equatable {
             self.createdAt = ts
         } else if let date = data["createdAt"] as? Date {
             self.createdAt = Timestamp(date: date)
+        } else if let num = data["createdAt"] as? NSNumber {
+            let millis = num.doubleValue
+            self.createdAt = Timestamp(date: Date(timeIntervalSince1970: millis / 1000.0))
         } else {
             self.createdAt = nil
         }

--- a/examples/swift-todo-app/Sources/ViewModels/TodoListViewModel.swift
+++ b/examples/swift-todo-app/Sources/ViewModels/TodoListViewModel.swift
@@ -1,8 +1,16 @@
 import Foundation
 import SwiftUI
 import PyricFirestore
+import PyricDatabase
 import FirebaseAuth
 import PyricDebugUI
+
+public enum DatabaseEngine: String, CaseIterable, Identifiable, Sendable {
+    case rtdb = "Realtime Database (RTDB)"
+    case firestore = "Cloud Firestore"
+
+    public var id: String { rawValue }
+}
 
 public struct SecurityRuleDenial: Identifiable, Equatable, Sendable {
     public let id = UUID()
@@ -44,19 +52,30 @@ public final class TodoListViewModel: ObservableObject {
     @Published public private(set) var currentUser: User? = nil
     @Published public private(set) var currentLens: AuthLens = .anon
     @Published public private(set) var effectiveUserId: String? = nil
+    @Published public var activeEngine: DatabaseEngine = .rtdb {
+        didSet {
+            if activeEngine != oldValue {
+                startListening()
+            }
+        }
+    }
 
     private var listenTask: Task<Void, Never>?
     private var authTask: Task<Void, Never>?
     public let db: Firestore
+    public let rtdb: Database
     public let auth: Auth
     public let debugManager: PyricDebugManager
 
     public init(
         firestore: Firestore = Firestore.firestore(),
+        rtdb: Database = Database.database(),
         auth: Auth = Auth.auth()
     ) {
         self.db = firestore
+        self.rtdb = rtdb
         self.auth = auth
+        self.rtdb.credentialProvider = auth
         self.debugManager = PyricDebugManager(firestore: firestore, auth: auth)
         self.currentUser = auth.currentUser
         self.currentLens = auth.currentAuthLens()
@@ -99,7 +118,7 @@ public final class TodoListViewModel: ObservableObject {
         }
     }
 
-    /// Connects to the Pyric sandbox bridge and starts real-time streaming of the 'todos' collection.
+    /// Connects to the Pyric sandbox bridge and starts real-time streaming of the 'todos' data.
     public func startListening() {
         stopListening()
 
@@ -111,6 +130,11 @@ public final class TodoListViewModel: ObservableObject {
         guard let uid = effectiveUserId, !uid.isEmpty else {
             statusMessage = "Not signed in. Tap the Pyric Chip or sign in below."
             todos = []
+            return
+        }
+
+        if activeEngine == .rtdb {
+            startRtdbListening(uid: uid)
             return
         }
 
@@ -127,7 +151,7 @@ public final class TodoListViewModel: ObservableObject {
                     self.hasError = false
                     self.errorMessage = nil
                     self.ruleDenial = nil
-                    self.statusMessage = "Connected as \(uid)"
+                    self.statusMessage = "Connected as \(uid) (Firestore)"
 
                     let mapped = snapshot.documents.compactMap { doc in
                         TodoItem(id: doc.documentID, data: doc.data())
@@ -152,6 +176,48 @@ public final class TodoListViewModel: ObservableObject {
         }
     }
 
+    private func startRtdbListening(uid: String) {
+        let query: DatabaseQuery = (currentLens == .admin)
+            ? rtdb.reference(withPath: "todos")
+            : rtdb.reference(withPath: "todos").queryOrdered(byChild: "userId").queryEqual(toValue: uid)
+
+        listenTask = Task { @MainActor [weak self] in
+            guard let self = self else { return }
+            do {
+                for try await snapshot in query.valueStream {
+                    guard !Task.isCancelled else { break }
+                    self.isConnected = true
+                    self.hasError = false
+                    self.errorMessage = nil
+                    self.ruleDenial = nil
+                    self.statusMessage = "Connected as \(uid) (RTDB)"
+
+                    let childSnaps = (snapshot.children.allObjects as? [DataSnapshot]) ?? []
+                    let mapped = childSnaps.compactMap { childSnap -> TodoItem? in
+                        guard let key = childSnap.key else { return nil }
+                        let data = childSnap.value as? [String: Any] ?? [:]
+                        return TodoItem(id: key, data: data)
+                    }
+
+                    self.todos = mapped.sorted { lhs, rhs in
+                        guard let lDate = lhs.createdAt?.dateValue() else { return false }
+                        guard let rDate = rhs.createdAt?.dateValue() else { return true }
+                        return lDate > rDate
+                    }
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.isConnected = false
+                self.hasError = true
+                self.errorMessage = error.localizedDescription
+                self.statusMessage = "Disconnected: \(error.localizedDescription)"
+                if let bridgeError = error as? PyricBridgeError {
+                    self.extractRuleDenial(bridgeError, operation: "Listen RTDB")
+                }
+            }
+        }
+    }
+
     /// Unsubscribes and cancels the background streaming task.
     public func stopListening() {
         listenTask?.cancel()
@@ -159,7 +225,7 @@ public final class TodoListViewModel: ObservableObject {
         isConnected = false
     }
 
-    /// Adds a new todo document for the active user.
+    /// Adds a new todo item for the active user.
     public func addTodo(title: String) async {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -170,12 +236,22 @@ public final class TodoListViewModel: ObservableObject {
         }
 
         do {
-            _ = try await db.collection("todos").addDocument(data: [
-                "title": trimmed,
-                "completed": false,
-                "userId": uid,
-                "createdAt": FieldValue.serverTimestamp()
-            ])
+            if activeEngine == .rtdb {
+                let ref = rtdb.reference(withPath: "todos").childByAutoId()
+                try await ref.setValue([
+                    "title": trimmed,
+                    "completed": false,
+                    "userId": uid,
+                    "createdAt": ServerValue.timestamp()
+                ])
+            } else {
+                _ = try await db.collection("todos").addDocument(data: [
+                    "title": trimmed,
+                    "completed": false,
+                    "userId": uid,
+                    "createdAt": FieldValue.serverTimestamp()
+                ])
+            }
         } catch {
             handleOperationError(error, operation: "Add task")
         }
@@ -184,33 +260,53 @@ public final class TodoListViewModel: ObservableObject {
     /// Deliberately attempts an unauthorized write (mismatched userId) to verify rule enforcement.
     public func triggerUnauthorizedWrite() async {
         do {
-            _ = try await db.collection("todos").addDocument(data: [
-                "title": "Unauthorized Hacker Todo",
-                "completed": false,
-                "userId": "attacker-wrong-uid-999",
-                "createdAt": FieldValue.serverTimestamp()
-            ])
+            if activeEngine == .rtdb {
+                let ref = rtdb.reference(withPath: "todos").childByAutoId()
+                try await ref.setValue([
+                    "title": "Unauthorized Hacker Todo (RTDB)",
+                    "completed": false,
+                    "userId": "attacker-wrong-uid-999",
+                    "createdAt": ServerValue.timestamp()
+                ])
+            } else {
+                _ = try await db.collection("todos").addDocument(data: [
+                    "title": "Unauthorized Hacker Todo",
+                    "completed": false,
+                    "userId": "attacker-wrong-uid-999",
+                    "createdAt": FieldValue.serverTimestamp()
+                ])
+            }
         } catch {
             handleOperationError(error, operation: "Create unauthorized todo")
         }
     }
 
-    /// Toggles the completion status of a todo document.
+    /// Toggles the completion status of a todo item.
     public func toggleTodo(item: TodoItem) async {
         do {
             let nextState = !item.completed
-            try await db.collection("todos").document(item.id).updateData([
-                "completed": nextState
-            ])
+            if activeEngine == .rtdb {
+                try await rtdb.reference(withPath: "todos/\(item.id)").updateChildValues([
+                    "completed": nextState
+                ])
+            } else {
+                try await db.collection("todos").document(item.id).updateData([
+                    "completed": nextState
+                ])
+            }
         } catch {
             handleOperationError(error, operation: "Toggle task")
         }
     }
 
-    /// Deletes a todo document from Firestore.
+    /// Deletes a todo item from the active database engine.
     public func deleteTodo(item: TodoItem) async {
         do {
-            try await db.collection("todos").document(item.id).delete()
+            if activeEngine == .rtdb {
+                try await rtdb.reference(withPath: "todos/\(item.id)").removeValue()
+            } else {
+                try await db.collection("todos").document(item.id).delete()
+            }
         } catch {
             handleOperationError(error, operation: "Delete task")
         }
@@ -283,7 +379,7 @@ public final class TodoListViewModel: ObservableObject {
         errorMessage = nil
         ruleDenial = nil
         if isConnected, let uid = effectiveUserId {
-            statusMessage = "Connected as \(uid)"
+            statusMessage = "Connected as \(uid) (\(activeEngine == .rtdb ? "RTDB" : "Firestore"))"
         }
     }
 

--- a/examples/swift-todo-app/Sources/Views/ContentView.swift
+++ b/examples/swift-todo-app/Sources/Views/ContentView.swift
@@ -88,18 +88,26 @@ public struct ContentView: View {
     }
 
     private var authenticatedHeader: some View {
-        HStack {
-            Image(systemName: "person.crop.circle.fill")
-                .foregroundColor(.blue)
-            Text("User: \(viewModel.effectiveUserId ?? "")")
-                .font(.subheadline.bold())
-                .lineLimit(1)
-            Spacer()
-            Button("Sign Out") {
-                viewModel.signOut()
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "person.crop.circle.fill")
+                    .foregroundColor(.blue)
+                Text("User: \(viewModel.effectiveUserId ?? "")")
+                    .font(.subheadline.bold())
+                    .lineLimit(1)
+                Spacer()
+                Button("Sign Out") {
+                    viewModel.signOut()
+                }
+                .font(.caption)
+                .buttonStyle(.bordered)
             }
-            .font(.caption)
-            .buttonStyle(.bordered)
+            Picker("Database Engine", selection: $viewModel.activeEngine) {
+                ForEach(DatabaseEngine.allCases) { engine in
+                    Text(engine.rawValue).tag(engine)
+                }
+            }
+            .pickerStyle(.segmented)
         }
     }
 

--- a/examples/swift-todo-app/database.rules.json
+++ b/examples/swift-todo-app/database.rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "todos": {
+      ".indexOn": ["userId"],
+      ".read": "auth != null && query.orderByChild == 'userId' && query.equalTo == auth.uid",
+      "$todoId": {
+        ".read": "auth != null && (!data.exists() || data.child('userId').val() == auth.uid)",
+        ".write": "auth != null && ((!data.exists() && newData.child('userId').val() == auth.uid) || (data.exists() && data.child('userId').val() == auth.uid && (!newData.exists() || newData.child('userId').val() == auth.uid)))"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Upgrades the Flutter, Swift, and Android (Jetpack Compose) Todo sample apps to switch between Realtime Database (RTDB) and Cloud Firestore at runtime using a shared `/todos/$todoId` schema and query-enforced RTDB security rules.

```json
{
  "rules": {
    "todos": {
      ".indexOn": ["userId"],
      ".read": "auth != null && query.orderByChild == 'userId' && query.equalTo == auth.uid",
      "$todoId": {
        ".read": "auth != null && (!data.exists() || data.child('userId').val() == auth.uid)",
        ".write": "auth != null && ((!data.exists() && newData.child('userId').val() == auth.uid) || (data.exists() && data.child('userId').val() == auth.uid && (!newData.exists() || newData.child('userId').val() == auth.uid)))"
      }
    }
  }
}
```

## Query-scoped RTDB security rules prevent cascading reads across users' todos

In Firebase Realtime Database, granting `.read: "auth != null"` on `/todos` cascades read permission to every child `/todos/$todoId` regardless of owner. The rules in `examples/shared/database.rules.json` require `query.orderByChild == 'userId' && query.equalTo == auth.uid` on `/todos`, matching the exact query executed by all three sample apps (`orderByChild('userId').equalTo(userId)`).

## Sample apps share a single PyricBridgeClient and clear impersonation lenses on Sign Out

- **Flutter (`examples/flutter-todo-app`)**: Registers `PyricFirebaseAuthPlatform`, `PyricFirestorePlatform`, and `PyricDatabase` with the same `auth.bridgeClient` in `main.dart`. Clicking Sign Out in `todo_screen.dart` calls `auth.switchAuthLens(null)` before `auth.signOut()` so impersonated identities set via the Pyric Debug Chip clear immediately.
- **Swift (`examples/swift-todo-app`)**: Wires `self.rtdb.credentialProvider = auth` in `TodoListViewModel.init` so `Database` observes `auth.authLensStream` regardless of default parameter evaluation order.
- **Android (`examples/android-todo-app`)**: Passes `firestore.bridgeClient` into `FirebaseDatabase.getInstance(...)` and combines `repository.bridgeConnectionFlow()` into `TodoViewModel.uiState` so the top-bar connection indicator transitions from `Offline` to `Connected` as soon as the WebSocket handshake completes.

## Risk

- **RTDB query index requirement**: Because `/todos/.read` enforces `query.orderByChild == 'userId'`, unindexed or unfiltered reads on `/todos` return `PERMISSION_DENIED` unless executed under an Admin Bypass lens (`actAs: { mode: 'admin' }`).

<details>
<summary>Implementation notes & verification</summary>

- **Stacked PR**: Stacked on #588 (`feat/rtdb-multiplatform-sdk`).
- **Verification**:
  - Verified live synchronization across Flutter macOS (`flutter run -d macos`), Swift macOS (`SwiftTodoApp`), and Android Emulator (`emulator-5554`) connected to `ws://127.0.0.1:5174/__pyric/sandbox`.
  - Confirmed `rtdb.set` and `worker-sub` on `/todos` succeed for `email-alice@example.com-1` and fail with `PERMISSION_DENIED` for unauthorized UIDs.
</details>
