### PR TITLE
fix(serve): options-second onSnapshot in the worker client

### DIFF
--- a/packages/cli/src/serve/worker/client/firestore-reads.ts
+++ b/packages/cli/src/serve/worker/client/firestore-reads.ts
@@ -122,17 +122,43 @@ export async function getAggregateFromServer<S extends AggregateSpecDescriptor>(
 
 // ─── onSnapshot ──────────────────────────────────────────────────────────
 
+type SnapshotCallback = (snap: ClientDocSnapshot | ClientQuerySnapshot) => void;
+type SnapshotErrorCallback = (err: unknown) => void;
+
 /**
- * Subscribe to a document or query. Mirrors `pyric/firestore`'s `onSnapshot`.
+ * Subscribe to a document or query. Mirrors `pyric/firestore`'s `onSnapshot`,
+ * including its options-second form `onSnapshot(target, options, next,
+ * error)`: `@pyric/ui`'s hooks pass `{ owner }` there for listener
+ * attribution, and a caller injecting this client as the hooks' backend must
+ * not lose its callback to that slot. The options are accepted and dropped;
+ * the worker protocol carries no listener owner yet.
  *
  * Returns an `unsub` function. Sends `{ t:'unsub', subId }` to the worker
  * to deregister the listener on the worker side.
  */
 export function onSnapshot(
   target: DocRefHandle | CollRefHandle | QueryHandle,
-  callback: (snap: ClientDocSnapshot | ClientQuerySnapshot) => void,
-  errorCallback?: (err: unknown) => void,
+  callback: SnapshotCallback,
+  errorCallback?: SnapshotErrorCallback,
+): Unsubscribe;
+export function onSnapshot(
+  target: DocRefHandle | CollRefHandle | QueryHandle,
+  options: object,
+  callback: SnapshotCallback,
+  errorCallback?: SnapshotErrorCallback,
+): Unsubscribe;
+export function onSnapshot(
+  target: DocRefHandle | CollRefHandle | QueryHandle,
+  optionsOrCallback: object | SnapshotCallback,
+  callbackOrError?: SnapshotCallback | SnapshotErrorCallback,
+  maybeError?: SnapshotErrorCallback,
 ): Unsubscribe {
+  const callback = (typeof optionsOrCallback === 'function'
+    ? optionsOrCallback
+    : callbackOrError) as SnapshotCallback;
+  const errorCallback = (typeof optionsOrCallback === 'function'
+    ? callbackOrError
+    : maybeError) as SnapshotErrorCallback | undefined;
   let currentSubId = nextSubId();
   const port = target.port;
 

--- a/packages/cli/test/serve/worker/integration.test.ts
+++ b/packages/cli/test/serve/worker/integration.test.ts
@@ -101,6 +101,37 @@ describe('client↔host round-trip (gate repro)', () => {
     expect(fires.at(-1)).toBe(1);
   });
 
+  it('onSnapshot accepts the options-second form the @pyric/ui hooks use', async () => {
+    const ctx = await makeHostCtx();
+    const { a: clientPort, b: hostPort } = portPair();
+    const hostPortLike: PortLike = { postMessage: (m: OutboundMessage) => hostPort.postMessage(m) };
+    hostPort.onmessage = (ev) => { void handleMessage(ctx, hostPortLike, ev.data as InboundMessage); };
+    (globalThis as { SharedWorker?: unknown }).SharedWorker = class {
+      port = clientPort;
+      constructor(_url: unknown, _opts: unknown) {}
+    };
+
+    const db = client.getFirestore('worker://test');
+    const auth = client.getAuth(db);
+    const cred = await client.createUserWithEmailAndPassword(auth, 'alice@example.com', 'pw123456');
+    const ref = client.doc(db, 'notes/astro-host');
+    await client.setDoc(ref, { uid: cred.user.uid, marker: 'shared' });
+
+    const seen: unknown[] = [];
+    const errors: unknown[] = [];
+    const unsubscribe = client.onSnapshot(
+      ref,
+      { owner: { kind: 'component', name: 'DocumentView' } },
+      (snap) => seen.push((snap as { data(): unknown }).data()),
+      (err) => errors.push(err),
+    );
+    await sleep();
+    unsubscribe();
+
+    expect(errors).toEqual([]);
+    expect((seen.at(-1) as { marker?: string }).marker).toBe('shared');
+  });
+
   it('excludes split transaction reads from activity warnings', async () => {
     const ctx = await makeHostCtx();
     const { a: clientPort, b: hostPort } = portPair();


### PR DESCRIPTION
Restores served-mode Studio after #621: the worker client's `onSnapshot` now accepts the options-second form `onSnapshot(target, options, next, error)` that `pyric/firestore` has and that the `@pyric/ui` hooks now use.

```ts
// @pyric/ui hooks, since #621:
onSnapshot(ref, { owner }, (snap) => ..., (err) => ...);
// Worker client, before this change:
onSnapshot(target, callback, errorCallback)   // { owner } became the callback
```

## Why main went red

Studio's served mode injects the worker client as the hooks' Firestore backend, cast to the in-process signatures. The hooks' new `{ owner }` argument landed in the worker client's callback slot, so no snapshot ever reached the page and the document view stayed on its loading state. The served-app conformance job caught it on the PR and again on main; the PR was merged before that job had finished, which was my error.

## The fix

The worker client mirrors the in-process overload and drops the options, since the worker protocol carries no listener owner yet; that transport is Route A work. A worker integration test covers the options-second form end to end, and the served-app Playwright suite passes locally again.

## Risk

None beyond the served path this restores. The callbacks-only form is unchanged.

<details>
<summary>Implementation notes</summary>

- `packages/cli/src/serve/worker/client/firestore-reads.ts`: two overload signatures and the argument shuffle.
- `bun test --cwd packages/cli` 3435 pass; `test:site-cli` 2 passed.

</details>
