### PR TITLE
docs(decisions): ratify ADR-0014

### DIFF
--- a/docs/decisions/0012-tool-naming-grammar.md
+++ b/docs/decisions/0012-tool-naming-grammar.md
@@ -1,6 +1,6 @@
 # 0012: One naming grammar for CLI commands and MCP tools
 
-Status: Accepted; Decision 1's MCP naming and Resolution 2 amended by ADR-0013
+Status: Accepted; Decisions 1 to 3 and Resolutions 2 and 4 superseded by ADR-0014
 
 Date: 2026-09-02
 

--- a/docs/decisions/0013-mcp-tool-names-carry-the-operation.md
+++ b/docs/decisions/0013-mcp-tool-names-carry-the-operation.md
@@ -1,6 +1,6 @@
 # 0013: MCP tool names carry the operation word
 
-Status: Accepted; amends ADR-0012
+Status: Superseded by ADR-0014
 
 Date: 2026-09-07
 

--- a/docs/decisions/0014-service-tools-with-sdk-methods.md
+++ b/docs/decisions/0014-service-tools-with-sdk-methods.md
@@ -1,6 +1,6 @@
 # 0014: Service tools carrying SDK method names
 
-Status: Proposed; supersedes ADR-0012 Decisions 1 to 3 and Resolutions 2 and 4,
+Status: Accepted; supersedes ADR-0012 Decisions 1 to 3 and Resolutions 2 and 4,
 and all of ADR-0013
 
 Date: 2026-09-09


### PR DESCRIPTION
Marks ADR-0014 Accepted and records on ADR-0012 and ADR-0013 which of their rulings it superseded, so the decision records agree with what `pyric mcp` serves.

```diff
- Status: Proposed; supersedes ADR-0012 Decisions 1 to 3 and Resolutions 2 and 4,
+ Status: Accepted; supersedes ADR-0012 Decisions 1 to 3 and Resolutions 2 and 4,

- Status: Accepted; amends ADR-0012
+ Status: Superseded by ADR-0014

- Status: Accepted; Decision 1's MCP naming and Resolution 2 amended by ADR-0013
+ Status: Accepted; Decisions 1 to 3 and Resolutions 2 and 4 superseded by ADR-0014
```

## The records now say what the code does

Main serves ten service tools with `{ method, args }` calls, the design ADR-0014 describes. Until this change, the two ADRs describing the earlier naming grammars carried Accepted while ADR-0014 carried Proposed, so a reader following the records would have built to a surface main no longer has. Only the three status lines change; the bodies of all three documents are as they were, which is what ADR-0014's closing paragraph specified.

## Risk

None to code. ADR-0012's surviving rulings (the closed service word set, `database` rather than `rtdb`, one declaration for both surfaces, transport as a property of the record) remain Accepted through ADR-0014's table of what survives.
