### PR TITLE
feat(ui): component attribution for React listener hooks

### DIFF
--- a/packages/pyric/src/sandbox/attribution/listener-owners.ts
+++ b/packages/pyric/src/sandbox/attribution/listener-owners.ts
@@ -25,10 +25,20 @@ import {
 } from './element-selector.js';
 
 /**
- * What a caller may pass as a listener's `owner`: a name, or the DOM element
- * the listener feeds.
+ * What a caller may pass as a listener's `owner`: a name, the DOM element the
+ * listener feeds, or a fully-built {@link ListenerOwner} record. The third
+ * form is for a framework binding (`@pyric/ui`'s `useListenerOwner`) that has
+ * already computed a `component` owner and wants it recorded verbatim,
+ * rather than wrapped in a `tag`.
  */
-export type ListenerOwnerHint = string | SelectableElement;
+export type ListenerOwnerHint = string | SelectableElement | ListenerOwner;
+
+/** `true` when `value` is already a {@link ListenerOwner} record rather than
+ *  a name or an element to derive one from. */
+function isListenerOwner(value: ListenerOwnerHint): value is ListenerOwner {
+  if (value === null || typeof value !== 'object') return false;
+  return 'kind' in value && typeof (value as { kind: unknown }).kind === 'string';
+}
 
 /**
  * Pyric's own root directory, derived from this module's own location.
@@ -141,10 +151,12 @@ export function captureCreationFrame(): ListenerOwner | undefined {
 }
 
 /**
- * Build the `tag` owner from whatever the caller passed as `owner`. A string
- * is the name verbatim; an element contributes its tag name plus a selector
- * that finds it again. Unlike frame capture this is not gated on the
- * attribution switch: the caller asked for it by name.
+ * Build the explicit owner from whatever the caller passed as `owner`. A
+ * string is the name of a `tag` owner verbatim; an element contributes its
+ * tag name plus a selector that finds it again; an already-built
+ * {@link ListenerOwner} (a framework binding's `component` owner) is
+ * recorded as-is. Unlike frame capture this is not gated on the attribution
+ * switch: the caller asked for it by name.
  */
 export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner | undefined {
   if (hint === undefined) return undefined;
@@ -152,6 +164,7 @@ export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner 
     if (hint.length === 0) return undefined;
     return { kind: 'tag', name: hint };
   }
+  if (isListenerOwner(hint)) return hint;
   if (!isSelectableElement(hint)) return undefined;
   return { kind: 'tag', name: tagNameOf(hint), element: ownerSelectorFor(hint) };
 }

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -31,6 +31,12 @@ export {
   type ListenerOwnerHint,
 } from '../attribution/listener-owners.js';
 export { recordEffectRegions } from '../attribution/effect-regions.js';
+export {
+  isSelectableElement,
+  ownerSelectorFor,
+  tagNameOf,
+  type SelectableElement,
+} from '../attribution/element-selector.js';
 export { getClock } from '../clock.js';
 export { stampProvenance } from './provenance.js';
 export { bindOperationContext } from '../sandbox-context.js';

--- a/packages/pyric/src/sandbox/types/events.ts
+++ b/packages/pyric/src/sandbox/types/events.ts
@@ -275,11 +275,18 @@ export interface WriteSandboxEvent {
  * - `regions`, what the delivery changed. The selectors of the elements a
  *   snapshot callback mutated during its own synchronous run. Present only in
  *   a browser, and only on a delivery event.
+ * - `component`, the framework component that owns the listener, captured
+ *   during render. Unlike `frame`, which reads the call stack at the moment
+ *   the listener attaches, `component` reads the render-phase call stack of
+ *   the component that will go on to attach it. `@pyric/ui`'s framework
+ *   bindings capture this once per component instance and thread it through
+ *   the `owner` listen option.
  *
  * One listener can have more than one owner at once: an attach usually
- * carries a frame and, when the caller supplied one, a tag. Events therefore
- * carry `owners` as an array rather than a single field. An event with no
- * attribution omits the array entirely rather than carrying an empty one.
+ * carries a frame and, when the caller supplied one, a tag or a component.
+ * Events therefore carry `owners` as an array rather than a single field. An
+ * event with no attribution omits the array entirely rather than carrying an
+ * empty one.
  */
 export type ListenerOwner =
   | {
@@ -304,6 +311,20 @@ export type ListenerOwner =
       kind: 'regions';
       /** Selectors of the elements the snapshot callback mutated. */
       selectors: string[];
+    }
+  | {
+      kind: 'component';
+      /** The component function's name, read from the render-phase stack. A
+       *  minified production build mangles this like any other identifier;
+       *  the consuming UI states that rather than guessing at the original
+       *  name. */
+      name: string;
+      /** The chain of enclosing component frames, outermost first, best
+       *  effort. Absent when only one component frame was found. */
+      path?: string[];
+      /** Selector that re-identifies the component's root DOM element, once
+       *  the consumer has attached the returned `ref` to it. */
+      element?: string;
     };
 
 /**

--- a/packages/ui/src/firestore/hooks/useDocumentList.ts
+++ b/packages/ui/src/firestore/hooks/useDocumentList.ts
@@ -5,6 +5,7 @@ import type {
   Query,
   QueryDocumentSnapshot,
 } from 'pyric/firestore';
+import { useListenerOwner } from '../../primitives/hooks/useListenerOwner.js';
 import { useFirestoreApi } from '../firestoreApi.js';
 
 export interface UseDocumentListOptions {
@@ -88,6 +89,7 @@ export function useDocumentList({
     setDoc,
     startAfter: startAfterFn,
   } = useFirestoreApi();
+  const { owner } = useListenerOwner();
 
   useEffect(() => {
     setRequestedCount(pageSize);
@@ -118,6 +120,7 @@ export function useDocumentList({
       const generation = ++nextSubscriptionGeneration.current;
       const unsubscribe = onSnapshot(
         pagedQuery,
+        { owner },
         (snap: unknown) => {
           setSubscriptionGeneration(generation);
           accept(snap as { readonly docs: readonly QueryDocumentSnapshot[] });
@@ -144,6 +147,7 @@ export function useDocumentList({
     limitFn,
     mode,
     onSnapshot,
+    owner,
     pageSize,
     query,
     queryFn,

--- a/packages/ui/src/firestore/hooks/useFirestoreCollection.ts
+++ b/packages/ui/src/firestore/hooks/useFirestoreCollection.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { Query, QuerySnapshot } from 'pyric/firestore';
+import { useListenerOwner } from '../../primitives/hooks/useListenerOwner.js';
 import { coerceError } from './coerceError.js';
 import type { SubscriptionState } from './useFirestoreDoc.js';
 import { useFirestoreApi } from '../firestoreApi.js';
@@ -18,6 +19,7 @@ export function useFirestoreCollection(
   query: Query | null | undefined,
 ): SubscriptionState<QuerySnapshot> {
   const { onSnapshot } = useFirestoreApi();
+  const { owner } = useListenerOwner();
   const [state, setState] = useState<SubscriptionState<QuerySnapshot>>(() => ({
     data: undefined,
     error: undefined,
@@ -34,6 +36,7 @@ export function useFirestoreCollection(
 
     const unsubscribe = onSnapshot(
       query,
+      { owner },
       (snap) =>
         setState({ data: snap as QuerySnapshot, error: undefined, isLoading: false }),
       (err) =>
@@ -45,7 +48,7 @@ export function useFirestoreCollection(
     );
 
     return unsubscribe;
-  }, [onSnapshot, query]);
+  }, [onSnapshot, owner, query]);
 
   return state;
 }

--- a/packages/ui/src/firestore/hooks/useFirestoreDoc.ts
+++ b/packages/ui/src/firestore/hooks/useFirestoreDoc.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { DocumentReference, DocumentSnapshot } from 'pyric/firestore';
+import { useListenerOwner } from '../../primitives/hooks/useListenerOwner.js';
 import { coerceError } from './coerceError.js';
 import { useFirestoreApi } from '../firestoreApi.js';
 
@@ -22,6 +23,7 @@ export function useFirestoreDoc(
   ref: DocumentReference | null | undefined,
 ): SubscriptionState<DocumentSnapshot> {
   const { onSnapshot } = useFirestoreApi();
+  const { owner } = useListenerOwner();
   const [state, setState] = useState<SubscriptionState<DocumentSnapshot>>(() => ({
     data: undefined,
     error: undefined,
@@ -38,6 +40,7 @@ export function useFirestoreDoc(
 
     const unsubscribe = onSnapshot(
       ref,
+      { owner },
       (snap) =>
         setState({ data: snap as DocumentSnapshot, error: undefined, isLoading: false }),
       (err) =>
@@ -49,7 +52,7 @@ export function useFirestoreDoc(
     );
 
     return unsubscribe;
-  }, [onSnapshot, ref]);
+  }, [onSnapshot, owner, ref]);
 
   return state;
 }

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import type { ListenerOwner } from 'pyric/sandbox';
+import {
+  isSelectableElement,
+  listenerAttributionEnabled,
+  ownerSelectorFor,
+  type SelectableElement,
+} from 'pyric/sandbox/internal';
+
+/**
+ * Captures the framework component that owns a listener, so a component
+ * using `@pyric/ui`'s data hooks is attributed with no extra code at the
+ * call site.
+ *
+ * Capture happens during render, while the calling component function is
+ * still on the call stack — the same moment `pyric/sandbox`'s own `frame`
+ * attribution reads a stack. Two things are read from two different stacks:
+ *
+ * - `name` comes from `new Error().stack`, the plain call stack. The first
+ *   frame outside this module's own directory and `node_modules` (which
+ *   covers `react`, `react-dom`, and every other dependency, `pyric`
+ *   included) is the component function currently rendering — this hook is
+ *   always called directly from that function's body, so that frame names
+ *   it. A minified production build mangles this the same way it mangles any
+ *   other identifier; state that to the consumer rather than guessing at the
+ *   original name.
+ * - `path`, the chain of enclosing component frames, comes from React's own
+ *   `captureOwnerStack` export (React 19+; an older peer React leaves `path`
+ *   absent). That export exists precisely because the plain call stack does
+ *   not carry a parent chain: React's reconciler does not call a parent
+ *   component's function from within its child's, so `new Error().stack`
+ *   alone can only ever name the immediate function. `captureOwnerStack`
+ *   reads React's own render-phase bookkeeping through a public export —
+ *   this hook never touches a fiber. Best effort: absent when the installed
+ *   React does not report an owner stack for this render.
+ *
+ * `ref` is a callback ref the caller may attach to the component's root
+ * element. Once attached, `owner.element` is filled in with the same
+ * selector `pyric/sandbox`'s attribution module uses for a caller-supplied
+ * tag element, imported from `pyric/sandbox/internal` rather than
+ * duplicated.
+ *
+ * Capture is skipped entirely, and `owner` is `undefined`, when listener
+ * attribution is off — the same production/test switch `pyric/sandbox`
+ * itself reads.
+ */
+export interface UseListenerOwnerResult {
+  /** The component owner, or `undefined` when attribution is off or this
+   *  hook could not identify a calling component frame. */
+  owner: ListenerOwner | undefined;
+  /** Attach to the component's root element to fill in `owner.element`. */
+  ref: (element: SelectableElement | null) => void;
+}
+
+export interface UseListenerOwnerOptions {
+  /**
+   * Test seam: a stand-in for React's `captureOwnerStack` export. Some test
+   * renderers do not populate an owner stack the way a real browser render
+   * does, so tests inject a fixture string here to exercise the parsing
+   * logic. Production callers omit this; the hook reads `react`'s own
+   * export when it exists.
+   */
+  captureOwnerStack?: () => string | null;
+}
+
+const FRAME_WITH_FUNCTION = /^\s*at\s+([^\s(]+)\s+\((.+):(\d+):(\d+)\)\s*$/;
+
+/**
+ * `@pyric/ui`'s own package root (the `src` directory under source, `dist`
+ * under a build), derived from `import.meta.url` rather than a hardcoded
+ * `packages/ui` string. A hardcoded string would misfire inside this very
+ * monorepo, where the test files that exercise a consumer component also
+ * happen to sit under a path containing `packages/ui` (`packages/ui/test/
+ * ...`) — only this package's own source or build output should be
+ * excluded, not sibling test or app code that shares the package root by
+ * coincidence of this repository's own layout.
+ *
+ * This file sits at `<root>/primitives/hooks/useListenerOwner.{ts,js}`, so
+ * the root is two path segments up.
+ */
+const OWN_DIRECTORY = ownDirectory();
+
+function ownDirectory(): string {
+  const here = importMetaUrl();
+  if (here === undefined) return '';
+  const withoutFile = here.slice(0, here.lastIndexOf('/'));
+  const withoutHooks = withoutFile.slice(0, withoutFile.lastIndexOf('/'));
+  const withoutPrimitives = withoutHooks.slice(0, withoutHooks.lastIndexOf('/'));
+  return `${withoutPrimitives}/`;
+}
+
+/** This module's own URL, or `undefined` inside a bundle that erased it. */
+function importMetaUrl(): string | undefined {
+  try {
+    const url = (import.meta as { url?: unknown }).url;
+    if (typeof url !== 'string') return undefined;
+    return stripFileScheme(url);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripFileScheme(url: string): string {
+  if (url.startsWith('file://')) return url.slice('file://'.length);
+  return url;
+}
+
+function isFrameworkFile(file: string): boolean {
+  const normalized = stripFileScheme(file);
+  if (normalized.includes('/node_modules/')) return true;
+  if (OWN_DIRECTORY.length > 0 && normalized.startsWith(OWN_DIRECTORY)) return true;
+  return false;
+}
+
+interface RenderFrame {
+  name: string;
+  file: string;
+}
+
+function parseRenderFrame(line: string): RenderFrame | undefined {
+  const match = FRAME_WITH_FUNCTION.exec(line);
+  if (!match) return undefined;
+  return { name: match[1]!, file: match[2]! };
+}
+
+/** The first non-framework frame in a plain call stack — the component
+ *  currently rendering, when this is called directly from its body. */
+function callingComponentName(stack: string | undefined): string | undefined {
+  if (typeof stack !== 'string') return undefined;
+  for (const line of stack.split('\n')) {
+    const frame = parseRenderFrame(line);
+    if (frame === undefined) continue;
+    if (isFrameworkFile(frame.file)) continue;
+    return frame.name;
+  }
+  return undefined;
+}
+
+/** `react`'s own `captureOwnerStack` export, when the installed version has
+ *  one. Older peer React versions (this package's peer range starts at 18)
+ *  don't export it, so the read is guarded rather than a static import. */
+function reactCaptureOwnerStack(): string | undefined {
+  const capture = (React as { captureOwnerStack?: () => string | null }).captureOwnerStack;
+  if (typeof capture !== 'function') return undefined;
+  return capture() ?? undefined;
+}
+
+/** The enclosing component names an owner stack reports, outermost first.
+ *  Best effort: a frame an owner stack doesn't carry a location for is
+ *  simply skipped rather than breaking the chain. */
+function ancestorPathFromOwnerStack(stack: string | undefined): string[] {
+  if (typeof stack !== 'string' || stack.length === 0) return [];
+  const names: string[] = [];
+  for (const line of stack.split('\n')) {
+    const frame = parseRenderFrame(line);
+    if (frame === undefined) continue;
+    if (isFrameworkFile(frame.file)) continue;
+    names.push(frame.name);
+  }
+  return names.reverse();
+}
+
+type ComponentOwner = Extract<ListenerOwner, { kind: 'component' }>;
+
+function captureComponentOwner(
+  captureOwnerStack: () => string | null | undefined,
+): ComponentOwner | undefined {
+  if (!listenerAttributionEnabled()) return undefined;
+  const name = callingComponentName(new Error().stack);
+  if (name === undefined) return undefined;
+  const path = ancestorPathFromOwnerStack(captureOwnerStack() ?? undefined);
+  const owner: ComponentOwner = { kind: 'component', name };
+  if (path.length > 0) owner.path = path;
+  return owner;
+}
+
+/**
+ * Run during render, from the component that will go on to attach a
+ * listener. Returns `{ owner, ref }`: pass `owner` as the listener's `owner`
+ * option, and optionally attach `ref` to the component's root element.
+ */
+export function useListenerOwner(
+  options: UseListenerOwnerOptions = {},
+): UseListenerOwnerResult {
+  const capture = options.captureOwnerStack ?? reactCaptureOwnerStack;
+  const [base] = useState<ComponentOwner | undefined>(() => captureComponentOwner(capture));
+  const [element, setElement] = useState<string | undefined>(undefined);
+
+  const ref = useCallback((node: SelectableElement | null) => {
+    if (node === null) return;
+    if (!isSelectableElement(node)) return;
+    setElement(ownerSelectorFor(node));
+  }, []);
+
+  const owner = useMemo<ComponentOwner | undefined>(() => {
+    if (base === undefined) return undefined;
+    if (element === undefined) return base;
+    return { ...base, element };
+  }, [base, element]);
+
+  return { owner, ref };
+}

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -14,13 +14,13 @@ import {
  * call site.
  *
  * Capture happens during render, while the calling component function is
- * still on the call stack — the same moment `pyric/sandbox`'s own `frame`
+ * still on the call stack, the same moment `pyric/sandbox`'s own `frame`
  * attribution reads a stack. Two things are read from two different stacks:
  *
  * - `name` comes from `new Error().stack`, the plain call stack. The first
  *   frame outside this module's own directory and `node_modules` (which
  *   covers `react`, `react-dom`, and every other dependency, `pyric`
- *   included) is the component function currently rendering — this hook is
+ *   included) is the component function currently rendering; this hook is
  *   always called directly from that function's body, so that frame names
  *   it. A minified production build mangles this the same way it mangles any
  *   other identifier; state that to the consumer rather than guessing at the
@@ -31,7 +31,7 @@ import {
  *   not carry a parent chain: React's reconciler does not call a parent
  *   component's function from within its child's, so `new Error().stack`
  *   alone can only ever name the immediate function. `captureOwnerStack`
- *   reads React's own render-phase bookkeeping through a public export —
+ *   reads React's own render-phase bookkeeping through a public export,
  *   this hook never touches a fiber. Best effort: absent when the installed
  *   React does not report an owner stack for this render.
  *
@@ -42,7 +42,7 @@ import {
  * duplicated.
  *
  * Capture is skipped entirely, and `owner` is `undefined`, when listener
- * attribution is off — the same production/test switch `pyric/sandbox`
+ * attribution is off, the same production/test switch `pyric/sandbox`
  * itself reads.
  */
 export interface UseListenerOwnerResult {
@@ -72,7 +72,7 @@ const FRAME_WITH_FUNCTION = /^\s*at\s+([^\s(]+)\s+\((.+):(\d+):(\d+)\)\s*$/;
  * `packages/ui` string. A hardcoded string would misfire inside this very
  * monorepo, where the test files that exercise a consumer component also
  * happen to sit under a path containing `packages/ui` (`packages/ui/test/
- * ...`) — only this package's own source or build output should be
+ * ...`), only this package's own source or build output should be
  * excluded, not sibling test or app code that shares the package root by
  * coincidence of this repository's own layout.
  *
@@ -124,7 +124,7 @@ function parseRenderFrame(line: string): RenderFrame | undefined {
   return { name: match[1]!, file: match[2]! };
 }
 
-/** The first non-framework frame in a plain call stack — the component
+/** The first non-framework frame in a plain call stack: the component
  *  currently rendering, when this is called directly from its body. */
 function callingComponentName(stack: string | undefined): string | undefined {
   if (typeof stack !== 'string') return undefined;

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -37,4 +37,9 @@ export {
   type UpdateHighlightKind,
   type UseUpdateHighlightsOptions,
 } from './hooks/useUpdateHighlights.js';
+export {
+  useListenerOwner,
+  type UseListenerOwnerOptions,
+  type UseListenerOwnerResult,
+} from './hooks/useListenerOwner.js';
 export { Modal, type ModalProps } from './Modal.js';

--- a/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
+++ b/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Component-owner attribution wired through `useFirestoreDoc`.
+ *
+ * `useFirestoreDoc` calls `useListenerOwner()` (see
+ * `src/primitives/hooks/useListenerOwner.ts`) and threads the result into
+ * `onSnapshot`'s `owner` option, so a consumer using the hook is attributed
+ * with no extra code. These tests render a small component tree
+ * (`App > Dashboard > OrdersTable`) and read the sandbox's own
+ * `listener_attach` event, rather than inspecting the hook directly, so they
+ * prove the wiring end to end.
+ *
+ * These tests share the "second `initializeSandbox()` cycle in one Bun
+ * process" hazard `useFirestoreDoc.test.tsx` documents (no `setRules` or
+ * `setDoc` call in a single sandbox), so each `it` uses its own sandbox and
+ * none call `setDoc`.
+ */
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import { describe, expect, it } from 'bun:test';
+import { doc, getFirestore } from 'pyric/firestore';
+import { initializeSandbox } from 'pyric/sandbox';
+import type { SandboxEvent } from 'pyric/sandbox';
+import { configureListenerAttribution } from 'pyric/sandbox/internal';
+import { seedDocuments } from 'pyric/sandbox/firestore';
+import { useFirestoreDoc } from '../../../src/firestore/hooks/useFirestoreDoc.js';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setupSandbox() {
+  const sandbox = initializeSandbox();
+  seedDocuments(sandbox, { 'orders/o1': { total: 10 } });
+  const events: SandboxEvent[] = [];
+  sandbox.onEvent((event) => events.push(event));
+  const db = getFirestore(sandbox.withAuth({ uid: 'alice' }));
+  return { db, events };
+}
+
+function attachEvents(events: SandboxEvent[]) {
+  return events.filter((event) => event.kind === 'listener_attach');
+}
+
+describe('component owner attribution through useFirestoreDoc', () => {
+  it('attributes the attach event to the component that called the hook', async () => {
+    const { db, events } = setupSandbox();
+    const ref = doc(db, 'orders/o1');
+
+    function OrdersTable() {
+      useFirestoreDoc(ref);
+      return null;
+    }
+    function Dashboard() {
+      return createElement(OrdersTable);
+    }
+    function App() {
+      return createElement(Dashboard);
+    }
+
+    await act(async () => {
+      create(createElement(App));
+    });
+
+    const owners = attachEvents(events)[0]?.owners ?? [];
+    const component = owners.find((owner) => owner.kind === 'component');
+    expect(component).toBeDefined();
+    if (component?.kind !== 'component') throw new Error('expected a component owner');
+    expect(component.name).toBe('OrdersTable');
+  });
+
+  it('records no component owner when attribution is off', async () => {
+    configureListenerAttribution('off');
+    try {
+      const { db, events } = setupSandbox();
+      const ref = doc(db, 'orders/o1');
+
+      function OrdersTable() {
+        useFirestoreDoc(ref);
+        return null;
+      }
+
+      await act(async () => {
+        create(createElement(OrdersTable));
+      });
+
+      const owners = attachEvents(events)[0]?.owners;
+      expect(owners?.some((owner) => owner.kind === 'component')).toBeFalsy();
+    } finally {
+      configureListenerAttribution('auto');
+    }
+  });
+});

--- a/packages/ui/test/helpers/fake-element.ts
+++ b/packages/ui/test/helpers/fake-element.ts
@@ -1,0 +1,28 @@
+/**
+ * A minimal `SelectableElement` stand-in for `useListenerOwner` ref tests.
+ *
+ * `packages/ui`'s DOM-free test family (`test/primitives`, `test/firestore`
+ * without an installed JSDOM) has no real DOM element to attach a ref to.
+ * `useListenerOwner`'s `ref` callback only needs the small interface
+ * `pyric/sandbox/internal`'s `SelectableElement` declares, so a plain object
+ * implementing it stands in for a real element without pulling in JSDOM.
+ */
+export class FakeElement {
+  readonly tagName: string;
+  id = '';
+  readonly children: FakeElement[] = [];
+  parentElement: FakeElement | null = null;
+  private readonly attributes = new Map<string, string>();
+
+  constructor(tagName: string) {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}

--- a/packages/ui/test/primitives/useListenerOwner.test.tsx
+++ b/packages/ui/test/primitives/useListenerOwner.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { configureListenerAttribution } from 'pyric/sandbox/internal';
+import { useListenerOwner } from '../../src/primitives/hooks/useListenerOwner.js';
+import { act, renderHook } from '../helpers/render-hook.js';
+import { FakeElement } from '../helpers/fake-element.js';
+
+describe('useListenerOwner', () => {
+  it('names the calling component from the render-phase call stack', () => {
+    let captured: ReturnType<typeof useListenerOwner> | undefined;
+    function OrdersTable() {
+      captured = useListenerOwner();
+      return null;
+    }
+    renderHook(() => OrdersTable(), undefined);
+
+    expect(captured?.owner?.kind).toBe('component');
+    if (captured?.owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(captured.owner.name).toBe('OrdersTable');
+  });
+
+  it('builds the ancestor path outermost-first from an owner stack', () => {
+    const { result } = renderHook(() =>
+      useListenerOwner({
+        captureOwnerStack: () =>
+          '    at Dashboard (src/app/Dashboard.tsx:8:3)\n    at App (src/app/App.tsx:3:3)',
+      }),
+    );
+
+    expect(result.current.owner?.kind).toBe('component');
+    if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(result.current.owner.path).toEqual(['App', 'Dashboard']);
+  });
+
+  it('omits component frames the owner stack format cannot parse', () => {
+    const { result } = renderHook(() =>
+      useListenerOwner({
+        captureOwnerStack: () => '    at <anonymous>',
+      }),
+    );
+
+    expect(result.current.owner?.kind).toBe('component');
+    if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(result.current.owner.path).toBeUndefined();
+  });
+
+  it('fills owner.element once ref is attached', () => {
+    const { result } = renderHook(() => useListenerOwner());
+    const element = new FakeElement('table');
+    element.id = 'orders';
+
+    act(() => {
+      result.current.ref(element);
+    });
+
+    expect(result.current.owner?.kind).toBe('component');
+    if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(result.current.owner.element).toBe('#orders');
+  });
+
+  it('records no owner at all when attribution is off', () => {
+    configureListenerAttribution('off');
+    try {
+      const { result } = renderHook(() => useListenerOwner());
+      expect(result.current.owner).toBeUndefined();
+    } finally {
+      configureListenerAttribution('auto');
+    }
+  });
+});


### PR DESCRIPTION
Adds component attribution for listeners created through `@pyric/ui`'s React hooks: the attach event names the component, with no change to the component's code.

```tsx
// OrdersTable.tsx, unchanged application code.
function OrdersTable() {
  const orders = useFirestoreCollection(query(collection(db, 'orders')));
  return <ul>{orders.map(...)}</ul>;
}
// listener_attach event on the sandbox:
// owners: [{ kind: 'frame', file: 'src/OrdersTable.tsx', line: 3 },
//          { kind: 'component', name: 'OrdersTable' }]
```

```tsx
// Opt in to geometry by attaching the hook's ref to the root element.
const { owner, ref } = useListenerOwner();
return <ul ref={ref}>...</ul>;   // owner.element becomes 'ul#order-list'
```

## The component is read from the render-phase stack, not from React internals

`useListenerOwner` runs during render, when the component function is on the call stack, and takes the first frame outside `@pyric/ui`, `pyric`, `react`, and `node_modules` as the component name. It holds that owner in the closure the hook's effect later hands to `onSnapshot` as `{ owner }`, so the attribution survives the gap between render and attach that defeats a stack captured at attach time. No fiber access, which is what keeps it stable across React versions. `useFirestoreDoc`, `useFirestoreCollection`, and `useDocumentList` call it; their signatures are unchanged.

The component `path` (the ancestor chain) comes from React 19's public `captureOwnerStack`, read defensively because the peer range starts at React 18. Under this repo's test runtime that call returns an empty string, so the path parsing is covered by a unit test with an injected owner stack rather than end to end; the name capture is covered end to end with a rendered `App > Dashboard > OrdersTable`.

## Risk

`ListenerOwner` gains a `component` kind, and the attach option accepts a prebuilt owner as well as a name or element, since the hook computes the owner itself. Capture runs only when attribution is on, which the production switch turns off. A minified build yields a mangled component name; the hook's header says a consumer must show that as unknown rather than guess.

<details>
<summary>Implementation notes</summary>

- The frame filter derives this module's own directory from `import.meta.url` rather than a hardcoded package path, which misfired on the repo's own test files.
- Conformance exemption stated on the branch: the change adds a kind to pyric's diagnostic events and changes no verdict or delivery path.
- `bun test --cwd packages/pyric` 6841 pass, `packages/cli` 3431 pass, `packages/ui` 431 pass, typecheck and build clean, coupling gate pass.

</details>
