### PR TITLE
feat(serve): a listener summary in the runtime chip

### DIFF
--- a/packages/cli/src/serve/entries/init.ts
+++ b/packages/cli/src/serve/entries/init.ts
@@ -28,6 +28,7 @@ import { useWorker, workerDb } from './worker-runtime.js';
 import { ServeAuthHelper, customClaimsFromTokenClaims } from './auth-helper-core.js';
 import { installServeAuthResolver } from './auth-helper-runtime.js';
 import { mountAuthHelperDialog } from './auth-helper-dom.js';
+import { configureListenerAttribution } from 'pyric/sandbox/internal';
 import { installPyricRuntimeChip } from '../runtime/chip-install.js';
 import { sandboxEventSource } from '../runtime/listener-event-source.js';
 import { getPyricRuntimeStatus } from '../runtime/status.js';
@@ -87,6 +88,10 @@ if (typeof document !== 'undefined' && typeof window !== 'undefined') {
   void initPayload.then((payload) => {
     installAvatarUpgrades(payload?.avatarUpgrades === true);
   });
+  // A served page is a development host whatever the app's bundle says: the
+  // template's served build is a Vite production build, which folds the
+  // bundled-production check to true and would leave listener attribution off.
+  configureListenerAttribution('on');
   installPyricRuntimeChip({
     runtime: getPyricRuntimeStatus(),
     document,

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -748,7 +748,9 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       listenerNotice = wanted && !mode.enabled()
         ? 'Listener attribution is off in this build, so there are no owners to outline.'
         : null;
-      if (!mode.enabled()) listenerOutlines = [];
+      // The summary reads the fold whether the outlines are on or off; the
+      // mode only reports on change, so take its current answer here.
+      listenerOutlines = mode.outlines();
       render();
     });
     root.querySelector('[data-open-impersonate]')?.addEventListener('click', (e) => {

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -11,7 +11,7 @@ import {
 } from './chip-dialog.js';
 import type { RuntimeIdentity, RuntimeIdentityBindings } from './identity.js';
 import type { ListenerMode } from './listener-mode.js';
-import type { ListenerOutline } from './listener-outline-model.js';
+import type { ListenerOutline, ListenerOutlineIncident } from './listener-outline-model.js';
 import {
   getLens as defaultGetLens,
   setLens as defaultSetLens,
@@ -149,8 +149,30 @@ const styles = `
   .worker-state-col { border-top: 1px solid var(--pyric-border-soft); color: var(--pyric-muted); font-size: 10px; display: flex; flex-direction: column; min-height: 34px; padding: 7px 12px; }
   .worker-state-row { align-items: center; display: flex; justify-content: space-between; width: 100%; }
   .worker-state-subline { color: #89899f; font: 9px/1.4 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; text-align: right; width: 100%; }
-  .listener-line, .listener-row { color: #d7d7df; display: block; font: 9px/1.6 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; }
-  .listener-link { color: var(--pyric-muted); text-decoration: none; }
+  .listener-header { border: 1px solid var(--pyric-border-soft); border-radius: 999px; color: var(--pyric-text); font: 9px/1 ui-monospace, monospace; padding: 4px 6px; }
+  .listener-header.has-incident { background: rgba(58,50,42,.3); border-color: #3a322a; color: var(--pyric-warning); }
+  .listener-rows { margin-top: 6px; }
+  .listener-row {
+    align-items: center;
+    border-bottom: 1px solid rgba(42,42,53,.7);
+    color: #d7d7df;
+    display: grid;
+    gap: 6px;
+    grid-template-columns: 16px minmax(0,1fr) minmax(0,1.2fr) 30px 34px 10px 24px 24px;
+    padding: 4px 0 4px 2px;
+  }
+  .listener-row:last-child { border-bottom: 0; }
+  .listener-row:hover { background: rgba(255,255,255,.05); }
+  .listener-number { color: var(--pyric-muted); font: 10px/18px ui-monospace, monospace; }
+  .listener-row.incident .listener-number, .listener-row.incident .listener-mark { color: var(--pyric-warning); }
+  .listener-label { font-size: 10px; line-height: 18px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .listener-target, .listener-count { font: 10px/18px ui-monospace, monospace; }
+  .listener-target { color: var(--pyric-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .listener-count { text-align: right; }
+  .listener-mark { font: 10px/18px ui-monospace, monospace; text-align: center; }
+  .listener-row .icon-button { height: 20px; width: 24px; }
+  .listener-row .icon-button .icon { height: 13px; width: 13px; }
+  .listener-link { align-self: flex-end; color: var(--pyric-muted); font-size: 11px; margin-top: 4px; text-decoration: none; }
   a.listener-link:hover { color: var(--pyric-text); }
   .listener-link[aria-disabled="true"] { cursor: not-allowed; opacity: .6; }
   .signal.error { color: var(--pyric-error); }
@@ -295,6 +317,7 @@ interface ListenerOwnerGroup {
   listeners: number;
   deliveries: number;
   targets: Set<string>;
+  incident: ListenerOutlineIncident | null;
 }
 
 /** The owner groups a Listeners panel lists, busiest by total deliveries
@@ -309,19 +332,18 @@ function listenerOwnerGroups(outlines: readonly ListenerOutline[]): ListenerOwne
       existing.listeners += 1;
       existing.deliveries += outline.deliveryCount;
       existing.targets.add(target);
+      existing.incident ??= outline.incident;
     } else {
-      groups.set(key, { key, listeners: 1, deliveries: outline.deliveryCount, targets: new Set([target]) });
+      groups.set(key, {
+        key,
+        listeners: 1,
+        deliveries: outline.deliveryCount,
+        targets: new Set([target]),
+        incident: outline.incident,
+      });
     }
   }
   return [...groups.values()].sort((a, b) => b.deliveries - a.deliveries || a.key.localeCompare(b.key));
-}
-
-/** `ChatPage · 4 listeners · 61 deliveries`, or, when every listener in the
- * group hits the same target, `ChatPage · users/u1 · 4 listeners · 61
- * deliveries` — the only way a single-listener group still names its target. */
-function listenerOwnerLine(group: ListenerOwnerGroup): string {
-  const target = group.targets.size === 1 ? ` · ${[...group.targets][0]}` : '';
-  return `${group.key}${target} · ${pluralize(group.listeners, 'listener')} · ${pluralize(group.deliveries, 'delivery', 'deliveries')}`;
 }
 
 /** `?view=listeners`, appended to whatever query string Studio's URL already carries. */
@@ -330,26 +352,129 @@ function studioListenersUrl(studioUrl: string): string {
   return `${studioUrl}${separator}view=listeners`;
 }
 
+/** One body row of the Listeners table. The columns line up across incident
+ * and owner rows, so the two read as one table. */
+interface ListenerTableRow {
+  /**
+   * Identifies the row across renders. It changes when the row's listener set
+   * changes, which is what brings a dismissed row back: a new attach moves an
+   * owner row's listener count, and a new incident moves the incident part.
+   */
+  signature: string;
+  isIncident: boolean;
+  label: string;
+  target: string;
+  /** The first count column: listeners for an owner row, attaches for an incident. */
+  first: string;
+  firstTitle: string;
+  /** The second count column: deliveries, empty on an incident row. */
+  second: string;
+  secondTitle: string;
+  mark: string;
+  markTitle: string;
+  copyText: string;
+}
+
+/** `duplicate ×2`, `churn ×40`: what an incident mark stands for. */
+function incidentMarkTitle(incident: ListenerOutlineIncident): string {
+  const word = incident.pattern === 'duplicate-listener' ? 'duplicate' : 'churn';
+  return `${word} ×${incident.count}`;
+}
+
+function incidentTableRow(group: ListenerIncidentGroup): ListenerTableRow {
+  const prose = listenerIncidentLine(group);
+  return {
+    signature: `incident:${group.pattern}:${group.target}:${group.count}:${group.windowMs}`,
+    isIncident: true,
+    label: group.pattern === 'duplicate-listener' ? 'duplicate' : 'churn',
+    target: group.target,
+    first: String(group.count),
+    firstTitle: prose,
+    second: '',
+    secondTitle: '',
+    mark: '!',
+    markTitle: prose,
+    copyText: prose,
+  };
+}
+
+function ownerTableRow(group: ListenerOwnerGroup): ListenerTableRow {
+  const target = group.targets.size === 1 ? [...group.targets][0] : `${group.targets.size} targets`;
+  const incidentSuffix = group.incident === null ? '' : ` · ${incidentMarkTitle(group.incident)}`;
+  const counts = `${pluralize(group.listeners, 'listener')} · ${pluralize(group.deliveries, 'delivery', 'deliveries')}`;
+  const incidentPart = group.incident === null
+    ? 'none'
+    : `${group.incident.pattern}:${group.incident.count}:${group.incident.windowMs}`;
+  return {
+    signature: `owner:${group.key}:${group.listeners}:${incidentPart}`,
+    isIncident: false,
+    label: group.key,
+    target,
+    first: String(group.listeners),
+    firstTitle: pluralize(group.listeners, 'listener'),
+    second: String(group.deliveries),
+    secondTitle: pluralize(group.deliveries, 'delivery', 'deliveries'),
+    mark: group.incident === null ? '' : '!',
+    markTitle: group.incident === null ? '' : incidentMarkTitle(group.incident),
+    copyText: `${group.key} · ${target} · ${counts}${incidentSuffix}`,
+  };
+}
+
 /**
- * The Listeners panel section: a header line, up to two incident lines, the
- * busiest owners filling what is left, and a link to Studio — six lines at
- * most. Incidents are kept first when the budget is tight, then owner
- * groups, and the Studio link always gets its line.
+ * The rows a Listeners panel shows, incidents first and then the busiest
+ * owners, minus the rows dismissed at their current signature. Four rows at
+ * most: the header and the Studio link take the other two of the six lines.
  */
-function listenerSectionHtml(outlines: readonly ListenerOutline[], studioUrl: string | null): string {
+function listenerTableRows(
+  outlines: readonly ListenerOutline[],
+  dismissed: ReadonlySet<string>,
+): ListenerTableRow[] {
+  const incidents = listenerIncidentGroups(outlines).slice(0, 2)
+    .map(incidentTableRow)
+    .filter((row) => !dismissed.has(row.signature));
+  const owners = listenerOwnerGroups(outlines)
+    .map(ownerTableRow)
+    .filter((row) => !dismissed.has(row.signature))
+    .slice(0, Math.max(0, 4 - incidents.length));
+  return [...incidents, ...owners];
+}
+
+function listenerRowHtml(row: ListenerTableRow, index: number, canCopy: boolean): string {
+  const ordinal = String(index + 1).padStart(2, '0');
+  const name = escapeAttribute(`${row.label} ${row.target}`);
+  return `<div class="listener-row${row.isIncident ? ' incident' : ''}" data-listener-row="${escapeAttribute(row.signature)}">
+      <span class="listener-number">${ordinal}</span>
+      <span class="listener-label" title="${escapeAttribute(row.label)}">${escapeAttribute(row.label)}</span>
+      <span class="listener-target" title="${escapeAttribute(row.target)}">${escapeAttribute(row.target)}</span>
+      <span class="listener-count" title="${escapeAttribute(row.firstTitle)}">${escapeAttribute(row.first)}</span>
+      <span class="listener-count" title="${escapeAttribute(row.secondTitle)}">${escapeAttribute(row.second)}</span>
+      <span class="listener-mark" title="${escapeAttribute(row.markTitle)}" aria-hidden="${row.mark === '' ? 'true' : 'false'}">${escapeAttribute(row.mark)}</span>
+      <button class="icon-button" type="button" data-copy-listener="${escapeAttribute(row.signature)}" aria-label="${canCopy ? `Copy ${name}` : 'Copy unavailable'}" title="${canCopy ? 'Copy listener row' : 'Clipboard unavailable'}" ${canCopy ? '' : 'disabled'}>${icons.copy}</button>
+      <button class="icon-button" type="button" data-dismiss-listener="${escapeAttribute(row.signature)}" aria-label="Dismiss ${name}" title="Dismiss listener row">${icons.close}</button>
+    </div>`;
+}
+
+/**
+ * The Listeners panel section: a header line, up to two incident rows, the
+ * busiest owners filling what is left, and a link to Studio, six lines at
+ * most. The rows share one grid so their columns line up.
+ */
+function listenerSectionHtml(
+  outlines: readonly ListenerOutline[],
+  studioUrl: string | null,
+  canCopy: boolean,
+  dismissed: ReadonlySet<string>,
+): string {
   const incidentGroups = listenerIncidentGroups(outlines);
   const duplicateCount = incidentGroups.filter((group) => group.pattern === 'duplicate-listener').length;
   const header = `${pluralize(outlines.length, 'listener')}${duplicateCount > 0 ? ` · ${pluralize(duplicateCount, 'duplicate')}` : ''}`;
-  const incidentLines = incidentGroups.slice(0, 2).map(listenerIncidentLine);
-  const ownerBudget = Math.max(0, 4 - incidentLines.length);
-  const ownerLines = listenerOwnerGroups(outlines).slice(0, ownerBudget).map(listenerOwnerLine);
+  const rows = listenerTableRows(outlines, dismissed);
   const linkHtml = studioUrl
-    ? `<a class="listener-line listener-link" data-open-listeners-studio href="${escapeAttribute(studioListenersUrl(studioUrl))}" target="_blank" rel="noopener noreferrer">All listeners in Studio</a>`
-    : `<span class="listener-line listener-link" data-open-listeners-studio aria-disabled="true" title="Pyric Studio is disabled">All listeners in Studio</span>`;
+    ? `<a class="listener-link" data-open-listeners-studio href="${escapeAttribute(studioListenersUrl(studioUrl))}" target="_blank" rel="noopener noreferrer">All listeners in Studio</a>`
+    : `<span class="listener-link" data-open-listeners-studio aria-disabled="true" title="Pyric Studio is disabled">All listeners in Studio</span>`;
   return `<div class="worker-state-col" data-listener-panel>
-      <div class="worker-state-row"><span class="state-label">${escapeAttribute(header)}</span></div>
-      ${incidentLines.map((line) => `<div class="listener-line">${escapeAttribute(line)}</div>`).join('')}
-      ${ownerLines.map((line) => `<div class="listener-row">${escapeAttribute(line)}</div>`).join('')}
+      <div class="worker-state-row"><span class="state-label listener-header${incidentGroups.length > 0 ? ' has-incident' : ''}">${escapeAttribute(header)}</span></div>
+      <div class="listener-rows">${rows.map((row, index) => listenerRowHtml(row, index, canCopy)).join('')}</div>
       ${linkHtml}
     </div>`;
 }
@@ -434,6 +559,10 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
   let everReportedListeners = false;
   /** Why the last Listeners toggle did nothing, shown until the next toggle. */
   let listenerNotice: string | null = null;
+  /** Signatures of the listener rows dismissed from the panel. A row comes
+   * back on its own once its signature moves, which a new attach on its
+   * target or a new incident does. */
+  const dismissedListenerRows = new Set<string>();
   const ensureListenerMode = (): ListenerMode | null => {
     if (listenerMode !== null) return listenerMode;
     const build = options.listeners;
@@ -473,10 +602,13 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
         }
       : null;
     const activeCopyId = active?.getAttribute('data-copy-error');
+    const activeCopyListener = active?.getAttribute('data-copy-listener');
     const activeControl = ['data-expand', 'data-collapse', 'data-update-worker', 'data-open-studio', 'data-open-impersonate']
       .find((attribute) => active?.hasAttribute(attribute));
     const focusToken = activeCopyId !== null && activeCopyId !== undefined
       ? { attribute: 'data-copy-error', value: activeCopyId }
+      : activeCopyListener !== null && activeCopyListener !== undefined
+      ? { attribute: 'data-copy-listener', value: activeCopyListener }
       : activeControl
         ? { attribute: activeControl, value: null }
         : null;
@@ -521,7 +653,7 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     } else if (listenersOn) {
       listenerPanelHtml = listenerOutlines.length === 0
         ? `<div class="worker-state-col" data-listener-panel><div class="worker-state-row"><span class="state-label">No listeners</span></div></div>`
-        : listenerSectionHtml(listenerOutlines, studioUrl ?? null);
+        : listenerSectionHtml(listenerOutlines, studioUrl ?? null, Boolean(clipboard), dismissedListenerRows);
     }
     const hasListenerIncident = listenerOutlines.some((outline) => outline.incident !== null);
     const listenerCountHtml = everReportedListeners && (listenerOutlines.length > 0 || listenersOn)
@@ -631,6 +763,26 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
           button.setAttribute('aria-label', 'Copy failed');
           button.title = 'Copy failed';
         });
+      });
+    }
+    for (const button of root.querySelectorAll<HTMLButtonElement>('[data-copy-listener]')) {
+      button.addEventListener('click', () => {
+        const signature = button.dataset.copyListener;
+        const row = listenerTableRows(listenerOutlines, dismissedListenerRows)
+          .find((candidate) => candidate.signature === signature);
+        if (!row || !clipboard) return;
+        void clipboard.writeText(row.copyText).catch(() => {
+          button.setAttribute('data-copy-failed', '');
+          button.setAttribute('aria-label', 'Copy failed');
+          button.title = 'Copy failed';
+        });
+      });
+    }
+    for (const button of root.querySelectorAll<HTMLButtonElement>('[data-dismiss-listener]')) {
+      button.addEventListener('click', () => {
+        if (!button.dataset.dismissListener) return;
+        dismissedListenerRows.add(button.dataset.dismissListener);
+        render();
       });
     }
     for (const button of root.querySelectorAll<HTMLButtonElement>('[data-dismiss-error]')) {

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -294,6 +294,8 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
 
   let listenerMode: ListenerMode | null = null;
   let unattributedListeners: readonly ListenerOutline[] = [];
+  /** Why the last Listeners toggle did nothing, shown until the next toggle. */
+  let listenerNotice: string | null = null;
   const ensureListenerMode = (): ListenerMode | null => {
     if (listenerMode !== null) return listenerMode;
     const build = options.listeners;
@@ -376,6 +378,9 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       listenersButtonHtml = `<button class="button" type="button" data-toggle-listeners aria-pressed="${listenersOn}">Listeners</button>`;
     }
     let listenerPanelHtml = '';
+    if (listenerNotice !== null) {
+      listenerPanelHtml = `<div class="worker-state-col" data-listener-notice><div class="worker-state-row"><span class="state-label">${escapeAttribute(listenerNotice)}</span></div></div>`;
+    }
     if (listenersOn && unattributedListeners.length > 0) {
       const rows = unattributedListeners.map((outline) => {
         const target = outline.isQuery ? `${outline.target} (query)` : outline.target;
@@ -425,7 +430,7 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       </button>
     `}`;
 
-    const announcement = `${workerLabel}. ${errorCount === 0 ? 'No runtime errors' : `${errorCount} runtime ${errorCount === 1 ? 'error' : 'errors'}`}.`;
+    const announcement = `${workerLabel}. ${errorCount === 0 ? 'No runtime errors' : `${errorCount} runtime ${errorCount === 1 ? 'error' : 'errors'}`}.${listenerNotice === null ? '' : ` ${listenerNotice}`}`;
     if (announcer.textContent !== announcement) announcer.textContent = announcement;
     const newViewport = view.querySelector<HTMLElement>('[data-error-viewport]');
     if (oldScroll && newViewport) {
@@ -469,7 +474,13 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     root.querySelector('[data-toggle-listeners]')?.addEventListener('click', () => {
       const mode = ensureListenerMode();
       if (mode === null) return;
-      mode.setEnabled(!mode.enabled());
+      const wanted = !mode.enabled();
+      mode.setEnabled(wanted);
+      // The mode refuses to start when attribution is off; say so rather than
+      // rebuilding the panel with nothing changed.
+      listenerNotice = wanted && !mode.enabled()
+        ? 'Listener attribution is off in this build, so there are no owners to outline.'
+        : null;
       if (!mode.enabled()) unattributedListeners = [];
       render();
     });

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -149,7 +149,11 @@ const styles = `
   .worker-state-col { border-top: 1px solid var(--pyric-border-soft); color: var(--pyric-muted); font-size: 10px; display: flex; flex-direction: column; min-height: 34px; padding: 7px 12px; }
   .worker-state-row { align-items: center; display: flex; justify-content: space-between; width: 100%; }
   .worker-state-subline { color: #89899f; font: 9px/1.4 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; text-align: right; width: 100%; }
-  .listener-row { color: #d7d7df; display: flex; font: 9px/1.6 ui-monospace, monospace; gap: 8px; justify-content: space-between; margin-top: 4px; overflow-wrap: anywhere; }
+  .listener-line, .listener-row { color: #d7d7df; display: block; font: 9px/1.6 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; }
+  .listener-link { color: var(--pyric-muted); text-decoration: none; }
+  a.listener-link:hover { color: var(--pyric-text); }
+  .listener-link[aria-disabled="true"] { cursor: not-allowed; opacity: .6; }
+  .signal.error { color: var(--pyric-error); }
   .button[aria-pressed="true"] { background: rgba(25,204,97,.12); border-color: rgba(25,204,97,.4); color: var(--pyric-accent); }
   .worker-state .available { color: var(--pyric-warning); }
   .worker-state .state-label, .worker-state-col .state-label { align-items: center; display: flex; gap: 7px; white-space: nowrap; }
@@ -213,10 +217,141 @@ export function formatPyricRuntimeError(error: PyricRuntimeError): string {
   return `${error.message}${context ? `\n${context}` : ''}${error.stack ? `\n${error.stack}` : ''}`;
 }
 
-/** `true` when two off-screen listener lists would render the same rows. */
+/** `true` when two listener lists would render the same Listeners summary. */
 function sameOutlines(a: readonly ListenerOutline[], b: readonly ListenerOutline[]): boolean {
   if (a.length !== b.length) return false;
-  return a.every((outline, i) => outline.listenerId === b[i].listenerId && outline.label === b[i].label && outline.target === b[i].target && outline.deliveryCount === b[i].deliveryCount);
+  return a.every((outline, i) => {
+    const other = b[i];
+    return outline.listenerId === other.listenerId
+      && outline.label === other.label
+      && outline.labelIsOwner === other.labelIsOwner
+      && outline.target === other.target
+      && outline.isQuery === other.isQuery
+      && outline.deliveryCount === other.deliveryCount
+      && outline.incident?.pattern === other.incident?.pattern
+      && outline.incident?.count === other.incident?.count
+      && outline.incident?.windowMs === other.incident?.windowMs;
+  });
+}
+
+/** `12 listeners`, `1 listener`, `2 duplicates`, etc. */
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/** The target the way the app wrote it: `conversations (query)`, `users/u1`. */
+function displayTarget(outline: ListenerOutline): string {
+  return outline.isQuery ? `${outline.target} (query)` : outline.target;
+}
+
+/** The group a listener's owner row belongs under: its owner label, or its
+ * target when nothing on the page named it. */
+function groupKey(outline: ListenerOutline): string {
+  return outline.labelIsOwner ? outline.label : displayTarget(outline);
+}
+
+interface ListenerIncidentGroup {
+  pattern: 'duplicate-listener' | 'listener-churn';
+  target: string;
+  label: string | null;
+  count: number;
+  windowMs: number;
+}
+
+/** One incident line per distinct (pattern, target, count) triple, so a
+ * duplicate or churn incident shared by several listeners reads once. */
+function listenerIncidentGroups(outlines: readonly ListenerOutline[]): ListenerIncidentGroup[] {
+  const groups = new Map<string, ListenerIncidentGroup>();
+  for (const outline of outlines) {
+    const incident = outline.incident;
+    if (incident === null) continue;
+    const target = displayTarget(outline);
+    const key = `${incident.pattern}:${target}:${incident.count}:${incident.windowMs}`;
+    if (groups.has(key)) continue;
+    groups.set(key, {
+      pattern: incident.pattern,
+      target,
+      label: outline.labelIsOwner ? outline.label : null,
+      count: incident.count,
+      windowMs: incident.windowMs,
+    });
+  }
+  return [...groups.values()];
+}
+
+function listenerIncidentLine(group: ListenerIncidentGroup): string {
+  if (group.pattern === 'duplicate-listener') {
+    const times = group.count === 2 ? 'twice' : `${group.count} times`;
+    const by = group.label !== null ? ` by ${group.label}` : '';
+    return `${group.target} attached ${times}${by}`;
+  }
+  const seconds = Math.round(group.windowMs / 1000);
+  const duration = seconds > 0 ? `${seconds}s` : `${group.windowMs}ms`;
+  return `${group.target} reattached ${group.count} times in ${duration}`;
+}
+
+interface ListenerOwnerGroup {
+  key: string;
+  listeners: number;
+  deliveries: number;
+  targets: Set<string>;
+}
+
+/** The owner groups a Listeners panel lists, busiest by total deliveries
+ * first. */
+function listenerOwnerGroups(outlines: readonly ListenerOutline[]): ListenerOwnerGroup[] {
+  const groups = new Map<string, ListenerOwnerGroup>();
+  for (const outline of outlines) {
+    const key = groupKey(outline);
+    const target = displayTarget(outline);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.listeners += 1;
+      existing.deliveries += outline.deliveryCount;
+      existing.targets.add(target);
+    } else {
+      groups.set(key, { key, listeners: 1, deliveries: outline.deliveryCount, targets: new Set([target]) });
+    }
+  }
+  return [...groups.values()].sort((a, b) => b.deliveries - a.deliveries || a.key.localeCompare(b.key));
+}
+
+/** `ChatPage · 4 listeners · 61 deliveries`, or, when every listener in the
+ * group hits the same target, `ChatPage · users/u1 · 4 listeners · 61
+ * deliveries` — the only way a single-listener group still names its target. */
+function listenerOwnerLine(group: ListenerOwnerGroup): string {
+  const target = group.targets.size === 1 ? ` · ${[...group.targets][0]}` : '';
+  return `${group.key}${target} · ${pluralize(group.listeners, 'listener')} · ${pluralize(group.deliveries, 'delivery', 'deliveries')}`;
+}
+
+/** `?view=listeners`, appended to whatever query string Studio's URL already carries. */
+function studioListenersUrl(studioUrl: string): string {
+  const separator = studioUrl.includes('?') ? '&' : '?';
+  return `${studioUrl}${separator}view=listeners`;
+}
+
+/**
+ * The Listeners panel section: a header line, up to two incident lines, the
+ * busiest owners filling what is left, and a link to Studio — six lines at
+ * most. Incidents are kept first when the budget is tight, then owner
+ * groups, and the Studio link always gets its line.
+ */
+function listenerSectionHtml(outlines: readonly ListenerOutline[], studioUrl: string | null): string {
+  const incidentGroups = listenerIncidentGroups(outlines);
+  const duplicateCount = incidentGroups.filter((group) => group.pattern === 'duplicate-listener').length;
+  const header = `${pluralize(outlines.length, 'listener')}${duplicateCount > 0 ? ` · ${pluralize(duplicateCount, 'duplicate')}` : ''}`;
+  const incidentLines = incidentGroups.slice(0, 2).map(listenerIncidentLine);
+  const ownerBudget = Math.max(0, 4 - incidentLines.length);
+  const ownerLines = listenerOwnerGroups(outlines).slice(0, ownerBudget).map(listenerOwnerLine);
+  const linkHtml = studioUrl
+    ? `<a class="listener-line listener-link" data-open-listeners-studio href="${escapeAttribute(studioListenersUrl(studioUrl))}" target="_blank" rel="noopener noreferrer">All listeners in Studio</a>`
+    : `<span class="listener-line listener-link" data-open-listeners-studio aria-disabled="true" title="Pyric Studio is disabled">All listeners in Studio</span>`;
+  return `<div class="worker-state-col" data-listener-panel>
+      <div class="worker-state-row"><span class="state-label">${escapeAttribute(header)}</span></div>
+      ${incidentLines.map((line) => `<div class="listener-line">${escapeAttribute(line)}</div>`).join('')}
+      ${ownerLines.map((line) => `<div class="listener-row">${escapeAttribute(line)}</div>`).join('')}
+      ${linkHtml}
+    </div>`;
 }
 
 function renderErrors(snapshot: PyricRuntimeSnapshot, canCopy: boolean): string {
@@ -293,7 +428,10 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
   };
 
   let listenerMode: ListenerMode | null = null;
-  let unattributedListeners: readonly ListenerOutline[] = [];
+  let listenerOutlines: readonly ListenerOutline[] = [];
+  /** `true` once the Listeners mode has reported at least once. The collapsed
+   * chip's listener count stays hidden until then. */
+  let everReportedListeners = false;
   /** Why the last Listeners toggle did nothing, shown until the next toggle. */
   let listenerNotice: string | null = null;
   const ensureListenerMode = (): ListenerMode | null => {
@@ -301,11 +439,11 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     const build = options.listeners;
     if (build === undefined) return null;
     listenerMode = build((outlines) => {
-      const next = outlines.filter((outline) => outline.selectors.length === 0);
-      // The mode reports on every attach, delivery, and resize; the chip only
-      // shows the off-screen list, so rebuild the view only when that changes.
-      if (sameOutlines(next, unattributedListeners)) return;
-      unattributedListeners = next;
+      everReportedListeners = true;
+      // The mode reports on every attach, delivery, and resize; rebuild the
+      // view only when what the Listeners summary shows actually changes.
+      if (sameOutlines(outlines, listenerOutlines)) return;
+      listenerOutlines = outlines;
       render();
     });
     return listenerMode;
@@ -380,18 +518,15 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     let listenerPanelHtml = '';
     if (listenerNotice !== null) {
       listenerPanelHtml = `<div class="worker-state-col" data-listener-notice><div class="worker-state-row"><span class="state-label">${escapeAttribute(listenerNotice)}</span></div></div>`;
+    } else if (listenersOn) {
+      listenerPanelHtml = listenerOutlines.length === 0
+        ? `<div class="worker-state-col" data-listener-panel><div class="worker-state-row"><span class="state-label">No listeners</span></div></div>`
+        : listenerSectionHtml(listenerOutlines, studioUrl ?? null);
     }
-    if (listenersOn && unattributedListeners.length > 0) {
-      const rows = unattributedListeners.map((outline) => {
-        const target = outline.isQuery ? `${outline.target} (query)` : outline.target;
-        return `<div class="listener-row"><span>${escapeAttribute(outline.label)}</span><span>${escapeAttribute(target)}</span></div>`;
-      }).join('');
-      listenerPanelHtml = `<div class="worker-state-col" data-listener-panel>
-          <div class="worker-state-row"><span class="state-label">Listeners off screen</span><span class="epochs">${unattributedListeners.length}</span></div>
-          ${rows}
-          <div class="worker-state-subline">Nothing on the page could be outlined for these.</div>
-        </div>`;
-    }
+    const hasListenerIncident = listenerOutlines.some((outline) => outline.incident !== null);
+    const listenerCountHtml = everReportedListeners && (listenerOutlines.length > 0 || listenersOn)
+      ? `<span class="signal${hasListenerIncident ? ' error' : ''}" data-listener-count>${pluralize(listenerOutlines.length, 'listener')}</span>`
+      : '';
 
     view.innerHTML = `${open ? `
       <section class="panel" role="dialog" aria-label="pyric">
@@ -426,7 +561,7 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     ` : `
       <button class="chip" type="button" data-expand aria-label="Open pyric" aria-expanded="false">
         <span class="brand"><span class="dot${errorCount > 0 ? ' error' : ''}"></span><span class="brand-label">pyric</span></span>
-        <span class="signals">${identitySignalHtml}${snapshot.updateAvailable ? '<span class="signal update">update</span>' : ''}${errorCount > 0 ? `<span class="signal">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span>` : ''}${icons.chevron}</span>
+        <span class="signals">${identitySignalHtml}${listenerCountHtml}${snapshot.updateAvailable ? '<span class="signal update">update</span>' : ''}${errorCount > 0 ? `<span class="signal">${errorCount} ${errorCount === 1 ? 'error' : 'errors'}</span>` : ''}${icons.chevron}</span>
       </button>
     `}`;
 
@@ -481,7 +616,7 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       listenerNotice = wanted && !mode.enabled()
         ? 'Listener attribution is off in this build, so there are no owners to outline.'
         : null;
-      if (!mode.enabled()) unattributedListeners = [];
+      if (!mode.enabled()) listenerOutlines = [];
       render();
     });
     root.querySelector('[data-open-impersonate]')?.addEventListener('click', (e) => {

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -650,13 +650,13 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     let listenerPanelHtml = '';
     if (listenerNotice !== null) {
       listenerPanelHtml = `<div class="worker-state-col" data-listener-notice><div class="worker-state-row"><span class="state-label">${escapeAttribute(listenerNotice)}</span></div></div>`;
-    } else if (listenersOn) {
+    } else if (listenerMode !== null) {
       listenerPanelHtml = listenerOutlines.length === 0
         ? `<div class="worker-state-col" data-listener-panel><div class="worker-state-row"><span class="state-label">No listeners</span></div></div>`
         : listenerSectionHtml(listenerOutlines, studioUrl ?? null, Boolean(clipboard), dismissedListenerRows);
     }
     const hasListenerIncident = listenerOutlines.some((outline) => outline.incident !== null);
-    const listenerCountHtml = everReportedListeners && (listenerOutlines.length > 0 || listenersOn)
+    const listenerCountHtml = everReportedListeners
       ? `<span class="signal${hasListenerIncident ? ' error' : ''}" data-listener-count>${pluralize(listenerOutlines.length, 'listener')}</span>`
       : '';
 
@@ -810,6 +810,10 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
   const unsubLens = subscribeLensFn(() => {
     render();
   });
+
+  // The Listeners summary and the collapsed count read the mode's fold, so the
+  // mode exists from the start; the button only toggles the outlines.
+  ensureListenerMode();
 
   const unsubAuth = identity.subscribeAuth((user) => {
     clientUser = user;

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -183,7 +183,8 @@ const styles = `
     .worker-state { align-items: flex-start; flex-direction: column; gap: 4px; }
   }
   @media (prefers-reduced-motion: no-preference) {
-    .chip, .panel { animation: pyric-enter 120ms ease-out; transform-origin: bottom right; }
+    .chip, .panel { transform-origin: bottom right; }
+    .entering { animation: pyric-enter 120ms ease-out; }
     @keyframes pyric-enter { from { opacity: 0; transform: translateY(4px) scale(.98); } }
   }
 
@@ -210,6 +211,12 @@ export function formatPyricRuntimeError(error: PyricRuntimeError): string {
     error.code,
   ].filter(Boolean).join(' · ');
   return `${error.message}${context ? `\n${context}` : ''}${error.stack ? `\n${error.stack}` : ''}`;
+}
+
+/** `true` when two off-screen listener lists would render the same rows. */
+function sameOutlines(a: readonly ListenerOutline[], b: readonly ListenerOutline[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((outline, i) => outline.listenerId === b[i].listenerId && outline.label === b[i].label && outline.target === b[i].target && outline.deliveryCount === b[i].deliveryCount);
 }
 
 function renderErrors(snapshot: PyricRuntimeSnapshot, canCopy: boolean): string {
@@ -251,6 +258,8 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     ? options.studioUrl
     : options.runtime.getSnapshot().manifest.studioUrl;
   let open = options.initiallyOpen ?? false;
+  /** The `open` value the view was last built for; the enter animation plays only when it changes. */
+  let renderedOpen: boolean | null = null;
   let snapshot = options.runtime.getSnapshot();
 
   const getLensFn = options.getLens ?? defaultGetLens;
@@ -290,7 +299,11 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     const build = options.listeners;
     if (build === undefined) return null;
     listenerMode = build((outlines) => {
-      unattributedListeners = outlines.filter((outline) => outline.selectors.length === 0);
+      const next = outlines.filter((outline) => outline.selectors.length === 0);
+      // The mode reports on every attach, delivery, and resize; the chip only
+      // shows the off-screen list, so rebuild the view only when that changes.
+      if (sameOutlines(next, unattributedListeners)) return;
+      unattributedListeners = next;
       render();
     });
     return listenerMode;
@@ -426,6 +439,11 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       const meta = row?.querySelector('.error-meta');
       if (code) code.textContent = error.message;
       if (meta) meta.textContent = [error.source, error.service && error.method ? `${error.service}.${error.method}` : error.service ?? error.method, error.path, error.code].filter(Boolean).join(' · ');
+    }
+
+    if (renderedOpen !== open) {
+      view.querySelector(open ? '.panel' : '.chip')?.classList.add('entering');
+      renderedOpen = open;
     }
 
     root.querySelector('[data-expand]')?.addEventListener('click', () => {

--- a/packages/cli/src/serve/runtime/listener-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-mode.ts
@@ -88,22 +88,23 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
     options.onChange?.(current);
   };
 
-  const stop = (): void => {
-    unsubscribe?.();
-    unsubscribe = null;
+  // The mode observes from the moment it exists: the chip's count and summary
+  // read the fold whether or not anything is outlined. Enabling the mode only
+  // adds the overlay on top of a fold that is already current.
+  unsubscribe = options.subscribeEvents((batch) => {
+    events.push(...batch);
+    recompute();
+  });
+  recompute();
+
+  const hideOutlines = (): void => {
     overlay?.dispose();
     overlay = null;
-    events.length = 0;
-    current = [];
   };
 
-  const start = (): void => {
+  const showOutlines = (): void => {
     overlay = createListenerOverlay({ document: documentLike, onSelect: openStudio });
-    unsubscribe = options.subscribeEvents((batch) => {
-      events.push(...batch);
-      recompute();
-    });
-    recompute();
+    overlay.update(current);
   };
 
   return {
@@ -111,11 +112,11 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       const isOn = overlay !== null;
       if (next === isOn) return;
       if (!next) {
-        stop();
+        hideOutlines();
         return;
       }
       if (!readAttribution()) return;
-      start();
+      showOutlines();
     },
     enabled() {
       return overlay !== null;
@@ -127,7 +128,11 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       return current.filter((outline) => outline.selectors.length === 0);
     },
     dispose() {
-      stop();
+      hideOutlines();
+      unsubscribe?.();
+      unsubscribe = null;
+      events.length = 0;
+      current = [];
     },
   };
 }

--- a/packages/cli/src/serve/runtime/listener-outline-model.ts
+++ b/packages/cli/src/serve/runtime/listener-outline-model.ts
@@ -48,6 +48,8 @@ interface RegionsOwner {
 export interface ListenerOutlineIncident {
   readonly pattern: 'duplicate-listener' | 'listener-churn';
   readonly count: number;
+  /** The window the count was measured over, in milliseconds. */
+  readonly windowMs: number;
 }
 
 /** One listener as the overlay draws it. */
@@ -55,6 +57,12 @@ export interface ListenerOutline {
   readonly listenerId: string;
   /** Component name, else owner tag name, else creating function or file. */
   readonly label: string;
+  /**
+   * `true` when `label` names an owner the app itself gave (a component or a
+   * tag). `false` means the label fell back to a frame's function or file
+   * name, or to the listener id, none of which the app wrote.
+   */
+  readonly labelIsOwner: boolean;
   /** Collection path for a query, document or node path otherwise. */
   readonly target: string;
   readonly isQuery: boolean;
@@ -109,6 +117,16 @@ function outlineLabel(owners: readonly unknown[], listenerId: string): string {
   return frame.file;
 }
 
+/**
+ * `true` when the label the app would see names an owner it gave itself (a
+ * component or a tag), rather than a frame's function or file name, or the
+ * listener id, both of which describe the sandbox's own bundle rather than
+ * anything the app wrote.
+ */
+function labelIsOwner(owners: readonly unknown[]): boolean {
+  return componentOwner(owners) !== null || tagOwner(owners) !== null;
+}
+
 /** The geometry, most specific owner first, then the latest delivery's regions. */
 function outlineSelectors(owners: readonly unknown[]): readonly string[] {
   const component = componentOwner(owners);
@@ -154,7 +172,7 @@ function incidentMark(
     const isListenerPattern = incident.pattern === 'duplicate-listener' || incident.pattern === 'listener-churn';
     if (!isListenerPattern) continue;
     if (!incident.evidenceEventIds.includes(attachEventId)) continue;
-    return { pattern: incident.pattern, count: incident.count };
+    return { pattern: incident.pattern, count: incident.count, windowMs: incident.windowMs };
   }
   return null;
 }
@@ -168,6 +186,7 @@ function outlineFor(
   return {
     listenerId: listener.id,
     label: outlineLabel(owners, listener.id),
+    labelIsOwner: labelIsOwner(owners),
     target: targetPath(listener.target),
     isQuery: targetIsQuery(listener.target),
     service: listener.service,

--- a/packages/cli/src/serve/worker/client/firestore-reads.ts
+++ b/packages/cli/src/serve/worker/client/firestore-reads.ts
@@ -12,6 +12,7 @@ import type {
 } from '../protocol.js';
 import { closeSubscription, nextId, nextSubId, dataRpc, _defaultLens, subscribeLens, openSnapshotSubscription, stampIssuer } from './core.js';
 import type { ClientDb, DocRefHandle, CollRefHandle, QueryHandle, Unsubscribe } from './handles.js';
+import { pageListenerOwners } from './listener-owners.js';
 import { makeDocSnapshot, makeQuerySnapshot } from './snapshots.js';
 import type { RawDocResult, RawQueryResult, ClientDocSnapshot, ClientQuerySnapshot } from './snapshots.js';
 
@@ -130,8 +131,8 @@ type SnapshotErrorCallback = (err: unknown) => void;
  * including its options-second form `onSnapshot(target, options, next,
  * error)`: `@pyric/ui`'s hooks pass `{ owner }` there for listener
  * attribution, and a caller injecting this client as the hooks' backend must
- * not lose its callback to that slot. The options are accepted and dropped;
- * the worker protocol carries no listener owner yet.
+ * not lose its callback to that slot. The owners are derived here, on the page
+ * whose stack and DOM they describe, and travel with the subscribe message.
  *
  * Returns an `unsub` function. Sends `{ t:'unsub', subId }` to the worker
  * to deregister the listener on the worker side.
@@ -153,6 +154,10 @@ export function onSnapshot(
   callbackOrError?: SnapshotCallback | SnapshotErrorCallback,
   maybeError?: SnapshotErrorCallback,
 ): Unsubscribe {
+  const listenOptions = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+  // Derived before the message is built: `captureCreationFrame` reads the
+  // stack this call is still on.
+  const owners = pageListenerOwners(listenOptions);
   const callback = (typeof optionsOrCallback === 'function'
     ? optionsOrCallback
     : callbackOrError) as SnapshotCallback;
@@ -189,8 +194,8 @@ export function onSnapshot(
     subscription,
     stampIssuer(
       (_defaultLens
-        ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: _defaultLens }
-        : { t: 'sub', subId: currentSubId, target: descriptor }) satisfies InboundMessage,
+        ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: _defaultLens, ...(owners ? { owners } : {}) }
+        : { t: 'sub', subId: currentSubId, target: descriptor, ...(owners ? { owners } : {}) }) satisfies InboundMessage,
     ),
   );
   if (!opened && errorCallback) queueMicrotask(() => errorCallback(new Error('Firebase App was deleted')));
@@ -206,8 +211,8 @@ export function onSnapshot(
       subscription,
       stampIssuer(
         (newLens
-          ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: newLens }
-          : { t: 'sub', subId: currentSubId, target: descriptor }) satisfies InboundMessage,
+          ? { t: 'sub', subId: currentSubId, target: descriptor, actAs: newLens, ...(owners ? { owners } : {}) }
+          : { t: 'sub', subId: currentSubId, target: descriptor, ...(owners ? { owners } : {}) }) satisfies InboundMessage,
       ),
     );
     if (!reopened && errorCallback) {

--- a/packages/cli/src/serve/worker/client/listener-owners.ts
+++ b/packages/cli/src/serve/worker/client/listener-owners.ts
@@ -1,0 +1,90 @@
+/**
+ * Listener owners, derived on the page rather than in the worker.
+ *
+ * The in-page sandbox attaches a listener in the same context as the call, so
+ * it reads the calling frame off its own stack, takes the `owner` the caller
+ * passed, and turns an element owner into a selector against the live
+ * document. On a served page none of that is true where the attach happens:
+ * the sandbox runs in a SharedWorker, the stack there belongs to the worker
+ * bundle, the caller's options never crossed the port, and there is no DOM to
+ * select against.
+ *
+ * So the client derives the owners here, where the call actually happened, and
+ * sends them with the subscribe message. The derivation is pyric's own,
+ * reached through `pyric/sandbox/internal`, so a served page and an in-page
+ * sandbox produce the same owners for the same call.
+ */
+import {
+  callerFrameFromStack,
+  listenerAttributionEnabled,
+  tagOwnerFor,
+} from 'pyric/sandbox/internal';
+import type { ListenerOwner } from 'pyric/sandbox';
+
+/** The listen options a caller may pass, as far as attribution is concerned. */
+export interface OwnerBearingOptions {
+  readonly owner?: unknown;
+}
+
+/**
+ * The directory this client is served from.
+ *
+ * `callerFrameFromStack` skips pyric's own frames, but between the application
+ * and pyric there are also this client's frames, which are the CLI's and which
+ * pyric cannot recognize. They all share one directory: under source that is
+ * `.../serve/worker/client`, and on a served page it is the directory the SDK
+ * bundle is served from, which the application's own modules are never in.
+ * Empty when a bundler erased `import.meta.url`, in which case the filter
+ * falls back to pyric's own.
+ */
+const CLIENT_ROOT = clientRoot();
+
+function clientRoot(): string {
+  let here: string | undefined;
+  try {
+    const url = (import.meta as { url?: unknown }).url;
+    if (typeof url === 'string') here = url;
+  } catch {
+    here = undefined;
+  }
+  if (here === undefined) return '';
+  const directory = here.slice(0, here.lastIndexOf('/'));
+  return directory.startsWith('file://') ? directory.slice('file://'.length) : directory;
+}
+
+/** A stack with this client's own frames removed, for pyric to read. */
+function callerStack(stack: string): string {
+  if (CLIENT_ROOT.length === 0) return stack;
+  return stack.split('\n').filter((line) => !line.includes(CLIENT_ROOT)).join('\n');
+}
+
+/**
+ * The owners for a listener the page is about to open, in the same order the
+ * in-page path records them: the calling frame first, then the explicit owner.
+ * `undefined` when neither is known, so the subscribe message omits the field.
+ *
+ * Frame capture follows the attribution switch exactly as the in-page path
+ * does. The explicit owner is not gated: the caller asked for it by name.
+ *
+ * Every owner returned is plain JSON. An element owner is already reduced to a
+ * selector by `tagOwnerFor`, so no DOM node is ever put on the wire.
+ */
+export function pageListenerOwners(
+  options: OwnerBearingOptions | undefined,
+): ListenerOwner[] | undefined {
+  const owners: ListenerOwner[] = [];
+  const frame = pageCreationFrame();
+  if (frame !== undefined) owners.push(frame);
+  const explicit = tagOwnerFor(options?.owner as Parameters<typeof tagOwnerFor>[0]);
+  if (explicit !== undefined) owners.push(explicit);
+  if (owners.length === 0) return undefined;
+  return owners;
+}
+
+/** The application frame that opened the listener, read from this call's stack. */
+function pageCreationFrame(): ListenerOwner | undefined {
+  if (!listenerAttributionEnabled()) return undefined;
+  const stack = new Error().stack;
+  if (typeof stack !== 'string') return undefined;
+  return callerFrameFromStack(callerStack(stack));
+}

--- a/packages/cli/src/serve/worker/client/rtdb-listeners.ts
+++ b/packages/cli/src/serve/worker/client/rtdb-listeners.ts
@@ -11,6 +11,7 @@ import {
   subscribeLens,
 } from './core.js';
 import type { ClientPort, RtdbDataSnapshot, Unsubscribe } from './handles.js';
+import { pageListenerOwners } from './listener-owners.js';
 import {
   isRtdbQuery,
   rtdbChild,
@@ -54,6 +55,13 @@ function targetScope(target: RtdbTarget): string {
   return queryIdentifier(target._spec);
 }
 
+/**
+ * The listen options a value subscription reads. `owner` is pyric's own listen
+ * option: the page names who owns the listener, and the owners derived from it
+ * travel with the subscribe message.
+ */
+type ValueListenOptions = { readonly onlyOnce?: boolean; readonly owner?: unknown };
+
 function removeRegistration(registration: ListenerRegistration): void {
   const index = registrations.indexOf(registration);
   if (index >= 0) registrations.splice(index, 1);
@@ -62,8 +70,8 @@ function removeRegistration(registration: ListenerRegistration): void {
 function openValueSubscription(
   target: RtdbTarget,
   next: (snap: RtdbDataSnapshot) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
 ): Unsubscribe {
   const { ref, query } = targetParts(target);
   const error = typeof cancelCallbackOrOptions === 'function' ? cancelCallbackOrOptions : undefined;
@@ -74,10 +82,15 @@ function openValueSubscription(
   let fired = false;
   let unsubscribed = false;
 
+  // Derived here, on the stack the caller is still on and against the page's
+  // own document. The worker's attach can read neither.
+  const owners = pageListenerOwners(listenOptions);
+  const ownerFields = owners ? { owners } : {};
+
   const makeSubMsg = (subId: string, lens: typeof _defaultLens): InboundMessage =>
     lens
-      ? { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, actAs: lens }
-      : { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) } };
+      ? { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, actAs: lens, ...ownerFields }
+      : { t: 'sub', subId, target: { service: 'rtdb', path: ref.path, ...(query ? { query } : {}) }, ...ownerFields };
 
   let unsubLens: () => void = () => {};
 
@@ -153,8 +166,8 @@ function registerListener(
 export function rtdbOnValue(
   target: RtdbTarget,
   next: (snap: RtdbDataSnapshot) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
   registryCallback: object = next,
 ): Unsubscribe {
   const listenOptions = typeof cancelCallbackOrOptions === 'function'
@@ -297,8 +310,8 @@ function subscribeChild(
   target: RtdbTarget,
   kind: ChildEventKind,
   next: (snap: RtdbDataSnapshot, previousChildName: string | null) => void,
-  cancelCallbackOrOptions?: ((err: unknown) => void) | { readonly onlyOnce?: boolean },
-  options?: { readonly onlyOnce?: boolean },
+  cancelCallbackOrOptions?: ((err: unknown) => void) | ValueListenOptions,
+  options?: ValueListenOptions,
   registryCallback: object = next,
 ): Unsubscribe {
   const error = typeof cancelCallbackOrOptions === 'function' ? cancelCallbackOrOptions : undefined;

--- a/packages/cli/src/serve/worker/host/subscriptions.ts
+++ b/packages/cli/src/serve/worker/host/subscriptions.ts
@@ -176,6 +176,8 @@ export function handleRtdbSub(ctx: HostCtx, port: PortLike, msg: RtdbValueSubMes
       ref as DatabaseReference | RtdbQuery,
       (snap) => post(port, { t: 'snap', subId: msg.subId, value: rtdbSnapToWire(snap) }),
       (err) => post(port, { t: 'snap', subId: msg.subId, value: { __error: serializeError(err) } }),
+      // Same reason as the Firestore path: the owners belong to the page.
+      { ...(msg.owners ? { owners: msg.owners } : {}) },
     );
 
     if (!msg.actAs || msg.actAs.mode === 'app-session') {
@@ -200,6 +202,10 @@ function registerListener(
 ): () => void {
   return onSnapshot(
     target as DocumentReference | Query,
+    // The page derived the owners where its stack and its DOM are. Handing
+    // them over makes the sandbox record those instead of capturing a frame
+    // out of this worker's own bundle.
+    { ...(msg.owners ? { owners: msg.owners } : {}) },
     (snap) => {
       // Detect doc vs query snapshot by shape.
       const snapAny = snap as {

--- a/packages/cli/src/serve/worker/protocol.ts
+++ b/packages/cli/src/serve/worker/protocol.ts
@@ -23,7 +23,13 @@ import type {
   ResolvedIdentity,
   AuthSubMessage,
 } from './protocol/auth.js';
-import type { AuthLens, SandboxClockState, SandboxEvent, DenialContext } from 'pyric/sandbox';
+import type {
+  AuthLens,
+  ListenerOwner,
+  SandboxClockState,
+  SandboxEvent,
+  DenialContext,
+} from 'pyric/sandbox';
 import type { Query as RtdbQuery } from 'pyric/database';
 import type {
   BrokerMessage,
@@ -255,6 +261,8 @@ export interface RtdbValueSubMessage {
   subId: string;
   target: { service: 'rtdb'; path: string; query?: RtdbQuerySpec };
   actAs?: AuthLens;
+  /** The listener's owners, derived on the page. See {@link FirestoreSubMessage}. */
+  owners?: ListenerOwner[];
   issuer?: 'studio';
   relaySource?: 'remote';
 }

--- a/packages/cli/src/serve/worker/protocol/firestore.ts
+++ b/packages/cli/src/serve/worker/protocol/firestore.ts
@@ -3,7 +3,7 @@
  * aggregate descriptors, write descriptors, and document data serialization.
  */
 import { rehydrateDocValue } from 'pyric/firestore/internal/value-codec';
-import type { AuthLens } from 'pyric/sandbox';
+import type { AuthLens, ListenerOwner } from 'pyric/sandbox';
 
 // ─── Ref descriptors (client-side, never cross the port directly) ──────────
 
@@ -162,6 +162,13 @@ export interface FirestoreSubMessage {
    * watches as the app's own session (the unchanged default).
    */
   actAs?: AuthLens;
+  /**
+   * The listener's owners, derived on the page that opened it. The sandbox
+   * attaches inside the worker, where the calling frame belongs to the worker
+   * bundle, the caller's `owner` option never arrived, and there is no DOM, so
+   * the page derives them and the host records these instead.
+   */
+  owners?: ListenerOwner[];
   /** Mechanical op provenance. */
   issuer?: 'studio';
   /** Marks traffic relayed from a remote Node/agent consumer, never page app activity. */

--- a/packages/cli/test/e2e/fixture/index.html
+++ b/packages/cli/test/e2e/fixture/index.html
@@ -8,6 +8,8 @@
     <p id="status">loading</p>
     <button id="signin">Sign in with Google</button>
     <img id="avatar" alt="avatar" />
+    <button id="listen">Watch the shared note</button>
+    <div id="notes-panel">no note yet</div>
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/packages/cli/test/e2e/fixture/main.js
+++ b/packages/cli/test/e2e/fixture/main.js
@@ -1,9 +1,11 @@
 // Minimal firebase/* app for the served-mode auth repro. Under `pyric dev`
 // these imports are swapped to the pyric sandbox (worker-backed auth).
 import { deleteApp, initializeApp } from 'firebase/app';
+import { doc, getFirestore, onSnapshot } from 'firebase/firestore';
 import {
   getAuth,
   onAuthStateChanged,
+  signInAnonymously,
   signInWithPopup,
   GoogleAuthProvider,
 } from 'firebase/auth';
@@ -54,3 +56,23 @@ document
       window.__authError = { code: error?.code, message: error?.message };
     });
   });
+
+// A page-side Firestore listener with an explicit owner. On a served page the
+// sandbox runs in a SharedWorker, so this call is what proves the owner the
+// caller passed reaches the worker's attach event instead of stopping at the
+// port.
+const db = getFirestore(app);
+window.__noteFires = 0;
+document.getElementById('listen').addEventListener('click', async () => {
+  // The fixture's rules allow reads to signed-in callers only.
+  if (!auth.currentUser) await signInAnonymously(auth);
+  onSnapshot(
+    doc(db, 'notes/astro-host'),
+    { owner: 'notes-panel' },
+    (snap) => {
+      window.__noteFires += 1;
+      const panel = document.getElementById('notes-panel');
+      if (panel) panel.textContent = JSON.stringify(snap.data() ?? null);
+    },
+  );
+});

--- a/packages/cli/test/e2e/site-cli/cli-site.pw.ts
+++ b/packages/cli/test/e2e/site-cli/cli-site.pw.ts
@@ -88,3 +88,31 @@ test('an app-triggered worker replacement moves an open Studio page to the annou
   expect(await studio.evaluate(() => localStorage.getItem('pyric:worker-generation'))).toBe(nextGeneration);
   await context.close();
 });
+
+test('a served page attributes a listener to the owner the page passed', async ({ browser }) => {
+  const context = await browser.newContext();
+  const app = await context.newPage();
+  await app.goto('/');
+  await expect(app.locator('#status')).not.toHaveText('loading');
+
+  // The listener is opened from the page with an owner the page named. The
+  // sandbox that records the attach runs in the SharedWorker.
+  await app.locator('#listen').click();
+  await expect.poll(() => app.evaluate(() => (
+    window as unknown as { __noteFires: number }
+  ).__noteFires)).toBeGreaterThan(0);
+
+  const chipHost = app.locator('[data-pyric-runtime-chip-host]');
+  await expect(chipHost).toBeAttached();
+  const expand = chipHost.locator('[data-expand]');
+  if (await expand.isVisible()) await expand.click();
+  await chipHost.locator('[data-toggle-listeners]').click();
+
+  // Nothing on the page can be outlined for a name-only owner, so the listener
+  // lands in the chip's own list. Its label is the name the page passed, not a
+  // function out of the worker bundle.
+  const rows = chipHost.locator('[data-listener-panel] .listener-row');
+  await expect(rows.filter({ hasText: 'notes-panel' })).toHaveCount(1, { timeout: 10_000 });
+  await expect(rows.filter({ hasText: 'notes/astro-host' })).toHaveCount(1);
+  await context.close();
+});

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -312,6 +312,19 @@ describe('the chip Listeners mode', () => {
     page.chip.dispose();
   });
 
+  it('keeps the summary when the outlines are toggled off and on again', () => {
+    const page = setup();
+    page.push([attach('e1', 'l1', { kind: 'query', collection: 'todos' }, [{ kind: 'tag', name: 'TodoList', element: '#todos' }])]);
+    toggle(page.root);
+    expect(page.root.querySelector('[data-listener-panel]')?.textContent).toContain('TodoList');
+    toggle(page.root);
+    expect(page.root.querySelector('[data-listener-panel]')?.textContent).toContain('TodoList');
+    toggle(page.root);
+    expect(page.root.querySelector('[data-listener-panel]')?.textContent).toContain('TodoList');
+    expect(page.doc.querySelector('[data-pyric-listener-overlay]')).not.toBeNull();
+    page.chip.dispose();
+  });
+
   it('draws nothing while listener attribution is off', () => {
     const page = setup({ attributionEnabled: false });
     toggle(page.root);

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -96,6 +96,7 @@ describe('the chip Listeners mode', () => {
 
     expect(page.doc.querySelector('[data-pyric-listener-overlay]')).toBeNull();
     expect(page.root.querySelector('[data-toggle-listeners]')?.getAttribute('aria-pressed')).toBe('false');
+    expect(page.root.querySelector('[data-listener-notice]')?.textContent).toContain('attribution is off');
     page.chip.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -4,6 +4,7 @@ import { mountPyricRuntimeChip } from '../../../src/serve/runtime/chip.js';
 import { createPyricRuntimeStatus } from '../../../src/serve/runtime/status.js';
 import type { PyricRuntimeManifest } from '../../../src/serve/runtime/manifest.js';
 import type { SandboxEvent } from 'pyric/sandbox';
+import type { ActivityIncident } from 'pyric/firestore/internal';
 import { createListenerMode } from '../../../src/serve/runtime/listener-mode.js';
 
 const manifest: PyricRuntimeManifest = {
@@ -25,7 +26,22 @@ function attach(id: string, listenerId: string, target: Target, owners: unknown[
   } as unknown as SandboxEvent;
 }
 
-function setup(options: { attributionEnabled?: boolean } = {}) {
+function delivery(id: string, listenerId: string, target: Target): SandboxEvent {
+  return {
+    kind: 'snapshot_delivery',
+    id,
+    at: 2,
+    listenerId,
+    target,
+    auth: { uid: null, token: null },
+  } as unknown as SandboxEvent;
+}
+
+function setup(options: {
+  attributionEnabled?: boolean;
+  studioUrl?: string | null;
+  incidents?: (events: readonly SandboxEvent[]) => readonly ActivityIncident[];
+} = {}) {
   const dom = new JSDOM(
     '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
@@ -36,6 +52,7 @@ function setup(options: { attributionEnabled?: boolean } = {}) {
     runtime: createPyricRuntimeStatus(manifest),
     document: doc,
     initiallyOpen: true,
+    ...('studioUrl' in options ? { studioUrl: options.studioUrl } : {}),
     identity: { subscribeAuth: () => () => {} },
     getLens: () => undefined,
     setLens: () => {},
@@ -44,7 +61,7 @@ function setup(options: { attributionEnabled?: boolean } = {}) {
       document: doc,
       onChange,
       attributionEnabled: () => options.attributionEnabled ?? true,
-      incidents: () => [],
+      incidents: options.incidents ?? (() => []),
       subscribeEvents: (callback) => {
         deliver = callback;
         return () => {
@@ -77,15 +94,202 @@ describe('the chip Listeners mode', () => {
     page.chip.dispose();
   });
 
-  it('lists a listener nothing on the page could be outlined for', () => {
+  it('falls back to the target when the only label is a frame function name', () => {
     const page = setup();
     toggle(page.root);
     page.push([attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'frame', file: '/src/a.ts', line: 2, function: 'useProfile' }])]);
 
     const panel = page.root.querySelector('[data-listener-panel]');
-    expect(panel?.textContent).toContain('useProfile');
+    expect(panel?.textContent).not.toContain('useProfile');
+    expect(panel?.textContent).not.toContain('l1');
     expect(panel?.textContent).toContain('users/u1');
-    expect(panel?.textContent).toContain('Nothing on the page could be outlined');
+    page.chip.dispose();
+  });
+
+  it('shows a header line with the listener count and no duplicate count when there are none', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }]),
+      attach('e2', 'l2', { kind: 'query', collection: 'todos' }, [{ kind: 'tag', name: 'TodoList', element: '#todos' }]),
+    ]);
+
+    const header = page.root.querySelector('[data-listener-panel] .state-label');
+    expect(header?.textContent).toBe('2 listeners');
+    page.chip.dispose();
+  });
+
+  it('uses singular phrasing for one listener', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }])]);
+
+    const header = page.root.querySelector('[data-listener-panel] .state-label');
+    expect(header?.textContent).toBe('1 listener');
+    page.chip.dispose();
+  });
+
+  it('adds the duplicate count to the header and an incident line first, from the incident', () => {
+    const page = setup({
+      incidents: (events) => {
+        const attachIds = events
+          .filter((event) => (event as { kind: string }).kind === 'listener_attach')
+          .map((event) => (event as { id: string }).id);
+        return [{
+          fingerprint: 'fp1',
+          pattern: 'duplicate-listener',
+          confidence: 'high',
+          severity: 'warning',
+          service: 'firestore',
+          method: 'listen',
+          targetFingerprint: 'conversations',
+          actor: { kind: 'unknown' },
+          authLens: 'app',
+          authUid: null,
+          count: 2,
+          windowMs: 5000,
+          evidenceEventIds: attachIds,
+        } as unknown as ActivityIncident];
+      },
+    });
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+      attach('e2', 'l2', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+    ]);
+
+    const panel = page.root.querySelector('[data-listener-panel]');
+    expect(panel?.querySelector('.state-label')?.textContent).toBe('2 listeners · 1 duplicate');
+    const incidentLine = panel?.querySelector('.listener-line:not(.listener-link)');
+    expect(incidentLine?.textContent).toBe('conversations (query) attached twice by ChatPage');
+    page.chip.dispose();
+  });
+
+  it('phrases a churn incident from the incident window and count', () => {
+    const page = setup({
+      incidents: (events) => {
+        const attachIds = events
+          .filter((event) => (event as { kind: string }).kind === 'listener_attach')
+          .map((event) => (event as { id: string }).id);
+        return [{
+          fingerprint: 'fp1',
+          pattern: 'listener-churn',
+          confidence: 'high',
+          severity: 'warning',
+          service: 'firestore',
+          method: 'listen',
+          targetFingerprint: 'presence',
+          actor: { kind: 'unknown' },
+          authLens: 'app',
+          authUid: null,
+          count: 40,
+          windowMs: 10_000,
+          evidenceEventIds: attachIds,
+        } as unknown as ActivityIncident];
+      },
+    });
+    toggle(page.root);
+    page.push([attach('e1', 'l1', { kind: 'doc', path: '/presence' }, [{ kind: 'tag', name: 'PresenceBadge' }])]);
+
+    const incidentLine = page.root.querySelector('[data-listener-panel] .listener-line:not(.listener-link)');
+    expect(incidentLine?.textContent).toBe('/presence reattached 40 times in 10s');
+    page.chip.dispose();
+  });
+
+  it('groups listeners by owner and orders groups by total deliveries, capped at six lines', () => {
+    const page = setup();
+    toggle(page.root);
+    const events: SandboxEvent[] = [];
+    for (let i = 0; i < 4; i++) {
+      events.push(attach(`chat-${i}`, `chat-l${i}`, { kind: 'doc', path: `conversations/c${i}` }, [{ kind: 'tag', name: 'ChatPage' }]));
+    }
+    for (let i = 0; i < 2; i++) {
+      events.push(attach(`side-${i}`, `side-l${i}`, { kind: 'doc', path: `users/u${i}` }, [{ kind: 'tag', name: 'Sidebar' }]));
+    }
+    events.push(attach('extra-1', 'extra-l1', { kind: 'doc', path: 'org/o1' }, [{ kind: 'tag', name: 'OrgPanel' }]));
+    page.push(events);
+    // Give ChatPage's listeners the most deliveries so it sorts first.
+    page.push([
+      delivery('d1', 'chat-l0', { kind: 'doc', path: 'conversations/c0' }),
+      delivery('d2', 'chat-l0', { kind: 'doc', path: 'conversations/c0' }),
+      delivery('d3', 'chat-l1', { kind: 'doc', path: 'conversations/c1' }),
+    ]);
+
+    const panel = page.root.querySelector('[data-listener-panel]')!;
+    const rows = [...panel.querySelectorAll('.listener-row')].map((row) => row.textContent);
+    expect(rows.length).toBeLessThanOrEqual(4);
+    expect(rows[0]).toContain('ChatPage');
+    expect(rows[0]).toContain('4 listeners');
+    expect(rows[0]).toContain('3 deliveries');
+    const lines = [...panel.children];
+    expect(lines.length).toBeLessThanOrEqual(6);
+    expect(lines.at(-1)?.className).toContain('listener-link');
+    page.chip.dispose();
+  });
+
+  it('shows the collapsed chip a listener count signal, red when a listener has an incident', () => {
+    const page = setup({
+      incidents: (events) => {
+        const attachIds = events
+          .filter((event) => (event as { kind: string }).kind === 'listener_attach')
+          .map((event) => (event as { id: string }).id);
+        return [{
+          fingerprint: 'fp1',
+          pattern: 'duplicate-listener',
+          confidence: 'high',
+          severity: 'warning',
+          service: 'firestore',
+          method: 'listen',
+          targetFingerprint: 'conversations',
+          actor: { kind: 'unknown' },
+          authLens: 'app',
+          authUid: null,
+          count: 2,
+          windowMs: 5000,
+          evidenceEventIds: attachIds,
+        } as unknown as ActivityIncident];
+      },
+    });
+    expect(page.root.querySelector('[data-listener-count]')).toBeNull();
+
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+      attach('e2', 'l2', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+    ]);
+
+    // Collapse to see the chip's own signal strip.
+    page.root.querySelector<HTMLButtonElement>('[data-collapse]')!.click();
+    const signal = page.root.querySelector('[data-listener-count]');
+    expect(signal?.textContent).toBe('2 listeners');
+    expect(signal?.classList.contains('error')).toBe(true);
+    page.chip.dispose();
+  });
+
+  it('links the Studio panel to the listeners view, or renders text when Studio is disabled', () => {
+    const page = setup({ studioUrl: 'https://studio.example/app' });
+    toggle(page.root);
+    page.push([attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }])]);
+    const link = page.root.querySelector<HTMLAnchorElement>('[data-listener-panel] [data-open-listeners-studio]');
+    expect(link?.getAttribute('href')).toBe('https://studio.example/app?view=listeners');
+    expect(link?.getAttribute('target')).toBe('_blank');
+    page.chip.dispose();
+
+    const disabledPage = setup({ studioUrl: null });
+    toggle(disabledPage.root);
+    disabledPage.push([attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }])]);
+    const disabledLink = disabledPage.root.querySelector('[data-listener-panel] [data-open-listeners-studio]');
+    expect(disabledLink?.tagName).toBe('SPAN');
+    expect(disabledLink?.getAttribute('aria-disabled')).toBe('true');
+    disabledPage.chip.dispose();
+  });
+
+  it('shows a single line when the mode is enabled with no listeners', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([]);
+    const panel = page.root.querySelector('[data-listener-panel]');
+    expect(panel?.textContent?.trim()).toBe('No listeners');
     page.chip.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -42,6 +42,7 @@ function setup(options: {
   studioUrl?: string | null;
   incidents?: (events: readonly SandboxEvent[]) => readonly ActivityIncident[];
 } = {}) {
+  const copied: string[] = [];
   const dom = new JSDOM(
     '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
@@ -52,6 +53,12 @@ function setup(options: {
     runtime: createPyricRuntimeStatus(manifest),
     document: doc,
     initiallyOpen: true,
+    clipboard: {
+      writeText: (text: string) => {
+        copied.push(text);
+        return Promise.resolve();
+      },
+    },
     ...('studioUrl' in options ? { studioUrl: options.studioUrl } : {}),
     identity: { subscribeAuth: () => () => {} },
     getLens: () => undefined,
@@ -73,6 +80,7 @@ function setup(options: {
   return {
     doc,
     chip,
+    copied,
     root: chip.element.shadowRoot!,
     push: (events: readonly SandboxEvent[]) => deliver?.(events),
   };
@@ -160,8 +168,11 @@ describe('the chip Listeners mode', () => {
 
     const panel = page.root.querySelector('[data-listener-panel]');
     expect(panel?.querySelector('.state-label')?.textContent).toBe('2 listeners · 1 duplicate');
-    const incidentLine = panel?.querySelector('.listener-line:not(.listener-link)');
-    expect(incidentLine?.textContent).toBe('conversations (query) attached twice by ChatPage');
+    const incidentRow = panel?.querySelector('.listener-row.incident');
+    expect(incidentRow?.querySelector('.listener-label')?.textContent).toBe('duplicate');
+    expect(incidentRow?.querySelector('.listener-target')?.textContent).toBe('conversations (query)');
+    expect(incidentRow?.querySelector('.listener-mark')?.getAttribute('title'))
+      .toBe('conversations (query) attached twice by ChatPage');
     page.chip.dispose();
   });
 
@@ -191,8 +202,10 @@ describe('the chip Listeners mode', () => {
     toggle(page.root);
     page.push([attach('e1', 'l1', { kind: 'doc', path: '/presence' }, [{ kind: 'tag', name: 'PresenceBadge' }])]);
 
-    const incidentLine = page.root.querySelector('[data-listener-panel] .listener-line:not(.listener-link)');
-    expect(incidentLine?.textContent).toBe('/presence reattached 40 times in 10s');
+    const incidentRow = page.root.querySelector('[data-listener-panel] .listener-row.incident');
+    expect(incidentRow?.querySelector('.listener-label')?.textContent).toBe('churn');
+    expect(incidentRow?.querySelector('.listener-mark')?.getAttribute('title'))
+      .toBe('/presence reattached 40 times in 10s');
     page.chip.dispose();
   });
 
@@ -216,14 +229,20 @@ describe('the chip Listeners mode', () => {
     ]);
 
     const panel = page.root.querySelector('[data-listener-panel]')!;
-    const rows = [...panel.querySelectorAll('.listener-row')].map((row) => row.textContent);
+    const rows = [...panel.querySelectorAll('.listener-row')];
     expect(rows.length).toBeLessThanOrEqual(4);
-    expect(rows[0]).toContain('ChatPage');
-    expect(rows[0]).toContain('4 listeners');
-    expect(rows[0]).toContain('3 deliveries');
-    const lines = [...panel.children];
-    expect(lines.length).toBeLessThanOrEqual(6);
-    expect(lines.at(-1)?.className).toContain('listener-link');
+    const cells = [...rows[0].children].map((cell) => cell.textContent);
+    expect(cells[0]).toBe('01');
+    expect(cells[1]).toBe('ChatPage');
+    expect(cells[2]).toBe('4 targets');
+    expect(cells[3]).toBe('4');
+    expect(cells[4]).toBe('3');
+    const counts = [...rows[0].querySelectorAll('.listener-count')]
+      .map((cell) => cell.getAttribute('title'));
+    expect(counts).toEqual(['4 listeners', '3 deliveries']);
+    // One header line, the rows, and the Studio link: six lines at most.
+    expect(2 + rows.length).toBeLessThanOrEqual(6);
+    expect(panel.lastElementChild?.className).toContain('listener-link');
     page.chip.dispose();
   });
 
@@ -301,6 +320,73 @@ describe('the chip Listeners mode', () => {
     expect(page.doc.querySelector('[data-pyric-listener-overlay]')).toBeNull();
     expect(page.root.querySelector('[data-toggle-listeners]')?.getAttribute('aria-pressed')).toBe('false');
     expect(page.root.querySelector('[data-listener-notice]')?.textContent).toContain('attribution is off');
+    page.chip.dispose();
+  });
+
+  it('copies a row as one plain-text line', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }]),
+      attach('e2', 'l2', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }]),
+    ]);
+    page.root.querySelector<HTMLButtonElement>('[data-listener-panel] [data-copy-listener]')!.click();
+    expect(page.copied).toEqual(['ProfileCard · users/u1 · 2 listeners · 0 deliveries']);
+    page.chip.dispose();
+  });
+
+  it('hides a dismissed row until a new listener attaches on it', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([attach('e1', 'l1', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }])]);
+    expect(page.root.querySelectorAll('[data-listener-panel] .listener-row')).toHaveLength(1);
+
+    page.root.querySelector<HTMLButtonElement>('[data-listener-panel] [data-dismiss-listener]')!.click();
+    expect(page.root.querySelectorAll('[data-listener-panel] .listener-row')).toHaveLength(0);
+
+    // A delivery leaves the row's listener set alone, so the row stays hidden.
+    page.push([delivery('d1', 'l1', { kind: 'doc', path: 'users/u1' })]);
+    expect(page.root.querySelectorAll('[data-listener-panel] .listener-row')).toHaveLength(0);
+
+    page.push([attach('e2', 'l2', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard' }])]);
+    const rows = page.root.querySelectorAll('[data-listener-panel] .listener-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].querySelector('.listener-count')?.textContent).toBe('2');
+    page.chip.dispose();
+  });
+
+  it('marks an owner row whose listeners are part of an incident', () => {
+    const page = setup({
+      incidents: (events) => {
+        const attachIds = events
+          .filter((event) => (event as { kind: string }).kind === 'listener_attach')
+          .map((event) => (event as { id: string }).id);
+        return [{
+          fingerprint: 'fp1',
+          pattern: 'duplicate-listener',
+          confidence: 'high',
+          severity: 'warning',
+          service: 'firestore',
+          method: 'listen',
+          targetFingerprint: 'conversations',
+          actor: { kind: 'unknown' },
+          authLens: 'app',
+          authUid: null,
+          count: 2,
+          windowMs: 5000,
+          evidenceEventIds: attachIds,
+        } as unknown as ActivityIncident];
+      },
+    });
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+      attach('e2', 'l2', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+    ]);
+    const ownerRow = page.root.querySelector('[data-listener-panel] .listener-row:not(.incident)');
+    expect(ownerRow?.querySelector('.listener-label')?.textContent).toBe('ChatPage');
+    expect(ownerRow?.querySelector('.listener-mark')?.textContent).toBe('!');
+    expect(ownerRow?.querySelector('.listener-mark')?.getAttribute('title')).toBe('duplicate ×2');
     page.chip.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/chip.test.ts
+++ b/packages/cli/test/serve/runtime/chip.test.ts
@@ -130,6 +130,20 @@ describe('PyricRuntimeChip', () => {
     expect(studio?.getAttribute('aria-disabled')).toBe('true');
   });
 
+  it('plays the enter animation only when the panel opens or closes, not on every render', () => {
+    const { runtime, root } = setup();
+    root.querySelector<HTMLButtonElement>('[data-expand]')!.click();
+    expect(root.querySelector('.panel')?.classList.contains('entering')).toBe(true);
+
+    // A state change rebuilds the view while it stays open; the panel must not re-enter.
+    runtime.setWorker({ mode: 'shared-worker', runningEpoch: 'aaaaaaaaaaaaaaaa' });
+    expect(root.querySelector('.panel')).not.toBeNull();
+    expect(root.querySelector('.panel')?.classList.contains('entering')).toBe(false);
+
+    root.querySelector<HTMLButtonElement>('[data-collapse]')!.click();
+    expect(root.querySelector('.chip')?.classList.contains('entering')).toBe(true);
+  });
+
   it('moves focus with the compact and expanded controls', () => {
     const { root } = setup();
     root.querySelector<HTMLButtonElement>('[data-expand]')!.click();

--- a/packages/cli/test/serve/runtime/listener-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-mode.test.ts
@@ -121,15 +121,18 @@ describe('createListenerMode', () => {
     page.mode.dispose();
   });
 
-  it('subscribes only while the mode is on', () => {
+  it('observes events from creation and only outlines while the mode is on', () => {
     const page = harness();
-    expect(page.subscriptions()).toBe(0);
+    expect(page.subscriptions()).toBe(1);
+    expect(page.doc.querySelector('[data-pyric-listener-overlay]')).toBeNull();
     page.mode.setEnabled(true);
     expect(page.subscriptions()).toBe(1);
+    expect(page.doc.querySelector('[data-pyric-listener-overlay]')).not.toBeNull();
     page.mode.setEnabled(false);
-    expect(page.subscriptions()).toBe(0);
+    expect(page.subscriptions()).toBe(1);
     expect(page.doc.querySelector('[data-pyric-listener-overlay]')).toBeNull();
     page.mode.dispose();
+    expect(page.subscriptions()).toBe(0);
   });
 });
 

--- a/packages/cli/test/serve/worker/integration.test.ts
+++ b/packages/cli/test/serve/worker/integration.test.ts
@@ -9,8 +9,11 @@ import type { InboundMessage, OutboundMessage } from '../../../src/serve/worker/
 import { getFirestore as ipGetFirestore } from 'pyric/firestore';
 import { monitorFirebaseActivity, type ActivityIncident } from 'pyric/firestore/internal';
 import * as client from '../../../src/serve/worker/client.js';
+import { rtdbGetDatabase, rtdbRef } from '../../../src/serve/worker/client/rtdb-references.js';
+import { rtdbOnValue } from '../../../src/serve/worker/client/rtdb-listeners.js';
 import {
   connectClient,
+  connectClientToHost,
   makeHostCtx,
   portPair,
   sleep,
@@ -130,6 +133,54 @@ describe('client↔host round-trip (gate repro)', () => {
 
     expect(errors).toEqual([]);
     expect((seen.at(-1) as { marker?: string }).marker).toBe('shared');
+  });
+
+  it('records the page-side owners on the worker attach, for both services', async () => {
+    const ctx = await makeHostCtx();
+    const { db } = connectClientToHost(ctx, 'worker://owners');
+    const auth = client.getAuth(db);
+    await client.createUserWithEmailAndPassword(auth, 'owner@example.com', 'pw123456');
+
+    const firestoreUnsub = client.onSnapshot(
+      client.doc(db, 'notes/owned'),
+      { owner: 'notes-panel' },
+      () => {},
+      () => {},
+    );
+    const databaseUnsub = rtdbOnValue(
+      rtdbRef(rtdbGetDatabase(db), 'rooms/owned'),
+      () => {},
+      () => {},
+      { owner: 'rooms-panel' },
+    );
+    await sleep();
+    firestoreUnsub();
+    databaseUnsub();
+
+    const attaches = ctx.sandbox.history().filter((event) => {
+      const candidate = event as { kind: string; phase?: string };
+      return candidate.kind === 'listener_attach'
+        || (candidate.kind === 'listener' && candidate.phase === 'attach');
+    }) as Array<{ kind: string; owners?: Array<Record<string, unknown>> }>;
+
+    const ownersFor = (name: string): Array<Record<string, unknown>> => {
+      const match = attaches.find((event) => (event.owners ?? []).some(
+        (owner) => owner.kind === 'tag' && owner.name === name,
+      ));
+      expect(match).toBeDefined();
+      return match!.owners!;
+    };
+
+    for (const name of ['notes-panel', 'rooms-panel']) {
+      const owners = ownersFor(name);
+      // The frame is the test's own call, not a function inside the worker
+      // client or the sandbox the worker holds.
+      const frame = owners.find((owner) => owner.kind === 'frame') as
+        { file: string; function?: string } | undefined;
+      expect(frame).toBeDefined();
+      expect(frame!.file).toContain('integration.test.ts');
+      expect(owners.map((owner) => owner.kind)).toEqual(['frame', 'tag']);
+    }
   });
 
   it('excludes split transaction reads from activity warnings', async () => {

--- a/packages/pyric/src/database/listeners.ts
+++ b/packages/pyric/src/database/listeners.ts
@@ -5,6 +5,7 @@ import { authFor, targetOf, type Target } from './routing.js';
 import { isDefaultQuerySpec, isQuery, queryIdentifier } from './query-shape.js';
 import type { QueryRow } from './sandbox/query.js';
 import type { DataSnapshot, DatabaseReference, ListenOptions, Query, Unsubscribe } from './types.js';
+import type { ListenerAttribution } from '../sandbox/attribution/listener-owners.js';
 import { child } from './references.js';
 import { buildSandboxQuerySnap, buildSandboxSnapFromRaw } from './snapshots.js';
 
@@ -52,13 +53,21 @@ function subscribeWithLiveAuth(
 }
 
 /**
- * The listen options a recursive `onlyOnce` subscribe should keep: the owner,
- * never `onlyOnce` itself, which the outer call already honored.
+ * The attribution a listen call carries, or `undefined` when it carries none.
+ * The backend takes both inputs as one argument.
+ */
+function attributionOf(options: ListenOptions | undefined): ListenerAttribution | undefined {
+  if (options === undefined) return undefined;
+  if (options.owner === undefined && options.owners === undefined) return undefined;
+  return { owner: options.owner, owners: options.owners };
+}
+
+/**
+ * The listen options a recursive `onlyOnce` subscribe should keep: the
+ * attribution, never `onlyOnce` itself, which the outer call already honored.
  */
 function ownerOnlyOptions(options: ListenOptions | undefined): ListenOptions | undefined {
-  const owner = options?.owner;
-  if (owner === undefined) return undefined;
-  return { owner };
+  return attributionOf(options);
 }
 
 function queryScope(r: DatabaseReference | Query): string {
@@ -163,7 +172,7 @@ function onValueInternal(
           q._spec,
           cancelCallback,
           onCanceled,
-          listenOptions?.owner,
+          attributionOf(listenOptions),
         ),
         unregister,
       );
@@ -200,7 +209,7 @@ function onValueInternal(
         undefined,
         cancelCallback,
         onCanceled,
-        listenOptions?.owner,
+        attributionOf(listenOptions),
       ),
       unregister,
     );

--- a/packages/pyric/src/database/sandbox/backend.ts
+++ b/packages/pyric/src/database/sandbox/backend.ts
@@ -14,7 +14,7 @@ import { Transactions } from './transactions.js';
 import { ValueListeners } from './value-listeners.js';
 import { WritePlane } from './write-plane.js';
 import type { JsonValue } from './data-tree.js';
-import type { ListenerOwnerHint } from '../../sandbox/attribution/listener-owners.js';
+import type { ListenerAttribution } from '../../sandbox/attribution/listener-owners.js';
 
 export class RtdbBackend {
   private readonly state: BackendState;
@@ -86,9 +86,9 @@ export class RtdbBackend {
     query?: QuerySpec,
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
-    return this.values.onValue(auth, path, cb, query, cancelCallback, onCanceled, owner);
+    return this.values.onValue(auth, path, cb, query, cancelCallback, onCanceled, attribution);
   }
 
   adminOnValue(

--- a/packages/pyric/src/database/sandbox/value-listeners.ts
+++ b/packages/pyric/src/database/sandbox/value-listeners.ts
@@ -3,7 +3,7 @@ import type { ListenerOwner } from '../../sandbox/types/events.js';
 import { recordEffectRegions } from '../../sandbox/attribution/effect-regions.js';
 import {
   listenerAttachOwners,
-  type ListenerOwnerHint,
+  type ListenerAttribution,
 } from '../../sandbox/attribution/listener-owners.js';
 import { jsonValuesEqual, joinPath, pathSegments, type JsonValue } from './data-tree.js';
 import type { BackendState } from './backend-state.js';
@@ -44,7 +44,7 @@ export class ValueListeners {
     query?: QuerySpec,
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
     const at = this.state.clock.now();
     const evaluation = this.state.rules.evaluate('read', path === '/' ? '/' : path, {
@@ -87,7 +87,7 @@ export class ValueListeners {
     }
     return this.attach(auth, path, cb, query, {
       origin: 'listener', result: 'allow', evaluation, at,
-    }, cancelCallback, onCanceled, owner);
+    }, cancelCallback, onCanceled, attribution);
   }
 
   adminOnValue(path: string, cb: (snap: ValueListenerSnapshot) => void, query?: QuerySpec): () => void {
@@ -109,10 +109,10 @@ export class ValueListeners {
     },
     cancelCallback?: (error: Error) => void,
     onCanceled?: () => void,
-    owner?: ListenerOwnerHint,
+    attribution?: ListenerAttribution,
   ): () => void {
     const id = this.state.events.nextListenerId();
-    const attachOwners = listenerAttachOwners(owner);
+    const attachOwners = listenerAttachOwners(attribution?.owner, attribution?.owners);
     this.state.events.operation(auth, 'listen', path, provenance.result, provenance.evaluation, {
       at: provenance.at, durationMs: this.state.clock.now() - provenance.at,
       request: query ? { query } : undefined, origin: provenance.origin,

--- a/packages/pyric/src/database/types.ts
+++ b/packages/pyric/src/database/types.ts
@@ -3,7 +3,10 @@ import { QUERY_SYMBOL } from './brands.js';
 import type { Database } from './database-handle.js';
 import type { DataSnapshot } from './data-snapshot.js';
 import type { JsonValue } from './sandbox/data-tree.js';
-import type { ListenerOwnerHint } from '../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../sandbox/attribution/listener-owners.js';
 import type { QuerySpec } from './sandbox/query.js';
 
 export { CONSTRAINT_SYMBOL, QUERY_SYMBOL } from './brands.js';
@@ -80,7 +83,7 @@ export type EventType =
   | 'child_moved'
   | 'child_removed';
 
-export interface ListenOptions {
+export interface ListenOptions extends RecordedListenerOwners {
   readonly onlyOnce?: boolean;
   /**
    * Pyric's own extension, absent from the Firebase Web SDK: who owns this

--- a/packages/pyric/src/firestore/listeners.ts
+++ b/packages/pyric/src/firestore/listeners.ts
@@ -10,7 +10,10 @@ import { AUTH_SESSION_SCOPE, FOLLOWS_CURRENT_USER } from 'pyric/firestore/intern
 import { FirebaseError } from '../sandbox/internal/firebase-error.js';
 import { toFirestoreFirebaseError } from './errors.js';
 import { clientStateFor } from './client-state.js';
-import type { ListenerOwnerHint } from '../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../sandbox/attribution/listener-owners.js';
 
 import {
   targetOf,
@@ -30,7 +33,7 @@ import type {
 
 // ─── Snapshot listeners ───────────────────────────────────────────────
 
-export interface SnapshotListenOptions {
+export interface SnapshotListenOptions extends RecordedListenerOwners {
   includeMetadataChanges?: boolean;
   /**
    * Pyric's own extension, absent from the Firebase Web SDK: who owns this

--- a/packages/pyric/src/firestore/sandbox/listener-dispatch.ts
+++ b/packages/pyric/src/firestore/sandbox/listener-dispatch.ts
@@ -271,8 +271,10 @@ export class ListenerDispatch {
   ): () => void {
     const id = String(this.nextListenerId++);
     // One `Error` construction per attach, on the caller's own stack, the
-    // only place the application frame is still reachable.
-    const attachOwners = listenerAttachOwners(options.owner);
+    // only place the application frame is still reachable. A caller reaching
+    // the sandbox across a port sends `options.owners` instead: its stack and
+    // its DOM are on the other side, and this one describes neither.
+    const attachOwners = listenerAttachOwners(options.owner, options.owners);
     const record: ListenerRecord = {
       id,
       target,

--- a/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
+++ b/packages/pyric/src/firestore/sandbox/snapshot-listeners.ts
@@ -11,7 +11,10 @@
  * section 4, section 5).
  */
 import type { DocumentData } from './local-state.js';
-import type { ListenerOwnerHint } from '../../sandbox/attribution/listener-owners.js';
+import type {
+  ListenerOwnerHint,
+  RecordedListenerOwners,
+} from '../../sandbox/attribution/listener-owners.js';
 import type { Operation } from './local-environment.js';
 // FS-B10 — translate the listener read path so `snap.data()` exposes the
 // SAME compat-shaped values (`Timestamp` `{seconds, nanoseconds}`, `Bytes`,
@@ -81,7 +84,7 @@ export type SnapshotTarget =
  * `LocalEnvironment.notifyDocListener` / `notifyQueryListener`. `fromCache`
  * remains constant `false` — the sandbox has no offline cache to serve from.
  */
-export interface SnapshotListenerOptions {
+export interface SnapshotListenerOptions extends RecordedListenerOwners {
   includeMetadataChanges?: boolean;
   source?: 'default' | 'cache';
   /**

--- a/packages/pyric/src/sandbox/attribution/listener-owners.ts
+++ b/packages/pyric/src/sandbox/attribution/listener-owners.ts
@@ -25,19 +25,69 @@ import {
 } from './element-selector.js';
 
 /**
- * What a caller may pass as a listener's `owner`: a name, the DOM element the
- * listener feeds, or a fully-built {@link ListenerOwner} record. The third
- * form is for a framework binding (`@pyric/ui`'s `useListenerOwner`) that has
- * already computed a `component` owner and wants it recorded verbatim,
- * rather than wrapped in a `tag`.
+ * The input form of a `component` owner, as a framework binding builds it.
+ *
+ * It differs from the recorded {@link ListenerOwner} `component` form in one
+ * field: `element` is the live DOM element, not a selector for it. The
+ * binding hands the element over and this module derives the selector,
+ * exactly as it does for an element hint, so that the selector rules live in
+ * one place and the binding never has to import pyric at runtime. Owners are
+ * serialized into events, so the element itself is never kept on the
+ * recorded owner.
  */
-export type ListenerOwnerHint = string | SelectableElement | ListenerOwner;
+export interface ComponentOwnerInput {
+  kind: 'component';
+  /** The component function's name, read from the render-phase stack. */
+  name: string;
+  /** The chain of enclosing component frames, outermost first. */
+  path?: string[];
+  /** The component's root element, when the binding's ref was attached. */
+  element?: SelectableElement;
+}
 
-/** `true` when `value` is already a {@link ListenerOwner} record rather than
- *  a name or an element to derive one from. */
-function isListenerOwner(value: ListenerOwnerHint): value is ListenerOwner {
+/**
+ * What a caller may pass as a listener's `owner`: a name, the DOM element the
+ * listener feeds, a fully-built {@link ListenerOwner} record, or a
+ * {@link ComponentOwnerInput}. The last two forms are for a framework binding
+ * (`@pyric/ui`'s `useListenerOwner`) that has already identified the owning
+ * component and wants it recorded as a `component` owner rather than wrapped
+ * in a `tag`.
+ */
+export type ListenerOwnerHint =
+  | string
+  | SelectableElement
+  | ListenerOwner
+  | ComponentOwnerInput;
+
+/** `true` when `value` is already an owner record rather than a name or an
+ *  element to derive one from. */
+function isOwnerRecord(
+  value: ListenerOwnerHint,
+): value is ListenerOwner | ComponentOwnerInput {
   if (value === null || typeof value !== 'object') return false;
   return 'kind' in value && typeof (value as { kind: unknown }).kind === 'string';
+}
+
+/**
+ * Turn an owner record into its recorded form. A `component` owner carrying a
+ * live element has that element replaced by a selector; a `component` owner
+ * whose `element` is not a selectable element drops the field. Every other
+ * owner kind is already in recorded form and passes through unchanged.
+ */
+function recordedOwner(value: ListenerOwner | ComponentOwnerInput): ListenerOwner {
+  if (value.kind !== 'component') return value as ListenerOwner;
+  const owner: Extract<ListenerOwner, { kind: 'component' }> = {
+    kind: 'component',
+    name: value.name,
+  };
+  if (value.path !== undefined && value.path.length > 0) owner.path = value.path;
+  const element = value.element;
+  if (typeof element === 'string') {
+    owner.element = element;
+  } else if (element !== undefined && isSelectableElement(element)) {
+    owner.element = ownerSelectorFor(element);
+  }
+  return owner;
 }
 
 /**
@@ -153,10 +203,11 @@ export function captureCreationFrame(): ListenerOwner | undefined {
 /**
  * Build the explicit owner from whatever the caller passed as `owner`. A
  * string is the name of a `tag` owner verbatim; an element contributes its
- * tag name plus a selector that finds it again; an already-built
- * {@link ListenerOwner} (a framework binding's `component` owner) is
- * recorded as-is. Unlike frame capture this is not gated on the attribution
- * switch: the caller asked for it by name.
+ * tag name plus a selector that finds it again; an owner record (a framework
+ * binding's `component` owner) is recorded as it stands, except that a live
+ * element on a `component` owner is reduced to a selector here. Unlike frame
+ * capture this is not gated on the attribution switch: the caller asked for
+ * it by name.
  */
 export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner | undefined {
   if (hint === undefined) return undefined;
@@ -164,7 +215,7 @@ export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner 
     if (hint.length === 0) return undefined;
     return { kind: 'tag', name: hint };
   }
-  if (isListenerOwner(hint)) return hint;
+  if (isOwnerRecord(hint)) return recordedOwner(hint);
   if (!isSelectableElement(hint)) return undefined;
   return { kind: 'tag', name: tagNameOf(hint), element: ownerSelectorFor(hint) };
 }

--- a/packages/pyric/src/sandbox/attribution/listener-owners.ts
+++ b/packages/pyric/src/sandbox/attribution/listener-owners.ts
@@ -221,13 +221,46 @@ export function tagOwnerFor(hint: ListenerOwnerHint | undefined): ListenerOwner 
 }
 
 /**
+ * The internal listen option that carries owners a caller already recorded.
+ *
+ * It exists for one caller: a client that reaches the sandbox across a port
+ * rather than calling it in the same context. The served page runs the
+ * sandbox in a SharedWorker, so an attach inside the worker sees a
+ * worker-bundle frame, no `owner` hint, and no DOM. That client derives the
+ * owners on the page, where all three are real, and hands them over here.
+ *
+ * The option is reached through `pyric/sandbox/internal` and is not part of
+ * any mirrored Firebase surface. The public `owner` hint is unchanged: a
+ * caller still passes a name, an element, or a component record, and the
+ * sandbox still derives the owners itself when no `owners` arrive.
+ */
+export interface RecordedListenerOwners {
+  readonly owners?: readonly ListenerOwner[];
+}
+
+/**
+ * Both attribution inputs a listen call can carry: the caller's `owner` hint
+ * and, for a caller on the other side of a port, the owners it already
+ * recorded. Backends that take attribution as one argument take this.
+ */
+export interface ListenerAttribution extends RecordedListenerOwners {
+  readonly owner?: ListenerOwnerHint;
+}
+
+/**
  * Every owner known at attach time, in a stable order: frame first, then tag.
  * Returns `undefined` rather than an empty array so an event with no
  * attribution omits the field entirely.
+ *
+ * `recorded` owners replace both: the caller derived them where the calling
+ * frame and the DOM exist, so deriving them again here would only describe
+ * this context.
  */
 export function listenerAttachOwners(
   hint?: ListenerOwnerHint,
+  recorded?: readonly ListenerOwner[],
 ): ListenerOwner[] | undefined {
+  if (recorded !== undefined && recorded.length > 0) return [...recorded];
   const owners: ListenerOwner[] = [];
   const frame = captureCreationFrame();
   if (frame !== undefined) owners.push(frame);

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -28,6 +28,7 @@ export {
   captureCreationFrame,
   listenerAttachOwners,
   tagOwnerFor,
+  type ComponentOwnerInput,
   type ListenerOwnerHint,
 } from '../attribution/listener-owners.js';
 export { recordEffectRegions } from '../attribution/effect-regions.js';

--- a/packages/pyric/src/sandbox/internal/index.ts
+++ b/packages/pyric/src/sandbox/internal/index.ts
@@ -25,11 +25,14 @@ export {
   type ListenerAttributionMode,
 } from '../attribution/attribution-mode.js';
 export {
+  callerFrameFromStack,
   captureCreationFrame,
   listenerAttachOwners,
   tagOwnerFor,
   type ComponentOwnerInput,
+  type ListenerAttribution,
   type ListenerOwnerHint,
+  type RecordedListenerOwners,
 } from '../attribution/listener-owners.js';
 export { recordEffectRegions } from '../attribution/effect-regions.js';
 export {

--- a/packages/pyric/test/sandbox/attribution/listener-owners.test.ts
+++ b/packages/pyric/test/sandbox/attribution/listener-owners.test.ts
@@ -101,6 +101,41 @@ describe('tagOwnerFor', () => {
     expect(owner.element).toBe(`[${OWNER_ATTRIBUTE}="${element.getAttribute(OWNER_ATTRIBUTE)}"]`);
   });
 
+  it('records a component owner as it stands', () => {
+    expect(tagOwnerFor({ kind: 'component', name: 'OrdersTable', path: ['App'] })).toEqual({
+      kind: 'component',
+      name: 'OrdersTable',
+      path: ['App'],
+    });
+  });
+
+  it('derives the selector for a component owner carrying an element', () => {
+    const element = new FakeElement('section');
+    element.id = 'orders';
+    expect(tagOwnerFor({ kind: 'component', name: 'OrdersTable', element })).toEqual({
+      kind: 'component',
+      name: 'OrdersTable',
+      element: '#orders',
+    });
+  });
+
+  it('keeps no element on the recorded component owner', () => {
+    const element = new FakeElement('section');
+    const owner = tagOwnerFor({ kind: 'component', name: 'OrdersTable', element });
+    if (owner?.kind !== 'component') throw new Error('expected a component owner');
+    expect(typeof owner.element).toBe('string');
+    expect(JSON.parse(JSON.stringify(owner))).toEqual(owner);
+  });
+
+  it('drops an element that cannot be turned into a selector', () => {
+    const owner = tagOwnerFor({
+      kind: 'component',
+      name: 'OrdersTable',
+      element: {} as never,
+    });
+    expect(owner).toEqual({ kind: 'component', name: 'OrdersTable' });
+  });
+
   it('reports nothing for an absent or empty hint', () => {
     expect(tagOwnerFor(undefined)).toBeUndefined();
     expect(tagOwnerFor('')).toBeUndefined();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/primitives/index.d.ts",
       "import": "./dist/primitives/index.js"
     },
+    "./listener-owner": {
+      "types": "./dist/listener-owner/index.d.ts",
+      "import": "./dist/listener-owner/index.js"
+    },
     "./firestore": {
       "types": "./dist/firestore/index.d.ts",
       "import": "./dist/firestore/index.js"
@@ -75,6 +79,7 @@
       "import": "./dist/rules/hooks/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "src",

--- a/packages/ui/src/listener-owner/index.ts
+++ b/packages/ui/src/listener-owner/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Component attribution for listeners, on its own entry point.
+ *
+ * `@pyric/ui/listener-owner` exists so an application can take the hook
+ * without importing the component library barrel and without pulling pyric
+ * into its bundle. The module graph reachable from here is this file, the
+ * hook, and `react`. Every pyric name it uses is a type, erased at build
+ * time, and the capture itself is behind a `process.env.NODE_ENV` gate a
+ * bundler folds to a constant, so a production build carries neither.
+ *
+ * The same hook is also exported from `@pyric/ui/primitives`.
+ */
+export {
+  useListenerOwner,
+  type ListenerOwner,
+  type UseListenerOwnerOptions,
+  type UseListenerOwnerResult,
+} from '../primitives/hooks/useListenerOwner.js';

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
-import type { ListenerOwner } from 'pyric/sandbox';
-import {
-  isSelectableElement,
-  listenerAttributionEnabled,
-  ownerSelectorFor,
-  type SelectableElement,
-} from 'pyric/sandbox/internal';
+import type { ComponentOwnerInput, SelectableElement } from 'pyric/sandbox/internal';
 
 /**
  * Captures the framework component that owns a listener, so a component
  * using `@pyric/ui`'s data hooks is attributed with no extra code at the
  * call site.
+ *
+ * This module imports pyric for types only. Nothing here reaches pyric at
+ * runtime, and capture itself is gated on `process.env.NODE_ENV`, which a
+ * bundler folds to a constant: in a production build the gate is
+ * statically false, the capture body is dead code, and an application that
+ * uses these hooks ships neither the capture nor pyric. The owner is handed
+ * to whatever Firestore implementation the app is wired to; under `pyric
+ * sandbox` that is pyric, which derives the element selector and records the
+ * owner, and in production the real Firebase SDK ignores the option.
  *
  * Capture happens during render, while the calling component function is
  * still on the call stack, the same moment `pyric/sandbox`'s own `frame`
@@ -22,9 +25,7 @@ import {
  *   covers `react`, `react-dom`, and every other dependency, `pyric`
  *   included) is the component function currently rendering; this hook is
  *   always called directly from that function's body, so that frame names
- *   it. A minified production build mangles this the same way it mangles any
- *   other identifier; state that to the consumer rather than guessing at the
- *   original name.
+ *   it.
  * - `path`, the chain of enclosing component frames, comes from React's own
  *   `captureOwnerStack` export (React 19+; an older peer React leaves `path`
  *   absent). That export exists precisely because the plain call stack does
@@ -33,22 +34,26 @@ import {
  *   alone can only ever name the immediate function. `captureOwnerStack`
  *   reads React's own render-phase bookkeeping through a public export,
  *   this hook never touches a fiber. Best effort: absent when the installed
- *   React does not report an owner stack for this render.
+ *   React does not report an owner stack for this render, and read
+ *   defensively so a React without it is not an error.
  *
  * `ref` is a callback ref the caller may attach to the component's root
- * element. Once attached, `owner.element` is filled in with the same
- * selector `pyric/sandbox`'s attribution module uses for a caller-supplied
- * tag element, imported from `pyric/sandbox/internal` rather than
- * duplicated.
- *
- * Capture is skipped entirely, and `owner` is `undefined`, when listener
- * attribution is off, the same production/test switch `pyric/sandbox`
- * itself reads.
+ * element. Once attached, the element itself travels on `owner.element`.
+ * Turning it into a selector is the sandbox's job, not this module's, so the
+ * selector rules stay in one place and this file keeps no runtime import.
  */
+/**
+ * The owner value this hook produces: a `component` owner carrying the live
+ * root element rather than a selector for it. Pyric's attribution derives
+ * the selector when the listener attaches; the Firebase SDKs ignore the
+ * option entirely.
+ */
+export type ListenerOwner = ComponentOwnerInput;
+
 export interface UseListenerOwnerResult {
-  /** The component owner, or `undefined` when attribution is off or this
+  /** The component owner, or `undefined` in a production build or when this
    *  hook could not identify a calling component frame. */
-  owner: ListenerOwner | undefined;
+  owner: ComponentOwnerInput | undefined;
   /** Attach to the component's root element to fill in `owner.element`. */
   ref: (element: SelectableElement | null) => void;
 }
@@ -78,10 +83,18 @@ const FRAME_WITH_FUNCTION = /^\s*at\s+([^\s(]+)\s+\((.+):(\d+):(\d+)\)\s*$/;
  *
  * This file sits at `<root>/primitives/hooks/useListenerOwner.{ts,js}`, so
  * the root is two path segments up.
+ *
+ * Computed on first use rather than at module load, so that a production
+ * build, where nothing ever asks for it, drops this and everything it calls.
  */
-const OWN_DIRECTORY = ownDirectory();
+let ownDirectoryCache: string | undefined;
 
 function ownDirectory(): string {
+  if (ownDirectoryCache === undefined) ownDirectoryCache = readOwnDirectory();
+  return ownDirectoryCache;
+}
+
+function readOwnDirectory(): string {
   const here = importMetaUrl();
   if (here === undefined) return '';
   const withoutFile = here.slice(0, here.lastIndexOf('/'));
@@ -109,7 +122,8 @@ function stripFileScheme(url: string): string {
 function isFrameworkFile(file: string): boolean {
   const normalized = stripFileScheme(file);
   if (normalized.includes('/node_modules/')) return true;
-  if (OWN_DIRECTORY.length > 0 && normalized.startsWith(OWN_DIRECTORY)) return true;
+  const own = ownDirectory();
+  if (own.length > 0 && normalized.startsWith(own)) return true;
   return false;
 }
 
@@ -161,16 +175,20 @@ function ancestorPathFromOwnerStack(stack: string | undefined): string[] {
   return names.reverse();
 }
 
-type ComponentOwner = Extract<ListenerOwner, { kind: 'component' }>;
-
 function captureComponentOwner(
-  captureOwnerStack: () => string | null | undefined,
-): ComponentOwner | undefined {
-  if (!listenerAttributionEnabled()) return undefined;
+  override: (() => string | null) | undefined,
+): ComponentOwnerInput | undefined {
+  // The production gate, written inline as a bare `process.env.NODE_ENV`
+  // comparison because that is the form every bundler folds to a literal.
+  // Folded to `true`, everything below it is dead code and the capture, the
+  // stack reading, and this module's pyric types all leave the build. A
+  // bundler defines `process.env.NODE_ENV`; under Node it is the real value.
+  if (process.env.NODE_ENV === 'production') return undefined;
   const name = callingComponentName(new Error().stack);
   if (name === undefined) return undefined;
-  const path = ancestorPathFromOwnerStack(captureOwnerStack() ?? undefined);
-  const owner: ComponentOwner = { kind: 'component', name };
+  const capture = override ?? reactCaptureOwnerStack;
+  const path = ancestorPathFromOwnerStack(capture() ?? undefined);
+  const owner: ComponentOwnerInput = { kind: 'component', name };
   if (path.length > 0) owner.path = path;
   return owner;
 }
@@ -183,17 +201,17 @@ function captureComponentOwner(
 export function useListenerOwner(
   options: UseListenerOwnerOptions = {},
 ): UseListenerOwnerResult {
-  const capture = options.captureOwnerStack ?? reactCaptureOwnerStack;
-  const [base] = useState<ComponentOwner | undefined>(() => captureComponentOwner(capture));
-  const [element, setElement] = useState<string | undefined>(undefined);
+  const [base] = useState<ComponentOwnerInput | undefined>(() =>
+    captureComponentOwner(options.captureOwnerStack),
+  );
+  const [element, setElement] = useState<SelectableElement | undefined>(undefined);
 
   const ref = useCallback((node: SelectableElement | null) => {
     if (node === null) return;
-    if (!isSelectableElement(node)) return;
-    setElement(ownerSelectorFor(node));
+    setElement(node);
   }, []);
 
-  const owner = useMemo<ComponentOwner | undefined>(() => {
+  const owner = useMemo<ComponentOwnerInput | undefined>(() => {
     if (base === undefined) return undefined;
     if (element === undefined) return base;
     return { ...base, element };

--- a/packages/ui/src/primitives/hooks/useListenerOwner.ts
+++ b/packages/ui/src/primitives/hooks/useListenerOwner.ts
@@ -140,15 +140,45 @@ function parseRenderFrame(line: string): RenderFrame | undefined {
 
 /** The first non-framework frame in a plain call stack: the component
  *  currently rendering, when this is called directly from its body. */
-function callingComponentName(stack: string | undefined): string | undefined {
+/**
+ * The component that called the hook, read from a render-phase stack.
+ *
+ * The stack below this hook is fixed in shape: this module's frames, then
+ * `useListenerOwner` itself, then any custom hooks the component routed
+ * through, then the component, then React. So the first named frame after
+ * `useListenerOwner` that is not itself a hook is the component, whatever
+ * file it lives in. That is what keeps the answer right in a bundled app,
+ * where every module shares one file and a file-based test would exclude the
+ * component along with this module. When the hook's own frame is absent, the
+ * file-based test is the fallback.
+ */
+export function componentNameFromStack(stack: string | undefined): string | undefined {
   if (typeof stack !== 'string') return undefined;
+  const frames: RenderFrame[] = [];
   for (const line of stack.split('\n')) {
     const frame = parseRenderFrame(line);
-    if (frame === undefined) continue;
+    if (frame !== undefined) frames.push(frame);
+  }
+  const hookIndex = frames.findIndex((frame) => frame.name === 'useListenerOwner');
+  if (hookIndex >= 0) {
+    for (const frame of frames.slice(hookIndex + 1)) {
+      if (isHookName(frame.name)) continue;
+      if (frame.file.includes('/node_modules/')) continue;
+      return frame.name;
+    }
+    return undefined;
+  }
+  for (const frame of frames) {
     if (isFrameworkFile(frame.file)) continue;
     return frame.name;
   }
   return undefined;
+}
+
+/** `true` for a frame name that follows React's hook convention (`useX`). */
+function isHookName(name: string): boolean {
+  const bare = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : name;
+  return /^use[A-Z0-9_]/.test(bare);
 }
 
 /** `react`'s own `captureOwnerStack` export, when the installed version has
@@ -169,7 +199,7 @@ function ancestorPathFromOwnerStack(stack: string | undefined): string[] {
   for (const line of stack.split('\n')) {
     const frame = parseRenderFrame(line);
     if (frame === undefined) continue;
-    if (isFrameworkFile(frame.file)) continue;
+    if (frame.file.includes('/node_modules/')) continue;
     names.push(frame.name);
   }
   return names.reverse();
@@ -184,7 +214,7 @@ function captureComponentOwner(
   // stack reading, and this module's pyric types all leave the build. A
   // bundler defines `process.env.NODE_ENV`; under Node it is the real value.
   if (process.env.NODE_ENV === 'production') return undefined;
-  const name = callingComponentName(new Error().stack);
+  const name = componentNameFromStack(new Error().stack);
   if (name === undefined) return undefined;
   const capture = override ?? reactCaptureOwnerStack;
   const path = ancestorPathFromOwnerStack(capture() ?? undefined);

--- a/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
+++ b/packages/ui/test/firestore/hooks/useFirestoreDoc.componentOwner.test.tsx
@@ -20,7 +20,6 @@ import { describe, expect, it } from 'bun:test';
 import { doc, getFirestore } from 'pyric/firestore';
 import { initializeSandbox } from 'pyric/sandbox';
 import type { SandboxEvent } from 'pyric/sandbox';
-import { configureListenerAttribution } from 'pyric/sandbox/internal';
 import { seedDocuments } from 'pyric/sandbox/firestore';
 import { useFirestoreDoc } from '../../../src/firestore/hooks/useFirestoreDoc.js';
 
@@ -66,8 +65,9 @@ describe('component owner attribution through useFirestoreDoc', () => {
     expect(component.name).toBe('OrdersTable');
   });
 
-  it('records no component owner when attribution is off', async () => {
-    configureListenerAttribution('off');
+  it('records no component owner in a production build', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     try {
       const { db, events } = setupSandbox();
       const ref = doc(db, 'orders/o1');
@@ -84,7 +84,7 @@ describe('component owner attribution through useFirestoreDoc', () => {
       const owners = attachEvents(events)[0]?.owners;
       expect(owners?.some((owner) => owner.kind === 'component')).toBeFalsy();
     } finally {
-      configureListenerAttribution('auto');
+      process.env.NODE_ENV = previous;
     }
   });
 });

--- a/packages/ui/test/primitives/listenerOwnerEntry.test.ts
+++ b/packages/ui/test/primitives/listenerOwnerEntry.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The `@pyric/ui/listener-owner` entry must not reach pyric at runtime.
+ *
+ * An application that uses the hook ships whatever this entry's module graph
+ * pulls in. If any module in that graph imported pyric for a value rather
+ * than a type, pyric would land in the application's production bundle, which
+ * is exactly what the separate entry exists to prevent.
+ *
+ * The check walks the source graph from the entry, following relative
+ * imports, and reads every specifier each module names. Type-only imports
+ * (`import type ...`) are erased by `tsc`, so they are allowed; a pyric
+ * specifier in any other position is a failure. Reading the source rather
+ * than a build keeps the test runnable without a prior `bun run build`, and
+ * the `import type` requirement is what makes the source reading equivalent
+ * to reading the output.
+ */
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTRY = resolve(HERE, '../../src/listener-owner/index.ts');
+
+/** Every `from '...'` specifier in a module, with its statement text. */
+const IMPORT_STATEMENT = /(?:^|\n)\s*(export|import)\s+(type\s+)?([\s\S]*?)from\s+'([^']+)';/g;
+
+interface Specifier {
+  text: string;
+  typeOnly: boolean;
+}
+
+function specifiersOf(source: string): Specifier[] {
+  const found: Specifier[] = [];
+  for (const match of source.matchAll(IMPORT_STATEMENT)) {
+    found.push({ text: match[4]!, typeOnly: match[2] !== undefined });
+  }
+  return found;
+}
+
+/** Resolve a relative `.js` specifier back to the `.ts` source it came from. */
+function sourcePathFor(from: string, specifier: string): string {
+  const target = resolve(dirname(from), specifier);
+  for (const candidate of [target.replace(/\.js$/, '.ts'), target.replace(/\.js$/, '.tsx')]) {
+    try {
+      readFileSync(candidate, 'utf8');
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`cannot resolve ${specifier} from ${from}`);
+}
+
+interface GraphRead {
+  modules: string[];
+  runtimeSpecifiers: string[];
+}
+
+function readGraph(entry: string): GraphRead {
+  const modules: string[] = [];
+  const runtimeSpecifiers = new Set<string>();
+  const pending = [entry];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (modules.includes(current)) continue;
+    modules.push(current);
+    const source = readFileSync(current, 'utf8');
+    for (const specifier of specifiersOf(source)) {
+      if (specifier.text.startsWith('.')) {
+        pending.push(sourcePathFor(current, specifier.text));
+        continue;
+      }
+      if (specifier.typeOnly) continue;
+      runtimeSpecifiers.add(specifier.text);
+    }
+  }
+  return { modules, runtimeSpecifiers: [...runtimeSpecifiers].sort() };
+}
+
+describe('@pyric/ui/listener-owner', () => {
+  it('names no pyric specifier in a runtime import', () => {
+    const { runtimeSpecifiers } = readGraph(ENTRY);
+    const pyric = runtimeSpecifiers.filter(
+      (specifier) => specifier === 'pyric' || specifier.startsWith('pyric/'),
+    );
+    expect(pyric).toEqual([]);
+  });
+
+  it('imports react and nothing else at runtime', () => {
+    const { runtimeSpecifiers } = readGraph(ENTRY);
+    expect(runtimeSpecifiers).toEqual(['react']);
+  });
+
+  it('reaches only the entry and the hook', () => {
+    const { modules } = readGraph(ENTRY);
+    expect(modules.length).toBe(2);
+  });
+});

--- a/packages/ui/test/primitives/useListenerOwner.test.tsx
+++ b/packages/ui/test/primitives/useListenerOwner.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'bun:test';
-import { configureListenerAttribution } from 'pyric/sandbox/internal';
 import { useListenerOwner } from '../../src/primitives/hooks/useListenerOwner.js';
 import { act, renderHook } from '../helpers/render-hook.js';
 import { FakeElement } from '../helpers/fake-element.js';
@@ -43,7 +42,7 @@ describe('useListenerOwner', () => {
     expect(result.current.owner.path).toBeUndefined();
   });
 
-  it('fills owner.element once ref is attached', () => {
+  it('hands the element itself over once ref is attached', () => {
     const { result } = renderHook(() => useListenerOwner());
     const element = new FakeElement('table');
     element.id = 'orders';
@@ -54,16 +53,17 @@ describe('useListenerOwner', () => {
 
     expect(result.current.owner?.kind).toBe('component');
     if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
-    expect(result.current.owner.element).toBe('#orders');
+    expect(result.current.owner.element).toBe(element);
   });
 
-  it('records no owner at all when attribution is off', () => {
-    configureListenerAttribution('off');
+  it('records no owner at all in a production build', () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     try {
       const { result } = renderHook(() => useListenerOwner());
       expect(result.current.owner).toBeUndefined();
     } finally {
-      configureListenerAttribution('auto');
+      process.env.NODE_ENV = previous;
     }
   });
 });

--- a/packages/ui/test/primitives/useListenerOwner.test.tsx
+++ b/packages/ui/test/primitives/useListenerOwner.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { componentNameFromStack } from '../../src/primitives/hooks/useListenerOwner.js';
 import { useListenerOwner } from '../../src/primitives/hooks/useListenerOwner.js';
 import { act, renderHook } from '../helpers/render-hook.js';
 import { FakeElement } from '../helpers/fake-element.js';
@@ -54,6 +55,21 @@ describe('useListenerOwner', () => {
     expect(result.current.owner?.kind).toBe('component');
     if (result.current.owner?.kind !== 'component') throw new Error('expected a component owner');
     expect(result.current.owner.element).toBe(element);
+  });
+
+  it('finds the component after the hook frame when every module shares one bundled file', () => {
+    const stack = [
+      'Error',
+      '    at captureComponentOwner (http://localhost:3473/assets/index-abc.js:10:5)',
+      '    at http://localhost:3473/assets/index-abc.js:20:5',
+      '    at mountMemo (http://localhost:3473/assets/index-abc.js:30:5)',
+      '    at Object.useMemo (http://localhost:3473/assets/index-abc.js:40:5)',
+      '    at useListenerOwner (http://localhost:3473/assets/index-abc.js:50:5)',
+      '    at useOrders (http://localhost:3473/assets/index-abc.js:60:5)',
+      '    at ChatPage (http://localhost:3473/assets/index-abc.js:70:5)',
+      '    at renderWithHooks (http://localhost:3473/assets/index-abc.js:80:5)',
+    ].join('\n');
+    expect(componentNameFromStack(stack)).toBe('ChatPage');
   });
 
   it('records no owner at all in a production build', () => {


### PR DESCRIPTION
Gives the runtime chip a listener summary that is always there: a count in the collapsed chip, a six-line table in the panel, and outlines that the Listeners button toggles on and off without the summary depending on them.

```
12 listeners · 2 duplicates
01  conversation-list   conversations (query)    1    4
02  /notify             /notify                  3    3
03  /presence           /presence                3    3
All listeners in Studio
```

## The summary reads the fold; the button paints

The Listeners mode observes the sandbox's events from the moment it exists and folds them into outlines; the chip builds it at setup, so the count and the table render on load and survive the outlines being switched off and on. The panel is a grid modelled on the chip's error list: index, label, target, listener and delivery counts right-aligned in the monospace stack, an incident mark, and the same copy and dismiss controls, capped at six lines with incidents first and a Studio link last. A label that would have been a frame's function name falls back to the target.

Two behaviours that read as a broken button are fixed on the way: the panel's enter animation replayed on every render because each render rebuilt it, and it now plays only when the panel opens or closes; and the mode refused silently while attribution was off, which a Vite production build of the served page always is, so the served page turns attribution on explicitly and the chip says why when a toggle does nothing.

## Risk

Runtime chip and served page init only. The chip's listener tests cover the count, the table's rows and cap, copy, dismiss, the incident mark, the animation gating, and the refusal notice; the served-app Playwright case asserts a tagged listener's row.

<details>
<summary>Implementation notes</summary>

- `listener-mode.ts` subscribes on creation; `setEnabled` adds or removes the overlay only.
- `chip.ts` keys dismissals by row signature so a new attach or incident brings a row back.
- `bun test --cwd packages/cli` 3449 pass; `test:site-cli` 3 passed; typecheck and build clean.

</details>
