### PR TITLE
feat(serve): listener owners across the worker port

### DIFF
--- a/packages/cli/src/serve/worker/client/firestore-reads.ts
+++ b/packages/cli/src/serve/worker/client/firestore-reads.ts
@@ -12,6 +12,7 @@ import type {
 } from '../protocol.js';
 import { closeSubscription, nextId, nextSubId, dataRpc, _defaultLens, subscribeLens, openSnapshotSubscription, stampIssuer } from './core.js';
 import type { ClientDb, DocRefHandle, CollRefHandle, QueryHandle, Unsubscribe } from './handles.js';
+import { pageListenerOwners } from './listener-owners.js';
 import { makeDocSnapshot, makeQuerySnapshot } from './snapshots.js';
 import type { RawDocResult, RawQueryResult, ClientDocSnapshot, ClientQuerySnapshot } from './snapshots.js';
 
@@ -130,8 +131,8 @@ type SnapshotErrorCallback = (err: unknown) => void;
  * including its options-second form `onSnapshot(target, options, next,
  * error)`: `@pyric/ui`'s hooks pass `{ owner }` there for listener
  * attribution, and a caller injecting this client as the hooks' backend must
- * not lose its callback to that slot. The options are accepted and dropped;
- * the worker protocol carries no listener owner yet.
+ * not lose its callback to that slot. The owners are derived here, on the page
+ * whose stack and DOM they describe, and travel with the subscribe message.
  *
  * Returns an `unsub` function. Sends `{ t:'unsub', subId }` to the worker
  * to deregister the listener on the worker side.
@@ -153,6 +154,10 @@ export function onSnapshot(
   callbackOrError?: SnapshotCallback | SnapshotErrorCallback,
   maybeError?: SnapshotErrorCallback,
 ): Unsubscribe {
+  const listenOptions = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+  // Derived before the message is built: `captureCreationFrame` reads the
+  // stack this call is still on.
+  const owners = pageListenerOwners(listenOptions);
   const callback = (typeof optionsOrCallback === 'function'
     ? optionsOrCallback
     : callbackOrError) as SnapshotCallback;
@@ -189,8 +194,8 @@ export function onSnapshot(
     subscription,
     stampIssuer(
       (_defaultLens
-        ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: _defaultLens }
-        : { t: 'sub', subId: currentSubId, target: descriptor }) satisfies InboundMessage,
+        ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: _defaultLens, ...(owners ? { owners } : {}) }
+        : { t: 'sub', subId: currentSubId, target: descriptor, ...(owners ? { owners } : {}) }) satisfies InboundMessage,
     ),
   );
   if (!opened && errorCallback) queueMicrotask(() => errorCallback(new Error('Firebase App was deleted')));
@@ -206,8 +211,8 @@ export function onSnapshot(
       subscription,
       stampIssuer(
         (newLens
-          ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: newLens }
-          : { t: 'sub', subId: currentSubId, target: descriptor }) satisfies InboundMessage,
+          ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: newLens, ...(owners ? { owners } : {}) }
+          : { t: 'sub', subId: currentSubId, target: descriptor, ...(owners ? { owners } : {}) }) satisfies InboundMessage,
       ),
     );
     if (!reopened && errorCallback) {

--- a/packages/cli/src/serve/worker/client/listener-owners.ts
+++ b/packages/cli/src/serve/worker/client/listener-owners.ts
@@ -1,0 +1,90 @@
+/**
+ * Listener owners, derived on the page rather than in the worker.
+ *
+ * The in-page sandbox attaches a listener in the same context as the call, so
+ * it reads the calling frame off its own stack, takes the `owner` the caller
+ * passed, and turns an element owner into a selector against the live
+ * document. On a served page none of that is true where the attach happens:
+ * the sandbox runs in a SharedWorker, the stack there belongs to the worker
+ * bundle, the caller's options never crossed the port, and there is no DOM to
+ * select against.
+ *
+ * So the client derives the owners here, where the call actually happened, and
+ * sends them with the subscribe message. The derivation is pyric's own,
+ * reached through `pyric/sandbox/internal`, so a served page and an in-page
+ * sandbox produce the same owners for the same call.
+ */
+import {
+  callerFrameFromStack,
+  listenerAttributionEnabled,
+  tagOwnerFor,
+} from 'pyric/sandbox/internal';
+import type { ListenerOwner } from 'pyric/sandbox';
+
+/** The listen options a caller may pass, as far as attribution is concerned. */
+export interface OwnerBearingOptions {
+  readonly owner?: unknown;
+}
+
+/**
+ * The directory this client is served from.
+ *
+ * `callerFrameFromStack` skips pyric's own frames, but between the application
+ * and pyric there are also this client's frames, which are the CLI's and which
+ * pyric cannot recognize. They all share one directory: under source that is
+ * `.../serve/worker/client`, and on a served page it is the directory the SDK
+ * bundle is served from, which the application's own modules are never in.
+ * Empty when a bundler erased `import.meta.url`, in which case the filter
+ * falls back to pyric's own.
+ */
+const CLIENT_ROOT = clientRoot();
+
+function clientRoot(): string {
+  let here: string | undefined;
+  try {
+    const url = (import.meta as { url?: unknown }).url;
+    if (typeof url === 'string') here = url;
+  } catch {
+    here = undefined;
+  }
+  if (here === undefined) return '';
+  const directory = here.slice(0, here.lastIndexOf('/'));
+  return directory.startsWith('file://') ? directory.slice('file://'.length) : directory;
+}
+
+/** A stack with this client's own frames removed, for pyric to read. */
+function callerStack(stack: string): string {
+  if (CLIENT_ROOT.length === 0) return stack;
+  return stack.split('\n').filter((line) => !line.includes(CLIENT_ROOT)).join('\n');
+}
+
+/**
+ * The owners for a listener the page is about to open, in the same order the
+ * in-page path records them: the calling frame first, then the explicit owner.
+ * `undefined` when neither is known, so the subscribe message omits the field.
+ *
+ * Frame capture follows the attribution switch exactly as the in-page path
+ * does. The explicit owner is not gated: the caller asked for it by name.
+ *
+ * Every owner returned is plain JSON. An element owner is already reduced to a
+ * selector by `tagOwnerFor`, so no DOM node is ever put on the wire.
+ */
+export function pageListenerOwners(
+  options: OwnerBearingOptions | undefined,
+): ListenerOwner[] | undefined {
+  const owners: ListenerOwner[] = [];
+  const frame = pageCreationFrame();
+  if (frame !== undefined) owners.push(frame);
+  const explicit = tagOwnerFor(options?.owner as Parameters<typeof tagOwnerFor>[0]);
+  if (explicit !== undefined) owners.push(explicit);
+  if (owners.length === 0) return undefined;
+  return owners;
+}
+
+/** The application frame that opened the listener, read from this call's stack. */
+function pageCreationFrame(): ListenerOwner | undefined {
+  if (!listenerAttributionEnabled()) return undefined;
+  const stack = new Error().stack;
+  if (typeof stack !== 'string') return undefined;
+  return callerFrameFromStack(callerStack(stack));
+}

--- a/packages/cli/src/serve/worker/client/rtdb-listeners.ts
+++ b/packages/cli/src/serve/worker/client/rtdb-listeners.ts
@@ -11,6 +11,7 @@ import {
   subscribeLens,
 } from './core.js';
 import type { ClientPort, RtdbDataSnapshot, Unsubscribe } from './handles.js';
+import { pageListenerOwners } from './listener-owners.js';
 import {
   isRtdbQuery,
   rtdbChild,
@@ -54,6 +55,13 @@ function targetScope(target: RtdbTarget): string {
   return queryIdentifier(target._spec);
 }
 
+/**
+ * The listen options a value subscription reads. `owner` is pyric's own listen
+ * option: the page names who owns the listener, and the owners derived from it
+ * travel with the subscribe message.
+ */
+type ValueListenOptions = { readonly onlyOnce?: boolean; readonly owner?: unknown };
+
 function removeRegistration(registration: ListenerRegistration): void {
   const index = registrations.indexOf(registration);
   if (index >= 0) registrations.splice(index, 1);
@@ -62,8 +70,8 @@ function removeRegistration(registration: ListenerRegistration): void {
 function openValueSubscription(
   target: RtdbTarget,
   next: (snap: RtdbDataSnapshot) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
 ): Unsubscribe {
   const { ref, query } = targetParts(target);
   const error = typeof cancelCallbackOrOptions === 'function' ? cancelCallbackOrOptions : undefined;
@@ -74,10 +82,15 @@ function openValueSubscription(
   let fired = false;
   let unsubscribed = false;
 
+  // Derived here, on the stack the caller is still on and against the page's
+  // own document. The worker's attach can read neither.
+  const owners = pageListenerOwners(listenOptions);
+  const ownerFields = owners ? { owners } : {};
+
   const makeSubMsg = (subId: string, lens: typeof _defaultLens): InboundMessage =>
     lens
-      ? { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, actAs: lens }
-      : { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) } };
+      ? { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, actAs: lens, ...ownerFields }
+      : { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, ...ownerFields };
 
   let unsubLens: () => void = () => {};
 
@@ -153,8 +166,8 @@ function registerListener(
 export function rtdbOnValue(
   target: RtdbTarget,
   next: (snap: RtdbDataSnapshot) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
   registryCallback: object = next,
 ): Unsubscribe {
   const listenOptions = typeof cancelCallbackOrOptions === 'function'
@@ -297,8 +310,8 @@ function subscribeChild(
   target: RtdbTarget,
   kind: ChildEventKind,
   next: (snap: RtdbDataSnapshot, previousChildName: string | null) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
   registryCallback: object = next,
 ): Unsubscribe {
   const error = typeof cancelCallbackOrOptions === 'function' ? cancelCallbackOrOptions : undefined;

--- a/packages/cli/src/serve/worker/host/subscriptions.ts
+++ b/packages/cli/src/serve/worker/host/subscriptions.ts
@@ -176,6 +176,8 @@ export function handleRtdbSub(ctx: HostCtx, port: PortLike, msg: RtdbValueSubMes
       ref as DatabaseReference | RtdbQuery,
       (snap) => post(port, { t: 'snap', subId: msg.subId, value: rtdbSnapToWire(snap) }),
       (err) => post(port, { t: 'snap', subId: msg.subId, value: { __error: serializeError(err) } }),
+      // Same reason as the Firestore path: the owners belong to the page.
+      { ...(msg.owners ? { owners: msg.owners } : {}) },
     );
 
     if (!msg.actAs || msg.actAs.mode === 'app-session') {
@@ -200,6 +202,10 @@ function registerListener(
 ): () => void {
   return onSnapshot(
     target as DocumentReference | Query,
+    // The page derived the owners where its stack and its DOM are. Handing
+    // them over makes the sandbox record those instead of capturing a frame
+    // out of this worker's own bundle.
+    { ...(msg.owners ? { owners: msg.owners } : {}) },
     (snap) => {
       // Detect doc vs query snapshot by shape.
       const snapAny = snap as {

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -23,7 +23,13 @@ import type {
   ResolvedIdentity,
   AuthSubMessage,
 } from './protocol/auth.js';
-import type { AuthLens, SandboxClockState, SandboxEvent, DenialContext } from 'pyric/sandbox';
+import type {
+  AuthLens,
+  ListenerOwner,
+  SandboxClockState,
+  SandboxEvent,
+  DenialContext,
+} from 'pyric/sandbox';
 import type { Query as RtdbQuery } from 'pyric/database';
 import type {
   BrokerMessage,
@@ -255,6 +261,8 @@ export interface RtdbValueSubMessage {
   subId: string;
   target: { service: 'rtdb'; path: string; query?: RtdbQuerySpec };
   actAs?: AuthLens;
+  /** The listener's owners, derived on the page. See {@link FirestoreSubMessage}. */
+  owners?: ListenerOwner[];
   issuer?: 'studio';
   relaySource?: 'remote';
 }

--- a/packages/cli/src/serve/worker/protocol/firestore.ts
+++ b/packages/cli/src/serve/worker/protocol/firestore.ts
@@ -3,7 +3,7 @@
  * aggregate descriptors, write descriptors, and document data serialization.
  */
 import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
-import type { AuthLens } from 'pyric/sandbox';
+import type { AuthLens, ListenerOwner } from 'pyric/sandbox';
 
 // ─── Ref descriptors (client-side, never cross the port directly) ──────────
 
@@ -162,6 +162,13 @@ export interface FirestoreSubMessage {
    * watches as the app's own session (the unchanged default).
    */
   actAs?: AuthLens;
+  /**
+   * The listener's owners, derived on the page that opened it. The sandbox
+   * attaches inside the worker, where the calling frame belongs to the worker
+   * bundle, the caller's `owner` option never arrived, and there is no DOM, so
+   * the page derives them and the host records these instead.
+   */
+  owners?: ListenerOwner[];
   /** Mechanical op provenance. */
   issuer?: 'studio';
   /** Marks traffic relayed from a remote Node/agent consumer, never page app activity. */

--- a/packages/cli/test/e2e/fixture/index.html
+++ b/packages/cli/test/e2e/fixture/index.html
@@ -8,6 +8,8 @@
     <p id="status">loading</p>
     <button id="signin">Sign in with Google</button>
     <img id="avatar" alt="avatar" />
+    <button id="listen">Watch the shared note</button>
+    <div id="notes-panel">no note yet</div>
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/packages/cli/test/e2e/fixture/main.js
+++ b/packages/cli/test/e2e/fixture/main.js
@@ -1,9 +1,11 @@
 // Minimal firebase/* app for the served-mode auth repro. Under `pyric dev`
 // these imports are swapped to the pyric sandbox (worker-backed auth).
 import { deleteApp, initializeApp } from 'firebase/app';
+import { doc, getFirestore, onSnapshot } from 'firebase/firestore';
 import {
   getAuth,
   onAuthStateChanged,
+  signInAnonymously,
   signInWithPopup,
   GoogleAuthProvider,
 } from 'firebase/auth';
@@ -54,3 +56,23 @@ document
       window.__authError = { code: error?.code, message: error?.message };
     });
   });
+
+// A page-side Firestore listener with an explicit owner. On a served page the
+// sandbox runs in a SharedWorker, so this call is what proves the owner the
+// caller passed reaches the worker's attach event instead of stopping at the
+// port.
+const db = getFirestore(app);
+window.__noteFires = 0;
+document.getElementById('listen').addEventListener('click', async () => {
+  // The fixture's rules allow reads to signed-in callers only.
+  if (!auth.currentUser) await signInAnonymously(auth);
+  onSnapshot(
+    doc(db, 'notes/astro-host'),
+    { owner: 'notes-panel' },
+    (snap) => {
+      window.__noteFires += 1;
+      const panel = document.getElementById('notes-panel');
+      if (panel) panel.textContent = JSON.stringify(snap.data() ?? null);
+    },
+  );
+});

--- a/packages/cli/test/e2e/site-cli/cli-site.pw.ts
+++ b/packages/cli/test/e2e/site-cli/cli-site.pw.ts
@@ -88,3 +88,31 @@ test('an app-triggered worker replacement moves an open Studio page to the annou
   expect(await studio.evaluate(() => localStorage.getItem('pyric:worker-generation'))).toBe(nextGeneration);
   await context.close();
 });
+
+test('a served page attributes a listener to the owner the page passed', async ({ browser }) => {
+  const context = await browser.newContext();
+  const app = await context.newPage();
+  await app.goto('/');
+  await expect(app.locator('#status')).not.toHaveText('loading');
+
+  // The listener is opened from the page with an owner the page named. The
+  // sandbox that records the attach runs in the SharedWorker.
+  await app.locator('#listen').click();
+  await expect.poll(() => app.evaluate(() => (
+    window as unknown as { __noteFires: number }
+  ).__noteFires)).toBeGreaterThan(0);
+
+  const chipHost = app.locator('[data-pyric-runtime-chip-host]');
+  await expect(chipHost).toBeAttached();
+  const expand = chipHost.locator('[data-expand]');
+  if (await expand.isVisible()) await expand.click();
+  await chipHost.locator('[data-toggle-listeners]').click();
+
+  // Nothing on the page can be outlined for a name-only owner, so the listener
+  // lands in the chip's own list. Its label is the name the page passed, not a
+  // function out of the worker bundle.
+  const rows = chipHost.locator('[data-listener-panel] .listener-row');
+  await expect(rows.filter({ hasText: 'notes-panel' })).toHaveCount(1, { timeout: 10_000 });
+  await expect(rows.filter({ hasText: 'notes/astro-host' })).toHaveCount(1);
+  await context.close();
+});

--- a/packages/cli/test/serve/worker/integration.test.ts
+++ b/packages/cli/test/serve/worker/integration.test.ts
@@ -9,8 +9,11 @@ import type { InboundMessage, OutboundMessage } from '../../../src/serve/worker/
 import { getFirestore as ipGetFirestore } from 'pyric/firestore';
 import { monitorFirebaseActivity, type ActivityIncident } from 'pyric/firestore/internal';
 import * as client from '../../../src/serve/worker/client.js';
+import { rtdbGetDatabase, rtdbRef } from '../../../src/serve/worker/client/rtdb-references.js';
+import { rtdbOnValue } from '../../../src/serve/worker/client/rtdb-listeners.js';
 import {
   connectClient,
+  connectClientToHost,
   makeHostCtx,
   portPair,
   sleep,
@@ -130,6 +133,54 @@ describe('client↔host round-trip (gate repro)', () => {
 
     expect(errors).toEqual([]);
     expect((seen.at(-1) as { marker?: string }).marker).toBe('shared');
+  });
+
+  it('records the page-side owners on the worker attach, for both services', async () => {
+    const ctx = await makeHostCtx();
+    const { db } = connectClientToHost(ctx, 'worker://owners');
+    const auth = client.getAuth(db);
+    await client.createUserWithEmailAndPassword(auth, 'owner@example.com', 'pw123456');
+
+    const firestoreUnsub = client.onSnapshot(
+      client.doc(db, 'notes/owned'),
+      { owner: 'notes-panel' },
+      () => {},
+      () => {},
+    );
+    const databaseUnsub = rtdbOnValue(
+      rtdbRef(rtdbGetDatabase(db), 'rooms/owned'),
+      () => {},
+      () => {},
+      { owner: 'rooms-panel' },
+    );
+    await sleep();
+    firestoreUnsub();
+    databaseUnsub();
+
+    const attaches = ctx.sandbox.history().filter((event) => {
+      const candidate = event as { kind: string; phase?: string };
+      return candidate.kind === 'listener_attach'
+        || (candidate.kind === 'listener' && candidate.phase === 'attach');
+    }) as Array<{ kind: string; owners?: Array<Record<string, unknown>> }>;
+
+    const ownersFor = (name: string): Array<Record<string, unknown>> => {
+      const match = attaches.find((event) => (event.owners ?? []).some(
+        (owner) => owner.kind === 'tag' && owner.name === name,
+      ));
+      expect(match).toBeDefined();
+      return match!.owners!;
+    };
+
+    for (const name of ['notes-panel', 'rooms-panel']) {
+      const owners = ownersFor(name);
+      // The frame is the test's own call, not a function inside the worker
+      // client or the sandbox the worker holds.
+      const frame = owners.find((owner) => owner.kind === 'frame') as
+        { file: string; function?: string } | undefined;
+      expect(frame).toBeDefined();
+      expect(frame!.file).toContain('integration.test.ts');
+      expect(owners.map((owner) => owner.kind)).toEqual(['frame', 'tag']);
+    }
   });
 
   it('excludes split transaction reads from activity warnings', async () => {

--- a/packages/pyric/src/database/listeners.ts
+++ b/packages/pyric/src/database/listeners.ts
@@ -5,6 +5,7 @@ import { authFor, targetOf, type Target } from './routing.js';
 import { isDefaultQuerySpec, isQuery, queryIdentifier } from './query-shape.js';
 import type { QueryRow } from './sandbox/query.js';
 import type { DataSnapshot, DatabaseReference, ListenOptions, Query, Unsubscribe } from './types.js';
+import type { ListenerAttribution } from '../sandbox/attribution/listener-owners.js';
 import { child } from './references.js';
 import { buildSandboxQuerySnap, buildSandboxSnapFromRaw } from './snapshots.js';
 
@@ -52,13 +53,21 @@ function subscribeWithLiveAuth(
 }
 
 /**
- * The listen options a recursive `onlyOnce` subscribe should keep: the owner,
- * never `onlyOnce` itself, which the outer call already honored.
+ * The attribution a listen call carries, or `undefined` when it carries none.
+ * The backend takes both inputs as one argument.
+ */
+function attributionOf(options: ListenOptions | undefined): ListenerAttribution | undefined {
+  if (options === undefined) return undefined;
+  if (options.owner === undefined && options.owners === undefined) return undefined;
+  return { owner: options.owner, owners: options.owners };
+}
+
+/**
+ * The listen options a recursive `onlyOnce` subscribe should keep: the
+ * attribution, never `onlyOnce` itself, which the outer call already honored.
  */
 function ownerOnlyOptions(options: ListenOptions | undefined): ListenOptions | undefined {
-  const owner = options?.owner;
-  if (owner === undefined) return undefined;
-  return { owner };
+  return attributionOf(options);
 }
 
 function queryScope(r: DatabaseReference | Query): string {
@@ -163,7 +172,7 @@ function onValueInternal(
           q._spec,
           cancelCallback,
           onCanceled,
-          listenOptions?.owner,
+          attributionOf(listenOptions),
         ),
         unregister,
       );
@@ -200,7 +209,7 @@ function onValueInternal(
         undefined,
         cancelCallback,
         onCanceled,
-        listenOptions?.owner,
+        attributionOf(listenOptions),
       ),
       unregister,
     );

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -14,7 +14,7 @@ import { Transactions } from './transactions.js';
 import { ValueListeners } from './value-listeners.js';
 import { WritePlane } from './write-plane.js';
 import type { JsonValue } from './data-tree.js';
-import type { ListenerOwnerHint } from '../../sandbox/attribution/listener-owners.js';
+import type { ListenerAttribution } from '../../sandbox/attribution/listener-owners.js';
 
 export class RtdbBackend {
   private readonly state: BackendState;
@@ -86,9 +86,9 @@ export class RtdbBackend {
     query?: QuerySpec,
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
-    return this.values.onValue(auth, path, cb, query, cancelCallback, onCanceled, owner);
+    return this.values.onValue(auth, path, cb, query, cancelCallback, onCanceled, attribution);
   }
 
   adminOnValue(

--- a/packages/pyric/src/database/sandbox/value-listeners.ts
+++ b/packages/pyric/src/database/sandbox/value-listeners.ts
@@ -3,7 +3,7 @@ import type { ListenerOwner } from '../../sandbox/types/events.js';
 import { recordEffectRegions } from '../../sandbox/attribution/effect-regions.js';
 import {
   listenerAttachOwners,
-  type ListenerOwnerHint,
+  type ListenerAttribution,
 } from '../../sandbox/attribution/listener-owners.js';
 import { jsonValuesEqual, joinPath, pathSegments, type JsonValue } from './data-tree.js';
 import type { BackendState } from './backend-state.js';
@@ -44,7 +44,7 @@ export class ValueListeners {
     query?: QuerySpec,
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
     const at = this.state.clock.now();
     const evaluation = this.state.rules.evaluate('read', path === '/' ? '/' : path, {
@@ -87,7 +87,7 @@ export class ValueListeners {
     }
     return this.attach(auth, path, cb, query, {
       origin: 'listener', result: 'allow', evaluation, at,
-    }, cancelCallback, onCanceled, owner);
+    }, cancelCallback, onCanceled, attribution);
   }
 
   adminOnValue(path: string, cb: (snap: ValueListenerSnapshot) => void, query?: QuerySpec): () => void {
@@ -109,10 +109,10 @@ export class ValueListeners {
     },
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
     const id = this.state.events.nextListenerId();
-    const attachOwners = listenerAttachOwners(owner);
+    const attachOwners = listenerAttachOwners(attribution?.owner, attribution?.owners);
     this.state.events.operation(auth, 'listen', path, provenance.result, provenance.evaluation, {
       at: provenance.at, durationMs: this.state.clock.now() - provenance.at,
       request: query ? { query } : undefined, origin: provenance.origin,

--- a/packages/pyric/src/database/types.ts
+++ b/packages/pyric/src/database/types.ts
@@ -3,7 +3,10 @@ import { QUERY_SYMBOL } from './brands.js';
 import type { Database } from './database-handle.js';
 import type { DataSnapshot } from './data-snapshot.js';
 import type { JsonValue } from './sandbox/data-tree.js';
-import type { ListenerOwnerHint } from '../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../sandbox/attribution/listener-owners.js';
 import type { QuerySpec } from './sandbox/query.js';
 
 export { CONSTRAINT_SYMBOL, QUERY_SYMBOL } from './brands.js';
@@ -80,7 +83,7 @@ export type EventType =
   | 'child_moved'
   | 'child_removed';
 
-export interface ListenOptions {
+export interface ListenOptions extends RecordedListenerOwners {
   readonly onlyOnce?: boolean;
   /**
    * Pyric's own extension, absent from the Firebase Web SDK: who owns this

--- a/packages/pyric/src/firestore/listeners.ts
+++ b/packages/pyric/src/firestore/listeners.ts
@@ -10,7 +10,10 @@ import { AUTH_SESSION_SCOPE, FOLLOWS_CURRENT_USER } from 'pyric/firestore/intern
 import { FirebaseError } from '../sandbox/internal/firebase-error.js';
 import { toFirestoreFirebaseError } from './errors.js';
 import { clientStateFor } from './client-state.js';
-import type { ListenerOwnerHint } from '../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../sandbox/attribution/listener-owners.js';
 
 import {
   targetOf,
@@ -30,7 +33,7 @@ import type {
 
 // ─── Snapshot listeners ───────────────────────────────────────────────
 
-export interface SnapshotListenOptions {
+export interface SnapshotListenOptions extends RecordedListenerOwners {
   includeMetadataChanges?: boolean;
   /**
    * Pyric's own extension, absent from the Firebase Web SDK: who owns this

--- a/packages/pyric/src/firestore/sandbox/listener-dispatch.ts
+++ b/packages/pyric/src/firestore/sandbox/listener-dispatch.ts
@@ -271,8 +271,10 @@ export class ListenerDispatch {
   ): () => void {
     const id = String(this.nextListenerId++);
     // One `Error` construction per attach, on the caller's own stack, the
-    // only place the application frame is still reachable.
-    const attachOwners = listenerAttachOwners(options.owner);
+    // only place the application frame is still reachable. A caller reaching
+    // the sandbox across a port sends `options.owners` instead: its stack and
+    // its DOM are on the other side, and this one describes neither.
+    const attachOwners = listenerAttachOwners(options.owner, options.owners);
     const record: ListenerRecord = {
       id,
       target,

--- a/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
+++ b/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
@@ -11,7 +11,10 @@
  * section 4, section 5).
  */
 import type { DocumentData } from './local-state.js';
-import type { ListenerOwnerHint } from '../../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../../sandbox/attribution/listener-owners.js';
 import type { Operation } from './local-environment.js';
 // FS-B10 — translate the listener read path so `snap.data()` exposes the
 // SAME compat-shaped values (`Timestamp` `{seconds, nanoseconds}`, `Bytes`,
@@ -81,7 +84,7 @@ export type SnapshotTarget =
  * `LocalEnvironment.notifyDocListener` / `notifyQueryListener`. `fromCache`
  * remains constant `false` — the sandbox has no offline cache to serve from.
  */
-export interface SnapshotListenerOptions {
+export interface SnapshotListenerOptions extends RecordedListenerOwners {
   includeMetadataChanges?: boolean;
   source?: 'default' | 'cache';
   /**

--- a/packages/pyric/src/sandbox/attribution/listener-owners.ts
+++ b/packages/pyric/src/sandbox/attribution/listener-owners.ts
@@ -25,19 +25,69 @@ import {
 } from './element-selector.js';
 
 /**
- * What a caller may pass as a listener's `owner`: a name, the DOM element the
- * listener feeds, or a fully-built {@link ListenerOwner} record. The third
- * form is for a framework binding (`@pyric/ui`'s `useListenerOwner`) that has
- * already computed a `component` owner and wants it recorded verbatim,
- * rather than wrapped in a `tag`.
+ * The input form of a `component` owner, as a framework binding builds it.
+ *
+ * It differs from the recorded {@link ListenerOwner} `component` form in one
+ * field: `element` is the live DOM element, not a selector for it. The
+ * binding hands the element over and this module derives the selector,
+ * exactly as it does for an element hint, so that the selector rules live in
+ * one place and the binding never has to import pyric at runtime. Owners are
+ * serialized into events, so the element itself is never kept on the
+ * recorded owner.
  */
-export type ListenerOwnerHint = string | SelectableElement | ListenerOwner;
+export interface ComponentOwnerInput {
+  kind: 'component';
+  /** The component function's name, read from the render-phase stack. */
+  name: string;
+  /** The chain of enclosing component frames, outermost first. */
+  path?: string[];
+  /** The component's root element, when the binding's ref was attached. */
+  element?: SelectableElement;
+}
 
-/** `true` when `value` is already a {@link ListenerOwner} record rather than
- *  a name or an element to derive one from. */
-function isListenerOwner(value: ListenerOwnerHint): value is ListenerOwner {
+/**
+ * What a caller may pass as a listener's `owner`: a name, the DOM element the
+ * listener feeds, a fully-built {@link ListenerOwner} record, or a
+ * {@link ComponentOwnerInput}. The last two forms are for a framework binding
+ * (`@pyric/ui`'s `useListenerOwner`) that has already identified the owning
+ * component and wants it recorded as a `component` owner rather than wrapped
+ * in a `tag`.
+ */
+export type ListenerOwnerHint =
+  | string
+  | SelectableElement
+  | ListenerOwner
+  | ComponentOwnerInput;
+
+/** `true` when `value` is already an owner record rather than a name or an
+ *  element to derive one from. */
+function isOwnerRecord(
+  value: ListenerOwnerHint,
+): value is ListenerOwner | ComponentOwnerInput {
   if (value === null || typeof value !== 'object') return false;
   return 'kind' in value && typeof (value as { kind: unknown }).kind === 'string';
+}
+
+/**
+ * Turn an owner record into its recorded form. A `component` owner carrying a
+ * live element has that element replaced by a selector; a `component` owner
+ * whose `element` is not a selectable element drops the field. Every other
+ * owner kind is already in recorded form and passes through unchanged.
+ */
+function recordedOwner(value: ListenerOwner | ComponentOwnerInput): ListenerOwner {
+  if (value.kind !== 'component') return value as ListenerOwner;
+  const owner: Extract<ListenerOwner, { kind: 'component' }> = {
+    kind: 'component',
+    name: value.name,
+  };
+  if (value.path !== undefined && value.path.length > 0) owner.path = value.path;
+  const element = value.element;
+  if (typeof element === 'string') {
+    owner.element = element;
+  } else if (element !== undefined && isSelectableElement(element)) {
+    owner.element = ownerSelectorFor(element);
+  }
+  return owner;
 }
 
 /**
@@ -153,10 +203,11 @@ export function captureCreationFrame(): ListenerOwner | undefined {
 /**
  * Build the explicit owner from whatever the caller passed as `owner`. A
  * string is the name of a `tag` owner verbatim; an element contributes its
- * tag name plus a selector that finds it again; an already-built
- * {@link ListenerOwner} (a framework binding's `component` owner) is
- * recorded as-is. Unlike frame capture this is not gated on the attribution
- * switch: the caller asked for it by name.
+ * tag name plus a selector that finds it again; an owner record (a framework
+ * binding's `component` owner) is recorded as it stands, except that a live
+ * element on a `component` owner is reduced to a selector here. Unlike frame
+ * capture this is not gated on the attribution switch: the caller asked for
+ * it by name.
  */
 export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner | undefined {
   if (hint === undefined) return undefined;
@@ -164,7 +215,7 @@ export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner 
     if (hint.length === 0) return undefined;
     return { kind: 'tag', name: hint };
   }
-  if (isListenerOwner(hint)) return hint;
+  if (isOwnerRecord(hint)) return recordedOwner(hint);
   if (!isSelectableElement(hint)) return undefined;
   return { kind: 'tag', name: tagNameOf(hint), element: ownerSelectorFor(hint) };
 }

--- a/packages/pyric/src/sandbox/attribution/listener-owners.ts
+++ b/packages/pyric/src/sandbox/attribution/listener-owners.ts
@@ -221,13 +221,46 @@ export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner 
 }
 
 /**
+ * The internal listen option that carries owners a caller already recorded.
+ *
+ * It exists for one caller: a client that reaches the sandbox across a port
+ * rather than calling it in the same context. The served page runs the
+ * sandbox in a SharedWorker, so an attach inside the worker sees a
+ * worker-bundle frame, no `owner` hint, and no DOM. That client derives the
+ * owners on the page, where all three are real, and hands them over here.
+ *
+ * The option is reached through `pyric/sandbox/internal` and is not part of
+ * any mirrored Firebase surface. The public `owner` hint is unchanged: a
+ * caller still passes a name, an element, or a component record, and the
+ * sandbox still derives the owners itself when no `owners` arrive.
+ */
+export interface RecordedListenerOwners {
+  readonly owners?: readonly ListenerOwner[];
+}
+
+/**
+ * Both attribution inputs a listen call can carry: the caller's `owner` hint
+ * and, for a caller on the other side of a port, the owners it already
+ * recorded. Backends that take attribution as one argument take this.
+ */
+export interface ListenerAttribution extends RecordedListenerOwners {
+  readonly owner?: ListenerOwnerHint;
+}
+
+/**
  * Every owner known at attach time, in a stable order: frame first, then tag.
  * Returns `undefined` rather than an empty array so an event with no
  * attribution omits the field entirely.
+ *
+ * `recorded` owners replace both: the caller derived them where the calling
+ * frame and the DOM exist, so deriving them again here would only describe
+ * this context.
  */
 export function listenerAttachOwners(
   hint?: ListenerOwnerHint,
+  recorded?: readonly ListenerOwner[],
 ): ListenerOwner[] | undefined {
+  if (recorded !== undefined && recorded.length > 0) return [...recorded];
   const owners: ListenerOwner[] = [];
   const frame = captureCreationFrame();
   if (frame !== undefined) owners.push(frame);

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -28,6 +28,7 @@ export {
   captureCreationFrame,
   listenerAttachOwners,
   tagOwnerFor,
+  type ComponentOwnerInput,
   type ListenerOwnerHint,
 } from '../attribution/listener-owners.js';
 export { recordEffectRegions } from '../attribution/effect-regions.js';

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -25,11 +25,14 @@ export {
   type ListenerAttributionMode,
 } from '../attribution/attribution-mode.js';
 export {
+  callerFrameFromStack,
   captureCreationFrame,
   listenerAttachOwners,
   tagOwnerFor,
   type ComponentOwnerInput,
+  type ListenerAttribution,
   type ListenerOwnerHint,
+  type RecordedListenerOwners,
 } from '../attribution/listener-owners.js';
 export { recordEffectRegions } from '../attribution/effect-regions.js';
 export {

--- a/packages/pyric/test/sandbox/attribution/listener-owners.test.ts
+++ b/packages/pyric/test/sandbox/attribution/listener-owners.test.ts
@@ -101,6 +101,41 @@ describe('tagOwnerFor', () => {
     expect(owner.element).toBe(`[${OWNER_ATTRIBUTE}="${element.getAttribute(OWNER_ATTRIBUTE)}"]`);
   });
 
+  it('records a component owner as it stands', () => {
+    expect(tagOwnerFor({ kind: 'component', name: 'OrdersTable', path: ['App'] })).toEqual({
+      kind: 'component',
+      name: 'OrdersTable',
+      path: ['App'],
+    });
+  });
+
+  it('derives the selector for a component owner carrying an element', () => {
+    const element = new FakeElement('section');
+    element.id = 'orders';
+    expect(tagOwnerFor({ kind: 'component', name: 'OrdersTable', element })).toEqual({
+      kind: 'component',
+      name: 'OrdersTable',
+      element: '#orders',
+    });
+  });
+
+  it('keeps no element on the recorded component owner', () => {
+    const element = new FakeElement('section');
+    const owner = tagOwnerFor({ kind: 'component', name: 'OrdersTable', element });
+    if (owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(typeof owner.element).toBe('string');
+    expect(JSON.parse(JSON.stringify(owner))).toEqual(owner);
+  });
+
+  it('drops an element that cannot be turned into a selector', () => {
+    const owner = tagOwnerFor({
+      kind: 'component',
+      name: 'OrdersTable',
+      element: {} as never,
+    });
+    expect(owner).toEqual({ kind: 'component', name: 'OrdersTable' });
+  });
+
   it('reports nothing for an absent or empty hint', () => {
     expect(tagOwnerFor(undefined)).toBeUndefined();
     expect(tagOwnerFor('')).toBeUndefined();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/primitives/index.d.ts",
       "import": "./dist/primitives/index.js"
     },
+    "./listener-owner": {
+      "types": "./dist/listener-owner/index.d.ts",
+      "import": "./dist/listener-owner/index.js"
+    },
     "./firestore": {
       "types": "./dist/firestore/index.d.ts",
       "import": "./dist/firestore/index.js"
@@ -75,6 +79,7 @@
       "import": "./dist/rules/hooks/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "src",

--- a/packages/ui/src/listener-owner/index.ts
+++ b/packages/ui/src/listener-owner/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Component attribution for listeners, on its own entry point.
+ *
+ * `@pyric/ui/listener-owner` exists so an application can take the hook
+ * without importing the component library barrel and without pulling pyric
+ * into its bundle. The module graph reachable from here is this file, the
+ * hook, and `react`. Every pyric name it uses is a type, erased at build
+ * time, and the capture itself is behind a `process.env.NODE_ENV` gate a
+ * bundler folds to a constant, so a production build carries neither.
+ *
+ * The same hook is also exported from `@pyric/ui/primitives`.
+ */
+export {
+  useListenerOwner,
+  type ListenerOwner,
+  type UseListenerOwnerOptions,
+  type UseListenerOwnerResult,
+} from '../primitives/hooks/useListenerOwner.js';

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
-import type { ListenerOwner } from 'pyric/sandbox';
-import {
-  isSelectableElement,
-  listenerAttributionEnabled,
-  ownerSelectorFor,
-  type SelectableElement,
-} from 'pyric/sandbox/internal';
+import type { ComponentOwnerInput, SelectableElement } from 'pyric/sandbox/internal';
 
 /**
  * Captures the framework component that owns a listener, so a component
  * using `@pyric/ui`'s data hooks is attributed with no extra code at the
  * call site.
+ *
+ * This module imports pyric for types only. Nothing here reaches pyric at
+ * runtime, and capture itself is gated on `process.env.NODE_ENV`, which a
+ * bundler folds to a constant: in a production build the gate is
+ * statically false, the capture body is dead code, and an application that
+ * uses these hooks ships neither the capture nor pyric. The owner is handed
+ * to whatever Firestore implementation the app is wired to; under `pyric
+ * sandbox` that is pyric, which derives the element selector and records the
+ * owner, and in production the real Firebase SDK ignores the option.
  *
  * Capture happens during render, while the calling component function is
  * still on the call stack, the same moment `pyric/sandbox`'s own `frame`
@@ -22,9 +25,7 @@ import {
  *   covers `react`, `react-dom`, and every other dependency, `pyric`
  *   included) is the component function currently rendering; this hook is
  *   always called directly from that function's body, so that frame names
- *   it. A minified production build mangles this the same way it mangles any
- *   other identifier; state that to the consumer rather than guessing at the
- *   original name.
+ *   it.
  * - `path`, the chain of enclosing component frames, comes from React's own
  *   `captureOwnerStack` export (React 19+; an older peer React leaves `path`
  *   absent). That export exists precisely because the plain call stack does
@@ -33,22 +34,26 @@ import {
  *   alone can only ever name the immediate function. `captureOwnerStack`
  *   reads React's own render-phase bookkeeping through a public export,
  *   this hook never touches a fiber. Best effort: absent when the installed
- *   React does not report an owner stack for this render.
+ *   React does not report an owner stack for this render, and read
+ *   defensively so a React without it is not an error.
  *
  * `ref` is a callback ref the caller may attach to the component's root
- * element. Once attached, `owner.element` is filled in with the same
- * selector `pyric/sandbox`'s attribution module uses for a caller-supplied
- * tag element, imported from `pyric/sandbox/internal` rather than
- * duplicated.
- *
- * Capture is skipped entirely, and `owner` is `undefined`, when listener
- * attribution is off, the same production/test switch `pyric/sandbox`
- * itself reads.
+ * element. Once attached, the element itself travels on `owner.element`.
+ * Turning it into a selector is the sandbox's job, not this module's, so the
+ * selector rules stay in one place and this file keeps no runtime import.
  */
+/**
+ * The owner value this hook produces: a `component` owner carrying the live
+ * root element rather than a selector for it. Pyric's attribution derives
+ * the selector when the listener attaches; the Firebase SDKs ignore the
+ * option entirely.
+ */
+export type ListenerOwner = ComponentOwnerInput;
+
 export interface UseListenerOwnerResult {
-  /** The component owner, or `undefined` when attribution is off or this
+  /** The component owner, or `undefined` in a production build or when this
    *  hook could not identify a calling component frame. */
-  owner: ListenerOwner | undefined;
+  owner: ComponentOwnerInput | undefined;
   /** Attach to the component's root element to fill in `owner.element`. */
   ref: (element: SelectableElement | null) => void;
 }
@@ -78,10 +83,18 @@ const FRAME_WITH_FUNCTION = /^\s*at\s+([^\s(]+)\s+\((.+):(\d+):(\d+)\)\s*$/;
  *
  * This file sits at `<root>/primitives/hooks/useListenerOwner.{ts,js}`, so
  * the root is two path segments up.
+ *
+ * Computed on first use rather than at module load, so that a production
+ * build, where nothing ever asks for it, drops this and everything it calls.
  */
-const OWN_DIRECTORY = ownDirectory();
+let ownDirectoryCache: string | undefined;
 
 function ownDirectory(): string {
+  if (ownDirectoryCache === undefined) ownDirectoryCache = readOwnDirectory();
+  return ownDirectoryCache;
+}
+
+function readOwnDirectory(): string {
   const here = importMetaUrl();
   if (here === undefined) return '';
   const withoutFile = here.slice(0, here.lastIndexOf('/'));
@@ -109,7 +122,8 @@ function stripFileScheme(url: string): string {
 function isFrameworkFile(file: string): boolean {
   const normalized = stripFileScheme(file);
   if (normalized.includes('/node_modules/')) return true;
-  if (OWN_DIRECTORY.length > 0 && normalized.startsWith(OWN_DIRECTORY)) return true;
+  const own = ownDirectory();
+  if (own.length > 0 && normalized.startsWith(own)) return true;
   return false;
 }
 
@@ -161,16 +175,20 @@ function ancestorPathFromOwnerStack(stack: string | undefined): string[] {
   return names.reverse();
 }
 
-type ComponentOwner = Extract<ListenerOwner, { kind: 'component' }>;
-
 function captureComponentOwner(
-  captureOwnerStack: () => string | null | undefined,
-): ComponentOwner | undefined {
-  if (!listenerAttributionEnabled()) return undefined;
+  override: (() => string | null) | undefined,
+): ComponentOwnerInput | undefined {
+  // The production gate, written inline as a bare `process.env.NODE_ENV`
+  // comparison because that is the form every bundler folds to a literal.
+  // Folded to `true`, everything below it is dead code and the capture, the
+  // stack reading, and this module's pyric types all leave the build. A
+  // bundler defines `process.env.NODE_ENV`; under Node it is the real value.
+  if (process.env.NODE_ENV === 'production') return undefined;
   const name = callingComponentName(new Error().stack);
   if (name === undefined) return undefined;
-  const path = ancestorPathFromOwnerStack(captureOwnerStack() ?? undefined);
-  const owner: ComponentOwner = { kind: 'component', name };
+  const capture = override ?? reactCaptureOwnerStack;
+  const path = ancestorPathFromOwnerStack(capture() ?? undefined);
+  const owner: ComponentOwnerInput = { kind: 'component', name };
   if (path.length > 0) owner.path = path;
   return owner;
 }
@@ -183,17 +201,17 @@ function captureComponentOwner(
 export function useListenerOwner(
   options: UseListenerOwnerOptions = {},
 ): UseListenerOwnerResult {
-  const capture = options.captureOwnerStack ?? reactCaptureOwnerStack;
-  const [base] = useState<ComponentOwner | undefined>(() => captureComponentOwner(capture));
-  const [element, setElement] = useState<string | undefined>(undefined);
+  const [base] = useState<ComponentOwnerInput | undefined>(() =>
+    captureComponentOwner(options.captureOwnerStack),
+  );
+  const [element, setElement] = useState<SelectableElement | undefined>(undefined);
 
   const ref = useCallback((node: SelectableElement | null) => {
     if (node === null) return;
-    if (!isSelectableElement(node)) return;
-    setElement(ownerSelectorFor(node));
+    setElement(node);
   }, []);
 
-  const owner = useMemo<ComponentOwner | undefined>(() => {
+  const owner = useMemo<ComponentOwnerInput | undefined>(() => {
     if (base === undefined) return undefined;
     if (element === undefined) return base;
     return { ...base, element };

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -140,15 +140,45 @@ function parseRenderFrame(line: string): RenderFrame | undefined {
 
 /** The first non-framework frame in a plain call stack: the component
  *  currently rendering, when this is called directly from its body. */
-function callingComponentName(stack: string | undefined): string | undefined {
+/**
+ * The component that called the hook, read from a render-phase stack.
+ *
+ * The stack below this hook is fixed in shape: this module's frames, then
+ * `useListenerOwner` itself, then any custom hooks the component routed
+ * through, then the component, then React. So the first named frame after
+ * `useListenerOwner` that is not itself a hook is the component, whatever
+ * file it lives in. That is what keeps the answer right in a bundled app,
+ * where every module shares one file and a file-based test would exclude the
+ * component along with this module. When the hook's own frame is absent, the
+ * file-based test is the fallback.
+ */
+export function componentNameFromStack(stack: string | undefined): string | undefined {
   if (typeof stack !== 'string') return undefined;
+  const frames: RenderFrame[] = [];
   for (const line of stack.split('\n')) {
     const frame = parseRenderFrame(line);
-    if (frame === undefined) continue;
+    if (frame !== undefined) frames.push(frame);
+  }
+  const hookIndex = frames.findIndex((frame) => frame.name === 'useListenerOwner');
+  if (hookIndex >= 0) {
+    for (const frame of frames.slice(hookIndex + 1)) {
+      if (isHookName(frame.name)) continue;
+      if (frame.file.includes('/node_modules/')) continue;
+      return frame.name;
+    }
+    return undefined;
+  }
+  for (const frame of frames) {
     if (isFrameworkFile(frame.file)) continue;
     return frame.name;
   }
   return undefined;
+}
+
+/** `true` for a frame name that follows React's hook convention (`useX`). */
+function isHookName(name: string): boolean {
+  const bare = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : name;
+  return /^use[A-Z0-9_]/.test(bare);
 }
 
 /** `react`'s own `captureOwnerStack` export, when the installed version has
@@ -169,7 +199,7 @@ function ancestorPathFromOwnerStack(stack: string | undefined): string[] {
   for (const line of stack.split('\n')) {
     const frame = parseRenderFrame(line);
     if (frame === undefined) continue;
-    if (isFrameworkFile(frame.file)) continue;
+    if (frame.file.includes('/node_modules/')) continue;
     names.push(frame.name);
   }
   return names.reverse();
@@ -184,7 +214,7 @@ function captureComponentOwner(
   // stack reading, and this module's pyric types all leave the build. A
   // bundler defines `process.env.NODE_ENV`; under Node it is the real value.
   if (process.env.NODE_ENV === 'production') return undefined;
-  const name = callingComponentName(new Error().stack);
+  const name = componentNameFromStack(new Error().stack);
   if (name === undefined) return undefined;
   const capture = override ?? reactCaptureOwnerStack;
   const path = ancestorPathFromOwnerStack(capture() ?? undefined);

--- a/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
+++ b/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
@@ -20,7 +20,6 @@ import { describe, expect, it } from 'bun:test';
 import { doc, getFirestore } from 'pyric/firestore';
 import { initializeSandbox } from 'pyric/sandbox';
 import type { SandboxEvent } from 'pyric/sandbox';
-import { configureListenerAttribution } from 'pyric/sandbox/internal';
 import { seedDocuments } from 'pyric/sandbox/firestore';
 import { useFirestoreDoc } from '../../../src/firestore/hooks/useFirestoreDoc.js';
 
@@ -66,8 +65,9 @@ describe('component owner attribution through useFirestoreDoc', () => {
     expect(component.name).toBe('OrdersTable');
   });
 
-  it('records no component owner when attribution is off', async () => {
-    configureListenerAttribution('off');
+  it('records no component owner in a production build', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     try {
       const { db, events } = setupSandbox();
       const ref = doc(db, 'orders/o1');
@@ -84,7 +84,7 @@ describe('component owner attribution through useFirestoreDoc', () => {
       const owners = attachEvents(events)[0]?.owners;
       expect(owners?.some((owner) => owner.kind === 'component')).toBeFalsy();
     } finally {
-      configureListenerAttribution('auto');
+      process.env.NODE_ENV = previous;
     }
   });
 });

--- a/packages/ui/test/primitives/listenerOwnerEntry.test.ts
+++ b/packages/ui/test/primitives/listenerOwnerEntry.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The `@pyric/ui/listener-owner` entry must not reach pyric at runtime.
+ *
+ * An application that uses the hook ships whatever this entry's module graph
+ * pulls in. If any module in that graph imported pyric for a value rather
+ * than a type, pyric would land in the application's production bundle, which
+ * is exactly what the separate entry exists to prevent.
+ *
+ * The check walks the source graph from the entry, following relative
+ * imports, and reads every specifier each module names. Type-only imports
+ * (`import type ...`) are erased by `tsc`, so they are allowed; a pyric
+ * specifier in any other position is a failure. Reading the source rather
+ * than a build keeps the test runnable without a prior `bun run build`, and
+ * the `import type` requirement is what makes the source reading equivalent
+ * to reading the output.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTRY = resolve(HERE, '../../src/listener-owner/index.ts');
+
+/** Every `from '...'` specifier in a module, with its statement text. */
+const IMPORT_STATEMENT = /(?:^|\n)\s*(export|import)\s+(type\s+)?([\s\S]*?)from\s+'([^']+)';/g;
+
+interface Specifier {
+  text: string;
+  typeOnly: boolean;
+}
+
+function specifiersOf(source: string): Specifier[] {
+  const found: Specifier[] = [];
+  for (const match of source.matchAll(IMPORT_STATEMENT)) {
+    found.push({ text: match[4]!, typeOnly: match[2] !== undefined });
+  }
+  return found;
+}
+
+/** Resolve a relative `.js` specifier back to the `.ts` source it came from. */
+function sourcePathFor(from: string, specifier: string): string {
+  const target = resolve(dirname(from), specifier);
+  for (const candidate of [target.replace(/\.js$/, '.ts'), target.replace(/\.js$/, '.tsx')]) {
+    try {
+      readFileSync(candidate, 'utf8');
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`cannot resolve ${specifier} from ${from}`);
+}
+
+interface GraphRead {
+  modules: string[];
+  runtimeSpecifiers: string[];
+}
+
+function readGraph(entry: string): GraphRead {
+  const modules: string[] = [];
+  const runtimeSpecifiers = new Set<string>();
+  const pending = [entry];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (modules.includes(current)) continue;
+    modules.push(current);
+    const source = readFileSync(current, 'utf8');
+    for (const specifier of specifiersOf(source)) {
+      if (specifier.text.startsWith('.')) {
+        pending.push(sourcePathFor(current, specifier.text));
+        continue;
+      }
+      if (specifier.typeOnly) continue;
+      runtimeSpecifiers.add(specifier.text);
+    }
+  }
+  return { modules, runtimeSpecifiers: [...runtimeSpecifiers].sort() };
+}
+
+describe('@pyric/ui/listener-owner', () => {
+  it('names no pyric specifier in a runtime import', () => {
+    const { runtimeSpecifiers } = readGraph(ENTRY);
+    const pyric = runtimeSpecifiers.filter(
+      (specifier) => specifier === 'pyric' || specifier.startsWith('pyric/'),
+    );
+    expect(pyric).toEqual([]);
+  });
+
+  it('imports react and nothing else at runtime', () => {
+    const { runtimeSpecifiers } = readGraph(ENTRY);
+    expect(runtimeSpecifiers).toEqual(['react']);
+  });
+
+  it('reaches only the entry and the hook', () => {
+    const { modules } = readGraph(ENTRY);
+    expect(modules.length).toBe(2);
+  });
+});

--- a/packages/ui/test/primitives/useListenerOwner.test.tsx
+++ b/packages/ui/test/primitives/useListenerOwner.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'bun:test';
-import { configureListenerAttribution } from 'pyric/sandbox/internal';
 import { useListenerOwner } from '../../src/primitives/hooks/useListenerOwner.js';
 import { act, renderHook } from '../helpers/render-hook.js';
 import { FakeElement } from '../helpers/fake-element.js';
@@ -43,7 +42,7 @@ describe('useListenerOwner', () => {
     expect(result.current.owner.path).toBeUndefined();
   });
 
-  it('fills owner.element once ref is attached', () => {
+  it('hands the element itself over once ref is attached', () => {
     const { result } = renderHook(() => useListenerOwner());
     const element = new FakeElement('table');
     element.id = 'orders';
@@ -54,16 +53,17 @@ describe('useListenerOwner', () => {
 
     expect(result.current.owner?.kind).toBe('component');
     if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
-    expect(result.current.owner.element).toBe('#orders');
+    expect(result.current.owner.element).toBe(element);
   });
 
-  it('records no owner at all when attribution is off', () => {
-    configureListenerAttribution('off');
+  it('records no owner at all in a production build', () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     try {
       const { result } = renderHook(() => useListenerOwner());
       expect(result.current.owner).toBeUndefined();
     } finally {
-      configureListenerAttribution('auto');
+      process.env.NODE_ENV = previous;
     }
   });
 });

--- a/packages/ui/test/primitives/useListenerOwner.test.tsx
+++ b/packages/ui/test/primitives/useListenerOwner.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { componentNameFromStack } from '../../src/primitives/hooks/useListenerOwner.js';
 import { useListenerOwner } from '../../src/primitives/hooks/useListenerOwner.js';
 import { act, renderHook } from '../helpers/render-hook.js';
 import { FakeElement } from '../helpers/fake-element.js';
@@ -54,6 +55,21 @@ describe('useListenerOwner', () => {
     expect(result.current.owner?.kind).toBe('component');
     if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
     expect(result.current.owner.element).toBe(element);
+  });
+
+  it('finds the component after the hook frame when every module shares one bundled file', () => {
+    const stack = [
+      'Error',
+      '    at captureComponentOwner (http://localhost:3473/assets/index-abc.js:10:5)',
+      '    at http://localhost:3473/assets/index-abc.js:20:5',
+      '    at mountMemo (http://localhost:3473/assets/index-abc.js:30:5)',
+      '    at Object.useMemo (http://localhost:3473/assets/index-abc.js:40:5)',
+      '    at useListenerOwner (http://localhost:3473/assets/index-abc.js:50:5)',
+      '    at useOrders (http://localhost:3473/assets/index-abc.js:60:5)',
+      '    at ChatPage (http://localhost:3473/assets/index-abc.js:70:5)',
+      '    at renderWithHooks (http://localhost:3473/assets/index-abc.js:80:5)',
+    ].join('\n');
+    expect(componentNameFromStack(stack)).toBe('ChatPage');
   });
 
   it('records no owner at all in a production build', () => {


### PR DESCRIPTION
Carries a listener's owners from the page that opened it to the sandbox that records it, so a served page's listeners are attributed to their React component and region the same way an in-page listener is.

```tsx
// In a component, with @pyric/ui's hook (no pyric import in the app's bundle):
const { owner, ref } = useListenerOwner();
onSnapshot(query, { owner: { ...owner, element: ref.current } }, cb);
// listener_attach event, on either host:
// owners: [{ kind: 'frame', file: 'src/ui/chat/chat-page.tsx', line: 318 },
//          { kind: 'component', name: 'ChatPage', element: '#conversations' }]
```

## The owner is captured where the page is and recorded where the sandbox is

On a served page the sandbox runs in a SharedWorker, and the attach used to happen there: the frame it captured was a worker-bundle function, the explicit owner was dropped before the subscribe message was built, and the DOM did not exist on that side. The worker client now computes the owners on the caller's stack before sending the subscribe message, the message carries them, and the host hands them to the sandbox's attach through an internal listen option, so the worker records the page's owners instead of capturing its own. The public `owner` hint is unchanged.

The React hook no longer imports pyric at runtime. It reads the component name by position after its own frame, which is what keeps it right in a bundled app where every module shares one file, and a production build gate folds the capture away entirely. The sandbox derives the element's selector from a `component` owner that carries the element, so the hook hands over the element rather than a selector.

## Risk

Diagnostic attribution only; no verdict, write, or delivery path changes, stated on the engine commits. A worker integration test covers attach owners on both services, and a served-app Playwright case opens a tagged listener from the served page and asserts the chip lists it.

<details>
<summary>Implementation notes</summary>

- `packages/cli/src/serve/worker/client/listener-owners.ts` derives the page-side owners; the client root is stripped from the stack by the module's own directory.
- `SnapshotListenOptions` and the database `ListenOptions` accept an internal `owners` record; `listenerAttachOwners` returns it verbatim when present.
- `bun test --cwd packages/pyric` 6845 pass, `packages/cli` 3433 pass, `packages/ui` 796 pass; typecheck and build clean; coupling gate pass.

</details>
