### PR TITLE
feat(sandbox): one event record per service, and Functions on the stream

### DIFF
--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -161,6 +161,12 @@ Rule: one feature, one place. The implementation of one surface gap lives in one
 
 Rule: append-friendly structures are per-record, not per-list. A shared list, registry, or switch that every feature must edit is a conflict generator. Replace it with one record per file and a computed aggregation. This is the data-record convention applied to code. The compat registry and the oracle observations already work this way and never conflict on additions. In source, `packages/cli/src/cli/service-command-records/` and `packages/cli/src/bridge/tool-family-records/` follow the same convention: one record per file, keyed by filename, with the aggregate rendered by a generator rather than maintained by hand.
 
+In `packages/pyric/src`, `<surface>/events.ts` follows the same convention for
+the sandbox event stream: one record per service, keyed by the service name the
+record itself declares, aggregated once in
+`sandbox/types/service-event-records.ts`. A service adds an operation by editing
+its own record, never a shared list.
+
 Rule: shared registries and lists must be computed or per-file. If the system needs a list of all X, it computes that list by reading the directory of X records at build or load time. No source file holds a hand-maintained master list that all contributors edit. A global counter for ordering is banned for the same reason; order by a stable key on each record.
 
 Rule: keep the seam stable, not the file small. Where files co-change because they implement one protocol across a boundary (client, host, wire protocol), splitting them further does not reduce conflict. Stabilize the shared contract, the protocol or type file, and change it deliberately and rarely. Treat a high-fan-out shared type file as a fragile contract.
@@ -502,8 +508,21 @@ every rule in this section mechanically.
    cross-surface state modules `sandbox/full-state.ts`,
    `sandbox/branches/promotion.ts`, and `sandbox/branches/engine.ts` importing
    the `pyric/auth`, `pyric/storage`, and `pyric/storage/internal` published
-   surfaces and the `database/sandbox` backend seam (8.3 case 5, upward). Any
-   other cross-surface deep import fails.
+   surfaces and the `database/sandbox` backend seam (8.3 case 5, upward); and
+   (g) `sandbox/types/service-event-records.ts` importing each surface's
+   `<surface>/events.ts` record. Any other cross-surface deep import fails.
+
+   Exception (g) in full. Every service declares what it puts on the sandbox
+   event stream in one record file beside its own code, and the stream's
+   service union and per-service operation enums are derived from those
+   declarations rather than restated in `sandbox/types`. The derivation has to
+   be static: `ServiceMutationEvent.op` is a type, and a record pushed into a
+   runtime registry at module load carries no type a `.d.ts` can name, so a
+   registry would also make the vocabulary depend on which surfaces a bundle
+   happened to load. The imported files declare data and import nothing but
+   the record type, so the edge costs the central runtime no capability code.
+   The aggregate is the only file allowed to hold it; no other file under
+   `sandbox/` may import a surface's record.
 
 3. **Central-sandbox whitelist.** The top-level entries of `src/sandbox/` must
    match the whitelist in 8.2 (`index.ts`, `internal`, `sandbox-context.ts`,

--- a/packages/cli/src/bridge/surface/methods/functions/executions.ts
+++ b/packages/cli/src/bridge/surface/methods/functions/executions.ts
@@ -1,6 +1,6 @@
 /** List the runs `fire` caused: cause, duration, and result or error. */
 import { z } from 'zod';
-import { executionLogFor } from '../../../../functions-rtdb/execution-log.js';
+import { listExecutions } from '../../../../functions-rtdb/execution-log.js';
 import type { MethodRecord } from '../../method-types.js';
 
 export default {
@@ -21,7 +21,7 @@ export default {
   example: {},
   async handler(args, ctx) {
     const since = args.since === undefined ? undefined : Number(args.since);
-    const executions = executionLogFor(ctx.sandbox).list(since);
+    const executions = listExecutions(ctx.sandbox, since);
     return {
       ok: true,
       summary: `${executions.length} execution(s)`,

--- a/packages/cli/src/bridge/surface/methods/functions/fire.ts
+++ b/packages/cli/src/bridge/surface/methods/functions/fire.ts
@@ -17,8 +17,12 @@ import {
 } from '../../../../functions-rtdb/event.js';
 import type { DiscoveredOnValueCreated } from '../../../../functions-rtdb/discovery.js';
 import {
-  executionLogFor,
-  type FunctionExecutionEntry,
+  emitExecutionFinished,
+  emitHandlerFired,
+  emitTriggerDiscovered,
+} from '../../../../functions-rtdb/events.js';
+import {
+  executionIdFor,
   type FunctionExecutionRecord,
 } from '../../../../functions-rtdb/execution-log.js';
 import { matchRtdbReference, normalizeRtdbReference } from '../../../../functions-rtdb/reference-pattern.js';
@@ -52,8 +56,8 @@ function eventOptionsFor(
   };
 }
 
-/** Record one finished run, folding in the result or the error the handler produced. */
-function logExecution(
+/** Report one finished run onto the stream, and read back the record it became. */
+function reportExecution(
   ctx: SurfaceContext,
   triggerName: string,
   ref: string,
@@ -62,16 +66,28 @@ function logExecution(
   durationMs: number,
   result: CreatedExecutionResult,
 ): FunctionExecutionRecord {
-  const entry: FunctionExecutionEntry = {
+  const id = executionIdFor(ctx.sandbox);
+  const record: FunctionExecutionRecord = {
+    id,
     trigger: triggerName,
     cause: { ref, params },
     startedAt,
     durationMs,
     status: result.status,
   };
-  if (result.status === 'fulfilled') entry.result = result.result;
-  if (result.status === 'rejected') entry.error = describeError(result.error);
-  return executionLogFor(ctx.sandbox).record(entry);
+  if (result.status === 'fulfilled') record.result = result.result;
+  if (result.status === 'rejected') record.error = describeError(result.error);
+  emitExecutionFinished(ctx.sandbox, {
+    trigger: triggerName,
+    ref,
+    params,
+    startedAt,
+    durationMs,
+    status: record.status,
+    result: record.result,
+    error: record.error,
+  });
+  return record;
 }
 
 export default {
@@ -101,7 +117,9 @@ export default {
         `functions.fire: '${path}' does not match ${triggerName}'s reference pattern '${trigger.reference}'.`,
       );
     }
+    emitTriggerDiscovered(ctx.sandbox, trigger);
     const ref = normalizeRtdbReference(path);
+    emitHandlerFired(ctx.sandbox, { trigger: triggerName, ref, params });
     const startedAt = getClock(ctx.sandbox).now();
     const startedMonotonic = performance.now();
     const result = await executeOnValueCreated(
@@ -110,7 +128,7 @@ export default {
       eventOptionsFor(ctx, trigger),
     );
     const durationMs = performance.now() - startedMonotonic;
-    const record = logExecution(ctx, triggerName, ref, params, startedAt, durationMs, result);
+    const record = reportExecution(ctx, triggerName, ref, params, startedAt, durationMs, result);
     if (result.status === 'rejected') {
       return operationFailure(`functions.fire: ${triggerName} threw: ${record.error}`, {
         executionId: record.id,

--- a/packages/cli/src/bridge/surface/methods/sandbox/events.ts
+++ b/packages/cli/src/bridge/surface/methods/sandbox/events.ts
@@ -7,7 +7,8 @@
  * continuation and is not one, so a cursor the log does not carry is refused.
  */
 import { z } from 'zod';
-import { toOperationRecord, type OperationRecord } from 'pyric/sandbox';
+import { toListenerRecord, toOperationRecord, type OperationRecord } from 'pyric/sandbox';
+import type { SandboxEvent } from 'pyric/sandbox';
 import { operationFailure } from '../../context.js';
 import type { MethodRecord } from '../../method-types.js';
 
@@ -24,17 +25,31 @@ function matchesKind(record: OperationRecord, kind: string): boolean {
   return isWrite(record);
 }
 
+/**
+ * The record one event contributes to the requested page, or `null` when the
+ * event belongs to a different page. `listeners` reads the lifecycle stream
+ * (attach, detach, delivery, suppressed, errored) and nothing else; every
+ * other kind reads the operation stream, where lifecycle never appeared.
+ */
+function recordForKind(event: SandboxEvent, kind: string): OperationRecord | null {
+  if (kind === 'listeners') return toListenerRecord(event);
+  const record = toOperationRecord(event);
+  if (record === null) return null;
+  if (!matchesKind(record, kind)) return null;
+  return record;
+}
+
 export default {
   tool: 'sandbox',
   method: 'events',
   sdkOrigin: 'pyric',
   effect: 'read',
-  signature: 'events(since?, limit?, kind?: all|denials|writes)',
+  signature: 'events(since?, limit?, kind?: all|denials|writes|listeners)',
   description: 'Page the operation log; since is a prior nextCursor.',
   args: z.object({
     since: z.string().optional().describe('The nextCursor a prior call returned.'),
     limit: z.number().int().positive().max(500).optional().describe('Default 50, maximum 500.'),
-    kind: z.enum(['all', 'denials', 'writes']).optional(),
+    kind: z.enum(['all', 'denials', 'writes', 'listeners']).optional(),
   }),
   operation: 'list_sandbox_events',
   example: { limit: 20, kind: 'denials' },
@@ -59,9 +74,8 @@ export default {
     let lastIndex = startIndex - 1;
     for (let i = startIndex; i < history.length && events.length < limit; i++) {
       lastIndex = i;
-      const record = toOperationRecord(history[i]!);
+      const record = recordForKind(history[i]!, kind);
       if (record === null) continue;
-      if (!matchesKind(record, kind)) continue;
       events.push(record);
     }
     const hasMore = lastIndex < history.length - 1;

--- a/packages/cli/src/functions-rtdb/events.ts
+++ b/packages/cli/src/functions-rtdb/events.ts
@@ -1,0 +1,91 @@
+/**
+ * The Functions trigger runtime's emit sites on the sandbox event stream.
+ *
+ * A run is three things worth seeing: which trigger the runtime resolved out
+ * of the project's source, the synthetic event a handler was then fired on,
+ * and how that run finished. Each lands as one cross-service mutation event so
+ * a caller reads Functions activity beside every other service's, and so
+ * `functions.executions` has a history to fold rather than a private log to
+ * keep.
+ *
+ * The runtime reaches a sandbox only where the in-process server holds one:
+ * the bridge surface context. Emission is best effort, the storage precedent:
+ * a throw from the emit path must never fail the run that caused it.
+ */
+import { getClock, type LocalSandbox, type ServiceEventOperation } from 'pyric/sandbox';
+import { emitSandboxEvent, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+
+/** Every operation the Functions record declares. */
+type FunctionsEventOperation = ServiceEventOperation<'functions'>;
+
+/** What one finished run reports. */
+export interface FunctionExecutionOutcome {
+  trigger: string;
+  ref: string;
+  params: Record<string, string>;
+  startedAt: number;
+  durationMs: number;
+  status: 'fulfilled' | 'rejected';
+  result?: unknown;
+  error?: string;
+}
+
+function emit(
+  sandbox: LocalSandbox,
+  op: FunctionsEventOperation,
+  path: string,
+  detail: Record<string, unknown>,
+): void {
+  try {
+    const event = makeServiceMutationEvent({
+      at: getClock(sandbox).now(),
+      service: 'functions',
+      op,
+      path,
+      auth: null,
+      detail,
+    });
+    emitSandboxEvent(sandbox, event, { service: 'functions' });
+  } catch {
+    // Observational: never let event emission break a trigger run.
+  }
+}
+
+/** The runtime resolved one trigger out of the project's Functions source. */
+export function emitTriggerDiscovered(
+  sandbox: LocalSandbox,
+  trigger: { exportName: string; reference: string; instance: string },
+): void {
+  emit(sandbox, 'trigger_discovered', trigger.reference, {
+    trigger: trigger.exportName,
+    instance: trigger.instance,
+  });
+}
+
+/** A handler was fired on a synthetic event at `ref`. */
+export function emitHandlerFired(
+  sandbox: LocalSandbox,
+  fired: { trigger: string; ref: string; params: Record<string, string> },
+): void {
+  emit(sandbox, 'handler_fired', fired.ref, {
+    trigger: fired.trigger,
+    params: fired.params,
+  });
+}
+
+/** A run finished, with how long it took and what it produced. */
+export function emitExecutionFinished(
+  sandbox: LocalSandbox,
+  outcome: FunctionExecutionOutcome,
+): void {
+  const detail: Record<string, unknown> = {
+    trigger: outcome.trigger,
+    params: outcome.params,
+    startedAt: outcome.startedAt,
+    durationMs: outcome.durationMs,
+    status: outcome.status,
+  };
+  if (outcome.status === 'fulfilled') detail.result = outcome.result;
+  if (outcome.status === 'rejected') detail.error = outcome.error;
+  emit(sandbox, 'execution_finished', outcome.ref, detail);
+}

--- a/packages/cli/src/functions-rtdb/execution-log.ts
+++ b/packages/cli/src/functions-rtdb/execution-log.ts
@@ -1,23 +1,18 @@
 /**
- * The record of runs `fire` caused, one log per sandbox.
+ * The record of runs `fire` caused, read back off the sandbox event stream.
  *
- * The runtime this package wraps had no execution log before this file: the
- * real dev runtime only ever reports an execution to a log line
- * (`vite-functions-development.ts`'s `reportEvent`) and forgets it. A synthetic
- * call needs somewhere to read that history back from, so this is a small,
- * one-file seam added to the runtime rather than a claim about a log that
- * already existed.
- *
- * The store is keyed on the sandbox rather than held as one process-wide
- * value, the same reason `assurance-campaigns.ts` keys its campaign store on
- * the sandbox: a second sandbox in the same process, which is what a test
- * suite is, never sees another sandbox's executions.
+ * The runtime this package wraps had no execution log: the real dev runtime
+ * only ever reports an execution to a log line and forgets it. A synthetic
+ * call needs somewhere to read that history back from, and that somewhere is
+ * the stream every other service already lands on, so `fire` emits one
+ * `execution_finished` event per run and this module folds those events back
+ * into the records a caller reads. There is no second copy to drift from it.
  */
-import type { LocalSandbox } from 'pyric/sandbox';
+import type { LocalSandbox, SandboxEvent } from 'pyric/sandbox';
 
 /** One run `fire` caused. */
 export interface FunctionExecutionRecord {
-  /** Stable id, assigned in log order. */
+  /** Stable id, assigned in the order runs finished. */
   id: string;
   /** The trigger export name `fire` ran. */
   trigger: string;
@@ -33,36 +28,55 @@ export interface FunctionExecutionRecord {
   error?: string;
 }
 
-/** What `fire` reports to the log once a run finishes. */
-export type FunctionExecutionEntry = Omit<FunctionExecutionRecord, 'id'>;
-
-export class FunctionsExecutionLog {
-  #records: FunctionExecutionRecord[] = [];
-  #sequence = 0;
-
-  /** Append one finished run and return the record it was stored as. */
-  record(entry: FunctionExecutionEntry): FunctionExecutionRecord {
-    this.#sequence += 1;
-    const stored: FunctionExecutionRecord = { id: String(this.#sequence), ...entry };
-    this.#records.push(stored);
-    return stored;
-  }
-
-  /** Every run at or after `since`, in the order they finished. */
-  list(since?: number): FunctionExecutionRecord[] {
-    if (since === undefined) return [...this.#records];
-    return this.#records.filter((record) => record.startedAt >= since);
-  }
+/** Whether one event is a finished Functions run. */
+function isExecutionFinished(event: SandboxEvent): boolean {
+  if (event.kind !== 'service_mutation') return false;
+  if (event.service !== 'functions') return false;
+  return event.op === 'execution_finished';
 }
 
-/** One execution log per sandbox, created the first time a call reaches it. */
-const LOGS = new WeakMap<LocalSandbox, FunctionsExecutionLog>();
+/** The finished-run events this sandbox carries, in the order they landed. */
+function finishedRuns(sandbox: LocalSandbox): SandboxEvent[] {
+  return sandbox.history().filter(isExecutionFinished);
+}
 
-/** The execution log this sandbox holds. */
-export function executionLogFor(sandbox: LocalSandbox): FunctionsExecutionLog {
-  const existing = LOGS.get(sandbox);
-  if (existing !== undefined) return existing;
-  const created = new FunctionsExecutionLog();
-  LOGS.set(sandbox, created);
-  return created;
+/**
+ * The id the next run to finish will carry.
+ *
+ * Ids count the finished runs the stream already holds, so they stay the
+ * one-based sequence a caller saw before the log became a fold, and a restore
+ * that replaces the stream renumbers with it rather than drifting past it.
+ */
+export function executionIdFor(sandbox: LocalSandbox): string {
+  return String(finishedRuns(sandbox).length + 1);
+}
+
+/** Rebuild one record from the event that reported the run. */
+function toRecord(event: SandboxEvent, ordinal: number): FunctionExecutionRecord {
+  const mutation = event as { path?: string; detail?: Record<string, unknown> };
+  const detail = mutation.detail ?? {};
+  const record: FunctionExecutionRecord = {
+    id: String(ordinal),
+    trigger: String(detail.trigger),
+    cause: {
+      ref: mutation.path ?? '',
+      params: (detail.params as Record<string, string> | undefined) ?? {},
+    },
+    startedAt: Number(detail.startedAt),
+    durationMs: Number(detail.durationMs),
+    status: detail.status === 'rejected' ? 'rejected' : 'fulfilled',
+  };
+  if (record.status === 'fulfilled') record.result = detail.result;
+  if (record.status === 'rejected') record.error = String(detail.error);
+  return record;
+}
+
+/** Every run at or after `since`, in the order they finished. */
+export function listExecutions(
+  sandbox: LocalSandbox,
+  since?: number,
+): FunctionExecutionRecord[] {
+  const records = finishedRuns(sandbox).map((event, index) => toRecord(event, index + 1));
+  if (since === undefined) return records;
+  return records.filter((record) => record.startedAt >= since);
 }

--- a/packages/cli/test/bridge/surface/handlers-functions.test.ts
+++ b/packages/cli/test/bridge/surface/handlers-functions.test.ts
@@ -105,6 +105,50 @@ it('reports a thrown handler as a rejected execution with its error', async () =
   expect(last.error).toContain('PYRIC_EXPECTED_FIRE_FAILURE');
 });
 
+it('lands the discovery, the firing, and the finish on the sandbox event stream', async () => {
+  const before = ctx.sandbox.history().length;
+  await run('functions.fire', {
+    trigger: 'makeUppercase',
+    path: 'messages/streamed/original',
+    value: 'hi',
+  });
+
+  const emitted = ctx.sandbox
+    .history()
+    .slice(before)
+    .filter((event) => event.kind === 'service_mutation' && event.service === 'functions');
+  expect(emitted.map((event) => (event as { op: string }).op)).toEqual([
+    'trigger_discovered',
+    'handler_fired',
+    'execution_finished',
+  ]);
+
+  const fired = emitted[1] as { path?: string };
+  expect(fired.path).toBe('messages/streamed/original');
+
+  const finished = emitted[2] as { detail?: Record<string, unknown> };
+  expect(finished.detail?.status).toBe('fulfilled');
+  expect(finished.detail?.result).toBe('HI');
+  expect(typeof finished.detail?.durationMs).toBe('number');
+});
+
+it('carries the thrown error on the finish event', async () => {
+  const before = ctx.sandbox.history().length;
+  await run('functions.fire', { trigger: 'alwaysThrows', path: 'failures/two', value: true });
+
+  const finished = ctx.sandbox
+    .history()
+    .slice(before)
+    .find(
+      (event) =>
+        event.kind === 'service_mutation'
+        && event.service === 'functions'
+        && event.op === 'execution_finished',
+    ) as { detail?: Record<string, unknown> } | undefined;
+  expect(finished?.detail?.status).toBe('rejected');
+  expect(String(finished?.detail?.error)).toContain('PYRIC_EXPECTED_FIRE_FAILURE');
+});
+
 it('refuses an unknown trigger, naming listTriggers', async () => {
   const refused = await run('functions.fire', {
     trigger: 'doesNotExist',

--- a/packages/cli/test/bridge/surface/methods/sandbox/events.test.ts
+++ b/packages/cli/test/bridge/surface/methods/sandbox/events.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initializeSandbox, type LocalSandbox } from 'pyric/sandbox';
 import { setRules } from 'pyric/sandbox/firestore';
+import { doc, getFirestore, onSnapshot } from 'pyric/firestore';
 
 import { createSurfaceContext, renderSurface } from '../../../../../src/bridge/surface/index.js';
 import type { OperationResult, SurfaceContext } from '../../../../../src/bridge/surface/index.js';
@@ -76,6 +77,37 @@ describe('sandbox.events', () => {
     expect(refused.summary).toContain(cursor);
     expect(refused.summary).toContain('replaced');
     expect(refused.summary).toContain("without 'since'");
+  });
+
+  it('pages listener lifecycle with kind listeners, and nothing else', async () => {
+    const stop = onSnapshot(doc(getFirestore(sandbox), 'ledger/one'), () => {});
+    await run('firestore.setDoc', { path: 'ledger/one', data: { n: 1 } });
+    stop();
+
+    const listed = await run('sandbox.events', { kind: 'listeners' });
+    expect(listed.ok).toBe(true);
+    const events = (listed.data as { events: Array<{ method: string }> }).events;
+    const phases = events.map((event) => event.method);
+    expect(phases).toContain('attach');
+    expect(phases).toContain('delivery');
+    expect(phases).toContain('detach');
+    for (const phase of phases) {
+      expect(['attach', 'detach', 'delivery', 'suppressed', 'errored']).toContain(phase);
+    }
+  });
+
+  it('keeps listener lifecycle out of the write and denial pages', async () => {
+    const stop = onSnapshot(doc(getFirestore(sandbox), 'ledger/one'), () => {});
+    await run('firestore.setDoc', { path: 'ledger/one', data: { n: 1 } });
+    stop();
+
+    const writes = await run('sandbox.events', { kind: 'writes' });
+    const methods = (writes.data as { events: Array<{ method: string }> }).events.map(
+      (event) => event.method,
+    );
+    expect(methods).not.toContain('attach');
+    expect(methods).not.toContain('detach');
+    expect(methods).not.toContain('delivery');
   });
 
   it('refuses a cursor the sandbox never handed out', async () => {

--- a/packages/cli/test/functions-rtdb/events.test.ts
+++ b/packages/cli/test/functions-rtdb/events.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The Functions trigger runtime's emit sites: what each one lands on the
+ * sandbox event stream, and that a failure to emit never reaches the caller.
+ */
+import { describe, expect, test } from 'bun:test';
+import { initializeSandbox, type LocalSandbox, type SandboxEvent } from 'pyric/sandbox';
+import {
+  emitExecutionFinished,
+  emitHandlerFired,
+  emitTriggerDiscovered,
+} from '../../src/functions-rtdb/events.js';
+
+function functionsEvents(sandbox: LocalSandbox): Array<SandboxEvent & { op: string }> {
+  return sandbox
+    .history()
+    .filter(
+      (event) => event.kind === 'service_mutation' && event.service === 'functions',
+    ) as Array<SandboxEvent & { op: string }>;
+}
+
+describe('functions event emission', () => {
+  test('reports a discovered trigger against its reference pattern', () => {
+    const sandbox = initializeSandbox();
+    emitTriggerDiscovered(sandbox, {
+      exportName: 'makeUppercase',
+      reference: '/messages/{pushId}/original',
+      instance: 'demo-default-rtdb',
+    });
+    const [event] = functionsEvents(sandbox) as Array<{
+      op: string;
+      path?: string;
+      detail?: Record<string, unknown>;
+    }>;
+    expect(event!.op).toBe('trigger_discovered');
+    expect(event!.path).toBe('/messages/{pushId}/original');
+    expect(event!.detail?.trigger).toBe('makeUppercase');
+  });
+
+  test("reports a fired handler against the synthetic event's own path", () => {
+    const sandbox = initializeSandbox();
+    emitHandlerFired(sandbox, {
+      trigger: 'makeUppercase',
+      ref: 'messages/abc/original',
+      params: { pushId: 'abc' },
+    });
+    const [event] = functionsEvents(sandbox) as Array<{ op: string; path?: string }>;
+    expect(event!.op).toBe('handler_fired');
+    expect(event!.path).toBe('messages/abc/original');
+  });
+
+  test('reports a finished run with its duration and its result', () => {
+    const sandbox = initializeSandbox();
+    emitExecutionFinished(sandbox, {
+      trigger: 'makeUppercase',
+      ref: 'messages/abc/original',
+      params: {},
+      startedAt: 5,
+      durationMs: 2,
+      status: 'fulfilled',
+      result: 'HELLO',
+    });
+    const [event] = functionsEvents(sandbox) as Array<{
+      op: string;
+      detail?: Record<string, unknown>;
+    }>;
+    expect(event!.op).toBe('execution_finished');
+    expect(event!.detail?.durationMs).toBe(2);
+    expect(event!.detail?.result).toBe('HELLO');
+    expect(event!.detail?.error).toBeUndefined();
+  });
+
+  test('never lets a refused sandbox handle reach the caller', () => {
+    const notASandbox = { history: () => [] } as unknown as LocalSandbox;
+    expect(() =>
+      emitTriggerDiscovered(notASandbox, {
+        exportName: 'a',
+        reference: '/x/{id}',
+        instance: 'demo',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/cli/test/functions-rtdb/execution-log.test.ts
+++ b/packages/cli/test/functions-rtdb/execution-log.test.ts
@@ -1,60 +1,83 @@
+/**
+ * The execution list is a fold over the sandbox event stream, so the same
+ * properties the private log used to guarantee have to hold of the fold:
+ * stable ids in the order runs finished, a cursor that filters by start
+ * instant, and one history per sandbox.
+ */
 import { describe, expect, test } from 'bun:test';
-import { initializeSandbox } from 'pyric/sandbox';
-import { executionLogFor } from '../../src/functions-rtdb/execution-log.js';
+import { initializeSandbox, type LocalSandbox } from 'pyric/sandbox';
+import { emitExecutionFinished } from '../../src/functions-rtdb/events.js';
+import { executionIdFor, listExecutions } from '../../src/functions-rtdb/execution-log.js';
 
-describe('FunctionsExecutionLog', () => {
-  test('assigns each record a stable id in log order', () => {
+function finish(
+  sandbox: LocalSandbox,
+  outcome: {
+    trigger: string;
+    ref: string;
+    params?: Record<string, string>;
+    startedAt: number;
+    status?: 'fulfilled' | 'rejected';
+    result?: unknown;
+    error?: string;
+  },
+): void {
+  emitExecutionFinished(sandbox, {
+    trigger: outcome.trigger,
+    ref: outcome.ref,
+    params: outcome.params ?? {},
+    startedAt: outcome.startedAt,
+    durationMs: 1,
+    status: outcome.status ?? 'fulfilled',
+    result: outcome.result,
+    error: outcome.error,
+  });
+}
+
+describe('functions execution history', () => {
+  test('assigns each record a stable id in the order runs finished', () => {
     const sandbox = initializeSandbox();
-    const log = executionLogFor(sandbox);
-    const first = log.record({
+    expect(executionIdFor(sandbox)).toBe('1');
+    finish(sandbox, { trigger: 'makeUppercase', ref: 'messages/one/original', startedAt: 100 });
+    expect(executionIdFor(sandbox)).toBe('2');
+    finish(sandbox, {
       trigger: 'makeUppercase',
-      cause: { ref: 'messages/one/original', params: { pushId: 'one' } },
-      startedAt: 100,
-      durationMs: 5,
-      status: 'fulfilled',
-    });
-    const second = log.record({
-      trigger: 'makeUppercase',
-      cause: { ref: 'messages/two/original', params: { pushId: 'two' } },
+      ref: 'messages/two/original',
       startedAt: 200,
-      durationMs: 3,
       status: 'rejected',
       error: 'boom',
     });
-    expect(first.id).not.toBe(second.id);
-    expect(log.list()).toEqual([first, second]);
+
+    const listed = listExecutions(sandbox);
+    expect(listed.map((record) => record.id)).toEqual(['1', '2']);
+    expect(listed[1]!.status).toBe('rejected');
+    expect(listed[1]!.error).toBe('boom');
+  });
+
+  test('carries the cause the synthetic event named', () => {
+    const sandbox = initializeSandbox();
+    finish(sandbox, {
+      trigger: 'makeUppercase',
+      ref: 'messages/one/original',
+      params: { pushId: 'one' },
+      startedAt: 100,
+      result: 'HELLO',
+    });
+    const [record] = listExecutions(sandbox);
+    expect(record!.cause).toEqual({ ref: 'messages/one/original', params: { pushId: 'one' } });
+    expect(record!.result).toBe('HELLO');
   });
 
   test('lists only records at or after the cursor', () => {
     const sandbox = initializeSandbox();
-    const log = executionLogFor(sandbox);
-    log.record({
-      trigger: 'a',
-      cause: { ref: 'x/1', params: {} },
-      startedAt: 10,
-      durationMs: 1,
-      status: 'fulfilled',
-    });
-    const later = log.record({
-      trigger: 'a',
-      cause: { ref: 'x/2', params: {} },
-      startedAt: 20,
-      durationMs: 1,
-      status: 'fulfilled',
-    });
-    expect(log.list(20)).toEqual([later]);
+    finish(sandbox, { trigger: 'a', ref: 'x/1', startedAt: 10 });
+    finish(sandbox, { trigger: 'a', ref: 'x/2', startedAt: 20 });
+    expect(listExecutions(sandbox, 20).map((record) => record.cause.ref)).toEqual(['x/2']);
   });
 
-  test('keeps one log per sandbox', () => {
+  test('keeps one history per sandbox', () => {
     const sandboxA = initializeSandbox();
     const sandboxB = initializeSandbox();
-    executionLogFor(sandboxA).record({
-      trigger: 'a',
-      cause: { ref: 'x/1', params: {} },
-      startedAt: 1,
-      durationMs: 1,
-      status: 'fulfilled',
-    });
-    expect(executionLogFor(sandboxB).list()).toEqual([]);
+    finish(sandboxA, { trigger: 'a', ref: 'x/1', startedAt: 1 });
+    expect(listExecutions(sandboxB)).toEqual([]);
   });
 });

--- a/packages/pyric/src/ai/broker/broker.ts
+++ b/packages/pyric/src/ai/broker/broker.ts
@@ -38,6 +38,7 @@
 
 import type { Sandbox } from 'pyric/sandbox';
 import { emitSandboxEvent, getClock, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { AiEventOperation } from '../events.js';
 
 import { describeResponseBlock } from '../blocked.js';
 import { AiBrokerError, Synthesizer, badRole, emptyContents, missingThoughtSignature } from './synthesizer.js';
@@ -373,7 +374,7 @@ export class AiBroker {
    * Best-effort, storage-precedent: a throw from the emit path must never
    * fail the AI operation the caller just completed.
    */
-  private emit(op: string, model: string, detail: Record<string, unknown>): void {
+  private emit(op: AiEventOperation, model: string, detail: Record<string, unknown>): void {
     if (this.sandbox === undefined) return;
     try {
       emitSandboxEvent(

--- a/packages/pyric/src/ai/events.ts
+++ b/packages/pyric/src/ai/events.ts
@@ -1,0 +1,29 @@
+/**
+ * What the AI surface puts on the sandbox event stream.
+ *
+ * The broker emits one event per answered call, per rejection, and per
+ * substitution. The scripted engine's pending entry queue is not here: a
+ * queued entry is a registration waiting to be used, not something that
+ * happened, and its matcher and responder are functions no event can carry.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const AI_EVENT_RECORD = {
+  service: 'ai',
+  operations: [
+    'generate_content',
+    'stream_generate_content',
+    'count_tokens',
+    'request_rejected',
+    'response_blocked',
+    'model_substituted',
+  ],
+  target: {
+    name: 'model',
+    description: 'The model name the call named, e.g. gemini-2.5-flash.',
+    always: false,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every operation the AI surface emits. */
+export type AiEventOperation = (typeof AI_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/src/auth/events.ts
+++ b/packages/pyric/src/auth/events.ts
@@ -1,0 +1,29 @@
+/**
+ * What the auth surface puts on the sandbox event stream.
+ *
+ * The sandbox core reads this record to derive the `auth` arm of
+ * `ServiceMutationEvent`; the emit sites in `auth/sandbox-backend.ts` are
+ * typed against the operations declared here.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const AUTH_EVENT_RECORD = {
+  service: 'auth',
+  operations: [
+    'user_create',
+    'user_update',
+    'user_delete',
+    'users_clear',
+    'sign_in',
+    'sign_out',
+    'provider_config_update',
+  ],
+  target: {
+    name: 'uid',
+    description: "The mutated user's uid, or '*' when every user was cleared.",
+    always: false,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every operation the auth surface emits. */
+export type AuthEventOperation = (typeof AUTH_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -52,6 +52,7 @@ import { defaultAvatarMint, type AvatarMint } from './sandbox/default-avatar.js'
 
 import type { AuthState, Sandbox } from 'pyric/sandbox';
 import { emitSandboxEvent, getClock, makeServiceMutationEvent } from 'pyric/sandbox/internal';
+import type { AuthEventOperation } from './events.js';
 
 import {
   USER_INTERNAL,
@@ -545,7 +546,7 @@ export class SandboxBackend {
    * via `stampProvenance`.
    */
   private emitAuthEvent(
-    op: string,
+    op: AuthEventOperation,
     fields: { path?: string; auth?: AuthState; before?: unknown; after?: unknown; detail?: Record<string, unknown> } = {},
   ): void {
     try {

--- a/packages/pyric/src/database/events.ts
+++ b/packages/pyric/src/database/events.ts
@@ -1,0 +1,20 @@
+/**
+ * What the Realtime Database surface puts on the sandbox event stream as a
+ * cross-service mutation. The surface's rich typed `operation`, `commit`, and
+ * `listener` events are declared on the event union itself; this record covers
+ * the generic mutation envelope only.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const RTDB_EVENT_RECORD = {
+  service: 'rtdb',
+  operations: ['set', 'update', 'remove', 'transaction', 'setPriority'],
+  target: {
+    name: 'path',
+    description: 'The database path the call targeted, e.g. /rooms/r1/messages.',
+    always: true,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every mutation operation the Realtime Database surface emits. */
+export type RtdbEventOperation = (typeof RTDB_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/src/functions/events.ts
+++ b/packages/pyric/src/functions/events.ts
@@ -1,0 +1,23 @@
+/**
+ * What the Functions trigger runtime puts on the sandbox event stream.
+ *
+ * The runtime itself lives in `@pyric/cli` because it loads a project's own
+ * trigger module from disk. The event vocabulary lives here, beside every
+ * other service's, because the sandbox core derives the stream's service union
+ * from these records and `@pyric/cli` depends downward on `pyric`.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const FUNCTIONS_EVENT_RECORD = {
+  service: 'functions',
+  operations: ['trigger_discovered', 'handler_fired', 'execution_finished'],
+  target: {
+    name: 'ref',
+    description:
+      "The trigger's reference pattern on discovery, and the synthetic event's concrete path once a handler fires.",
+    always: false,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every operation the Functions trigger runtime emits. */
+export type FunctionsEventOperation = (typeof FUNCTIONS_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/src/functions/events.ts
+++ b/packages/pyric/src/functions/events.ts
@@ -5,6 +5,10 @@
  * trigger module from disk. The event vocabulary lives here, beside every
  * other service's, because the sandbox core derives the stream's service union
  * from these records and `@pyric/cli` depends downward on `pyric`.
+ *
+ * This file is not part of the deferred `pyric/functions` mirror beside it,
+ * which stands in for `firebase/functions` callables. It is data, and the
+ * deferred barrel does not re-export it.
  */
 import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
 

--- a/packages/pyric/src/messaging/broker/broker.test.ts
+++ b/packages/pyric/src/messaging/broker/broker.test.ts
@@ -300,9 +300,31 @@ describe('messaging broker, registered tokens and their topics', () => {
   });
 });
 
-describe('messaging broker, the delivery log', () => {
+describe('messaging broker, the delivery history', () => {
+  it('reads the delivery history off the sandbox event stream', () => {
+    const sandbox = initializeSandbox();
+    const broker = new MessagingBroker({ sandbox });
+    broker.setClientVisibility('window-0', 'visible');
+    broker.deliver({ data: { k: 'v' } });
+
+    const delivered = sandbox
+      .history()
+      .filter(
+        (event) =>
+          event.kind === 'service_mutation'
+          && event.service === 'messaging'
+          && event.op === 'message_delivered',
+      ) as Array<{ at: number; detail?: Record<string, unknown> }>;
+    expect(delivered.length).toBe(1);
+
+    const [entry] = broker.deliveries();
+    expect(entry!.messageId).toBe(delivered[0]!.detail!.messageId as string);
+    expect(entry!.at).toBe(delivered[0]!.at);
+    expect(entry!.payload).toEqual(delivered[0]!.detail!.payload as never);
+  });
+
   it('records a topic send as delivered, foreground or background, per the visibility rule', () => {
-    const broker = new MessagingBroker();
+    const broker = new MessagingBroker({ sandbox: initializeSandbox() });
     const token = broker.getTokenFor('reg-1');
     broker.subscribeToTopic([token], 'news');
 
@@ -320,7 +342,7 @@ describe('messaging broker, the delivery log', () => {
   });
 
   it('records a delivery with no matching recipient as unhandled, and never delivers unrouted sends', () => {
-    const broker = new MessagingBroker();
+    const broker = new MessagingBroker({ sandbox: initializeSandbox() });
     const token = broker.getTokenFor('reg-1');
     broker.setClientVisibility('window-0', 'visible');
     broker.onForegroundMessage(() => {});
@@ -339,7 +361,7 @@ describe('messaging broker, the delivery log', () => {
   });
 
   it('filters by since, the cursor the deliveries method reads', () => {
-    const broker = new MessagingBroker();
+    const broker = new MessagingBroker({ sandbox: initializeSandbox() });
     broker.deliver({ data: { seq: '1' } });
     const cursor = Date.now();
     broker.deliver({ data: { seq: '2' } });

--- a/packages/pyric/src/messaging/broker/broker.ts
+++ b/packages/pyric/src/messaging/broker/broker.ts
@@ -35,6 +35,7 @@
  */
 import type { Sandbox } from '../../sandbox/types/service.js';
 import type { AuthState } from '../../sandbox/types/auth-state.js';
+import type { ServiceMutationEvent } from '../../sandbox/types/events.js';
 import { emitSandboxEvent, makeServiceMutationEvent } from '../../sandbox/internal/sandbox-impl.js';
 import type { MessagingEventOperation } from '../events.js';
 import { getClock } from '../../sandbox/clock.js';
@@ -76,6 +77,22 @@ interface TokenRecord {
 /** Ops run on the admin/send plane or the SDK control plane — never a rules identity. */
 const ADMIN_AUTH: AuthState = null;
 
+/**
+ * Rebuild one delivery entry from the event that reported the delivery. The
+ * event carries everything the entry reports, so this reads fields rather than
+ * recomputing any of them.
+ */
+function toDeliveryLogEntry(event: ServiceMutationEvent): DeliveryLogEntry {
+  const detail = event.detail ?? {};
+  return {
+    messageId: String(detail.messageId),
+    route: detail.route as DeliveryRoute,
+    handled: detail.handled === true,
+    at: event.at,
+    payload: detail.payload as DeliveredPayload,
+  };
+}
+
 export class MessagingBroker {
   readonly projectId: string;
   readonly senderId: string;
@@ -91,8 +108,6 @@ export class MessagingBroker {
   private readonly clients = new Map<string, ClientVisibilityState>();
   private readonly foregroundHandlers = new Set<PayloadHandler>();
   private readonly backgroundHandlers = new Set<PayloadHandler>();
-  /** Every past delivery, in routing order. The `deliveries` method's own state. */
-  private readonly deliveryLog: DeliveryLogEntry[] = [];
   private numericIdCounter = 0;
 
   constructor(options: MessagingBrokerConfig & { sandbox?: Sandbox } = {}) {
@@ -418,39 +433,47 @@ export class MessagingBroker {
       }
     }
 
+    // The delivery history IS this event. `deliveries` folds the stream back
+    // into entries, so everything an entry reports has to ride here.
     this.emit('message_delivered', {
-      detail: { route, handlerCount, messageId: payload.messageId },
-    });
-    this.deliveryLog.push({
-      messageId: payload.messageId,
-      route,
-      handled: handlerCount > 0,
-      at: this.clockNow(),
-      payload: structuredClone(payload),
+      detail: {
+        route,
+        handlerCount,
+        handled: handlerCount > 0,
+        messageId: payload.messageId,
+        payload: structuredClone(payload),
+      },
     });
     return { route, handlerCount, payload };
   }
 
   /**
    * What was delivered, in delivery order: foreground or background, handled
-   * or not (the `deliveries` service-tool method's read). `since` is a clock
-   * timestamp cursor; entries at or after it are returned. A `send` with no
-   * matching recipient never calls {@link route}, so it never logs here.
-   * Only an actual routing decision does.
+   * or not (the `deliveries` service-tool method's read). Folded out of the
+   * sandbox event stream's `message_delivered` events, which are the delivery
+   * history; the broker keeps no second copy. `since` is a clock timestamp
+   * cursor; entries at or after it are returned. A `send` with no matching
+   * recipient never calls {@link route}, so it emits nothing here. Only an
+   * actual routing decision does.
    */
   deliveries(since?: number): DeliveryLogEntry[] {
-    if (since === undefined) return [...this.deliveryLog];
-    return this.deliveryLog.filter((entry) => entry.at >= since);
+    const entries = this.deliveredEvents().map((event) => toDeliveryLogEntry(event));
+    if (since === undefined) return entries;
+    return entries.filter((entry) => entry.at >= since);
   }
 
-  /** The sandbox clock's current time, or the wall clock with no bound sandbox. */
-  private clockNow(): number {
-    if (this.sandbox === undefined) return Date.now();
-    try {
-      return getClock(this.sandbox).now();
-    } catch {
-      return Date.now();
+  /** The `message_delivered` events this broker's sandbox carries, in order. */
+  private deliveredEvents(): ServiceMutationEvent[] {
+    if (this.sandbox === undefined) return [];
+    const history = this.sandbox.history();
+    const delivered: ServiceMutationEvent[] = [];
+    for (const event of history) {
+      if (event.kind !== 'service_mutation') continue;
+      if (event.service !== 'messaging') continue;
+      if (event.op !== 'message_delivered') continue;
+      delivered.push(event);
     }
+    return delivered;
   }
 
   // ── Event emission (Studio stream consumer seam) ──────────────────────────

--- a/packages/pyric/src/messaging/broker/broker.ts
+++ b/packages/pyric/src/messaging/broker/broker.ts
@@ -36,6 +36,7 @@
 import type { Sandbox } from '../../sandbox/types/service.js';
 import type { AuthState } from '../../sandbox/types/auth-state.js';
 import { emitSandboxEvent, makeServiceMutationEvent } from '../../sandbox/internal/sandbox-impl.js';
+import type { MessagingEventOperation } from '../events.js';
 import { getClock } from '../../sandbox/clock.js';
 import { BrokerSendError, unregisteredTokenEnvelope, invalidTopicNameEnvelope } from './envelopes.js';
 import { mintToken } from './tokens.js';
@@ -459,7 +460,7 @@ export class MessagingBroker {
    * Best-effort, storage-precedent: a throw from the emit path must never
    * fail the messaging operation the caller just completed.
    */
-  private emit(op: string, fields: { path?: string; detail?: Record<string, unknown> }): void {
+  private emit(op: MessagingEventOperation, fields: { path?: string; detail?: Record<string, unknown> }): void {
     if (this.sandbox === undefined) return;
     try {
       emitSandboxEvent(

--- a/packages/pyric/src/messaging/events.ts
+++ b/packages/pyric/src/messaging/events.ts
@@ -1,0 +1,28 @@
+/**
+ * What the messaging surface puts on the sandbox event stream.
+ *
+ * The broker emits one event per token, subscription, and routing decision, so
+ * the stream carries the whole delivery history and no private log has to.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const MESSAGING_EVENT_RECORD = {
+  service: 'messaging',
+  operations: [
+    'token_minted',
+    'token_deleted',
+    'subscription_changed',
+    'message_accepted',
+    'message_rejected',
+    'delivery_routed',
+    'message_delivered',
+  ],
+  target: {
+    name: 'token',
+    description: 'The registration token a token or subscription operation addressed.',
+    always: false,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every operation the messaging surface emits. */
+export type MessagingEventOperation = (typeof MESSAGING_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -30,6 +30,7 @@ export type {
   OperationContext,
   ListenerLifecycleEvent,
   LocalSandbox,
+  MutationEventService,
   PersistableService,
   RequestEvent,
   RulesDisposition,
@@ -43,14 +44,18 @@ export type {
   SandboxOperationEvent,
   SandboxRuntimeErrorEvent,
   SandboxSnapshot,
+  ServiceEventOperation,
+  ServiceEventRecord,
+  ServiceEventTarget,
   ServiceMutationEvent,
+  ServiceMutationEventFields,
   SessionBoundaryEvent,
   SnapshotDeliveryEvent,
   SnapshotErrorEvent,
   SnapshotSuppressedEvent,
   WriteSandboxEvent,
 } from './types/index.js';
-export { SandboxError } from './types/index.js';
+export { SandboxError, MUTATION_EVENT_SERVICES, SERVICE_EVENT_RECORDS } from './types/index.js';
 export {
   SandboxContextImpl,
   normalizeAuthState,

--- a/packages/pyric/src/sandbox/index.ts
+++ b/packages/pyric/src/sandbox/index.ts
@@ -75,9 +75,10 @@ export {
   isOperationEvent,
   operationContextFor,
   rulesDispositionFor,
+  toListenerRecord,
   toOperationRecord,
 } from './operation-record.js';
-export type { OperationRecord } from './operation-record.js';
+export type { ListenerPhase, OperationRecord } from './operation-record.js';
 
 // Remote sandbox (slice 1) — the brand + minimal channel contract that
 // lets `pyric-admin` recognize a Node-side handle onto the browser-hosted

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -751,18 +751,14 @@ export function primeEventHistory(
  * their activity lands on the same stream — e.g.
  *   `emitSandboxEvent(sandbox, userCreatedEvent, { service: 'auth' })`.
  *
- * STATUS (Wave 1.5, Gap #1): Auth / Storage / RTDB now emit here. They share
- * one additive union variant — {@link ServiceMutationEvent} (`kind:
- * 'service_mutation'`) — built via {@link makeServiceMutationEvent}, rather
- * than bending into Firestore's rule-eval-shaped `request`/`write` kinds.
- * Wired emit sites:
- *   - auth:    user create/update/delete, users-clear, sign-in, sign-out
- *              (`SandboxBackend` in `pyric/auth`).
- *   - storage: object put / delete / metadata-update (`pyric/storage`).
- *   - rtdb:    set / update / remove / transaction-commit
- *              (`RtdbBackend` in `pyric/database`, via the modular surface).
- * Firestore still rides the env→sandbox fan-out and is unchanged. See
- * the design rationale.
+ * Every non-Firestore service emits here, sharing one additive union variant —
+ * {@link ServiceMutationEvent} (`kind: 'service_mutation'`) — built via
+ * {@link makeServiceMutationEvent}, rather than bending into Firestore's
+ * rule-eval-shaped `request`/`write` kinds. Which services those are, and
+ * which operations each of them emits, is declared once per service in
+ * `<surface>/events.ts` and derived into this variant's types by
+ * `sandbox/types/service-event-records.ts`. Firestore still rides the
+ * env→sandbox fan-out and is unchanged.
  *
  * Throws if `sandbox` wasn't produced by `initializeSandbox()` (same guard
  * as {@link getInternalEnv}).

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -32,6 +32,7 @@ import type {
   SandboxOperationEvent,
   SandboxRuntimeErrorEvent,
   ServiceMutationEvent,
+  ServiceMutationEventFields,
   SessionBoundaryEvent,
 } from '../types/events.js';
 import type { PersistableService, SandboxSnapshot } from '../types/persistence.js';
@@ -796,7 +797,7 @@ export function emitSandboxEvent(
  * site is `emitSandboxEvent(sandbox, makeServiceMutationEvent({ ... }), { service })`.
  */
 export function makeServiceMutationEvent(
-  fields: Omit<ServiceMutationEvent, 'kind' | 'id'>,
+  fields: ServiceMutationEventFields,
 ): ServiceMutationEvent {
   const { at, ...rest } = fields;
   return {

--- a/packages/pyric/src/sandbox/internal/sandbox-impl.ts
+++ b/packages/pyric/src/sandbox/internal/sandbox-impl.ts
@@ -751,8 +751,8 @@ export function primeEventHistory(
  * their activity lands on the same stream — e.g.
  *   `emitSandboxEvent(sandbox, userCreatedEvent, { service: 'auth' })`.
  *
- * Every non-Firestore service emits here, sharing one additive union variant —
- * {@link ServiceMutationEvent} (`kind: 'service_mutation'`) — built via
+ * Every non-Firestore service emits here, sharing one additive union variant,
+ * {@link ServiceMutationEvent} (`kind: 'service_mutation'`), built via
  * {@link makeServiceMutationEvent}, rather than bending into Firestore's
  * rule-eval-shaped `request`/`write` kinds. Which services those are, and
  * which operations each of them emits, is declared once per service in

--- a/packages/pyric/src/sandbox/operation-record.ts
+++ b/packages/pyric/src/sandbox/operation-record.ts
@@ -252,3 +252,75 @@ export function toOperationRecord(event: SandboxEvent): OperationRecord | null {
     queryProof,
   });
 }
+
+/** The five phases a listener passes through, whatever variant carried it. */
+export type ListenerPhase = 'attach' | 'detach' | 'delivery' | 'suppressed' | 'errored';
+
+/** Which phase an event reports, or `null` when it is not listener lifecycle. */
+function listenerPhaseOf(event: SandboxEvent): ListenerPhase | null {
+  if (event.kind === 'listener') return event.phase;
+  if (event.kind === 'listener_attach') return 'attach';
+  if (event.kind === 'listener_detach') return 'detach';
+  if (event.kind === 'listener_errored') return 'errored';
+  if (event.kind === 'snapshot_delivery') return 'delivery';
+  if (event.kind === 'snapshot_suppressed') return 'suppressed';
+  return null;
+}
+
+/** Only an errored listener met Security Rules; the other phases never did. */
+function listenerRulesDisposition(event: SandboxEvent, phase: ListenerPhase): RulesDisposition {
+  if (phase !== 'errored') return { kind: 'not-evaluated', reason: 'not-a-rules-operation' };
+  return rulesDispositionFor(event as OperationEvent);
+}
+
+/** The listener-shaped fields every lifecycle variant carries. */
+interface ListenerShape {
+  target: { kind: string; path?: string };
+  auth: AuthState;
+}
+
+/**
+ * Project one listener lifecycle event into the canonical record, with the
+ * phase as the record's `method`.
+ *
+ * Firestore reports lifecycle through its own `listener_attach` /
+ * `listener_detach` / `listener_errored` / `snapshot_delivery` /
+ * `snapshot_suppressed` variants; every other service reports it through the
+ * canonical `listener` variant. Both arrive here as the same five phases, so a
+ * caller paging listener activity never has to know which service produced it.
+ *
+ * Returns `null` for anything that is not listener lifecycle.
+ */
+export function toListenerRecord(event: SandboxEvent): OperationRecord | null {
+  const phase = listenerPhaseOf(event);
+  if (phase === null) return null;
+  const listener = event as unknown as ListenerShape;
+
+  let serviceVal: EventService = 'firestore';
+  if (event.service !== undefined) {
+    serviceVal = event.service;
+  }
+
+  let resultVal: OperationRecord['result'] = undefined;
+  if (event.kind === 'listener' && event.result !== undefined) {
+    resultVal = event.result;
+  } else if (phase === 'errored') {
+    resultVal = 'deny';
+  }
+
+  const record: {
+    -readonly [Key in keyof OperationRecord]: OperationRecord[Key];
+  } = {
+    id: event.id,
+    at: event.at,
+    eventKind: 'listener',
+    service: serviceVal,
+    method: phase,
+    auth: immutableAuthState(listener.auth),
+    result: resultVal,
+    context: operationContextFor(event),
+    rules: Object.freeze(listenerRulesDisposition(event, phase)),
+  };
+  if (listener.target.path !== undefined) record.path = listener.target.path;
+  return Object.freeze(record);
+}

--- a/packages/pyric/src/sandbox/types/events.ts
+++ b/packages/pyric/src/sandbox/types/events.ts
@@ -7,11 +7,20 @@ import type { QueryProofDiagnostic } from './query-proof.js';
 
 import type { AuthState } from './auth-state.js';
 import type {
+  MutationEventService,
+  ServiceEventOperation,
+} from './service-event-records.js';
+import type {
   EventProvenance,
   EventService,
   OperationContext,
   RulesDisposition,
 } from './operation.js';
+export type { MutationEventService, ServiceEventOperation } from './service-event-records.js';
+export type {
+  ServiceEventRecord,
+  ServiceEventTarget,
+} from './service-event-record.js';
 export type {
   ActivityEventProvenance,
   AuthLens,
@@ -365,7 +374,7 @@ export interface SessionBoundaryEvent {
  * data grids / Action Center render `service` + `op` + `path` directly and
  * diff `before`→`after` when both are present.
  */
-export interface ServiceMutationEvent {
+export interface ServiceMutationEventOf<Service extends MutationEventService> {
   kind: 'service_mutation';
   id: string;
   at: number;
@@ -375,21 +384,17 @@ export interface ServiceMutationEvent {
    * provenance `service` field on the stamped event mirrors this; it is set
    * redundantly here so a consumer matching purely on `kind` still gets the
    * discriminator without reaching into provenance.)
+   *
+   * Derived from the per-service records in `service-event-records.ts`, so a
+   * service reaches this union by declaring an event record beside its own
+   * code and no other way.
    */
-  service: 'auth' | 'storage' | 'rtdb' | 'messaging' | 'ai';
+  service: Service;
   /**
-   * Service-scoped operation name. Stable, lowercase, snake/kebab-free:
-   *   - auth:    `user_create` | `user_update` | `user_delete` |
-   *              `users_clear` | `sign_in` | `sign_out`
-   *   - storage: `object_put` | `object_delete` | `metadata_update`
-   *   - rtdb:    `set` | `update` | `remove` | `transaction`
-   *   - ai:      `generate_content` | `stream_generate_content` |
-   *              `count_tokens` | `request_rejected` | `response_blocked` |
-   *              `model_substituted`
-   * New ops can be added without a breaking change (consumers switch with a
-   * default branch).
+   * Service-scoped operation name, drawn from the operations that service's
+   * own record declares. A service adds an operation by adding it there.
    */
-  op: string;
+  op: ServiceEventOperation<Service>;
   /**
    * The thing mutated, in the service's own addressing scheme:
    *   - auth:    the user `uid` (or `'*'` for a clear-all). Absent for a
@@ -416,6 +421,24 @@ export interface ServiceMutationEvent {
    *  display hint, not a contract. */
   detail?: Record<string, unknown>;
 }
+
+/**
+ * The cross-service mutation envelope, as the union over every service that
+ * declared an event record. Narrowing on `service` narrows `op` to that
+ * service's own operations.
+ */
+export type ServiceMutationEvent = {
+  [Service in MutationEventService]: ServiceMutationEventOf<Service>;
+}[MutationEventService];
+
+/**
+ * The fields a caller supplies to build a {@link ServiceMutationEvent}; `kind`
+ * and `id` are the emitter's. Distributed per service so `op` stays bound to
+ * the `service` beside it.
+ */
+export type ServiceMutationEventFields = {
+  [Service in MutationEventService]: Omit<ServiceMutationEventOf<Service>, 'kind' | 'id'>;
+}[MutationEventService];
 
 /**
  * Canonical service operation event. This is the service-neutral successor to

--- a/packages/pyric/src/sandbox/types/events.ts
+++ b/packages/pyric/src/sandbox/types/events.ts
@@ -1,4 +1,5 @@
 import type { QueryProofDiagnostic } from './query-proof.js';
+import type { ServiceMutationEvent } from './service-mutation-event.js';
 /**
  * The sandbox event surface: every discriminated event variant the
  * sandbox can emit, the shared provenance/service/actor/lens types that
@@ -7,16 +8,17 @@ import type { QueryProofDiagnostic } from './query-proof.js';
 
 import type { AuthState } from './auth-state.js';
 import type {
-  MutationEventService,
-  ServiceEventOperation,
-} from './service-event-records.js';
-import type {
   EventProvenance,
   EventService,
   OperationContext,
   RulesDisposition,
 } from './operation.js';
 export type { MutationEventService, ServiceEventOperation } from './service-event-records.js';
+export type {
+  ServiceMutationEvent,
+  ServiceMutationEventFields,
+  ServiceMutationEventOf,
+} from './service-mutation-event.js';
 export type {
   ServiceEventRecord,
   ServiceEventTarget,
@@ -351,94 +353,6 @@ export interface SessionBoundaryEvent {
   priorOpCount: number;
 }
 
-/**
- * Cross-service mutation event — the unified envelope the NON-Firestore
- * services (`auth` / `storage` / `rtdb`) emit into the single
- * `onEvent`/`history()` stream (Pyric Studio keystone, track T1).
- *
- * **Why a new variant rather than reusing `request`/`write`.** Firestore's
- * existing kinds are tightly coupled to the rules-simulator: `RequestEvent`
- * carries `result: 'allow'|'deny'`, `evalMs`, the simulator's `reasons[]`,
- * and `matchedRule`; `WriteSandboxEvent` carries Firestore-specific
- * `sentinels`, `autoId`, and a Firestore `requestTime` Timestamp. Auth user-
- * DB mutations (no path, no rule eval), Storage object puts, and RTDB tree
- * writes don't have those concepts, and bending them into the Firestore
- * shapes would either lie (synthesize a fake `result`/`requestTime`) or
- * pollute the Firestore consumer contract. So this is ONE small, additive
- * variant the three services share — Firestore consumers filter on their
- * existing `kind`s and never see it. See the design rationale.
- *
- * It is intentionally generic: `op` is a free-ish string discriminated by
- * `service`, and `before`/`after` are best-effort serializable snapshots
- * (omitted when not meaningful — e.g. a sign-out has no `after`). Studio's
- * data grids / Action Center render `service` + `op` + `path` directly and
- * diff `before`→`after` when both are present.
- */
-export interface ServiceMutationEventOf<Service extends MutationEventService> {
-  kind: 'service_mutation';
-  id: string;
-  at: number;
-  /**
-   * Which service performed the mutation. Always one of the non-Firestore
-   * services — Firestore rides its own `request`/`write` path. (The
-   * provenance `service` field on the stamped event mirrors this; it is set
-   * redundantly here so a consumer matching purely on `kind` still gets the
-   * discriminator without reaching into provenance.)
-   *
-   * Derived from the per-service records in `service-event-records.ts`, so a
-   * service reaches this union by declaring an event record beside its own
-   * code and no other way.
-   */
-  service: Service;
-  /**
-   * Service-scoped operation name, drawn from the operations that service's
-   * own record declares. A service adds an operation by adding it there.
-   */
-  op: ServiceEventOperation<Service>;
-  /**
-   * The thing mutated, in the service's own addressing scheme:
-   *   - auth:    the user `uid` (or `'*'` for a clear-all). Absent for a
-   *              sign-out with no prior user.
-   *   - storage: the object `fullPath` (e.g. `avatars/alice.png`).
-   *   - rtdb:    the database path (e.g. `/rooms/r1/messages`), or for a
-   *              multi-path `update` the ref path the call targeted.
-   */
-  path?: string;
-  /** Identity in effect when the op ran (the service's `request.auth`
-   *  equivalent). `null` for admin/anonymous-driven mutations (e.g.
-   *  `sandbox.createUser`, an unauthenticated RTDB write). */
-  auth: AuthState;
-  /** Best-effort serializable snapshot of the state BEFORE the mutation.
-   *  Absent when there was no prior state (a create) or it isn't cheap to
-   *  capture. */
-  before?: unknown;
-  /** Best-effort serializable snapshot of the state AFTER the mutation.
-   *  Absent on deletes / sign-outs (nothing remains). */
-  after?: unknown;
-  /** Free-form, service-specific extras a consumer may surface without
-   *  re-deriving (e.g. storage `{ size, contentType }`, rtdb
-   *  `{ committed }` for a transaction). Kept loose on purpose — it's a
-   *  display hint, not a contract. */
-  detail?: Record<string, unknown>;
-}
-
-/**
- * The cross-service mutation envelope, as the union over every service that
- * declared an event record. Narrowing on `service` narrows `op` to that
- * service's own operations.
- */
-export type ServiceMutationEvent = {
-  [Service in MutationEventService]: ServiceMutationEventOf<Service>;
-}[MutationEventService];
-
-/**
- * The fields a caller supplies to build a {@link ServiceMutationEvent}; `kind`
- * and `id` are the emitter's. Distributed per service so `op` stays bound to
- * the `service` beside it.
- */
-export type ServiceMutationEventFields = {
-  [Service in MutationEventService]: Omit<ServiceMutationEventOf<Service>, 'kind' | 'id'>;
-}[MutationEventService];
 
 /**
  * Canonical service operation event. This is the service-neutral successor to

--- a/packages/pyric/src/sandbox/types/index.ts
+++ b/packages/pyric/src/sandbox/types/index.ts
@@ -25,16 +25,26 @@ export { SandboxError } from './errors.js';
 
 export type { PersistableService, SandboxSnapshot } from './persistence.js';
 
+export {
+  MUTATION_EVENT_SERVICES,
+  SERVICE_EVENT_RECORDS,
+} from './service-event-records.js';
+
 export type {
   DenialEvent,
   ListenerLifecycleEvent,
+  MutationEventService,
   RequestEvent,
   SandboxCommitEvent,
   SandboxEvent,
   SandboxListenerEvent,
   SandboxOperationEvent,
   SandboxRuntimeErrorEvent,
+  ServiceEventOperation,
+  ServiceEventRecord,
+  ServiceEventTarget,
   ServiceMutationEvent,
+  ServiceMutationEventFields,
   SessionBoundaryEvent,
   SnapshotDeliveryEvent,
   SnapshotErrorEvent,

--- a/packages/pyric/src/sandbox/types/operation.ts
+++ b/packages/pyric/src/sandbox/types/operation.ts
@@ -1,7 +1,12 @@
 /** Cross-service operation identity and Security Rules disposition. */
 
-/** Which sandbox service emitted an event. */
-export type EventService = 'firestore' | 'auth' | 'storage' | 'rtdb' | 'messaging' | 'ai';
+import type { MutationEventService } from './service-event-records.js';
+
+/** Which sandbox service emitted an event. Firestore is named directly because
+ * it rides its own rule-eval-shaped `request`/`write` path rather than the
+ * cross-service mutation envelope; every other service reaches this union by
+ * declaring an event record beside its own code. */
+export type EventService = 'firestore' | MutationEventService;
 
 /** Who initiated the operation behind an event. Missing source is represented
  * explicitly as `unattributed`; it is never silently promoted to app traffic. */

--- a/packages/pyric/src/sandbox/types/service-event-record.ts
+++ b/packages/pyric/src/sandbox/types/service-event-record.ts
@@ -1,0 +1,34 @@
+/**
+ * The shape one service declares so the sandbox core knows what that service
+ * puts on the event stream.
+ *
+ * A record is authored next to the service it describes
+ * (`packages/pyric/src/<surface>/events.ts`), the way one tool method is one
+ * record file. The sandbox core derives the service union and each service's
+ * operation enum from those declarations rather than restating them, so a
+ * service cannot emit an operation it never declared and cannot be added to
+ * the stream vocabulary without declaring one.
+ */
+
+/** What a service event's `path` addresses, in that service's own scheme. */
+export interface ServiceEventTarget {
+  /** The addressing scheme's own name for the target, e.g. `uid`, `fullPath`. */
+  readonly name: string;
+  /** What the target names, for a consumer rendering the event. */
+  readonly description: string;
+  /** Whether every operation this service emits carries a target. */
+  readonly always: boolean;
+}
+
+/** One service's declaration of its slice of the event stream. */
+export interface ServiceEventRecord<
+  Service extends string = string,
+  Operation extends string = string,
+> {
+  /** The service name that appears on the event and in its provenance. */
+  readonly service: Service;
+  /** Every operation this service emits, in no significant order. */
+  readonly operations: readonly Operation[];
+  /** What the event's `path` addresses. */
+  readonly target: ServiceEventTarget;
+}

--- a/packages/pyric/src/sandbox/types/service-event-records.ts
+++ b/packages/pyric/src/sandbox/types/service-event-records.ts
@@ -1,0 +1,42 @@
+/**
+ * Every service's event declaration, in one place, so the sandbox core can
+ * derive the stream's vocabulary instead of restating it.
+ *
+ * Why static imports rather than a registry the capabilities register into.
+ * The operation enums have to exist as types: `ServiceMutationEvent.op` is
+ * derived from them, and a value pushed into a registry at module load carries
+ * no type a `.d.ts` can name. A registry would also make the vocabulary depend
+ * on which surfaces a bundle happened to load, so the same event would be
+ * well-typed in one entry point and untyped in another. These imports reach
+ * six leaf files that declare data and import nothing but the record type, so
+ * the edge costs the central runtime no capability code.
+ */
+import { AI_EVENT_RECORD } from '../../ai/events.js';
+import { AUTH_EVENT_RECORD } from '../../auth/events.js';
+import { RTDB_EVENT_RECORD } from '../../database/events.js';
+import { FUNCTIONS_EVENT_RECORD } from '../../functions/events.js';
+import { MESSAGING_EVENT_RECORD } from '../../messaging/events.js';
+import { STORAGE_EVENT_RECORD } from '../../storage/events.js';
+import type { ServiceEventRecord } from './service-event-record.js';
+
+/** Keyed by the service name each record declares. */
+export const SERVICE_EVENT_RECORDS = {
+  auth: AUTH_EVENT_RECORD,
+  storage: STORAGE_EVENT_RECORD,
+  rtdb: RTDB_EVENT_RECORD,
+  messaging: MESSAGING_EVENT_RECORD,
+  ai: AI_EVENT_RECORD,
+  functions: FUNCTIONS_EVENT_RECORD,
+} as const satisfies Record<string, ServiceEventRecord>;
+
+/** Every service that emits the cross-service mutation envelope. */
+export type MutationEventService = keyof typeof SERVICE_EVENT_RECORDS;
+
+/** The operations one service declared. */
+export type ServiceEventOperation<Service extends MutationEventService> =
+  (typeof SERVICE_EVENT_RECORDS)[Service]['operations'][number];
+
+/** Every declared service name, as a runtime list. */
+export const MUTATION_EVENT_SERVICES = Object.keys(
+  SERVICE_EVENT_RECORDS,
+) as MutationEventService[];

--- a/packages/pyric/src/sandbox/types/service-mutation-event.ts
+++ b/packages/pyric/src/sandbox/types/service-mutation-event.ts
@@ -69,7 +69,7 @@ export interface ServiceMutationEventOf<Service extends MutationEventService> {
   after?: unknown;
   /** Free-form, service-specific extras a consumer may surface without
    *  re-deriving (e.g. storage `{ size, contentType }`, rtdb
-   *  `{ committed }` for a transaction). Kept loose on purpose — it's a
+   *  `{ committed }` for a transaction). Kept loose on purpose: it is a
    *  display hint, not a contract. */
   detail?: Record<string, unknown>;
 }

--- a/packages/pyric/src/sandbox/types/service-mutation-event.ts
+++ b/packages/pyric/src/sandbox/types/service-mutation-event.ts
@@ -1,0 +1,93 @@
+/**
+ * The cross-service mutation envelope: the one event shape every non-Firestore
+ * service uses to report a state change.
+ *
+ * Firestore's existing kinds are tightly coupled to the rules simulator:
+ * `RequestEvent` carries `result`, `evalMs`, the simulator's `reasons[]`, and
+ * `matchedRule`; `WriteSandboxEvent` carries Firestore-specific `sentinels`,
+ * `autoId`, and a Firestore `requestTime`. An auth user-DB mutation has no
+ * path and no rule evaluation, a storage put and an RTDB tree write have
+ * neither sentinels nor auto-ids, and bending them into the Firestore shapes
+ * would either synthesize a fake `result` or pollute the Firestore consumer
+ * contract. So this is one small additive variant those services share;
+ * Firestore consumers filter on their existing kinds and never see it.
+ *
+ * The `service` and `op` fields are derived from the per-service records in
+ * `service-event-records.ts`, so a service joins this envelope by declaring
+ * an event record beside its own code and no other way.
+ */
+import type { AuthState } from './auth-state.js';
+import type {
+  MutationEventService,
+  ServiceEventOperation,
+} from './service-event-records.js';
+
+/**
+ * One state change one service reported.
+ *
+ * `before` and `after` are best-effort serializable snapshots, omitted when
+ * there is nothing meaningful to carry (a create has no before, a sign-out no
+ * after). Studio's data grids and Action Center render `service`, `op`, and
+ * `path` directly and diff `before` against `after` when both are present.
+ */
+export interface ServiceMutationEventOf<Service extends MutationEventService> {
+  kind: 'service_mutation';
+  id: string;
+  at: number;
+  /**
+   * Which service performed the mutation. Always one of the non-Firestore
+   * services; Firestore rides its own `request`/`write` path. The provenance
+   * `service` field on the stamped event mirrors this, set redundantly here so
+   * a consumer matching purely on `kind` still gets the discriminator without
+   * reaching into provenance.
+   */
+  service: Service;
+  /**
+   * Service-scoped operation name, drawn from the operations that service's
+   * own record declares. A service adds an operation by adding it there.
+   */
+  op: ServiceEventOperation<Service>;
+  /**
+   * The thing mutated, in the service's own addressing scheme:
+   *   - auth:    the user `uid` (or `'*'` for a clear-all). Absent for a
+   *              sign-out with no prior user.
+   *   - storage: the object `fullPath` (e.g. `avatars/alice.png`).
+   *   - rtdb:    the database path (e.g. `/rooms/r1/messages`), or for a
+   *              multi-path `update` the ref path the call targeted.
+   */
+  path?: string;
+  /** Identity in effect when the op ran (the service's `request.auth`
+   *  equivalent). `null` for admin/anonymous-driven mutations (e.g.
+   *  `sandbox.createUser`, an unauthenticated RTDB write). */
+  auth: AuthState;
+  /** Best-effort serializable snapshot of the state BEFORE the mutation.
+   *  Absent when there was no prior state (a create) or it isn't cheap to
+   *  capture. */
+  before?: unknown;
+  /** Best-effort serializable snapshot of the state AFTER the mutation.
+   *  Absent on deletes / sign-outs (nothing remains). */
+  after?: unknown;
+  /** Free-form, service-specific extras a consumer may surface without
+   *  re-deriving (e.g. storage `{ size, contentType }`, rtdb
+   *  `{ committed }` for a transaction). Kept loose on purpose — it's a
+   *  display hint, not a contract. */
+  detail?: Record<string, unknown>;
+}
+
+/**
+ * The cross-service mutation envelope, as the union over every service that
+ * declared an event record. Narrowing on `service` narrows `op` to that
+ * service's own operations.
+ */
+export type ServiceMutationEvent = {
+  [Service in MutationEventService]: ServiceMutationEventOf<Service>;
+}[MutationEventService];
+
+/**
+ * The fields a caller supplies to build a {@link ServiceMutationEvent}; `kind`
+ * and `id` are the emitter's. Distributed per service so `op` stays bound to
+ * the `service` beside it.
+ */
+export type ServiceMutationEventFields = {
+  [Service in MutationEventService]: Omit<ServiceMutationEventOf<Service>, 'kind' | 'id'>;
+}[MutationEventService];

--- a/packages/pyric/src/storage/events.ts
+++ b/packages/pyric/src/storage/events.ts
@@ -1,0 +1,21 @@
+/**
+ * What the storage surface puts on the sandbox event stream.
+ *
+ * The sandbox core reads this record to derive the `storage` arm of
+ * `ServiceMutationEvent`; `upload.ts`, `download.ts`, and `metadata.ts` are
+ * typed against the operations declared here.
+ */
+import type { ServiceEventRecord } from '../sandbox/types/service-event-record.js';
+
+export const STORAGE_EVENT_RECORD = {
+  service: 'storage',
+  operations: ['object_put', 'object_delete', 'metadata_update'],
+  target: {
+    name: 'fullPath',
+    description: "The object's full path within the bucket, e.g. avatars/alice.png.",
+    always: true,
+  },
+} as const satisfies ServiceEventRecord;
+
+/** Every operation the storage surface emits. */
+export type StorageEventOperation = (typeof STORAGE_EVENT_RECORD)['operations'][number];

--- a/packages/pyric/test/ai/events.test.ts
+++ b/packages/pyric/test/ai/events.test.ts
@@ -1,0 +1,24 @@
+/** What the AI surface declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { AI_EVENT_RECORD } from '../../src/ai/events.js';
+
+describe('ai event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(AI_EVENT_RECORD.service).toBe('ai');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...AI_EVENT_RECORD.operations]).toEqual([
+      'generate_content',
+      'stream_generate_content',
+      'count_tokens',
+      'request_rejected',
+      'response_blocked',
+      'model_substituted',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(AI_EVENT_RECORD.target.name).toBe('model');
+  });
+});

--- a/packages/pyric/test/auth/events.test.ts
+++ b/packages/pyric/test/auth/events.test.ts
@@ -1,0 +1,25 @@
+/** What the auth surface declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { AUTH_EVENT_RECORD } from '../../src/auth/events.js';
+
+describe('auth event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(AUTH_EVENT_RECORD.service).toBe('auth');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...AUTH_EVENT_RECORD.operations]).toEqual([
+      'user_create',
+      'user_update',
+      'user_delete',
+      'users_clear',
+      'sign_in',
+      'sign_out',
+      'provider_config_update',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(AUTH_EVENT_RECORD.target.name).toBe('uid');
+  });
+});

--- a/packages/pyric/test/database/events.test.ts
+++ b/packages/pyric/test/database/events.test.ts
@@ -1,0 +1,23 @@
+/** What the Realtime Database surface declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { RTDB_EVENT_RECORD } from '../../src/database/events.js';
+
+describe('rtdb event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(RTDB_EVENT_RECORD.service).toBe('rtdb');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...RTDB_EVENT_RECORD.operations]).toEqual([
+      'set',
+      'update',
+      'remove',
+      'transaction',
+      'setPriority',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(RTDB_EVENT_RECORD.target.name).toBe('path');
+  });
+});

--- a/packages/pyric/test/functions/events.test.ts
+++ b/packages/pyric/test/functions/events.test.ts
@@ -1,0 +1,21 @@
+/** What the Functions trigger runtime declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { FUNCTIONS_EVENT_RECORD } from '../../src/functions/events.js';
+
+describe('functions event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(FUNCTIONS_EVENT_RECORD.service).toBe('functions');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...FUNCTIONS_EVENT_RECORD.operations]).toEqual([
+      'trigger_discovered',
+      'handler_fired',
+      'execution_finished',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(FUNCTIONS_EVENT_RECORD.target.name).toBe('ref');
+  });
+});

--- a/packages/pyric/test/messaging/events.test.ts
+++ b/packages/pyric/test/messaging/events.test.ts
@@ -1,0 +1,25 @@
+/** What the messaging surface declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { MESSAGING_EVENT_RECORD } from '../../src/messaging/events.js';
+
+describe('messaging event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(MESSAGING_EVENT_RECORD.service).toBe('messaging');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...MESSAGING_EVENT_RECORD.operations]).toEqual([
+      'token_minted',
+      'token_deleted',
+      'subscription_changed',
+      'message_accepted',
+      'message_rejected',
+      'delivery_routed',
+      'message_delivered',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(MESSAGING_EVENT_RECORD.target.name).toBe('token');
+  });
+});

--- a/packages/pyric/test/sandbox/event-stream-completeness.test.ts
+++ b/packages/pyric/test/sandbox/event-stream-completeness.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Every service that declares an event record puts its state changes on the
+ * one sandbox event stream, and puts nothing there for a read.
+ *
+ * The test drives each service through its own public seam, so it fails when a
+ * service declares a record and never emits, when a service emits an operation
+ * its record does not declare, and when a service joins the stream's
+ * vocabulary with no case here to exercise it.
+ *
+ * Two things this asserts more narrowly than "one event, no event", because
+ * more would be false:
+ *
+ *   - It counts `service_mutation` events for the service under test. A read
+ *     against a rules-backed service legitimately puts a rules-evaluation
+ *     `operation` event on the stream; what a read must never do is report a
+ *     mutation.
+ *   - It compares the captured sandbox state only for the services the
+ *     sandbox captures state for. Messaging and AI hold no state a capture
+ *     reaches, so there is no hash to move.
+ *
+ * `functions` is the one declared service whose seam is not in this package:
+ * its trigger runtime lives in `@pyric/cli`, which depends downward on pyric.
+ * `packages/cli/test/functions-rtdb/events.test.ts` and
+ * `packages/cli/test/bridge/surface/handlers-functions.test.ts` exercise it,
+ * and the partition below is what fails if a new service arrives with neither
+ * a case here nor a place on that list.
+ */
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'bun:test';
+import {
+  MUTATION_EVENT_SERVICES,
+  SERVICE_EVENT_RECORDS,
+  captureFullState,
+  initializeSandbox,
+  type LocalSandbox,
+  type MutationEventService,
+  type SandboxEvent,
+} from 'pyric/sandbox';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
+import { getStorageSandbox, ref as storageRef, uploadBytes, getMetadata } from 'pyric/storage';
+import { getDatabase, ref as dbRef, set, get, sandbox as rtdbSandbox } from 'pyric/database';
+import { getMessaging, getToken } from 'pyric/messaging';
+import { getAI, getGenerativeModel } from 'pyric/ai';
+import { script, aiStatus } from 'pyric/ai/scripting';
+
+const STORAGE_RULES = `rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} { allow read, write: if true; }
+  }
+}`;
+
+/** One service's public seam: the change it makes, and the read beside it. */
+interface ServiceCase {
+  /** The operation the change is expected to report. */
+  operation: string;
+  /** Whether the sandbox captures state this change moves. */
+  capturesState: boolean;
+  /** Open the service and grant the change the rules it needs. */
+  setup(sandbox: LocalSandbox): void;
+  change(sandbox: LocalSandbox): Promise<void>;
+  read(sandbox: LocalSandbox): Promise<void>;
+}
+
+/** The mutation events one service put on the stream. */
+function mutationsFor(sandbox: LocalSandbox, service: MutationEventService): SandboxEvent[] {
+  return sandbox
+    .history()
+    .filter((event) => event.kind === 'service_mutation' && event.service === service);
+}
+
+const CASES: Record<Exclude<MutationEventService, 'functions'>, ServiceCase> = {
+  auth: {
+    operation: 'user_create',
+    capturesState: true,
+    setup(sandbox) {
+      getAuth(sandbox);
+    },
+    async change(sandbox) {
+      authSandbox.createUser(getAuth(sandbox), { uid: 'alice', email: 'alice@example.com' });
+    },
+    async read(sandbox) {
+      authSandbox.listUsers(getAuth(sandbox));
+    },
+  },
+  storage: {
+    operation: 'object_put',
+    capturesState: true,
+    setup(sandbox) {
+      getStorageSandbox(sandbox, { rules: STORAGE_RULES });
+    },
+    async change(sandbox) {
+      await uploadBytes(storageRef(getStorageSandbox(sandbox), 'notes/one.txt'), new Uint8Array([1, 2, 3]));
+    },
+    async read(sandbox) {
+      await getMetadata(storageRef(getStorageSandbox(sandbox), 'notes/one.txt'));
+    },
+  },
+  rtdb: {
+    operation: 'set',
+    capturesState: true,
+    setup(sandbox) {
+      rtdbSandbox.setDefaultPolicy(getDatabase(sandbox), 'allow');
+    },
+    async change(sandbox) {
+      await set(dbRef(getDatabase(sandbox), 'rooms/r1/topic'), 'hello');
+    },
+    async read(sandbox) {
+      await get(dbRef(getDatabase(sandbox), 'rooms/r1/topic'));
+    },
+  },
+  messaging: {
+    operation: 'token_minted',
+    capturesState: false,
+    setup(sandbox) {
+      getMessaging(sandbox);
+    },
+    async change(sandbox) {
+      await getToken(getMessaging(sandbox));
+    },
+    // A registration's token is minted once and stable after: a second call
+    // reads the token the first minted, and mints nothing.
+    async read(sandbox) {
+      await getToken(getMessaging(sandbox));
+    },
+  },
+  ai: {
+    operation: 'generate_content',
+    capturesState: false,
+    setup(sandbox) {
+      getAI(sandbox);
+    },
+    async change(sandbox) {
+      const ai = getAI(sandbox);
+      script(ai, [{ respond: { text: 'hi' } }]);
+      await getGenerativeModel(ai, { model: 'gemini-2.5-flash' }).generateContent('hello');
+    },
+    async read(sandbox) {
+      aiStatus(getAI(sandbox));
+    },
+  },
+};
+
+describe('event stream completeness', () => {
+  it('has a case for every declared service, or names where the case lives', () => {
+    const covered = [...Object.keys(CASES), 'functions'].sort();
+    expect(covered).toEqual([...MUTATION_EVENT_SERVICES].sort());
+  });
+
+  for (const [name, serviceCase] of Object.entries(CASES)) {
+    const service = name as MutationEventService;
+
+    it(`reports one ${service} ${serviceCase.operation} for one state change`, async () => {
+      const sandbox = initializeSandbox();
+      serviceCase.setup(sandbox);
+      const before = await captureFullState(sandbox);
+
+      await serviceCase.change(sandbox);
+
+      const emitted = mutationsFor(sandbox, service) as Array<SandboxEvent & { op: string }>;
+      const matching = emitted.filter((event) => event.op === serviceCase.operation);
+      expect(matching.length).toBe(1);
+      expect([...SERVICE_EVENT_RECORDS[service].operations]).toContain(serviceCase.operation);
+      for (const event of emitted) {
+        expect([...SERVICE_EVENT_RECORDS[service].operations]).toContain(event.op);
+      }
+
+      if (serviceCase.capturesState) {
+        const after = await captureFullState(sandbox);
+        expect(JSON.stringify(after)).not.toBe(JSON.stringify(before));
+      }
+    });
+
+    it(`reports no ${service} mutation and moves no state for a read`, async () => {
+      const sandbox = initializeSandbox();
+      serviceCase.setup(sandbox);
+      await serviceCase.change(sandbox);
+      const beforeCount = mutationsFor(sandbox, service).length;
+      const beforeState = await captureFullState(sandbox);
+
+      await serviceCase.read(sandbox);
+
+      expect(mutationsFor(sandbox, service).length).toBe(beforeCount);
+      const afterState = await captureFullState(sandbox);
+      expect(JSON.stringify(afterState)).toBe(JSON.stringify(beforeState));
+    });
+  }
+});

--- a/packages/pyric/test/sandbox/listener-record.test.ts
+++ b/packages/pyric/test/sandbox/listener-record.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Listener lifecycle projects into the canonical record with the phase as the
+ * method, whether the event arrived in Firestore's own lifecycle variants or
+ * in the canonical cross-service `listener` variant.
+ */
+import { describe, it, expect } from 'bun:test';
+import { toListenerRecord, toOperationRecord } from '../../src/sandbox/operation-record.js';
+import type { SandboxEvent } from '../../src/sandbox/types/events.js';
+
+function firestoreAttach(): SandboxEvent {
+  return {
+    kind: 'listener_attach',
+    id: 'e1',
+    at: 10,
+    listenerId: 'l1',
+    target: { kind: 'doc', path: 'notes/one' },
+    auth: null,
+  };
+}
+
+function rtdbDelivery(): SandboxEvent {
+  return {
+    kind: 'listener',
+    id: 'e2',
+    at: 20,
+    service: 'rtdb',
+    phase: 'delivery',
+    listenerId: 'l2',
+    target: { kind: 'value', path: '/rooms/r1' },
+    auth: null,
+    size: 3,
+  };
+}
+
+describe('toListenerRecord', () => {
+  it("reads Firestore's own lifecycle variants as phases", () => {
+    const record = toListenerRecord(firestoreAttach());
+    expect(record?.method).toBe('attach');
+    expect(record?.eventKind).toBe('listener');
+    expect(record?.service).toBe('firestore');
+    expect(record?.path).toBe('notes/one');
+  });
+
+  it('reads the cross-service listener variant as the same phases', () => {
+    const record = toListenerRecord(rtdbDelivery());
+    expect(record?.method).toBe('delivery');
+    expect(record?.service).toBe('rtdb');
+    expect(record?.path).toBe('/rooms/r1');
+  });
+
+  it('reports that a non-errored phase never met Security Rules', () => {
+    expect(toListenerRecord(firestoreAttach())?.rules).toEqual({
+      kind: 'not-evaluated',
+      reason: 'not-a-rules-operation',
+    });
+  });
+
+  it('reads an errored phase as a denial', () => {
+    const errored: SandboxEvent = {
+      kind: 'listener_errored',
+      id: 'e3',
+      at: 30,
+      listenerId: 'l3',
+      target: { kind: 'doc', path: 'notes/two' },
+      auth: null,
+      error: { code: 'permission-denied', message: 'denied' },
+    };
+    const record = toListenerRecord(errored);
+    expect(record?.method).toBe('errored');
+    expect(record?.result).toBe('deny');
+    expect(record?.rules).toEqual({ kind: 'evaluated', verdict: 'deny' });
+  });
+
+  it('returns null for anything that is not listener lifecycle', () => {
+    const write: SandboxEvent = {
+      kind: 'session_boundary',
+      id: 'e4',
+      at: 40,
+      phase: 'reset',
+      priorOpCount: 0,
+    };
+    expect(toListenerRecord(write)).toBeNull();
+  });
+
+  it('leaves the operation projection unchanged for lifecycle it never carried', () => {
+    expect(toOperationRecord(firestoreAttach())).toBeNull();
+    expect(toOperationRecord(rtdbDelivery())).toBeNull();
+  });
+});

--- a/packages/pyric/test/sandbox/types/service-event-records.test.ts
+++ b/packages/pyric/test/sandbox/types/service-event-records.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The stream's vocabulary is derived from the per-service records, not
+ * restated. These tests pin the aggregate's shape so a service cannot join the
+ * stream without declaring what it emits.
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+  MUTATION_EVENT_SERVICES,
+  SERVICE_EVENT_RECORDS,
+} from '../../../src/sandbox/types/service-event-records.js';
+
+describe('service event records', () => {
+  it('keys every record by the service name the record itself declares', () => {
+    for (const [key, record] of Object.entries(SERVICE_EVENT_RECORDS)) {
+      expect(record.service).toBe(key);
+    }
+  });
+
+  it('declares every service that emits the cross-service mutation envelope', () => {
+    expect([...MUTATION_EVENT_SERVICES].sort()).toEqual([
+      'ai',
+      'auth',
+      'functions',
+      'messaging',
+      'rtdb',
+      'storage',
+    ]);
+  });
+
+  it('gives every service at least one operation and a named target', () => {
+    for (const record of Object.values(SERVICE_EVENT_RECORDS)) {
+      expect(record.operations.length).toBeGreaterThan(0);
+      expect(new Set(record.operations).size).toBe(record.operations.length);
+      expect(record.target.name.length).toBeGreaterThan(0);
+      expect(record.target.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/pyric/test/sandbox/types/service-mutation-event.test.ts
+++ b/packages/pyric/test/sandbox/types/service-mutation-event.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The cross-service mutation envelope binds `op` to the `service` beside it:
+ * a service's own operations type-check, another service's do not.
+ */
+import { describe, it, expect } from 'bun:test';
+import type {
+  ServiceMutationEvent,
+  ServiceMutationEventOf,
+} from '../../../src/sandbox/types/service-mutation-event.js';
+
+const AUTH_EVENT: ServiceMutationEventOf<'auth'> = {
+  kind: 'service_mutation',
+  id: 'e1',
+  at: 1,
+  service: 'auth',
+  op: 'user_create',
+  path: 'alice',
+  auth: null,
+};
+
+describe('ServiceMutationEvent', () => {
+  it('accepts an operation the service declared', () => {
+    expect(AUTH_EVENT.op).toBe('user_create');
+  });
+
+  it('narrows op to the service when a consumer narrows on service', () => {
+    const event: ServiceMutationEvent = AUTH_EVENT;
+    expect(event.kind).toBe('service_mutation');
+    if (event.service !== 'auth') throw new Error('expected the auth arm');
+    // `event.op` is the auth operation union here, not `string`.
+    const op: 'user_create' | 'user_update' | 'user_delete' | 'users_clear'
+      | 'sign_in' | 'sign_out' | 'provider_config_update' = event.op;
+    expect(op).toBe('user_create');
+  });
+
+  it("refuses an operation another service owns", () => {
+    // @ts-expect-error 'object_put' belongs to storage, not auth.
+    const wrong: ServiceMutationEventOf<'auth'> = { ...AUTH_EVENT, op: 'object_put' };
+    expect(wrong.op).toBe('object_put');
+  });
+});

--- a/packages/pyric/test/storage/events.test.ts
+++ b/packages/pyric/test/storage/events.test.ts
@@ -1,0 +1,21 @@
+/** What the storage surface declares it puts on the sandbox event stream. */
+import { describe, it, expect } from 'bun:test';
+import { STORAGE_EVENT_RECORD } from '../../src/storage/events.js';
+
+describe('storage event record', () => {
+  it('declares the service name the stream attributes its events to', () => {
+    expect(STORAGE_EVENT_RECORD.service).toBe('storage');
+  });
+
+  it('enumerates every operation it emits', () => {
+    expect([...STORAGE_EVENT_RECORD.operations]).toEqual([
+      'object_put',
+      'object_delete',
+      'metadata_update',
+    ]);
+  });
+
+  it('names what the event path addresses', () => {
+    expect(STORAGE_EVENT_RECORD.target.name).toBe('fullPath');
+  });
+});

--- a/packages/studio/src/features/action-center/reducer.ts
+++ b/packages/studio/src/features/action-center/reducer.ts
@@ -281,7 +281,7 @@ export function toMutation(event: SandboxEvent): Mutation | null {
 
   if (event.kind === 'service_mutation') {
     // AI broker ops (generate_content, count_tokens, …) and Functions trigger
-    // runs don't mutate backend state — they're Traffic's domain, not the
+    // runs don't mutate backend state; they are Traffic's domain, not the
     // activity digest's.
     if (event.service === 'ai' || event.service === 'functions') return null;
     const target =

--- a/packages/studio/src/features/action-center/reducer.ts
+++ b/packages/studio/src/features/action-center/reducer.ts
@@ -280,9 +280,10 @@ export function toMutation(event: SandboxEvent): Mutation | null {
   }
 
   if (event.kind === 'service_mutation') {
-    // AI broker ops (generate_content, count_tokens, …) don't mutate backend
-    // state — they're Traffic's domain, not the activity digest's.
-    if (event.service === 'ai') return null;
+    // AI broker ops (generate_content, count_tokens, …) and Functions trigger
+    // runs don't mutate backend state — they're Traffic's domain, not the
+    // activity digest's.
+    if (event.service === 'ai' || event.service === 'functions') return null;
     const target =
       event.path ?? (event.service === 'auth' ? 'session' : '');
     return {


### PR DESCRIPTION
Makes the sandbox event stream one shape across services: each service declares its own event record, the core derives the vocabulary from those records, Functions emits events, and the reads that had grown private logs read the stream instead.

```ts
// packages/pyric/src/messaging/events.ts: a service declares what it emits.
export const MESSAGING_EVENT_RECORD = {
  service: 'messaging',
  operations: ['token_minted', 'token_deleted', 'topic_subscribed', 'topic_unsubscribed', 'message_delivered'],
  target: 'the token, or the topic',
} as const satisfies ServiceEventRecord;
```

```ts
// The core derives the union instead of restating it. Adding a service means
// adding a record file, never editing sandbox/types.
export type MutationEventService = keyof typeof SERVICE_EVENT_RECORDS;
export type ServiceEventOperation<S extends MutationEventService> =
  (typeof SERVICE_EVENT_RECORDS)[S]['operations'][number];
```

```json
// sandbox.events now pages listener lifecycle too.
{ "method": "events", "args": { "kind": "listeners", "limit": 50 } }
```

## One declaration per service, and the type system enforces it

`ServiceMutationEvent.service` was a hand-written union of five names and `op` was a free string. Both are now derived from six record files, one per service next to its code, aggregated in `sandbox/types/service-event-records.ts`. The aggregate uses static imports rather than a runtime registry because the operation enums have to exist as types: a value pushed into a registry at module load carries no type a declaration file can name, and the vocabulary would then depend on which surfaces a bundle loaded. The three emit sites that passed an undeclared operation failed typecheck and were fixed; that is the enforcement.

## Functions is on the stream, and the shadow logs are gone

The trigger runtime emits `trigger_discovered`, `handler_fired`, and `execution_finished`. `functions.executions` folds the stream and its private execution log is deleted; `messaging.deliveries` folds `message_delivered`, which now carries route, handled, and payload, and the broker's delivery log is deleted. Two stores stay by design: the AI scripted queue holds pending registrations with matcher predicates and responder closures, which are not history and cannot serialize; the assurance campaign holds authored actors, invariants, and probes, and `inspect` reads the current merged verdict, not a run history.

## One test keeps the next service honest

`event-stream-completeness.test.ts` drives every declared service through its public seam and asserts a state change puts exactly one mutation event for that service on the stream and moves the captured state, and a read puts no mutation event and moves nothing. Its case list is checked against the declared services, so a service that arrives with a record and no case fails, and a service that emits an undeclared operation fails at typecheck.

## Risk

The `service` and `op` types on `ServiceMutationEvent` narrowed from strings to derived unions; any external code constructing those events by hand now typechecks against the declared vocabulary. Replay, branches, session capture, and Studio's traffic view are unchanged and their suites pass. The conformance coupling gate is exempt for this change with the reason that the stream is pyric's own diagnostics surface with no upstream Firebase behaviour to observe.

<details>
<summary>Implementation notes</summary>

- Studio's action-center reducer returns `null` for `functions` as it already did for `ai`: trigger runs are traffic, not backend mutations.
- Sandbox tool description: 1,582 characters against the 2,000 limit.
- `bun test --cwd packages/pyric` 6785 pass, `packages/cli` 3379 pass, `compat:check` no regressions.

</details>
