### PR TITLE
feat(sandbox): listeners report their owners

### DIFF
--- a/packages/cli/src/bridge/surface/methods/sandbox/listeners.ts
+++ b/packages/cli/src/bridge/surface/methods/sandbox/listeners.ts
@@ -26,7 +26,7 @@ function listenerView(listener: ActiveListener): Record<string, unknown> {
     suppressedCount: listener.suppressedCount,
   };
   if (listener.lastDeliveryAt !== undefined) view.lastDeliveryAt = listener.lastDeliveryAt;
-  if (listener.callSite !== undefined) view.callSite = listener.callSite;
+  if (listener.owners !== undefined) view.owners = listener.owners;
   return view;
 }
 

--- a/packages/pyric/src/sandbox/active-listeners.ts
+++ b/packages/pyric/src/sandbox/active-listeners.ts
@@ -15,7 +15,7 @@
  */
 import type { AuthLens, EventActor, EventService } from './types/operation.js';
 import { operationContextFor } from './operation-record.js';
-import type { SandboxEvent } from './types/events.js';
+import type { ListenerOwner, SandboxEvent } from './types/events.js';
 
 /** The two families of target a listener watches. */
 export type ActiveListenerTarget =
@@ -33,9 +33,12 @@ export interface ActiveListener {
   readonly deliveryCount: number;
   readonly suppressedCount: number;
   readonly lastDeliveryAt?: number;
-  /** Where the listener was attached in application code. Not yet carried by
-   * any emitter; present when a future attach event names one. */
-  readonly callSite?: string;
+  /**
+   * Who owns the listener, as its attach event recorded it (a creation frame,
+   * an explicit tag) and as its deliveries revealed it (the DOM regions its
+   * callback changed). Absent when the emitter recorded nothing.
+   */
+  readonly owners?: readonly ListenerOwner[];
 }
 
 type ListenerPhase = 'attach' | 'detach' | 'delivery' | 'suppressed' | 'errored';
@@ -48,7 +51,7 @@ interface ListenerEventInfo {
   readonly target: ActiveListenerTarget;
   readonly actor: EventActor;
   readonly authLens: AuthLens;
-  readonly callSite?: string;
+  readonly owners?: readonly ListenerOwner[];
 }
 
 /** The internal service token 'rtdb' translated to the word this module's
@@ -76,11 +79,8 @@ function canonicalTarget(target: { kind: string; path?: string; query?: unknown 
  * listener lifecycle. */
 function listenerEventInfo(event: SandboxEvent): ListenerEventInfo | null {
   const context = operationContextFor(event);
-  let callSite: string | undefined;
-  if (event.kind === 'listener' && typeof event.detail?.callSite === 'string') {
-    callSite = event.detail.callSite;
-  }
-  const identity = { actor: context.source, authLens: context.authLens, callSite };
+  const owners = 'owners' in event && Array.isArray(event.owners) ? event.owners : undefined;
+  const identity = { actor: context.source, authLens: context.authLens, owners };
 
   if (event.kind === 'listener_attach') {
     return { phase: 'attach', listenerId: event.listenerId, service: 'firestore', target: firestoreTarget(event.target), ...identity };
@@ -119,7 +119,7 @@ interface ActiveListenerDraft {
   deliveryCount: number;
   suppressedCount: number;
   lastDeliveryAt?: number;
-  callSite?: string;
+  owners?: ListenerOwner[];
 }
 
 /**
@@ -143,7 +143,7 @@ export function activeListeners(events: readonly SandboxEvent[]): readonly Activ
         deliveryCount: 0,
         suppressedCount: 0,
       };
-      if (info.callSite !== undefined) draft.callSite = info.callSite;
+      if (info.owners !== undefined) draft.owners = [...info.owners];
       active.set(info.listenerId, draft);
       continue;
     }
@@ -152,6 +152,7 @@ export function activeListeners(events: readonly SandboxEvent[]): readonly Activ
     if (info.phase === 'delivery') {
       entry.deliveryCount += 1;
       entry.lastDeliveryAt = event.at;
+      if (info.owners !== undefined) entry.owners = withDeliveryOwners(entry.owners, info.owners);
       continue;
     }
     if (info.phase === 'suppressed') {
@@ -162,6 +163,21 @@ export function activeListeners(events: readonly SandboxEvent[]): readonly Activ
     active.delete(info.listenerId);
   }
   return Object.freeze([...active.values()].map((entry) => Object.freeze({ ...entry })));
+}
+
+/**
+ * A listener's owners after one delivery: the attach-time owners stay, and the
+ * delivery's `regions` replace any earlier regions, since the latest delivery
+ * is the current answer to what the callback paints.
+ */
+function withDeliveryOwners(
+  current: readonly ListenerOwner[] | undefined,
+  delivered: readonly ListenerOwner[],
+): ListenerOwner[] {
+  const regions = delivered.filter((owner) => owner.kind === 'regions');
+  if (regions.length === 0) return [...(current ?? [])];
+  const kept = (current ?? []).filter((owner) => owner.kind !== 'regions');
+  return [...kept, ...regions];
 }
 
 /** Whether a listener's target starts with a caller-supplied prefix. A

--- a/packages/pyric/test/sandbox/active-listeners.test.ts
+++ b/packages/pyric/test/sandbox/active-listeners.test.ts
@@ -84,3 +84,31 @@ describe('activeListeners', () => {
     expect(activeListeners(sandbox.history())).toHaveLength(0);
   });
 });
+
+describe('activeListeners owners', () => {
+  it('carries the owners the attach event recorded: the creation frame and an explicit tag', () => {
+    const sandbox = initializeSandbox();
+    setRules(sandbox, OPEN_FIRESTORE_RULES);
+    const db = getFirestore(sandbox);
+
+    const unsubscribe = onSnapshot(doc(db, 'notes/tagged'), { owner: 'notes-panel' }, () => {});
+
+    const [listener] = activeListeners(sandbox.history());
+    expect(listener.owners).toBeDefined();
+    const kinds = (listener.owners ?? []).map((owner) => owner.kind);
+    expect(kinds).toContain('tag');
+    expect(kinds).toContain('frame');
+    const tag = (listener.owners ?? []).find((owner) => owner.kind === 'tag');
+    expect(tag).toMatchObject({ kind: 'tag', name: 'notes-panel' });
+    const frame = (listener.owners ?? []).find((owner) => owner.kind === 'frame');
+    expect(frame && 'file' in frame && frame.file.endsWith('active-listeners.test.ts')).toBe(true);
+
+    unsubscribe();
+    expect(activeListeners(sandbox.history())).toHaveLength(0);
+  });
+
+  it('reports no owners for a listener whose attach event recorded none', () => {
+    const events = [] as const;
+    expect(activeListeners(events)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Makes `sandbox.listeners` report who owns each listener, by carrying the `owners` the attach and delivery events already record through the active-listener fold.

```json
{ "method": "listeners", "args": { "service": "firestore" } }
```

```json
{
  "id": "0", "service": "firestore", "target": { "kind": "query", "collection": "orders" },
  "deliveryCount": 3,
  "owners": [
    { "kind": "frame", "file": "src/orders.ts", "line": 41 },
    { "kind": "tag", "name": "orders-table" },
    { "kind": "regions", "selectors": ["div#order-list"] }
  ]
}
```

## The fold keeps what the events already know

Attribution landed on the listener events in the previous change, but the fold that answers `listeners` still carried a `callSite` field no emitter ever filled. The fold now copies the attach event's owners onto the listener and, on each delivery, replaces its `regions` with the latest delivery's, since the most recent paint is the current answer to what the callback drives. The frame and tag from attach are kept as they were.

## Risk

None to behaviour: an event with no owners yields a listener with no owners, and every existing listener test passes unchanged. `callSite` is removed rather than kept beside `owners`; nothing wrote it.

<details>
<summary>Implementation notes</summary>

- Test: an `onSnapshot` with `{ owner: 'notes-panel' }` lists a listener whose owners include the tag and a frame pointing at the test file.
- `bun test --cwd packages/pyric` and the CLI listener handler and read-effect suites pass; typecheck clean in both packages.

</details>
