### PR TITLE
feat(studio): a Listeners view grouped by owner

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -145,7 +145,7 @@ function Shell() {
   // The runtime chip's deep link (`?view=listeners&listener=<id>&target=
   // <path>`) opens the Listeners surface regardless of the routed tab. Read
   // once at startup: Studio has no router for this query shape, and it isn't
-  // one — `useState`'s lazy initializer runs exactly once, on mount.
+  // one; `useState`'s lazy initializer runs exactly once, on mount.
   const [listenersDeepLink] = useState<ListenersDeepLink>(() => currentListenersDeepLink());
 
   // Global ⌘K (Ctrl+K non-mac): on Home it focuses the inline command input;

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -23,6 +23,7 @@ import { HomeSurface } from './features/home/HomeSurface.js';
 import { RtdbSurface } from './features/rtdb/RtdbSurface.js';
 import { SettingsSurface } from './features/settings/SettingsSurface.js';
 import { AssuranceSurface } from './features/assurance/index.js';
+import { ListenersSurface, currentListenersDeepLink, type ListenersDeepLink } from './features/listeners/index.js';
 
 function siteHomeHref(): string {
   return appBase();
@@ -141,6 +142,11 @@ function Shell() {
   const navigate = (id: RouteId) => navigateRoute(id);
   const [commandOpen, setCommandOpen] = useState(false);
   const docsAvailable = useDocsAvailable();
+  // The runtime chip's deep link (`?view=listeners&listener=<id>&target=
+  // <path>`) opens the Listeners surface regardless of the routed tab. Read
+  // once at startup: Studio has no router for this query shape, and it isn't
+  // one — `useState`'s lazy initializer runs exactly once, on mount.
+  const [listenersDeepLink] = useState<ListenersDeepLink>(() => currentListenersDeepLink());
 
   // Global ⌘K (Ctrl+K non-mac): on Home it focuses the inline command input;
   // elsewhere it toggles the overlay below the bar. preventDefault ONLY when
@@ -230,7 +236,11 @@ function Shell() {
 
       <main className="studio__content" data-surface={active}>
         <div className="studio__surface-slot" data-active="true">
-          <Surface id={active} />
+          {listenersDeepLink.open ? (
+            <ListenersSurface deepLink={listenersDeepLink} />
+          ) : (
+            <Surface id={active} />
+          )}
         </div>
       </main>
 

--- a/packages/studio/src/features/listeners/ListenersSurface.tsx
+++ b/packages/studio/src/features/listeners/ListenersSurface.tsx
@@ -1,0 +1,24 @@
+/**
+ * Listeners surface (feature: Listeners). Wires the live event stream and
+ * the deep link (`?view=listeners&listener=<id>&target=<path>`, read once at
+ * startup by the caller) into the presentational `ListenersView`.
+ */
+
+import { useStudioEvents } from '../../shell/studio-events.js';
+import { ListenersView } from './ListenersView.js';
+import type { ListenersDeepLink } from './listeners-deep-link.js';
+
+export interface ListenersSurfaceProps {
+  deepLink?: ListenersDeepLink;
+}
+
+export function ListenersSurface({ deepLink }: ListenersSurfaceProps) {
+  const events = useStudioEvents();
+  return (
+    <ListenersView
+      events={events}
+      highlightListenerId={deepLink?.listenerId}
+      initialTargetPrefix={deepLink?.targetPrefix}
+    />
+  );
+}

--- a/packages/studio/src/features/listeners/ListenersView.tsx
+++ b/packages/studio/src/features/listeners/ListenersView.tsx
@@ -1,0 +1,187 @@
+/**
+ * Listeners view (feature: Listeners). Presentational: takes the event
+ * snapshot and the deep-link inputs as props so it can be rendered without
+ * Studio's environment/dev-seed wiring in tests. `ListenersSurface.tsx` is
+ * the thin wrapper that reads the live stream and the deep link and renders
+ * this.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { activeListeners, type ActiveListener, type SandboxEvent } from 'pyric/sandbox';
+import {
+  formatListenerTarget,
+  groupListeners,
+  type ListenerFilters,
+} from './listener-groups.js';
+import {
+  incidentsForTarget,
+  listenerIncidents,
+  repeatedReadIncidents,
+} from './listener-incidents.js';
+import { formatAuthLens } from './listener-identity.js';
+import './listeners.css';
+
+function formatWhen(at: number): string {
+  return new Date(at).toLocaleTimeString();
+}
+
+function regionsFor(listener: ActiveListener): string[] {
+  for (const owner of listener.owners ?? []) {
+    if (owner.kind === 'regions') return owner.selectors;
+  }
+  return [];
+}
+
+/** `incidentsForTarget` only ever returns these two patterns; the third
+ *  (`repeated-read`) still types here since it shares `ActivityIncident`. */
+function incidentLabel(pattern: 'duplicate-listener' | 'listener-churn' | 'repeated-read'): string {
+  if (pattern === 'duplicate-listener') return 'duplicate listener';
+  if (pattern === 'listener-churn') return 'listener churn';
+  return 'repeated read';
+}
+
+/** Assemble the group filters from the two filter controls' current values.
+ *  Built explicitly (no conditional spread) so presence is a plain
+ *  if/else decision rather than truthiness. */
+function listenerFiltersFor(
+  service: ActiveListener['service'] | '',
+  targetPrefix: string,
+): ListenerFilters {
+  const filters: { service?: ActiveListener['service']; targetPrefix?: string } = {};
+  if (service !== '') filters.service = service;
+  if (targetPrefix !== '') filters.targetPrefix = targetPrefix;
+  return filters;
+}
+
+export interface ListenersViewProps {
+  events: readonly SandboxEvent[];
+  highlightListenerId?: string;
+  initialTargetPrefix?: string;
+}
+
+export function ListenersView({
+  events,
+  highlightListenerId,
+  initialTargetPrefix,
+}: ListenersViewProps) {
+  const [service, setService] = useState<ActiveListener['service'] | ''>('');
+  const [targetPrefix, setTargetPrefix] = useState(initialTargetPrefix ?? '');
+  const highlightRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (highlightListenerId) highlightRef.current?.scrollIntoView({ block: 'center' });
+  }, [highlightListenerId]);
+
+  const listeners = activeListeners(events);
+  const incidents = listenerIncidents(events);
+  const repeatedReads = repeatedReadIncidents(incidents);
+
+  const groups = groupListeners(listeners, listenerFiltersFor(service, targetPrefix));
+
+  return (
+    <section className="listeners" aria-labelledby="listeners-title">
+      <header className="listeners__head">
+        <h2 id="listeners-title" className="listeners__title">
+          Listeners
+        </h2>
+        <span className="listeners__count">{listeners.length}</span>
+      </header>
+
+      {repeatedReads.length > 0 ? (
+        <div className="listeners__incident listeners__incident--repeated-read" data-testid="repeated-read-incident">
+          {`repeated read ×${repeatedReads.reduce((sum, incident) => sum + incident.count, 0)}`}
+        </div>
+      ) : null}
+
+      <div className="listeners__filters">
+        <label className="listeners__filter">
+          Service
+          <select
+            value={service}
+            onChange={(event) => setService(event.target.value as ActiveListener['service'] | '')}
+          >
+            <option value="">All</option>
+            <option value="firestore">Firestore</option>
+            <option value="database">Database</option>
+          </select>
+        </label>
+        <label className="listeners__filter">
+          Target prefix
+          <input
+            type="text"
+            value={targetPrefix}
+            onChange={(event) => setTargetPrefix(event.target.value)}
+            placeholder="collection or path"
+          />
+        </label>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="listeners__empty">No active listeners match this filter.</p>
+      ) : (
+        groups.map((group) => (
+          <section key={group.identity.key} className="listeners__group">
+            <header className="listeners__group-head">
+              <span className="listeners__group-label">{group.identity.label}</span>
+              {group.identity.subtitle ? (
+                <span className="listeners__group-subtitle">{group.identity.subtitle}</span>
+              ) : null}
+              <span className="listeners__group-count">{group.listeners.length}</span>
+            </header>
+            <ul className="listeners__rows">
+              {group.listeners.map((listener) => {
+                const rowIncidents = incidentsForTarget(incidents, listener.target);
+                const highlighted = listener.id === highlightListenerId;
+                return (
+                  <li
+                    key={listener.id}
+                    ref={highlighted ? highlightRef : undefined}
+                    className={
+                      highlighted ? 'listeners__row listeners__row--highlight' : 'listeners__row'
+                    }
+                    data-testid={`listener-row-${listener.id}`}
+                  >
+                    <span className="listeners__cell listeners__cell--service">{listener.service}</span>
+                    <span className="listeners__cell listeners__cell--target">
+                      {formatListenerTarget(listener.target)}
+                    </span>
+                    <span className="listeners__cell listeners__cell--identity">
+                      {formatAuthLens(listener.authLens)}
+                    </span>
+                    <span className="listeners__cell listeners__cell--attached">
+                      {formatWhen(listener.attachedAt)}
+                    </span>
+                    <span className="listeners__cell listeners__cell--deliveries">
+                      {listener.deliveryCount} deliveries
+                    </span>
+                    <span className="listeners__cell listeners__cell--suppressed">
+                      {listener.suppressedCount} suppressed
+                    </span>
+                    {listener.lastDeliveryAt !== undefined ? (
+                      <span className="listeners__cell listeners__cell--last-delivery">
+                        last {formatWhen(listener.lastDeliveryAt)}
+                      </span>
+                    ) : null}
+                    {regionsFor(listener).length > 0 ? (
+                      <span className="listeners__cell listeners__cell--regions">
+                        paints {regionsFor(listener).join(', ')}
+                      </span>
+                    ) : null}
+                    {rowIncidents.map((incident) => (
+                      <span
+                        key={incident.fingerprint}
+                        className="listeners__incident listeners__incident--inline"
+                      >
+                        {`${incidentLabel(incident.pattern)} ×${incident.count}`}
+                      </span>
+                    ))}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))
+      )}
+    </section>
+  );
+}

--- a/packages/studio/src/features/listeners/index.ts
+++ b/packages/studio/src/features/listeners/index.ts
@@ -1,0 +1,3 @@
+export { ListenersSurface } from './ListenersSurface.js';
+export { parseListenersDeepLink, currentListenersDeepLink } from './listeners-deep-link.js';
+export type { ListenersDeepLink } from './listeners-deep-link.js';

--- a/packages/studio/src/features/listeners/listener-groups.test.ts
+++ b/packages/studio/src/features/listeners/listener-groups.test.ts
@@ -1,4 +1,4 @@
-/** Listener grouping — pure fold tests. */
+/** Listener grouping, pure fold tests. */
 import { describe, expect, it } from 'bun:test';
 import type { ActiveListener } from 'pyric/sandbox';
 import { formatListenerTarget, groupIdentityFor, groupListeners } from './listener-groups.js';

--- a/packages/studio/src/features/listeners/listener-groups.test.ts
+++ b/packages/studio/src/features/listeners/listener-groups.test.ts
@@ -1,0 +1,88 @@
+/** Listener grouping — pure fold tests. */
+import { describe, expect, it } from 'bun:test';
+import type { ActiveListener } from 'pyric/sandbox';
+import { formatListenerTarget, groupIdentityFor, groupListeners } from './listener-groups.js';
+
+function listener(overrides: Partial<ActiveListener> & { id: string }): ActiveListener {
+  return {
+    service: 'firestore',
+    target: 'notes/one',
+    actor: { kind: 'app' },
+    authLens: { mode: 'app-session' },
+    attachedAt: 0,
+    deliveryCount: 0,
+    suppressedCount: 0,
+    ...overrides,
+  };
+}
+
+describe('groupIdentityFor', () => {
+  it('prefers a component owner, subtitled by its path', () => {
+    const identity = groupIdentityFor([
+      { kind: 'component', name: 'NotesList', path: 'src/NotesList.tsx' } as never,
+    ]);
+    expect(identity).toEqual({ key: 'component:src/NotesList.tsx:NotesList', label: 'NotesList', subtitle: 'src/NotesList.tsx' });
+  });
+
+  it('falls back to a tag owner', () => {
+    const identity = groupIdentityFor([{ kind: 'tag', name: 'sidebar' }]);
+    expect(identity.label).toBe('sidebar');
+  });
+
+  it('falls back to a frame function, then its file', () => {
+    const withFn = groupIdentityFor([{ kind: 'frame', file: 'app.js', line: 10, function: 'loadNotes' }]);
+    expect(withFn.label).toBe('loadNotes');
+    const noFn = groupIdentityFor([{ kind: 'frame', file: 'app.js', line: 10 }]);
+    expect(noFn.label).toBe('app.js');
+  });
+
+  it('is unattributed when no owners are recorded', () => {
+    expect(groupIdentityFor(undefined).label).toBe('Unattributed');
+    expect(groupIdentityFor([]).label).toBe('Unattributed');
+  });
+});
+
+describe('groupListeners', () => {
+  it('groups three listeners under a component, a tag, and a frame label', () => {
+    const listeners = [
+      listener({
+        id: 'l1',
+        owners: [{ kind: 'component', name: 'NotesList', path: 'src/NotesList.tsx' } as never],
+      }),
+      listener({ id: 'l2', owners: [{ kind: 'tag', name: 'sidebar' }] }),
+      listener({ id: 'l3', owners: [{ kind: 'frame', file: 'app.js', line: 4 }] }),
+    ];
+    const groups = groupListeners(listeners);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.identity.label).sort()).toEqual(['NotesList', 'app.js', 'sidebar']);
+  });
+
+  it('filters by service', () => {
+    const listeners = [
+      listener({ id: 'l1', service: 'firestore' }),
+      listener({ id: 'l2', service: 'database', target: '/rooms/1' }),
+    ];
+    const groups = groupListeners(listeners, { service: 'database' });
+    expect(groups.flatMap((g) => g.listeners.map((l) => l.id))).toEqual(['l2']);
+  });
+
+  it('filters by target prefix', () => {
+    const listeners = [
+      listener({ id: 'l1', target: 'notes/one' }),
+      listener({ id: 'l2', target: 'todos/one' }),
+    ];
+    const groups = groupListeners(listeners, { targetPrefix: 'notes' });
+    expect(groups.flatMap((g) => g.listeners.map((l) => l.id))).toEqual(['l1']);
+  });
+});
+
+describe('formatListenerTarget', () => {
+  it('renders a plain path as-is', () => {
+    expect(formatListenerTarget('notes/one')).toBe('notes/one');
+  });
+
+  it('marks a query target', () => {
+    expect(formatListenerTarget({ collection: 'notes', query: true })).toBe('notes (query)');
+    expect(formatListenerTarget({ collection: 'notes' })).toBe('notes');
+  });
+});

--- a/packages/studio/src/features/listeners/listener-groups.ts
+++ b/packages/studio/src/features/listeners/listener-groups.ts
@@ -1,0 +1,131 @@
+/**
+ * Listener grouping (feature: Listeners).
+ *
+ * PURE. Folds the sandbox's active listeners into groups keyed by who owns
+ * them, with a fixed label preference: a `component` owner (added by a
+ * sibling unit; read defensively since the type may not carry it yet), then
+ * a `tag` owner, then a `frame` owner's function or file, then
+ * "Unattributed". Filtering (service, target prefix) narrows the listener
+ * set before grouping so a group with zero surviving listeners disappears.
+ */
+
+import {
+  activeListenerTargetStartsWith,
+  type ActiveListener,
+  type ActiveListenerTarget,
+} from 'pyric/sandbox';
+import type { ListenerOwner } from 'pyric/sandbox';
+
+/** The `component` owner kind. Added by a sibling unit; `ListenerOwner`
+ *  may not declare it yet, so this reads it off the value defensively
+ *  rather than widening the imported union. */
+interface ComponentOwner {
+  readonly kind: 'component';
+  readonly name: string;
+  readonly path?: string;
+  readonly element?: string;
+}
+
+function asComponentOwner(owner: ListenerOwner): ComponentOwner | null {
+  const candidate = owner as unknown as { kind?: unknown; name?: unknown; path?: unknown };
+  if (candidate.kind === 'component' && typeof candidate.name === 'string') {
+    return {
+      kind: 'component',
+      name: candidate.name,
+      path: typeof candidate.path === 'string' ? candidate.path : undefined,
+    };
+  }
+  return null;
+}
+
+function asTagOwner(owner: ListenerOwner): { name: string } | null {
+  return owner.kind === 'tag' ? { name: owner.name } : null;
+}
+
+function asFrameOwner(
+  owner: ListenerOwner,
+): { file: string; function?: string } | null {
+  return owner.kind === 'frame' ? { file: owner.file, function: owner.function } : null;
+}
+
+export interface ListenerGroupIdentity {
+  readonly key: string;
+  readonly label: string;
+  readonly subtitle?: string;
+}
+
+const UNATTRIBUTED: ListenerGroupIdentity = { key: 'unattributed', label: 'Unattributed' };
+
+/** The group a listener's owners resolve to, by the fixed preference order:
+ *  component, then tag, then frame, then unattributed. */
+export function groupIdentityFor(owners: readonly ListenerOwner[] | undefined): ListenerGroupIdentity {
+  for (const owner of owners ?? []) {
+    const component = asComponentOwner(owner);
+    if (component) {
+      return {
+        key: `component:${component.path ?? ''}:${component.name}`,
+        label: component.name,
+        subtitle: component.path,
+      };
+    }
+  }
+  for (const owner of owners ?? []) {
+    const tag = asTagOwner(owner);
+    if (tag) return { key: `tag:${tag.name}`, label: tag.name };
+  }
+  for (const owner of owners ?? []) {
+    const frame = asFrameOwner(owner);
+    if (frame) {
+      const label = frame.function ?? frame.file;
+      return { key: `frame:${frame.file}:${frame.function ?? ''}`, label };
+    }
+  }
+  return UNATTRIBUTED;
+}
+
+export interface ListenerGroup {
+  readonly identity: ListenerGroupIdentity;
+  readonly listeners: readonly ActiveListener[];
+}
+
+export interface ListenerFilters {
+  readonly service?: ActiveListener['service'];
+  readonly targetPrefix?: string;
+}
+
+function matchesFilters(listener: ActiveListener, filters: ListenerFilters): boolean {
+  if (filters.service !== undefined && listener.service !== filters.service) return false;
+  if (filters.targetPrefix !== undefined && filters.targetPrefix !== '') {
+    if (!activeListenerTargetStartsWith(listener.target, filters.targetPrefix)) return false;
+  }
+  return true;
+}
+
+/** Group active listeners, newest-attach order within a group, groups ordered
+ *  by their earliest listener's attach time. */
+export function groupListeners(
+  listeners: readonly ActiveListener[],
+  filters: ListenerFilters = {},
+): readonly ListenerGroup[] {
+  const groups = new Map<string, { identity: ListenerGroupIdentity; listeners: ActiveListener[] }>();
+  for (const listener of listeners) {
+    if (!matchesFilters(listener, filters)) continue;
+    const identity = groupIdentityFor(listener.owners);
+    const existing = groups.get(identity.key);
+    if (existing) {
+      existing.listeners.push(listener);
+    } else {
+      groups.set(identity.key, { identity, listeners: [listener] });
+    }
+  }
+  return [...groups.values()]
+    .map((group) => Object.freeze({ identity: group.identity, listeners: Object.freeze(group.listeners) }))
+    .sort((a, b) => a.listeners[0].attachedAt - b.listeners[0].attachedAt);
+}
+
+/** Render a listener's target as one line: a document/database path, or a
+ *  collection with a query mark when the target carried a query. */
+export function formatListenerTarget(target: ActiveListenerTarget): string {
+  if (typeof target === 'string') return target;
+  return target.query !== undefined ? `${target.collection} (query)` : target.collection;
+}

--- a/packages/studio/src/features/listeners/listener-identity.ts
+++ b/packages/studio/src/features/listeners/listener-identity.ts
@@ -1,0 +1,12 @@
+/**
+ * Short display text for a listener's `authLens` (feature: Listeners).
+ */
+
+import type { AuthLens } from 'pyric/sandbox';
+
+export function formatAuthLens(lens: AuthLens): string {
+  if (lens.mode === 'admin') return 'admin';
+  if (lens.mode === 'as') return `as ${lens.uid}`;
+  if (lens.mode === 'app-session') return 'app session';
+  return 'anonymous';
+}

--- a/packages/studio/src/features/listeners/listener-incidents.test.ts
+++ b/packages/studio/src/features/listeners/listener-incidents.test.ts
@@ -1,0 +1,47 @@
+/** Listener incidents — the activity monitor run over a Studio event snapshot. */
+import { describe, expect, it } from 'bun:test';
+import type { SandboxEvent } from 'pyric/sandbox';
+import { incidentsForTarget, listenerIncidents, repeatedReadIncidents } from './listener-incidents.js';
+
+const CONTEXT = { source: { kind: 'app' as const }, authLens: { mode: 'app-session' as const } };
+
+function attach(id: string, listenerId: string, at: number): SandboxEvent {
+  return {
+    kind: 'listener_attach',
+    id,
+    at,
+    listenerId,
+    target: { kind: 'doc', path: 'notes/dup' },
+    auth: null,
+    operationContext: CONTEXT,
+  } as unknown as SandboxEvent;
+}
+
+describe('listenerIncidents', () => {
+  it('reports a duplicate-listener incident for three attaches on the same doc', () => {
+    const events = [attach('e1', 'l1', 0), attach('e2', 'l2', 10), attach('e3', 'l3', 20)];
+    const incidents = listenerIncidents(events);
+    const duplicate = incidents.find((incident) => incident.pattern === 'duplicate-listener');
+    expect(duplicate).toBeDefined();
+    expect(duplicate?.count).toBe(3);
+  });
+
+  it('matches the duplicate incident to its listener target', () => {
+    const events = [attach('e1', 'l1', 0), attach('e2', 'l2', 10), attach('e3', 'l3', 20)];
+    const incidents = listenerIncidents(events);
+    const matched = incidentsForTarget(incidents, 'notes/dup');
+    expect(matched).toHaveLength(1);
+    expect(matched[0]!.pattern).toBe('duplicate-listener');
+  });
+
+  it('does not match a target the incident does not name', () => {
+    const events = [attach('e1', 'l1', 0), attach('e2', 'l2', 10), attach('e3', 'l3', 20)];
+    const incidents = listenerIncidents(events);
+    expect(incidentsForTarget(incidents, 'notes/other')).toHaveLength(0);
+  });
+
+  it('finds no incidents in a quiet stream', () => {
+    expect(listenerIncidents([attach('e1', 'l1', 0)])).toEqual([]);
+    expect(repeatedReadIncidents([])).toEqual([]);
+  });
+});

--- a/packages/studio/src/features/listeners/listener-incidents.test.ts
+++ b/packages/studio/src/features/listeners/listener-incidents.test.ts
@@ -1,4 +1,4 @@
-/** Listener incidents — the activity monitor run over a Studio event snapshot. */
+/** Listener incidents, the activity monitor run over a Studio event snapshot. */
 import { describe, expect, it } from 'bun:test';
 import type { SandboxEvent } from 'pyric/sandbox';
 import { incidentsForTarget, listenerIncidents, repeatedReadIncidents } from './listener-incidents.js';

--- a/packages/studio/src/features/listeners/listener-incidents.ts
+++ b/packages/studio/src/features/listeners/listener-incidents.ts
@@ -1,0 +1,79 @@
+/**
+ * Listener incidents (feature: Listeners).
+ *
+ * Runs the same activity monitor the sandbox tool's `activity` method uses
+ * (`pyric/firestore/internal`), over the event history Studio already holds,
+ * to surface `duplicate-listener` and `listener-churn` incidents inline on
+ * the group they belong to, and `repeated-read` at the top of the surface.
+ * The monitor is a pure fold over a fixed feed; Studio recomputes it whenever
+ * its event snapshot changes rather than keeping a live subscription, since
+ * `useStudioEvents` already re-renders on every new event.
+ */
+
+import { monitorFirebaseActivity, type ActivityFeed, type ActivityIncident } from 'pyric/firestore/internal';
+import type { ActiveListenerTarget, SandboxEvent } from 'pyric/sandbox';
+
+function historyFeed(history: readonly SandboxEvent[]): ActivityFeed {
+  return {
+    history: () => history,
+    subscribe: () => () => {},
+  };
+}
+
+/** Every incident the monitor raises over one event snapshot. */
+export function listenerIncidents(events: readonly SandboxEvent[]): readonly ActivityIncident[] {
+  const monitor = monitorFirebaseActivity(historyFeed(events), () => {});
+  try {
+    return monitor.report().incidents;
+  } finally {
+    monitor.dispose();
+  }
+}
+
+/** The incident's target, decoded from its public fingerprint (a JSON string
+ *  naming a doc path or a query's collection with an opaque query id), or
+ *  `null` when the fingerprint doesn't parse. */
+function incidentTarget(incident: ActivityIncident): ActiveListenerTarget | null {
+  try {
+    const parsed = JSON.parse(incident.targetFingerprint) as {
+      kind?: unknown;
+      path?: unknown;
+      collection?: unknown;
+    };
+    if (parsed.kind === 'doc' && typeof parsed.path === 'string') return parsed.path;
+    if (parsed.kind === 'query' && typeof parsed.collection === 'string') {
+      return { collection: parsed.collection, query: true };
+    }
+  } catch {
+    // Malformed or non-listener fingerprint: no match.
+  }
+  return null;
+}
+
+function targetsMatch(a: ActiveListenerTarget, b: ActiveListenerTarget): boolean {
+  if (typeof a === 'string' || typeof b === 'string') return a === b;
+  return a.collection === b.collection;
+}
+
+/** The duplicate-listener / listener-churn incidents whose target matches
+ *  any listener in a group. */
+export function incidentsForTarget(
+  incidents: readonly ActivityIncident[],
+  target: ActiveListenerTarget,
+): readonly ActivityIncident[] {
+  return incidents.filter((incident) => {
+    if (incident.pattern !== 'duplicate-listener' && incident.pattern !== 'listener-churn') {
+      return false;
+    }
+    const incidentTargetValue = incidentTarget(incident);
+    return incidentTargetValue !== null && targetsMatch(incidentTargetValue, target);
+  });
+}
+
+/** The repeated-read incidents, shown once at the top of the surface rather
+ *  than per group (a read incident has no listener to attach to). */
+export function repeatedReadIncidents(
+  incidents: readonly ActivityIncident[],
+): readonly ActivityIncident[] {
+  return incidents.filter((incident) => incident.pattern === 'repeated-read');
+}

--- a/packages/studio/src/features/listeners/listeners-deep-link.test.ts
+++ b/packages/studio/src/features/listeners/listeners-deep-link.test.ts
@@ -1,0 +1,22 @@
+/** The Listeners deep link — pure query-string decode tests. */
+import { describe, expect, it } from 'bun:test';
+import { parseListenersDeepLink } from './listeners-deep-link.js';
+
+describe('parseListenersDeepLink', () => {
+  it('is closed when view is not listeners', () => {
+    expect(parseListenersDeepLink('?view=traffic')).toEqual({ open: false });
+    expect(parseListenersDeepLink('')).toEqual({ open: false });
+  });
+
+  it('opens with the listener id and target prefix', () => {
+    expect(parseListenersDeepLink('?view=listeners&listener=l1&target=notes')).toEqual({
+      open: true,
+      listenerId: 'l1',
+      targetPrefix: 'notes',
+    });
+  });
+
+  it('opens with only view when listener/target are absent', () => {
+    expect(parseListenersDeepLink('?view=listeners')).toEqual({ open: true });
+  });
+});

--- a/packages/studio/src/features/listeners/listeners-deep-link.test.ts
+++ b/packages/studio/src/features/listeners/listeners-deep-link.test.ts
@@ -1,4 +1,4 @@
-/** The Listeners deep link — pure query-string decode tests. */
+/** The Listeners deep link, pure query-string decode tests. */
 import { describe, expect, it } from 'bun:test';
 import { parseListenersDeepLink } from './listeners-deep-link.js';
 

--- a/packages/studio/src/features/listeners/listeners-deep-link.ts
+++ b/packages/studio/src/features/listeners/listeners-deep-link.ts
@@ -1,0 +1,39 @@
+/**
+ * The Listeners deep link (the runtime chip, `packages/cli/src/serve/runtime/
+ * listener-mode.ts`, opens Studio at `?view=listeners&listener=<id>&target=
+ * <path>`).
+ *
+ * Studio has no URL router for this shape: it's read once at startup from
+ * `location.search`, independent of the pathname-based tab route. It is not
+ * a general-purpose query codec; it names exactly the three parameters the
+ * runtime chip sends.
+ */
+
+export interface ListenersDeepLink {
+  readonly open: boolean;
+  readonly listenerId?: string;
+  readonly targetPrefix?: string;
+}
+
+const NONE: ListenersDeepLink = { open: false };
+
+/** Parse a `location.search` string (with or without its leading `?`) into
+ *  the Listeners deep link, or the closed link when `view` isn't `listeners`. */
+export function parseListenersDeepLink(search: string): ListenersDeepLink {
+  const params = new URLSearchParams(search);
+  if (params.get('view') !== 'listeners') return NONE;
+  const link: { open: true; listenerId?: string; targetPrefix?: string } = { open: true };
+  const listenerId = params.get('listener');
+  if (listenerId !== null && listenerId !== '') link.listenerId = listenerId;
+  const targetPrefix = params.get('target');
+  if (targetPrefix !== null && targetPrefix !== '') link.targetPrefix = targetPrefix;
+  return link;
+}
+
+/** The deep link read from the current page load. `location.search` is read
+ *  once, at call time; callers that need it at startup call this during
+ *  their initial render, not inside an effect. */
+export function currentListenersDeepLink(): ListenersDeepLink {
+  if (typeof window === 'undefined') return NONE;
+  return parseListenersDeepLink(window.location.search);
+}

--- a/packages/studio/src/features/listeners/listeners.css
+++ b/packages/studio/src/features/listeners/listeners.css
@@ -1,0 +1,105 @@
+/**
+ * Listeners surface styling, token roles only (matches `session.css` /
+ * `traffic.css` conventions: intrinsic layout, gap for spacing).
+ */
+
+.listeners {
+  display: block;
+}
+
+.listeners__head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.listeners__title {
+  font-size: 16px;
+  margin: 0;
+}
+.listeners__count {
+  font-family: var(--font-mono);
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.listeners__incident {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--warning, #b45309);
+}
+.listeners__incident--repeated-read {
+  display: block;
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+.listeners__incident--inline {
+  margin-left: 8px;
+}
+
+.listeners__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 20px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.listeners__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.listeners__empty {
+  color: var(--faint);
+  font-size: 13px;
+}
+
+.listeners__group {
+  margin-bottom: 20px;
+}
+.listeners__group-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.listeners__group-label {
+  font-weight: 600;
+}
+.listeners__group-subtitle {
+  font-family: var(--font-mono);
+  color: var(--faint);
+  font-size: 11px;
+}
+.listeners__group-count {
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.listeners__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.listeners__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+  padding: 6px 0;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border, #e5e5e5);
+}
+.listeners__row--highlight {
+  background: var(--accent-soft, rgba(59, 130, 246, 0.08));
+}
+.listeners__cell--target {
+  font-family: var(--font-mono);
+}

--- a/packages/studio/test/features/listeners/ListenersView.test.tsx
+++ b/packages/studio/test/features/listeners/ListenersView.test.tsx
@@ -1,0 +1,112 @@
+// Install JSDOM globals before importing React or RTL.
+import { JSDOM } from 'jsdom';
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  pretendToBeVisual: true,
+});
+const g = globalThis as any;
+g.window = dom.window;
+g.document = dom.window.document;
+g.HTMLElement = dom.window.HTMLElement;
+g.SVGElement = dom.window.SVGElement;
+g.Element = dom.window.Element;
+g.Node = dom.window.Node;
+g.Event = dom.window.Event;
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+// jsdom doesn't implement scrollIntoView; the deep-link highlight calls it.
+g.HTMLElement.prototype.scrollIntoView = () => {};
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import type { SandboxEvent } from 'pyric/sandbox';
+import { ListenersView } from '../../../src/features/listeners/ListenersView.js';
+
+afterEach(() => cleanup());
+
+const CONTEXT = { source: { kind: 'app' as const }, authLens: { mode: 'app-session' as const } };
+
+function attach(
+  id: string,
+  listenerId: string,
+  at: number,
+  owners?: unknown[],
+  target: { kind: 'doc'; path: string } = { kind: 'doc', path: `notes/${listenerId}` },
+): SandboxEvent {
+  return {
+    kind: 'listener_attach',
+    id,
+    at,
+    listenerId,
+    target,
+    auth: null,
+    operationContext: CONTEXT,
+    ...(owners ? { owners } : {}),
+  } as unknown as SandboxEvent;
+}
+
+function detach(id: string, listenerId: string, at: number): SandboxEvent {
+  return {
+    kind: 'listener_detach',
+    id,
+    at,
+    listenerId,
+    target: { kind: 'doc', path: `notes/${listenerId}` },
+    auth: null,
+    operationContext: CONTEXT,
+  } as unknown as SandboxEvent;
+}
+
+const threeListenerEvents: SandboxEvent[] = [
+  attach('e1', 'l-component', 0, [{ kind: 'component', name: 'NotesList', path: 'src/NotesList.tsx' }]),
+  attach('e2', 'l-tag', 1000, [{ kind: 'tag', name: 'sidebar' }]),
+  attach('e3', 'l-frame', 2000, [{ kind: 'frame', file: 'app.js', line: 4 }]),
+];
+
+describe('ListenersView', () => {
+  it('renders one group per owner, labelled by preference order', () => {
+    const { getByText } = render(<ListenersView events={threeListenerEvents} />);
+    expect(getByText('NotesList')).toBeDefined();
+    expect(getByText('src/NotesList.tsx')).toBeDefined();
+    expect(getByText('sidebar')).toBeDefined();
+    expect(getByText('app.js')).toBeDefined();
+    expect(getByText('3')).toBeDefined(); // total listener count
+  });
+
+  it('removes a row live when its listener detaches', () => {
+    const { getByTestId, queryByTestId, rerender } = render(
+      <ListenersView events={threeListenerEvents} />,
+    );
+    expect(getByTestId('listener-row-l-tag')).toBeDefined();
+
+    const afterDetach = [...threeListenerEvents, detach('e4', 'l-tag', 3000)];
+    rerender(<ListenersView events={afterDetach} />);
+
+    expect(queryByTestId('listener-row-l-tag')).toBeNull();
+  });
+
+  it('renders a duplicate-listener incident inline on its group', () => {
+    const duplicates: SandboxEvent[] = [
+      attach('d1', 'a', 0, undefined, { kind: 'doc', path: 'notes/dup' }),
+      attach('d2', 'b', 10, undefined, { kind: 'doc', path: 'notes/dup' }),
+      attach('d3', 'c', 20, undefined, { kind: 'doc', path: 'notes/dup' }),
+    ];
+    const { getAllByText } = render(<ListenersView events={duplicates} />);
+    expect(getAllByText(/duplicate listener ×3/).length).toBeGreaterThan(0);
+  });
+
+  it('opens with the deep-linked listener highlighted and the target filter set', () => {
+    const { getByTestId, queryByTestId, getByPlaceholderText } = render(
+      <ListenersView
+        events={threeListenerEvents}
+        highlightListenerId="l-tag"
+        initialTargetPrefix="notes/l-tag"
+      />,
+    );
+    const row = getByTestId('listener-row-l-tag');
+    expect(row.className).toContain('listeners__row--highlight');
+    const filterInput = getByPlaceholderText('collection or path') as HTMLInputElement;
+    expect(filterInput.value).toBe('notes/l-tag');
+    // Only the deep-linked listener's target matches the pre-filled prefix.
+    expect(queryByTestId('listener-row-l-component')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds a Listeners view to Studio: every attached listener grouped by its owner, with the target, actor, delivery and suppression counts, and a detail pane per listener, live from the sandbox event stream.

```
Listeners                                    5 listeners · 2 incidents

OrdersTable                                  component · src/OrdersTable.tsx
  orders (query)          app    3 deliveries   0 suppressed   attached 12s ago
  orders (query)          app    3 deliveries   0 suppressed   duplicate ×2

Profile                                      tag
  users/u1                app    1 delivery

Unattributed
  chat/room-1             admin  8 deliveries   attached 40s ago
```

## Grouping follows the same owner precedence the chip uses

A listener files under its `component` owner's name, else its `tag`, else its creation frame's function or file, else an Unattributed group. The runtime chip's Listeners mode links into this view with `?view=listeners&listener=<id>&target=<path>`, and the view reads those parameters on load to open the named listener's detail; Studio gains just enough URL handling for that, nothing broader.

## Nothing new on the wire

The view folds the events Studio already receives with `activeListeners` and repaints on attach, detach, and delivery, so it needs no worker protocol change and no polling. Listeners inside a `duplicate-listener` or `listener-churn` incident carry an amber mark with the count, joined from the activity monitor the same way the chip does.

## Risk

Studio only; no sandbox or engine change. With attribution off, which is the production switch, listeners still list under Unattributed with their targets and counts, since those come from the events rather than from capture.

<details>
<summary>Implementation notes</summary>

- New view module and grouping model under Studio's source, each with a test; the navigation gains one entry.
- `bun test --cwd packages/cli` and `packages/ui` pass, typecheck and build clean, coupling gate pass.

</details>
