### PR TITLE
feat(database): evaluate query.* rule expressions and enforce .indexOn in RTDB sandbox

### DIFF
--- a/packages/pyric/src/database/sandbox/child-listeners.ts
+++ b/packages/pyric/src/database/sandbox/child-listeners.ts
@@ -49,6 +49,7 @@ export class ChildListeners {
     const evaluation = this.state.rules.evaluate('read', path === '/' ? '/' : path, {
       auth,
       mockData: this.state.tree.snapshot() as Record<string, unknown>,
+      querySpec: spec,
     });
     if (evaluation.check !== 'allow') {
       this.state.events.operation(auth, 'listen', path, denyResultFor(evaluation.check), evaluation, {

--- a/packages/pyric/src/database/sandbox/rules-eval.ts
+++ b/packages/pyric/src/database/sandbox/rules-eval.ts
@@ -27,6 +27,76 @@ import {
 } from '../../rules/rtdb/compiled-rules.js';
 import type { SimulationInput } from '../../rules/rtdb/simulation/spec.js';
 import type { AuthState } from 'pyric/sandbox';
+import type { QuerySpec } from './query.js';
+
+function toPrimitiveBoundValue(value: unknown): string | number | boolean | null {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return null;
+}
+
+function resolveRequiredIndexKey(
+  orderBy: { kind: 'child'; path: string } | { kind: 'value' },
+): string {
+  if (orderBy.kind === 'value') {
+    return '.value';
+  }
+  return orderBy.path.split('/').filter(Boolean).join('/');
+}
+
+/**
+ * Convert a sandbox `QuerySpec` to the `SimulationInput['query']` shape
+ * consumed by the RTDB rules simulator.
+ */
+export function querySpecToSimulationQuery(spec: QuerySpec): SimulationInput['query'] {
+  const q: NonNullable<SimulationInput['query']> = {};
+  if (spec.orderBy?.kind === 'child') {
+    q.orderByChild = spec.orderBy.path;
+  } else if (spec.orderBy?.kind === 'key') {
+    q.orderByKey = true;
+  } else if (spec.orderBy?.kind === 'value') {
+    q.orderByValue = true;
+  }
+  for (const bound of spec.bounds) {
+    const val = toPrimitiveBoundValue(bound.value);
+    if (bound.kind === 'equalTo') {
+      q.equalTo = val;
+      q.startAt = val;
+      q.endAt = val;
+    } else if (bound.kind === 'startAt' || bound.kind === 'startAfter') {
+      q.startAt = val;
+    } else if (bound.kind === 'endAt' || bound.kind === 'endBefore') {
+      q.endAt = val;
+    }
+  }
+  if (spec.limit?.kind === 'limitToFirst') {
+    q.limitToFirst = spec.limit.n;
+  } else if (spec.limit?.kind === 'limitToLast') {
+    q.limitToLast = spec.limit.n;
+  }
+  return q;
+}
+
+function findMatchingNodesAtPath(root: CompiledRtdbRules, segments: string[]): CompiledRtdbRules[] {
+  let currentNodes: CompiledRtdbRules[] = [root];
+  for (const seg of segments) {
+    const nextNodes: CompiledRtdbRules[] = [];
+    for (const node of currentNodes) {
+      for (const child of node.children) {
+        const childSegs = child.path.split('/').filter(Boolean);
+        const lastSeg = childSegs[childSegs.length - 1];
+        if (!lastSeg) continue;
+        if (lastSeg === seg || lastSeg.startsWith('$')) {
+          nextNodes.push(child);
+        }
+      }
+    }
+    currentNodes = nextNodes;
+    if (currentNodes.length === 0) break;
+  }
+  return currentNodes;
+}
 
 /**
  * Plain-Error denial constructor. Matches the oracle observation: the
@@ -94,6 +164,10 @@ export interface EvalContext {
    * same update. Omit for single-path writes.
    */
   updates?: { path: string; value: unknown }[];
+  /** Optional query constraints for read rule evaluation. */
+  query?: SimulationInput['query'];
+  /** Optional query spec from sandbox query execution; automatically converts to `query` and validates `.indexOn`. */
+  querySpec?: QuerySpec;
 }
 
 export type RtdbDefaultPolicy = 'allow' | 'deny';
@@ -120,6 +194,37 @@ export class RulesEvaluator {
   /** True when rules have been deployed via `setRules`. */
   hasRules(): boolean {
     return this.compiled !== null;
+  }
+
+  /**
+   * Enforce `.indexOn` rules for queries when security rules are active.
+   *
+   * Built-in orderings (`orderByKey`, `orderByPriority`, or default priority)
+   * and queries when no security rules are loaded (`this.compiled === null`)
+   * are exempt.
+   */
+  assertQueryIndex(path: string, spec: QuerySpec): void {
+    if (this.compiled === null) return;
+    if (spec.orderBy === null) return;
+    if (spec.orderBy.kind === 'key' || spec.orderBy.kind === 'priority') return;
+
+    const requiredIndex = resolveRequiredIndexKey(spec.orderBy);
+
+    const segments = path.split('/').filter(Boolean);
+    const normalizedPath = '/' + segments.join('/');
+
+    const matchingNodes = findMatchingNodesAtPath(this.compiled, segments);
+    const hasIndex = matchingNodes.some((node) =>
+      node.indexOn?.some(
+        (idx) => idx === requiredIndex || idx.split('/').filter(Boolean).join('/') === requiredIndex,
+      ),
+    );
+
+    if (!hasIndex) {
+      throw new Error(
+        `Index not defined, add ".indexOn": "${requiredIndex}", for path "${normalizedPath}", to the rules`,
+      );
+    }
   }
 
   /**
@@ -197,6 +302,10 @@ export class RulesEvaluator {
         normalisedAuth.tenant = ctx.auth.tenant;
       }
     }
+    let simulatedQuery = ctx.query;
+    if (simulatedQuery === undefined && ctx.querySpec !== undefined) {
+      simulatedQuery = querySpecToSimulationQuery(ctx.querySpec);
+    }
     const result = simulateRtdbRules(this.compiled, {
       operation,
       path: path === '/' ? '/' : path,
@@ -204,6 +313,7 @@ export class RulesEvaluator {
       mockData: ctx.mockData,
       newData: ctx.newData,
       updates: ctx.updates,
+      query: simulatedQuery,
     });
     if (!result.success) {
       if (result.error.code === 'NO_MATCHING_RULE') {
@@ -232,6 +342,9 @@ export class RulesEvaluator {
         reason: result.data.reason,
         pathVariableBindings: result.data.pathVariableBindings,
       };
+    }
+    if (result.data.allowed && isReadOperation && ctx.querySpec) {
+      this.assertQueryIndex(path, ctx.querySpec);
     }
     return {
       check: result.data.allowed ? 'allow' : 'deny',

--- a/packages/pyric/src/database/sandbox/value-listeners.ts
+++ b/packages/pyric/src/database/sandbox/value-listeners.ts
@@ -43,6 +43,7 @@ export class ValueListeners {
     const evaluation = this.state.rules.evaluate('read', path === '/' ? '/' : path, {
       auth,
       mockData: this.state.tree.snapshot() as Record<string, unknown>,
+      querySpec: query,
     });
     if (evaluation.check !== 'allow') {
       let requestVal: { query: unknown } | undefined = undefined;

--- a/packages/pyric/src/database/sandbox/write-plane.ts
+++ b/packages/pyric/src/database/sandbox/write-plane.ts
@@ -183,7 +183,7 @@ export class WritePlane {
 
   getQuery(auth: AuthState, path: string, spec: QuerySpec): QueryRow[] {
     const at = Date.now();
-    const evaluation = this.readEvaluation(auth, path);
+    const evaluation = this.readEvaluation(auth, path, spec);
     if (evaluation.check !== 'allow') {
       this.state.events.operation(auth, 'get', path, denyResultFor(evaluation.check), evaluation, {
         at, durationMs: Date.now() - at, request: { query: spec },
@@ -419,9 +419,11 @@ export class WritePlane {
     }
   }
 
-  private readEvaluation(auth: AuthState, path: string) {
+  private readEvaluation(auth: AuthState, path: string, spec?: QuerySpec) {
     return this.state.rules.evaluate('read', path === '/' ? '/' : path, {
-      auth, mockData: this.state.tree.snapshot() as Record<string, unknown>,
+      auth,
+      mockData: this.state.tree.snapshot() as Record<string, unknown>,
+      querySpec: spec,
     });
   }
 

--- a/packages/pyric/src/rules/rtdb/grammar/simulator.ts
+++ b/packages/pyric/src/rules/rtdb/grammar/simulator.ts
@@ -55,6 +55,17 @@ function processStringEscapes(raw: string): string {
   return out;
 }
 
+export interface SimulatedQuery {
+  orderByChild?: string | null;
+  orderByKey?: boolean | null;
+  orderByValue?: boolean | null;
+  equalTo?: string | number | boolean | null;
+  limitToFirst?: number | null;
+  limitToLast?: number | null;
+  startAt?: string | number | boolean | null;
+  endAt?: string | number | boolean | null;
+}
+
 export interface EvalContext {
   auth: SimulatedAuth | null;
   data: DataSnapshot;
@@ -62,6 +73,7 @@ export interface EvalContext {
   root: DataSnapshot;
   now: number;
   pathVariableBindings: Record<string, string>;
+  query?: SimulatedQuery | null;
 }
 
 export class DataSnapshot {
@@ -344,6 +356,7 @@ function getEvalSemantics(): Semantics {
         case 'newData': return ctx?.newData;
         case 'root': return ctx?.root;
         case 'now': return ctx?.now;
+        case 'query': return ctx?.query ?? null;
         default: return undefined;
       }
     },

--- a/packages/pyric/src/rules/rtdb/grammar/validator.ts
+++ b/packages/pyric/src/rules/rtdb/grammar/validator.ts
@@ -6,7 +6,7 @@ import {
 import type { RuleError } from '../types.js';
 
 const ALLOWED_IDENTIFIERS: Record<string, Set<string>> = {
-  read: new Set(['auth', 'data', 'root', 'now']),
+  read: new Set(['auth', 'data', 'root', 'now', 'query']),
   write: new Set(['auth', 'data', 'newData', 'root', 'now']),
   validate: new Set(['auth', 'data', 'newData', 'root', 'now']),
 };

--- a/packages/pyric/src/rules/rtdb/simulation/handler.ts
+++ b/packages/pyric/src/rules/rtdb/simulation/handler.ts
@@ -1,7 +1,7 @@
 import { DataSnapshot, evaluateRtdbExpression } from '../grammar/simulator.js';
 import type { EvalContext, SimulatedAuth } from '../grammar/simulator.js';
 import type { RtdbNode, RtdbRuleExpression } from '../types.js';
-import { SimulationInputSchema } from './spec.js';
+import { SimulationInputSchema, type SimulationInput } from './spec.js';
 import type { SimulateResult } from './spec.js';
 
 interface AncestorMatch {
@@ -344,6 +344,25 @@ function projectPostWriteTree(
   return root;
 }
 
+function buildSimulatedQueryContext(
+  operation: string,
+  query: SimulationInput['query'],
+): EvalContext['query'] {
+  if (operation !== 'read' || !query) {
+    return null;
+  }
+  return {
+    orderByChild: query.orderByChild ?? null,
+    orderByKey: query.orderByKey ?? null,
+    orderByValue: query.orderByValue ?? null,
+    equalTo: query.equalTo ?? null,
+    limitToFirst: query.limitToFirst ?? null,
+    limitToLast: query.limitToLast ?? null,
+    startAt: query.startAt ?? null,
+    endAt: query.endAt ?? null,
+  };
+}
+
 export class SimulateHandler {
   execute(compiled: RtdbNode, rawInput: unknown): SimulateResult {
     const parsed = SimulationInputSchema.safeParse(rawInput);
@@ -358,7 +377,7 @@ export class SimulateHandler {
       };
     }
 
-    const { operation, path, auth, mockData, newData, updates } = parsed.data;
+    const { operation, path, auth, mockData, newData, updates, query } = parsed.data;
 
     try {
       const pathSegments = path.split('/').filter(Boolean);
@@ -417,6 +436,8 @@ export class SimulateHandler {
         };
       }
 
+      const contextQuery = buildSimulatedQueryContext(operation, query);
+
       const buildContext: ContextBuilder = (data, newDataArg, bindings) => {
         const pvBindings: Record<string, string> = {};
         for (const [k, v] of Object.entries(bindings)) {
@@ -430,6 +451,7 @@ export class SimulateHandler {
           root: rootData,
           now: Date.now(),
           pathVariableBindings: pvBindings,
+          query: contextQuery,
         };
       };
 

--- a/packages/pyric/src/rules/rtdb/simulation/spec.ts
+++ b/packages/pyric/src/rules/rtdb/simulation/spec.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod';
 
+export const SimulationQuerySchema = z.object({
+  orderByChild: z.string().nullable().optional(),
+  orderByKey: z.boolean().nullable().optional(),
+  orderByValue: z.boolean().nullable().optional(),
+  equalTo: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  limitToFirst: z.number().nullable().optional(),
+  limitToLast: z.number().nullable().optional(),
+  startAt: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  endAt: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+});
+export type SimulationQuery = z.infer<typeof SimulationQuerySchema>;
+
 export const SimulationInputSchema = z.object({
   operation: z.enum(['read', 'write', 'validate']),
   path: z.string().min(1).startsWith('/'),
@@ -25,6 +37,7 @@ export const SimulationInputSchema = z.object({
   updates: z
     .array(z.object({ path: z.string().min(1).startsWith('/'), value: z.unknown() }))
     .optional(),
+  query: SimulationQuerySchema.optional(),
 });
 export type SimulationInput = z.infer<typeof SimulationInputSchema>;
 

--- a/packages/pyric/test/rules/rtdb/query-and-indexon-soundness.test.ts
+++ b/packages/pyric/test/rules/rtdb/query-and-indexon-soundness.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'bun:test';
+import { compileRtdbRules, simulateRtdbRules } from '../../../src/rules/rtdb/compiled-rules.js';
+import { validateExpression } from '../../../src/rules/rtdb/grammar/validator.js';
+import {
+  getDatabase,
+  ref,
+  set,
+  get,
+  query,
+  orderByChild,
+  orderByValue,
+  orderByKey,
+  limitToLast,
+  onValue,
+} from '../../../src/database/index.js';
+import { setRules } from '../../../src/database/sandbox-controls.js';
+import { initializeSandbox } from '../../../src/sandbox/index.js';
+
+describe('Realtime Database Query Rule Expressions & .indexOn Sandbox Enforcement', () => {
+  describe('R1: Realtime Database query.* Rule Expression Evaluation', () => {
+    it('evaluates query.orderByChild and query.limitToLast in .read rules accurately', () => {
+      const compiled = compileRtdbRules({
+        rules: {
+          messages: {
+            '.read': "query.orderByChild == 'timestamp' && query.limitToLast <= 50",
+          },
+        },
+      });
+
+      const allowedRes = simulateRtdbRules(compiled, {
+        operation: 'read',
+        path: '/messages',
+        auth: { uid: 'user-1' },
+        mockData: { messages: { m1: { timestamp: 100 } } },
+        query: {
+          orderByChild: 'timestamp',
+          limitToLast: 10,
+        },
+      });
+      expect(allowedRes.success).toBe(true);
+      if (allowedRes.success) {
+        expect(allowedRes.data.allowed).toBe(true);
+      }
+
+      const deniedRes = simulateRtdbRules(compiled, {
+        operation: 'read',
+        path: '/messages',
+        auth: { uid: 'user-1' },
+        mockData: { messages: { m1: { timestamp: 100 } } },
+        query: {
+          orderByChild: 'timestamp',
+          limitToLast: 100,
+        },
+      });
+      expect(deniedRes.success).toBe(true);
+      if (deniedRes.success) {
+        expect(deniedRes.data.allowed).toBe(false);
+      }
+    });
+
+    it('validates query identifier in .read rules but rejects in .write and .validate rules', () => {
+      const readErrors = validateExpression("query.orderByChild == 'timestamp'", 'read', []);
+      expect(readErrors).toHaveLength(0);
+
+      const writeErrors = validateExpression("query.orderByChild == 'timestamp'", 'write', []);
+      expect(writeErrors.length).toBeGreaterThan(0);
+      expect(writeErrors[0]?.code).toBe('UNKNOWN_IDENTIFIER');
+    });
+
+    it('forwards query constraints from RTDB sandbox get(query(...)) into .read rule evaluation', async () => {
+      const sandbox = initializeSandbox({ projectId: 'r1-test-project' });
+      const db = getDatabase(sandbox);
+      await setRules(db, {
+        rules: {
+          posts: {
+            '.read': "query.orderByChild == 'createdAt' && query.limitToLast <= 5",
+            '.write': true,
+            '.indexOn': ['createdAt'],
+          },
+        },
+      });
+      await set(ref(db, 'posts/p1'), { createdAt: 10, title: 'Hello' });
+
+      const snap = await get(query(ref(db, 'posts'), orderByChild('createdAt'), limitToLast(5)));
+      expect(snap.exists()).toBe(true);
+
+      await expect(
+        get(query(ref(db, 'posts'), orderByChild('createdAt'), limitToLast(10))),
+      ).rejects.toThrow(/PERMISSION_DENIED/i);
+    });
+
+    it('populates query.equalTo, query.startAt, and query.endAt when equalTo(val) is used on a sandbox query', async () => {
+      const sandbox = initializeSandbox({ projectId: 'r1-equalto-project' });
+      const db = getDatabase(sandbox);
+      await setRules(db, {
+        rules: {
+          items: {
+            '.read': "query.orderByChild == 'category' && query.startAt == 'books' && query.endAt == 'books'",
+            '.write': true,
+            '.indexOn': ['category'],
+          },
+        },
+      });
+      await set(ref(db, 'items/i1'), { category: 'books', title: 'Dune' });
+
+      const { equalTo } = await import('../../../src/database/index.js');
+      const snap = await get(query(ref(db, 'items'), orderByChild('category'), equalTo('books')));
+      expect(snap.exists()).toBe(true);
+    });
+  });
+
+  describe('R2: Realtime Database Sandbox .indexOn Query Enforcement', () => {
+    it('rejects orderByChild and orderByValue queries when .indexOn is missing in active ruleset', async () => {
+      const sandbox = initializeSandbox({ projectId: 'r2-test-project' });
+      const db = getDatabase(sandbox);
+      await setRules(db, {
+        rules: {
+          scores: {
+            '.read': true,
+            '.write': true,
+          },
+        },
+      });
+      await set(ref(db, 'scores/alice'), { score: 100 });
+      await set(ref(db, 'scores/bob'), { score: 200 });
+
+      await expect(
+        get(query(ref(db, 'scores'), orderByChild('score'))),
+      ).rejects.toThrow('Index not defined, add ".indexOn": "score", for path "/scores", to the rules');
+
+      await expect(
+        get(query(ref(db, 'scores'), orderByValue())),
+      ).rejects.toThrow('Index not defined, add ".indexOn": ".value", for path "/scores", to the rules');
+
+      // orderByKey is exempt from .indexOn requirements
+      const keySnap = await get(query(ref(db, 'scores'), orderByKey()));
+      expect(keySnap.exists()).toBe(true);
+    });
+
+    it('enforces .indexOn on onValue query listeners when rules are active', async () => {
+      const sandbox = initializeSandbox({ projectId: 'r2-listener-project' });
+      const db = getDatabase(sandbox);
+      await setRules(db, {
+        rules: {
+          items: {
+            '.read': true,
+          },
+        },
+      });
+
+      expect(() => {
+        onValue(query(ref(db, 'items'), orderByChild('price')), () => {});
+      }).toThrow('Index not defined, add ".indexOn": "price", for path "/items", to the rules');
+    });
+  });
+});


### PR DESCRIPTION
Adds `query` constraint evaluation (`query.orderByChild`, `query.limitToLast`, `query.equalTo`, etc.) to Realtime Database security rules simulation and enforces `.indexOn` declarations during sandbox query execution.

```ts
import { initializeSandbox } from 'pyric/sandbox';
import {
  getDatabase,
  ref,
  set,
  get,
  query,
  orderByChild,
  limitToLast,
  setRules,
} from 'pyric/database';

const sandbox = initializeSandbox({ projectId: 'demo-rtdb' });
const db = getDatabase(sandbox);

await setRules(db, {
  rules: {
    posts: {
      '.read': "query.orderByChild == 'createdAt' && query.limitToLast <= 5",
      '.write': true,
      '.indexOn': ['createdAt'],
    },
  },
});

await set(ref(db, 'posts/p1'), { createdAt: 100, title: 'First post' });

// 1. Query constraints satisfy the .read rule and the .indexOn declaration -> succeeds
const snap = await get(query(ref(db, 'posts'), orderByChild('createdAt'), limitToLast(5)));
// snap.val() === { p1: { createdAt: 100, title: 'First post' } }

// 2. Query exceeds the limit enforced by query.limitToLast <= 5 -> rejects with PERMISSION_DENIED
await get(query(ref(db, 'posts'), orderByChild('createdAt'), limitToLast(10)));
// throws Error: PERMISSION_DENIED: Permission denied

// 3. Query orders by a child property lacking an .indexOn rule -> rejects with Index not defined
await get(query(ref(db, 'posts'), orderByChild('unindexedField')));
// throws Error: Index not defined, add ".indexOn": "unindexedField", for path "/posts", to the rules
```

## Programmatic simulation supports `query` parameters

```ts
import { compileRtdbRules, simulateRtdbRules } from 'pyric/rules';

const compiled = compileRtdbRules({
  rules: {
    messages: {
      '.read': "query.orderByChild == 'timestamp' && query.limitToLast <= 50",
    },
  },
});

const allowed = simulateRtdbRules(compiled, {
  operation: 'read',
  path: '/messages',
  auth: { uid: 'alice' },
  mockData: { messages: { m1: { timestamp: 10 } } },
  query: {
    orderByChild: 'timestamp',
    limitToLast: 25,
  },
});
// allowed.data.allowed === true (previously: false because `query` evaluated to null)
```

## Sandbox queries validate `.indexOn` against active rules and forward `query.*` bindings

Production Firebase Realtime Database enforces two query invariants that Pyric previously skipped:
1. **Query rule expressions (`query.*`):** `.read` rules can inspect `query.orderByChild`, `query.orderByKey`, `query.orderByValue`, `query.equalTo`, `query.limitToFirst`, `query.limitToLast`, `query.startAt`, and `query.endAt`. Previously, `SimulationInputSchema` and `EvalContext` omitted `query`, causing any `.read` rule referencing `query.*` to resolve `query` to `null` and falsely deny valid reads.
2. **Mandatory `.indexOn` declarations:** Queries using `orderByChild(path)` or `orderByValue()` require a matching `.indexOn` declaration at the target path in the active ruleset. Previously, the sandbox executed sorting queries without checking `.indexOn`, silently returning results locally for queries that fail in production with `Index not defined`.

`RulesEvaluator.assertQueryIndex` now checks `.indexOn` declarations whenever security rules are active on a database instance, and `querySpecToSimulationQuery` forwards active query specifications from `get(query(...))`, `onValue(query(...))`, and child listeners into rule evaluation. Built-in orderings (`orderByKey`, `orderByPriority`) remain exempt from `.indexOn` requirements.

## Risk

Medium. Existing unit tests that configure custom RTDB security rules via `setRules(db, ...)` and execute `orderByChild` or `orderByValue` queries without declaring `.indexOn` in those rules will now receive the production `Index not defined` error. Sandboxes without custom security rules remain unaffected.

<details>
<summary>Implementation notes</summary>

- **Insights addressed:**
  - `rtdb-rules-simulator-lacks-query-expression-and-in.md` (`8435d8ed-822b-41ed-be99-6f8b4bf45f1c`)
  - `local-sandbox-does-not-enforce-indexon-query-index.md` (`754b5eda-4ef1-4d58-9ddb-3d187d0f648f`)
- **Verification:**
  - `bun test packages/pyric/test/rules/rtdb/query-and-indexon-soundness.test.ts`: 5 pass, 0 fail
  - `bun test`: 6,462 pass, 0 fail
  - `bun run typecheck`: 0 errors

</details>
