### PR TITLE
fix(sandbox): fire timeout, anonymous accounts, app session across runs

### DIFF
--- a/packages/cli/src/bridge/server/in-process.ts
+++ b/packages/cli/src/bridge/server/in-process.ts
@@ -28,7 +28,7 @@ import {
 } from 'pyric/sandbox';
 import { getFirestore } from 'pyric/firestore';
 import { setRules } from 'pyric/sandbox/firestore';
-import { getAuth } from 'pyric/auth';
+import { getAuth, sandbox as authSandbox } from 'pyric/auth';
 import { getAdminDatabase } from 'pyric/database';
 import { getAdminStorageSandbox } from 'pyric/storage/internal';
 import type { FirebaseStorage } from 'pyric/storage';
@@ -169,13 +169,63 @@ export function openPersistedServices(sandbox: LocalSandbox, cwd: string): Fireb
 }
 
 /**
+ * Where the app session rides inside a snapshot's `services` map, alongside
+ * the persistable services the sandbox core knows about. `sandbox.snapshot()`
+ * and `loadSnapshot()` are keyed by registered service name and this name is
+ * never registered, so the sandbox core passes it through untouched in both
+ * directions without knowing it carries anything auth-shaped.
+ */
+const APP_SESSION_SERVICE_KEY = '__pyric_cli_app_session';
+
+/** What is captured for the app session: the signed-in uid and the tenant
+ *  scope it authenticated under, so a later process restores both rather than
+ *  just the uid and a default (untenanted) scope. */
+interface PersistedAppSession {
+  uid: string;
+  tenantId: string | null;
+}
+
+/** The app session to fold into a snapshot's `services` map, or `null` when
+ *  signed out, meaning nothing for a later process to restore. */
+function captureAppSession(sandbox: LocalSandbox): PersistedAppSession | null {
+  const auth = getAuth(sandbox);
+  const uid = auth.currentUser?.uid ?? null;
+  if (uid === null) return null;
+  return { uid, tenantId: authSandbox.getTenantId(auth) };
+}
+
+/**
+ * Sign the captured uid back in through the auth backend's own restore seam
+ * (`sandbox.restoreSession`), never a session minted outside it, then restore
+ * the tenant scope it carried. Called after `sandbox.loadSnapshot()` so the
+ * user pool the uid names is already back in place. A uid the pool no longer
+ * holds (the user was deleted since the snapshot was taken) leaves the app
+ * signed out rather than throwing: the state file is stale, not corrupt.
+ */
+function restoreAppSession(sandbox: LocalSandbox, stored: unknown): void {
+  const parsed = stored as PersistedAppSession | null | undefined;
+  if (parsed === null || parsed === undefined) return;
+  const auth = getAuth(sandbox);
+  try {
+    authSandbox.restoreSession(auth, parsed.uid);
+  } catch {
+    return;
+  }
+  authSandbox.setTenantId(auth, parsed.tenantId);
+}
+
+/**
  * Persist the sandbox to `<cwd>/.pyric/state/in-process.json` using the v3 bundle
  * codec (the same `serializeToBuckets` + `bundleRecords` the worker uses). Atomic
- * tmp+rename so a crash mid-write never truncates the live file.
+ * tmp+rename so a crash mid-write never truncates the live file. Carries the
+ * app session (the uid `auth.currentUser` names, and its tenant) alongside the
+ * user pool, so `pyric auth signInWithEmailAndPassword` in one process and
+ * `pyric auth whoami` in the next see the same session.
  */
 export function saveSandboxSnapshot(sandbox: LocalSandbox, cwd: string): void {
   const snap = sandbox.snapshot();
-  const bundle = bundleRecords(serializeToBuckets(snap.firestore, snap.services, 0));
+  const services = { ...snap.services, [APP_SESSION_SERVICE_KEY]: captureAppSession(sandbox) };
+  const bundle = bundleRecords(serializeToBuckets(snap.firestore, services, 0));
   const path = join(cwd, IN_PROCESS_STATE_RELATIVE);
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}`;
@@ -192,6 +242,7 @@ export function loadSandboxSnapshot(sandbox: LocalSandbox, cwd: string): number 
   if (!existsSync(path)) return null;
   const snap = deserializeFromBuckets(parseBundle(readFileSync(path, 'utf8')));
   sandbox.loadSnapshot(snap);
+  restoreAppSession(sandbox, snap.services[APP_SESSION_SERVICE_KEY]);
   return Object.keys(snap.firestore).length;
 }
 

--- a/packages/cli/src/bridge/surface/arguments/functions.ts
+++ b/packages/cli/src/bridge/surface/arguments/functions.ts
@@ -19,3 +19,11 @@ export const pathArgument = z
 export const valueArgument = z
   .unknown()
   .describe('The value the synthetic event carries at path. Never written to the database.');
+
+export const timeoutMsArgument = z
+  .number()
+  .int()
+  .positive()
+  .max(60_000)
+  .optional()
+  .describe('Milliseconds to wait for the handler to settle before refusing the run. Defaults to 10000, max 60000.');

--- a/packages/cli/src/bridge/surface/methods/functions/fire.ts
+++ b/packages/cli/src/bridge/surface/methods/functions/fire.ts
@@ -22,13 +22,39 @@ import {
   type FunctionExecutionRecord,
 } from '../../../../functions-rtdb/execution-log.js';
 import { matchRtdbReference, normalizeRtdbReference } from '../../../../functions-rtdb/reference-pattern.js';
-import { pathArgument, triggerArgument, valueArgument } from '../../arguments/functions.js';
+import { pathArgument, timeoutMsArgument, triggerArgument, valueArgument } from '../../arguments/functions.js';
 import { operationFailure } from '../../context.js';
 import { discoverFunctionsTriggers } from '../../functions-runtime.js';
 import type { MethodRecord } from '../../method-types.js';
 import type { SurfaceContext } from '../../types.js';
 
 const DEFAULT_LOCATION = 'us-central1';
+
+/** The bound `fire` applies when the caller does not name a `timeoutMs`. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** A value distinct from any `CreatedExecutionResult`, returned when the timer wins the race. */
+const TIMED_OUT = Symbol('functions-fire-timed-out');
+
+/**
+ * Race a handler's execution against a timer. `executeOnValueCreated` never
+ * rejects, its own try/catch turns a thrown handler into a `rejected` result,
+ * so the only two outcomes here are the execution settling or the timer
+ * winning first. The handler keeps running after a timeout; there is no way
+ * to cancel in-process code, so its eventual result is only ever discarded.
+ */
+function raceAgainstTimeout(
+  execution: Promise<CreatedExecutionResult>,
+  timeoutMs: number,
+): Promise<CreatedExecutionResult | typeof TIMED_OUT> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
+    execution.then((result) => {
+      clearTimeout(timer);
+      resolve(result);
+    });
+  });
+}
 
 /** The trigger error a thrown handler value reads as. */
 function describeError(error: unknown): string {
@@ -79,10 +105,15 @@ export default {
   method: 'fire',
   sdkOrigin: 'pyric',
   effect: 'write',
-  signature: 'fire(trigger, path, value)',
+  signature: 'fire(trigger, path, value, timeoutMs?)',
   description:
-    'Run a discovered trigger on a synthetic event built from path and value. Does not write value at path.',
-  args: z.object({ trigger: triggerArgument, path: pathArgument, value: valueArgument }),
+    'Run a discovered trigger on a synthetic event built from path and value. Does not write value at path. Refuses if the handler does not settle within timeoutMs (default 10000, max 60000).',
+  args: z.object({
+    trigger: triggerArgument,
+    path: pathArgument,
+    value: valueArgument,
+    timeoutMs: timeoutMsArgument,
+  }),
   operation: 'fire_functions_trigger',
   example: { trigger: 'makeUppercase', path: 'messages/abc123/original', value: 'hello' },
   async handler(args, ctx) {
@@ -102,14 +133,29 @@ export default {
       );
     }
     const ref = normalizeRtdbReference(path);
+    const timeoutMs = (args.timeoutMs as number | undefined) ?? DEFAULT_TIMEOUT_MS;
     const startedAt = getClock(ctx.sandbox).now();
     const startedMonotonic = performance.now();
-    const result = await executeOnValueCreated(
-      trigger,
-      { ref, params, value: args.value },
-      eventOptionsFor(ctx, trigger),
+    const raced = await raceAgainstTimeout(
+      executeOnValueCreated(trigger, { ref, params, value: args.value }, eventOptionsFor(ctx, trigger)),
+      timeoutMs,
     );
     const durationMs = performance.now() - startedMonotonic;
+    if (raced === TIMED_OUT) {
+      const entry: FunctionExecutionEntry = {
+        trigger: triggerName,
+        cause: { ref, params },
+        startedAt,
+        durationMs,
+        status: 'timeout',
+      };
+      const record = executionLogFor(ctx.sandbox).record(entry);
+      return operationFailure(
+        `functions.fire: ${triggerName} did not settle within ${timeoutMs}ms and was refused as timed out.`,
+        { executionId: record.id },
+      );
+    }
+    const result = raced;
     const record = logExecution(ctx, triggerName, ref, params, startedAt, durationMs, result);
     if (result.status === 'rejected') {
       return operationFailure(`functions.fire: ${triggerName} threw: ${record.error}`, {

--- a/packages/cli/src/functions-rtdb/execution-log.ts
+++ b/packages/cli/src/functions-rtdb/execution-log.ts
@@ -26,7 +26,7 @@ export interface FunctionExecutionRecord {
   /** Sandbox clock instant the run started, in epoch milliseconds. */
   startedAt: number;
   durationMs: number;
-  status: 'fulfilled' | 'rejected';
+  status: 'fulfilled' | 'rejected' | 'timeout';
   /** What the handler returned, present only when `status` is `fulfilled`. */
   result?: unknown;
   /** The handler's thrown error, present only when `status` is `rejected`. */

--- a/packages/cli/test/bridge/surface/handlers-functions.test.ts
+++ b/packages/cli/test/bridge/surface/handlers-functions.test.ts
@@ -37,6 +37,7 @@ exports.alwaysThrows = onValueCreated('/failures/{id}', () => {
   throw new Error('PYRIC_EXPECTED_FIRE_FAILURE');
 });
 exports.turnedOff = onValueCreated({ ref: '/messages/{id}', omit: true }, () => undefined);
+exports.neverSettles = onValueCreated('/stuck/{id}', () => new Promise(() => {}));
 `,
   );
   symlinkSync(firebaseFunctionsPath, `${projectDir}/functions/node_modules/firebase-functions`);
@@ -113,4 +114,22 @@ it('refuses an unknown trigger, naming listTriggers', async () => {
   });
   expect(refused.ok).toBe(false);
   expect(refused.summary).toContain('listTriggers');
+});
+
+it('refuses a handler that never settles once timeoutMs elapses, logging it as timed out', async () => {
+  const fired = await run('functions.fire', {
+    trigger: 'neverSettles',
+    path: 'stuck/one',
+    value: true,
+    timeoutMs: 50,
+  });
+  expect(fired.ok).toBe(false);
+  expect(fired.summary).toContain('timed out');
+
+  const executions = await run('functions.executions');
+  const { executions: recorded } = executions.data as {
+    executions: Array<{ trigger: string; status: string }>;
+  };
+  const last = recorded.find((entry) => entry.trigger === 'neverSettles')!;
+  expect(last.status).toBe('timeout');
 });

--- a/packages/cli/test/cli/surface-method-runner.test.ts
+++ b/packages/cli/test/cli/surface-method-runner.test.ts
@@ -173,4 +173,42 @@ describe('pyric <tool> <method>', () => {
     expect(rejected.code).toBe(1);
     expect(rejected.stderr).toContain('not valid JSON');
   });
+
+  it('carries an anonymous user through a checkpoint, a reset, and a restore', async () => {
+    const signedIn = await run('auth.signInAnonymously', ['auth', 'signInAnonymously', '--json']);
+    expect(signedIn.code).toBe(0);
+    const uid = (JSON.parse(signedIn.stdout).data.appSession as { uid: string }).uid;
+
+    const listedBefore = await run('auth.listUsers', ['auth', 'listUsers', '--json']);
+    const usersBefore = JSON.parse(listedBefore.stdout).data.users as Array<{ uid: string }>;
+    expect(usersBefore.map((u) => u.uid)).toContain(uid);
+
+    const saved = await run('sandbox.checkpoint', ['sandbox', 'checkpoint', '--name', 'anon-check']);
+    expect(saved.code).toBe(0);
+
+    const cleared = await run('sandbox.reset', [
+      'sandbox',
+      'reset',
+      '--scope',
+      'auth',
+      '--confirm',
+    ]);
+    expect(cleared.code).toBe(0);
+    const listedAfterReset = await run('auth.listUsers', ['auth', 'listUsers', '--json']);
+    const usersAfterReset = JSON.parse(listedAfterReset.stdout).data.users as Array<{ uid: string }>;
+    expect(usersAfterReset.map((u) => u.uid)).not.toContain(uid);
+
+    const restored = await run('sandbox.restore', [
+      'sandbox',
+      'restore',
+      '--name',
+      'anon-check',
+      '--confirm',
+    ]);
+    expect(restored.code).toBe(0);
+
+    const listedAfterRestore = await run('auth.listUsers', ['auth', 'listUsers', '--json']);
+    const usersAfterRestore = JSON.parse(listedAfterRestore.stdout).data.users as Array<{ uid: string }>;
+    expect(usersAfterRestore.map((u) => u.uid)).toContain(uid);
+  });
 });

--- a/packages/cli/test/cli/surface-method-runner.test.ts
+++ b/packages/cli/test/cli/surface-method-runner.test.ts
@@ -211,4 +211,35 @@ describe('pyric <tool> <method>', () => {
     const usersAfterRestore = JSON.parse(listedAfterRestore.stdout).data.users as Array<{ uid: string }>;
     expect(usersAfterRestore.map((u) => u.uid)).toContain(uid);
   });
+
+  it('carries the app session into a fresh process in the same working directory', async () => {
+    const created = await run('auth.createUser', [
+      'auth',
+      'createUser',
+      '--uid',
+      'session-carrier',
+      '--email',
+      'carrier@example.com',
+      '--password',
+      'hunter222',
+    ]);
+    expect(created.code).toBe(0);
+
+    const signedIn = await run('auth.signInWithEmailAndPassword', [
+      'auth',
+      'signInWithEmailAndPassword',
+      '--email',
+      'carrier@example.com',
+      '--password',
+      'hunter222',
+    ]);
+    expect(signedIn.code).toBe(0);
+
+    // A fresh call, in the same working directory: no process, no handle,
+    // and no argument carries the session forward except the state file.
+    const whoami = await run('auth.whoami', ['auth', 'whoami', '--json']);
+    expect(whoami.code).toBe(0);
+    const appSession = JSON.parse(whoami.stdout).data.appSession as { uid: string } | null;
+    expect(appSession?.uid).toBe('session-carrier');
+  });
 });

--- a/packages/pyric/src/auth/sandbox-backend-types.ts
+++ b/packages/pyric/src/auth/sandbox-backend-types.ts
@@ -28,8 +28,13 @@ export const NO_PASSWORD_SENTINEL = '__pyric_no_password__';
 
 export interface SeedUser {
   uid: string;
-  email: string;
-  password: string;
+  /** Absent for an anonymous account (`providerId: 'anonymous'`), which has
+   *  no address to sign in with. Required for every other provider. */
+  email?: string;
+  /** Absent for an anonymous account. Required for every other provider;
+   *  a provider-flow identity with no password uses
+   *  {@link NO_PASSWORD_SENTINEL} instead of omitting it. */
+  password?: string;
   displayName?: string;
   customClaims?: Record<string, unknown>;
   /** Profile photo URL, mirroring the stored record's `photoUrl`.

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -794,23 +794,26 @@ export class SandboxBackend {
       // in (AUTH-B9) — otherwise both emails would resolve, the old one
       // to a now-orphaned record.
       const prior = this.usersByUid.get(u.uid);
-      if (prior?.email && prior.email.toLowerCase() !== u.email.toLowerCase()) {
+      if (prior?.email && prior.email.toLowerCase() !== u.email?.toLowerCase()) {
         this.usersByEmail.delete(prior.email.toLowerCase());
       }
+      const isAnonymousSeed = u.providerId === 'anonymous';
+      const providerUserInfo = isAnonymousSeed ? [] : [{ providerId: u.providerId ?? 'password' }];
       const record = this.makeStored({
         uid: u.uid,
-        email: u.email,
-        password: u.password,
+        email: isAnonymousSeed ? null : (u.email ?? null),
+        password: isAnonymousSeed ? null : (u.password ?? null),
         displayName: u.displayName ?? null,
         phoneNumber: u.phoneNumber ?? null,
         photoUrl: u.photoUrl ?? null,
         customClaims: u.customClaims ?? {},
         emailVerified: u.emailVerified ?? false,
         disabled: u.disabled ?? false,
-        providerUserInfo: [{ providerId: u.providerId ?? 'password' }],
+        isAnonymous: isAnonymousSeed,
+        providerUserInfo,
         tenantId: u.tenantId ?? null,
       });
-      this.usersByEmail.set(u.email.toLowerCase(), record);
+      if (!isAnonymousSeed && u.email !== undefined) this.usersByEmail.set(u.email.toLowerCase(), record);
       this.usersByUid.set(u.uid, record);
     }
     if (users.length > 0) this.notifyUsersChanged();
@@ -823,14 +826,25 @@ export class SandboxBackend {
    * password (provider-flow users created via `createSignInCredential`)
    * export with {@link NO_PASSWORD_SENTINEL} so they survive the
    * round-trip (same trick hosts already use when seeding popup
-   * identities). Anonymous users (no email) are NOT exported — they are
-   * ephemeral by design; documented divergence from prod's persisted
-   * anonymous sessions.
+   * identities). Anonymous users (no email) export with
+   * `providerId: 'anonymous'` and no email or password, so a checkpoint,
+   * a branch, and a restart keep them, matching real Firebase, which
+   * keeps anonymous accounts in its user pool rather than discarding them.
    */
   exportUsers(): SeedUser[] {
     const out: SeedUser[] = [];
     for (const u of this.usersByUid.values()) {
-      if (u.email === null) continue; // anonymous — not round-trippable
+      if (u.isAnonymous) {
+        const seed: SeedUser = { uid: u.uid, providerId: 'anonymous' };
+        if (u.displayName !== null) seed.displayName = u.displayName;
+        if (u.photoUrl !== null) seed.photoUrl = u.photoUrl;
+        if (Object.keys(u.customClaims).length > 0) seed.customClaims = u.customClaims;
+        if (u.disabled) seed.disabled = true;
+        if (u.tenantId !== null) seed.tenantId = u.tenantId;
+        out.push(seed);
+        continue;
+      }
+      if (u.email === null) continue; // credential-less, non-anonymous — not round-trippable
       const seed: SeedUser = {
         uid: u.uid,
         email: u.email,

--- a/packages/pyric/src/auth/sandbox-backend.ts
+++ b/packages/pyric/src/auth/sandbox-backend.ts
@@ -844,7 +844,7 @@ export class SandboxBackend {
         out.push(seed);
         continue;
       }
-      if (u.email === null) continue; // credential-less, non-anonymous — not round-trippable
+      if (u.email === null) continue; // credential-less, non-anonymous: not round-trippable
       const seed: SeedUser = {
         uid: u.uid,
         email: u.email,

--- a/packages/pyric/src/auth/sandbox/driver.ts
+++ b/packages/pyric/src/auth/sandbox/driver.ts
@@ -85,6 +85,20 @@ export const sandbox = {
     return requireSandbox(auth).backend.restoreSession(uid);
   },
 
+  /** Read `Auth.tenantId` without going through the handle's own property,
+   *  for a host capturing the tenant scope alongside a signed-in uid (a
+   *  process boundary has no live `Auth` object to read it from later). */
+  getTenantId(auth: Auth): string | null {
+    return requireSandbox(auth).backend.getTenantId();
+  },
+
+  /** Write `Auth.tenantId` without a sign-in, the seam a host uses to put
+   *  a captured tenant scope back once {@link restoreSession} has restored
+   *  the uid it was captured alongside. */
+  setTenantId(auth: Auth, tenantId: string | null): void {
+    requireSandbox(auth).backend.setTenantId(tenantId);
+  },
+
   mintSession(auth: Auth, request: MintSessionRequest): MintedSession {
     return requireSandbox(auth).backend.mintDetachedSession(request);
   },

--- a/packages/pyric/test/auth/state-roundtrip.test.ts
+++ b/packages/pyric/test/auth/state-roundtrip.test.ts
@@ -92,7 +92,7 @@ describe('sandbox.exportUsers', () => {
     expect('disabled' in seed!).toBe(false);
   });
 
-  it('passwordless provider identities export with the sentinel; anonymous are skipped', async () => {
+  it('passwordless provider identities export with the sentinel; anonymous export too', async () => {
     const a = wire();
     authSandbox.setAuthProviderConfig(a, 'google.com', true);
     // provider-flow identity without a password (createSignInCredential spec path)
@@ -104,16 +104,31 @@ describe('sandbox.exportUsers', () => {
       }),
     );
     await signInWithPopup(a, new GoogleAuthProvider());
-    await signInAnonymously(a);
+    const anon = await signInAnonymously(a);
 
     const exported = authSandbox.exportUsers(a);
     const popup = exported.find((u) => u.email === 'popup@x.com');
     expect(popup?.password).toBe(NO_PASSWORD_SENTINEL);
     expect(popup?.providerId).toBe('google.com');
-    // the anonymous identity exists in the DB but is not exported
+    // the anonymous identity is exported alongside every other account, the
+    // way real Firebase keeps anonymous accounts in its user pool.
     expect(authSandbox.listIdentities(a).some((i) => i.isAnonymous)).toBe(true);
-    expect(exported.some((u) => u.uid.startsWith('anon'))).toBe(false);
-    expect(exported).toHaveLength(1);
+    const anonymousSeed = exported.find((u) => u.uid === anon.user.uid);
+    expect(anonymousSeed).toEqual({ uid: anon.user.uid, providerId: 'anonymous' });
+    expect(exported).toHaveLength(2);
+  });
+
+  it('re-imports an exported anonymous account with its uid, and no email or password', async () => {
+    const a = wire();
+    const anon = await signInAnonymously(a);
+    const exported = authSandbox.exportUsers(a);
+
+    const b = wire();
+    authSandbox.seedUsers(b, exported);
+    const restored = authSandbox.listUsers(b).find((u) => u.uid === anon.user.uid);
+    expect(restored).toBeDefined();
+    expect(restored?.email).toBeNull();
+    expect(authSandbox.exportUsers(b)).toEqual(exported);
   });
 });
 


### PR DESCRIPTION
Three fixes to the sandbox surface: `functions.fire` is bounded by a timeout, anonymous accounts survive a restart, and the app session carries between `pyric <tool> <method>` runs.

```json
{ "method": "fire", "args": { "trigger": "onMessageCreated", "path": "rooms/lobby/messages/m1", "value": { "text": "hi" }, "timeoutMs": 5000 } }
```

```sh
pyric auth signInAnonymously
pyric sandbox checkpoint --name before
pyric sandbox reset --scope auth --confirm
pyric sandbox restore --name before --confirm
pyric auth listUsers          # the anonymous account is back

pyric auth signInWithEmailAndPassword --email riley@acme.test --password seed-riley
pyric auth whoami             # a new process, and the app session is still riley
```

## A handler cannot hold the server hostage

`fire` runs the project's own handler in the server process. It now races the handler against `timeoutMs` (default 10 seconds, at most 60), and a handler that does not settle is reported as timed out with its execution record marked `timeout`.

## Anonymous accounts are accounts

The auth sandbox exported every user except anonymous ones, so `signInAnonymously` produced a user that `listUsers` showed and a restart, a checkpoint, or a branch forgot. Real Firebase keeps anonymous accounts in the pool; so does pyric now, with `providerId: 'anonymous'` and no email or password.

## The app session is state

The in-process state file carried the user pool but not the signed-in user, so a sign-in in one command was gone in the next. The session's uid and tenant are saved beside the snapshot and restored through the auth sandbox's own session seam, which gained the smallest addition it lacked: a way to carry the tenant scope.

## Risk

The first attempt at the session fix went through the persistence hook the browser's `enablePersistence` controller shares, which has its own mode semantics, and broke three of its tests; the shipped fix is scoped to the in-process server's own save and load. `SeedUser.email` and `password` become optional, since an anonymous entry has neither.

<details>
<summary>Implementation notes</summary>

- The Kotlin `debug-compose` flake was diagnosed without changing code: `PyricDebugController.refreshUsers()` launches on a hardcoded `Dispatchers.IO` instead of the injected scope, and `FirebaseAuth`'s collectors run on a hardcoded IO scope with no injection point, so the test's virtual-time dispatcher cannot drain them. The fixes are one deletion and one constructor parameter; they are recorded for a separate change.
- `bun test --cwd packages/pyric` 6744 pass, `packages/cli` 3373 pass, coupling gate and `compat:check` clean, packaging smoke pass.

</details>
