### PR TITLE
feat(serve): a Flow painting mode for the runtime chip

### DIFF
--- a/packages/cli/src/serve/runtime/chip-install.ts
+++ b/packages/cli/src/serve/runtime/chip-install.ts
@@ -9,6 +9,7 @@ import type { RuntimeIdentityBindings } from './identity.js';
 import { listenerAttributionEnabled } from 'pyric/sandbox/internal';
 import { createListenerMode } from './listener-mode.js';
 import type { SandboxEventSource } from './listener-event-source.js';
+import { installReactCommitSource, type ReactCommitSource } from './react-commit-source.js';
 
 export interface InstallPyricRuntimeChipOptions {
   runtime: PyricRuntimeStatus;
@@ -16,6 +17,14 @@ export interface InstallPyricRuntimeChipOptions {
   identity?: Partial<RuntimeIdentityBindings>;
   /** The page's sandbox event source. Omitted leaves the Listeners mode out. */
   listenerEvents?: SandboxEventSource | null;
+  /**
+   * React's commits, for the Listeners mode's Flow painting. Install this from
+   * the page's own init script, before the application's script runs: React
+   * reads the hook global once, while its own module first evaluates, so a
+   * source installed later never sees a commit. Omitted, the chip installs one
+   * here, which is in time only when the chip itself mounts that early.
+   */
+  commits?: ReactCommitSource;
   mount?: (options: PyricRuntimeChipOptions) => PyricRuntimeChip;
 }
 
@@ -38,11 +47,15 @@ export function installPyricRuntimeChip(
     const studioUrl = config.studioEnabled
       ? options.runtime.getSnapshot().manifest.studioUrl
       : null;
+    // Installed here rather than inside the mode, which the chip builds only
+    // when a developer first opens the Listeners panel, long after React.
+    const commits = options.commits ?? installReactCommitSource(options.document.defaultView);
     chipOptions.listeners = (onChange) => createListenerMode({
       document: options.document,
       subscribeEvents: events,
       attributionEnabled: listenerAttributionEnabled,
       studioUrl,
+      commits,
       onChange,
     });
   }

--- a/packages/cli/src/serve/runtime/chip-install.ts
+++ b/packages/cli/src/serve/runtime/chip-install.ts
@@ -10,6 +10,7 @@ import { listenerAttributionEnabled } from 'pyric/sandbox/internal';
 import { createListenerMode } from './listener-mode.js';
 import type { SandboxEventSource } from './listener-event-source.js';
 import { installReactCommitSource, type ReactCommitSource } from './react-commit-source.js';
+import type { OverlayTheme } from './overlay-theme.js';
 
 export interface InstallPyricRuntimeChipOptions {
   runtime: PyricRuntimeStatus;
@@ -25,6 +26,12 @@ export interface InstallPyricRuntimeChipOptions {
    * here, which is in time only when the chip itself mounts that early.
    */
   commits?: ReactCommitSource;
+  /**
+   * Custom property overrides for the painted listener overlay, for a served
+   * page that wants its own look. The page's own stored overrides win over
+   * these, and both win over the contract's defaults. See `overlay-theme.ts`.
+   */
+  overlayTheme?: OverlayTheme;
   mount?: (options: PyricRuntimeChipOptions) => PyricRuntimeChip;
 }
 
@@ -56,6 +63,7 @@ export function installPyricRuntimeChip(
       attributionEnabled: listenerAttributionEnabled,
       studioUrl,
       commits,
+      overlayTheme: options.overlayTheme ?? null,
       onChange,
     });
   }

--- a/packages/cli/src/serve/runtime/chip-theme-dialog.ts
+++ b/packages/cli/src/serve/runtime/chip-theme-dialog.ts
@@ -1,0 +1,185 @@
+/**
+ * The chip's Theme dialog: the overlay's custom properties, as text a
+ * developer can edit while the page is painting.
+ *
+ * The dialog is the third of the overlay theme's entry points, next to the
+ * served page's option and the page's own stored overrides. It shows the
+ * overrides in effect, or the whole contract when there are none, so the
+ * developer can see every property there is to set. Apply parses the text,
+ * keeps it in the page's storage, and hands it to the painting now. Reset
+ * takes the stored overrides away and goes back to what the page was served
+ * with.
+ *
+ * Unknown property names are not an error: the theme keeps them out when it
+ * resolves, so a stale name in the text changes nothing.
+ */
+import {
+  clearStoredOverlayTheme,
+  OVERLAY_THEME_DEFAULTS,
+  parseOverlayTheme,
+  writeStoredOverlayTheme,
+  type OverlayTheme,
+  type OverlayThemeStorage,
+} from './overlay-theme.js';
+
+export interface ChipThemeDialogOptions {
+  shadowRoot: ShadowRoot;
+  /** The overrides in effect, for the text the dialog opens with. */
+  readTheme: () => OverlayTheme;
+  /** Draw with these overrides now. `null` goes back to the served page's. */
+  applyTheme: (theme: OverlayTheme | null) => void;
+  /** Where the overrides are kept. */
+  storage: OverlayThemeStorage | null;
+}
+
+export interface ChipThemeDialogController {
+  element: HTMLDialogElement;
+  open(triggerElement?: HTMLElement): void;
+  close(): void;
+  dispose(): void;
+}
+
+export const THEME_DIALOG_STYLES = `
+  .theme-dialog:not([open]) { display: none !important; }
+  .theme-dialog {
+    all: initial; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    margin: 0; padding: 0; border: 1px solid var(--pyric-border, #33333f); border-radius: 12px;
+    background: var(--pyric-content, #16161a); color: var(--pyric-text, #fbfbfe);
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 13px; line-height: 1.45; box-shadow: 0 16px 40px rgba(0, 0, 0, 0.6);
+    width: min(440px, 92vw); overflow: hidden; z-index: 2147483647;
+  }
+  .theme-dialog::backdrop { background: rgba(0, 0, 0, 0.65); backdrop-filter: blur(2px); }
+  .theme-dialog-panel { display: flex; flex-direction: column; gap: 10px; padding: 20px; box-sizing: border-box; }
+  .theme-dialog header { display: flex; align-items: center; justify-content: space-between; }
+  .theme-dialog h2 { margin: 0; font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+  .theme-hint { color: var(--pyric-muted, #89899f); font-size: 11px; margin: 0; }
+  .theme-input {
+    all: initial; box-sizing: border-box; width: 100%; height: 220px; resize: vertical;
+    background: #121215; border: 1px solid var(--pyric-border-soft, #2a2a35); border-radius: 6px;
+    color: var(--pyric-text, #fbfbfe); font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 11px; line-height: 1.5; padding: 8px 10px; white-space: pre;
+  }
+  .theme-input:focus { border-color: #4a4a58; }
+  .theme-error { color: var(--pyric-error, #f0a0a0); font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 10px; margin: 0; }
+  .theme-footer { display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+  .theme-footer .button {
+    align-items: center; appearance: none; background: #24242c; border: 1px solid #2a2a35;
+    border-radius: 6px; color: #fbfbfe; cursor: pointer; display: inline-flex;
+    font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11px; justify-content: center;
+    letter-spacing: .04em; min-height: 32px; min-width: 96px; padding: 6px 14px;
+    text-transform: uppercase; box-sizing: border-box;
+  }
+  .theme-footer .button:hover { border-color: #3a3a48; background: #2a2a34; color: #ffffff; }
+`;
+
+/** The text the dialog opens with: the overrides, or the whole contract. */
+export function themeDialogText(theme: OverlayTheme): string {
+  const shown = Object.keys(theme).length > 0 ? theme : OVERLAY_THEME_DEFAULTS;
+  return JSON.stringify(shown, null, 2);
+}
+
+/** Build the Theme dialog in the chip's shadow root. */
+export function createChipThemeDialog(
+  options: ChipThemeDialogOptions,
+): ChipThemeDialogController {
+  const { shadowRoot, readTheme, applyTheme, storage } = options;
+  const dialog = shadowRoot.ownerDocument.createElement('dialog');
+  dialog.className = 'theme-dialog';
+  dialog.setAttribute('data-overlay-theme-dialog', '');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-labelledby', 'dialog-theme-title');
+  dialog.innerHTML = `
+    <div class="theme-dialog-panel">
+      <header>
+        <h2 id="dialog-theme-title">Overlay theme</h2>
+        <button type="button" class="dialog-close" data-close-theme aria-label="Close dialog">✕</button>
+      </header>
+      <p class="theme-hint">Custom properties for the painted boxes. Names outside the contract are ignored.</p>
+      <textarea class="theme-input" data-theme-input spellcheck="false" aria-label="Overlay theme JSON"></textarea>
+      <p class="theme-error" data-theme-error hidden></p>
+      <footer class="theme-footer">
+        <button type="button" class="button" data-theme-reset>Reset</button>
+        <button type="button" class="button" data-theme-apply>Apply</button>
+      </footer>
+    </div>
+  `;
+  shadowRoot.appendChild(dialog);
+
+  const input = dialog.querySelector<HTMLTextAreaElement>('[data-theme-input]')!;
+  const error = dialog.querySelector<HTMLElement>('[data-theme-error]')!;
+  const closeButton = dialog.querySelector<HTMLButtonElement>('[data-close-theme]')!;
+  const applyButton = dialog.querySelector<HTMLButtonElement>('[data-theme-apply]')!;
+  const resetButton = dialog.querySelector<HTMLButtonElement>('[data-theme-reset]')!;
+  let trigger: HTMLElement | null = null;
+
+  const showError = (message: string | null): void => {
+    if (message === null) {
+      error.textContent = '';
+      error.hidden = true;
+      return;
+    }
+    error.textContent = message;
+    error.hidden = false;
+  };
+
+  const close = (): void => {
+    if (dialog.open) {
+      if (typeof dialog.close === 'function') dialog.close();
+      else dialog.removeAttribute('open');
+    }
+    if (trigger !== null && typeof trigger.focus === 'function' && trigger.isConnected) {
+      trigger.focus();
+    }
+  };
+
+  closeButton.addEventListener('click', () => close());
+  dialog.addEventListener('cancel', (event: Event) => {
+    event.preventDefault();
+    close();
+  });
+  dialog.addEventListener('click', (event: MouseEvent) => {
+    if (event.target === dialog) close();
+  });
+  dialog.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key !== 'Escape') return;
+    event.stopPropagation();
+    close();
+  });
+
+  applyButton.addEventListener('click', () => {
+    const theme = parseOverlayTheme(input.value);
+    if (theme === null) {
+      showError('That is not a JSON object of property name to value.');
+      return;
+    }
+    showError(null);
+    writeStoredOverlayTheme(storage, theme);
+    applyTheme(theme);
+    close();
+  });
+
+  resetButton.addEventListener('click', () => {
+    showError(null);
+    clearStoredOverlayTheme(storage);
+    applyTheme(null);
+    input.value = themeDialogText(readTheme());
+  });
+
+  return {
+    element: dialog,
+    open(triggerElement) {
+      if (triggerElement !== undefined) trigger = triggerElement;
+      showError(null);
+      input.value = themeDialogText(readTheme());
+      if (typeof dialog.showModal === 'function') dialog.showModal();
+      else dialog.setAttribute('open', '');
+      if (typeof input.focus === 'function') input.focus();
+    },
+    close,
+    dispose() {
+      dialog.remove();
+    },
+  };
+}

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -219,6 +219,7 @@ const styles = `
   .error-meta { color: var(--pyric-muted); font: 9px/1.4 ui-monospace, monospace; margin-top: 4px; overflow-wrap: anywhere; }
   .empty { align-items: center; color: var(--pyric-muted); display: flex; font: 11px/1.5 ui-monospace, monospace; min-height: 57px; padding: 12px; }
   .actions { display: grid; gap: 8px; grid-template-columns: repeat(3, 1fr); min-height: 56px; padding: 10px 12px; }
+  .flow-waiting { color: var(--pyric-muted); font: 9px/1.4 ui-monospace, monospace; grid-column: 1 / -1; }
   .button { align-items: center; background: transparent; border: 1px solid var(--pyric-border-soft); border-radius: 4px; color: var(--pyric-muted); display: inline-flex; font-size: 10px; justify-content: center; letter-spacing: .06em; min-height: 34px; padding: 6px 8px; text-decoration: none; text-transform: uppercase; }
   button.button { cursor: pointer; }
   .button:hover:not(:disabled):not([aria-disabled="true"]), a.button:hover { border-color: #3a3a48; color: var(--pyric-text); }
@@ -630,6 +631,8 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
    * back on its own once its signature moves, which a new attach on its
    * target or a new incident does. */
   const dismissedListenerRows = new Set<string>();
+  /** Whether the last rendered panel carried the Flow waiting line. */
+  let renderedFlowWaiting = false;
   const ensureListenerMode = (): ListenerMode | null => {
     if (listenerMode !== null) return listenerMode;
     const build = options.listeners;
@@ -637,8 +640,12 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     listenerMode = build((outlines) => {
       everReportedListeners = true;
       // The mode reports on every attach, delivery, and resize; rebuild the
-      // view only when what the Listeners summary shows actually changes.
-      if (sameOutlines(outlines, listenerOutlines)) return;
+      // view only when what the panel shows actually changes. The first
+      // painted flow changes the panel without changing the outlines, because
+      // it is what takes the waiting line away.
+      const waiting = listenerMode?.flowWaiting() === true;
+      if (sameOutlines(outlines, listenerOutlines) && waiting === renderedFlowWaiting) return;
+      renderedFlowWaiting = waiting;
       listenerOutlines = outlines;
       render();
     });
@@ -722,6 +729,14 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
             <button type="button" data-listener-mode="overview" aria-pressed="${paintMode === 'overview'}" title="Outline every attached listener">Overview</button>
             <button type="button" data-listener-mode="flow" aria-pressed="${paintMode === 'flow'}"${flowOff ? ` aria-disabled="true" title="${escapeAttribute(flowReason)}"` : ' title="Outline what rendered after each delivery"'}>Flow</button>
           </div>`;
+      // Flow paints on delivery, so a page that is sitting idle shows nothing
+      // and looks broken. The line says what the mode is waiting for, and goes
+      // as soon as the first delivery is painted.
+      renderedFlowWaiting = listenerMode?.flowWaiting() === true;
+      if (renderedFlowWaiting) {
+        listenersButtonHtml += `
+          <div class="flow-waiting" data-flow-waiting>Waiting for a delivery to show its flow.</div>`;
+      }
     }
     let listenerPanelHtml = '';
     if (listenerNotice !== null) {

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -12,6 +12,12 @@ import {
 import type { RuntimeIdentity, RuntimeIdentityBindings } from './identity.js';
 import type { ListenerMode } from './listener-mode.js';
 import type { ListenerOutline, ListenerOutlineIncident } from './listener-outline-model.js';
+import { listenerColors } from './listener-palette.js';
+import {
+  pagePaintModeStorage,
+  readListenerPaintMode,
+  type ListenerPaintMode,
+} from './listener-paint-mode.js';
 import {
   getLens as defaultGetLens,
   setLens as defaultSetLens,
@@ -158,9 +164,26 @@ const styles = `
     color: #d7d7df;
     display: grid;
     gap: 6px;
-    grid-template-columns: 16px minmax(0,1fr) minmax(0,1.2fr) 30px 34px 10px 24px 24px;
+    grid-template-columns: 14px 8px minmax(0,1fr) minmax(0,1.1fr) 28px 32px 10px 16px 22px 22px;
     padding: 4px 0 4px 2px;
   }
+  .listener-swatch { border-radius: 2px; height: 8px; width: 8px; }
+  .listener-swatch.empty { background: transparent; }
+  .listener-paint { accent-color: var(--pyric-accent); cursor: pointer; height: 11px; margin: 0; width: 11px; }
+  .listener-paint:disabled { cursor: not-allowed; opacity: .3; }
+  .listener-row.hidden-paint .listener-label, .listener-row.hidden-paint .listener-target { opacity: .5; }
+  .segmented { border: 1px solid var(--pyric-border-soft); border-radius: 999px; display: inline-flex; overflow: hidden; }
+  .segmented button {
+    background: transparent;
+    border: 0;
+    color: var(--pyric-muted);
+    cursor: pointer;
+    font: 10px/1 ui-monospace, monospace;
+    padding: 5px 9px;
+  }
+  .segmented button:hover { color: var(--pyric-text); }
+  .segmented button[aria-pressed="true"] { background: rgba(25,204,97,.12); color: var(--pyric-accent); }
+  .segmented button[aria-disabled="true"] { cursor: not-allowed; opacity: .45; }
   .listener-row:last-child { border-bottom: 0; }
   .listener-row:hover { background: rgba(255,255,255,.05); }
   .listener-number { color: var(--pyric-muted); font: 10px/18px ui-monospace, monospace; }
@@ -318,6 +341,11 @@ interface ListenerOwnerGroup {
   deliveries: number;
   targets: Set<string>;
   incident: ListenerOutlineIncident | null;
+  /**
+   * The listeners the row stands for. A row collapsed from several listeners
+   * under one owner switches all of them at once.
+   */
+  listenerIds: string[];
 }
 
 /** The owner groups a Listeners panel lists, busiest by total deliveries
@@ -333,6 +361,7 @@ function listenerOwnerGroups(outlines: readonly ListenerOutline[]): ListenerOwne
       existing.deliveries += outline.deliveryCount;
       existing.targets.add(target);
       existing.incident ??= outline.incident;
+      existing.listenerIds.push(outline.listenerId);
     } else {
       groups.set(key, {
         key,
@@ -340,6 +369,7 @@ function listenerOwnerGroups(outlines: readonly ListenerOutline[]): ListenerOwne
         deliveries: outline.deliveryCount,
         targets: new Set([target]),
         incident: outline.incident,
+        listenerIds: [outline.listenerId],
       });
     }
   }
@@ -373,6 +403,8 @@ interface ListenerTableRow {
   mark: string;
   markTitle: string;
   copyText: string;
+  /** The listeners this row paints, empty on an incident row. */
+  listenerIds: readonly string[];
 }
 
 /** `duplicate ×2`, `churn ×40`: what an incident mark stands for. */
@@ -395,6 +427,7 @@ function incidentTableRow(group: ListenerIncidentGroup): ListenerTableRow {
     mark: '!',
     markTitle: prose,
     copyText: prose,
+    listenerIds: [],
   };
 }
 
@@ -417,6 +450,7 @@ function ownerTableRow(group: ListenerOwnerGroup): ListenerTableRow {
     mark: group.incident === null ? '' : '!',
     markTitle: group.incident === null ? '' : incidentMarkTitle(group.incident),
     copyText: `${group.key} · ${target} · ${counts}${incidentSuffix}`,
+    listenerIds: group.listenerIds,
   };
 }
 
@@ -439,16 +473,45 @@ function listenerTableRows(
   return [...incidents, ...owners];
 }
 
-function listenerRowHtml(row: ListenerTableRow, index: number, canCopy: boolean): string {
+/**
+ * The swatch a row shows: the listener's own colour, or a band across the
+ * colours of the listeners an owner row collapsed together.
+ */
+function listenerSwatchStyle(listenerIds: readonly string[]): string {
+  const colors = listenerIds.map((listenerId) => listenerColors(listenerId).swatch);
+  if (colors.length === 0) return '';
+  if (colors.length === 1) return `background:${colors[0]}`;
+  const stops = colors
+    .slice(0, 4)
+    .map((color, index, all) => `${color} ${Math.round((index / all.length) * 100)}% ${Math.round(((index + 1) / all.length) * 100)}%`)
+    .join(',');
+  return `background:linear-gradient(180deg,${stops})`;
+}
+
+function listenerRowHtml(
+  row: ListenerTableRow,
+  index: number,
+  canCopy: boolean,
+  isPainted: (listenerId: string) => boolean,
+): string {
   const ordinal = String(index + 1).padStart(2, '0');
   const name = escapeAttribute(`${row.label} ${row.target}`);
-  return `<div class="listener-row${row.isIncident ? ' incident' : ''}" data-listener-row="${escapeAttribute(row.signature)}">
+  const painted = row.listenerIds.length > 0 && row.listenerIds.some(isPainted);
+  const paintLabel = row.listenerIds.length > 1
+    ? `Paint the ${row.listenerIds.length} listeners under ${row.label}`
+    : `Paint ${row.label} ${row.target}`;
+  const paintHtml = row.listenerIds.length === 0
+    ? '<span class="listener-paint" aria-hidden="true"></span>'
+    : `<input class="listener-paint" type="checkbox" data-toggle-listener-paint="${escapeAttribute(row.signature)}" ${painted ? 'checked' : ''} aria-label="${escapeAttribute(paintLabel)}" title="${escapeAttribute(paintLabel)}">`;
+  return `<div class="listener-row${row.isIncident ? ' incident' : ''}${row.listenerIds.length > 0 && !painted ? ' hidden-paint' : ''}" data-listener-row="${escapeAttribute(row.signature)}">
       <span class="listener-number">${ordinal}</span>
+      <span class="listener-swatch${row.listenerIds.length === 0 ? ' empty' : ''}" data-listener-swatch style="${escapeAttribute(listenerSwatchStyle(row.listenerIds))}" aria-hidden="true"></span>
       <span class="listener-label" title="${escapeAttribute(row.label)}">${escapeAttribute(row.label)}</span>
       <span class="listener-target" title="${escapeAttribute(row.target)}">${escapeAttribute(row.target)}</span>
       <span class="listener-count" title="${escapeAttribute(row.firstTitle)}">${escapeAttribute(row.first)}</span>
       <span class="listener-count" title="${escapeAttribute(row.secondTitle)}">${escapeAttribute(row.second)}</span>
       <span class="listener-mark" title="${escapeAttribute(row.markTitle)}" aria-hidden="${row.mark === '' ? 'true' : 'false'}">${escapeAttribute(row.mark)}</span>
+      ${paintHtml}
       <button class="icon-button" type="button" data-copy-listener="${escapeAttribute(row.signature)}" aria-label="${canCopy ? `Copy ${name}` : 'Copy unavailable'}" title="${canCopy ? 'Copy listener row' : 'Clipboard unavailable'}" ${canCopy ? '' : 'disabled'}>${icons.copy}</button>
       <button class="icon-button" type="button" data-dismiss-listener="${escapeAttribute(row.signature)}" aria-label="Dismiss ${name}" title="Dismiss listener row">${icons.close}</button>
     </div>`;
@@ -464,6 +527,7 @@ function listenerSectionHtml(
   studioUrl: string | null,
   canCopy: boolean,
   dismissed: ReadonlySet<string>,
+  isPainted: (listenerId: string) => boolean,
 ): string {
   const incidentGroups = listenerIncidentGroups(outlines);
   const duplicateCount = incidentGroups.filter((group) => group.pattern === 'duplicate-listener').length;
@@ -474,7 +538,7 @@ function listenerSectionHtml(
     : `<span class="listener-link" data-open-listeners-studio aria-disabled="true" title="Pyric Studio is disabled">All listeners in Studio</span>`;
   return `<div class="worker-state-col" data-listener-panel>
       <div class="worker-state-row"><span class="state-label listener-header${incidentGroups.length > 0 ? ' has-incident' : ''}">${escapeAttribute(header)}</span></div>
-      <div class="listener-rows">${rows.map((row, index) => listenerRowHtml(row, index, canCopy)).join('')}</div>
+      <div class="listener-rows">${rows.map((row, index) => listenerRowHtml(row, index, canCopy, isPainted)).join('')}</div>
       ${linkHtml}
     </div>`;
 }
@@ -554,6 +618,9 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
 
   let listenerMode: ListenerMode | null = null;
   let listenerOutlines: readonly ListenerOutline[] = [];
+  /** The remembered painting mode, for the control the chip draws before the
+   * Listeners mode is built. */
+  const paintModeBeforeBuild = readListenerPaintMode(pagePaintModeStorage(documentLike));
   /** `true` once the Listeners mode has reported at least once. The collapsed
    * chip's listener count stays hidden until then. */
   let everReportedListeners = false;
@@ -645,7 +712,16 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     const listenersOn = listenerMode?.enabled() === true;
     let listenersButtonHtml = '';
     if (options.listeners) {
-      listenersButtonHtml = `<button class="button" type="button" data-toggle-listeners aria-pressed="${listenersOn}">Listeners</button>`;
+      // The mode may not be built yet; the control still has to show which way
+      // the painting would go, so it falls back to the remembered mode.
+      const paintMode: ListenerPaintMode = listenerMode?.mode() ?? paintModeBeforeBuild;
+      const flowReason = listenerMode === null ? null : listenerMode.flowUnavailableReason();
+      const flowOff = flowReason !== null;
+      listenersButtonHtml = `<button class="button" type="button" data-toggle-listeners aria-pressed="${listenersOn}">Listeners</button>
+          <div class="segmented" role="group" aria-label="How listeners are painted" data-listener-modes>
+            <button type="button" data-listener-mode="overview" aria-pressed="${paintMode === 'overview'}" title="Outline every attached listener">Overview</button>
+            <button type="button" data-listener-mode="flow" aria-pressed="${paintMode === 'flow'}"${flowOff ? ` aria-disabled="true" title="${escapeAttribute(flowReason)}"` : ' title="Outline what rendered after each delivery"'}>Flow</button>
+          </div>`;
     }
     let listenerPanelHtml = '';
     if (listenerNotice !== null) {
@@ -653,7 +729,13 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     } else if (listenerMode !== null) {
       listenerPanelHtml = listenerOutlines.length === 0
         ? `<div class="worker-state-col" data-listener-panel><div class="worker-state-row"><span class="state-label">No listeners</span></div></div>`
-        : listenerSectionHtml(listenerOutlines, studioUrl ?? null, Boolean(clipboard), dismissedListenerRows);
+        : listenerSectionHtml(
+          listenerOutlines,
+          studioUrl ?? null,
+          Boolean(clipboard),
+          dismissedListenerRows,
+          (listenerId) => listenerMode?.isListenerVisible(listenerId) !== false,
+        );
     }
     const hasListenerIncident = listenerOutlines.some((outline) => outline.incident !== null);
     const listenerCountHtml = everReportedListeners
@@ -753,6 +835,30 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       listenerOutlines = mode.outlines();
       render();
     });
+    for (const button of root.querySelectorAll<HTMLButtonElement>('[data-listener-mode]')) {
+      button.addEventListener('click', () => {
+        const mode = ensureListenerMode();
+        if (mode === null) return;
+        const wanted = button.dataset.listenerMode === 'flow' ? 'flow' : 'overview';
+        mode.setMode(wanted);
+        // The mode refuses Flow on a page whose renders it cannot read; say
+        // which of the two is missing rather than leaving the control still.
+        listenerNotice = mode.mode() === wanted ? null : mode.flowUnavailableReason();
+        listenerOutlines = mode.outlines();
+        render();
+      });
+    }
+    for (const box of root.querySelectorAll<HTMLInputElement>('[data-toggle-listener-paint]')) {
+      box.addEventListener('change', () => {
+        const mode = listenerMode;
+        if (mode === null) return;
+        const row = listenerTableRows(listenerOutlines, dismissedListenerRows)
+          .find((candidate) => candidate.signature === box.dataset.toggleListenerPaint);
+        if (row === undefined) return;
+        for (const listenerId of row.listenerIds) mode.setListenerVisible(listenerId, box.checked);
+        render();
+      });
+    }
     root.querySelector('[data-open-impersonate]')?.addEventListener('click', (e) => {
       void dialogController.open(e.currentTarget as HTMLElement);
     });

--- a/packages/cli/src/serve/runtime/chip.ts
+++ b/packages/cli/src/serve/runtime/chip.ts
@@ -9,6 +9,12 @@ import {
   DIALOG_STYLES,
   type ChipDialogController,
 } from './chip-dialog.js';
+import {
+  createChipThemeDialog,
+  THEME_DIALOG_STYLES,
+  type ChipThemeDialogController,
+} from './chip-theme-dialog.js';
+import { pageOverlayThemeStorage } from './overlay-theme.js';
 import type { RuntimeIdentity, RuntimeIdentityBindings } from './identity.js';
 import type { ListenerMode } from './listener-mode.js';
 import type { ListenerOutline, ListenerOutlineIncident } from './listener-outline-model.js';
@@ -239,6 +245,7 @@ const styles = `
   }
 
   ${DIALOG_STYLES}
+  ${THEME_DIALOG_STYLES}
 `;
 
 const icons = {
@@ -652,6 +659,21 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
     return listenerMode;
   };
 
+  /** The Theme dialog, built on the first open: the panel usually never asks. */
+  let themeDialogController: ChipThemeDialogController | null = null;
+  const themeDialog = (): ChipThemeDialogController => {
+    if (themeDialogController !== null) return themeDialogController;
+    themeDialogController = createChipThemeDialog({
+      shadowRoot: root,
+      storage: pageOverlayThemeStorage(documentLike),
+      readTheme: () => ensureListenerMode()?.overlayTheme() ?? {},
+      applyTheme: (theme) => {
+        ensureListenerMode()?.setOverlayTheme(theme);
+      },
+    });
+    return themeDialogController;
+  };
+
   const dialogController: ChipDialogController = createChipDialogController({
     shadowRoot: root,
     identity,
@@ -728,7 +750,8 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
           <div class="segmented" role="group" aria-label="How listeners are painted" data-listener-modes>
             <button type="button" data-listener-mode="overview" aria-pressed="${paintMode === 'overview'}" title="Outline every attached listener">Overview</button>
             <button type="button" data-listener-mode="flow" aria-pressed="${paintMode === 'flow'}"${flowOff ? ` aria-disabled="true" title="${escapeAttribute(flowReason)}"` : ' title="Outline what rendered after each delivery"'}>Flow</button>
-          </div>`;
+          </div>
+          <button class="button" type="button" data-open-overlay-theme title="Edit the overlay's custom properties">Theme</button>`;
       // Flow paints on delivery, so a page that is sitting idle shows nothing
       // and looks broken. The line says what the mode is waiting for, and goes
       // as soon as the first delivery is painted.
@@ -874,6 +897,10 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
         render();
       });
     }
+    root.querySelector('[data-open-overlay-theme]')?.addEventListener('click', (e) => {
+      if (ensureListenerMode() === null) return;
+      themeDialog().open(e.currentTarget as HTMLElement);
+    });
     root.querySelector('[data-open-impersonate]')?.addEventListener('click', (e) => {
       void dialogController.open(e.currentTarget as HTMLElement);
     });
@@ -953,6 +980,7 @@ export function mountPyricRuntimeChip(options: PyricRuntimeChipOptions): PyricRu
       unsubAuth();
       documentLike.removeEventListener('astro:after-swap', reattachAfterAstroSwap);
       dialogController.dispose();
+      themeDialogController?.dispose();
       listenerMode?.dispose();
       host.remove();
     },

--- a/packages/cli/src/serve/runtime/delivery-correlation.ts
+++ b/packages/cli/src/serve/runtime/delivery-correlation.ts
@@ -1,0 +1,144 @@
+/**
+ * The window between a listener delivery and the render that follows it.
+ *
+ * A delivery is the moment the worker client hands a snapshot to the
+ * application's own callback. The page cannot see what the application then
+ * does with the data, so this module states a weaker and honest thing: it
+ * opens a window at the delivery, collects the nodes the page changed while
+ * the window is open, and closes the window at the next React commit. What
+ * comes out is "these nodes changed after that delivery", which is
+ * correlation, not data tracing.
+ *
+ * Two consequences are deliberate and are what the badges say rather than
+ * hide. A state update the application batched into the same commit is
+ * attributed to the listener whose delivery opened the window. Two deliveries
+ * that land before one commit are both attributed to that commit's changes,
+ * and each gets its own flow record, because nothing on the page can separate
+ * them.
+ *
+ * The module is pure apart from the timer it is handed: it holds no DOM, no
+ * React, and no sandbox types, and every clock it reads is injectable.
+ */
+
+/** One delivery and the nodes the page changed after it. */
+export interface DeliveryFlow {
+  /** The sandbox listener id, which is the worker subscription id. */
+  readonly listenerId: string;
+  /** When the delivery arrived, on the injected clock. */
+  readonly at: number;
+  /** How long the window stayed open, in milliseconds. */
+  readonly elapsedMs: number;
+  /** The nodes the page changed while the window was open. */
+  readonly nodes: readonly unknown[];
+}
+
+export interface DeliveryCorrelationOptions {
+  /** Called once per delivery whose window closed on a commit that changed something. */
+  onFlow: (flow: DeliveryFlow) => void;
+  /**
+   * How long a delivery waits for a commit. A window that expires is dropped:
+   * a commit that far from the delivery says nothing about it.
+   */
+  windowMs?: number;
+  /** The clock. Defaults to `Date.now`. */
+  now?: () => number;
+  /** How the sweep is scheduled. Returns the cancel function. */
+  schedule?: (run: () => void, delayMs: number) => () => void;
+}
+
+export interface DeliveryCorrelation {
+  /** A listener handed a snapshot to the application. Opens a window. */
+  delivered(listenerId: string): void;
+  /** Nodes the page changed. Ignored when no window is open. */
+  changed(nodes: Iterable<unknown>): void;
+  /** React finished a commit. Closes every open window. */
+  committed(): void;
+  /** The listener ids whose windows are still open, oldest first. */
+  pending(): readonly string[];
+  /** Close every window without reporting, and cancel the sweep. */
+  dispose(): void;
+}
+
+/** How long a delivery waits for a commit, in milliseconds. */
+const DEFAULT_WINDOW_MS = 250;
+
+function defaultSchedule(run: () => void, delayMs: number): () => void {
+  const handle = setTimeout(run, delayMs);
+  return () => {
+    clearTimeout(handle);
+  };
+}
+
+/** Build the correlation. It starts with no window open. */
+export function createDeliveryCorrelation(
+  options: DeliveryCorrelationOptions,
+): DeliveryCorrelation {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = options.now ?? (() => Date.now());
+  const schedule = options.schedule ?? defaultSchedule;
+
+  let open: Array<{ listenerId: string; at: number }> = [];
+  let changedNodes: unknown[] = [];
+  let cancelSweep: (() => void) | null = null;
+
+  const stopSweep = (): void => {
+    cancelSweep?.();
+    cancelSweep = null;
+  };
+
+  const closeAll = (): void => {
+    open = [];
+    changedNodes = [];
+    stopSweep();
+  };
+
+  function sweep(): void {
+    cancelSweep = null;
+    const deadline = now() - windowMs;
+    open = open.filter((entry) => entry.at > deadline);
+    if (open.length === 0) {
+      changedNodes = [];
+      return;
+    }
+    startSweep();
+  }
+
+  function startSweep(): void {
+    if (cancelSweep !== null) return;
+    cancelSweep = schedule(sweep, windowMs);
+  }
+
+  return {
+    delivered(listenerId) {
+      open.push({ listenerId, at: now() });
+      startSweep();
+    },
+    changed(nodes) {
+      if (open.length === 0) return;
+      for (const node of nodes) changedNodes.push(node);
+    },
+    committed() {
+      if (open.length === 0) return;
+      const at = now();
+      const deadline = at - windowMs;
+      const live = open.filter((entry) => entry.at > deadline);
+      const nodes = changedNodes.slice();
+      closeAll();
+      if (nodes.length === 0) return;
+      for (const entry of live) {
+        options.onFlow({
+          listenerId: entry.listenerId,
+          at: entry.at,
+          elapsedMs: at - entry.at,
+          nodes,
+        });
+      }
+    },
+    pending() {
+      return open.map((entry) => entry.listenerId);
+    },
+    dispose() {
+      closeAll();
+    },
+  };
+}

--- a/packages/cli/src/serve/runtime/fiber-flow.ts
+++ b/packages/cli/src/serve/runtime/fiber-flow.ts
@@ -29,47 +29,44 @@ export interface FiberLike {
 }
 
 /**
- * What a painted box stands for. A `component` box is a component fiber the
- * walk named. A `region` box is the element the listener's owner registered,
- * which the paint is rooted on rather than on the owning component's own host
- * node. A `host` box is a changed element no component named, badged by the
- * element itself.
+ * What a painted mark stands for. A `component` mark is a component fiber the
+ * walk named. A `host` mark is a changed element no component named, labelled
+ * by the element itself.
  */
-export type FlowBoxKind = 'component' | 'region' | 'host';
+export type FlowBoxKind = 'component' | 'host';
 
-/** One box the flow painter draws, and the element it covers. */
+/** One element the flow painter marks, and what to call it. */
 export interface FlowComponent {
   /** `type.displayName`, else `type.name`, else the element's own label. */
   readonly name: string;
   /** The first host element at or below the component, or the changed node. */
   readonly element: Element;
-  /** How many collected boxes sit above this one, root first at 0. */
+  /** How many collected marks sit above this one, root first at 0. */
   readonly depth: number;
-  /** What this box stands for. */
+  /** What this mark stands for. */
   readonly kind: FlowBoxKind;
 }
 
 /** A delivery's rendered subtree, as the flow painter draws it. */
 export interface FlowSubtree {
-  /** The box the root badge goes on, or `null` when nothing was found. */
+  /** The mark the full label goes on, or `null` when nothing was found. */
   readonly root: FlowComponent | null;
-  /** Every collected box, outermost first, the root included. */
+  /** Every collected mark, outermost first, the root included. */
   readonly components: readonly FlowComponent[];
-  /** The collected boxes nothing else collected sits below. */
+  /** The collected marks nothing else collected sits below. */
   readonly leaves: readonly FlowComponent[];
 }
 
 /** How the subtree is rooted, and which component the badge already names. */
 export interface FlowSubtreeOptions {
   /**
-   * The element the listener's owner registered. When the page still holds
-   * one, the paint is rooted on it and the owning component is named in the
-   * badge rather than outlined.
+   * The element the listener's owner registered. Flow never marks it: it is
+   * the whole area the listener feeds rather than something that changed.
    */
   readonly regionElement?: Element | null;
   /**
-   * The owner the root badge names. A component of this name is never given a
-   * box of its own, because the badge already says it.
+   * The owner the first label names. A component of this name is never marked,
+   * because the label already says it.
    */
   readonly ownerName?: string | null;
 }
@@ -240,20 +237,20 @@ export function regionSubtree(element: Element, ownerName?: string | null): Flow
   const name = ownerName !== null && ownerName !== undefined && ownerName.length > 0
     ? ownerName
     : elementLabel(element);
-  const root: FlowComponent = { name, element, depth: 0, kind: 'region' };
+  const root: FlowComponent = { name, element, depth: 0, kind: 'component' };
   return { root, components: [root], leaves: [] };
 }
 
 /**
- * The subtree of boxes above the nodes that changed.
+ * The subtree of marks above the nodes that changed.
  *
  * Every node is resolved to its fiber and the `return` chain above it is
- * collected, but the owner the root badge names is never given a box. On a
- * page whose owning component renders its list, header, and thread as inline
- * JSX, that component is the only one between the page root and a new list
- * item, so outlining it outlines the whole page. The root is instead the
- * element the owner registered, when the page still holds one, and a changed
- * node no component named becomes a box of its own, badged by the element.
+ * collected, but the owner is never marked. On a page whose owning component
+ * renders its list, header, and thread as inline JSX, that component is the
+ * only one between the page root and a new list item, so outlining it outlines
+ * the whole page. The registered region is not marked either, for the same
+ * reason; a changed node no component named becomes a mark of its own,
+ * labelled by the element.
  *
  * Strict Mode renders a component twice into the same fiber and React keeps
  * two alternates of every fiber, so components are deduplicated by the pair of
@@ -268,8 +265,8 @@ export function flowSubtree(
   const collected: Array<{ name: string; element: Element; distance: number }> = [];
   const hosts: Element[] = [];
 
-  // The owner is already spelled on the root badge and the region is already
-  // the root box, so neither earns a box of its own.
+  // The owner is already spelled on the first label and the region is the
+  // whole area the listener feeds, so neither earns a mark of its own.
   const isAlreadyDrawn = (name: string, element: Element): boolean =>
     (ownerName !== null && name === ownerName) || (region !== null && element === region);
 
@@ -306,40 +303,31 @@ export function flowSubtree(
   ));
 
   // Nothing on the page was attributable to this delivery. The region is not
-  // drawn on its own here: a box with no changed element under it would claim
-  // a render the walk never found. {@link regionSubtree} is what draws a region
-  // by itself, for the replay that has no changed nodes to read.
+  // marked on its own here: a mark with no changed element under it would
+  // claim a render the walk never found. {@link regionSubtree} is what marks a
+  // region by itself, for the replay that has no changed nodes to read.
   if (collected.length === 0 && topHosts.length === 0) {
     return { root: null, components: [], leaves: [] };
   }
 
   const boxes: FlowComponent[] = [];
-  if (region !== null) {
-    boxes.push({
-      name: ownerName !== null && ownerName.length > 0 ? ownerName : elementLabel(region),
-      element: region,
-      depth: 0,
-      kind: 'region',
-    });
-  }
-  const shift = region === null ? 0 : 1;
   for (const entry of collected) {
     boxes.push({
       name: entry.name,
       element: entry.element,
-      depth: distances.indexOf(entry.distance) + shift,
+      depth: distances.indexOf(entry.distance),
       kind: 'component',
     });
   }
-  const hostDepth = shift + distances.length;
+  const hostDepth = distances.length;
   for (const element of topHosts) {
     boxes.push({ name: elementLabel(element), element, depth: hostDepth, kind: 'host' });
   }
 
   const root = boxes.length === 0 ? null : boxes[0]!;
 
-  // A leaf is a box with no other box under it. Nesting is read off the page
-  // rather than off the fibers, so a box reached from two mutated nodes at
+  // A leaf is a mark with no other mark under it. Nesting is read off the page
+  // rather than off the fibers, so a mark reached from two mutated nodes at
   // once is still counted once.
   const leaves = boxes.filter((box) => box !== root && !boxes.some((other) => (
     other !== box

--- a/packages/cli/src/serve/runtime/fiber-flow.ts
+++ b/packages/cli/src/serve/runtime/fiber-flow.ts
@@ -28,24 +28,50 @@ export interface FiberLike {
   readonly alternate?: FiberLike | null;
 }
 
-/** One component the page rendered, and the element it owns. */
+/**
+ * What a painted box stands for. A `component` box is a component fiber the
+ * walk named. A `region` box is the element the listener's owner registered,
+ * which the paint is rooted on rather than on the owning component's own host
+ * node. A `host` box is a changed element no component named, badged by the
+ * element itself.
+ */
+export type FlowBoxKind = 'component' | 'region' | 'host';
+
+/** One box the flow painter draws, and the element it covers. */
 export interface FlowComponent {
-  /** `type.displayName`, else `type.name`. */
+  /** `type.displayName`, else `type.name`, else the element's own label. */
   readonly name: string;
-  /** The first host element at or below the component. */
+  /** The first host element at or below the component, or the changed node. */
   readonly element: Element;
-  /** How many collected components sit above this one, root first at 0. */
+  /** How many collected boxes sit above this one, root first at 0. */
   readonly depth: number;
+  /** What this box stands for. */
+  readonly kind: FlowBoxKind;
 }
 
 /** A delivery's rendered subtree, as the flow painter draws it. */
 export interface FlowSubtree {
-  /** The outermost collected component, or `null` when none was found. */
+  /** The box the root badge goes on, or `null` when nothing was found. */
   readonly root: FlowComponent | null;
-  /** Every collected component, outermost first. */
+  /** Every collected box, outermost first, the root included. */
   readonly components: readonly FlowComponent[];
-  /** The collected components nothing else collected sits below. */
+  /** The collected boxes nothing else collected sits below. */
   readonly leaves: readonly FlowComponent[];
+}
+
+/** How the subtree is rooted, and which component the badge already names. */
+export interface FlowSubtreeOptions {
+  /**
+   * The element the listener's owner registered. When the page still holds
+   * one, the paint is rooted on it and the owning component is named in the
+   * badge rather than outlined.
+   */
+  readonly regionElement?: Element | null;
+  /**
+   * The owner the root badge names. A component of this name is never given a
+   * box of its own, because the badge already says it.
+   */
+  readonly ownerName?: string | null;
 }
 
 /**
@@ -73,6 +99,34 @@ function isElement(value: unknown): value is Element {
     && typeof candidate === 'object'
     && candidate.nodeType === 1
     && typeof candidate.getBoundingClientRect === 'function';
+}
+
+/**
+ * What a changed element is called when no component named it: its tag name,
+ * narrowed by its id when it has one and by its first class otherwise.
+ */
+export function elementLabel(element: Element): string {
+  const tag = typeof element.tagName === 'string' && element.tagName.length > 0
+    ? element.tagName.toLowerCase()
+    : 'node';
+  const id = element.getAttribute?.('id');
+  if (typeof id === 'string' && id.length > 0) return `${tag}#${id}`;
+  const className = element.getAttribute?.('class');
+  if (typeof className === 'string') {
+    const first = className.trim().split(/\s+/)[0];
+    if (first !== undefined && first.length > 0) return `${tag}.${first}`;
+  }
+  return tag;
+}
+
+/** The changed node itself as an element, or the element that holds it. */
+function nearestElement(node: unknown, maxAscent = 4): Element | null {
+  let current = node as { parentNode?: unknown } | null;
+  for (let step = 0; step < maxAscent && current !== null && current !== undefined; step += 1) {
+    if (isElement(current)) return current;
+    current = current.parentNode as { parentNode?: unknown } | null;
+  }
+  return null;
 }
 
 /**
@@ -175,53 +229,124 @@ export function componentChain(fiber: FiberLike, maxAscent = MAX_ASCENT): FiberL
 }
 
 /**
- * The subtree of components above the nodes that changed.
+ * A listener's region on its own, with no changed nodes under it.
  *
- * Every node is resolved to its fiber, the `return` chain above it is
- * collected, and the collected components are ordered by how far each sits
- * from the root. Strict Mode renders a component twice into the same fiber and
- * React keeps two alternates of every fiber, so components are deduplicated by
- * the pair of name and host element rather than by fiber identity.
+ * This is what the switch into Flow replays. The fold records when each
+ * listener last delivered but not what the page then changed, so a replayed
+ * delivery can only say which region the listener registered, which is the one
+ * claim the fold supports on its own.
  */
-export function flowSubtree(nodes: Iterable<unknown>): FlowSubtree {
+export function regionSubtree(element: Element, ownerName?: string | null): FlowSubtree {
+  const name = ownerName !== null && ownerName !== undefined && ownerName.length > 0
+    ? ownerName
+    : elementLabel(element);
+  const root: FlowComponent = { name, element, depth: 0, kind: 'region' };
+  return { root, components: [root], leaves: [] };
+}
+
+/**
+ * The subtree of boxes above the nodes that changed.
+ *
+ * Every node is resolved to its fiber and the `return` chain above it is
+ * collected, but the owner the root badge names is never given a box. On a
+ * page whose owning component renders its list, header, and thread as inline
+ * JSX, that component is the only one between the page root and a new list
+ * item, so outlining it outlines the whole page. The root is instead the
+ * element the owner registered, when the page still holds one, and a changed
+ * node no component named becomes a box of its own, badged by the element.
+ *
+ * Strict Mode renders a component twice into the same fiber and React keeps
+ * two alternates of every fiber, so components are deduplicated by the pair of
+ * name and host element rather than by fiber identity.
+ */
+export function flowSubtree(
+  nodes: Iterable<unknown>,
+  options: FlowSubtreeOptions = {},
+): FlowSubtree {
+  const region = options.regionElement ?? null;
+  const ownerName = options.ownerName ?? null;
   const collected: Array<{ name: string; element: Element; distance: number }> = [];
-  const seen = (name: string, element: Element): boolean =>
-    collected.some((entry) => entry.name === name && entry.element === element);
+  const hosts: Element[] = [];
+
+  // The owner is already spelled on the root badge and the region is already
+  // the root box, so neither earns a box of its own.
+  const isAlreadyDrawn = (name: string, element: Element): boolean =>
+    (ownerName !== null && name === ownerName) || (region !== null && element === region);
 
   for (const node of nodes) {
     const fiber = nearestFiber(node);
     if (fiber === null) continue;
     const chain = componentChain(fiber);
+    let named = 0;
     for (let index = 0; index < chain.length; index += 1) {
-      const name = componentName(chain[index]);
+      const name = componentName(chain[index]!);
       if (name === null) continue;
-      const element = hostElementFor(chain[index]);
+      const element = hostElementFor(chain[index]!);
       if (element === null) continue;
-      if (seen(name, element)) continue;
+      if (isAlreadyDrawn(name, element)) continue;
+      named += 1;
+      if (collected.some((entry) => entry.name === name && entry.element === element)) continue;
       collected.push({ name, element, distance: index });
     }
+    // Nothing between the root and this node named it, so the node speaks for
+    // itself.
+    if (named > 0) continue;
+    const host = nearestElement(node);
+    if (host === null || host === region) continue;
+    if (!hosts.includes(host)) hosts.push(host);
   }
 
   collected.sort((a, b) => a.distance - b.distance);
   const distances = [...new Set(collected.map((entry) => entry.distance))].sort((a, b) => a - b);
-  const components: FlowComponent[] = collected.map((entry) => ({
-    name: entry.name,
-    element: entry.element,
-    depth: distances.indexOf(entry.distance),
-  }));
 
-  // A leaf is a collected component with no other collected component under
-  // it. Nesting is read off the page rather than off the fibers, so a
-  // component reached from two mutated nodes at once is still counted once.
-  const leaves = components.filter((component) => !components.some((other) => (
-    other !== component
-    && other.element !== component.element
-    && component.element.contains(other.element)
+  // A changed subtree paints once at its top: a host box inside another host
+  // box says nothing the outer box does not already say.
+  const topHosts = hosts.filter((element) => !hosts.some(
+    (other) => other !== element && other.contains(element),
+  ));
+
+  // Nothing on the page was attributable to this delivery. The region is not
+  // drawn on its own here: a box with no changed element under it would claim
+  // a render the walk never found. {@link regionSubtree} is what draws a region
+  // by itself, for the replay that has no changed nodes to read.
+  if (collected.length === 0 && topHosts.length === 0) {
+    return { root: null, components: [], leaves: [] };
+  }
+
+  const boxes: FlowComponent[] = [];
+  if (region !== null) {
+    boxes.push({
+      name: ownerName !== null && ownerName.length > 0 ? ownerName : elementLabel(region),
+      element: region,
+      depth: 0,
+      kind: 'region',
+    });
+  }
+  const shift = region === null ? 0 : 1;
+  for (const entry of collected) {
+    boxes.push({
+      name: entry.name,
+      element: entry.element,
+      depth: distances.indexOf(entry.distance) + shift,
+      kind: 'component',
+    });
+  }
+  const hostDepth = shift + distances.length;
+  for (const element of topHosts) {
+    boxes.push({ name: elementLabel(element), element, depth: hostDepth, kind: 'host' });
+  }
+
+  const root = boxes.length === 0 ? null : boxes[0]!;
+
+  // A leaf is a box with no other box under it. Nesting is read off the page
+  // rather than off the fibers, so a box reached from two mutated nodes at
+  // once is still counted once.
+  const leaves = boxes.filter((box) => box !== root && !boxes.some((other) => (
+    other !== box
+    && other.element !== box.element
+    && box.element.contains(other.element)
   )));
 
-  return {
-    root: components.length === 0 ? null : components[0],
-    components,
-    leaves: components.length <= 1 ? [] : leaves,
-  };
+  return { root, components: boxes, leaves };
 }
+

--- a/packages/cli/src/serve/runtime/fiber-flow.ts
+++ b/packages/cli/src/serve/runtime/fiber-flow.ts
@@ -274,8 +274,15 @@ export function flowSubtree(
     const fiber = nearestFiber(node);
     if (fiber === null) continue;
     const chain = componentChain(fiber);
+    // Data flows down from the owner, so nothing at or above it in the chain
+    // is part of the flow: the owner itself is named in the badge, and a page
+    // root such as `App` above it shares the page's host element.
+    const ownerIndex = ownerName === null
+      ? -1
+      : chain.findIndex((entry) => componentName(entry) === ownerName);
     let named = 0;
     for (let index = 0; index < chain.length; index += 1) {
+      if (index <= ownerIndex) continue;
       const name = componentName(chain[index]!);
       if (name === null) continue;
       const element = hostElementFor(chain[index]!);

--- a/packages/cli/src/serve/runtime/fiber-flow.ts
+++ b/packages/cli/src/serve/runtime/fiber-flow.ts
@@ -1,0 +1,227 @@
+/**
+ * What rendered after a listener delivery, read off React's fiber tree.
+ *
+ * This is correlation, not data tracing. The page opens a window when the
+ * worker client hands a snapshot to an application callback and closes it on
+ * the next React commit; every component this module names is a component that
+ * rendered inside that window. A state update the application batched into the
+ * same commit is attributed to the listener too, and the badges say "rendered
+ * after delivery" rather than claiming the data reached those components.
+ *
+ * The only entry point into React is the `__reactFiber$…` property React puts
+ * on the host nodes it creates. The module reads it, walks `return` upwards,
+ * and reads `child` downwards to find a component's own host node. It writes
+ * nothing back, calls nothing on React, and treats every field as optional:
+ * a fiber shape it does not recognise yields no components rather than an
+ * error.
+ */
+
+/** The fiber fields this module reads. Everything is optional on purpose. */
+export interface FiberLike {
+  readonly tag?: number;
+  readonly type?: unknown;
+  readonly elementType?: unknown;
+  readonly stateNode?: unknown;
+  readonly return?: FiberLike | null;
+  readonly child?: FiberLike | null;
+  readonly sibling?: FiberLike | null;
+  readonly alternate?: FiberLike | null;
+}
+
+/** One component the page rendered, and the element it owns. */
+export interface FlowComponent {
+  /** `type.displayName`, else `type.name`. */
+  readonly name: string;
+  /** The first host element at or below the component. */
+  readonly element: Element;
+  /** How many collected components sit above this one, root first at 0. */
+  readonly depth: number;
+}
+
+/** A delivery's rendered subtree, as the flow painter draws it. */
+export interface FlowSubtree {
+  /** The outermost collected component, or `null` when none was found. */
+  readonly root: FlowComponent | null;
+  /** Every collected component, outermost first. */
+  readonly components: readonly FlowComponent[];
+  /** The collected components nothing else collected sits below. */
+  readonly leaves: readonly FlowComponent[];
+}
+
+/**
+ * React's fiber tags for the component kinds worth naming: a function
+ * component, a class component, an unresolved component that has not settled
+ * into one of those yet, and the `forwardRef` and `memo` wrappers, which carry
+ * the name of the function they were given. Host components,
+ * text, fragments, providers, and the internal wrappers Strict Mode and
+ * Suspense insert are skipped: they carry no name the application wrote.
+ */
+const COMPONENT_TAGS = new Set([0, 1, 2, 11, 14, 15]);
+
+/** React's fiber tag for a host component, whose `stateNode` is the element. */
+const HOST_COMPONENT_TAG = 5;
+
+/** How far up the `return` chain one mutated node is followed. */
+const MAX_ASCENT = 60;
+
+/** How far down `child` a component's own host node is looked for. */
+const MAX_DESCENT = 30;
+
+function isElement(value: unknown): value is Element {
+  const candidate = value as { nodeType?: number; getBoundingClientRect?: unknown } | null;
+  return candidate !== null
+    && typeof candidate === 'object'
+    && candidate.nodeType === 1
+    && typeof candidate.getBoundingClientRect === 'function';
+}
+
+/**
+ * The fiber React attached to this node, or `null`. React names the property
+ * `__reactFiber$<random>`, so the key is found by prefix rather than spelled
+ * out. The older `__reactInternalInstance$` name is read too, because a page
+ * may be running a renderer that still writes it.
+ */
+export function fiberFromNode(node: unknown): FiberLike | null {
+  if (node === null || typeof node !== 'object') return null;
+  const record = node as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (!key.startsWith('__reactFiber$') && !key.startsWith('__reactInternalInstance$')) continue;
+    const fiber = record[key];
+    if (fiber !== null && typeof fiber === 'object') return fiber as FiberLike;
+  }
+  return null;
+}
+
+/** The nearest node at or above this one that React created, or `null`. */
+export function nearestFiber(node: unknown, maxAscent = MAX_ASCENT): FiberLike | null {
+  let current = node as { parentNode?: unknown } | null;
+  for (let step = 0; step <= maxAscent && current !== null && current !== undefined; step += 1) {
+    const fiber = fiberFromNode(current);
+    if (fiber !== null) return fiber;
+    current = (current as { parentNode?: unknown }).parentNode as { parentNode?: unknown } | null;
+  }
+  return null;
+}
+
+/** `displayName`, else `name`, else `null` when the type names nothing. */
+export function componentName(fiber: FiberLike): string | null {
+  const type = (fiber.type ?? fiber.elementType) as
+    | { displayName?: unknown; name?: unknown; type?: unknown; render?: unknown }
+    | string
+    | null
+    | undefined;
+  if (type === null || type === undefined) return null;
+  if (typeof type === 'string') return null;
+  if (typeof type.displayName === 'string' && type.displayName.length > 0) return type.displayName;
+  if (typeof type.name === 'string' && type.name.length > 0) return type.name;
+  // `memo(Component)` and `forwardRef(Component)` keep the named function one
+  // level in.
+  const inner = (type.type ?? type.render) as { displayName?: unknown; name?: unknown } | undefined;
+  if (inner !== undefined && inner !== null && (typeof inner === 'object' || typeof inner === 'function')) {
+    if (typeof inner.displayName === 'string' && inner.displayName.length > 0) return inner.displayName;
+    if (typeof inner.name === 'string' && inner.name.length > 0) return inner.name;
+  }
+  if (typeof type === 'function' && typeof (type as { name?: unknown }).name === 'string') {
+    const name = (type as { name: string }).name;
+    return name.length > 0 ? name : null;
+  }
+  return null;
+}
+
+/** `true` when this fiber is a component the application itself named. */
+export function isNamedComponent(fiber: FiberLike): boolean {
+  const tag = fiber.tag;
+  if (typeof tag === 'number' && !COMPONENT_TAGS.has(tag)) return false;
+  return componentName(fiber) !== null;
+}
+
+/**
+ * The first host element at or below this fiber, in render order. A component
+ * that renders no host node of its own borrows the nearest host node above it,
+ * so a wrapper still has somewhere to draw.
+ */
+export function hostElementFor(fiber: FiberLike, maxDescent = MAX_DESCENT): Element | null {
+  const queue: Array<{ fiber: FiberLike; depth: number }> = [{ fiber, depth: 0 }];
+  while (queue.length > 0) {
+    const entry = queue.shift()!;
+    const candidate = entry.fiber;
+    if (candidate.tag === HOST_COMPONENT_TAG && isElement(candidate.stateNode)) {
+      return candidate.stateNode;
+    }
+    if (entry.depth >= maxDescent) continue;
+    let child = candidate.child ?? null;
+    while (child !== null && child !== undefined) {
+      queue.push({ fiber: child, depth: entry.depth + 1 });
+      child = child.sibling ?? null;
+    }
+  }
+  let parent = fiber.return ?? null;
+  for (let step = 0; step < maxDescent && parent !== null && parent !== undefined; step += 1) {
+    if (parent.tag === HOST_COMPONENT_TAG && isElement(parent.stateNode)) return parent.stateNode;
+    parent = parent.return ?? null;
+  }
+  return null;
+}
+
+/** Every named component from this fiber up to the root, outermost first. */
+export function componentChain(fiber: FiberLike, maxAscent = MAX_ASCENT): FiberLike[] {
+  const chain: FiberLike[] = [];
+  let current: FiberLike | null | undefined = fiber;
+  for (let step = 0; step <= maxAscent && current !== null && current !== undefined; step += 1) {
+    if (isNamedComponent(current)) chain.push(current);
+    current = current.return ?? null;
+  }
+  return chain.reverse();
+}
+
+/**
+ * The subtree of components above the nodes that changed.
+ *
+ * Every node is resolved to its fiber, the `return` chain above it is
+ * collected, and the collected components are ordered by how far each sits
+ * from the root. Strict Mode renders a component twice into the same fiber and
+ * React keeps two alternates of every fiber, so components are deduplicated by
+ * the pair of name and host element rather than by fiber identity.
+ */
+export function flowSubtree(nodes: Iterable<unknown>): FlowSubtree {
+  const collected: Array<{ name: string; element: Element; distance: number }> = [];
+  const seen = (name: string, element: Element): boolean =>
+    collected.some((entry) => entry.name === name && entry.element === element);
+
+  for (const node of nodes) {
+    const fiber = nearestFiber(node);
+    if (fiber === null) continue;
+    const chain = componentChain(fiber);
+    for (let index = 0; index < chain.length; index += 1) {
+      const name = componentName(chain[index]);
+      if (name === null) continue;
+      const element = hostElementFor(chain[index]);
+      if (element === null) continue;
+      if (seen(name, element)) continue;
+      collected.push({ name, element, distance: index });
+    }
+  }
+
+  collected.sort((a, b) => a.distance - b.distance);
+  const distances = [...new Set(collected.map((entry) => entry.distance))].sort((a, b) => a - b);
+  const components: FlowComponent[] = collected.map((entry) => ({
+    name: entry.name,
+    element: entry.element,
+    depth: distances.indexOf(entry.distance),
+  }));
+
+  // A leaf is a collected component with no other collected component under
+  // it. Nesting is read off the page rather than off the fibers, so a
+  // component reached from two mutated nodes at once is still counted once.
+  const leaves = components.filter((component) => !components.some((other) => (
+    other !== component
+    && other.element !== component.element
+    && component.element.contains(other.element)
+  )));
+
+  return {
+    root: components.length === 0 ? null : components[0],
+    components,
+    leaves: components.length <= 1 ? [] : leaves,
+  };
+}

--- a/packages/cli/src/serve/runtime/listener-flow-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-mode.ts
@@ -18,7 +18,7 @@
  * correlation, not data tracing: a state update the application batched into
  * the same commit is attributed to the listener too.
  */
-import { flowSubtree } from './fiber-flow.js';
+import { flowSubtree, regionSubtree } from './fiber-flow.js';
 import { createDeliveryCorrelation, type DeliveryCorrelation } from './delivery-correlation.js';
 import { createFlowPainter, type FlowPainter } from './listener-flow-painter.js';
 import type { ReactCommitSource } from './react-commit-source.js';
@@ -48,8 +48,33 @@ export interface FlowModeOptions {
   changedNodes?: (documentLike: Document, container: HTMLElement) => ChangedNodeSource;
   /** How long a delivery waits for a commit. */
   windowMs?: number;
-  /** How long a delivery's boxes stay on the page. */
+  /** How long a delivery's boxes stay at full strength. */
   fadeMs?: number;
+  /**
+   * The element the listener's owner registered, which the paint is rooted
+   * on. Defaults to the first of the outline's selectors the page still
+   * holds, which is the element Overview outlines.
+   */
+  regionFor?: (outline: ListenerOutline) => Element | null;
+  /**
+   * The deliveries the fold already recorded, newest per listener, so the
+   * switch into Flow shows the latest flow rather than an empty page.
+   */
+  recentDeliveries?: () => readonly RecentDelivery[];
+  /** How old a recorded delivery may be and still be replayed. */
+  replayWindowMs?: number;
+  /** The clock the replay window is measured on. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Called with the outline's listener id after every painted delivery. */
+  onPaint?: (listenerId: string) => void;
+}
+
+/** One delivery the fold recorded, for the replay on the switch into Flow. */
+export interface RecentDelivery {
+  /** The listener id the outline carries. */
+  readonly listenerId: string;
+  /** When the delivery arrived, on the fold's clock. */
+  readonly at: number;
 }
 
 export interface FlowMode {
@@ -115,6 +140,22 @@ function observePageChanges(documentLike: Document, container: HTMLElement): Cha
   };
 }
 
+/** The first element the outline's selectors still name on the page. */
+function regionElement(documentLike: Document, outline: ListenerOutline): Element | null {
+  for (const selector of outline.selectors) {
+    try {
+      const found = documentLike.querySelector(selector);
+      if (found !== null) return found;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** How old a recorded delivery may be and still be replayed, in milliseconds. */
+const DEFAULT_REPLAY_WINDOW_MS = 5000;
+
 /** Start painting flows. The caller owns the overlay container. */
 export function startFlowMode(options: FlowModeOptions): FlowMode {
   const painter: FlowPainter = createFlowPainter({
@@ -123,23 +164,56 @@ export function startFlowMode(options: FlowModeOptions): FlowMode {
     ...(options.fadeMs === undefined ? {} : { fadeMs: options.fadeMs }),
   });
 
+  const readRegion = options.regionFor
+    ?? ((outline: ListenerOutline) => regionElement(options.document, outline));
+
+  /**
+   * Draw one listener's flow. The paint is keyed by the id the outline
+   * carries rather than by the id the delivery arrived under, because that is
+   * the id the panel's toggles and the mode's clears use; a page-side delivery
+   * names the listener by the client's own subscription id.
+   */
+  const paintFlow = (listenerId: string, nodes: Iterable<unknown> | null): void => {
+    const outline = options.outlineFor(listenerId);
+    if (outline === null) return;
+    if (!options.isVisible(outline.listenerId)) return;
+    const region = readRegion(outline);
+    const ownerName = outline.labelIsOwner ? outline.label : null;
+    // A replay has no changed nodes to read, so it draws the region alone.
+    const subtree = nodes === null
+      ? (region === null ? null : regionSubtree(region, ownerName))
+      : flowSubtree(nodes, { regionElement: region, ownerName });
+    if (subtree === null || subtree.components.length === 0) return;
+    painter.paint({
+      listenerId: outline.listenerId,
+      label: outline.label,
+      target: outline.isQuery ? `${outline.target} (query)` : outline.target,
+      deliveryCount: outline.deliveryCount,
+      subtree,
+    });
+    options.onPaint?.(outline.listenerId);
+  };
+
   const correlation: DeliveryCorrelation = createDeliveryCorrelation({
     ...(options.windowMs === undefined ? {} : { windowMs: options.windowMs }),
     onFlow: (flow) => {
-      if (!options.isVisible(flow.listenerId)) return;
-      const outline = options.outlineFor(flow.listenerId);
-      if (outline === null) return;
-      const subtree = flowSubtree(flow.nodes);
-      if (subtree.components.length === 0) return;
-      painter.paint({
-        listenerId: flow.listenerId,
-        label: outline.label,
-        target: outline.isQuery ? `${outline.target} (query)` : outline.target,
-        deliveryCount: outline.deliveryCount,
-        subtree,
-      });
+      paintFlow(flow.listenerId, flow.nodes);
     },
   });
+
+  // The switch into Flow starts from what the fold already knows. A listener
+  // that delivered moments ago has its region drawn straight away, so the
+  // first thing the mode shows is the latest flow rather than an empty page.
+  const replay = (): void => {
+    const recent = options.recentDeliveries?.() ?? [];
+    if (recent.length === 0) return;
+    const now = (options.now ?? (() => Date.now()))();
+    const windowMs = options.replayWindowMs ?? DEFAULT_REPLAY_WINDOW_MS;
+    for (const delivery of recent) {
+      if (now - delivery.at > windowMs) continue;
+      paintFlow(delivery.listenerId, null);
+    }
+  };
 
   const changes = (options.changedNodes ?? observePageChanges)(options.document, options.container);
   const subscribeDeliveries = options.subscribeDeliveries ?? onListenerDelivery;
@@ -151,6 +225,8 @@ export function startFlowMode(options: FlowModeOptions): FlowMode {
     correlation.changed(changes.drain());
     correlation.committed();
   });
+
+  replay();
 
   return {
     clear() {

--- a/packages/cli/src/serve/runtime/listener-flow-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-mode.ts
@@ -1,0 +1,173 @@
+/**
+ * The chip's Flow painting mode: where a listener's data went, as it arrives.
+ *
+ * The mode joins four pieces that each know one thing. The worker client says
+ * when a listener handed a snapshot to the application. A `MutationObserver`
+ * says which nodes the page changed. React's commit hook says when a render
+ * finished. The fiber walk says which components own those nodes. The
+ * correlation window holds them together, and the painter draws the result in
+ * the listener's colour.
+ *
+ * The order matters and is why the mode drains the observer itself. React
+ * calls the commit hook synchronously inside the commit; a `MutationObserver`
+ * callback runs a microtask later. So on every commit the mode takes the
+ * records the observer is holding, feeds them to the window, and only then
+ * closes it.
+ *
+ * What comes out is "these components rendered after that delivery". It is
+ * correlation, not data tracing: a state update the application batched into
+ * the same commit is attributed to the listener too.
+ */
+import { flowSubtree } from './fiber-flow.js';
+import { createDeliveryCorrelation, type DeliveryCorrelation } from './delivery-correlation.js';
+import { createFlowPainter, type FlowPainter } from './listener-flow-painter.js';
+import type { ReactCommitSource } from './react-commit-source.js';
+import type { ListenerOutline } from './listener-outline-model.js';
+import { onListenerDelivery } from '../worker/client/listener-delivery.js';
+
+/** A source of changed nodes the mode can drain on demand. */
+export interface ChangedNodeSource {
+  /** Every node changed since the last drain. */
+  drain(): readonly unknown[];
+  stop(): void;
+}
+
+export interface FlowModeOptions {
+  document: Document;
+  /** The overlay's container. Flow draws into the layer Overview owns. */
+  container: HTMLElement;
+  /** React's commits, already installed on the page. */
+  commits: ReactCommitSource;
+  /** The listener's outline record, for the badge words. */
+  outlineFor: (listenerId: string) => ListenerOutline | null;
+  /** `false` hides this listener's paint, in either mode. */
+  isVisible: (listenerId: string) => boolean;
+  /** Deliveries. Defaults to the worker client's own hook. */
+  subscribeDeliveries?: (listener: (listenerId: string) => void) => () => void;
+  /** Changed nodes. Defaults to a `MutationObserver` over the page body. */
+  changedNodes?: (documentLike: Document, container: HTMLElement) => ChangedNodeSource;
+  /** How long a delivery waits for a commit. */
+  windowMs?: number;
+  /** How long a delivery's boxes stay on the page. */
+  fadeMs?: number;
+}
+
+export interface FlowMode {
+  /** Take every box away without stopping the mode. */
+  clear(): void;
+  /** Take one listener's boxes away, for a listener switched off. */
+  clearListener(listenerId: string): void;
+  /** Recompute the boxes already drawn against the page's current geometry. */
+  reposition(): void;
+  dispose(): void;
+}
+
+/** The chip's own chrome, which is never part of an application's render. */
+function isChipOwned(node: unknown, container: HTMLElement): boolean {
+  const element = node as Node | null;
+  if (element === null || element === undefined) return true;
+  if (container.contains(element)) return true;
+  const owner = (element.nodeType === 1 ? element : element.parentNode) as Element | null;
+  if (owner === null) return false;
+  try {
+    return owner.closest('[data-pyric-runtime-chip-host], pyric-runtime-chip') !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** A `MutationObserver` over the page body, drained rather than subscribed to. */
+function observePageChanges(documentLike: Document, container: HTMLElement): ChangedNodeSource {
+  const view = documentLike.defaultView as { MutationObserver?: typeof MutationObserver } | null;
+  const Observer = view?.MutationObserver
+    ?? (typeof MutationObserver === 'function' ? MutationObserver : undefined);
+  const body = documentLike.body;
+  if (Observer === undefined || body === null) {
+    return { drain: () => [], stop: () => {} };
+  }
+  // The callback does nothing: the mode drains on the commit, so what the
+  // observer holds between commits is exactly the window's evidence.
+  const observer = new Observer(() => {});
+  try {
+    observer.observe(body, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+    });
+  } catch {
+    return { drain: () => [], stop: () => {} };
+  }
+  return {
+    drain() {
+      const nodes: unknown[] = [];
+      for (const record of observer.takeRecords()) {
+        if (!isChipOwned(record.target, container)) nodes.push(record.target);
+        for (const added of record.addedNodes) {
+          if (!isChipOwned(added, container)) nodes.push(added);
+        }
+      }
+      return nodes;
+    },
+    stop() {
+      observer.disconnect();
+    },
+  };
+}
+
+/** Start painting flows. The caller owns the overlay container. */
+export function startFlowMode(options: FlowModeOptions): FlowMode {
+  const painter: FlowPainter = createFlowPainter({
+    document: options.document,
+    container: options.container,
+    ...(options.fadeMs === undefined ? {} : { fadeMs: options.fadeMs }),
+  });
+
+  const correlation: DeliveryCorrelation = createDeliveryCorrelation({
+    ...(options.windowMs === undefined ? {} : { windowMs: options.windowMs }),
+    onFlow: (flow) => {
+      if (!options.isVisible(flow.listenerId)) return;
+      const outline = options.outlineFor(flow.listenerId);
+      if (outline === null) return;
+      const subtree = flowSubtree(flow.nodes);
+      if (subtree.components.length === 0) return;
+      painter.paint({
+        listenerId: flow.listenerId,
+        label: outline.label,
+        target: outline.isQuery ? `${outline.target} (query)` : outline.target,
+        deliveryCount: outline.deliveryCount,
+        subtree,
+      });
+    },
+  });
+
+  const changes = (options.changedNodes ?? observePageChanges)(options.document, options.container);
+  const subscribeDeliveries = options.subscribeDeliveries ?? onListenerDelivery;
+
+  const stopDeliveries = subscribeDeliveries((listenerId) => {
+    correlation.delivered(listenerId);
+  });
+  const stopCommits = options.commits.subscribe(() => {
+    correlation.changed(changes.drain());
+    correlation.committed();
+  });
+
+  return {
+    clear() {
+      painter.clear();
+    },
+    clearListener(listenerId) {
+      painter.clearListener(listenerId);
+    },
+    reposition() {
+      painter.reposition();
+    },
+    dispose() {
+      stopDeliveries();
+      stopCommits();
+      changes.stop();
+      correlation.dispose();
+      painter.dispose();
+    },
+  };
+}

--- a/packages/cli/src/serve/runtime/listener-flow-painter.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-painter.ts
@@ -1,0 +1,211 @@
+/**
+ * The boxes the chip's Flow mode paints, and how they fade.
+ *
+ * Overview draws one box per listener and leaves it there. Flow draws a box
+ * per component that rendered after a delivery and takes them away again over
+ * a few seconds, so the page shows where the data went as it arrives rather
+ * than what is attached.
+ *
+ * The painter derives nothing. It is handed a listener, the words for its
+ * badge, and the subtree {@link FlowSubtree} already named, and it draws that
+ * in the listener's own colour into the container the overlay owns. A second
+ * delivery from the same listener replaces that listener's boxes rather than
+ * stacking on them.
+ *
+ * The root badge reads the way the Overview badge does: owner, target,
+ * deliveries. Its title says these components rendered after the delivery,
+ * which is the only claim the correlation supports.
+ */
+import { listenerColors } from './listener-palette.js';
+import type { FlowSubtree } from './fiber-flow.js';
+
+/** One delivery, ready to draw. */
+export interface FlowPaint {
+  readonly listenerId: string;
+  /** The owner label the Listeners panel uses. */
+  readonly label: string;
+  /** The target the way the application wrote it. */
+  readonly target: string;
+  /** The listener's delivery count at this delivery. */
+  readonly deliveryCount: number;
+  readonly subtree: FlowSubtree;
+}
+
+export interface FlowPainterOptions {
+  document: Document;
+  /** The overlay's container. The painter appends to it and never replaces it. */
+  container: HTMLElement;
+  /** How long a delivery's boxes stay on the page. */
+  fadeMs?: number;
+  /** How the removal is scheduled. Returns the cancel function. */
+  schedule?: (run: () => void, delayMs: number) => () => void;
+}
+
+export interface FlowPainter {
+  /** Draw one delivery, replacing whatever that listener last drew. */
+  paint(paint: FlowPaint): void;
+  /** Take this listener's boxes away now. */
+  clearListener(listenerId: string): void;
+  /** Take every box away now. */
+  clear(): void;
+  /** Recompute the boxes already drawn against the page's current geometry. */
+  reposition(): void;
+  dispose(): void;
+}
+
+/** How long a delivery's boxes stay on the page, in milliseconds. */
+const DEFAULT_FADE_MS = 3000;
+
+const BOX_STYLE = [
+  'position:absolute',
+  'border-radius:4px',
+  'pointer-events:none',
+].join(';');
+
+const BADGE_STYLE = [
+  'position:absolute',
+  'top:-9px',
+  'left:0',
+  'background:#16161a',
+  'border:1px solid #33333f',
+  'border-radius:4px',
+  'font:10px/1.6 "JetBrains Mono", ui-monospace, monospace',
+  'padding:1px 6px',
+  'pointer-events:none',
+  'white-space:nowrap',
+].join(';');
+
+const LEAF_BADGE_STYLE = [
+  'position:absolute',
+  'bottom:-9px',
+  'right:0',
+  'background:#16161a',
+  'border:1px solid #33333f',
+  'border-radius:4px',
+  'font:9px/1.6 "JetBrains Mono", ui-monospace, monospace',
+  'padding:0 4px',
+  'pointer-events:none',
+  'white-space:nowrap',
+].join(';');
+
+/** What the root badge says: owner, target, deliveries. */
+export function flowBadgeText(paint: FlowPaint): string {
+  return `${paint.label} · ${paint.target} · ${paint.deliveryCount}`;
+}
+
+function positionBox(box: HTMLElement, element: Element): void {
+  const rect = element.getBoundingClientRect();
+  box.style.left = `${rect.left}px`;
+  box.style.top = `${rect.top}px`;
+  box.style.width = `${rect.width}px`;
+  box.style.height = `${rect.height}px`;
+}
+
+function defaultSchedule(run: () => void, delayMs: number): () => void {
+  const handle = setTimeout(run, delayMs);
+  return () => {
+    clearTimeout(handle);
+  };
+}
+
+/** Build the Flow painter over an overlay container. */
+export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
+  const documentLike = options.document;
+  const fadeMs = options.fadeMs ?? DEFAULT_FADE_MS;
+  const schedule = options.schedule ?? defaultSchedule;
+
+  interface Group {
+    boxes: Array<{ box: HTMLElement; element: Element }>;
+    cancel: () => void;
+  }
+  const groups = new Map<string, Group>();
+
+  const removeGroup = (listenerId: string): void => {
+    const group = groups.get(listenerId);
+    if (group === undefined) return;
+    group.cancel();
+    for (const entry of group.boxes) entry.box.remove();
+    groups.delete(listenerId);
+  };
+
+  return {
+    paint(paint) {
+      removeGroup(paint.listenerId);
+      if (paint.subtree.components.length === 0) return;
+      const colors = listenerColors(paint.listenerId);
+      const boxes: Array<{ box: HTMLElement; element: Element }> = [];
+      const leafElements = new Set(paint.subtree.leaves.map((leaf) => leaf.element));
+
+      for (const component of paint.subtree.components) {
+        const box = documentLike.createElement('div');
+        box.setAttribute('data-pyric-flow-box', '');
+        box.setAttribute('style', BOX_STYLE);
+        box.dataset.listenerId = paint.listenerId;
+        box.dataset.component = component.name;
+        box.dataset.depth = String(component.depth);
+        box.style.border = `1px solid ${colors.border}`;
+        box.style.background = colors.fill;
+        // The fade is a style the page carries out; the removal below is what
+        // takes the box off the page whether or not transitions run here.
+        box.style.transition = `opacity ${fadeMs}ms linear`;
+        box.style.opacity = '1';
+
+        const root = paint.subtree.root;
+        const isRoot = root !== null && root.name === component.name && root.element === component.element;
+        if (isRoot) {
+          const badge = documentLike.createElement('span');
+          badge.setAttribute('data-pyric-flow-badge', '');
+          badge.setAttribute('style', BADGE_STYLE);
+          badge.style.borderColor = colors.border;
+          badge.style.color = colors.accent;
+          badge.dataset.listenerId = paint.listenerId;
+          badge.title = `${component.name} rendered after a delivery from ${paint.target}`;
+          badge.textContent = flowBadgeText(paint);
+          box.append(badge);
+        } else if (leafElements.has(component.element)) {
+          const badge = documentLike.createElement('span');
+          badge.setAttribute('data-pyric-flow-leaf-badge', '');
+          badge.setAttribute('style', LEAF_BADGE_STYLE);
+          badge.style.borderColor = colors.border;
+          badge.style.color = colors.accent;
+          badge.dataset.listenerId = paint.listenerId;
+          badge.title = `${component.name} rendered after a delivery from ${paint.target}`;
+          badge.textContent = component.name;
+          box.append(badge);
+        }
+
+        positionBox(box, component.element);
+        options.container.append(box);
+        boxes.push({ box, element: component.element });
+      }
+
+      const cancel = schedule(() => {
+        removeGroup(paint.listenerId);
+      }, fadeMs);
+      groups.set(paint.listenerId, { boxes, cancel });
+
+      // Hand the fade to the page on the next frame, so the browser has the
+      // starting opacity to transition away from.
+      const view = documentLike.defaultView;
+      const fade = (): void => {
+        for (const entry of boxes) entry.box.style.opacity = '0';
+      };
+      if (view?.requestAnimationFrame) view.requestAnimationFrame(fade);
+      else schedule(fade, 0);
+    },
+    clearListener(listenerId) {
+      removeGroup(listenerId);
+    },
+    clear() {
+      for (const listenerId of [...groups.keys()]) removeGroup(listenerId);
+    },
+    reposition() {
+      for (const group of groups.values()) {
+        for (const entry of group.boxes) positionBox(entry.box, entry.element);
+      }
+    },
+    dispose() {
+      for (const listenerId of [...groups.keys()]) removeGroup(listenerId);
+    },
+  };
+}

--- a/packages/cli/src/serve/runtime/listener-flow-painter.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-painter.ts
@@ -1,30 +1,36 @@
 /**
- * The boxes the chip's Flow mode paints, and how they fade.
+ * The marks the chip's Flow mode puts on the page, and how they fade.
  *
- * Overview draws one box per listener and leaves it there. Flow draws a box
- * per element that changed after a delivery and fades it to a dimmed state
- * over a few seconds, so the page shows where the data went as it arrives
- * rather than what is attached. The dimmed subtree stays until that listener
- * delivers again or is switched off, so the last flow is still readable after
- * the movement stops.
+ * Overview draws one measured box per listener and leaves it there. Flow marks
+ * the elements themselves. An element that changed after a delivery is given
+ * `data-pyric-flow` attributes, and the stylesheet in `overlay-theme.ts` draws
+ * an outline and a badge through those attributes. Nothing is measured, so the
+ * mark moves with the element, survives a scroll or a reflow, and goes away
+ * with the element when the application removes it.
  *
- * The painter puts structure in the DOM and nothing else. Each box says what
- * kind of thing it outlines, which listener it belongs to, which hue that
- * listener draws in, and how far through its fade it is; the drawing comes
- * from the stylesheet in `overlay-theme.ts`, which the container carries.
+ * The outline is what draws the mark, because it takes no space. The badge is
+ * an `::after` pseudo-element reading its words out of `data-pyric-flow-label`,
+ * so no node is added to the application's tree either. An element that cannot
+ * carry a pseudo-element (an `img`, an `input`, and the other replaced
+ * elements) gets a positioned badge in the overlay container instead, which is
+ * the one thing here that is measured.
  *
- * The painter derives nothing. It is handed a listener, the words for its
- * badge, and the subtree {@link FlowSubtree} already named, and it draws that
- * in the listener's own colour into the container the overlay owns. A second
- * delivery from the same listener replaces that listener's boxes rather than
- * stacking on them.
+ * The listener's registered region is not marked. Flow says where a delivery
+ * landed, and the region is the whole area the listener feeds rather than
+ * something that changed. The listener is named in the labels instead: the
+ * first element of a delivery carries the full owner, target, and delivery
+ * count, and every other element carries its own component or element name.
  *
- * The root badge reads the way the Overview badge does: owner, target,
- * deliveries. Its title says these components rendered after the delivery,
- * which is the only claim the correlation supports.
+ * Bursts accumulate. A delivery adds to what its listener already has on the
+ * page rather than replacing it, so ten deliveries in a second leave ten
+ * marked elements, each running its own fade. When a fade ends, the mark is
+ * held dimmed if it belongs to the listener's most recent delivery and is
+ * taken away otherwise, so the last delivery stays readable while the ones
+ * before it clear themselves. A delivery that marks an element that is already
+ * marked restarts that element's fade rather than adding a second mark.
  */
 import { listenerHueIndex } from './listener-palette.js';
-import { ensureOverlayStyleSheet } from './overlay-theme.js';
+import { ensureFlowStyleSheet, ensureOverlayStyleSheet } from './overlay-theme.js';
 import type { FlowSubtree } from './fiber-flow.js';
 
 /** One delivery, ready to draw. */
@@ -41,44 +47,55 @@ export interface FlowPaint {
 
 export interface FlowPainterOptions {
   document: Document;
-  /** The overlay's container. The painter appends to it and never replaces it. */
+  /**
+   * The overlay's container. The painter uses it only for the badges of
+   * elements that cannot carry a pseudo-element, and never replaces it.
+   */
   container: HTMLElement;
   /**
-   * How long a delivery's boxes stay at full strength before the painter
-   * marks them retained. The fade the page runs is the theme's
+   * How long a mark stays at full strength before the painter either holds it
+   * dimmed or takes it away. The fade the page runs is the theme's
    * `--pyric-overlay-fade-duration`, which defaults to the same length.
    */
   fadeMs?: number;
-  /** How the removal is scheduled. Returns the cancel function. */
+  /** How the fade's end is scheduled. Returns the cancel function. */
   schedule?: (run: () => void, delayMs: number) => () => void;
 }
 
 export interface FlowPainter {
-  /** Draw one delivery, replacing whatever that listener last drew. */
+  /** Mark one delivery, adding to what this listener already has on the page. */
   paint(paint: FlowPaint): void;
-  /** Take this listener's boxes away now. */
+  /** Take this listener's marks away now. */
   clearListener(listenerId: string): void;
-  /** Take every box away now. */
+  /** Take every mark away now. */
   clear(): void;
-  /** Recompute the boxes already drawn against the page's current geometry. */
+  /** Recompute the measured badges against the page's current geometry. */
   reposition(): void;
   dispose(): void;
 }
 
-/** How long a delivery's boxes stay at full strength, in milliseconds. */
+/** How long a mark stays at full strength, in milliseconds. */
 const DEFAULT_FADE_MS = 3000;
 
-/** What the root badge says: owner, target, deliveries. */
+/**
+ * The elements that render content of their own instead of their children, and
+ * so have no box a pseudo-element can be placed in. These get a measured badge
+ * in the overlay container.
+ */
+const REPLACED_TAGS = new Set([
+  'AREA', 'AUDIO', 'BR', 'CANVAS', 'COL', 'EMBED', 'HR', 'IFRAME', 'IMG', 'INPUT',
+  'OBJECT', 'PARAM', 'PROGRESS', 'SELECT', 'SOURCE', 'TEXTAREA', 'TRACK', 'VIDEO', 'WBR',
+]);
+
+/** What the first element's label says: owner, target, deliveries. */
 export function flowBadgeText(paint: FlowPaint): string {
   return `${paint.label} · ${paint.target} · ${paint.deliveryCount}`;
 }
 
-function positionBox(box: HTMLElement, element: Element): void {
-  const rect = element.getBoundingClientRect();
-  box.style.left = `${rect.left}px`;
-  box.style.top = `${rect.top}px`;
-  box.style.width = `${rect.width}px`;
-  box.style.height = `${rect.height}px`;
+/** `true` when a badge cannot be drawn on this element as a pseudo-element. */
+export function needsMeasuredBadge(element: Element): boolean {
+  const tag = typeof element.tagName === 'string' ? element.tagName.toUpperCase() : '';
+  return REPLACED_TAGS.has(tag);
 }
 
 function defaultSchedule(run: () => void, delayMs: number): () => void {
@@ -88,97 +105,197 @@ function defaultSchedule(run: () => void, delayMs: number): () => void {
   };
 }
 
-/** Build the Flow painter over an overlay container. */
+/**
+ * Give a statically positioned element something to hang its badge off.
+ *
+ * The badge is absolutely positioned against the marked element, which only
+ * works when that element is positioned. This is read per element rather than
+ * written in the stylesheet, because a rule would override the position an
+ * application chose. Returns what puts the element back, or `null` when
+ * nothing was changed.
+ */
+function anchorElement(documentLike: Document, element: Element): (() => void) | null {
+  const style = (element as HTMLElement).style as CSSStyleDeclaration | undefined;
+  if (style === undefined) return null;
+  const view = documentLike.defaultView;
+  let position = 'static';
+  try {
+    position = view?.getComputedStyle(element).position ?? 'static';
+  } catch {
+    position = 'static';
+  }
+  if (position !== 'static') return null;
+  const previous = style.getPropertyValue('position');
+  const priority = style.getPropertyPriority('position');
+  style.setProperty('position', 'relative');
+  return () => {
+    if (previous === '') style.removeProperty('position');
+    else style.setProperty('position', previous, priority);
+  };
+}
+
+/** Build the Flow painter. The container is only for the measured badges. */
 export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
   const documentLike = options.document;
   const fadeMs = options.fadeMs ?? DEFAULT_FADE_MS;
   const schedule = options.schedule ?? defaultSchedule;
   ensureOverlayStyleSheet(documentLike, options.container);
+  ensureFlowStyleSheet(documentLike);
 
-  interface Group {
-    boxes: Array<{ box: HTMLElement; element: Element }>;
+  /** One marked element, with the delivery that last marked it. */
+  interface Mark {
+    readonly element: Element;
+    /** The delivery this mark is currently running on. */
+    paintId: number;
+    /** Stops the fade's end from arriving. */
     cancel: () => void;
-    /** `true` once the fade finished and the boxes are held dimmed. */
-    retained: boolean;
+    /** The measured badge, for an element that cannot carry a pseudo one. */
+    badge: HTMLElement | null;
+    /** Puts an element's own `position` back, when the painter set one. */
+    restore: (() => void) | null;
   }
+
+  /** One listener's marks, keyed by the element each is on. */
+  interface Group {
+    readonly marks: Map<Element, Mark>;
+    /** The newest delivery from this listener, which is the one retained. */
+    latestPaintId: number;
+  }
+
   const groups = new Map<string, Group>();
+  let paintCounter = 0;
+
+  const removeMark = (group: Group, listenerId: string, mark: Mark): void => {
+    mark.cancel();
+    const element = mark.element as HTMLElement;
+    mark.badge?.remove();
+    mark.restore?.();
+    group.marks.delete(mark.element);
+    // Two listeners can land on the same element. The attributes name one of
+    // them, so only the listener they name takes them off.
+    if (element.getAttribute('data-pyric-flow-listener') !== listenerId) return;
+    element.removeAttribute('data-pyric-flow');
+    element.removeAttribute('data-pyric-flow-listener');
+    element.removeAttribute('data-pyric-flow-role');
+    element.removeAttribute('data-pyric-flow-label');
+    element.removeAttribute('data-pyric-flow-fading');
+    element.removeAttribute('data-pyric-flow-retained');
+  };
 
   const removeGroup = (listenerId: string): void => {
     const group = groups.get(listenerId);
     if (group === undefined) return;
-    group.cancel();
-    for (const entry of group.boxes) entry.box.remove();
+    for (const mark of [...group.marks.values()]) removeMark(group, listenerId, mark);
     groups.delete(listenerId);
+  };
+
+  const positionBadge = (badge: HTMLElement, element: Element): void => {
+    const rect = element.getBoundingClientRect();
+    badge.style.left = `${rect.left}px`;
+    badge.style.top = `${rect.top}px`;
+  };
+
+  /**
+   * The end of one element's fade. The mark is held dimmed when it belongs to
+   * this listener's newest delivery, so the page still shows where the last
+   * delivery went, and is taken away when an older delivery in a burst put it
+   * there. A restart has already moved the mark on to a newer delivery, which
+   * is what the identity check reads.
+   */
+  const fadeEnded = (listenerId: string, element: Element, paintId: number): void => {
+    const group = groups.get(listenerId);
+    if (group === undefined) return;
+    const mark = group.marks.get(element);
+    if (mark === undefined || mark.paintId !== paintId) return;
+    if (paintId === group.latestPaintId) {
+      (element as HTMLElement).setAttribute('data-pyric-flow-retained', '');
+      mark.badge?.setAttribute('data-pyric-flow-retained', '');
+      return;
+    }
+    removeMark(group, listenerId, mark);
+    if (group.marks.size === 0) groups.delete(listenerId);
   };
 
   return {
     paint(paint) {
-      removeGroup(paint.listenerId);
       if (paint.subtree.components.length === 0) return;
       const hue = String(listenerHueIndex(paint.listenerId));
-      const boxes: Array<{ box: HTMLElement; element: Element }> = [];
-      const leafElements = new Set(paint.subtree.leaves.map((leaf) => leaf.element));
+      const existing = groups.get(paint.listenerId);
+      const group: Group = existing ?? { marks: new Map<Element, Mark>(), latestPaintId: 0 };
+      if (existing === undefined) groups.set(paint.listenerId, group);
 
-      for (const component of paint.subtree.components) {
-        const box = documentLike.createElement('div');
-        box.setAttribute('data-pyric-flow-box', '');
-        box.dataset.listenerId = paint.listenerId;
-        box.dataset.component = component.name;
-        box.dataset.depth = String(component.depth);
-        box.dataset.flowKind = component.kind;
-        box.dataset.pyricRole = component.kind;
-        box.dataset.hue = hue;
+      paintCounter += 1;
+      const paintId = paintCounter;
+      group.latestPaintId = paintId;
+      const painted: Mark[] = [];
 
-        const root = paint.subtree.root;
-        const isRoot = root !== null
-          && (root === component || (root.name === component.name && root.element === component.element));
-        if (isRoot) {
-          const badge = documentLike.createElement('span');
-          badge.setAttribute('data-pyric-flow-badge', '');
-          badge.dataset.pyricRole = 'badge';
-          badge.dataset.hue = hue;
-          badge.dataset.listenerId = paint.listenerId;
-          badge.title = `${component.name} rendered after a delivery from ${paint.target}`;
-          badge.textContent = flowBadgeText(paint);
-          box.append(badge);
-        } else if (leafElements.has(component.element)) {
-          const badge = documentLike.createElement('span');
-          badge.setAttribute('data-pyric-flow-leaf-badge', '');
-          badge.dataset.pyricRole = 'leaf-badge';
-          badge.dataset.hue = hue;
-          badge.dataset.listenerId = paint.listenerId;
-          badge.dataset.flowKind = component.kind;
-          badge.title = component.kind === 'host'
-            ? `${component.name} changed after a delivery from ${paint.target}`
-            : `${component.name} rendered after a delivery from ${paint.target}`;
-          badge.textContent = component.name;
-          box.append(badge);
+      paint.subtree.components.forEach((component, index) => {
+        const element = component.element as HTMLElement;
+        // The listener is named once per delivery, on the first element it
+        // marked; everything else says what it is.
+        const label = index === 0 ? flowBadgeText(paint) : component.name;
+        const measured = needsMeasuredBadge(element);
+
+        let mark = group.marks.get(component.element);
+        if (mark === undefined) {
+          mark = {
+            element: component.element,
+            paintId,
+            cancel: () => {},
+            badge: null,
+            restore: measured ? null : anchorElement(documentLike, component.element),
+          };
+          group.marks.set(component.element, mark);
+        } else {
+          // A newer delivery on an element that is still marked restarts that
+          // element's fade rather than marking it twice.
+          mark.cancel();
+          element.removeAttribute('data-pyric-flow-fading');
+          element.removeAttribute('data-pyric-flow-retained');
+          mark.badge?.removeAttribute('data-pyric-flow-fading');
+          mark.badge?.removeAttribute('data-pyric-flow-retained');
+          mark.paintId = paintId;
         }
 
-        positionBox(box, component.element);
-        options.container.append(box);
-        boxes.push({ box, element: component.element });
-      }
+        element.setAttribute('data-pyric-flow', hue);
+        element.setAttribute('data-pyric-flow-listener', paint.listenerId);
+        element.setAttribute('data-pyric-flow-role', component.kind);
 
-      // The fade ends at the dimmed state rather than at nothing: the last
-      // subtree a listener painted stays on the page until that listener
-      // delivers again, so a developer who looks after the delivery still
-      // sees where it went. The timer is what marks the group retained
-      // whether or not transitions run here.
-      const cancel = schedule(() => {
-        const group = groups.get(paint.listenerId);
-        if (group === undefined) return;
-        group.retained = true;
-        for (const entry of group.boxes) entry.box.dataset.flowRetained = '';
-      }, fadeMs);
-      groups.set(paint.listenerId, { boxes, cancel, retained: false });
+        if (measured) {
+          element.removeAttribute('data-pyric-flow-label');
+          if (mark.badge === null) {
+            const badge = documentLike.createElement('span');
+            badge.setAttribute('data-pyric-flow-badge', '');
+            badge.dataset.pyricRole = 'leaf-badge';
+            badge.dataset.hue = hue;
+            badge.dataset.listenerId = paint.listenerId;
+            options.container.append(badge);
+            mark.badge = badge;
+          }
+          mark.badge.textContent = label;
+          mark.badge.title = `${component.name} changed after a delivery from ${paint.target}`;
+          positionBadge(mark.badge, component.element);
+        } else {
+          element.setAttribute('data-pyric-flow-label', label);
+        }
+
+        mark.paintId = paintId;
+        mark.cancel = schedule(() => {
+          fadeEnded(paint.listenerId, component.element, paintId);
+        }, fadeMs);
+        painted.push(mark);
+      });
 
       // Hand the fade to the page on the next frame, so the browser has the
-      // starting opacity to transition away from. The attribute is what the
-      // stylesheet reads; the timer above is what marks the fade over.
+      // starting colour to transition away from. The attribute is what the
+      // stylesheet reads; the timer above is what decides how the fade ends.
       const view = documentLike.defaultView;
       const fade = (): void => {
-        for (const entry of boxes) entry.box.dataset.flowFading = '';
+        for (const mark of painted) {
+          if (mark.paintId !== paintId) continue;
+          (mark.element as HTMLElement).setAttribute('data-pyric-flow-fading', '');
+          mark.badge?.setAttribute('data-pyric-flow-fading', '');
+        }
       };
       if (view?.requestAnimationFrame) view.requestAnimationFrame(fade);
       else schedule(fade, 0);
@@ -191,7 +308,9 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
     },
     reposition() {
       for (const group of groups.values()) {
-        for (const entry of group.boxes) positionBox(entry.box, entry.element);
+        for (const mark of group.marks.values()) {
+          if (mark.badge !== null) positionBadge(mark.badge, mark.element);
+        }
       }
     },
     dispose() {

--- a/packages/cli/src/serve/runtime/listener-flow-painter.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-painter.ts
@@ -2,9 +2,11 @@
  * The boxes the chip's Flow mode paints, and how they fade.
  *
  * Overview draws one box per listener and leaves it there. Flow draws a box
- * per component that rendered after a delivery and takes them away again over
- * a few seconds, so the page shows where the data went as it arrives rather
- * than what is attached.
+ * per element that changed after a delivery and fades it to a dimmed state
+ * over a few seconds, so the page shows where the data went as it arrives
+ * rather than what is attached. The dimmed subtree stays until that listener
+ * delivers again or is switched off, so the last flow is still readable after
+ * the movement stops.
  *
  * The painter derives nothing. It is handed a listener, the words for its
  * badge, and the subtree {@link FlowSubtree} already named, and it draws that
@@ -53,8 +55,15 @@ export interface FlowPainter {
   dispose(): void;
 }
 
-/** How long a delivery's boxes stay on the page, in milliseconds. */
+/** How long a delivery's boxes stay at full strength, in milliseconds. */
 const DEFAULT_FADE_MS = 3000;
+
+/**
+ * What a faded subtree is left at. The last flow stays readable so a developer
+ * who looks at the page after the delivery still sees where it went, and the
+ * next delivery from the same listener replaces it.
+ */
+const RETAINED_OPACITY = '0.3';
 
 const BOX_STYLE = [
   'position:absolute',
@@ -117,6 +126,8 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
   interface Group {
     boxes: Array<{ box: HTMLElement; element: Element }>;
     cancel: () => void;
+    /** `true` once the fade finished and the boxes are held dimmed. */
+    retained: boolean;
   }
   const groups = new Map<string, Group>();
 
@@ -143,6 +154,7 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         box.dataset.listenerId = paint.listenerId;
         box.dataset.component = component.name;
         box.dataset.depth = String(component.depth);
+        box.dataset.flowKind = component.kind;
         box.style.border = `1px solid ${colors.border}`;
         box.style.background = colors.fill;
         // The fade is a style the page carries out; the removal below is what
@@ -151,7 +163,8 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         box.style.opacity = '1';
 
         const root = paint.subtree.root;
-        const isRoot = root !== null && root.name === component.name && root.element === component.element;
+        const isRoot = root !== null
+          && (root === component || (root.name === component.name && root.element === component.element));
         if (isRoot) {
           const badge = documentLike.createElement('span');
           badge.setAttribute('data-pyric-flow-badge', '');
@@ -169,7 +182,10 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
           badge.style.borderColor = colors.border;
           badge.style.color = colors.accent;
           badge.dataset.listenerId = paint.listenerId;
-          badge.title = `${component.name} rendered after a delivery from ${paint.target}`;
+          badge.dataset.flowKind = component.kind;
+          badge.title = component.kind === 'host'
+            ? `${component.name} changed after a delivery from ${paint.target}`
+            : `${component.name} rendered after a delivery from ${paint.target}`;
           badge.textContent = component.name;
           box.append(badge);
         }
@@ -179,16 +195,27 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         boxes.push({ box, element: component.element });
       }
 
+      // The fade ends at the dimmed state rather than at nothing: the last
+      // subtree a listener painted stays on the page until that listener
+      // delivers again, so a developer who looks after the delivery still
+      // sees where it went. The timer is what marks the group retained
+      // whether or not transitions run here.
       const cancel = schedule(() => {
-        removeGroup(paint.listenerId);
+        const group = groups.get(paint.listenerId);
+        if (group === undefined) return;
+        group.retained = true;
+        for (const entry of group.boxes) {
+          entry.box.dataset.flowRetained = '';
+          entry.box.style.opacity = RETAINED_OPACITY;
+        }
       }, fadeMs);
-      groups.set(paint.listenerId, { boxes, cancel });
+      groups.set(paint.listenerId, { boxes, cancel, retained: false });
 
       // Hand the fade to the page on the next frame, so the browser has the
       // starting opacity to transition away from.
       const view = documentLike.defaultView;
       const fade = (): void => {
-        for (const entry of boxes) entry.box.style.opacity = '0';
+        for (const entry of boxes) entry.box.style.opacity = RETAINED_OPACITY;
       };
       if (view?.requestAnimationFrame) view.requestAnimationFrame(fade);
       else schedule(fade, 0);

--- a/packages/cli/src/serve/runtime/listener-flow-painter.ts
+++ b/packages/cli/src/serve/runtime/listener-flow-painter.ts
@@ -8,6 +8,11 @@
  * delivers again or is switched off, so the last flow is still readable after
  * the movement stops.
  *
+ * The painter puts structure in the DOM and nothing else. Each box says what
+ * kind of thing it outlines, which listener it belongs to, which hue that
+ * listener draws in, and how far through its fade it is; the drawing comes
+ * from the stylesheet in `overlay-theme.ts`, which the container carries.
+ *
  * The painter derives nothing. It is handed a listener, the words for its
  * badge, and the subtree {@link FlowSubtree} already named, and it draws that
  * in the listener's own colour into the container the overlay owns. A second
@@ -18,7 +23,8 @@
  * deliveries. Its title says these components rendered after the delivery,
  * which is the only claim the correlation supports.
  */
-import { listenerColors } from './listener-palette.js';
+import { listenerHueIndex } from './listener-palette.js';
+import { ensureOverlayStyleSheet } from './overlay-theme.js';
 import type { FlowSubtree } from './fiber-flow.js';
 
 /** One delivery, ready to draw. */
@@ -37,7 +43,11 @@ export interface FlowPainterOptions {
   document: Document;
   /** The overlay's container. The painter appends to it and never replaces it. */
   container: HTMLElement;
-  /** How long a delivery's boxes stay on the page. */
+  /**
+   * How long a delivery's boxes stay at full strength before the painter
+   * marks them retained. The fade the page runs is the theme's
+   * `--pyric-overlay-fade-duration`, which defaults to the same length.
+   */
   fadeMs?: number;
   /** How the removal is scheduled. Returns the cancel function. */
   schedule?: (run: () => void, delayMs: number) => () => void;
@@ -57,45 +67,6 @@ export interface FlowPainter {
 
 /** How long a delivery's boxes stay at full strength, in milliseconds. */
 const DEFAULT_FADE_MS = 3000;
-
-/**
- * What a faded subtree is left at. The last flow stays readable so a developer
- * who looks at the page after the delivery still sees where it went, and the
- * next delivery from the same listener replaces it.
- */
-const RETAINED_OPACITY = '0.3';
-
-const BOX_STYLE = [
-  'position:absolute',
-  'border-radius:4px',
-  'pointer-events:none',
-].join(';');
-
-const BADGE_STYLE = [
-  'position:absolute',
-  'top:-9px',
-  'left:0',
-  'background:#16161a',
-  'border:1px solid #33333f',
-  'border-radius:4px',
-  'font:10px/1.6 "JetBrains Mono", ui-monospace, monospace',
-  'padding:1px 6px',
-  'pointer-events:none',
-  'white-space:nowrap',
-].join(';');
-
-const LEAF_BADGE_STYLE = [
-  'position:absolute',
-  'bottom:-9px',
-  'right:0',
-  'background:#16161a',
-  'border:1px solid #33333f',
-  'border-radius:4px',
-  'font:9px/1.6 "JetBrains Mono", ui-monospace, monospace',
-  'padding:0 4px',
-  'pointer-events:none',
-  'white-space:nowrap',
-].join(';');
 
 /** What the root badge says: owner, target, deliveries. */
 export function flowBadgeText(paint: FlowPaint): string {
@@ -122,6 +93,7 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
   const documentLike = options.document;
   const fadeMs = options.fadeMs ?? DEFAULT_FADE_MS;
   const schedule = options.schedule ?? defaultSchedule;
+  ensureOverlayStyleSheet(documentLike, options.container);
 
   interface Group {
     boxes: Array<{ box: HTMLElement; element: Element }>;
@@ -143,24 +115,19 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
     paint(paint) {
       removeGroup(paint.listenerId);
       if (paint.subtree.components.length === 0) return;
-      const colors = listenerColors(paint.listenerId);
+      const hue = String(listenerHueIndex(paint.listenerId));
       const boxes: Array<{ box: HTMLElement; element: Element }> = [];
       const leafElements = new Set(paint.subtree.leaves.map((leaf) => leaf.element));
 
       for (const component of paint.subtree.components) {
         const box = documentLike.createElement('div');
         box.setAttribute('data-pyric-flow-box', '');
-        box.setAttribute('style', BOX_STYLE);
         box.dataset.listenerId = paint.listenerId;
         box.dataset.component = component.name;
         box.dataset.depth = String(component.depth);
         box.dataset.flowKind = component.kind;
-        box.style.border = `1px solid ${colors.border}`;
-        box.style.background = colors.fill;
-        // The fade is a style the page carries out; the removal below is what
-        // takes the box off the page whether or not transitions run here.
-        box.style.transition = `opacity ${fadeMs}ms linear`;
-        box.style.opacity = '1';
+        box.dataset.pyricRole = component.kind;
+        box.dataset.hue = hue;
 
         const root = paint.subtree.root;
         const isRoot = root !== null
@@ -168,9 +135,8 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         if (isRoot) {
           const badge = documentLike.createElement('span');
           badge.setAttribute('data-pyric-flow-badge', '');
-          badge.setAttribute('style', BADGE_STYLE);
-          badge.style.borderColor = colors.border;
-          badge.style.color = colors.accent;
+          badge.dataset.pyricRole = 'badge';
+          badge.dataset.hue = hue;
           badge.dataset.listenerId = paint.listenerId;
           badge.title = `${component.name} rendered after a delivery from ${paint.target}`;
           badge.textContent = flowBadgeText(paint);
@@ -178,9 +144,8 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         } else if (leafElements.has(component.element)) {
           const badge = documentLike.createElement('span');
           badge.setAttribute('data-pyric-flow-leaf-badge', '');
-          badge.setAttribute('style', LEAF_BADGE_STYLE);
-          badge.style.borderColor = colors.border;
-          badge.style.color = colors.accent;
+          badge.dataset.pyricRole = 'leaf-badge';
+          badge.dataset.hue = hue;
           badge.dataset.listenerId = paint.listenerId;
           badge.dataset.flowKind = component.kind;
           badge.title = component.kind === 'host'
@@ -204,18 +169,16 @@ export function createFlowPainter(options: FlowPainterOptions): FlowPainter {
         const group = groups.get(paint.listenerId);
         if (group === undefined) return;
         group.retained = true;
-        for (const entry of group.boxes) {
-          entry.box.dataset.flowRetained = '';
-          entry.box.style.opacity = RETAINED_OPACITY;
-        }
+        for (const entry of group.boxes) entry.box.dataset.flowRetained = '';
       }, fadeMs);
       groups.set(paint.listenerId, { boxes, cancel, retained: false });
 
       // Hand the fade to the page on the next frame, so the browser has the
-      // starting opacity to transition away from.
+      // starting opacity to transition away from. The attribute is what the
+      // stylesheet reads; the timer above is what marks the fade over.
       const view = documentLike.defaultView;
       const fade = (): void => {
-        for (const entry of boxes) entry.box.style.opacity = RETAINED_OPACITY;
+        for (const entry of boxes) entry.box.dataset.flowFading = '';
       };
       if (view?.requestAnimationFrame) view.requestAnimationFrame(fade);
       else schedule(fade, 0);

--- a/packages/cli/src/serve/runtime/listener-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-mode.ts
@@ -80,6 +80,11 @@ export interface ListenerMode {
   flowAvailable(): boolean;
   /** Why Flow is unavailable, or `null` when it is available. */
   flowUnavailableReason(): string | null;
+  /**
+   * `true` while Flow is on and nothing has been painted since the switch, so
+   * the panel can say what it is waiting for.
+   */
+  flowWaiting(): boolean;
   /** Every outlined listener, drawn or not. */
   outlines(): readonly ListenerOutline[];
   /** The listeners nothing on the page could be outlined for. */
@@ -123,6 +128,8 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   let stopFollowing: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
   let paintMode: ListenerPaintMode = readListenerPaintMode(paintStorage);
+  /** `true` once Flow painted a delivery since the switch into Flow. */
+  let flowPainted = false;
   /** Listeners the developer switched off. Page session only, never stored. */
   const hidden = new Set<string>();
 
@@ -154,7 +161,15 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   };
 
   const recompute = (): void => {
+    const previous = current;
     current = listenerOutlines(events, readIncidents(events));
+    // A detached listener keeps no paint. Flow holds its last subtree until
+    // the next delivery, and for a listener that is gone there will not be
+    // one.
+    for (const outline of previous) {
+      if (current.some((next) => next.listenerId === outline.listenerId)) continue;
+      flow?.clearListener(outline.listenerId);
+    }
     paint();
     options.onChange?.(current);
   };
@@ -167,6 +182,7 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   const startFlow = (): void => {
     if (flow !== null || overlay === null) return;
     if (!flowAvailable()) return;
+    flowPainted = false;
     flow = startFlowMode({
       document: documentLike,
       container: overlay.container(),
@@ -175,6 +191,19 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       // the outline knows both ids.
       outlineFor: (listenerId) => current.find((outline) => outline.listenerId === listenerId || outline.clientListenerId === listenerId) ?? null,
       isVisible: (listenerId) => !hidden.has(listenerId),
+      // The switch into Flow replays what the fold already recorded, so the
+      // developer sees the latest flow rather than waiting for the next
+      // delivery on a page that may be idle.
+      recentDeliveries: () => visibleOutlines()
+        .filter((outline) => outline.lastDeliveryAt !== undefined)
+        .map((outline) => ({ listenerId: outline.listenerId, at: outline.lastDeliveryAt! })),
+      onPaint: () => {
+        if (flowPainted) return;
+        flowPainted = true;
+        // The panel's waiting hint is gone as of this paint, and the panel
+        // only rebuilds when the mode says something changed.
+        options.onChange?.(current);
+      },
       ...(options.flow ?? {}),
     });
     const followFlow = flow;
@@ -243,6 +272,9 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       if (flowAvailable()) return null;
       return reactRendered(documentLike) ? LATE_HOOK_REASON : NO_REACT_REASON;
     },
+    flowWaiting() {
+      return flow !== null && !flowPainted;
+    },
     outlines() {
       return current;
     },
@@ -256,6 +288,10 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       if (visible) hidden.delete(listenerId);
       else hidden.add(listenerId);
       paint();
+      // Switching a listener off takes its paint away now rather than only
+      // suppressing the next one: Flow holds its last subtree on the page, so
+      // leaving it there would leave a box no row is checked for. Switching
+      // back on leaves the page empty until the next delivery.
       if (!visible) flow?.clearListener(listenerId);
     },
     dispose() {

--- a/packages/cli/src/serve/runtime/listener-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-mode.ts
@@ -1,21 +1,43 @@
 /**
- * The chip's Listeners mode: what on the page has a listener, and what it
- * listens to.
+ * The chip's Listeners mode: what on the page has a listener, what it listens
+ * to, and where its data goes.
  *
  * The mode folds the sandbox event stream the page already receives into
- * outline records, paints them, and lists the listeners nothing on the page
- * could be outlined for. It holds a subscription only while it is on, so a
- * page that never opens the mode pays nothing for it.
+ * outline records and paints them one of two ways. Overview paints one box per
+ * attached listener and leaves it there. Flow paints, for each delivery, the
+ * component subtree that rendered after it, and fades it away. The two share
+ * the fold, the owners, the colours, the overlay container, and the
+ * per-listener toggles; only the painting differs.
  *
- * Listener attribution is a development diagnostic. When the production
- * switch has it off there are no owners to place, so the mode refuses to turn
- * on and draws nothing.
+ * The mode observes from the moment it exists, so the chip's count and summary
+ * read the fold whether or not anything is painted. It holds an overlay only
+ * while it is on, so a page that never turns the painting on pays only for the
+ * fold.
+ *
+ * Listener attribution is a development diagnostic. When the production switch
+ * has it off there are no owners to place, so the mode refuses to turn on and
+ * draws nothing.
  */
 import type { SandboxEvent } from 'pyric/sandbox';
 import type { ActivityIncident } from 'pyric/firestore/internal';
 import { listenerOutlines, type ListenerOutline } from './listener-outline-model.js';
 import { createListenerOverlay, type ListenerOverlay } from './listener-overlay.js';
 import { incidentsFromEvents } from './listener-incidents.js';
+import { startFlowMode, type FlowMode } from './listener-flow-mode.js';
+import {
+  installReactCommitSource,
+  reactRendered,
+  type ReactCommitSource,
+} from './react-commit-source.js';
+import {
+  pagePaintModeStorage,
+  readListenerPaintMode,
+  writeListenerPaintMode,
+  type ListenerPaintMode,
+  type PaintModeStorage,
+} from './listener-paint-mode.js';
+
+export type { ListenerPaintMode } from './listener-paint-mode.js';
 
 export interface ListenerModeOptions {
   document: Document;
@@ -35,17 +57,42 @@ export interface ListenerModeOptions {
   openStudio?: (url: string) => void;
   /** Called after every recomputation, for the chip's own panel. */
   onChange?: (outlines: readonly ListenerOutline[]) => void;
+  /**
+   * React's commits. Defaults to installing the hook on this page's window,
+   * which only reports commits when it got there before the application's
+   * script.
+   */
+  commits?: ReactCommitSource;
+  /** Where the painting mode is remembered. Defaults to the page's storage. */
+  paintStorage?: PaintModeStorage | null;
+  /** How the Flow mode watches the page. Passed through for tests. */
+  flow?: Partial<Pick<Parameters<typeof startFlowMode>[0], 'changedNodes' | 'subscribeDeliveries' | 'windowMs' | 'fadeMs'>>;
 }
 
 export interface ListenerMode {
   setEnabled(enabled: boolean): void;
   enabled(): boolean;
+  /** Which way the listeners are painted. */
+  mode(): ListenerPaintMode;
+  /** Switch the painting. Remembered for the page. */
+  setMode(mode: ListenerPaintMode): void;
+  /** `true` when this page has a React whose commits the mode can read. */
+  flowAvailable(): boolean;
+  /** Why Flow is unavailable, or `null` when it is available. */
+  flowUnavailableReason(): string | null;
   /** Every outlined listener, drawn or not. */
   outlines(): readonly ListenerOutline[];
   /** The listeners nothing on the page could be outlined for. */
   unattributed(): readonly ListenerOutline[];
+  /** `false` when this listener's paint is hidden in both modes. */
+  isListenerVisible(listenerId: string): boolean;
+  /** Show or hide one listener's paint. Remembered for this page session. */
+  setListenerVisible(listenerId: string, visible: boolean): void;
   dispose(): void;
 }
+
+const NO_REACT_REASON = 'Flow needs a React renderer on this page.';
+const LATE_HOOK_REASON = 'React loaded before pyric could watch its renders, so Flow has nothing to follow.';
 
 /**
  * Studio's listeners view, filtered to one listener. Studio has no listeners
@@ -65,11 +112,27 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   const documentLike = options.document;
   const readAttribution = options.attributionEnabled ?? (() => true);
   const readIncidents = options.incidents ?? incidentsFromEvents;
+  const paintStorage = options.paintStorage === undefined
+    ? pagePaintModeStorage(documentLike)
+    : options.paintStorage;
 
   const events: SandboxEvent[] = [];
   let current: readonly ListenerOutline[] = [];
   let overlay: ListenerOverlay | null = null;
+  let flow: FlowMode | null = null;
+  let stopFollowing: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
+  let paintMode: ListenerPaintMode = readListenerPaintMode(paintStorage);
+  /** Listeners the developer switched off. Page session only, never stored. */
+  const hidden = new Set<string>();
+
+  // The commit source is installed once, whether or not Flow is ever turned
+  // on: React reads the hook global while its own module first evaluates, so
+  // installing it later would be too late to matter.
+  const commits = options.commits ?? installReactCommitSource(documentLike.defaultView);
+
+  const visibleOutlines = (): readonly ListenerOutline[] =>
+    current.filter((outline) => !hidden.has(outline.listenerId));
 
   const openStudio = (outline: ListenerOutline): void => {
     const studioUrl = options.studioUrl;
@@ -82,14 +145,51 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
     documentLike.defaultView?.open(url, '_blank', 'noopener');
   };
 
+  const paint = (): void => {
+    if (overlay === null) return;
+    // Overview owns the boxes in the container; Flow owns its own and is
+    // driven by deliveries rather than by the fold, so an Overview pass in
+    // Flow mode clears the Overview boxes and leaves the flows alone.
+    overlay.update(paintMode === 'overview' ? visibleOutlines() : []);
+  };
+
   const recompute = (): void => {
     current = listenerOutlines(events, readIncidents(events));
-    overlay?.update(current);
+    paint();
     options.onChange?.(current);
   };
 
+  // Flow needs commits, not just a React. A React that loaded before the hook
+  // was installed renders without ever calling it, and saying so is more use
+  // than a mode that is on and paints nothing.
+  const flowAvailable = (): boolean => commits.available();
+
+  const startFlow = (): void => {
+    if (flow !== null || overlay === null) return;
+    if (!flowAvailable()) return;
+    flow = startFlowMode({
+      document: documentLike,
+      container: overlay.container(),
+      commits,
+      outlineFor: (listenerId) => current.find((outline) => outline.listenerId === listenerId) ?? null,
+      isVisible: (listenerId) => !hidden.has(listenerId),
+      ...(options.flow ?? {}),
+    });
+    const followFlow = flow;
+    stopFollowing = overlay.onReposition(() => {
+      followFlow.reposition();
+    });
+  };
+
+  const stopFlow = (): void => {
+    stopFollowing?.();
+    stopFollowing = null;
+    flow?.dispose();
+    flow = null;
+  };
+
   // The mode observes from the moment it exists: the chip's count and summary
-  // read the fold whether or not anything is outlined. Enabling the mode only
+  // read the fold whether or not anything is painted. Enabling the mode only
   // adds the overlay on top of a fold that is already current.
   unsubscribe = options.subscribeEvents((batch) => {
     events.push(...batch);
@@ -97,14 +197,16 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   });
   recompute();
 
-  const hideOutlines = (): void => {
+  const hidePainting = (): void => {
+    stopFlow();
     overlay?.dispose();
     overlay = null;
   };
 
-  const showOutlines = (): void => {
+  const showPainting = (): void => {
     overlay = createListenerOverlay({ document: documentLike, onSelect: openStudio });
-    overlay.update(current);
+    paint();
+    if (paintMode === 'flow') startFlow();
   };
 
   return {
@@ -112,14 +214,32 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       const isOn = overlay !== null;
       if (next === isOn) return;
       if (!next) {
-        hideOutlines();
+        hidePainting();
         return;
       }
       if (!readAttribution()) return;
-      showOutlines();
+      showPainting();
     },
     enabled() {
       return overlay !== null;
+    },
+    mode() {
+      return paintMode;
+    },
+    setMode(next) {
+      if (next === paintMode) return;
+      if (next === 'flow' && !flowAvailable()) return;
+      paintMode = next;
+      writeListenerPaintMode(paintStorage, next);
+      if (overlay === null) return;
+      if (next === 'overview') stopFlow();
+      paint();
+      if (next === 'flow') startFlow();
+    },
+    flowAvailable,
+    flowUnavailableReason() {
+      if (flowAvailable()) return null;
+      return reactRendered(documentLike) ? LATE_HOOK_REASON : NO_REACT_REASON;
     },
     outlines() {
       return current;
@@ -127,12 +247,22 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
     unattributed() {
       return current.filter((outline) => outline.selectors.length === 0);
     },
+    isListenerVisible(listenerId) {
+      return !hidden.has(listenerId);
+    },
+    setListenerVisible(listenerId, visible) {
+      if (visible) hidden.delete(listenerId);
+      else hidden.add(listenerId);
+      paint();
+      if (!visible) flow?.clearListener(listenerId);
+    },
     dispose() {
-      hideOutlines();
+      hidePainting();
       unsubscribe?.();
       unsubscribe = null;
       events.length = 0;
       current = [];
+      hidden.clear();
     },
   };
 }

--- a/packages/cli/src/serve/runtime/listener-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-mode.ts
@@ -171,7 +171,9 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       document: documentLike,
       container: overlay.container(),
       commits,
-      outlineFor: (listenerId) => current.find((outline) => outline.listenerId === listenerId) ?? null,
+      // A delivery observed on the page carries the client's subscription id;
+      // the outline knows both ids.
+      outlineFor: (listenerId) => current.find((outline) => outline.listenerId === listenerId || outline.clientListenerId === listenerId) ?? null,
       isVisible: (listenerId) => !hidden.has(listenerId),
       ...(options.flow ?? {}),
     });

--- a/packages/cli/src/serve/runtime/listener-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-mode.ts
@@ -30,6 +30,13 @@ import {
   type ReactCommitSource,
 } from './react-commit-source.js';
 import {
+  pageOverlayThemeStorage,
+  OVERLAY_THEME_KEY,
+  readStoredOverlayTheme,
+  type OverlayTheme,
+  type OverlayThemeStorage,
+} from './overlay-theme.js';
+import {
   pagePaintModeStorage,
   readListenerPaintMode,
   writeListenerPaintMode,
@@ -65,6 +72,13 @@ export interface ListenerModeOptions {
   commits?: ReactCommitSource;
   /** Where the painting mode is remembered. Defaults to the page's storage. */
   paintStorage?: PaintModeStorage | null;
+  /**
+   * The served page's overlay theme. The page's own stored overrides win over
+   * it. See `overlay-theme.ts` for the contract.
+   */
+  overlayTheme?: OverlayTheme | null;
+  /** Where the page's overrides are kept. Defaults to the page's storage. */
+  themeStorage?: OverlayThemeStorage | null;
   /** How the Flow mode watches the page. Passed through for tests. */
   flow?: Partial<Pick<Parameters<typeof startFlowMode>[0], 'changedNodes' | 'subscribeDeliveries' | 'windowMs' | 'fadeMs'>>;
 }
@@ -93,6 +107,13 @@ export interface ListenerMode {
   isListenerVisible(listenerId: string): boolean;
   /** Show or hide one listener's paint. Remembered for this page session. */
   setListenerVisible(listenerId: string, visible: boolean): void;
+  /** The overrides in effect, page storage over the served page's option. */
+  overlayTheme(): OverlayTheme;
+  /**
+   * Draw with these overrides from now on. Passing `null` goes back to the
+   * served page's option, and from there to the contract's defaults.
+   */
+  setOverlayTheme(theme: OverlayTheme | null): void;
   dispose(): void;
 }
 
@@ -120,6 +141,16 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   const paintStorage = options.paintStorage === undefined
     ? pagePaintModeStorage(documentLike)
     : options.paintStorage;
+  const themeStorage = options.themeStorage === undefined
+    ? pageOverlayThemeStorage(documentLike)
+    : options.themeStorage;
+  // The served page's option is the floor, the page's own overrides the
+  // ceiling. A theme is resolved on the container, so both layers travel.
+  let storedTheme: OverlayTheme | null = readStoredOverlayTheme(themeStorage);
+  const effectiveTheme = (): OverlayTheme => ({
+    ...(options.overlayTheme ?? {}),
+    ...(storedTheme ?? {}),
+  });
 
   const events: SandboxEvent[] = [];
   let current: readonly ListenerOutline[] = [];
@@ -235,10 +266,25 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
   };
 
   const showPainting = (): void => {
-    overlay = createListenerOverlay({ document: documentLike, onSelect: openStudio });
+    overlay = createListenerOverlay({
+      document: documentLike,
+      onSelect: openStudio,
+      theme: effectiveTheme(),
+      mode: paintMode,
+    });
     paint();
     if (paintMode === 'flow') startFlow();
   };
+
+  // Another tab, or this page's own Theme dialog, writes the overrides; the
+  // event is what puts them on a container that is already drawing.
+  const view = documentLike.defaultView;
+  const onStorage = (event: StorageEvent): void => {
+    if (event.key !== null && event.key !== OVERLAY_THEME_KEY) return;
+    storedTheme = readStoredOverlayTheme(themeStorage);
+    overlay?.setTheme(effectiveTheme());
+  };
+  view?.addEventListener('storage', onStorage);
 
   return {
     setEnabled(next) {
@@ -263,6 +309,7 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       paintMode = next;
       writeListenerPaintMode(paintStorage, next);
       if (overlay === null) return;
+      overlay.setMode(next);
       if (next === 'overview') stopFlow();
       paint();
       if (next === 'flow') startFlow();
@@ -294,7 +341,15 @@ export function createListenerMode(options: ListenerModeOptions): ListenerMode {
       // back on leaves the page empty until the next delivery.
       if (!visible) flow?.clearListener(listenerId);
     },
+    overlayTheme() {
+      return effectiveTheme();
+    },
+    setOverlayTheme(theme) {
+      storedTheme = theme;
+      overlay?.setTheme(effectiveTheme());
+    },
     dispose() {
+      view?.removeEventListener('storage', onStorage);
       hidePainting();
       unsubscribe?.();
       unsubscribe = null;

--- a/packages/cli/src/serve/runtime/listener-outline-model.ts
+++ b/packages/cli/src/serve/runtime/listener-outline-model.ts
@@ -71,6 +71,8 @@ export interface ListenerOutline {
   readonly isQuery: boolean;
   readonly service: 'firestore' | 'database';
   readonly deliveryCount: number;
+  /** When this listener last handed the application a snapshot, when it has. */
+  readonly lastDeliveryAt?: number;
   /** Selectors to outline. Empty when nothing on the page could be found. */
   readonly selectors: readonly string[];
   readonly incident: ListenerOutlineIncident | null;
@@ -195,6 +197,7 @@ function outlineFor(
     isQuery: targetIsQuery(listener.target),
     service: listener.service,
     deliveryCount: listener.deliveryCount,
+    ...(listener.lastDeliveryAt === undefined ? {} : { lastDeliveryAt: listener.lastDeliveryAt }),
     selectors: outlineSelectors(owners),
     incident: incidentMark(incidents, attachEventIds.get(listener.id)),
   };

--- a/packages/cli/src/serve/runtime/listener-outline-model.ts
+++ b/packages/cli/src/serve/runtime/listener-outline-model.ts
@@ -55,6 +55,9 @@ export interface ListenerOutlineIncident {
 /** One listener as the overlay draws it. */
 export interface ListenerOutline {
   readonly listenerId: string;
+  /** The page client's own subscription id, when the attach carried it; a
+   * delivery observed on the page names the listener by this id. */
+  readonly clientListenerId?: string;
   /** Component name, else owner tag name, else creating function or file. */
   readonly label: string;
   /**
@@ -185,6 +188,7 @@ function outlineFor(
   const owners = listener.owners ?? [];
   return {
     listenerId: listener.id,
+    ...(listener.clientListenerId === undefined ? {} : { clientListenerId: listener.clientListenerId }),
     label: outlineLabel(owners, listener.id),
     labelIsOwner: labelIsOwner(owners),
     target: targetPath(listener.target),

--- a/packages/cli/src/serve/runtime/listener-overlay.ts
+++ b/packages/cli/src/serve/runtime/listener-overlay.ts
@@ -6,17 +6,33 @@
  * It derives nothing: the model decides which listeners exist, what they are
  * called, what they listen to, and which incident they are part of.
  *
+ * The overlay puts structure in the DOM and nothing else. Each box says what
+ * it is, which listener it belongs to, which hue that listener draws in, and
+ * whether an incident is on it; the drawing comes from the stylesheet in
+ * `overlay-theme.ts`, which the container carries. Position and size stay
+ * inline, because they are measured from the page rather than chosen.
+ *
  * The overlay reads page geometry and never writes it. Its only page-level
  * listener is a window resize handler, which recomputes the boxes it already
  * drew. It installs nothing on application elements.
  */
 import type { ListenerOutline } from './listener-outline-model.js';
-import { listenerColors } from './listener-palette.js';
+import { listenerHueIndex } from './listener-palette.js';
+import {
+  applyOverlayTheme,
+  ensureOverlayStyleSheet,
+  type OverlayTheme,
+} from './overlay-theme.js';
+import type { ListenerPaintMode } from './listener-paint-mode.js';
 
 export interface ListenerOverlayOptions {
   document: Document;
   /** Called when a developer clicks a badge, for the Studio hand-off. */
   onSelect?: (outline: ListenerOutline) => void;
+  /** Custom property overrides for the container. See `overlay-theme.ts`. */
+  theme?: OverlayTheme | null;
+  /** Which painting mode the container starts in, for the mode attribute. */
+  mode?: ListenerPaintMode;
 }
 
 export interface ListenerOverlay {
@@ -31,6 +47,10 @@ export interface ListenerOverlay {
   reposition(): void;
   /** Called after a resize, so a second painter can follow the page too. */
   onReposition(listener: () => void): () => void;
+  /** Say which painting mode the container is in, for the stylesheet. */
+  setMode(mode: ListenerPaintMode): void;
+  /** Replace the container's custom properties with these overrides. */
+  setTheme(theme: OverlayTheme | null): void;
   /** Remove the container and its resize handler. */
   dispose(): void;
 }
@@ -42,37 +62,12 @@ const CONTAINER_STYLE = [
   'z-index:2147482999',
 ].join(';');
 
-const BOX_STYLE = [
-  'position:absolute',
-  'border:1px solid #19cc61',
-  'border-radius:4px',
-  'background:rgba(25,204,97,.08)',
-  'pointer-events:none',
-].join(';');
-
 /**
  * The container is a layer both painting modes draw into, so the boxes an
  * Overview pass replaces are addressed by their own attribute rather than by
  * clearing the container.
  */
 const BOX_ATTRIBUTE = 'data-pyric-listener-box';
-
-const BADGE_STYLE = [
-  'position:absolute',
-  'top:-9px',
-  'left:0',
-  'background:#16161a',
-  'border:1px solid #33333f',
-  'border-radius:4px',
-  'color:#fbfbfe',
-  'cursor:pointer',
-  'font:10px/1.6 "JetBrains Mono", ui-monospace, monospace',
-  'padding:1px 6px',
-  'pointer-events:auto',
-  'white-space:nowrap',
-].join(';');
-
-const INCIDENT_BORDER = '#e6c79c';
 
 /** The words on a badge: what owns the listener, and what it listens to. */
 function badgeText(outline: ListenerOutline): string {
@@ -111,7 +106,10 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
   const documentLike = options.document;
   const container = documentLike.createElement('div');
   container.setAttribute('data-pyric-listener-overlay', '');
+  container.setAttribute('data-pyric-mode', options.mode ?? 'overview');
   container.setAttribute('style', CONTAINER_STYLE);
+  ensureOverlayStyleSheet(documentLike, container);
+  applyOverlayTheme(container, options.theme);
   documentLike.body.append(container);
 
   let drawn: Array<{ box: HTMLElement; element: Element }> = [];
@@ -120,30 +118,26 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
     for (const previous of [...container.querySelectorAll(`[${BOX_ATTRIBUTE}]`)]) previous.remove();
     drawn = [];
     for (const outline of outlines) {
-      const colors = listenerColors(outline.listenerId);
+      const hue = String(listenerHueIndex(outline.listenerId));
       for (const element of ownedElements(documentLike, outline)) {
         const box = documentLike.createElement('div');
         box.setAttribute(BOX_ATTRIBUTE, '');
-        box.setAttribute('style', BOX_STYLE);
+        box.dataset.pyricRole = 'region';
         box.dataset.listenerId = outline.listenerId;
         box.dataset.listenerTarget = outline.target;
-        box.style.borderColor = colors.border;
-        box.style.background = colors.fill;
-        // An incident outranks the listener's own colour: the warm border is
-        // what a duplicate or a churn reads as everywhere else in the chip.
-        if (outline.incident !== null) box.style.borderColor = INCIDENT_BORDER;
+        box.dataset.hue = hue;
+        // An incident outranks the listener's own colour: the warm border the
+        // stylesheet gives an incident is what a duplicate or a churn reads as
+        // everywhere else in the chip.
+        if (outline.incident !== null) box.dataset.incident = outline.incident.pattern;
 
         const badge = documentLike.createElement('button');
         badge.type = 'button';
         badge.setAttribute('data-pyric-listener-badge', '');
-        badge.setAttribute('style', BADGE_STYLE);
+        badge.dataset.pyricRole = 'badge';
         badge.dataset.listenerId = outline.listenerId;
-        badge.style.borderColor = colors.border;
-        badge.style.color = colors.accent;
-        if (outline.incident !== null) {
-          badge.dataset.incident = outline.incident.pattern;
-          badge.style.borderColor = INCIDENT_BORDER;
-        }
+        badge.dataset.hue = hue;
+        if (outline.incident !== null) badge.dataset.incident = outline.incident.pattern;
         badge.textContent = badgeText(outline);
         badge.addEventListener('click', () => {
           options.onSelect?.(outline);
@@ -175,6 +169,12 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
       return container;
     },
     reposition,
+    setMode(mode) {
+      container.setAttribute('data-pyric-mode', mode);
+    },
+    setTheme(theme) {
+      applyOverlayTheme(container, theme);
+    },
     onReposition(listener) {
       followers.add(listener);
       return () => {

--- a/packages/cli/src/serve/runtime/listener-overlay.ts
+++ b/packages/cli/src/serve/runtime/listener-overlay.ts
@@ -11,6 +11,7 @@
  * drew. It installs nothing on application elements.
  */
 import type { ListenerOutline } from './listener-outline-model.js';
+import { listenerColors } from './listener-palette.js';
 
 export interface ListenerOverlayOptions {
   document: Document;
@@ -21,6 +22,15 @@ export interface ListenerOverlayOptions {
 export interface ListenerOverlay {
   /** Replace every box with the ones these outlines describe. */
   update(outlines: readonly ListenerOutline[]): void;
+  /**
+   * The container both painting modes draw into. The Flow painter appends its
+   * own boxes here, so the two modes share one layer and one z-index.
+   */
+  container(): HTMLElement;
+  /** Recompute the boxes already drawn against the page's current geometry. */
+  reposition(): void;
+  /** Called after a resize, so a second painter can follow the page too. */
+  onReposition(listener: () => void): () => void;
   /** Remove the container and its resize handler. */
   dispose(): void;
 }
@@ -39,6 +49,13 @@ const BOX_STYLE = [
   'background:rgba(25,204,97,.08)',
   'pointer-events:none',
 ].join(';');
+
+/**
+ * The container is a layer both painting modes draw into, so the boxes an
+ * Overview pass replaces are addressed by their own attribute rather than by
+ * clearing the container.
+ */
+const BOX_ATTRIBUTE = 'data-pyric-listener-box';
 
 const BADGE_STYLE = [
   'position:absolute',
@@ -100,15 +117,20 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
   let drawn: Array<{ box: HTMLElement; element: Element }> = [];
 
   const draw = (outlines: readonly ListenerOutline[]): void => {
-    container.replaceChildren();
+    for (const previous of [...container.querySelectorAll(`[${BOX_ATTRIBUTE}]`)]) previous.remove();
     drawn = [];
     for (const outline of outlines) {
+      const colors = listenerColors(outline.listenerId);
       for (const element of ownedElements(documentLike, outline)) {
         const box = documentLike.createElement('div');
-        box.setAttribute('data-pyric-listener-box', '');
+        box.setAttribute(BOX_ATTRIBUTE, '');
         box.setAttribute('style', BOX_STYLE);
         box.dataset.listenerId = outline.listenerId;
         box.dataset.listenerTarget = outline.target;
+        box.style.borderColor = colors.border;
+        box.style.background = colors.fill;
+        // An incident outranks the listener's own colour: the warm border is
+        // what a duplicate or a churn reads as everywhere else in the chip.
         if (outline.incident !== null) box.style.borderColor = INCIDENT_BORDER;
 
         const badge = documentLike.createElement('button');
@@ -116,6 +138,8 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
         badge.setAttribute('data-pyric-listener-badge', '');
         badge.setAttribute('style', BADGE_STYLE);
         badge.dataset.listenerId = outline.listenerId;
+        badge.style.borderColor = colors.border;
+        badge.style.color = colors.accent;
         if (outline.incident !== null) {
           badge.dataset.incident = outline.incident.pattern;
           badge.style.borderColor = INCIDENT_BORDER;
@@ -133,8 +157,11 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
     }
   };
 
+  const followers = new Set<() => void>();
+
   const reposition = (): void => {
     for (const entry of drawn) positionBox(entry.box, entry.element);
+    for (const follower of [...followers]) follower();
   };
 
   const view = documentLike.defaultView;
@@ -144,8 +171,19 @@ export function createListenerOverlay(options: ListenerOverlayOptions): Listener
     update(outlines) {
       draw(outlines);
     },
+    container() {
+      return container;
+    },
+    reposition,
+    onReposition(listener) {
+      followers.add(listener);
+      return () => {
+        followers.delete(listener);
+      };
+    },
     dispose() {
       view?.removeEventListener('resize', reposition);
+      followers.clear();
       drawn = [];
       container.remove();
     },

--- a/packages/cli/src/serve/runtime/listener-paint-mode.ts
+++ b/packages/cli/src/serve/runtime/listener-paint-mode.ts
@@ -1,0 +1,73 @@
+/**
+ * Which of the chip's two painting modes a page is in, and where that choice
+ * is kept.
+ *
+ * Overview paints one box per attached listener and leaves it there. Flow
+ * paints, for each delivery, the component subtree that rendered after it and
+ * fades it away. The two share the listener fold, the owners, the colours, the
+ * overlay container, and the per-listener toggles; only the painting differs.
+ *
+ * The choice is remembered per page origin in `localStorage`, so a developer
+ * who works in Flow keeps Flow across reloads. Storage is a page capability
+ * that can be absent, full, or blocked by the browser's settings, so every
+ * read and write is guarded and a failure leaves the default mode rather than
+ * an error.
+ */
+
+/** The painting modes the chip offers. */
+export type ListenerPaintMode = 'overview' | 'flow';
+
+/** The mode a page starts in when nothing was remembered. */
+export const DEFAULT_LISTENER_PAINT_MODE: ListenerPaintMode = 'overview';
+
+/** Where the choice is kept. */
+export const LISTENER_PAINT_MODE_KEY = 'pyric:listener-paint-mode';
+
+/** The part of `localStorage` this module uses. */
+export interface PaintModeStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/** `true` when this string names a mode. */
+export function isListenerPaintMode(value: unknown): value is ListenerPaintMode {
+  return value === 'overview' || value === 'flow';
+}
+
+/** The remembered mode, or the default when nothing readable was kept. */
+export function readListenerPaintMode(
+  storage: PaintModeStorage | null | undefined,
+): ListenerPaintMode {
+  if (storage === null || storage === undefined) return DEFAULT_LISTENER_PAINT_MODE;
+  try {
+    const stored = storage.getItem(LISTENER_PAINT_MODE_KEY);
+    return isListenerPaintMode(stored) ? stored : DEFAULT_LISTENER_PAINT_MODE;
+  } catch {
+    return DEFAULT_LISTENER_PAINT_MODE;
+  }
+}
+
+/** Remember this mode for the page. A storage that refuses is not an error. */
+export function writeListenerPaintMode(
+  storage: PaintModeStorage | null | undefined,
+  mode: ListenerPaintMode,
+): void {
+  if (storage === null || storage === undefined) return;
+  try {
+    storage.setItem(LISTENER_PAINT_MODE_KEY, mode);
+  } catch {
+    /* a page that cannot remember the choice still honours it for this session */
+  }
+}
+
+/** The page's own storage, when it has one this module can use. */
+export function pagePaintModeStorage(
+  documentLike: Document | null | undefined,
+): PaintModeStorage | null {
+  try {
+    const storage = documentLike?.defaultView?.localStorage;
+    return storage ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/serve/runtime/listener-palette.ts
+++ b/packages/cli/src/serve/runtime/listener-palette.ts
@@ -1,0 +1,64 @@
+/**
+ * The colour one listener is painted in, in either of the chip's painting
+ * modes.
+ *
+ * A listener keeps its colour for as long as its id does, so the same box on
+ * the page, the same flow subtree, and the same swatch in the chip's panel all
+ * read as one listener. The colour is derived, not assigned: nothing has to
+ * hold a registry, and two views of the same listener id agree without
+ * exchanging anything.
+ *
+ * The palette is eight hues chosen to stay apart from each other on the dark
+ * overlay chrome the overlay already draws, with the Listeners green first so
+ * a page with one listener looks the way it did before there were colours.
+ */
+
+/** The hues, in degrees, the palette draws from. */
+const HUES = [146, 200, 44, 280, 12, 172, 320, 96] as const;
+
+/** How a listener's colour reads against the overlay's dark chrome. */
+export interface ListenerColors {
+  /** The outline stroke. */
+  readonly border: string;
+  /** The wash inside the outline. */
+  readonly fill: string;
+  /** The badge's text. */
+  readonly accent: string;
+  /** The swatch in the chip's panel. */
+  readonly swatch: string;
+}
+
+/**
+ * A stable index into the palette. The hash is the 32-bit FNV-1a of the id,
+ * which spreads the sandbox's sequential subscription ids across the eight
+ * hues rather than handing consecutive listeners neighbouring entries.
+ */
+export function listenerHueIndex(listenerId: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < listenerId.length; i += 1) {
+    hash ^= listenerId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % HUES.length;
+}
+
+/** The hue, in degrees, this listener is painted in. */
+export function listenerHue(listenerId: string): number {
+  return HUES[listenerHueIndex(listenerId)];
+}
+
+/** Every colour the overlay and the panel need for one listener. */
+export function listenerColors(listenerId: string): ListenerColors {
+  const hue = listenerHue(listenerId);
+  return {
+    border: `hsl(${hue} 72% 52%)`,
+    fill: `hsla(${hue}, 72%, 52%, .08)`,
+    accent: `hsl(${hue} 72% 66%)`,
+    swatch: `hsl(${hue} 72% 52%)`,
+  };
+}
+
+/** The whole palette, in order, for a caller that wants to show it. */
+export function listenerPalette(): readonly number[] {
+  return HUES;
+}

--- a/packages/cli/src/serve/runtime/overlay-theme.ts
+++ b/packages/cli/src/serve/runtime/overlay-theme.ts
@@ -1,0 +1,294 @@
+/**
+ * The overlay's theme contract: every CSS custom property the painted boxes
+ * read, what each one defaults to, and how an override reaches the page.
+ *
+ * The painters put structure in the DOM and nothing else. A box says what it
+ * is (`data-pyric-role`), which listener it belongs to, which hue that
+ * listener draws in (`data-hue`), whether an incident is on it, and whether
+ * its flow is retained. Everything visible about it comes from one stylesheet
+ * injected into the overlay container, which reads the properties below off
+ * that container. Geometry stays inline on each box, because it is measured
+ * from the page rather than chosen.
+ *
+ * Three layers set those properties, later layers winning:
+ *
+ * 1. the defaults in {@link OVERLAY_THEME_DEFAULTS}, which reproduce what the
+ *    overlay drew before there was a stylesheet;
+ * 2. the `overlayTheme` option the served page passes to the runtime chip;
+ * 3. the JSON object under {@link OVERLAY_THEME_KEY} in `localStorage`, which
+ *    the chip's Theme dialog writes and a `storage` event re-applies live.
+ *
+ * A theme is a flat object of property name to property value. Names that are
+ * not in this contract are ignored. Values are applied verbatim, so the page
+ * decides what a valid value is: a property the browser rejects leaves that
+ * part of the drawing at whatever the cascade already had.
+ *
+ * The names follow the chip's own host properties (`--pyric-bg`,
+ * `--pyric-accent`, `--pyric-warning`, and the rest): the hues are
+ * `--pyric-hue-N`, and everything specific to the painted overlay is
+ * `--pyric-overlay-*`.
+ */
+import { listenerPalette } from './listener-palette.js';
+
+/** A flat set of overrides: custom property name to custom property value. */
+export type OverlayTheme = Readonly<Record<string, string>>;
+
+/** Where the page's own overrides are kept. */
+export const OVERLAY_THEME_KEY = 'pyric:overlay-theme';
+
+/** The part of `localStorage` this module uses. */
+export interface OverlayThemeStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * The hue a listener is painted in, and the lighter tone its badge text takes.
+ * One pair per palette entry, so a theme can repaint the palette without
+ * knowing how a listener is assigned to it.
+ */
+function hueDefaults(): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  listenerPalette().forEach((hue, index) => {
+    defaults[`--pyric-hue-${index}`] = `hsl(${hue} 72% 52%)`;
+    defaults[`--pyric-hue-${index}-text`] = `hsl(${hue} 72% 66%)`;
+  });
+  return defaults;
+}
+
+/**
+ * Every property the overlay stylesheet reads, with the value that reproduces
+ * what the overlay drew before the stylesheet existed.
+ *
+ * An empty default means the property is left unset, and the stylesheet falls
+ * back to something it derives per box. `--pyric-overlay-badge-fg` is the one
+ * such property: unset, a badge takes its listener's own hue text tone, and a
+ * theme that sets it paints every badge the same colour.
+ */
+export const OVERLAY_THEME_DEFAULTS: OverlayTheme = Object.freeze({
+  ...hueDefaults(),
+  '--pyric-overlay-outline-width': '1px',
+  '--pyric-overlay-outline-style': 'solid',
+  '--pyric-overlay-radius': '4px',
+  '--pyric-overlay-fill-opacity': '8%',
+  '--pyric-overlay-incident': '#e6c79c',
+  '--pyric-overlay-badge-bg': '#16161a',
+  '--pyric-overlay-badge-fg': '',
+  '--pyric-overlay-badge-font-family': '"JetBrains Mono", ui-monospace, monospace',
+  '--pyric-overlay-badge-font-size': '10px',
+  '--pyric-overlay-badge-padding': '1px 6px',
+  '--pyric-overlay-leaf-badge-font-size': '9px',
+  '--pyric-overlay-leaf-badge-padding': '0 4px',
+  '--pyric-overlay-fade-duration': '3000ms',
+  '--pyric-overlay-retained-opacity': '0.3',
+});
+
+/** Every property name a theme may set, in contract order. */
+export const OVERLAY_THEME_VARIABLES: readonly string[] = Object.freeze(
+  Object.keys(OVERLAY_THEME_DEFAULTS),
+);
+
+/** `true` when this name is part of the contract. */
+export function isOverlayThemeVariable(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(OVERLAY_THEME_DEFAULTS, name);
+}
+
+/** The contract's names and values only, in the order the layers were given. */
+export function resolveOverlayTheme(
+  ...layers: readonly (OverlayTheme | null | undefined)[]
+): Record<string, string> {
+  const resolved: Record<string, string> = { ...OVERLAY_THEME_DEFAULTS };
+  for (const layer of layers) {
+    if (layer === null || layer === undefined) continue;
+    for (const [name, value] of Object.entries(layer)) {
+      if (!isOverlayThemeVariable(name)) continue;
+      if (typeof value !== 'string') continue;
+      resolved[name] = value;
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Put a resolved theme on the container. A property resolved to the empty
+ * string is removed rather than set, so the stylesheet's own fallback applies
+ * and a Reset takes an override away instead of pinning it.
+ */
+export function applyOverlayTheme(
+  container: HTMLElement,
+  ...layers: readonly (OverlayTheme | null | undefined)[]
+): void {
+  const resolved = resolveOverlayTheme(...layers);
+  for (const name of OVERLAY_THEME_VARIABLES) {
+    const value = resolved[name] ?? '';
+    if (value === '') container.style.removeProperty(name);
+    else container.style.setProperty(name, value);
+  }
+}
+
+/** A theme object out of a JSON string, or `null` when it is not one. */
+export function parseOverlayTheme(text: string): Record<string, string> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  const theme: Record<string, string> = {};
+  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value === 'string') theme[name] = value;
+  }
+  return theme;
+}
+
+/** The overrides the page kept, or `null` when there are none to read. */
+export function readStoredOverlayTheme(
+  storage: OverlayThemeStorage | null | undefined,
+): Record<string, string> | null {
+  if (storage === null || storage === undefined) return null;
+  try {
+    const stored = storage.getItem(OVERLAY_THEME_KEY);
+    return stored === null ? null : parseOverlayTheme(stored);
+  } catch {
+    return null;
+  }
+}
+
+/** Keep these overrides for the page. A storage that refuses is not an error. */
+export function writeStoredOverlayTheme(
+  storage: OverlayThemeStorage | null | undefined,
+  theme: OverlayTheme,
+): void {
+  if (storage === null || storage === undefined) return;
+  try {
+    storage.setItem(OVERLAY_THEME_KEY, JSON.stringify(theme));
+  } catch {
+    /* a page that cannot keep the overrides still draws with them this session */
+  }
+}
+
+/** Take the page's overrides away. */
+export function clearStoredOverlayTheme(
+  storage: OverlayThemeStorage | null | undefined,
+): void {
+  if (storage === null || storage === undefined) return;
+  try {
+    storage.removeItem(OVERLAY_THEME_KEY);
+  } catch {
+    /* nothing was kept, which is the state a clear was asking for */
+  }
+}
+
+/** The page's own storage, when it has one this module can use. */
+export function pageOverlayThemeStorage(
+  documentLike: Document | null | undefined,
+): OverlayThemeStorage | null {
+  try {
+    const storage = documentLike?.defaultView?.localStorage;
+    return storage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** The attribute the injected stylesheet carries, so it is injected once. */
+export const OVERLAY_STYLE_ATTRIBUTE = 'data-pyric-overlay-style';
+
+function hueRules(): string {
+  return listenerPalette()
+    .map((_hue, index) => `[data-pyric-listener-overlay] [data-hue="${index}"] {
+    --pyric-overlay-hue: var(--pyric-hue-${index});
+    --pyric-overlay-hue-text: var(--pyric-hue-${index}-text);
+  }`)
+    .join('\n  ');
+}
+
+/**
+ * Everything the overlay draws, off the container's properties.
+ *
+ * The fade is two states rather than one: the painter marks a group fading on
+ * the frame after it draws, which is what starts the transition, and marks it
+ * retained when the fade is over. Both land on the same opacity, so a page
+ * that runs no transitions still shows the retained state.
+ */
+export function overlayStyleSheetText(): string {
+  return `
+  ${hueRules()}
+  [data-pyric-listener-overlay] [data-pyric-listener-box],
+  [data-pyric-listener-overlay] [data-pyric-flow-box] {
+    position: absolute;
+    pointer-events: none;
+    border: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
+    border-radius: var(--pyric-overlay-radius);
+    background: color-mix(in srgb, var(--pyric-overlay-hue) var(--pyric-overlay-fill-opacity), transparent);
+  }
+  [data-pyric-listener-overlay] [data-pyric-listener-box][data-incident],
+  [data-pyric-listener-overlay] [data-pyric-flow-box][data-incident] {
+    border-color: var(--pyric-overlay-incident);
+  }
+  [data-pyric-listener-overlay] [data-pyric-flow-box] {
+    opacity: 1;
+    transition: opacity var(--pyric-overlay-fade-duration) linear;
+  }
+  [data-pyric-listener-overlay] [data-pyric-flow-box][data-flow-fading],
+  [data-pyric-listener-overlay] [data-pyric-flow-box][data-flow-retained] {
+    opacity: var(--pyric-overlay-retained-opacity);
+  }
+  [data-pyric-listener-overlay] [data-pyric-role="badge"],
+  [data-pyric-listener-overlay] [data-pyric-role="leaf-badge"] {
+    position: absolute;
+    background: var(--pyric-overlay-badge-bg);
+    border: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
+    border-radius: var(--pyric-overlay-radius);
+    color: var(--pyric-overlay-badge-fg, var(--pyric-overlay-hue-text));
+    font-family: var(--pyric-overlay-badge-font-family);
+    font-size: var(--pyric-overlay-badge-font-size);
+    line-height: 1.6;
+    padding: var(--pyric-overlay-badge-padding);
+    pointer-events: none;
+    white-space: nowrap;
+  }
+  [data-pyric-listener-overlay] [data-pyric-role="badge"] {
+    top: -9px;
+    left: 0;
+  }
+  [data-pyric-listener-overlay] [data-pyric-role="leaf-badge"] {
+    bottom: -9px;
+    right: 0;
+    font-size: var(--pyric-overlay-leaf-badge-font-size);
+    padding: var(--pyric-overlay-leaf-badge-padding);
+  }
+  [data-pyric-listener-overlay] [data-pyric-listener-badge] {
+    cursor: pointer;
+    pointer-events: auto;
+  }
+  [data-pyric-listener-overlay] [data-pyric-role="badge"][data-incident],
+  [data-pyric-listener-overlay] [data-pyric-role="leaf-badge"][data-incident] {
+    border-color: var(--pyric-overlay-incident);
+  }
+`;
+}
+
+/**
+ * Put the stylesheet in the container, once. Both painters call this, so a
+ * painter drawing into a container the other one made still has the rules.
+ */
+export function ensureOverlayStyleSheet(
+  documentLike: Document,
+  container: HTMLElement,
+): HTMLStyleElement {
+  // Every rule is scoped to the overlay container, so the container a painter
+  // was handed has to be marked as one before the rules can reach its boxes.
+  if (!container.hasAttribute('data-pyric-listener-overlay')) {
+    container.setAttribute('data-pyric-listener-overlay', '');
+  }
+  const existing = container.querySelector<HTMLStyleElement>(`[${OVERLAY_STYLE_ATTRIBUTE}]`);
+  if (existing !== null) return existing;
+  const style = documentLike.createElement('style');
+  style.setAttribute(OVERLAY_STYLE_ATTRIBUTE, '');
+  style.textContent = overlayStyleSheetText();
+  container.prepend(style);
+  return style;
+}

--- a/packages/cli/src/serve/runtime/overlay-theme.ts
+++ b/packages/cli/src/serve/runtime/overlay-theme.ts
@@ -10,6 +10,13 @@
  * that container. Geometry stays inline on each box, because it is measured
  * from the page rather than chosen.
  *
+ * There are two stylesheets, because there are two things to draw. Overview's
+ * measured boxes live inside the overlay container and read the properties off
+ * it. Flow marks the page's own elements, which inherit nothing from that
+ * container, so its rules go in the document head and read the properties off
+ * `:root`; {@link applyOverlayTheme} writes a resolved theme to both places so
+ * one theme stands behind both.
+ *
  * Three layers set those properties, later layers winning:
  *
  * 1. the defaults in {@link OVERLAY_THEME_DEFAULTS}, which reproduce what the
@@ -111,19 +118,34 @@ export function resolveOverlayTheme(
 }
 
 /**
- * Put a resolved theme on the container. A property resolved to the empty
- * string is removed rather than set, so the stylesheet's own fallback applies
- * and a Reset takes an override away instead of pinning it.
+ * Put a resolved theme on the container, and mirror it onto the document root.
+ *
+ * A property resolved to the empty string is removed rather than set, so the
+ * stylesheet's own fallback applies and a Reset takes an override away instead
+ * of pinning it.
+ *
+ * The mirror is what keeps the theme over Flow. Flow marks the page's own
+ * elements, which are not inside the overlay container and so inherit nothing
+ * from it; the rules that draw those marks live in a stylesheet in the
+ * document head and read the properties off `:root`. Writing the same resolved
+ * values onto the root element puts one theme behind both, so the Theme dialog
+ * still repaints the marked elements.
  */
 export function applyOverlayTheme(
   container: HTMLElement,
   ...layers: readonly (OverlayTheme | null | undefined)[]
 ): void {
   const resolved = resolveOverlayTheme(...layers);
+  const root = container.ownerDocument?.documentElement ?? null;
   for (const name of OVERLAY_THEME_VARIABLES) {
     const value = resolved[name] ?? '';
-    if (value === '') container.style.removeProperty(name);
-    else container.style.setProperty(name, value);
+    if (value === '') {
+      container.style.removeProperty(name);
+      root?.style.removeProperty(name);
+    } else {
+      container.style.setProperty(name, value);
+      root?.style.setProperty(name, value);
+    }
   }
 }
 
@@ -216,25 +238,15 @@ function hueRules(): string {
 export function overlayStyleSheetText(): string {
   return `
   ${hueRules()}
-  [data-pyric-listener-overlay] [data-pyric-listener-box],
-  [data-pyric-listener-overlay] [data-pyric-flow-box] {
+  [data-pyric-listener-overlay] [data-pyric-listener-box] {
     position: absolute;
     pointer-events: none;
     border: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
     border-radius: var(--pyric-overlay-radius);
     background: color-mix(in srgb, var(--pyric-overlay-hue) var(--pyric-overlay-fill-opacity), transparent);
   }
-  [data-pyric-listener-overlay] [data-pyric-listener-box][data-incident],
-  [data-pyric-listener-overlay] [data-pyric-flow-box][data-incident] {
+  [data-pyric-listener-overlay] [data-pyric-listener-box][data-incident] {
     border-color: var(--pyric-overlay-incident);
-  }
-  [data-pyric-listener-overlay] [data-pyric-flow-box] {
-    opacity: 1;
-    transition: opacity var(--pyric-overlay-fade-duration) linear;
-  }
-  [data-pyric-listener-overlay] [data-pyric-flow-box][data-flow-fading],
-  [data-pyric-listener-overlay] [data-pyric-flow-box][data-flow-retained] {
-    opacity: var(--pyric-overlay-retained-opacity);
   }
   [data-pyric-listener-overlay] [data-pyric-role="badge"],
   [data-pyric-listener-overlay] [data-pyric-role="leaf-badge"] {
@@ -260,6 +272,18 @@ export function overlayStyleSheetText(): string {
     font-size: var(--pyric-overlay-leaf-badge-font-size);
     padding: var(--pyric-overlay-leaf-badge-padding);
   }
+  [data-pyric-listener-overlay] [data-pyric-flow-badge] {
+    position: absolute;
+    right: auto;
+    bottom: auto;
+    transform: translateY(-100%);
+    opacity: 1;
+    transition: opacity var(--pyric-overlay-fade-duration) linear;
+  }
+  [data-pyric-listener-overlay] [data-pyric-flow-badge][data-pyric-flow-fading],
+  [data-pyric-listener-overlay] [data-pyric-flow-badge][data-pyric-flow-retained] {
+    opacity: var(--pyric-overlay-retained-opacity);
+  }
   [data-pyric-listener-overlay] [data-pyric-listener-badge] {
     cursor: pointer;
     pointer-events: auto;
@@ -269,6 +293,105 @@ export function overlayStyleSheetText(): string {
     border-color: var(--pyric-overlay-incident);
   }
 `;
+}
+
+/** The attribute the head stylesheet carries, so it is injected once. */
+export const FLOW_STYLE_ATTRIBUTE = 'data-pyric-flow-style';
+
+/** The contract's defaults as one `:root` block, for the head stylesheet. */
+function rootDefaults(): string {
+  const body = OVERLAY_THEME_VARIABLES
+    .map((name) => {
+      const value = OVERLAY_THEME_DEFAULTS[name] ?? '';
+      return value === '' ? null : `    ${name}: ${value};`;
+    })
+    .filter((line): line is string => line !== null)
+    .join('\n');
+  return `:root {\n${body}\n  }`;
+}
+
+function flowHueRules(): string {
+  return listenerPalette()
+    .map((_hue, index) => `[data-pyric-flow="${index}"] {
+    --pyric-overlay-hue: var(--pyric-hue-${index});
+    --pyric-overlay-hue-text: var(--pyric-hue-${index}-text);
+  }`)
+    .join('\n  ');
+}
+
+/**
+ * Everything Flow draws on the page's own elements.
+ *
+ * Flow marks the element that changed rather than measuring a box over it, so
+ * these rules have to reach elements outside the overlay container. They carry
+ * the contract's defaults on `:root` themselves, and {@link applyOverlayTheme}
+ * writes a resolved theme onto the same root element, so an override still
+ * wins over the defaults here.
+ *
+ * The outline is what draws the mark, because it takes no space and so moves
+ * nothing on the page. The fade runs on the outline's colour rather than on
+ * the element's opacity, which would fade the application's own content, and
+ * ends at the retained colour rather than at nothing.
+ */
+export function flowStyleSheetText(): string {
+  return `
+  ${rootDefaults()}
+  ${flowHueRules()}
+  [data-pyric-flow] {
+    outline: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
+    outline-offset: 0;
+    border-radius: var(--pyric-overlay-radius);
+    transition: outline-color var(--pyric-overlay-fade-duration) linear;
+  }
+  [data-pyric-flow][data-pyric-flow-fading],
+  [data-pyric-flow][data-pyric-flow-retained] {
+    outline-color: color-mix(in srgb, var(--pyric-overlay-hue) calc(var(--pyric-overlay-retained-opacity) * 100%), transparent);
+  }
+  [data-pyric-flow][data-pyric-flow-label]::after {
+    content: attr(data-pyric-flow-label);
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translateY(-100%);
+    z-index: 2147483000;
+    background: var(--pyric-overlay-badge-bg);
+    border: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
+    border-radius: var(--pyric-overlay-radius);
+    color: var(--pyric-overlay-badge-fg, var(--pyric-overlay-hue-text));
+    font-family: var(--pyric-overlay-badge-font-family);
+    font-size: var(--pyric-overlay-leaf-badge-font-size);
+    font-weight: 400;
+    line-height: 1.6;
+    padding: var(--pyric-overlay-leaf-badge-padding);
+    pointer-events: none;
+    white-space: nowrap;
+    opacity: 1;
+    transition: opacity var(--pyric-overlay-fade-duration) linear;
+  }
+  [data-pyric-flow][data-pyric-flow-fading][data-pyric-flow-label]::after,
+  [data-pyric-flow][data-pyric-flow-retained][data-pyric-flow-label]::after {
+    opacity: var(--pyric-overlay-retained-opacity);
+  }
+`;
+}
+
+/**
+ * Put the flow stylesheet in the document head, once.
+ *
+ * The head rather than the overlay container, because Flow's marks are on the
+ * application's own elements and a stylesheet inside the container reaches
+ * only what is inside it.
+ */
+export function ensureFlowStyleSheet(documentLike: Document): HTMLStyleElement | null {
+  const head = documentLike.head ?? documentLike.documentElement ?? null;
+  if (head === null) return null;
+  const existing = documentLike.querySelector<HTMLStyleElement>(`[${FLOW_STYLE_ATTRIBUTE}]`);
+  if (existing !== null) return existing;
+  const style = documentLike.createElement('style');
+  style.setAttribute(FLOW_STYLE_ATTRIBUTE, '');
+  style.textContent = flowStyleSheetText();
+  head.append(style);
+  return style;
 }
 
 /**

--- a/packages/cli/src/serve/runtime/overlay-theme.ts
+++ b/packages/cli/src/serve/runtime/overlay-theme.ts
@@ -88,6 +88,8 @@ export const OVERLAY_THEME_DEFAULTS: OverlayTheme = Object.freeze({
   '--pyric-overlay-leaf-badge-font-size': '9px',
   '--pyric-overlay-leaf-badge-padding': '0 4px',
   '--pyric-overlay-fade-duration': '3000ms',
+  '--pyric-overlay-hold-duration': '1500ms',
+  '--pyric-overlay-flow-outline-width': '2px',
   '--pyric-overlay-retained-opacity': '0.3',
 });
 
@@ -338,10 +340,10 @@ export function flowStyleSheetText(): string {
   ${rootDefaults()}
   ${flowHueRules()}
   [data-pyric-flow] {
-    outline: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
+    outline: var(--pyric-overlay-flow-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
     outline-offset: 0;
     border-radius: var(--pyric-overlay-radius);
-    transition: outline-color var(--pyric-overlay-fade-duration) linear;
+    transition: outline-color var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration);
   }
   [data-pyric-flow][data-pyric-flow-fading],
   [data-pyric-flow][data-pyric-flow-retained] {
@@ -366,7 +368,7 @@ export function flowStyleSheetText(): string {
     pointer-events: none;
     white-space: nowrap;
     opacity: 1;
-    transition: opacity var(--pyric-overlay-fade-duration) linear;
+    transition: opacity var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration);
   }
   [data-pyric-flow][data-pyric-flow-fading][data-pyric-flow-label]::after,
   [data-pyric-flow][data-pyric-flow-retained][data-pyric-flow-label]::after {

--- a/packages/cli/src/serve/runtime/overlay-theme.ts
+++ b/packages/cli/src/serve/runtime/overlay-theme.ts
@@ -60,6 +60,8 @@ function hueDefaults(): Record<string, string> {
   listenerPalette().forEach((hue, index) => {
     defaults[`--pyric-hue-${index}`] = `hsl(${hue} 72% 52%)`;
     defaults[`--pyric-hue-${index}-text`] = `hsl(${hue} 72% 66%)`;
+    // The colour a mark settles on once retained: the same hue, mostly clear.
+    defaults[`--pyric-hue-${index}-retained`] = `hsl(${hue} 72% 52% / 0.35)`;
   });
   return defaults;
 }
@@ -225,6 +227,7 @@ function hueRules(): string {
     .map((_hue, index) => `[data-pyric-listener-overlay] [data-hue="${index}"] {
     --pyric-overlay-hue: var(--pyric-hue-${index});
     --pyric-overlay-hue-text: var(--pyric-hue-${index}-text);
+    --pyric-overlay-hue-retained: var(--pyric-hue-${index}-retained);
   }`)
     .join('\n  ');
 }
@@ -339,22 +342,30 @@ export function flowStyleSheetText(): string {
   return `
   ${rootDefaults()}
   ${flowHueRules()}
+  @keyframes pyric-flow-mark {
+    from { outline-color: var(--pyric-overlay-hue); }
+    to { outline-color: var(--pyric-overlay-hue-retained); }
+  }
+  @keyframes pyric-flow-badge {
+    from { opacity: 1; }
+    to { opacity: var(--pyric-overlay-retained-opacity); }
+  }
   [data-pyric-flow] {
     outline: var(--pyric-overlay-flow-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
     outline-offset: 0;
     border-radius: var(--pyric-overlay-radius);
-    transition: outline-color var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration);
   }
-  [data-pyric-flow][data-pyric-flow-fading],
+  [data-pyric-flow][data-pyric-flow-fading] {
+    animation: pyric-flow-mark var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration) forwards;
+  }
   [data-pyric-flow][data-pyric-flow-retained] {
-    outline-color: color-mix(in srgb, var(--pyric-overlay-hue) calc(var(--pyric-overlay-retained-opacity) * 100%), transparent);
+    outline-color: var(--pyric-overlay-hue-retained);
   }
   [data-pyric-flow][data-pyric-flow-label]::after {
     content: attr(data-pyric-flow-label);
     position: absolute;
-    top: 0;
-    right: 0;
-    transform: translateY(-100%);
+    top: 2px;
+    right: 2px;
     z-index: 2147483000;
     background: var(--pyric-overlay-badge-bg);
     border: var(--pyric-overlay-outline-width) var(--pyric-overlay-outline-style) var(--pyric-overlay-hue);
@@ -368,9 +379,10 @@ export function flowStyleSheetText(): string {
     pointer-events: none;
     white-space: nowrap;
     opacity: 1;
-    transition: opacity var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration);
   }
-  [data-pyric-flow][data-pyric-flow-fading][data-pyric-flow-label]::after,
+  [data-pyric-flow][data-pyric-flow-fading][data-pyric-flow-label]::after {
+    animation: pyric-flow-badge var(--pyric-overlay-fade-duration) linear var(--pyric-overlay-hold-duration) forwards;
+  }
   [data-pyric-flow][data-pyric-flow-retained][data-pyric-flow-label]::after {
     opacity: var(--pyric-overlay-retained-opacity);
   }

--- a/packages/cli/src/serve/runtime/react-commit-source.ts
+++ b/packages/cli/src/serve/runtime/react-commit-source.ts
@@ -1,0 +1,181 @@
+/**
+ * When React finished rendering, and whether there is a React on the page at
+ * all.
+ *
+ * React calls `onCommitFiberRoot` on `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`
+ * after every commit, and reads that global once, while its own module is
+ * first evaluated. So the hook has to be installed before the application's
+ * script runs: the served page puts pyric's init tag ahead of the
+ * application's module script for exactly this.
+ *
+ * The React DevTools extension installs the same global. When it got there
+ * first this module wraps the hook's `onCommitFiberRoot` rather than replacing
+ * it, so the extension keeps working and the panel keeps its data.
+ *
+ * Everything here is guarded. No React, no hook, or a hook shaped differently
+ * from the one this module knows leaves the commit source unavailable with a
+ * reason to show, and nothing throws.
+ */
+
+/** The hook fields this module reads and writes. */
+interface DevToolsHook {
+  renderers?: Map<unknown, unknown>;
+  supportsFiber?: boolean;
+  inject?: (renderer: unknown) => number;
+  onCommitFiberRoot?: (...args: unknown[]) => void;
+  onPostCommitFiberRoot?: (...args: unknown[]) => void;
+  onCommitFiberUnmount?: (...args: unknown[]) => void;
+  checkDCE?: (fn: unknown) => void;
+}
+
+interface HookWindow {
+  __REACT_DEVTOOLS_GLOBAL_HOOK__?: DevToolsHook;
+  document?: { querySelector?: unknown };
+}
+
+/** The commit source the flow mode reads. */
+export interface ReactCommitSource {
+  /** `true` once a React renderer has injected itself into the hook. */
+  available(): boolean;
+  /** Why the flow mode is unavailable, or `null` when it is available. */
+  reason(): string | null;
+  /** Called after every commit, until the returned function is called. */
+  subscribe(listener: () => void): () => void;
+  /** Give the hook back the handler it had, and drop every subscriber. */
+  dispose(): void;
+}
+
+/** The global name React reads to find the hook. */
+const HOOK_KEY = '__REACT_DEVTOOLS_GLOBAL_HOOK__';
+
+const NO_REACT = 'No React renderer on this page, so there is nothing to follow a delivery into.';
+const NOT_INSTALLED = 'The commit hook could not be installed on this page.';
+
+/**
+ * `true` when some element on the page carries the property React puts on the
+ * host nodes it creates. A page whose React loaded before the hook was
+ * installed still answers `true` here, which is how the chip tells "no React"
+ * apart from "React, but this source never saw its commits".
+ */
+export function reactRendered(documentLike: Document | null | undefined): boolean {
+  if (documentLike === null || documentLike === undefined) return false;
+  let elements: ArrayLike<Element>;
+  try {
+    elements = documentLike.querySelectorAll('*');
+  } catch {
+    return false;
+  }
+  for (let index = 0; index < elements.length; index += 1) {
+    const record = elements[index] as unknown as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (key.startsWith('__reactFiber$') || key.startsWith('__reactContainer$')) return true;
+    }
+  }
+  return false;
+}
+
+/** A hook object with the members React checks for before it injects. */
+function freshHook(): DevToolsHook {
+  let nextId = 1;
+  const renderers = new Map<unknown, unknown>();
+  return {
+    renderers,
+    supportsFiber: true,
+    inject(renderer: unknown) {
+      const id = nextId;
+      nextId += 1;
+      renderers.set(id, renderer);
+      return id;
+    },
+    onCommitFiberRoot() {},
+    onPostCommitFiberRoot() {},
+    onCommitFiberUnmount() {},
+    checkDCE() {},
+  };
+}
+
+/**
+ * Install or wrap the commit hook on this window.
+ *
+ * Call this before the application's script runs. Calling it after React has
+ * already loaded leaves a source that never reports a commit, which
+ * {@link ReactCommitSource.reason} says.
+ */
+export function installReactCommitSource(target: unknown): ReactCommitSource {
+  const listeners = new Set<() => void>();
+  const view = target as HookWindow | null;
+  if (view === null || typeof view !== 'object') {
+    return {
+      available: () => false,
+      reason: () => NOT_INSTALLED,
+      subscribe: () => () => {},
+      dispose: () => {},
+    };
+  }
+
+  let hook: DevToolsHook;
+  let installed = false;
+  try {
+    const existing = view[HOOK_KEY];
+    hook = existing !== null && typeof existing === 'object' ? existing : freshHook();
+    if (view[HOOK_KEY] !== hook) view[HOOK_KEY] = hook;
+    installed = true;
+  } catch {
+    return {
+      available: () => false,
+      reason: () => NOT_INSTALLED,
+      subscribe: () => () => {},
+      dispose: () => {},
+    };
+  }
+
+  const previous = hook.onCommitFiberRoot;
+  const wrapped = (...args: unknown[]): void => {
+    // The extension's own handler runs first and unchanged; a subscriber that
+    // throws must not take React's commit down with it.
+    try {
+      previous?.apply(hook, args);
+    } catch {
+      /* the extension's handler owns its own failures */
+    }
+    for (const listener of [...listeners]) {
+      try {
+        listener();
+      } catch {
+        /* one subscriber's failure is not React's problem */
+      }
+    }
+  };
+  try {
+    hook.onCommitFiberRoot = wrapped;
+  } catch {
+    installed = false;
+  }
+
+  const rendererCount = (): number => {
+    const renderers = hook.renderers;
+    if (renderers === null || renderers === undefined) return 0;
+    return typeof renderers.size === 'number' ? renderers.size : 0;
+  };
+
+  return {
+    available() {
+      return installed && rendererCount() > 0;
+    },
+    reason() {
+      if (!installed) return NOT_INSTALLED;
+      if (rendererCount() === 0) return NO_REACT;
+      return null;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      listeners.clear();
+      if (hook.onCommitFiberRoot === wrapped) hook.onCommitFiberRoot = previous;
+    },
+  };
+}

--- a/packages/cli/src/serve/vite-page-runtime.ts
+++ b/packages/cli/src/serve/vite-page-runtime.ts
@@ -32,8 +32,21 @@ function swapsInBuild(env: ConfigEnv, override: boolean | undefined): boolean {
   return override ?? env.mode !== 'production';
 }
 
+/**
+ * Put pyric's tags ahead of the page's own scripts.
+ *
+ * The sandbox init script has to run before the application's module script.
+ * It configures listener attribution and installs the React commit hook the
+ * chip's Flow painting reads, and React reads that hook global once, while its
+ * own module first evaluates. A build puts the application's script in the
+ * head, so appending at the end of the head would be too late.
+ */
 function injectIntoHead(html: string, tags: string): string {
-  if (html.includes('</head>')) return html.replace('</head>', `${tags}</head>`);
+  const headEnd = html.indexOf('</head>');
+  const scanEnd = headEnd === -1 ? html.length : headEnd;
+  const firstScript = html.slice(0, scanEnd).search(/<script[\s>]/i);
+  if (firstScript >= 0) return html.slice(0, firstScript) + tags + html.slice(firstScript);
+  if (headEnd >= 0) return html.slice(0, headEnd) + tags + html.slice(headEnd);
   return tags + html;
 }
 

--- a/packages/cli/src/serve/worker/client/firestore-reads.ts
+++ b/packages/cli/src/serve/worker/client/firestore-reads.ts
@@ -13,6 +13,7 @@ import type {
 import { closeSubscription, nextId, nextSubId, dataRpc, _defaultLens, subscribeLens, openSnapshotSubscription, stampIssuer } from './core.js';
 import type { ClientDb, DocRefHandle, CollRefHandle, QueryHandle, Unsubscribe } from './handles.js';
 import { pageListenerOwners } from './listener-owners.js';
+import { reportListenerDelivery } from './listener-delivery.js';
 import { makeDocSnapshot, makeQuerySnapshot } from './snapshots.js';
 import type { RawDocResult, RawQueryResult, ClientDocSnapshot, ClientQuerySnapshot } from './snapshots.js';
 
@@ -171,6 +172,9 @@ export function onSnapshot(
     port,
     service: 'firestore' as const,
     next: (raw: unknown) => {
+      // Reported on the subscription id the sandbox also records as the
+      // listener id, immediately before the application's callback runs.
+      reportListenerDelivery(currentSubId);
       const r = raw as Record<string, unknown>;
       if ('docs' in r) {
         callback(makeQuerySnapshot(r as unknown as RawQueryResult, port));

--- a/packages/cli/src/serve/worker/client/listener-delivery.ts
+++ b/packages/cli/src/serve/worker/client/listener-delivery.ts
@@ -1,0 +1,41 @@
+/**
+ * The moment a listener hands a snapshot to the application.
+ *
+ * The worker tells the page that a subscription produced data; the page is the
+ * only side that knows when the application's own callback runs. Page-side
+ * diagnostics that want to follow a delivery into the render it caused need
+ * that moment, so the read paths report it here, immediately before invoking
+ * the callback.
+ *
+ * The key is the worker subscription id, which is the same string the sandbox
+ * records as a listener id on its attach and delivery events. So a subscriber
+ * matches a delivery to a listener by identity and needs no mapping by target.
+ *
+ * Nothing is reported when nobody is listening, and a subscriber that throws
+ * never reaches the application's callback.
+ */
+
+/** Called with the subscription id whose callback is about to run. */
+export type ListenerDeliveryListener = (listenerId: string) => void;
+
+const listeners = new Set<ListenerDeliveryListener>();
+
+/** Watch for deliveries. Returns the function that stops watching. */
+export function onListenerDelivery(listener: ListenerDeliveryListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Report that this subscription is about to invoke the application's callback. */
+export function reportListenerDelivery(listenerId: string): void {
+  if (listeners.size === 0) return;
+  for (const listener of [...listeners]) {
+    try {
+      listener(listenerId);
+    } catch {
+      /* a diagnostic must never break the application's delivery */
+    }
+  }
+}

--- a/packages/cli/src/serve/worker/client/rtdb-listeners.ts
+++ b/packages/cli/src/serve/worker/client/rtdb-listeners.ts
@@ -12,6 +12,7 @@ import {
 } from './core.js';
 import type { ClientPort, RtdbDataSnapshot, Unsubscribe } from './handles.js';
 import { pageListenerOwners } from './listener-owners.js';
+import { reportListenerDelivery } from './listener-delivery.js';
 import {
   isRtdbQuery,
   rtdbChild,
@@ -99,6 +100,9 @@ function openValueSubscription(
     next: (wire: unknown) => {
       if (listenOptions?.onlyOnce && fired) return;
       fired = true;
+      // Reported on the subscription id the sandbox also records as the
+      // listener id, immediately before the application's callback runs.
+      reportListenerDelivery(currentSubId);
       if (listenOptions?.onlyOnce) {
         unsubLens();
         closeSubscription(ref.port, currentSubId);

--- a/packages/cli/src/serve/worker/host/core.ts
+++ b/packages/cli/src/serve/worker/host/core.ts
@@ -362,11 +362,15 @@ export function opProvenance(
     ?? ((msg as { clientSessionId?: string }).clientSessionId ? 'remote' : undefined);
   const actAs = (msg as { actAs?: AuthLens }).actAs;
   const target = msg.t === 'sub' ? msg.target : undefined;
-  const isAppFirestoreSubscription = issuer !== 'studio'
+  // A page's own subscription, on either service, carries its client
+  // subscription id as the activity listener id, so the page can match a
+  // delivery it observes to the listener the sandbox recorded.
+  const isAppSubscription = issuer !== 'studio'
     && relaySource !== 'remote'
     && target !== null
     && typeof target === 'object'
-    && '__ref' in target;
+    && ('__ref' in target || (target as { service?: string }).service === 'rtdb');
+  const isAppFirestoreSubscription = isAppSubscription;
   if (
     issuer !== 'studio'
     && relaySource !== 'remote'

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -41,8 +41,17 @@ function setup(options: {
   attributionEnabled?: boolean;
   studioUrl?: string | null;
   incidents?: (events: readonly SandboxEvent[]) => readonly ActivityIncident[];
+  /** Whether the page has a React whose commits the chip can read. */
+  react?: boolean;
 } = {}) {
   const copied: string[] = [];
+  const paintStore = new Map<string, string>();
+  const paintStorage = {
+    getItem: (key: string) => paintStore.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      paintStore.set(key, value);
+    },
+  };
   const dom = new JSDOM(
     '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
@@ -69,6 +78,17 @@ function setup(options: {
       onChange,
       attributionEnabled: () => options.attributionEnabled ?? true,
       incidents: options.incidents ?? (() => []),
+      commits: {
+        available: () => options.react ?? false,
+        reason: () => ((options.react ?? false) ? null : 'no React'),
+        subscribe: () => () => {},
+        dispose: () => {},
+      },
+      paintStorage,
+      flow: {
+        subscribeDeliveries: () => () => {},
+        changedNodes: () => ({ drain: () => [], stop: () => {} }),
+      },
       subscribeEvents: (callback) => {
         deliver = callback;
         return () => {
@@ -231,12 +251,11 @@ describe('the chip Listeners mode', () => {
     const panel = page.root.querySelector('[data-listener-panel]')!;
     const rows = [...panel.querySelectorAll('.listener-row')];
     expect(rows.length).toBeLessThanOrEqual(4);
-    const cells = [...rows[0].children].map((cell) => cell.textContent);
-    expect(cells[0]).toBe('01');
-    expect(cells[1]).toBe('ChatPage');
-    expect(cells[2]).toBe('4 targets');
-    expect(cells[3]).toBe('4');
-    expect(cells[4]).toBe('3');
+    expect(rows[0].querySelector('.listener-number')?.textContent).toBe('01');
+    expect(rows[0].querySelector('.listener-label')?.textContent).toBe('ChatPage');
+    expect(rows[0].querySelector('.listener-target')?.textContent).toBe('4 targets');
+    expect([...rows[0].querySelectorAll('.listener-count')].map((cell) => cell.textContent))
+      .toEqual(['4', '3']);
     const counts = [...rows[0].querySelectorAll('.listener-count')]
       .map((cell) => cell.getAttribute('title'));
     expect(counts).toEqual(['4 listeners', '3 deliveries']);
@@ -409,5 +428,166 @@ describe('the chip Listeners mode', () => {
     page.push([attach('e1', 'l1', { kind: 'query', collection: 'todos' }, [{ kind: 'tag', name: 'TodoList', element: '#todos' }])]);
     page.chip.dispose();
     expect(page.doc.querySelector('[data-pyric-listener-overlay]')).toBeNull();
+  });
+});
+
+function modeButton(root: ShadowRoot, mode: 'overview' | 'flow'): HTMLButtonElement {
+  return root.querySelector<HTMLButtonElement>(`[data-listener-mode="${mode}"]`)!;
+}
+
+function paintBoxes(root: ShadowRoot): HTMLInputElement[] {
+  return [...root.querySelectorAll<HTMLInputElement>('[data-toggle-listener-paint]')];
+}
+
+const todos = attach('e1', 'l1', { kind: 'query', collection: 'todos' }, [{ kind: 'tag', name: 'TodoList', element: '#todos' }]);
+const profile = attach('e2', 'l2', { kind: 'doc', path: 'users/u1' }, [{ kind: 'tag', name: 'ProfileCard', element: '#profile' }]);
+
+describe('the chip painting-mode control', () => {
+  it('offers Overview and Flow beside the Listeners button, Overview first', () => {
+    const page = setup({ react: true });
+    const group = page.root.querySelector('[data-listener-modes]');
+    expect(group?.getAttribute('role')).toBe('group');
+    expect([...group!.querySelectorAll('button')].map((button) => button.textContent))
+      .toEqual(['Overview', 'Flow']);
+    expect(modeButton(page.root, 'overview').getAttribute('aria-pressed')).toBe('true');
+    page.chip.dispose();
+  });
+
+  it('switches to Flow and takes the Overview outlines down', () => {
+    const page = setup({ react: true });
+    toggle(page.root);
+    page.push([todos]);
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(1);
+
+    modeButton(page.root, 'flow').click();
+    expect(modeButton(page.root, 'flow').getAttribute('aria-pressed')).toBe('true');
+    expect(modeButton(page.root, 'overview').getAttribute('aria-pressed')).toBe('false');
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(0);
+    page.chip.dispose();
+  });
+
+  it('switches back to Overview and paints the listeners again', () => {
+    const page = setup({ react: true });
+    toggle(page.root);
+    page.push([todos]);
+    modeButton(page.root, 'flow').click();
+    modeButton(page.root, 'overview').click();
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(1);
+    page.chip.dispose();
+  });
+
+  it('disables Flow with a reason when the page has no React', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([todos]);
+
+    const flow = modeButton(page.root, 'flow');
+    expect(flow.getAttribute('aria-disabled')).toBe('true');
+    expect(flow.getAttribute('title')).toContain('React');
+
+    flow.click();
+    expect(modeButton(page.root, 'overview').getAttribute('aria-pressed')).toBe('true');
+    expect(page.root.querySelector('[data-listener-notice]')?.textContent).toContain('React');
+    page.chip.dispose();
+  });
+});
+
+describe('the chip per-listener toggles', () => {
+  it('shows a swatch and a paint checkbox on every owner row', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([todos, profile]);
+
+    const swatches = page.root.querySelectorAll<HTMLElement>('[data-listener-swatch]');
+    expect(swatches).toHaveLength(2);
+    expect(swatches[0].getAttribute('style')).toContain('background');
+    expect(swatches[0].getAttribute('style')).not.toBe(swatches[1].getAttribute('style'));
+
+    const boxes = paintBoxes(page.root);
+    expect(boxes).toHaveLength(2);
+    expect(boxes.every((box) => box.checked)).toBe(true);
+    page.chip.dispose();
+  });
+
+  it('stops painting the listener whose box is cleared', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([todos, profile]);
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(2);
+
+    const box = paintBoxes(page.root)[0];
+    box.checked = false;
+    box.dispatchEvent(new page.doc.defaultView!.Event('change'));
+
+    const drawn = [...page.doc.querySelectorAll<HTMLElement>('[data-pyric-listener-box]')];
+    expect(drawn).toHaveLength(1);
+    expect(paintBoxes(page.root)[0].checked).toBe(false);
+    page.chip.dispose();
+  });
+
+  it('paints the listener again when its box is set', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([todos, profile]);
+    const off = paintBoxes(page.root)[0];
+    off.checked = false;
+    off.dispatchEvent(new page.doc.defaultView!.Event('change'));
+
+    const on = paintBoxes(page.root)[0];
+    on.checked = true;
+    on.dispatchEvent(new page.doc.defaultView!.Event('change'));
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(2);
+    page.chip.dispose();
+  });
+
+  it('switches every listener a collapsed owner row stands for', () => {
+    const page = setup();
+    toggle(page.root);
+    page.push([
+      attach('c1', 'chat-1', { kind: 'doc', path: 'conversations/c1' }, [{ kind: 'tag', name: 'ChatPage', element: '#todos' }]),
+      attach('c2', 'chat-2', { kind: 'doc', path: 'conversations/c2' }, [{ kind: 'tag', name: 'ChatPage', element: '#profile' }]),
+    ]);
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(2);
+
+    const box = paintBoxes(page.root)[0];
+    expect(box.getAttribute('aria-label')).toContain('2 listeners');
+    box.checked = false;
+    box.dispatchEvent(new page.doc.defaultView!.Event('change'));
+    expect(page.doc.querySelectorAll('[data-pyric-listener-box]')).toHaveLength(0);
+    page.chip.dispose();
+  });
+
+  it('leaves an incident row without a listener to switch', () => {
+    const page = setup({
+      incidents: (events) => {
+        const attachIds = events
+          .filter((event) => (event as { kind: string }).kind === 'listener_attach')
+          .map((event) => (event as { id: string }).id);
+        return [{
+          fingerprint: 'fp1',
+          pattern: 'duplicate-listener',
+          confidence: 'high',
+          severity: 'warning',
+          service: 'firestore',
+          method: 'listen',
+          targetFingerprint: 'conversations',
+          actor: { kind: 'unknown' },
+          authLens: 'app',
+          authUid: null,
+          count: 2,
+          windowMs: 5000,
+          evidenceEventIds: attachIds,
+        } as unknown as ActivityIncident];
+      },
+    });
+    toggle(page.root);
+    page.push([
+      attach('e1', 'l1', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+      attach('e2', 'l2', { kind: 'query', collection: 'conversations' }, [{ kind: 'tag', name: 'ChatPage' }]),
+    ]);
+
+    const incidentRow = page.root.querySelector('.listener-row.incident')!;
+    expect(incidentRow.querySelector('[data-toggle-listener-paint]')).toBeNull();
+    page.chip.dispose();
   });
 });

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -543,7 +543,7 @@ describe('the chip painting-mode control', () => {
     modeButton(page.root, 'flow').click();
 
     page.flowDelivery('l1');
-    expect(page.doc.querySelectorAll('[data-pyric-flow-box]').length).toBeGreaterThan(0);
+    expect(page.doc.querySelectorAll('[data-pyric-flow]').length).toBeGreaterThan(0);
     expect(page.root.querySelector('[data-flow-waiting]')).toBeNull();
     page.chip.dispose();
   });

--- a/packages/cli/test/serve/runtime/chip-listeners.test.ts
+++ b/packages/cli/test/serve/runtime/chip-listeners.test.ts
@@ -53,11 +53,21 @@ function setup(options: {
     },
   };
   const dom = new JSDOM(
-    '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
+    '<!doctype html><body><div id="todos"><span id="row">a</span></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
   );
   const doc = dom.window.document;
+  // A row React rendered inline inside the todos region, so a delivery has
+  // something the fiber walk can attribute.
+  const rowEl = doc.querySelector('#row')!;
+  const regionHost = { tag: 5, type: 'div', stateNode: doc.querySelector('#todos')!, return: null, child: null };
+  (rowEl as unknown as Record<string, unknown>)['__reactFiber$k'] = {
+    tag: 5, type: 'span', stateNode: rowEl, return: regionHost, child: null,
+  };
   let deliver: ((events: readonly SandboxEvent[]) => void) | null = null;
+  let delivered: ((listenerId: string) => void) | null = null;
+  let commit: (() => void) | null = null;
+  let changedNodes: unknown[] = [];
   const chip = mountPyricRuntimeChip({
     runtime: createPyricRuntimeStatus(manifest),
     document: doc,
@@ -81,13 +91,30 @@ function setup(options: {
       commits: {
         available: () => options.react ?? false,
         reason: () => ((options.react ?? false) ? null : 'no React'),
-        subscribe: () => () => {},
+        subscribe: (listener) => {
+          commit = listener;
+          return () => {
+            commit = null;
+          };
+        },
         dispose: () => {},
       },
       paintStorage,
       flow: {
-        subscribeDeliveries: () => () => {},
-        changedNodes: () => ({ drain: () => [], stop: () => {} }),
+        subscribeDeliveries: (listener) => {
+          delivered = listener;
+          return () => {
+            delivered = null;
+          };
+        },
+        changedNodes: () => ({
+          drain: () => {
+            const drained = changedNodes;
+            changedNodes = [];
+            return drained;
+          },
+          stop: () => {},
+        }),
       },
       subscribeEvents: (callback) => {
         deliver = callback;
@@ -103,6 +130,12 @@ function setup(options: {
     copied,
     root: chip.element.shadowRoot!,
     push: (events: readonly SandboxEvent[]) => deliver?.(events),
+    /** A delivery the worker client reported, and the render that followed. */
+    flowDelivery: (listenerId: string) => {
+      delivered?.(listenerId);
+      changedNodes = [rowEl];
+      commit?.();
+    },
   };
 }
 
@@ -488,6 +521,44 @@ describe('the chip painting-mode control', () => {
     flow.click();
     expect(modeButton(page.root, 'overview').getAttribute('aria-pressed')).toBe('true');
     expect(page.root.querySelector('[data-listener-notice]')?.textContent).toContain('React');
+    page.chip.dispose();
+  });
+
+  it('says what Flow is waiting for while no delivery has been painted', () => {
+    const page = setup({ react: true });
+    toggle(page.root);
+    page.push([todos]);
+    expect(page.root.querySelector('[data-flow-waiting]')).toBeNull();
+
+    modeButton(page.root, 'flow').click();
+    expect(page.root.querySelector('[data-flow-waiting]')?.textContent)
+      .toBe('Waiting for a delivery to show its flow.');
+    page.chip.dispose();
+  });
+
+  it('takes the waiting line away once the first flow is painted', () => {
+    const page = setup({ react: true });
+    toggle(page.root);
+    page.push([todos]);
+    modeButton(page.root, 'flow').click();
+
+    page.flowDelivery('l1');
+    expect(page.doc.querySelectorAll('[data-pyric-flow-box]').length).toBeGreaterThan(0);
+    expect(page.root.querySelector('[data-flow-waiting]')).toBeNull();
+    page.chip.dispose();
+  });
+
+  it('says it is waiting again after a turn back into Flow', () => {
+    const page = setup({ react: true });
+    toggle(page.root);
+    page.push([todos]);
+    modeButton(page.root, 'flow').click();
+    page.flowDelivery('l1');
+
+    modeButton(page.root, 'overview').click();
+    expect(page.root.querySelector('[data-flow-waiting]')).toBeNull();
+    modeButton(page.root, 'flow').click();
+    expect(page.root.querySelector('[data-flow-waiting]')).not.toBeNull();
     page.chip.dispose();
   });
 });

--- a/packages/cli/test/serve/runtime/delivery-correlation.test.ts
+++ b/packages/cli/test/serve/runtime/delivery-correlation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  createDeliveryCorrelation,
+  type DeliveryFlow,
+} from '../../../src/serve/runtime/delivery-correlation.js';
+
+/** A clock and a scheduler the test drives by hand. */
+function fakeClock() {
+  let now = 1_000;
+  const timers: Array<{ at: number; run: () => void }> = [];
+  return {
+    now: () => now,
+    schedule: (run: () => void, delayMs: number) => {
+      const timer = { at: now + delayMs, run };
+      timers.push(timer);
+      return () => {
+        const index = timers.indexOf(timer);
+        if (index >= 0) timers.splice(index, 1);
+      };
+    },
+    advance(ms: number) {
+      const target = now + ms;
+      for (;;) {
+        const due = timers
+          .filter((timer) => timer.at <= target)
+          .sort((a, b) => a.at - b.at)[0];
+        if (due === undefined) break;
+        timers.splice(timers.indexOf(due), 1);
+        now = due.at;
+        due.run();
+      }
+      now = target;
+    },
+    outstanding: () => timers.length,
+  };
+}
+
+function setup(windowMs = 250) {
+  const clock = fakeClock();
+  const flows: DeliveryFlow[] = [];
+  const correlation = createDeliveryCorrelation({
+    windowMs,
+    now: clock.now,
+    schedule: clock.schedule,
+    onFlow: (flow) => flows.push(flow),
+  });
+  return { clock, flows, correlation };
+}
+
+describe('the delivery-to-commit window', () => {
+  it('reports the nodes that changed between a delivery and the commit', () => {
+    const page = setup();
+    page.correlation.delivered('sub-1');
+    page.correlation.changed(['a', 'b']);
+    page.clock.advance(10);
+    page.correlation.committed();
+
+    expect(page.flows).toHaveLength(1);
+    expect(page.flows[0].listenerId).toBe('sub-1');
+    expect(page.flows[0].nodes).toEqual(['a', 'b']);
+    expect(page.flows[0].elapsedMs).toBe(10);
+  });
+
+  it('ignores changes while no window is open', () => {
+    const page = setup();
+    page.correlation.changed(['stray']);
+    page.correlation.committed();
+    expect(page.flows).toHaveLength(0);
+  });
+
+  it('reports nothing when the commit changed no node', () => {
+    const page = setup();
+    page.correlation.delivered('sub-1');
+    page.correlation.committed();
+    expect(page.flows).toHaveLength(0);
+    expect(page.correlation.pending()).toEqual([]);
+  });
+
+  it('drops a delivery no commit followed inside the window', () => {
+    const page = setup(250);
+    page.correlation.delivered('sub-1');
+    page.correlation.changed(['a']);
+    page.clock.advance(400);
+    expect(page.correlation.pending()).toEqual([]);
+
+    page.correlation.committed();
+    expect(page.flows).toHaveLength(0);
+  });
+
+  it('keeps a delivery that is still inside its window', () => {
+    const page = setup(250);
+    page.correlation.delivered('sub-1');
+    page.clock.advance(100);
+    expect(page.correlation.pending()).toEqual(['sub-1']);
+    page.correlation.changed(['a']);
+    page.correlation.committed();
+    expect(page.flows).toHaveLength(1);
+  });
+
+  it('attributes one commit to every delivery still open, and says so once each', () => {
+    const page = setup();
+    page.correlation.delivered('sub-1');
+    page.clock.advance(5);
+    page.correlation.delivered('sub-2');
+    page.correlation.changed(['row']);
+    page.correlation.committed();
+
+    expect(page.flows.map((flow) => flow.listenerId)).toEqual(['sub-1', 'sub-2']);
+    expect(page.flows[0].nodes).toEqual(['row']);
+    expect(page.flows[1].nodes).toEqual(['row']);
+  });
+
+  it('drops only the expired delivery when a later one is still open', () => {
+    const page = setup(250);
+    page.correlation.delivered('sub-1');
+    page.clock.advance(200);
+    page.correlation.delivered('sub-2');
+    page.clock.advance(100);
+
+    expect(page.correlation.pending()).toEqual(['sub-2']);
+  });
+
+  it('starts each window fresh, so one commit is never reported twice', () => {
+    const page = setup();
+    page.correlation.delivered('sub-1');
+    page.correlation.changed(['a']);
+    page.correlation.committed();
+    page.correlation.committed();
+    expect(page.flows).toHaveLength(1);
+  });
+
+  it('cancels its sweep when disposed', () => {
+    const page = setup();
+    page.correlation.delivered('sub-1');
+    expect(page.clock.outstanding()).toBe(1);
+    page.correlation.dispose();
+    expect(page.clock.outstanding()).toBe(0);
+    expect(page.correlation.pending()).toEqual([]);
+  });
+});

--- a/packages/cli/test/serve/runtime/fiber-flow.test.ts
+++ b/packages/cli/test/serve/runtime/fiber-flow.test.ts
@@ -1,0 +1,199 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import {
+  componentChain,
+  componentName,
+  fiberFromNode,
+  flowSubtree,
+  hostElementFor,
+  isNamedComponent,
+  nearestFiber,
+  type FiberLike,
+} from '../../../src/serve/runtime/fiber-flow.js';
+
+/**
+ * A fiber-shaped fixture. React is not a dependency of this package, so the
+ * walk is exercised against the same field names React writes: `tag`, `type`,
+ * `stateNode`, `return`, `child`, and `sibling`, plus the `__reactFiber$`
+ * property React puts on host nodes.
+ */
+interface MutableFiber {
+  tag: number;
+  type: unknown;
+  stateNode: unknown;
+  return: MutableFiber | null;
+  child: MutableFiber | null;
+  sibling: MutableFiber | null;
+}
+
+function component(name: string): MutableFiber {
+  const type = { displayName: name };
+  return { tag: 0, type, stateNode: null, return: null, child: null, sibling: null };
+}
+
+function host(element: Element): MutableFiber {
+  return { tag: 5, type: element.tagName.toLowerCase(), stateNode: element, return: null, child: null, sibling: null };
+}
+
+function appendChild(parent: MutableFiber, child: MutableFiber): MutableFiber {
+  child.return = parent;
+  if (parent.child === null) {
+    parent.child = child;
+    return child;
+  }
+  let last = parent.child;
+  while (last.sibling !== null) last = last.sibling;
+  last.sibling = child;
+  return child;
+}
+
+/** Attach a fiber to its host node the way React does. */
+function link(element: Element, fiber: MutableFiber): void {
+  (element as unknown as Record<string, unknown>)['__reactFiber$abc123'] = fiber;
+}
+
+/**
+ * ChatPage
+ *   ConversationList  -> #list, with an #item inside it
+ *   MessageThread     -> #thread, with a #bubble inside it
+ */
+function buildPage() {
+  const dom = new JSDOM(`<!doctype html><body><div id="page">
+    <div id="list"><span id="item">one</span></div>
+    <div id="thread"><span id="bubble">hi</span></div>
+  </div></body>`);
+  const doc = dom.window.document;
+  const pageEl = doc.querySelector('#page')!;
+  const listEl = doc.querySelector('#list')!;
+  const itemEl = doc.querySelector('#item')!;
+  const threadEl = doc.querySelector('#thread')!;
+  const bubbleEl = doc.querySelector('#bubble')!;
+
+  const chatPage = component('ChatPage');
+  const pageHost = appendChild(chatPage, host(pageEl));
+  const list = appendChild(pageHost, component('ConversationList'));
+  const listHost = appendChild(list, host(listEl));
+  const itemHost = appendChild(listHost, host(itemEl));
+  const thread = appendChild(pageHost, component('MessageThread'));
+  const threadHost = appendChild(thread, host(threadEl));
+  const bubbleHost = appendChild(threadHost, host(bubbleEl));
+
+  link(pageEl, pageHost);
+  link(listEl, listHost);
+  link(itemEl, itemHost);
+  link(threadEl, threadHost);
+  link(bubbleEl, bubbleHost);
+
+  return { doc, pageEl, listEl, itemEl, threadEl, bubbleEl, chatPage, list, thread };
+}
+
+describe('reading a fiber off a node', () => {
+  it('finds the fiber React attached under its random suffix', () => {
+    const page = buildPage();
+    expect(fiberFromNode(page.listEl)).not.toBeNull();
+  });
+
+  it('returns null for a node React never touched', () => {
+    const page = buildPage();
+    expect(fiberFromNode(page.doc.createElement('div'))).toBeNull();
+    expect(fiberFromNode(null)).toBeNull();
+    expect(fiberFromNode('text')).toBeNull();
+  });
+
+  it('climbs to the nearest node React did create', () => {
+    const page = buildPage();
+    const text = page.bubbleEl.firstChild;
+    expect(nearestFiber(text)).not.toBeNull();
+    expect(hostElementFor(nearestFiber(text)!)).toBe(page.bubbleEl);
+  });
+});
+
+describe('naming a component fiber', () => {
+  it('prefers displayName and falls back to the function name', () => {
+    function MessageRow(): null {
+      return null;
+    }
+    const named: FiberLike = { tag: 0, type: MessageRow };
+    expect(componentName(named)).toBe('MessageRow');
+    expect(componentName({ tag: 0, type: { displayName: 'Wrapped', name: 'inner' } })).toBe('Wrapped');
+  });
+
+  it('reads through a memo or forwardRef wrapper', () => {
+    function PresenceBar(): null {
+      return null;
+    }
+    expect(componentName({ tag: 14, type: { type: PresenceBar } })).toBe('PresenceBar');
+    expect(componentName({ tag: 11, type: { render: PresenceBar } })).toBe('PresenceBar');
+  });
+
+  it('names no host component and no unnamed type', () => {
+    expect(componentName({ tag: 5, type: 'div' })).toBeNull();
+    expect(componentName({ tag: 0, type: null })).toBeNull();
+    expect(isNamedComponent({ tag: 5, type: 'div' })).toBe(false);
+    expect(isNamedComponent({ tag: 0, type: { displayName: 'ChatPage' } })).toBe(true);
+  });
+});
+
+describe('the component chain above a node', () => {
+  it('lists every component from the root down to the node, outermost first', () => {
+    const page = buildPage();
+    const chain = componentChain(fiberFromNode(page.itemEl)!);
+    expect(chain.map((fiber) => componentName(fiber))).toEqual(['ChatPage', 'ConversationList']);
+  });
+
+  it('gives each component the first host element below it', () => {
+    const page = buildPage();
+    expect(hostElementFor(page.chatPage)).toBe(page.pageEl);
+    expect(hostElementFor(page.list)).toBe(page.listEl);
+    expect(hostElementFor(page.thread)).toBe(page.threadEl);
+  });
+
+  it('borrows the nearest host node above a component that renders none', () => {
+    const page = buildPage();
+    const empty = appendChild(fiberFromNode(page.threadEl)! as MutableFiber, component('Empty'));
+    expect(hostElementFor(empty)).toBe(page.threadEl);
+  });
+});
+
+describe('the subtree a delivery rendered', () => {
+  it('names the owner at the root and the component that changed as a leaf', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.bubbleEl]);
+    expect(subtree.root?.name).toBe('ChatPage');
+    expect(subtree.root?.element).toBe(page.pageEl);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['ChatPage', 'MessageThread']);
+    expect(subtree.leaves.map((entry) => entry.name)).toEqual(['MessageThread']);
+  });
+
+  it('joins two mutated branches under one root', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.bubbleEl, page.itemEl]);
+    expect(subtree.root?.name).toBe('ChatPage');
+    expect(subtree.components.map((entry) => entry.name).sort())
+      .toEqual(['ChatPage', 'ConversationList', 'MessageThread']);
+    expect(subtree.leaves.map((entry) => entry.name).sort())
+      .toEqual(['ConversationList', 'MessageThread']);
+    expect(subtree.components.filter((entry) => entry.depth === 0)).toHaveLength(1);
+  });
+
+  it('counts a component once when the same render is reported twice', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.bubbleEl, page.bubbleEl, page.threadEl]);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['ChatPage', 'MessageThread']);
+  });
+
+  it('names nothing when no mutated node belongs to React', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.doc.createElement('div')]);
+    expect(subtree.root).toBeNull();
+    expect(subtree.components).toHaveLength(0);
+    expect(subtree.leaves).toHaveLength(0);
+  });
+
+  it('leaves a single component without a leaf badge of its own', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.pageEl]);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['ChatPage']);
+    expect(subtree.leaves).toHaveLength(0);
+  });
+});

--- a/packages/cli/test/serve/runtime/fiber-flow.test.ts
+++ b/packages/cli/test/serve/runtime/fiber-flow.test.ts
@@ -179,6 +179,27 @@ describe('the subtree a delivery rendered', () => {
     expect(subtree.leaves.map((entry) => entry.name)).toEqual(['MessageThread']);
   });
 
+  it('leaves out the owner and everything above it, such as a page root sharing the host', () => {
+    const dom = new JSDOM('<!doctype html><body><main id="page"><div id="list"><span id="item">one</span></div></main></body>');
+    const doc = dom.window.document;
+    const pageEl = doc.querySelector('#page')!;
+    const listEl = doc.querySelector('#list')!;
+    const itemEl = doc.querySelector('#item')!;
+    const app = component('App');
+    const chatPage = appendChild(app, component('ChatPage'));
+    const pageHost = appendChild(chatPage, host(pageEl));
+    const list = appendChild(pageHost, component('ConversationList'));
+    const listHost = appendChild(list, host(listEl));
+    const itemHost = appendChild(listHost, host(itemEl));
+    link(pageEl, pageHost);
+    link(listEl, listHost);
+    link(itemEl, itemHost);
+
+    const subtree = flowSubtree([itemEl], { ownerName: 'ChatPage' });
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['ConversationList']);
+    expect(subtree.components.some((entry) => entry.element === pageEl)).toBe(false);
+  });
+
   it('joins two mutated branches under one root', () => {
     const page = buildPage();
     const subtree = flowSubtree([page.bubbleEl, page.itemEl]);

--- a/packages/cli/test/serve/runtime/fiber-flow.test.ts
+++ b/packages/cli/test/serve/runtime/fiber-flow.test.ts
@@ -204,37 +204,36 @@ describe('the subtree a delivery rendered', () => {
     expect(subtree.leaves).toHaveLength(0);
   });
 
-  it('roots on the registered region and leaves the named owner unoutlined', () => {
+  it('marks neither the registered region nor the named owner', () => {
     const page = buildPage();
     const subtree = flowSubtree([page.bubbleEl], {
       regionElement: page.pageEl,
       ownerName: 'ChatPage',
     });
-    expect(subtree.root?.element).toBe(page.pageEl);
-    expect(subtree.root?.kind).toBe('region');
-    expect(subtree.root?.name).toBe('ChatPage');
-    // ChatPage's own host node is the page root; the badge names it instead.
-    expect(subtree.components.filter((box) => box.name === 'ChatPage')).toHaveLength(1);
-    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['MessageThread']);
+    // ChatPage's own host node is the page root, which is also the region: the
+    // first label names the owner instead of outlining the whole page.
+    expect(subtree.components.some((entry) => entry.element === page.pageEl)).toBe(false);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['MessageThread']);
+    expect(subtree.root?.element).toBe(page.threadEl);
+    expect(subtree.root?.kind).toBe('component');
   });
 
-  it('names the region by its element when the owner label is not one the app gave', () => {
+  it('leaves the region unmarked even when the owner label is not one the app gave', () => {
     const page = buildPage();
     const subtree = flowSubtree([page.bubbleEl], { regionElement: page.pageEl });
-    expect(subtree.root?.name).toBe('div#page');
-    expect(subtree.root?.kind).toBe('region');
+    expect(subtree.components.some((entry) => entry.element === page.pageEl)).toBe(false);
   });
 
-  it('makes a changed node its own leaf when only the owner sits above it', () => {
+  it('makes a changed node its own mark when only the owner sits above it', () => {
     const page = buildPage();
     const subtree = flowSubtree([page.barEl], {
       regionElement: page.pageEl,
       ownerName: 'ChatPage',
     });
-    expect(subtree.leaves).toHaveLength(1);
-    expect(subtree.leaves[0]?.kind).toBe('host');
-    expect(subtree.leaves[0]?.name).toBe('div#bar');
-    expect(subtree.leaves[0]?.element).toBe(page.barEl);
+    expect(subtree.components).toHaveLength(1);
+    expect(subtree.components[0]?.kind).toBe('host');
+    expect(subtree.components[0]?.name).toBe('div#bar');
+    expect(subtree.components[0]?.element).toBe(page.barEl);
   });
 
   it('labels a changed element by its first class when it carries no id', () => {
@@ -243,7 +242,7 @@ describe('the subtree a delivery rendered', () => {
       regionElement: page.pageEl,
       ownerName: 'ChatPage',
     });
-    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['span.conversation']);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['span.conversation']);
   });
 
   it('collapses nested changed nodes to the one at the top', () => {
@@ -252,7 +251,7 @@ describe('the subtree a delivery rendered', () => {
       regionElement: page.pageEl,
       ownerName: 'ChatPage',
     });
-    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['div#bar']);
+    expect(subtree.components.map((entry) => entry.name)).toEqual(['div#bar']);
   });
 
   it('draws nothing when the delivery changed nothing the walk could attribute', () => {
@@ -265,11 +264,12 @@ describe('the subtree a delivery rendered', () => {
     expect(subtree.components).toHaveLength(0);
   });
 
-  it('draws the region alone for a replayed delivery, with no leaves', () => {
+  it('marks the registered element alone for a replayed delivery, with no leaves', () => {
     const page = buildPage();
     const subtree = regionSubtree(page.pageEl, 'ChatPage');
     expect(subtree.root?.element).toBe(page.pageEl);
     expect(subtree.root?.name).toBe('ChatPage');
+    expect(subtree.root?.kind).toBe('component');
     expect(subtree.components).toHaveLength(1);
     expect(subtree.leaves).toHaveLength(0);
   });

--- a/packages/cli/test/serve/runtime/fiber-flow.test.ts
+++ b/packages/cli/test/serve/runtime/fiber-flow.test.ts
@@ -8,6 +8,7 @@ import {
   hostElementFor,
   isNamedComponent,
   nearestFiber,
+  regionSubtree,
   type FiberLike,
 } from '../../../src/serve/runtime/fiber-flow.js';
 
@@ -56,11 +57,17 @@ function link(element: Element, fiber: MutableFiber): void {
  * ChatPage
  *   ConversationList  -> #list, with an #item inside it
  *   MessageThread     -> #thread, with a #bubble inside it
+ *   #bar              -> inline JSX, with a .conversation chip inside it
+ *
+ * The #bar branch is what the chat template looks like: the page component
+ * renders it directly, so nothing between the page root and those elements is
+ * a component of its own.
  */
 function buildPage() {
   const dom = new JSDOM(`<!doctype html><body><div id="page">
     <div id="list"><span id="item">one</span></div>
     <div id="thread"><span id="bubble">hi</span></div>
+    <div id="bar"><span class="conversation pinned">c</span></div>
   </div></body>`);
   const doc = dom.window.document;
   const pageEl = doc.querySelector('#page')!;
@@ -68,6 +75,8 @@ function buildPage() {
   const itemEl = doc.querySelector('#item')!;
   const threadEl = doc.querySelector('#thread')!;
   const bubbleEl = doc.querySelector('#bubble')!;
+  const barEl = doc.querySelector('#bar')!;
+  const chipEl = doc.querySelector('.conversation')!;
 
   const chatPage = component('ChatPage');
   const pageHost = appendChild(chatPage, host(pageEl));
@@ -78,13 +87,18 @@ function buildPage() {
   const threadHost = appendChild(thread, host(threadEl));
   const bubbleHost = appendChild(threadHost, host(bubbleEl));
 
+  const barHost = appendChild(pageHost, host(barEl));
+  const chipHost = appendChild(barHost, host(chipEl));
+
   link(pageEl, pageHost);
   link(listEl, listHost);
   link(itemEl, itemHost);
   link(threadEl, threadHost);
   link(bubbleEl, bubbleHost);
+  link(barEl, barHost);
+  link(chipEl, chipHost);
 
-  return { doc, pageEl, listEl, itemEl, threadEl, bubbleEl, chatPage, list, thread };
+  return { doc, pageEl, listEl, itemEl, threadEl, bubbleEl, barEl, chipEl, chatPage, list, thread };
 }
 
 describe('reading a fiber off a node', () => {
@@ -187,6 +201,76 @@ describe('the subtree a delivery rendered', () => {
     const subtree = flowSubtree([page.doc.createElement('div')]);
     expect(subtree.root).toBeNull();
     expect(subtree.components).toHaveLength(0);
+    expect(subtree.leaves).toHaveLength(0);
+  });
+
+  it('roots on the registered region and leaves the named owner unoutlined', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.bubbleEl], {
+      regionElement: page.pageEl,
+      ownerName: 'ChatPage',
+    });
+    expect(subtree.root?.element).toBe(page.pageEl);
+    expect(subtree.root?.kind).toBe('region');
+    expect(subtree.root?.name).toBe('ChatPage');
+    // ChatPage's own host node is the page root; the badge names it instead.
+    expect(subtree.components.filter((box) => box.name === 'ChatPage')).toHaveLength(1);
+    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['MessageThread']);
+  });
+
+  it('names the region by its element when the owner label is not one the app gave', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.bubbleEl], { regionElement: page.pageEl });
+    expect(subtree.root?.name).toBe('div#page');
+    expect(subtree.root?.kind).toBe('region');
+  });
+
+  it('makes a changed node its own leaf when only the owner sits above it', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.barEl], {
+      regionElement: page.pageEl,
+      ownerName: 'ChatPage',
+    });
+    expect(subtree.leaves).toHaveLength(1);
+    expect(subtree.leaves[0]?.kind).toBe('host');
+    expect(subtree.leaves[0]?.name).toBe('div#bar');
+    expect(subtree.leaves[0]?.element).toBe(page.barEl);
+  });
+
+  it('labels a changed element by its first class when it carries no id', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.chipEl], {
+      regionElement: page.pageEl,
+      ownerName: 'ChatPage',
+    });
+    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['span.conversation']);
+  });
+
+  it('collapses nested changed nodes to the one at the top', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.chipEl, page.barEl], {
+      regionElement: page.pageEl,
+      ownerName: 'ChatPage',
+    });
+    expect(subtree.leaves.map((leaf) => leaf.name)).toEqual(['div#bar']);
+  });
+
+  it('draws nothing when the delivery changed nothing the walk could attribute', () => {
+    const page = buildPage();
+    const subtree = flowSubtree([page.doc.createElement('div')], {
+      regionElement: page.pageEl,
+      ownerName: 'ChatPage',
+    });
+    expect(subtree.root).toBeNull();
+    expect(subtree.components).toHaveLength(0);
+  });
+
+  it('draws the region alone for a replayed delivery, with no leaves', () => {
+    const page = buildPage();
+    const subtree = regionSubtree(page.pageEl, 'ChatPage');
+    expect(subtree.root?.element).toBe(page.pageEl);
+    expect(subtree.root?.name).toBe('ChatPage');
+    expect(subtree.components).toHaveLength(1);
     expect(subtree.leaves).toHaveLength(0);
   });
 

--- a/packages/cli/test/serve/runtime/listener-delivery.test.ts
+++ b/packages/cli/test/serve/runtime/listener-delivery.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  onListenerDelivery,
+  reportListenerDelivery,
+} from '../../../src/serve/worker/client/listener-delivery.js';
+
+describe('the delivery hook the read paths report to', () => {
+  it('hands every subscriber the subscription id that delivered', () => {
+    const seen: string[] = [];
+    const stop = onListenerDelivery((listenerId) => seen.push(listenerId));
+
+    reportListenerDelivery('sub-1');
+    reportListenerDelivery('sub-2');
+    expect(seen).toEqual(['sub-1', 'sub-2']);
+
+    stop();
+    reportListenerDelivery('sub-3');
+    expect(seen).toEqual(['sub-1', 'sub-2']);
+  });
+
+  it('reports to every subscriber and survives one that throws', () => {
+    const seen: string[] = [];
+    const stopFirst = onListenerDelivery(() => {
+      throw new Error('diagnostic');
+    });
+    const stopSecond = onListenerDelivery((listenerId) => seen.push(listenerId));
+
+    expect(() => reportListenerDelivery('sub-1')).not.toThrow();
+    expect(seen).toEqual(['sub-1']);
+    stopFirst();
+    stopSecond();
+  });
+
+  it('costs nothing when nobody is watching', () => {
+    expect(() => reportListenerDelivery('sub-1')).not.toThrow();
+  });
+});

--- a/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
@@ -1,0 +1,265 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import { startFlowMode } from '../../../src/serve/runtime/listener-flow-mode.js';
+import type { ReactCommitSource } from '../../../src/serve/runtime/react-commit-source.js';
+import type { ListenerOutline } from '../../../src/serve/runtime/listener-outline-model.js';
+
+function outline(listenerId: string, label: string, target: string): ListenerOutline {
+  return {
+    listenerId,
+    label,
+    labelIsOwner: true,
+    target,
+    isQuery: true,
+    service: 'firestore',
+    deliveryCount: 2,
+    selectors: ['#page'],
+    incident: null,
+  };
+}
+
+/**
+ * A page with a ChatPage above a MessageThread, wired the way React wires its
+ * host nodes, so the flow mode's own walk has something to read.
+ */
+function buildPage() {
+  const dom = new JSDOM(`<!doctype html><body>
+    <div id="page"><div id="thread"><span id="bubble">hi</span></div></div>
+  </body>`);
+  const doc = dom.window.document;
+  const pageEl = doc.querySelector('#page')!;
+  const threadEl = doc.querySelector('#thread')!;
+  const bubbleEl = doc.querySelector('#bubble')!;
+
+  const chatPage = { tag: 0, type: { displayName: 'ChatPage' }, return: null as unknown, child: null as unknown };
+  const pageHost = { tag: 5, type: 'div', stateNode: pageEl, return: chatPage, child: null as unknown };
+  const thread = { tag: 0, type: { displayName: 'MessageThread' }, return: pageHost, child: null as unknown };
+  const threadHost = { tag: 5, type: 'div', stateNode: threadEl, return: thread, child: null };
+  const bubbleHost = { tag: 5, type: 'span', stateNode: bubbleEl, return: threadHost, child: null };
+  chatPage.child = pageHost;
+  pageHost.child = thread;
+  thread.child = threadHost;
+  (threadHost as { child: unknown }).child = bubbleHost;
+  (pageEl as unknown as Record<string, unknown>)['__reactFiber$k'] = pageHost;
+  (threadEl as unknown as Record<string, unknown>)['__reactFiber$k'] = threadHost;
+  (bubbleEl as unknown as Record<string, unknown>)['__reactFiber$k'] = bubbleHost;
+
+  return { doc, pageEl, threadEl, bubbleEl };
+}
+
+function setup(options: { visible?: (listenerId: string) => boolean } = {}) {
+  const page = buildPage();
+  const container = page.doc.createElement('div');
+  page.doc.body.append(container);
+
+  let commit: (() => void) | null = null;
+  const commits: ReactCommitSource = {
+    available: () => true,
+    reason: () => null,
+    subscribe: (listener) => {
+      commit = listener;
+      return () => {
+        commit = null;
+      };
+    },
+    dispose: () => {},
+  };
+
+  let deliver: ((listenerId: string) => void) | null = null;
+  let changed: unknown[] = [];
+  const outlines = new Map([
+    ['sub-1', outline('sub-1', 'ChatPage', 'conversations/c1/messages')],
+  ]);
+
+  const mode = startFlowMode({
+    document: page.doc,
+    container,
+    commits,
+    outlineFor: (listenerId) => outlines.get(listenerId) ?? null,
+    isVisible: options.visible ?? (() => true),
+    subscribeDeliveries: (listener) => {
+      deliver = listener;
+      return () => {
+        deliver = null;
+      };
+    },
+    changedNodes: () => ({
+      drain: () => {
+        const drained = changed;
+        changed = [];
+        return drained;
+      },
+      stop: () => {},
+    }),
+  });
+
+  return {
+    ...page,
+    container,
+    mode,
+    outlines,
+    deliver: (listenerId: string) => deliver?.(listenerId),
+    change: (nodes: unknown[]) => {
+      changed = nodes;
+    },
+    commit: () => commit?.(),
+  };
+}
+
+describe('the Flow painting mode', () => {
+  it('paints the components that rendered after a delivery', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
+    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
+      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+    page.mode.dispose();
+  });
+
+  it('drains the observer before it closes the window, so a commit sees its own changes', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    // The nodes are queued the way a MutationObserver queues them: available
+    // to a drain, never pushed at the mode.
+    page.change([page.bubbleEl]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]').length).toBeGreaterThan(0);
+    page.mode.dispose();
+  });
+
+  it('paints nothing for a commit no delivery preceded', () => {
+    const page = setup();
+    page.change([page.bubbleEl]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('paints nothing for a listener that is switched off', () => {
+    const page = setup({ visible: () => false });
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('paints nothing for a listener the fold does not know', () => {
+    const page = setup();
+    page.deliver('sub-unknown');
+    page.change([page.bubbleEl]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('paints nothing when the changed nodes belong to no React component', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.doc.createElement('div')]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('takes one listener boxes away on request and everything on dispose', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+    page.mode.clearListener('sub-1');
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+    page.mode.dispose();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+
+  it('reads the page own changes through a MutationObserver by default', () => {
+    const page = buildPage();
+    const container = page.doc.createElement('div');
+    page.doc.body.append(container);
+    let commit: (() => void) | null = null;
+    let deliver: ((listenerId: string) => void) | null = null;
+    const mode = startFlowMode({
+      document: page.doc,
+      container,
+      commits: {
+        available: () => true,
+        reason: () => null,
+        subscribe: (listener) => {
+          commit = listener;
+          return () => {};
+        },
+        dispose: () => {},
+      },
+      outlineFor: () => outline('sub-1', 'ChatPage', 'conversations/c1/messages'),
+      isVisible: () => true,
+      subscribeDeliveries: (listener) => {
+        deliver = listener;
+        return () => {};
+      },
+    });
+
+    deliver!('sub-1');
+    page.bubbleEl.textContent = 'two';
+    commit!();
+
+    const boxes = [...container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
+    mode.dispose();
+  });
+
+  it('ignores the chip own chrome', () => {
+    const page = buildPage();
+    const container = page.doc.createElement('div');
+    page.doc.body.append(container);
+    let commit: (() => void) | null = null;
+    let deliver: ((listenerId: string) => void) | null = null;
+    const mode = startFlowMode({
+      document: page.doc,
+      container,
+      commits: {
+        available: () => true,
+        reason: () => null,
+        subscribe: (listener) => {
+          commit = listener;
+          return () => {};
+        },
+        dispose: () => {},
+      },
+      outlineFor: () => outline('sub-1', 'ChatPage', 'conversations/c1/messages'),
+      isVisible: () => true,
+      subscribeDeliveries: (listener) => {
+        deliver = listener;
+        return () => {};
+      },
+    });
+
+    deliver!('sub-1');
+    const chipHost = page.doc.createElement('div');
+    chipHost.setAttribute('data-pyric-runtime-chip-host', '');
+    page.doc.body.append(chipHost);
+    chipHost.textContent = 'chip';
+    container.append(page.doc.createElement('span'));
+    commit!();
+
+    expect(container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    mode.dispose();
+  });
+
+  it('stops listening for deliveries and commits once disposed', () => {
+    const page = setup();
+    page.mode.dispose();
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+});

--- a/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'bun:test';
-import { startFlowMode } from '../../../src/serve/runtime/listener-flow-mode.js';
+import { startFlowMode, type RecentDelivery } from '../../../src/serve/runtime/listener-flow-mode.js';
 import type { ReactCommitSource } from '../../../src/serve/runtime/react-commit-source.js';
 import type { ListenerOutline } from '../../../src/serve/runtime/listener-outline-model.js';
 
@@ -24,12 +24,17 @@ function outline(listenerId: string, label: string, target: string): ListenerOut
  */
 function buildPage() {
   const dom = new JSDOM(`<!doctype html><body>
-    <div id="page"><div id="thread"><span id="bubble">hi</span></div></div>
+    <div id="page">
+      <div id="thread"><span id="bubble">hi</span></div>
+      <div id="presence"><span id="dot">1</span></div>
+    </div>
   </body>`);
   const doc = dom.window.document;
   const pageEl = doc.querySelector('#page')!;
   const threadEl = doc.querySelector('#thread')!;
   const bubbleEl = doc.querySelector('#bubble')!;
+  const presenceEl = doc.querySelector('#presence')!;
+  const dotEl = doc.querySelector('#dot')!;
 
   const chatPage = { tag: 0, type: { displayName: 'ChatPage' }, return: null as unknown, child: null as unknown };
   const pageHost = { tag: 5, type: 'div', stateNode: pageEl, return: chatPage, child: null as unknown };
@@ -40,14 +45,31 @@ function buildPage() {
   pageHost.child = thread;
   thread.child = threadHost;
   (threadHost as { child: unknown }).child = bubbleHost;
+  // The presence bar is inline JSX: its host fibers hang off the page's own
+  // host node with no component of their own in between.
+  const presenceHost = { tag: 5, type: 'div', stateNode: presenceEl, return: pageHost, child: null as unknown };
+  const dotHost = { tag: 5, type: 'span', stateNode: dotEl, return: presenceHost, child: null };
+  presenceHost.child = dotHost;
+  (thread as { sibling?: unknown }).sibling = presenceHost;
+
   (pageEl as unknown as Record<string, unknown>)['__reactFiber$k'] = pageHost;
   (threadEl as unknown as Record<string, unknown>)['__reactFiber$k'] = threadHost;
   (bubbleEl as unknown as Record<string, unknown>)['__reactFiber$k'] = bubbleHost;
+  (presenceEl as unknown as Record<string, unknown>)['__reactFiber$k'] = presenceHost;
+  (dotEl as unknown as Record<string, unknown>)['__reactFiber$k'] = dotHost;
 
-  return { doc, pageEl, threadEl, bubbleEl };
+  return { doc, pageEl, threadEl, bubbleEl, presenceEl, dotEl };
 }
 
-function setup(options: { visible?: (listenerId: string) => boolean } = {}) {
+interface SetupOptions {
+  visible?: (listenerId: string) => boolean;
+  recentDeliveries?: () => readonly RecentDelivery[];
+  replayWindowMs?: number;
+  now?: () => number;
+  onPaint?: (listenerId: string) => void;
+}
+
+function setup(options: SetupOptions = {}) {
   const page = buildPage();
   const container = page.doc.createElement('div');
   page.doc.body.append(container);
@@ -91,6 +113,10 @@ function setup(options: { visible?: (listenerId: string) => boolean } = {}) {
       },
       stop: () => {},
     }),
+    ...(options.recentDeliveries === undefined ? {} : { recentDeliveries: options.recentDeliveries }),
+    ...(options.replayWindowMs === undefined ? {} : { replayWindowMs: options.replayWindowMs }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+    ...(options.onPaint === undefined ? {} : { onPaint: options.onPaint }),
   });
 
   return {
@@ -118,6 +144,82 @@ describe('the Flow painting mode', () => {
     expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
       .toBe('ChatPage · conversations/c1/messages (query) · 2');
     page.mode.dispose();
+  });
+
+  it('roots the paint on the region the owner registered, and never on the owner itself', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.bubbleEl]);
+    page.commit();
+
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    const root = boxes.find((box) => box.dataset.flowKind === 'region');
+    expect(root?.dataset.component).toBe('ChatPage');
+    expect(root?.dataset.depth).toBe('0');
+    // The owner is named on the root badge rather than given a box of its own,
+    // so the page component's host node is never outlined twice.
+    expect(boxes.filter((box) => box.dataset.component === 'ChatPage')).toHaveLength(1);
+    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
+      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+  });
+
+  it('badges a changed element by itself when no component sits between it and the root', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.presenceEl]);
+    page.commit();
+
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    const host = boxes.find((box) => box.dataset.flowKind === 'host');
+    expect(host?.dataset.component).toBe('div#presence');
+    expect(page.container.querySelector('[data-pyric-flow-leaf-badge]')?.textContent).toBe('div#presence');
+  });
+
+  it('collapses a changed subtree to the element at its top', () => {
+    const page = setup();
+    page.deliver('sub-1');
+    page.change([page.presenceEl, page.dotEl]);
+    page.commit();
+
+    const hosts = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box][data-flow-kind="host"]')];
+    expect(hosts.map((box) => box.dataset.component)).toEqual(['div#presence']);
+  });
+
+  it('replays the last delivery on the switch when it is inside the window', () => {
+    const page = setup({
+      now: () => 10_000,
+      replayWindowMs: 5000,
+      recentDeliveries: () => [{ listenerId: 'sub-1', at: 8000 }],
+    });
+
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0]?.dataset.flowKind).toBe('region');
+    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
+      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+  });
+
+  it('replays nothing for a delivery older than the window', () => {
+    const page = setup({
+      now: () => 10_000,
+      replayWindowMs: 5000,
+      recentDeliveries: () => [{ listenerId: 'sub-1', at: 1000 }],
+    });
+
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+
+  it('reports the outline own listener id when it paints, whatever id the delivery carried', () => {
+    const painted: string[] = [];
+    const page = setup({ onPaint: (listenerId) => painted.push(listenerId) });
+    page.outlines.set('client-9', { ...page.outlines.get('sub-1')!, clientListenerId: 'client-9' });
+    page.deliver('client-9');
+    page.change([page.bubbleEl]);
+    page.commit();
+
+    expect(painted).toEqual(['sub-1']);
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(boxes.every((box) => box.dataset.listenerId === 'sub-1')).toBe(true);
   });
 
   it('drains the observer before it closes the window, so a commit sees its own changes', () => {

--- a/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-mode.test.ts
@@ -61,6 +61,16 @@ function buildPage() {
   return { doc, pageEl, threadEl, bubbleEl, presenceEl, dotEl };
 }
 
+/** Every element Flow has marked, in document order. */
+function marked(doc: Document): HTMLElement[] {
+  return [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow]')];
+}
+
+/** What each marked element says it is. */
+function labels(doc: Document): (string | null)[] {
+  return marked(doc).map((element) => element.getAttribute('data-pyric-flow-label'));
+}
+
 interface SetupOptions {
   visible?: (listenerId: string) => boolean;
   recentDeliveries?: () => readonly RecentDelivery[];
@@ -139,40 +149,33 @@ describe('the Flow painting mode', () => {
     page.change([page.bubbleEl]);
     page.commit();
 
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
-    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
-      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+    expect(marked(page.doc)).toEqual([page.threadEl as HTMLElement]);
+    expect(labels(page.doc)).toEqual(['ChatPage · conversations/c1/messages (query) · 2']);
     page.mode.dispose();
   });
 
-  it('roots the paint on the region the owner registered, and never on the owner itself', () => {
+  it('never marks the registered region or the owner that registered it', () => {
     const page = setup();
     page.deliver('sub-1');
     page.change([page.bubbleEl]);
     page.commit();
 
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    const root = boxes.find((box) => box.dataset.flowKind === 'region');
-    expect(root?.dataset.component).toBe('ChatPage');
-    expect(root?.dataset.depth).toBe('0');
-    // The owner is named on the root badge rather than given a box of its own,
-    // so the page component's host node is never outlined twice.
-    expect(boxes.filter((box) => box.dataset.component === 'ChatPage')).toHaveLength(1);
-    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
-      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+    // The owner is named in the label rather than outlined, and the region it
+    // registered is the whole area the listener feeds rather than something
+    // that changed, so neither carries a mark.
+    expect(page.pageEl.hasAttribute('data-pyric-flow')).toBe(false);
+    expect(page.threadEl.getAttribute('data-pyric-flow-role')).toBe('component');
+    expect(page.container.children).toHaveLength(1);
   });
 
-  it('badges a changed element by itself when no component sits between it and the root', () => {
+  it('marks a changed element by itself when no component sits between it and the root', () => {
     const page = setup();
     page.deliver('sub-1');
     page.change([page.presenceEl]);
     page.commit();
 
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    const host = boxes.find((box) => box.dataset.flowKind === 'host');
-    expect(host?.dataset.component).toBe('div#presence');
-    expect(page.container.querySelector('[data-pyric-flow-leaf-badge]')?.textContent).toBe('div#presence');
+    expect(page.presenceEl.getAttribute('data-pyric-flow-role')).toBe('host');
+    expect(labels(page.doc)).toEqual(['ChatPage · conversations/c1/messages (query) · 2']);
   });
 
   it('collapses a changed subtree to the element at its top', () => {
@@ -181,8 +184,7 @@ describe('the Flow painting mode', () => {
     page.change([page.presenceEl, page.dotEl]);
     page.commit();
 
-    const hosts = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box][data-flow-kind="host"]')];
-    expect(hosts.map((box) => box.dataset.component)).toEqual(['div#presence']);
+    expect(marked(page.doc)).toEqual([page.presenceEl as HTMLElement]);
   });
 
   it('replays the last delivery on the switch when it is inside the window', () => {
@@ -192,11 +194,10 @@ describe('the Flow painting mode', () => {
       recentDeliveries: () => [{ listenerId: 'sub-1', at: 8000 }],
     });
 
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(boxes).toHaveLength(1);
-    expect(boxes[0]?.dataset.flowKind).toBe('region');
-    expect(page.container.querySelector('[data-pyric-flow-badge]')?.textContent)
-      .toBe('ChatPage · conversations/c1/messages (query) · 2');
+    // A replay has no changed nodes to read, so the registered element is the
+    // one claim the fold supports, and it carries the full label.
+    expect(marked(page.doc)).toEqual([page.pageEl as HTMLElement]);
+    expect(labels(page.doc)).toEqual(['ChatPage · conversations/c1/messages (query) · 2']);
   });
 
   it('replays nothing for a delivery older than the window', () => {
@@ -206,7 +207,7 @@ describe('the Flow painting mode', () => {
       recentDeliveries: () => [{ listenerId: 'sub-1', at: 1000 }],
     });
 
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
   });
 
   it('reports the outline own listener id when it paints, whatever id the delivery carried', () => {
@@ -218,8 +219,9 @@ describe('the Flow painting mode', () => {
     page.commit();
 
     expect(painted).toEqual(['sub-1']);
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(boxes.every((box) => box.dataset.listenerId === 'sub-1')).toBe(true);
+    expect(marked(page.doc).every((element) => (
+      element.getAttribute('data-pyric-flow-listener') === 'sub-1'
+    ))).toBe(true);
   });
 
   it('drains the observer before it closes the window, so a commit sees its own changes', () => {
@@ -229,7 +231,7 @@ describe('the Flow painting mode', () => {
     // to a drain, never pushed at the mode.
     page.change([page.bubbleEl]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]').length).toBeGreaterThan(0);
+    expect(marked(page.doc).length).toBeGreaterThan(0);
     page.mode.dispose();
   });
 
@@ -237,7 +239,7 @@ describe('the Flow painting mode', () => {
     const page = setup();
     page.change([page.bubbleEl]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 
@@ -246,7 +248,7 @@ describe('the Flow painting mode', () => {
     page.deliver('sub-1');
     page.change([page.bubbleEl]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 
@@ -255,7 +257,7 @@ describe('the Flow painting mode', () => {
     page.deliver('sub-unknown');
     page.change([page.bubbleEl]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 
@@ -264,23 +266,25 @@ describe('the Flow painting mode', () => {
     page.deliver('sub-1');
     page.change([page.doc.createElement('div')]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 
-  it('takes one listener boxes away on request and everything on dispose', () => {
+  it('takes one listener marks away on request and everything on dispose', () => {
     const page = setup();
     page.deliver('sub-1');
     page.change([page.bubbleEl]);
     page.commit();
     page.mode.clearListener('sub-1');
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
+    expect(page.doc.querySelectorAll('[data-pyric-flow-label]')).toHaveLength(0);
 
     page.deliver('sub-1');
     page.change([page.bubbleEl]);
     page.commit();
     page.mode.dispose();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
+    expect(page.doc.querySelectorAll('[data-pyric-flow-label]')).toHaveLength(0);
   });
 
   it('reads the page own changes through a MutationObserver by default', () => {
@@ -313,8 +317,7 @@ describe('the Flow painting mode', () => {
     page.bubbleEl.textContent = 'two';
     commit!();
 
-    const boxes = [...container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
+    expect(marked(page.doc)).toEqual([page.threadEl as HTMLElement]);
     mode.dispose();
   });
 
@@ -352,7 +355,7 @@ describe('the Flow painting mode', () => {
     container.append(page.doc.createElement('span'));
     commit!();
 
-    expect(container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
     mode.dispose();
   });
 
@@ -362,6 +365,6 @@ describe('the Flow painting mode', () => {
     page.deliver('sub-1');
     page.change([page.bubbleEl]);
     page.commit();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(marked(page.doc)).toHaveLength(0);
   });
 });

--- a/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
@@ -2,11 +2,16 @@ import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'bun:test';
 import { createFlowPainter, flowBadgeText } from '../../../src/serve/runtime/listener-flow-painter.js';
 import { listenerHueIndex } from '../../../src/serve/runtime/listener-palette.js';
-import type { FlowSubtree } from '../../../src/serve/runtime/fiber-flow.js';
+import { FLOW_STYLE_ATTRIBUTE } from '../../../src/serve/runtime/overlay-theme.js';
+import type { FlowComponent, FlowSubtree } from '../../../src/serve/runtime/fiber-flow.js';
 
 function setup() {
   const dom = new JSDOM(`<!doctype html><body>
-    <div id="page"><div id="thread"><span id="bubble">hi</span></div></div>
+    <div id="page">
+      <div id="thread"><span id="bubble">hi</span></div>
+      <div id="presence">1</div>
+      <img id="avatar" />
+    </div>
   </body>`);
   const doc = dom.window.document;
   const container = doc.createElement('div');
@@ -33,82 +38,73 @@ function setup() {
       timer.run();
     }
   };
-  return { doc, container, painter, advance, timers };
+  const el = (selector: string): HTMLElement => doc.querySelector<HTMLElement>(selector)!;
+  const marked = (): HTMLElement[] => [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow]')];
+  return { doc, container, painter, advance, timers, el, marked };
 }
 
-function subtree(doc: Document): FlowSubtree {
-  const page = doc.querySelector('#page')!;
-  const thread = doc.querySelector('#thread')!;
-  return {
-    root: { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
-    components: [
-      { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
-      { name: 'MessageThread', element: thread, depth: 1, kind: 'component' },
-    ],
-    leaves: [{ name: 'MessageThread', element: thread, depth: 1, kind: 'component' }],
-  };
+function component(element: Element, name: string, depth = 0): FlowComponent {
+  return { name, element, depth, kind: 'component' };
 }
 
-/** A delivery whose leaf is the changed element itself, named by the element. */
-function hostLeafSubtree(doc: Document): FlowSubtree {
-  const page = doc.querySelector('#page')!;
-  const bubble = doc.querySelector('#bubble')!;
-  return {
-    root: { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
-    components: [
-      { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
-      { name: 'span#bubble', element: bubble, depth: 1, kind: 'host' },
-    ],
-    leaves: [{ name: 'span#bubble', element: bubble, depth: 1, kind: 'host' }],
-  };
+function subtreeOf(components: FlowComponent[]): FlowSubtree {
+  return { root: components[0] ?? null, components, leaves: components.slice(1) };
 }
 
-const paintOf = (doc: Document) => ({
+const paintOf = (page: ReturnType<typeof setup>, over?: Partial<{ listenerId: string; subtree: FlowSubtree }>) => ({
   listenerId: 'sub-1',
   label: 'ChatPage',
   target: 'conversations/c1/messages (query)',
   deliveryCount: 3,
-  subtree: subtree(doc),
+  subtree: subtreeOf([
+    component(page.el('#thread'), 'MessageThread'),
+    component(page.el('#bubble'), 'MessageBubble', 1),
+  ]),
+  ...over,
 });
 
-describe('painting one delivery', () => {
-  it('draws a box for every component in the listener colour', () => {
+describe('marking one delivery', () => {
+  it('marks the elements themselves in the listener colour', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
+    page.painter.paint(paintOf(page));
 
-    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(boxes).toHaveLength(2);
-    for (const box of boxes) expect(box.dataset.listenerId).toBe('sub-1');
-    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
-    // The colour is the stylesheet's, off the hue the box names: one hue
-    // across the subtree, and a different one for another listener.
-    expect(boxes[0].dataset.hue).toBe(String(listenerHueIndex('sub-1')));
-    expect(boxes[0].dataset.hue).toBe(boxes[1].dataset.hue);
-    expect(boxes.map((box) => box.dataset.pyricRole)).toEqual(['region', 'component']);
-    // Nothing visual is inline: only the measured geometry is.
-    for (const box of boxes) {
-      expect([...box.style]).toEqual(['left', 'top', 'width', 'height']);
+    expect(page.marked()).toEqual([page.el('#thread'), page.el('#bubble')]);
+    for (const element of page.marked()) {
+      expect(element.getAttribute('data-pyric-flow-listener')).toBe('sub-1');
+      expect(element.getAttribute('data-pyric-flow-role')).toBe('component');
+      expect(element.getAttribute('data-pyric-flow')).toBe(String(listenerHueIndex('sub-1')));
     }
+    // Nothing is measured into the overlay: the container holds its stylesheet
+    // and nothing else.
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
 
-    page.painter.paint({ ...paintOf(page.doc), listenerId: 'sub-2' });
-    const other = page.container.querySelector<HTMLElement>('[data-pyric-flow-box][data-listener-id="sub-2"]');
+    page.painter.paint(paintOf(page, {
+      listenerId: 'sub-2',
+      subtree: subtreeOf([component(page.el('#presence'), 'PresenceBar')]),
+    }));
     expect(listenerHueIndex('sub-2')).not.toBe(listenerHueIndex('sub-1'));
-    expect(other?.dataset.hue).not.toBe(boxes[0].dataset.hue);
+    expect(page.el('#presence').getAttribute('data-pyric-flow'))
+      .toBe(String(listenerHueIndex('sub-2')));
   });
 
-  it('names the owner and target on the root badge and the component on the leaf', () => {
+  it('marks a changed element no component named as a host', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
-
-    const badge = page.container.querySelector('[data-pyric-flow-badge]');
-    expect(badge?.textContent).toBe('ChatPage · conversations/c1/messages (query) · 3');
-    expect(badge?.getAttribute('title')).toContain('rendered after a delivery');
-
-    const leaf = page.container.querySelector('[data-pyric-flow-leaf-badge]');
-    expect(leaf?.textContent).toBe('MessageThread');
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([{ name: 'div#presence', element: page.el('#presence'), depth: 0, kind: 'host' }]),
+    }));
+    expect(page.el('#presence').getAttribute('data-pyric-flow-role')).toBe('host');
   });
 
-  it('spells the root badge the way the Overview badge does', () => {
+  it('names the listener on the first element and the rest by themselves', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page));
+
+    expect(page.el('#thread').getAttribute('data-pyric-flow-label'))
+      .toBe('ChatPage · conversations/c1/messages (query) · 3');
+    expect(page.el('#bubble').getAttribute('data-pyric-flow-label')).toBe('MessageBubble');
+  });
+
+  it('spells the first label the way the Overview badge does', () => {
     expect(flowBadgeText({
       listenerId: 'sub-1',
       label: 'PresenceBar',
@@ -118,83 +114,161 @@ describe('painting one delivery', () => {
     })).toBe('PresenceBar · status/u1 · 1');
   });
 
-  it('holds the boxes dimmed once the fade is over, rather than taking them away', () => {
+  it('falls back to a measured badge for an element that carries no pseudo one', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(2);
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#avatar'), 'img#avatar')]),
+    }));
 
-    page.advance(3000);
-    const held = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(held).toHaveLength(2);
-    expect(held.every((box) => box.dataset.flowRetained === '')).toBe(true);
-    // The dimming is the stylesheet's, off the retained attribute.
-    expect(held.every((box) => box.style.opacity === '')).toBe(true);
+    // The outline is still on the element itself; only the words are measured.
+    expect(page.el('#avatar').getAttribute('data-pyric-flow')).toBe(String(listenerHueIndex('sub-1')));
+    expect(page.el('#avatar').hasAttribute('data-pyric-flow-label')).toBe(false);
+    const badge = page.container.querySelector<HTMLElement>('[data-pyric-flow-badge]');
+    expect(badge?.textContent).toBe('ChatPage · conversations/c1/messages (query) · 3');
+    expect(badge?.dataset.listenerId).toBe('sub-1');
+    expect(badge?.dataset.hue).toBe(String(listenerHueIndex('sub-1')));
+
+    page.painter.clearListener('sub-1');
+    expect(page.container.querySelectorAll('[data-pyric-flow-badge]')).toHaveLength(0);
   });
 
-  it('replaces a retained subtree on the next delivery for that listener', () => {
+  it('puts the stylesheet in the document head, once', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
-    page.advance(3000);
-
-    page.painter.paint(paintOf(page.doc));
-    const drawn = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    expect(drawn).toHaveLength(2);
-    expect(drawn.some((box) => box.dataset.flowRetained === '')).toBe(false);
+    expect(page.doc.head.querySelectorAll(`[${FLOW_STYLE_ATTRIBUTE}]`)).toHaveLength(1);
+    createFlowPainter({ document: page.doc, container: page.container });
+    expect(page.doc.querySelectorAll(`[${FLOW_STYLE_ATTRIBUTE}]`)).toHaveLength(1);
   });
 
-  it('takes a retained subtree away when its listener is switched off', () => {
+  it('holds the marks dimmed once the fade is over, rather than taking them away', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
+    page.painter.paint(paintOf(page));
+    page.advance(3000);
+
+    expect(page.marked()).toHaveLength(2);
+    expect(page.marked().every((element) => element.hasAttribute('data-pyric-flow-retained')))
+      .toBe(true);
+  });
+
+  it('takes a retained mark away when its listener is switched off', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page));
     page.advance(3000);
 
     page.painter.clearListener('sub-1');
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
-  });
-
-  it('badges a changed element by its tag and id when no component named it', () => {
-    const page = setup();
-    page.painter.paint({ ...paintOf(page.doc), subtree: hostLeafSubtree(page.doc) });
-    const leaf = page.container.querySelector<HTMLElement>('[data-pyric-flow-leaf-badge]');
-    expect(leaf?.textContent).toBe('span#bubble');
-    expect(leaf?.dataset.flowKind).toBe('host');
-    const kinds = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')]
-      .map((box) => box.dataset.flowKind);
-    expect(kinds).toEqual(['region', 'host']);
-  });
-
-  it('replaces the same listener rather than stacking on it', () => {
-    const page = setup();
-    page.painter.paint(paintOf(page.doc));
-    page.painter.paint(paintOf(page.doc));
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(2);
-  });
-
-  it('keeps two listeners apart by colour and clears one at a time', () => {
-    const page = setup();
-    page.painter.paint(paintOf(page.doc));
-    page.painter.paint({ ...paintOf(page.doc), listenerId: 'sub-2', label: 'PresenceBar' });
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(4);
-
-    page.painter.clearListener('sub-1');
-    const left = page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]');
-    expect(left).toHaveLength(2);
-    expect([...left].every((box) => box.dataset.listenerId === 'sub-2')).toBe(true);
+    expect(page.marked()).toHaveLength(0);
   });
 
   it('draws nothing for a delivery that rendered nothing', () => {
     const page = setup();
-    page.painter.paint({
-      ...paintOf(page.doc),
-      subtree: { root: null, components: [], leaves: [] },
-    });
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    page.painter.paint(paintOf(page, { subtree: { root: null, components: [], leaves: [] } }));
+    expect(page.marked()).toHaveLength(0);
   });
 
-  it('clears everything and cancels its timers on dispose', () => {
+  it('keeps two listeners apart and clears one at a time', () => {
     const page = setup();
-    page.painter.paint(paintOf(page.doc));
+    page.painter.paint(paintOf(page));
+    page.painter.paint(paintOf(page, {
+      listenerId: 'sub-2',
+      subtree: subtreeOf([component(page.el('#presence'), 'PresenceBar')]),
+    }));
+    expect(page.marked()).toHaveLength(3);
+
+    page.painter.clearListener('sub-1');
+    expect(page.marked()).toEqual([page.el('#presence')]);
+  });
+});
+
+describe('a burst of deliveries', () => {
+  it('adds to what is on the page rather than replacing it', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#thread'), 'MessageThread')]),
+    }));
+    page.advance(500);
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#presence'), 'PresenceBar')]),
+    }));
+    page.advance(500);
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#bubble'), 'MessageBubble')]),
+    }));
+
+    expect(page.marked()).toEqual([page.el('#thread'), page.el('#bubble'), page.el('#presence')]);
+  });
+
+  it('fades every mark on its own clock and keeps only the last delivery', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#thread'), 'MessageThread')]),
+    }));
+    page.advance(1000);
+    page.painter.paint(paintOf(page, {
+      subtree: subtreeOf([component(page.el('#presence'), 'PresenceBar')]),
+    }));
+
+    // The first mark is three seconds old before the second one is.
+    page.advance(2000);
+    expect(page.marked()).toEqual([page.el('#presence')]);
+    expect(page.el('#presence').hasAttribute('data-pyric-flow-retained')).toBe(false);
+
+    page.advance(1000);
+    // The newest delivery is what stays, dimmed.
+    expect(page.marked()).toEqual([page.el('#presence')]);
+    expect(page.el('#presence').hasAttribute('data-pyric-flow-retained')).toBe(true);
+  });
+
+  it('restarts the fade of an element that is marked again', () => {
+    const page = setup();
+    const one = paintOf(page, { subtree: subtreeOf([component(page.el('#thread'), 'MessageThread')]) });
+    page.painter.paint(one);
+    page.advance(2500);
+    page.painter.paint(one);
+
+    page.advance(1000);
+    // The first clock would have ended by now; the restart is what keeps the
+    // mark at full strength.
+    expect(page.el('#thread').hasAttribute('data-pyric-flow-retained')).toBe(false);
+    page.advance(2000);
+    expect(page.el('#thread').hasAttribute('data-pyric-flow-retained')).toBe(true);
+  });
+
+  it('takes a whole burst away when its listener is switched off', () => {
+    const page = setup();
+    for (const selector of ['#thread', '#presence', '#bubble']) {
+      page.painter.paint(paintOf(page, {
+        subtree: subtreeOf([component(page.el(selector), selector)]),
+      }));
+      page.advance(100);
+    }
+    expect(page.marked()).toHaveLength(3);
+
+    page.painter.clearListener('sub-1');
+    expect(page.marked()).toHaveLength(0);
+  });
+});
+
+describe('taking the marks off', () => {
+  it('leaves no flow attributes behind on clear', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page));
+    page.painter.paint(paintOf(page, {
+      listenerId: 'sub-2',
+      subtree: subtreeOf([component(page.el('#avatar'), 'img#avatar')]),
+    }));
+    page.painter.clear();
+
+    expect(page.doc.querySelectorAll('[data-pyric-flow], [data-pyric-flow-listener], [data-pyric-flow-role], [data-pyric-flow-label], [data-pyric-flow-fading], [data-pyric-flow-retained]'))
+      .toHaveLength(0);
+    expect(page.container.querySelectorAll('[data-pyric-flow-badge]')).toHaveLength(0);
+  });
+
+  it('leaves no flow attributes behind and cancels its timers on dispose', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page));
     page.painter.dispose();
-    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+
+    expect(page.doc.querySelectorAll('[data-pyric-flow], [data-pyric-flow-label], [data-pyric-flow-listener], [data-pyric-flow-role]'))
+      .toHaveLength(0);
     expect(page.timers.filter((timer) => timer.at > 0)).toHaveLength(0);
   });
 });

--- a/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
@@ -40,12 +40,26 @@ function subtree(doc: Document): FlowSubtree {
   const page = doc.querySelector('#page')!;
   const thread = doc.querySelector('#thread')!;
   return {
-    root: { name: 'ChatPage', element: page, depth: 0 },
+    root: { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
     components: [
-      { name: 'ChatPage', element: page, depth: 0 },
-      { name: 'MessageThread', element: thread, depth: 1 },
+      { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
+      { name: 'MessageThread', element: thread, depth: 1, kind: 'component' },
     ],
-    leaves: [{ name: 'MessageThread', element: thread, depth: 1 }],
+    leaves: [{ name: 'MessageThread', element: thread, depth: 1, kind: 'component' }],
+  };
+}
+
+/** A delivery whose leaf is the changed element itself, named by the element. */
+function hostLeafSubtree(doc: Document): FlowSubtree {
+  const page = doc.querySelector('#page')!;
+  const bubble = doc.querySelector('#bubble')!;
+  return {
+    root: { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
+    components: [
+      { name: 'ChatPage', element: page, depth: 0, kind: 'region' },
+      { name: 'span#bubble', element: bubble, depth: 1, kind: 'host' },
+    ],
+    leaves: [{ name: 'span#bubble', element: bubble, depth: 1, kind: 'host' }],
   };
 }
 
@@ -99,13 +113,47 @@ describe('painting one delivery', () => {
     })).toBe('PresenceBar · status/u1 · 1');
   });
 
-  it('takes the boxes away once the fade is over', () => {
+  it('holds the boxes dimmed once the fade is over, rather than taking them away', () => {
     const page = setup();
     page.painter.paint(paintOf(page.doc));
     expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(2);
 
     page.advance(3000);
+    const held = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(held).toHaveLength(2);
+    expect(held.every((box) => box.dataset.flowRetained === '')).toBe(true);
+    expect(held.every((box) => Number(box.style.opacity) > 0 && Number(box.style.opacity) < 1)).toBe(true);
+  });
+
+  it('replaces a retained subtree on the next delivery for that listener', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    page.advance(3000);
+
+    page.painter.paint(paintOf(page.doc));
+    const drawn = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(drawn).toHaveLength(2);
+    expect(drawn.some((box) => box.dataset.flowRetained === '')).toBe(false);
+  });
+
+  it('takes a retained subtree away when its listener is switched off', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    page.advance(3000);
+
+    page.painter.clearListener('sub-1');
     expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+
+  it('badges a changed element by its tag and id when no component named it', () => {
+    const page = setup();
+    page.painter.paint({ ...paintOf(page.doc), subtree: hostLeafSubtree(page.doc) });
+    const leaf = page.container.querySelector<HTMLElement>('[data-pyric-flow-leaf-badge]');
+    expect(leaf?.textContent).toBe('span#bubble');
+    expect(leaf?.dataset.flowKind).toBe('host');
+    const kinds = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')]
+      .map((box) => box.dataset.flowKind);
+    expect(kinds).toEqual(['region', 'host']);
   });
 
   it('replaces the same listener rather than stacking on it', () => {

--- a/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
@@ -1,0 +1,146 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import { createFlowPainter, flowBadgeText } from '../../../src/serve/runtime/listener-flow-painter.js';
+import { listenerColors } from '../../../src/serve/runtime/listener-palette.js';
+import type { FlowSubtree } from '../../../src/serve/runtime/fiber-flow.js';
+
+function setup() {
+  const dom = new JSDOM(`<!doctype html><body>
+    <div id="page"><div id="thread"><span id="bubble">hi</span></div></div>
+  </body>`);
+  const doc = dom.window.document;
+  const container = doc.createElement('div');
+  doc.body.append(container);
+  const timers: Array<{ at: number; run: () => void }> = [];
+  let now = 0;
+  const painter = createFlowPainter({
+    document: doc,
+    container,
+    fadeMs: 3000,
+    schedule: (run, delayMs) => {
+      const timer = { at: now + delayMs, run };
+      timers.push(timer);
+      return () => {
+        const index = timers.indexOf(timer);
+        if (index >= 0) timers.splice(index, 1);
+      };
+    },
+  });
+  const advance = (ms: number): void => {
+    now += ms;
+    for (const timer of timers.filter((entry) => entry.at <= now)) {
+      timers.splice(timers.indexOf(timer), 1);
+      timer.run();
+    }
+  };
+  return { doc, container, painter, advance, timers };
+}
+
+function subtree(doc: Document): FlowSubtree {
+  const page = doc.querySelector('#page')!;
+  const thread = doc.querySelector('#thread')!;
+  return {
+    root: { name: 'ChatPage', element: page, depth: 0 },
+    components: [
+      { name: 'ChatPage', element: page, depth: 0 },
+      { name: 'MessageThread', element: thread, depth: 1 },
+    ],
+    leaves: [{ name: 'MessageThread', element: thread, depth: 1 }],
+  };
+}
+
+const paintOf = (doc: Document) => ({
+  listenerId: 'sub-1',
+  label: 'ChatPage',
+  target: 'conversations/c1/messages (query)',
+  deliveryCount: 3,
+  subtree: subtree(doc),
+});
+
+describe('painting one delivery', () => {
+  it('draws a box for every component in the listener colour', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+
+    const boxes = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    expect(boxes).toHaveLength(2);
+    for (const box of boxes) expect(box.dataset.listenerId).toBe('sub-1');
+    expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
+    // The page normalises the hue to rgb, so the colour is checked by the
+    // property it agrees on: one colour across the subtree, another listener's.
+    expect(boxes[0].style.borderColor).toBe(boxes[1].style.borderColor);
+    expect(boxes[0].style.borderColor).not.toBe('');
+
+    page.painter.paint({ ...paintOf(page.doc), listenerId: 'sub-2' });
+    const other = page.container.querySelector<HTMLElement>('[data-pyric-flow-box][data-listener-id="sub-2"]');
+    expect(listenerColors('sub-2').border).not.toBe(listenerColors('sub-1').border);
+    expect(other?.style.borderColor).not.toBe(boxes[0].style.borderColor);
+  });
+
+  it('names the owner and target on the root badge and the component on the leaf', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+
+    const badge = page.container.querySelector('[data-pyric-flow-badge]');
+    expect(badge?.textContent).toBe('ChatPage · conversations/c1/messages (query) · 3');
+    expect(badge?.getAttribute('title')).toContain('rendered after a delivery');
+
+    const leaf = page.container.querySelector('[data-pyric-flow-leaf-badge]');
+    expect(leaf?.textContent).toBe('MessageThread');
+  });
+
+  it('spells the root badge the way the Overview badge does', () => {
+    expect(flowBadgeText({
+      listenerId: 'sub-1',
+      label: 'PresenceBar',
+      target: 'status/u1',
+      deliveryCount: 1,
+      subtree: { root: null, components: [], leaves: [] },
+    })).toBe('PresenceBar · status/u1 · 1');
+  });
+
+  it('takes the boxes away once the fade is over', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(2);
+
+    page.advance(3000);
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+
+  it('replaces the same listener rather than stacking on it', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    page.painter.paint(paintOf(page.doc));
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(2);
+  });
+
+  it('keeps two listeners apart by colour and clears one at a time', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    page.painter.paint({ ...paintOf(page.doc), listenerId: 'sub-2', label: 'PresenceBar' });
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(4);
+
+    page.painter.clearListener('sub-1');
+    const left = page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]');
+    expect(left).toHaveLength(2);
+    expect([...left].every((box) => box.dataset.listenerId === 'sub-2')).toBe(true);
+  });
+
+  it('draws nothing for a delivery that rendered nothing', () => {
+    const page = setup();
+    page.painter.paint({
+      ...paintOf(page.doc),
+      subtree: { root: null, components: [], leaves: [] },
+    });
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+  });
+
+  it('clears everything and cancels its timers on dispose', () => {
+    const page = setup();
+    page.painter.paint(paintOf(page.doc));
+    page.painter.dispose();
+    expect(page.container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(page.timers.filter((timer) => timer.at > 0)).toHaveLength(0);
+  });
+});

--- a/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-painter.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'bun:test';
 import { createFlowPainter, flowBadgeText } from '../../../src/serve/runtime/listener-flow-painter.js';
-import { listenerColors } from '../../../src/serve/runtime/listener-palette.js';
+import { listenerHueIndex } from '../../../src/serve/runtime/listener-palette.js';
 import type { FlowSubtree } from '../../../src/serve/runtime/fiber-flow.js';
 
 function setup() {
@@ -80,15 +80,20 @@ describe('painting one delivery', () => {
     expect(boxes).toHaveLength(2);
     for (const box of boxes) expect(box.dataset.listenerId).toBe('sub-1');
     expect(boxes.map((box) => box.dataset.component)).toEqual(['ChatPage', 'MessageThread']);
-    // The page normalises the hue to rgb, so the colour is checked by the
-    // property it agrees on: one colour across the subtree, another listener's.
-    expect(boxes[0].style.borderColor).toBe(boxes[1].style.borderColor);
-    expect(boxes[0].style.borderColor).not.toBe('');
+    // The colour is the stylesheet's, off the hue the box names: one hue
+    // across the subtree, and a different one for another listener.
+    expect(boxes[0].dataset.hue).toBe(String(listenerHueIndex('sub-1')));
+    expect(boxes[0].dataset.hue).toBe(boxes[1].dataset.hue);
+    expect(boxes.map((box) => box.dataset.pyricRole)).toEqual(['region', 'component']);
+    // Nothing visual is inline: only the measured geometry is.
+    for (const box of boxes) {
+      expect([...box.style]).toEqual(['left', 'top', 'width', 'height']);
+    }
 
     page.painter.paint({ ...paintOf(page.doc), listenerId: 'sub-2' });
     const other = page.container.querySelector<HTMLElement>('[data-pyric-flow-box][data-listener-id="sub-2"]');
-    expect(listenerColors('sub-2').border).not.toBe(listenerColors('sub-1').border);
-    expect(other?.style.borderColor).not.toBe(boxes[0].style.borderColor);
+    expect(listenerHueIndex('sub-2')).not.toBe(listenerHueIndex('sub-1'));
+    expect(other?.dataset.hue).not.toBe(boxes[0].dataset.hue);
   });
 
   it('names the owner and target on the root badge and the component on the leaf', () => {
@@ -122,7 +127,8 @@ describe('painting one delivery', () => {
     const held = [...page.container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
     expect(held).toHaveLength(2);
     expect(held.every((box) => box.dataset.flowRetained === '')).toBe(true);
-    expect(held.every((box) => Number(box.style.opacity) > 0 && Number(box.style.opacity) < 1)).toBe(true);
+    // The dimming is the stylesheet's, off the retained attribute.
+    expect(held.every((box) => box.style.opacity === '')).toBe(true);
   });
 
   it('replaces a retained subtree on the next delivery for that listener', () => {

--- a/packages/cli/test/serve/runtime/listener-flow-react.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-react.test.ts
@@ -26,7 +26,8 @@ const outline: ListenerOutline = {
   isQuery: true,
   service: 'firestore',
   deliveryCount: 1,
-  selectors: [],
+  // The element the owner registered, which is what the paint is rooted on.
+  selectors: ['#page'],
   incident: null,
 };
 
@@ -78,16 +79,27 @@ describe.if(reactInstalled)('the Flow path against a real React', () => {
     };
 
     let publish: ((messages: string[]) => void) | null = null;
+    let announce: ((presence: string) => void) | null = null;
     function MessageThread({ messages }: { messages: string[] }): unknown {
       return h('div', { id: 'thread' }, messages.map((text, index) => h('span', { key: index }, text)));
     }
     function Sidebar(): unknown {
       return h('div', { id: 'sidebar' }, 'rooms');
     }
+    // The page renders its presence bar as inline JSX, so nothing between the
+    // page root and that element is a component of its own.
     function ChatPage(): unknown {
       const [messages, setMessages] = useState<string[]>(['one']);
+      const [presence, setPresence] = useState('1 online');
       publish = setMessages;
-      return h('div', { id: 'page' }, h(Sidebar, null), h(MessageThread, { messages }));
+      announce = setPresence;
+      return h(
+        'div',
+        { id: 'page' },
+        h(Sidebar, null),
+        h('div', { id: 'presence' }, presence),
+        h(MessageThread, { messages }),
+      );
     }
 
     const doc = dom.window.document;
@@ -116,14 +128,21 @@ describe.if(reactInstalled)('the Flow path against a real React', () => {
     deliver!('sub-1');
     await act(() => {
       publish!(['one', 'two']);
+      announce!('2 online');
     });
 
     const boxes = [...container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
     const names = boxes.map((box) => box.dataset.component);
-    expect(names).toContain('ChatPage');
+    // The root is the region the owner registered, not the owner's own host,
+    // and the badge is where the owner is named.
+    const rootBox = boxes.find((box) => box.dataset.flowKind === 'region');
+    expect(rootBox?.dataset.component).toBe('ChatPage');
     expect(names).toContain('MessageThread');
     // Nothing in the branch that did not re-render is named.
     expect(names).not.toContain('Sidebar');
+    // The presence bar is inline JSX, so the changed element speaks for itself.
+    expect(names).toContain('div#presence');
+    expect(boxes.find((box) => box.dataset.component === 'div#presence')?.dataset.flowKind).toBe('host');
     expect(container.querySelector('[data-pyric-flow-badge]')?.textContent)
       .toBe('ChatPage · conversations/c1/messages (query) · 1');
     expect(boxes.every((box) => box.dataset.listenerId === 'sub-1')).toBe(true);

--- a/packages/cli/test/serve/runtime/listener-flow-react.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-react.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The whole Flow path against a real React: the commit hook installed before
+ * React loads, a delivery reported the way the worker client reports one, a
+ * render, and the boxes that come out of the fiber walk.
+ *
+ * React is not a dependency of this package. It is a dependency of `@pyric/ui`
+ * in the same workspace, so the test reaches it there and skips itself when it
+ * is not installed. Everything else here is pyric's own code.
+ */
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import { installReactCommitSource } from '../../../src/serve/runtime/react-commit-source.js';
+import { startFlowMode } from '../../../src/serve/runtime/listener-flow-mode.js';
+import type { ListenerOutline } from '../../../src/serve/runtime/listener-outline-model.js';
+
+const reactDir = fileURLToPath(new URL('../../../../ui/node_modules/react/', import.meta.url));
+const reactInstalled = existsSync(reactDir);
+
+const outline: ListenerOutline = {
+  listenerId: 'sub-1',
+  label: 'ChatPage',
+  labelIsOwner: true,
+  target: 'conversations/c1/messages',
+  isQuery: true,
+  service: 'firestore',
+  deliveryCount: 1,
+  selectors: [],
+  incident: null,
+};
+
+/**
+ * The page globals React reads while its own module first evaluates. Returns
+ * the function that puts the process's own globals back, so this file does not
+ * leave a JSDOM behind for the rest of the suite.
+ */
+function installPageGlobals(dom: JSDOM): () => void {
+  const view = dom.window as unknown as Record<string, unknown>;
+  const target = globalThis as unknown as Record<string, unknown>;
+  const saved = new Map<string, unknown>();
+  const keys = [
+    'window', 'document', 'navigator', 'Node', 'Element', 'HTMLElement', 'Event',
+    'MutationObserver', 'requestAnimationFrame', 'cancelAnimationFrame',
+    'requestIdleCallback', 'DocumentFragment', 'Text', 'IS_REACT_ACT_ENVIRONMENT',
+  ];
+  for (const key of keys) {
+    saved.set(key, target[key]);
+    // React batches its test renders only inside an environment that declares
+    // itself one.
+    const value = key === 'window'
+      ? dom.window
+      : key === 'IS_REACT_ACT_ENVIRONMENT' ? true : view[key];
+    if (value !== undefined) target[key] = value;
+  }
+  return () => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete target[key];
+      else target[key] = value;
+    }
+  };
+}
+
+describe.if(reactInstalled)('the Flow path against a real React', () => {
+  it('paints the components that rendered after a delivery', async () => {
+    const dom = new JSDOM('<!doctype html><body><div id="root"></div></body>', { url: 'http://localhost/' });
+    const restoreGlobals = installPageGlobals(dom);
+    // Installed before React's module is pulled in, which is the whole point
+    // of the served page's script order.
+    const commits = installReactCommitSource(globalThis);
+
+    const React = await import('../../../../ui/node_modules/react/index.js');
+    const client = await import('../../../../ui/node_modules/react-dom/client.js');
+    const { createElement: h, useState, act } = React as unknown as {
+      createElement: (...args: unknown[]) => unknown;
+      useState: <T>(initial: T) => [T, (next: T) => void];
+      act: (fn: () => void | Promise<void>) => Promise<void>;
+    };
+
+    let publish: ((messages: string[]) => void) | null = null;
+    function MessageThread({ messages }: { messages: string[] }): unknown {
+      return h('div', { id: 'thread' }, messages.map((text, index) => h('span', { key: index }, text)));
+    }
+    function Sidebar(): unknown {
+      return h('div', { id: 'sidebar' }, 'rooms');
+    }
+    function ChatPage(): unknown {
+      const [messages, setMessages] = useState<string[]>(['one']);
+      publish = setMessages;
+      return h('div', { id: 'page' }, h(Sidebar, null), h(MessageThread, { messages }));
+    }
+
+    const doc = dom.window.document;
+    const root = client.createRoot(doc.querySelector('#root')!);
+    await act(() => {
+      root.render(h(ChatPage, null));
+    });
+    expect(commits.available()).toBe(true);
+
+    const container = doc.createElement('div');
+    doc.body.append(container);
+    let deliver: ((listenerId: string) => void) | null = null;
+    const flow = startFlowMode({
+      document: doc,
+      container,
+      commits,
+      outlineFor: () => outline,
+      isVisible: () => true,
+      subscribeDeliveries: (listener) => {
+        deliver = listener;
+        return () => {};
+      },
+    });
+
+    // The delivery the worker client would report, then the render it caused.
+    deliver!('sub-1');
+    await act(() => {
+      publish!(['one', 'two']);
+    });
+
+    const boxes = [...container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+    const names = boxes.map((box) => box.dataset.component);
+    expect(names).toContain('ChatPage');
+    expect(names).toContain('MessageThread');
+    // Nothing in the branch that did not re-render is named.
+    expect(names).not.toContain('Sidebar');
+    expect(container.querySelector('[data-pyric-flow-badge]')?.textContent)
+      .toBe('ChatPage · conversations/c1/messages (query) · 1');
+    expect(boxes.every((box) => box.dataset.listenerId === 'sub-1')).toBe(true);
+
+    flow.dispose();
+    commits.dispose();
+    restoreGlobals();
+  });
+});

--- a/packages/cli/test/serve/runtime/listener-flow-react.test.ts
+++ b/packages/cli/test/serve/runtime/listener-flow-react.test.ts
@@ -131,23 +131,26 @@ describe.if(reactInstalled)('the Flow path against a real React', () => {
       announce!('2 online');
     });
 
-    const boxes = [...container.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
-    const names = boxes.map((box) => box.dataset.component);
-    // The root is the region the owner registered, not the owner's own host,
-    // and the badge is where the owner is named.
-    const rootBox = boxes.find((box) => box.dataset.flowKind === 'region');
-    expect(rootBox?.dataset.component).toBe('ChatPage');
-    expect(names).toContain('MessageThread');
-    // Nothing in the branch that did not re-render is named.
-    expect(names).not.toContain('Sidebar');
+    const marked = [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow]')];
+    const labels = marked.map((element) => element.getAttribute('data-pyric-flow-label'));
+    // The marks are on the page's own elements, not on measured boxes in the
+    // overlay, and the region the owner registered is not one of them.
+    expect(container.querySelectorAll('[data-pyric-flow-box]')).toHaveLength(0);
+    expect(doc.querySelector('#page')?.hasAttribute('data-pyric-flow')).toBe(false);
+    expect(doc.querySelector('#thread')?.getAttribute('data-pyric-flow-role')).toBe('component');
+    // Nothing in the branch that did not re-render is marked.
+    expect(doc.querySelector('#sidebar')?.hasAttribute('data-pyric-flow')).toBe(false);
     // The presence bar is inline JSX, so the changed element speaks for itself.
-    expect(names).toContain('div#presence');
-    expect(boxes.find((box) => box.dataset.component === 'div#presence')?.dataset.flowKind).toBe('host');
-    expect(container.querySelector('[data-pyric-flow-badge]')?.textContent)
-      .toBe('ChatPage · conversations/c1/messages (query) · 1');
-    expect(boxes.every((box) => box.dataset.listenerId === 'sub-1')).toBe(true);
+    expect(doc.querySelector('#presence')?.getAttribute('data-pyric-flow-role')).toBe('host');
+    // The listener is named once, on the first element the delivery marked.
+    expect(labels).toContain('ChatPage · conversations/c1/messages (query) · 1');
+    expect(labels.filter((label) => label?.includes(' · ')).length).toBe(1);
+    expect(marked.every((element) => (
+      element.getAttribute('data-pyric-flow-listener') === 'sub-1'
+    ))).toBe(true);
 
     flow.dispose();
+    expect(doc.querySelectorAll('[data-pyric-flow], [data-pyric-flow-label]')).toHaveLength(0);
     commits.dispose();
     restoreGlobals();
   });

--- a/packages/cli/test/serve/runtime/listener-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-mode.test.ts
@@ -58,10 +58,17 @@ function harness(options: {
   paintStorage?: Parameters<typeof createListenerMode>[0]['paintStorage'];
 } = {}) {
   const dom = new JSDOM(
-    '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
+    '<!doctype html><body><div id="todos"><span id="row">a</span></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
   );
   const doc = dom.window.document;
+  // A row inside the todos region, wired the way React wires a host node it
+  // rendered inline: nothing between it and the region is a component.
+  const rowEl = doc.querySelector('#row')!;
+  const regionHost = { tag: 5, type: 'div', stateNode: doc.querySelector('#todos')!, return: null, child: null };
+  const rowHost = { tag: 5, type: 'span', stateNode: rowEl, return: regionHost, child: null };
+  (rowEl as unknown as Record<string, unknown>)['__reactFiber$k'] = rowHost;
+  let changedNodes: unknown[] = [];
   let deliver: ((events: readonly SandboxEvent[]) => void) | null = null;
   let subscriptions = 0;
   let delivered: ((listenerId: string) => void) | null = null;
@@ -79,7 +86,14 @@ function harness(options: {
           delivered = null;
         };
       },
-      changedNodes: () => ({ drain: () => [], stop: () => {} }),
+      changedNodes: () => ({
+        drain: () => {
+          const drained = changedNodes;
+          changedNodes = [];
+          return drained;
+        },
+        stop: () => {},
+      }),
     },
     subscribeEvents: (callback) => {
       subscriptions += 1;
@@ -94,10 +108,21 @@ function harness(options: {
     doc,
     mode,
     commits,
+    rowEl,
     push: (events: readonly SandboxEvent[]) => deliver?.(events),
     subscriptions: () => subscriptions,
     flowWatching: () => delivered !== null,
+    /** A delivery the worker client reported, and the render that followed. */
+    flowDelivery: (listenerId: string, nodes: unknown[]) => {
+      delivered?.(listenerId);
+      changedNodes = nodes;
+      commits.fire();
+    },
   };
+}
+
+function flowBoxes(doc: Document): HTMLElement[] {
+  return [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
 }
 
 function badges(doc: Document): string[] {
@@ -385,5 +410,79 @@ describe('switching one listener off', () => {
     page.mode.setListenerVisible('l1', false);
     page.mode.dispose();
     expect(page.mode.isListenerVisible('l1')).toBe(true);
+  });
+});
+
+describe('what a painted flow is held for', () => {
+  /** A mode in Flow with one delivery painted: the region and the changed row. */
+  function painted() {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.mode.setMode('flow');
+    page.push([todosAttach]);
+    page.flowDelivery('l1', [page.rowEl]);
+    return page;
+  }
+
+  it('paints the region and the changed row, and holds them after the delivery', () => {
+    const page = painted();
+    const drawn = flowBoxes(page.doc);
+    expect(drawn).toHaveLength(2);
+    expect(drawn.map((box) => box.dataset.flowKind)).toEqual(['region', 'host']);
+    expect(drawn.every((box) => box.dataset.listenerId === 'l1')).toBe(true);
+    page.mode.dispose();
+  });
+
+  it('takes the held paint away as soon as the listener is switched off', () => {
+    const page = painted();
+    page.mode.setListenerVisible('l1', false);
+    expect(flowBoxes(page.doc)).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('leaves the page empty after a switch back on, until the next delivery', () => {
+    const page = painted();
+    page.mode.setListenerVisible('l1', false);
+    page.mode.setListenerVisible('l1', true);
+    expect(flowBoxes(page.doc)).toHaveLength(0);
+
+    page.flowDelivery('l1', [page.rowEl]);
+    expect(flowBoxes(page.doc)).toHaveLength(2);
+    page.mode.dispose();
+  });
+
+  it('takes the held paint away when the listener detaches', () => {
+    const page = painted();
+    page.push([detach('e9', 'l1', { kind: 'query', collection: 'todos' })]);
+    expect(flowBoxes(page.doc)).toHaveLength(0);
+    page.mode.dispose();
+  });
+
+  it('says it is waiting for a delivery until one has been painted', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.mode.setMode('flow');
+    page.push([todosAttach]);
+    expect(page.mode.flowWaiting()).toBe(true);
+
+    page.flowDelivery('l1', [page.rowEl]);
+    expect(page.mode.flowWaiting()).toBe(false);
+    page.mode.dispose();
+  });
+
+  it('is not waiting while Overview is the mode', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach]);
+    expect(page.mode.flowWaiting()).toBe(false);
+    page.mode.dispose();
+  });
+
+  it('waits again after a turn back into Flow', () => {
+    const page = painted();
+    page.mode.setMode('overview');
+    page.mode.setMode('flow');
+    expect(page.mode.flowWaiting()).toBe(true);
+    page.mode.dispose();
   });
 });

--- a/packages/cli/test/serve/runtime/listener-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-mode.test.ts
@@ -32,7 +32,31 @@ function delivery(id: string, listenerId: string, target: Target, owners?: unkno
   return event as unknown as SandboxEvent;
 }
 
-function harness(options: { attributionEnabled?: boolean } = {}) {
+/** A commit source that reports a React the test drives. */
+function fakeCommits(available: boolean) {
+  let commit: (() => void) | null = null;
+  return {
+    source: {
+      available: () => available,
+      reason: () => (available ? null : 'no React'),
+      subscribe: (listener: () => void) => {
+        commit = listener;
+        return () => {
+          commit = null;
+        };
+      },
+      dispose: () => {},
+    },
+    fire: () => commit?.(),
+    subscribed: () => commit !== null,
+  };
+}
+
+function harness(options: {
+  attributionEnabled?: boolean;
+  react?: boolean;
+  paintStorage?: Parameters<typeof createListenerMode>[0]['paintStorage'];
+} = {}) {
   const dom = new JSDOM(
     '<!doctype html><body><div id="todos"></div><div id="profile"></div></body>',
     { url: 'http://localhost/' },
@@ -40,10 +64,23 @@ function harness(options: { attributionEnabled?: boolean } = {}) {
   const doc = dom.window.document;
   let deliver: ((events: readonly SandboxEvent[]) => void) | null = null;
   let subscriptions = 0;
+  let delivered: ((listenerId: string) => void) | null = null;
+  const commits = fakeCommits(options.react ?? true);
   const mode = createListenerMode({
     document: doc,
     attributionEnabled: () => options.attributionEnabled ?? true,
     incidents: () => [],
+    commits: commits.source,
+    paintStorage: options.paintStorage ?? null,
+    flow: {
+      subscribeDeliveries: (listener) => {
+        delivered = listener;
+        return () => {
+          delivered = null;
+        };
+      },
+      changedNodes: () => ({ drain: () => [], stop: () => {} }),
+    },
     subscribeEvents: (callback) => {
       subscriptions += 1;
       deliver = callback;
@@ -56,8 +93,10 @@ function harness(options: { attributionEnabled?: boolean } = {}) {
   return {
     doc,
     mode,
+    commits,
     push: (events: readonly SandboxEvent[]) => deliver?.(events),
     subscriptions: () => subscriptions,
+    flowWatching: () => delivered !== null,
   };
 }
 
@@ -196,5 +235,155 @@ describe('studio hand-off', () => {
 
     expect(opened).toEqual(['/__pyric/ui/studio?view=listeners&listener=l1&target=todos']);
     mode.dispose();
+  });
+});
+
+const todosAttach = attach(
+  'e1',
+  'l1',
+  { kind: 'query', collection: 'todos' },
+  [{ kind: 'tag', name: 'TodoList', element: '#todos' }],
+);
+const profileAttach = attach(
+  'e3',
+  'l2',
+  { kind: 'doc', path: 'users/u1' },
+  [{ kind: 'tag', name: 'ProfileCard', element: '#profile' }],
+);
+
+function boxes(doc: Document): HTMLElement[] {
+  return [...doc.querySelectorAll<HTMLElement>('[data-pyric-listener-box]')];
+}
+
+describe('the two painting modes', () => {
+  it('starts in Overview and paints one box per listener', () => {
+    const page = harness();
+    expect(page.mode.mode()).toBe('overview');
+    page.mode.setEnabled(true);
+    page.push([todosAttach, profileAttach]);
+    expect(boxes(page.doc)).toHaveLength(2);
+    page.mode.dispose();
+  });
+
+  it('gives each listener its own colour', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach, profileAttach]);
+    const drawn = boxes(page.doc);
+    expect(drawn[0].style.borderColor).not.toBe('');
+    expect(drawn[0].style.borderColor).not.toBe(drawn[1].style.borderColor);
+    page.mode.dispose();
+  });
+
+  it('takes the Overview boxes down when it switches to Flow, and watches for deliveries', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach]);
+    expect(boxes(page.doc)).toHaveLength(1);
+
+    page.mode.setMode('flow');
+    expect(page.mode.mode()).toBe('flow');
+    expect(boxes(page.doc)).toHaveLength(0);
+    expect(page.flowWatching()).toBe(true);
+    page.mode.dispose();
+  });
+
+  it('brings the Overview boxes back and stops watching when it switches back', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach]);
+    page.mode.setMode('flow');
+    page.mode.setMode('overview');
+
+    expect(boxes(page.doc)).toHaveLength(1);
+    expect(page.flowWatching()).toBe(false);
+    page.mode.dispose();
+  });
+
+  it('keeps the mode across a turn of the painting off and on', () => {
+    const page = harness();
+    page.mode.setMode('flow');
+    page.mode.setEnabled(true);
+    page.push([todosAttach]);
+    expect(boxes(page.doc)).toHaveLength(0);
+    expect(page.flowWatching()).toBe(true);
+
+    page.mode.setEnabled(false);
+    expect(page.flowWatching()).toBe(false);
+    page.mode.setEnabled(true);
+    expect(page.mode.mode()).toBe('flow');
+    expect(page.flowWatching()).toBe(true);
+    page.mode.dispose();
+  });
+
+  it('refuses Flow and says why when the page has no React', () => {
+    const page = harness({ react: false });
+    expect(page.mode.flowAvailable()).toBe(false);
+    expect(page.mode.flowUnavailableReason()).toContain('React');
+
+    page.mode.setMode('flow');
+    expect(page.mode.mode()).toBe('overview');
+    page.mode.dispose();
+  });
+
+  it('remembers the mode where the page keeps it', () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+    };
+    const first = harness({ paintStorage: storage });
+    first.mode.setMode('flow');
+    first.mode.dispose();
+
+    const second = harness({ paintStorage: storage });
+    expect(second.mode.mode()).toBe('flow');
+    second.mode.dispose();
+  });
+});
+
+describe('switching one listener off', () => {
+  it('stops painting that listener and leaves the others', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach, profileAttach]);
+
+    page.mode.setListenerVisible('l1', false);
+    const drawn = boxes(page.doc);
+    expect(drawn).toHaveLength(1);
+    expect(drawn[0].dataset.listenerId).toBe('l2');
+    expect(page.mode.isListenerVisible('l1')).toBe(false);
+    expect(page.mode.isListenerVisible('l2')).toBe(true);
+    page.mode.dispose();
+  });
+
+  it('paints it again when it is switched back on', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach, profileAttach]);
+    page.mode.setListenerVisible('l1', false);
+    page.mode.setListenerVisible('l1', true);
+    expect(boxes(page.doc)).toHaveLength(2);
+    page.mode.dispose();
+  });
+
+  it('keeps the listener in the panel summary while its paint is off', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach, profileAttach]);
+    page.mode.setListenerVisible('l1', false);
+    expect(page.mode.outlines()).toHaveLength(2);
+    page.mode.dispose();
+  });
+
+  it('forgets which listeners were off once the mode is disposed', () => {
+    const page = harness();
+    page.mode.setEnabled(true);
+    page.push([todosAttach]);
+    page.mode.setListenerVisible('l1', false);
+    page.mode.dispose();
+    expect(page.mode.isListenerVisible('l1')).toBe(true);
   });
 });

--- a/packages/cli/test/serve/runtime/listener-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-mode.test.ts
@@ -295,8 +295,8 @@ describe('the two painting modes', () => {
     page.mode.setEnabled(true);
     page.push([todosAttach, profileAttach]);
     const drawn = boxes(page.doc);
-    expect(drawn[0].style.borderColor).not.toBe('');
-    expect(drawn[0].style.borderColor).not.toBe(drawn[1].style.borderColor);
+    expect(drawn[0].dataset.hue).not.toBe(undefined);
+    expect(drawn[0].dataset.hue).not.toBe(drawn[1].dataset.hue);
     page.mode.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/listener-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-mode.test.ts
@@ -121,8 +121,8 @@ function harness(options: {
   };
 }
 
-function flowBoxes(doc: Document): HTMLElement[] {
-  return [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow-box]')];
+function flowMarks(doc: Document): HTMLElement[] {
+  return [...doc.querySelectorAll<HTMLElement>('[data-pyric-flow]')];
 }
 
 function badges(doc: Document): string[] {
@@ -414,7 +414,7 @@ describe('switching one listener off', () => {
 });
 
 describe('what a painted flow is held for', () => {
-  /** A mode in Flow with one delivery painted: the region and the changed row. */
+  /** A mode in Flow with one delivery painted: the changed row. */
   function painted() {
     const page = harness();
     page.mode.setEnabled(true);
@@ -424,19 +424,19 @@ describe('what a painted flow is held for', () => {
     return page;
   }
 
-  it('paints the region and the changed row, and holds them after the delivery', () => {
+  it('marks the changed row itself, and holds it after the delivery', () => {
     const page = painted();
-    const drawn = flowBoxes(page.doc);
-    expect(drawn).toHaveLength(2);
-    expect(drawn.map((box) => box.dataset.flowKind)).toEqual(['region', 'host']);
-    expect(drawn.every((box) => box.dataset.listenerId === 'l1')).toBe(true);
+    const drawn = flowMarks(page.doc);
+    expect(drawn).toEqual([page.rowEl as HTMLElement]);
+    expect(drawn[0]?.getAttribute('data-pyric-flow-role')).toBe('host');
+    expect(drawn.every((mark) => mark.getAttribute('data-pyric-flow-listener') === 'l1')).toBe(true);
     page.mode.dispose();
   });
 
   it('takes the held paint away as soon as the listener is switched off', () => {
     const page = painted();
     page.mode.setListenerVisible('l1', false);
-    expect(flowBoxes(page.doc)).toHaveLength(0);
+    expect(flowMarks(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 
@@ -444,17 +444,17 @@ describe('what a painted flow is held for', () => {
     const page = painted();
     page.mode.setListenerVisible('l1', false);
     page.mode.setListenerVisible('l1', true);
-    expect(flowBoxes(page.doc)).toHaveLength(0);
+    expect(flowMarks(page.doc)).toHaveLength(0);
 
     page.flowDelivery('l1', [page.rowEl]);
-    expect(flowBoxes(page.doc)).toHaveLength(2);
+    expect(flowMarks(page.doc)).toHaveLength(1);
     page.mode.dispose();
   });
 
   it('takes the held paint away when the listener detaches', () => {
     const page = painted();
     page.push([detach('e9', 'l1', { kind: 'query', collection: 'todos' })]);
-    expect(flowBoxes(page.doc)).toHaveLength(0);
+    expect(flowMarks(page.doc)).toHaveLength(0);
     page.mode.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/listener-overlay.test.ts
+++ b/packages/cli/test/serve/runtime/listener-overlay.test.ts
@@ -1,6 +1,8 @@
 import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'bun:test';
 import { createListenerOverlay } from '../../../src/serve/runtime/listener-overlay.js';
+import { listenerHueIndex } from '../../../src/serve/runtime/listener-palette.js';
+import { OVERLAY_STYLE_ATTRIBUTE } from '../../../src/serve/runtime/overlay-theme.js';
 import type { ListenerOutline } from '../../../src/serve/runtime/listener-outline-model.js';
 
 function outline(overrides: Partial<ListenerOutline>): ListenerOutline {
@@ -91,6 +93,46 @@ describe('createListenerOverlay', () => {
     overlay.update([outline({})]);
     doc.querySelector<HTMLElement>('[data-pyric-listener-badge]')?.click();
     expect(selected).toEqual(['l1']);
+    overlay.dispose();
+  });
+
+  it('says what each box and badge is, and leaves the drawing to the stylesheet', () => {
+    const doc = page();
+    const overlay = createListenerOverlay({ document: doc });
+    overlay.update([outline({ incident: { pattern: 'duplicate-listener', count: 2 } })]);
+
+    const box = boxes(doc)[0]!;
+    expect(box.dataset.pyricRole).toBe('region');
+    expect(box.dataset.listenerId).toBe('l1');
+    expect(box.dataset.listenerTarget).toBe('todos');
+    expect(box.dataset.hue).toBe(String(listenerHueIndex('l1')));
+    expect(box.dataset.incident).toBe('duplicate-listener');
+    // Geometry is measured, so it stays inline. Nothing else does.
+    expect([...box.style]).toEqual(['left', 'top', 'width', 'height']);
+
+    const badge = doc.querySelector<HTMLElement>('[data-pyric-listener-badge]')!;
+    expect(badge.dataset.pyricRole).toBe('badge');
+    expect(badge.dataset.hue).toBe(box.dataset.hue);
+    expect([...badge.style]).toEqual([]);
+    overlay.dispose();
+  });
+
+  it('says which painting mode the container is in', () => {
+    const doc = page();
+    const overlay = createListenerOverlay({ document: doc });
+    const container = doc.querySelector<HTMLElement>('[data-pyric-listener-overlay]')!;
+    expect(container.getAttribute('data-pyric-mode')).toBe('overview');
+    overlay.setMode('flow');
+    expect(container.getAttribute('data-pyric-mode')).toBe('flow');
+    overlay.dispose();
+  });
+
+  it('injects the stylesheet once, however many times it redraws', () => {
+    const doc = page();
+    const overlay = createListenerOverlay({ document: doc });
+    overlay.update([outline({})]);
+    overlay.update([outline({}), outline({ listenerId: 'l2', selectors: ['#profile'] })]);
+    expect(doc.querySelectorAll(`[${OVERLAY_STYLE_ATTRIBUTE}]`)).toHaveLength(1);
     overlay.dispose();
   });
 

--- a/packages/cli/test/serve/runtime/listener-paint-mode.test.ts
+++ b/packages/cli/test/serve/runtime/listener-paint-mode.test.ts
@@ -1,0 +1,75 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_LISTENER_PAINT_MODE,
+  LISTENER_PAINT_MODE_KEY,
+  isListenerPaintMode,
+  pagePaintModeStorage,
+  readListenerPaintMode,
+  writeListenerPaintMode,
+  type PaintModeStorage,
+} from '../../../src/serve/runtime/listener-paint-mode.js';
+
+function memoryStorage(initial: Record<string, string> = {}): PaintModeStorage {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+const refusing: PaintModeStorage = {
+  getItem() {
+    throw new Error('blocked');
+  },
+  setItem() {
+    throw new Error('blocked');
+  },
+};
+
+describe('remembering the painting mode', () => {
+  it('starts in Overview when nothing was kept', () => {
+    expect(readListenerPaintMode(memoryStorage())).toBe('overview');
+    expect(DEFAULT_LISTENER_PAINT_MODE).toBe('overview');
+  });
+
+  it('reads back the mode it wrote', () => {
+    const storage = memoryStorage();
+    writeListenerPaintMode(storage, 'flow');
+    expect(storage.getItem(LISTENER_PAINT_MODE_KEY)).toBe('flow');
+    expect(readListenerPaintMode(storage)).toBe('flow');
+  });
+
+  it('keeps its key under the pyric prefix', () => {
+    expect(LISTENER_PAINT_MODE_KEY.startsWith('pyric:')).toBe(true);
+  });
+
+  it('falls back to the default for a value it does not recognise', () => {
+    expect(readListenerPaintMode(memoryStorage({ [LISTENER_PAINT_MODE_KEY]: 'sideways' })))
+      .toBe('overview');
+  });
+
+  it('treats a storage that refuses as no storage at all', () => {
+    expect(readListenerPaintMode(refusing)).toBe('overview');
+    expect(() => writeListenerPaintMode(refusing, 'flow')).not.toThrow();
+    expect(readListenerPaintMode(null)).toBe('overview');
+    expect(() => writeListenerPaintMode(undefined, 'flow')).not.toThrow();
+  });
+
+  it('names the two modes and nothing else', () => {
+    expect(isListenerPaintMode('overview')).toBe(true);
+    expect(isListenerPaintMode('flow')).toBe(true);
+    expect(isListenerPaintMode('outline')).toBe(false);
+    expect(isListenerPaintMode(null)).toBe(false);
+  });
+
+  it('finds the page own storage and round-trips through it', () => {
+    const dom = new JSDOM('<!doctype html><body></body>', { url: 'http://localhost/' });
+    const storage = pagePaintModeStorage(dom.window.document);
+    expect(storage).not.toBeNull();
+    writeListenerPaintMode(storage, 'flow');
+    expect(readListenerPaintMode(pagePaintModeStorage(dom.window.document))).toBe('flow');
+  });
+});

--- a/packages/cli/test/serve/runtime/listener-palette.test.ts
+++ b/packages/cli/test/serve/runtime/listener-palette.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  listenerColors,
+  listenerHue,
+  listenerHueIndex,
+  listenerPalette,
+} from '../../../src/serve/runtime/listener-palette.js';
+
+describe('the listener palette', () => {
+  it('gives one listener id the same hue every time', () => {
+    expect(listenerHue('sub-7')).toBe(listenerHue('sub-7'));
+    expect(listenerHueIndex('sub-7')).toBe(listenerHueIndex('sub-7'));
+  });
+
+  it('keeps every index inside the palette', () => {
+    const palette = listenerPalette();
+    for (let i = 0; i < 200; i += 1) {
+      const index = listenerHueIndex(`sub-${i}`);
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(index).toBeLessThan(palette.length);
+      expect(palette).toContain(listenerHue(`sub-${i}`));
+    }
+  });
+
+  it('spreads consecutive subscription ids over every hue', () => {
+    const used = new Set<number>();
+    for (let i = 0; i < 40; i += 1) used.add(listenerHueIndex(`sub-${i}`));
+    expect(used.size).toBe(listenerPalette().length);
+  });
+
+  it('separates the first few listeners a page attaches', () => {
+    const ids = ['sub-1', 'sub-2', 'sub-3', 'sub-4'];
+    const hues = new Set(ids.map(listenerHue));
+    expect(hues.size).toBe(ids.length);
+  });
+
+  it('builds every colour a painter needs from one hue', () => {
+    const colors = listenerColors('sub-1');
+    const hue = listenerHue('sub-1');
+    expect(colors.border).toContain(String(hue));
+    expect(colors.fill).toContain(String(hue));
+    expect(colors.accent).toContain(String(hue));
+    expect(colors.swatch).toBe(colors.border);
+  });
+
+  it('gives different ids different colours when their hues differ', () => {
+    const a = listenerColors('sub-1');
+    const b = listenerColors('sub-2');
+    expect(a.border).not.toBe(b.border);
+  });
+});

--- a/packages/cli/test/serve/runtime/overlay-theme.test.ts
+++ b/packages/cli/test/serve/runtime/overlay-theme.test.ts
@@ -1,0 +1,243 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import { createListenerMode } from '../../../src/serve/runtime/listener-mode.js';
+import {
+  createChipThemeDialog,
+  themeDialogText,
+} from '../../../src/serve/runtime/chip-theme-dialog.js';
+import {
+  applyOverlayTheme,
+  OVERLAY_THEME_DEFAULTS,
+  OVERLAY_THEME_KEY,
+  OVERLAY_THEME_VARIABLES,
+  resolveOverlayTheme,
+} from '../../../src/serve/runtime/overlay-theme.js';
+import type { SandboxEvent } from 'pyric/sandbox';
+
+function page(): { doc: Document; window: JSDOM['window'] } {
+  const dom = new JSDOM('<!doctype html><body><div id="todos"></div></body>', {
+    url: 'http://localhost/',
+  });
+  return { doc: dom.window.document, window: dom.window };
+}
+
+/** A storage this test drives, standing in for the page's `localStorage`. */
+function memoryStorage(initial: Record<string, string> = {}) {
+  const entries = new Map(Object.entries(initial));
+  return {
+    entries,
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      entries.set(key, value);
+    },
+    removeItem: (key: string) => {
+      entries.delete(key);
+    },
+  };
+}
+
+const attach: SandboxEvent = {
+  kind: 'listener_attach',
+  id: 'e1',
+  at: 1,
+  listenerId: 'l1',
+  target: { kind: 'query', collection: 'todos' },
+  auth: { uid: null, token: null },
+  owners: [{ kind: 'tag', name: 'TodoList', element: '#todos' }],
+} as unknown as SandboxEvent;
+
+function mode(options: {
+  doc: Document;
+  overlayTheme?: Record<string, string> | null;
+  themeStorage?: ReturnType<typeof memoryStorage> | null;
+}) {
+  let push: (events: readonly SandboxEvent[]) => void = () => {};
+  const listenerMode = createListenerMode({
+    document: options.doc,
+    subscribeEvents: (callback) => {
+      push = callback;
+      return () => {};
+    },
+    attributionEnabled: () => true,
+    incidents: () => [],
+    paintStorage: null,
+    commits: {
+      available: () => false,
+      reason: () => 'no React',
+      subscribe: () => () => {},
+      dispose: () => {},
+    },
+    themeStorage: options.themeStorage ?? null,
+    overlayTheme: options.overlayTheme ?? null,
+  });
+  listenerMode.setEnabled(true);
+  push([attach]);
+  const container = options.doc.querySelector<HTMLElement>('[data-pyric-listener-overlay]')!;
+  return { listenerMode, container };
+}
+
+describe('the theme contract', () => {
+  it('names a default for every variable it exports', () => {
+    expect(OVERLAY_THEME_VARIABLES.length).toBeGreaterThan(0);
+    for (const name of OVERLAY_THEME_VARIABLES) {
+      expect(name.startsWith('--pyric-')).toBe(true);
+      expect(typeof OVERLAY_THEME_DEFAULTS[name]).toBe('string');
+    }
+    expect(OVERLAY_THEME_DEFAULTS['--pyric-hue-0']).toBe('hsl(146 72% 52%)');
+  });
+
+  it('takes a known override and ignores everything else', () => {
+    const resolved = resolveOverlayTheme({
+      '--pyric-overlay-radius': '0px',
+      '--not-a-pyric-variable': 'red',
+    });
+    expect(resolved['--pyric-overlay-radius']).toBe('0px');
+    expect(resolved['--not-a-pyric-variable']).toBe(undefined);
+  });
+
+  it('leaves a property the theme empties unset, so the stylesheet falls back', () => {
+    const { doc } = page();
+    const container = doc.createElement('div');
+    applyOverlayTheme(container, { '--pyric-overlay-badge-fg': '#ffffff' });
+    expect(container.style.getPropertyValue('--pyric-overlay-badge-fg')).toBe('#ffffff');
+    applyOverlayTheme(container, null);
+    expect(container.style.getPropertyValue('--pyric-overlay-badge-fg')).toBe('');
+    expect(container.style.getPropertyValue('--pyric-overlay-radius')).toBe('4px');
+  });
+});
+
+describe('the three ways a theme reaches the container', () => {
+  it('puts the contract on the container when nothing overrides it', () => {
+    const { doc } = page();
+    const painted = mode({ doc });
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('4px');
+    painted.listenerMode.dispose();
+  });
+
+  it('takes the option the served page passed', () => {
+    const { doc } = page();
+    const painted = mode({ doc, overlayTheme: { '--pyric-overlay-radius': '0px' } });
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('0px');
+    painted.listenerMode.dispose();
+  });
+
+  it('lets the stored overrides win over the served option', () => {
+    const { doc } = page();
+    const painted = mode({
+      doc,
+      overlayTheme: { '--pyric-overlay-radius': '0px', '--pyric-overlay-badge-font-size': '8px' },
+      themeStorage: memoryStorage({
+        [OVERLAY_THEME_KEY]: JSON.stringify({ '--pyric-overlay-radius': '12px' }),
+      }),
+    });
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('12px');
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-badge-font-size')).toBe('8px');
+    painted.listenerMode.dispose();
+  });
+
+  it('ignores a stored name that is not part of the contract', () => {
+    const { doc } = page();
+    const painted = mode({
+      doc,
+      themeStorage: memoryStorage({
+        [OVERLAY_THEME_KEY]: JSON.stringify({ '--not-a-pyric-variable': 'red' }),
+      }),
+    });
+    expect(painted.container.style.getPropertyValue('--not-a-pyric-variable')).toBe('');
+    painted.listenerMode.dispose();
+  });
+
+  it('survives storage that throws and unreadable JSON', () => {
+    const { doc } = page();
+    const painted = mode({
+      doc,
+      themeStorage: {
+        entries: new Map(),
+        getItem: () => 'not json',
+        setItem: () => {},
+        removeItem: () => {},
+      } as unknown as ReturnType<typeof memoryStorage>,
+    });
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('4px');
+    painted.listenerMode.dispose();
+  });
+
+  it('applies a write from another tab when the storage event arrives', () => {
+    const { doc, window } = page();
+    const storage = memoryStorage();
+    const painted = mode({ doc, themeStorage: storage });
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('4px');
+
+    storage.setItem(OVERLAY_THEME_KEY, JSON.stringify({ '--pyric-overlay-radius': '20px' }));
+    const event = new window.Event('storage') as Event & { key: string | null };
+    Object.defineProperty(event, 'key', { value: OVERLAY_THEME_KEY });
+    window.dispatchEvent(event);
+
+    expect(painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('20px');
+    painted.listenerMode.dispose();
+  });
+});
+
+describe('the Theme dialog', () => {
+  function dialogPage() {
+    const { doc } = page();
+    const storage = memoryStorage();
+    const painted = mode({ doc, themeStorage: storage });
+    const host = doc.createElement('div');
+    doc.body.append(host);
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const dialog = createChipThemeDialog({
+      shadowRoot,
+      storage,
+      readTheme: () => painted.listenerMode.overlayTheme(),
+      applyTheme: (theme) => painted.listenerMode.setOverlayTheme(theme),
+    });
+    const input = dialog.element.querySelector<HTMLTextAreaElement>('[data-theme-input]')!;
+    const apply = dialog.element.querySelector<HTMLButtonElement>('[data-theme-apply]')!;
+    const reset = dialog.element.querySelector<HTMLButtonElement>('[data-theme-reset]')!;
+    return { painted, storage, dialog, input, apply, reset };
+  }
+
+  it('opens on the whole contract when nothing is overridden', () => {
+    const text = themeDialogText({});
+    expect(JSON.parse(text)['--pyric-overlay-radius']).toBe('4px');
+    expect(JSON.parse(themeDialogText({ '--pyric-overlay-radius': '9px' }))).toEqual({
+      '--pyric-overlay-radius': '9px',
+    });
+  });
+
+  it('keeps what Apply was given and paints with it now', () => {
+    const helper = dialogPage();
+    helper.dialog.open();
+    helper.input.value = JSON.stringify({ '--pyric-overlay-radius': '16px' });
+    helper.apply.click();
+
+    expect(helper.painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('16px');
+    expect(helper.storage.entries.get(OVERLAY_THEME_KEY)).toContain('16px');
+    helper.painted.listenerMode.dispose();
+  });
+
+  it('says so rather than throwing when the text is not a theme', () => {
+    const helper = dialogPage();
+    helper.dialog.open();
+    helper.input.value = '{ not json';
+    helper.apply.click();
+
+    const error = helper.dialog.element.querySelector<HTMLElement>('[data-theme-error]')!;
+    expect(error.hidden).toBe(false);
+    expect(helper.storage.entries.has(OVERLAY_THEME_KEY)).toBe(false);
+    helper.painted.listenerMode.dispose();
+  });
+
+  it('takes the overrides away on Reset', () => {
+    const helper = dialogPage();
+    helper.dialog.open();
+    helper.input.value = JSON.stringify({ '--pyric-overlay-radius': '16px' });
+    helper.apply.click();
+    helper.reset.click();
+
+    expect(helper.painted.container.style.getPropertyValue('--pyric-overlay-radius')).toBe('4px');
+    expect(helper.storage.entries.has(OVERLAY_THEME_KEY)).toBe(false);
+    helper.painted.listenerMode.dispose();
+  });
+});

--- a/packages/cli/test/serve/runtime/react-commit-source.test.ts
+++ b/packages/cli/test/serve/runtime/react-commit-source.test.ts
@@ -1,0 +1,115 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'bun:test';
+import {
+  installReactCommitSource,
+  reactRendered,
+} from '../../../src/serve/runtime/react-commit-source.js';
+
+interface HookLike {
+  renderers?: Map<unknown, unknown>;
+  inject?: (renderer: unknown) => number;
+  onCommitFiberRoot?: (...args: unknown[]) => void;
+}
+
+function hookOn(view: Record<string, unknown>): HookLike {
+  return view.__REACT_DEVTOOLS_GLOBAL_HOOK__ as HookLike;
+}
+
+describe('installing the commit source', () => {
+  it('installs a hook React can inject into', () => {
+    const view: Record<string, unknown> = {};
+    const source = installReactCommitSource(view);
+    const hook = hookOn(view);
+    expect(typeof hook.inject).toBe('function');
+    expect(source.available()).toBe(false);
+    expect(source.reason()).toContain('No React renderer');
+
+    hook.inject!({ version: '19.0.0' });
+    expect(source.available()).toBe(true);
+    expect(source.reason()).toBeNull();
+  });
+
+  it('reports every commit to its subscribers', () => {
+    const view: Record<string, unknown> = {};
+    const source = installReactCommitSource(view);
+    const seen: number[] = [];
+    const stop = source.subscribe(() => seen.push(seen.length));
+
+    hookOn(view).onCommitFiberRoot!(1, { current: {} });
+    hookOn(view).onCommitFiberRoot!(1, { current: {} });
+    expect(seen).toHaveLength(2);
+
+    stop();
+    hookOn(view).onCommitFiberRoot!(1, { current: {} });
+    expect(seen).toHaveLength(2);
+  });
+
+  it('keeps an extension handler that got there first', () => {
+    const calls: unknown[][] = [];
+    const view: Record<string, unknown> = {
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: {
+        renderers: new Map([[1, { version: '19.0.0' }]]),
+        onCommitFiberRoot: (...args: unknown[]) => calls.push(args),
+      },
+    };
+    const source = installReactCommitSource(view);
+    let commits = 0;
+    source.subscribe(() => {
+      commits += 1;
+    });
+
+    hookOn(view).onCommitFiberRoot!(1, { current: {} });
+    expect(calls).toHaveLength(1);
+    expect(commits).toBe(1);
+    expect(source.available()).toBe(true);
+  });
+
+  it('gives the extension its handler back when disposed', () => {
+    const original = (): void => {};
+    const view: Record<string, unknown> = {
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: { renderers: new Map(), onCommitFiberRoot: original },
+    };
+    const source = installReactCommitSource(view);
+    expect(hookOn(view).onCommitFiberRoot).not.toBe(original);
+    source.dispose();
+    expect(hookOn(view).onCommitFiberRoot).toBe(original);
+  });
+
+  it('survives a subscriber that throws and still runs the rest', () => {
+    const view: Record<string, unknown> = {};
+    const source = installReactCommitSource(view);
+    let reached = 0;
+    source.subscribe(() => {
+      throw new Error('subscriber');
+    });
+    source.subscribe(() => {
+      reached += 1;
+    });
+
+    expect(() => hookOn(view).onCommitFiberRoot!(1, {})).not.toThrow();
+    expect(reached).toBe(1);
+  });
+
+  it('reports a target it cannot install on rather than throwing', () => {
+    const source = installReactCommitSource(null);
+    expect(source.available()).toBe(false);
+    expect(source.reason()).toContain('could not be installed');
+    expect(() => source.subscribe(() => {})()).not.toThrow();
+    expect(() => source.dispose()).not.toThrow();
+  });
+});
+
+describe('detecting a React that already rendered', () => {
+  it('finds the property React puts on its host nodes', () => {
+    const dom = new JSDOM('<!doctype html><body><div id="app"></div></body>');
+    const element = dom.window.document.querySelector('#app')!;
+    expect(reactRendered(dom.window.document)).toBe(false);
+    (element as unknown as Record<string, unknown>)['__reactFiber$xyz'] = {};
+    expect(reactRendered(dom.window.document)).toBe(true);
+  });
+
+  it('answers false without a document', () => {
+    expect(reactRendered(null)).toBe(false);
+    expect(reactRendered(undefined)).toBe(false);
+  });
+});

--- a/packages/cli/test/serve/vite-page-runtime.test.ts
+++ b/packages/cli/test/serve/vite-page-runtime.test.ts
@@ -57,6 +57,25 @@ describe('Vite page runtime', () => {
     expect(page.transformIndexHtml(html)).toBe(html);
   });
 
+  it('puts the sandbox init script ahead of the page own scripts', () => {
+    const page = runtime();
+    page.config({}, { command: 'build', mode: 'development' } as never);
+    page.buildStart(() => 'chunk-ref');
+    page.generateBundle(() => 'assets/init.js');
+    const html = page.transformIndexHtml(
+      '<html><head><script type="module" crossorigin src="/assets/app.js"></script></head><body></body></html>',
+    );
+    expect(html.indexOf('/assets/init.js')).toBeLessThan(html.indexOf('/assets/app.js'));
+  });
+
+  it('puts the development bootstrap ahead of a script the page has in its head', () => {
+    const page = runtime();
+    const html = page.transformIndexHtml(
+      '<html><head><script type="module" src="/src/main.tsx"></script></head><body></body></html>',
+    );
+    expect(html.indexOf(defaultSdkEntries().init)).toBeLessThan(html.indexOf('/src/main.tsx'));
+  });
+
   it('loads mode-specific AI environment during Vite config', () => {
     const page = runtime();
     page.config({}, { command: 'serve', mode: 'development' } as never);

--- a/packages/cli/test/serve/worker/integration.test.ts
+++ b/packages/cli/test/serve/worker/integration.test.ts
@@ -11,6 +11,8 @@ import { monitorFirebaseActivity, type ActivityIncident } from 'pyric/firestore/
 import * as client from '../../../src/serve/worker/client.js';
 import { rtdbGetDatabase, rtdbRef } from '../../../src/serve/worker/client/rtdb-references.js';
 import { rtdbOnValue } from '../../../src/serve/worker/client/rtdb-listeners.js';
+import { onListenerDelivery } from '../../../src/serve/worker/client/listener-delivery.js';
+import { activeListeners } from 'pyric/sandbox';
 import {
   connectClient,
   connectClientToHost,
@@ -133,6 +135,28 @@ describe('client↔host round-trip (gate repro)', () => {
 
     expect(errors).toEqual([]);
     expect((seen.at(-1) as { marker?: string }).marker).toBe('shared');
+  });
+
+  it('stamps the client subscription id on the attach of both services and reports deliveries by it', async () => {
+    const ctx = await makeHostCtx();
+    const { db } = connectClientToHost(ctx, 'worker://client-ids');
+    const auth = client.getAuth(db);
+    const cred = await client.createUserWithEmailAndPassword(auth, 'ids@example.com', 'pw123456');
+    await client.setDoc(client.doc(db, 'notes/ids'), { uid: cred.user.uid });
+    const reported: string[] = [];
+    const stopReports = onListenerDelivery((id) => reported.push(id));
+    const firestoreUnsub = client.onSnapshot(client.doc(db, 'notes/ids'), { owner: 'notes-panel' }, () => {}, () => {});
+    const databaseUnsub = rtdbOnValue(rtdbRef(rtdbGetDatabase(db), 'rooms/ids'), () => {}, () => {}, { owner: 'rooms-panel' });
+    await sleep();
+    const listeners = activeListeners(ctx.sandbox.history());
+    const clientIds = listeners.map((listener) => listener.clientListenerId).filter((id): id is string => typeof id === 'string');
+    expect(clientIds).toHaveLength(2);
+    expect(new Set(listeners.map((listener) => listener.service))).toEqual(new Set(['firestore', 'database']));
+    expect(reported.length).toBeGreaterThan(0);
+    for (const id of reported) expect(clientIds).toContain(id);
+    firestoreUnsub();
+    databaseUnsub();
+    stopReports();
   });
 
   it('records the page-side owners on the worker attach, for both services', async () => {

--- a/packages/pyric/src/sandbox/active-listeners.ts
+++ b/packages/pyric/src/sandbox/active-listeners.ts
@@ -39,6 +39,13 @@ export interface ActiveListener {
    * callback changed). Absent when the emitter recorded nothing.
    */
   readonly owners?: readonly ListenerOwner[];
+  /**
+   * The id the page's own client gave this subscription, when the host
+   * stamped it on the attach as the activity listener id. A page that
+   * observes a delivery knows only this id, so it is how a page-side
+   * observation finds the listener the sandbox recorded.
+   */
+  readonly clientListenerId?: string;
 }
 
 type ListenerPhase = 'attach' | 'detach' | 'delivery' | 'suppressed' | 'errored';
@@ -120,6 +127,7 @@ interface ActiveListenerDraft {
   suppressedCount: number;
   lastDeliveryAt?: number;
   owners?: ListenerOwner[];
+  clientListenerId?: string;
 }
 
 /**
@@ -144,6 +152,8 @@ export function activeListeners(events: readonly SandboxEvent[]): readonly Activ
         suppressedCount: 0,
       };
       if (info.owners !== undefined) draft.owners = [...info.owners];
+      const clientListenerId = (event as { activity?: { listenerId?: unknown } }).activity?.listenerId;
+      if (typeof clientListenerId === 'string') draft.clientListenerId = clientListenerId;
       active.set(info.listenerId, draft);
       continue;
     }


### PR DESCRIPTION
Adds Flow, a second painting mode for the runtime chip that outlines the elements a listener's delivery re-rendered, next to Overview, which outlines the listener's owner.

```tsx
// The app opens a listener with an owner, as in the chat template:
const { owner, ref } = useListenerOwner();
onSnapshot(query, { owner: { ...owner, element: ref.current } }, cb);

// Chip panel, Flow switched on for `conversations (query)`:
//   a new conversation arrives, the sandbox delivers the snapshot,
//   React commits, and the new ConversationItem's <li> gets a 2px
//   outline in the listener's hue that holds, then fades to the
//   retained tint. The badge inside it reads `ChatPage · conversations (query)`.
```

## Flow reads React's commits, not the DOM

A delivery has no DOM footprint of its own, so Flow correlates two signals: the worker client reports each delivery to the chip with the listener id the sandbox recorded, and a DevTools global hook, installed before React because the sandbox tags are now injected ahead of the page's first script, reports each commit. The fibers committed after a delivery give the rendered subtree; the listener's owner component and its ancestors are excluded so a page-level provider does not mark the whole page. Marks are painted on the page's own elements through `data-pyric-flow*` attributes and one head stylesheet, so nothing moves and the badge is clipped by nothing but the element itself.

## One stylesheet, one theme contract

The overlay's colours, outline width, hold and fade durations are CSS variables with defaults, overridable from the served page's `localStorage`, a Theme dialog in the chip, or the host at init. Both modes draw from the same sheet. The chip remembers the chosen mode, replays the last flow when switched on, and says `Waiting for a delivery to show its flow.` when none has arrived.

## Risk

Runtime chip and worker client only; no sandbox verdict or delivery path changes. Unit tests cover the hook installation order, commit draining, fiber subtree extraction, delivery correlation, mode persistence, and the stylesheet; a Playwright case drives a real React app through a delivery and asserts the outlined element and badge.

<details>
<summary>Implementation notes</summary>

- `react-commit-source.ts` installs the hook and drains one MutationObserver batch per commit; `fiber-flow.ts` walks fibers from the commit root and excludes the owner chain.
- `overlay-theme.ts` owns `OVERLAY_THEME_VARIABLES` and `OVERLAY_THEME_DEFAULTS`; the keyframe fades from the hue to `--pyric-hue-N-retained`.
- `bun test --cwd packages/cli` 3583 pass, `packages/pyric` 6845 pass; `test:site-cli` passing; typecheck, build, and coupling gate clean.

</details>
