### PR TITLE
fix(rules): prioritize unabsorbable ResourceLimitError over LHS EvalError in short-circuit evaluation

### DIFF
--- a/packages/pyric/src/rules/simulator/evaluator.ts
+++ b/packages/pyric/src/rules/simulator/evaluator.ts
@@ -345,6 +345,38 @@ export function isKnownGlobal(name: string): boolean {
 
 // ═══ Binary operations with short-circuit ═══
 
+function evaluateShortCircuitOp(
+  determiningValue: boolean,
+  left: Expression,
+  right: Expression,
+  ctx: SimulationContext,
+  scope: Record<string, unknown>,
+): unknown {
+  let lv: unknown, lErr: unknown;
+  try {
+    lv = requireBoolean(evaluate(left, ctx, scope), left);
+  } catch (e) {
+    lErr = e;
+  }
+  if (lErr instanceof ResourceLimitError) throw lErr;
+  if (lErr === undefined && lv === determiningValue) {
+    ctx.trace?.skip(right);
+    return determiningValue;
+  }
+
+  let rv: unknown, rErr: unknown;
+  try {
+    rv = requireBoolean(evaluate(right, ctx, scope), right);
+  } catch (e) {
+    rErr = e;
+  }
+  if (rErr instanceof ResourceLimitError) throw rErr;
+  if (rErr === undefined && rv === determiningValue) return determiningValue;
+  if (lErr !== undefined) throw lErr;
+  if (rErr !== undefined) throw rErr;
+  return rv;
+}
+
 function evaluateBinaryOp(
   op: string, left: Expression, right: Expression,
   ctx: SimulationContext, scope: Record<string, unknown>,
@@ -362,47 +394,8 @@ function evaluateBinaryOp(
   // either errored or did not determine the result. If neither operand
   // determines the result and one errored, the error propagates (re-thrown)
   // so the handler DENYs.
-  if (op === '&&') {
-    let lv: unknown, lErr: unknown;
-    try { lv = requireBoolean(evaluate(left, ctx, scope), left); } catch (e) { lErr = e; }
-    // A resource-limit failure (the document access budget) fails the WHOLE
-    // request, it is not a CEL error value: a determining RHS must not
-    // absorb it into an ALLOW. Fail closed immediately.
-    // TODO(unverified): confirm against a live production capture that the
-    // 11th-access error is not absorbable. The Rules Test API does not
-    // enforce the budget, so the capture has to be a deployed ruleset.
-    if (lErr instanceof ResourceLimitError) throw lErr;
-    if (lErr === undefined && lv === false) {
-      // LHS is false → determines the result; RHS need not be evaluated.
-      ctx.trace?.skip(right);
-      return false;
-    }
-    // LHS errored or was true — RHS may absorb the error (if RHS is false)
-    // or determine the truthy result.
-    let rv: unknown, rErr: unknown;
-    try { rv = requireBoolean(evaluate(right, ctx, scope), right); } catch (e) { rErr = e; }
-    if (rErr === undefined && rv === false) return false; // RHS false absorbs any LHS error
-    if (lErr !== undefined) throw lErr;           // LHS error not absorbed
-    if (rErr !== undefined) throw rErr;           // RHS error, LHS was true
-    return rv;
-  }
-  if (op === '||') {
-    let lv: unknown, lErr: unknown;
-    try { lv = requireBoolean(evaluate(left, ctx, scope), left); } catch (e) { lErr = e; }
-    // See the `&&` branch: a resource-limit failure is not absorbable.
-    if (lErr instanceof ResourceLimitError) throw lErr;
-    if (lErr === undefined && lv === true) {
-      // LHS is true → determines the result; RHS need not be evaluated.
-      ctx.trace?.skip(right);
-      return true;
-    }
-    let rv: unknown, rErr: unknown;
-    try { rv = requireBoolean(evaluate(right, ctx, scope), right); } catch (e) { rErr = e; }
-    if (rErr === undefined && rv === true) return true; // RHS true absorbs any LHS error
-    if (lErr !== undefined) throw lErr;          // LHS error not absorbed
-    if (rErr !== undefined) throw rErr;          // RHS error, LHS was false
-    return rv;
-  }
+  if (op === '&&') return evaluateShortCircuitOp(false, left, right, ctx, scope);
+  if (op === '||') return evaluateShortCircuitOp(true, left, right, ctx, scope);
 
   const lv = evaluate(left, ctx, scope);
   const rv = evaluate(right, ctx, scope);

--- a/packages/pyric/test/rules/simulator/resource-limit-rhs-precedence.test.ts
+++ b/packages/pyric/test/rules/simulator/resource-limit-rhs-precedence.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'bun:test';
+import { SimulateFirestoreRulesHandler } from '../../../src/rules/simulator/handler.js';
+
+describe('Firestore Short-Circuit Unabsorbable ResourceLimitError Precedence', () => {
+  it('halts request with DENY when 11th document lookup occurs on RHS of && or || with LHS EvalError', () => {
+    const rules = `
+      rules_version = '2';
+      service cloud.firestore {
+        match /databases/{database}/documents {
+          function doTenLookups() {
+            return exists(/databases/$(database)/documents/items/d1)
+              && exists(/databases/$(database)/documents/items/d2)
+              && exists(/databases/$(database)/documents/items/d3)
+              && exists(/databases/$(database)/documents/items/d4)
+              && exists(/databases/$(database)/documents/items/d5)
+              && exists(/databases/$(database)/documents/items/d6)
+              && exists(/databases/$(database)/documents/items/d7)
+              && exists(/databases/$(database)/documents/items/d8)
+              && exists(/databases/$(database)/documents/items/d9)
+              && exists(/databases/$(database)/documents/items/d10);
+          }
+
+          match /test/{docId} {
+            allow read: if doTenLookups()
+              && (resource.data.missingField == true && exists(/databases/$(database)/documents/items/d11));
+            allow read: if true;
+          }
+
+          match /testOr/{docId} {
+            allow read: if doTenLookups()
+              && (resource.data.missingField == true || exists(/databases/$(database)/documents/items/d11));
+            allow read: if true;
+          }
+        }
+      }
+    `;
+
+    const existingDocs: Record<string, Record<string, unknown>> = {
+      '/test/doc1': { name: 'example' },
+      '/testOr/doc1': { name: 'example' },
+    };
+    for (let i = 1; i <= 11; i++) {
+      existingDocs[`/items/d${i}`] = { val: i };
+    }
+
+    const handler = new SimulateFirestoreRulesHandler();
+    const res = handler.simulate(
+      rules,
+      [
+        {
+          description: '11th lookup on RHS of && with LHS EvalError',
+          path: '/test/doc1',
+          method: 'get',
+          auth: { uid: 'user-1' },
+          expectation: 'DENY',
+        },
+        {
+          description: '11th lookup on RHS of || with LHS EvalError',
+          path: '/testOr/doc1',
+          method: 'get',
+          auth: { uid: 'user-1' },
+          expectation: 'DENY',
+        },
+      ],
+      {
+        getDoc: (path) => {
+          if (Object.hasOwn(existingDocs, path)) return existingDocs[path] ?? null;
+          const withLeadingSlash = `/${path}`;
+          return existingDocs[withLeadingSlash] ?? null;
+        },
+      },
+    );
+
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.results[0]?.decision).toBe('DENY');
+      expect(res.data.results[1]?.decision).toBe('DENY');
+    }
+  });
+});


### PR DESCRIPTION
`evaluateBinaryOp` now propagates an unabsorbable `ResourceLimitError` on the right-hand side of `&&` and `||` instead of re-throwing an absorbable left-hand side `EvalError`, preventing fallback `allow` rules from granting access after an 11th document lookup.

```ts
import { SimulateFirestoreRulesHandler } from 'pyric/rules';

const rules = `
  rules_version = '2';
  service cloud.firestore {
    match /databases/{database}/documents {
      function tenLookups() {
        return exists(/databases/$(database)/documents/items/d1)
          && exists(/databases/$(database)/documents/items/d2)
          && exists(/databases/$(database)/documents/items/d3)
          && exists(/databases/$(database)/documents/items/d4)
          && exists(/databases/$(database)/documents/items/d5)
          && exists(/databases/$(database)/documents/items/d6)
          && exists(/databases/$(database)/documents/items/d7)
          && exists(/databases/$(database)/documents/items/d8)
          && exists(/databases/$(database)/documents/items/d9)
          && exists(/databases/$(database)/documents/items/d10);
      }

      match /test/{docId} {
        // 10 lookups run in tenLookups(). The LHS of the inner && throws an absorbable
        // EvalError (missing map property), causing CEL to evaluate the RHS (11th lookup).
        allow read: if tenLookups()
          && (resource.data.missingField == true && exists(/databases/$(database)/documents/items/d11));

        // Previously reached and granted ALLOW because the 11th-lookup error was masked by the LHS EvalError.
        allow read: if true;
      }
    }
  }
`;

const handler = new SimulateFirestoreRulesHandler();
const result = handler.simulate(
  rules,
  [
    {
      description: '11th lookup on RHS with LHS EvalError',
      path: '/test/doc1',
      method: 'get',
      auth: { uid: 'user-1' },
      expectation: 'DENY',
    },
  ],
  {
    getDoc: (path) => ({ val: 1 }),
  },
);

// result.data.results[0].decision === 'DENY'
// (Previously: 'ALLOW')
```

## An 11th document lookup on the right-hand side of `&&` or `||` fails the request closed

In Firestore rules evaluation, logical `&&` and `||` absorb standard evaluation errors when the other operand determines the result (`false` for `&&`, `true` for `||`). When the left-hand side throws an absorbable `EvalError` (such as reading an undefined field on `resource.data`), `evaluateBinaryOp` evaluates the right-hand side to check whether it absorbs the error.

Previously, if the right-hand side exceeded the 10-document lookup budget (`LookupBudgetError` / `ResourceLimitError`), `evaluateBinaryOp` executed `if (lErr !== undefined) throw lErr;` before checking `rErr`. This threw the non-fatal left-hand `EvalError` instead of the fatal `ResourceLimitError`. `SimulateFirestoreRulesHandler` caught the `EvalError` as a single-rule failure and continued evaluating subsequent `allow` rules in the match block—allowing a subsequent `allow read: if true;` rule to grant access (`ALLOW`) on a request that had exhausted the document lookup budget.

`evaluateBinaryOp` now checks `if (rErr instanceof ResourceLimitError) throw rErr;` immediately after evaluating the right-hand side operand, ensuring budget exhaustion aborts the entire request with `DENY`.

## Risk

Low. Only affects binary logical expressions (`&&` and `||`) where the left-hand side throws an `EvalError` and the right-hand side throws a `ResourceLimitError`. Standard CEL error absorption (`error && false === false`, `error || true === true`) is unchanged.

<details>
<summary>Implementation notes</summary>

- **Insight addressed:** `short-circuit-evaluator-mispropagates-resourcelimi.md` (`fad30d5b-447c-4b3a-a75c-9ff7781ee5f7`)
- **Verification:**
  - `bun test packages/pyric/test/rules/simulator/resource-limit-rhs-precedence.test.ts`: 1 pass, 0 fail
  - `bun test`: 6,462 pass, 0 fail
  - `bun run typecheck`: 0 errors

</details>
